### PR TITLE
fw/drivers/sf32lb52: Fix gpio driver path

### DIFF
--- a/src/fw/drivers/wscript_build
+++ b/src/fw/drivers/wscript_build
@@ -830,7 +830,7 @@ elif mcu_family == 'SF32LB52':
     bld.objects(
         name='driver_gpio',
         source=[
-            'stubs/gpio.c',
+            'sf32lb52/gpio.c',
         ],
         use=[
             'fw_includes',


### PR DESCRIPTION
Added the GPIO driver in #78, but it's still the wrong path in wscript_build, now fix it