### PR TITLE
bluetooth-fw/init: Increase the host stop timeout

### DIFF
--- a/src/bluetooth-fw/nimble/init.c
+++ b/src/bluetooth-fw/nimble/init.c
@@ -33,7 +33,7 @@
 
 #include "nimble_store.h"
 
-static const uint32_t s_bt_stack_start_stop_timeout_ms = 2000;
+static const uint32_t s_bt_stack_start_stop_timeout_ms = 3000;
 
 extern void pebble_pairing_service_init(void);
 


### PR DESCRIPTION
The host stop procedure initiated with ble_hs_stop may take a little longer than the timeout value specified by
MYNEWT_VAL_BLE_HS_STOP_ON_SHUTDOWN_TIMEOUT. To make sure that the s_host_stopped semaphore is not released too early, let's increase the s_bt_stack_start_stop_timeout_ms to be much greater.