### PR TITLE
Add option to Timeline menu that brings back Timeline Past

### DIFF
--- a/src/fw/apps/system_apps/settings/settings_timeline.c
+++ b/src/fw/apps/system_apps/settings/settings_timeline.c
@@ -47,6 +47,7 @@ typedef struct SettingsTimelinePeekData {
 } SettingsTimelinePeekData;
 
 typedef enum TimelinePeekMenuIndex {
+  TimelinePeekMenuIndex_PastOnUp,
   TimelinePeekMenuIndex_Toggle,
   TimelinePeekMenuIndex_Timing,
 
@@ -147,6 +148,13 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
       subtitle = s_before_time_strings[
           prv_before_time_min_to_index(timeline_peek_prefs_get_before_time())];
       break;
+    case TimelinePeekMenuIndex_PastOnUp:
+      /// Shows up in the Timeline settings as the title for the menu item that controls if
+      /// the up button launches Health or Timeline Past.
+      title = i18n_noop("Past on Up Button");
+      subtitle = timeline_prefs_get_past_on_up() ? i18n_noop("On") :
+                                                   i18n_noop("Off");
+      break;
     case TimelinePeekMenuIndexCount:
       break;
   }
@@ -163,6 +171,9 @@ static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
       goto done;
     case TimelinePeekMenuIndex_Timing:
       prv_push_before_time_menu(data);
+      goto done;
+    case TimelinePeekMenuIndex_PastOnUp:
+      timeline_prefs_set_past_on_up(!timeline_prefs_get_past_on_up());
       goto done;
     case TimelinePeekMenuIndexCount:
       break;

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -170,6 +170,9 @@ static bool s_should_prompt_display_calibration = true;
 #define PREF_KEY_TIMELINE_SETTINGS_OPENED "timelineSettingsOpened"
 static uint8_t s_timeline_settings_opened = 0;
 
+#define PREF_KEY_TIMELINE_PAST_ON_UP "timelinePastOnUp"
+static bool s_timeline_past_on_up = false;
+
 #define PREF_KEY_TIMELINE_PEEK_ENABLED "timelineQuickViewEnabled"
 static bool s_timeline_peek_enabled = true;
 
@@ -417,6 +420,11 @@ static bool prv_set_s_should_prompt_display_calibration(bool should_prompt) {
 #if CAPABILITY_HAS_TIMELINE_PEEK
 static uint8_t prv_set_s_timeline_settings_opened(uint8_t *version) {
   s_timeline_settings_opened = *version;
+  return true;
+}
+
+static bool prv_set_s_timeline_past_on_up(bool *enabled){
+  s_timeline_past_on_up = *enabled;
   return true;
 }
 
@@ -1154,6 +1162,14 @@ void timeline_prefs_set_settings_opened(uint8_t version) {
 
 uint8_t timeline_prefs_get_settings_opened(void) {
   return s_timeline_settings_opened;
+}
+
+void timeline_prefs_set_past_on_up(bool enabled) {
+  prv_pref_set(PREF_KEY_TIMELINE_PAST_ON_UP, &enabled, sizeof(enabled));
+}
+
+bool timeline_prefs_get_past_on_up(void) {
+  return s_timeline_past_on_up;
 }
 
 void timeline_peek_prefs_set_enabled(bool enabled) {

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -37,4 +37,5 @@
   PREFS_MACRO(PREF_KEY_TIMELINE_SETTINGS_OPENED, s_timeline_settings_opened)
   PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_ENABLED, s_timeline_peek_enabled)
   PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_BEFORE_TIME_M, s_timeline_peek_before_time_m)
+  PREFS_MACRO(PREF_KEY_TIMELINE_PAST_ON_UP, s_timeline_past_on_up)
 #endif

--- a/src/fw/shell/normal/watchface.c
+++ b/src/fw/shell/normal/watchface.c
@@ -34,6 +34,7 @@
 #include "services/normal/notifications/do_not_disturb.h"
 #include "system/logging.h"
 #include "system/passert.h"
+#include "shell/prefs.h"
 
 #define QUICK_LAUNCH_HOLD_MS (400)
 
@@ -122,16 +123,20 @@ static void prv_launch_launcher_app(ClickRecognizerRef recognizer, void *data) {
 }
 
 #if CAPABILITY_HAS_CORE_NAVIGATION4
-static void prv_launch_health_app(ClickRecognizerRef recognizer, void *data) {
-  prv_launch_app_via_button(&(AppLaunchEventConfig) {
-    .id = APP_ID_HEALTH_APP,
-  }, recognizer);
+static void prv_launch_health_or_timeline(ClickRecognizerRef recognizer, void *data) {
+  if(timeline_prefs_get_past_on_up()) {
+    prv_launch_timeline(recognizer, data);
+  } else {
+    prv_launch_app_via_button(&(AppLaunchEventConfig) {
+      .id = APP_ID_HEALTH_APP,
+    }, recognizer);
+  }
 }
 #endif // CAPABILITY_HAS_CORE_NAVIGATION4
 
 static ClickHandler prv_get_up_click_handler(void) {
 #if CAPABILITY_HAS_CORE_NAVIGATION4
-  return prv_launch_health_app;
+  return prv_launch_health_or_timeline;
 #else
   return prv_launch_timeline;
 #endif // CAPABILITY_HAS_CORE_NAVIGATION4

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -111,6 +111,8 @@ void shell_prefs_set_should_prompt_display_calibration(bool should_prompt);
 
 uint8_t timeline_prefs_get_settings_opened(void);
 void timeline_prefs_set_settings_opened(uint8_t version);
+void timeline_prefs_set_past_on_up(bool enabled);
+bool timeline_prefs_get_past_on_up(void);
 void timeline_peek_prefs_set_enabled(bool enabled);
 bool timeline_peek_prefs_get_enabled(void);
 void timeline_peek_prefs_set_before_time(uint16_t before_time_m);


### PR DESCRIPTION
This PR introduces an option in the Timeline Settings menu that brings back Timeline Past when pressing the Up button. 

At some point, I would like to implement https://github.com/pebble-dev/pebble-firmware/issues/208, but right now I don't have a lot of time, so this is my attempt at a minimum viable solution for bringing back Timeline Past on the Up button.

This is marked as draft because I haven't figured out yet how to update the translations - any help on this matter would be appreciated. :-)

Comments, criticisms and suggestions are welcome.