### PR TITLE
fw/memfault: Push memfault chunks to datalogging

### DIFF
--- a/src/fw/services/normal/data_logging/data_logging_service.h
+++ b/src/fw/services/normal/data_logging/data_logging_service.h
@@ -39,6 +39,9 @@ typedef enum {
   DlsSystemTagActivityAccelSamples = 82,
   DlsSystemTagActivitySession = 84,
   DlsSystemTagProtobufLogSession = 85,
+#ifdef MEMFAULT
+  DlsSystemTagMemfaultChunksSession = 86,
+#endif
 } DlsSystemTag;
 
 //! Init the data logging service. Called by the system at boot time.

--- a/third_party/memfault/port/src/memfault_chunk_collector.c
+++ b/third_party/memfault/port/src/memfault_chunk_collector.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 Core Devices LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Logging Memfault chunks to datalogging can only happen in normal FW
+#include "memfault/components.h"
+
+#include "services/common/system_task.h"
+#include "services/normal/data_logging/data_logging_service.h"
+#include "services/common/new_timer/new_timer.h"
+#include "system/logging.h"
+
+#define MAX_CHUNK_SIZE 250
+#define MEMFAULT_CHUNK_COLLECTION_INTERVAL_SECS (15 * 60)
+
+static DataLoggingSessionRef s_chunks_session;
+static TimerID s_memfault_chunks_timer;
+
+// Datalogging packet sizes are fixed, so we need a wrapper to include the (variable) chunk size.
+typedef struct PACKED {
+  uint32_t length;
+  uint8_t buf[MAX_CHUNK_SIZE];
+} ChunkWrapper;
+
+static void prv_create_dls_session() {
+  if (s_chunks_session != NULL) {
+    return;
+  }
+  Uuid system_uuid = UUID_SYSTEM;
+  uint32_t item_length = sizeof(ChunkWrapper);
+  s_chunks_session = dls_create(
+      DlsSystemTagMemfaultChunksSession, DATA_LOGGING_BYTE_ARRAY, item_length, false, false, &system_uuid);
+}
+
+static void prv_memfault_gather_chunks() {
+  if (!dls_initialized()) {
+    // We need to wait until data logging is initialized before we can add chunks
+    PBL_LOG(LOG_LEVEL_ERROR, "!dls_initialized");
+    return;
+  }
+
+  // We can't do this in init_memfault_chunk_collection because datalogging isn't initialized
+  // yet, so do it here.
+  prv_create_dls_session();
+  if (s_chunks_session == NULL) {
+    PBL_LOG(LOG_LEVEL_ERROR, "!s_chunks_session");
+    return;
+  }
+
+  ChunkWrapper wrapper;
+  bool data_available = true;
+  size_t buf_len;
+
+  while (data_available) {
+    // always reset buf_len to the size of the output buffer before calling
+    // memfault_packetizer_get_chunk
+    buf_len = MAX_CHUNK_SIZE;
+    data_available = memfault_packetizer_get_chunk(wrapper.buf, &buf_len);
+    wrapper.length = buf_len;
+
+    if (data_available) {
+      bool res = dls_log(s_chunks_session, &wrapper, 1);
+      if (res != DATA_LOGGING_SUCCESS) {
+        break;
+      }
+    }
+  }
+}
+
+static void prv_memfault_gather_chunks_cb() {
+    system_task_add_callback(prv_memfault_gather_chunks, NULL);
+}
+
+void init_memfault_chunk_collection() {
+    s_memfault_chunks_timer = new_timer_create();
+    new_timer_start(s_memfault_chunks_timer, MEMFAULT_CHUNK_COLLECTION_INTERVAL_SECS * 1000, 
+        prv_memfault_gather_chunks_cb, (void *) NULL, TIMER_START_FLAG_REPEATING);
+}

--- a/third_party/memfault/port/src/memfault_chunk_collector.h
+++ b/third_party/memfault/port/src/memfault_chunk_collector.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 Core Devices LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#ifndef RECOVERY_FW
+void init_memfault_chunk_collection(void);
+#else
+static inline void init_memfault_chunk_collection(void) {}
+#endif

--- a/third_party/memfault/port/src/memfault_platform_port.c
+++ b/third_party/memfault/port/src/memfault_platform_port.c
@@ -11,6 +11,7 @@
 #include "memfault/ports/freertos.h"
 #include "memfault/ports/freertos_coredump.h"
 #include "memfault/ports/reboot_reason.h"
+#include "memfault_chunk_collector.h"
 
 #include "mfg/mfg_serials.h"
 #include "os/mutex.h"
@@ -152,6 +153,7 @@ int memfault_platform_boot(void) {
 
   memfault_build_info_dump();
   memfault_device_info_dump();
+  init_memfault_chunk_collection();
   MEMFAULT_LOG_INFO("Memfault Initialized!");
 
   return 0;


### PR DESCRIPTION
In normal FW only, collect chunks from Memfault every 15
minutes and forward them to the mobile app using datalogging.

Mobile implementation to read/upload these is already done.

Signed-off-by: Steve Penna <steve@penna.org.uk>