### PR TITLE
asterix: explicitly shut down sleeping peripherals

### DIFF
--- a/src/fw/board/boards/board_asterix.c
+++ b/src/fw/board/boards/board_asterix.c
@@ -201,13 +201,6 @@ IRQ_MAP_NRFX(RTC1, rtc_irq_handler);
 void board_early_init(void) {
   PBL_LOG(LOG_LEVEL_ERROR, "asterix early init");
 
-  /* shared SPI chip outputs */
-  nrf_gpio_cfg_output(15);
-  nrf_gpio_cfg_output(16);
-  nrf_gpio_pin_set(15);
-  
-  nrf_gpio_pin_set(16);
-
   nrf_clock_lf_src_set(NRF_CLOCK, NRF_CLOCK_LFCLK_XTAL);
   nrf_clock_event_clear(NRF_CLOCK, NRF_CLOCK_EVENT_LFCLKSTARTED);
   nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_LFCLKSTART);

--- a/src/fw/board/boards/board_asterix.c
+++ b/src/fw/board/boards/board_asterix.c
@@ -162,6 +162,27 @@ static const I2CSlavePort I2C_SLAVE_DA7212 = {
 
 I2CSlavePort *const I2C_DA7212 = &I2C_SLAVE_DA7212;
 
+static const I2CSlavePort I2C_SLAVE_MMC5603NJ = {
+    .bus = &I2C_IIC2_BUS,
+    .address = 0x30 << 1,
+};
+
+I2CSlavePort *const I2C_MMC5603NJ = &I2C_SLAVE_MMC5603NJ;
+
+static const I2CSlavePort I2C_SLAVE_BMP390 = {
+    .bus = &I2C_IIC2_BUS,
+    .address = 0x76 << 1,
+};
+
+I2CSlavePort *const I2C_BMP390 = &I2C_SLAVE_BMP390;
+
+static const I2CSlavePort I2C_SLAVE_LSM6D = {
+    .bus = &I2C_IIC2_BUS,
+    .address = 0x6A << 1,
+};
+
+I2CSlavePort *const I2C_LSM6D = &I2C_SLAVE_LSM6D;
+
 IRQ_MAP_NRFX(I2S, nrfx_i2s_0_irq_handler);
 
 IRQ_MAP_NRFX(PDM, NRFX_PDM_INST_HANDLER_GET(0));
@@ -202,6 +223,11 @@ void board_early_init(void) {
 void board_init(void) {
   i2c_init(&I2C_NPMC_IIC1_BUS);
   i2c_init(&I2C_IIC2_BUS);
+
+  uint8_t da7212_powerdown[] = { 0xFD /* SYSTEM_ACTIVE */, 0 };
+  i2c_use(I2C_DA7212);
+  i2c_write_block(I2C_DA7212, 2, da7212_powerdown);
+  i2c_release(I2C_DA7212);
 
 #if 0
   i2c_init(&I2C_PMIC_HRM_BUS);

--- a/src/fw/board/boards/board_asterix.h
+++ b/src/fw/board/boards/board_asterix.h
@@ -255,3 +255,6 @@ extern I2CSlavePort * const I2C_NPM1300;
 extern I2CSlavePort * const I2C_DRV2604;
 extern I2CSlavePort * const I2C_OPT3001;
 extern I2CSlavePort * const I2C_DA7212;
+extern I2CSlavePort * const I2C_MMC5603NJ;
+extern I2CSlavePort * const I2C_BMP390;
+extern I2CSlavePort * const I2C_LSM6D;

--- a/src/fw/drivers/imu/imu_asterix.c
+++ b/src/fw/drivers/imu/imu_asterix.c
@@ -4,11 +4,75 @@
 #include "drivers/imu.h"
 #include "drivers/spi.h"
 #include "kernel/util/delay.h"
+#include "drivers/i2c.h"
 
-#include "drivers/imu/bmm350/bmm350.h"
+#define MMC5603_PRODUCT_ID 0x39
+#define MMC5603_PRODUCT_ID_VALUE 0x10
+#define MMC5603_CONTROL2 0x1D
+
+#define BMP390_CHIP_ID 0x00
+#define BMP390_CHIP_ID_VALUE 0x60
+#define BMP390_PWR_CTRL 0x1B
+
+#define LSM6D_FUNC_CFG_ACCESS 0x01
+
+#define LSM6D_WHO_AM_I 0x0F
+#define LSM6D_WHO_AM_I_VALUE 0x6C
+
+#define LSM6D_CTRL1_XL 0x10
+#define LSM6D_CTRL2_G 0x11
+#define LSM6D_CTRL4_C 0x13
+#define LSM6D_CTRL4_C_SLEEP_G 0x40
+
+
+
+static bool prv_read_register(I2CSlavePort *i2c, uint8_t register_address, uint8_t *result) {
+  i2c_use(i2c);
+  bool rv = i2c_write_block(i2c, 1, &register_address);
+  if (rv)
+    rv = i2c_read_block(i2c, 1, result);
+  i2c_release(i2c);
+  return rv;
+}
+
+static bool prv_write_register(I2CSlavePort *i2c, uint8_t register_address, uint8_t datum) {
+  i2c_use(i2c);
+  uint8_t d[2] = { register_address, datum };
+  bool rv = i2c_write_block(i2c, 2, d);
+  i2c_release(i2c);
+  return rv;
+}
 
 void imu_init(void) {
-  /* no IMU on asterix */
+  bool rv;
+  uint8_t result;
+  
+  rv = prv_read_register(I2C_MMC5603NJ, MMC5603_PRODUCT_ID, &result);
+  if (!rv || result != MMC5603_PRODUCT_ID_VALUE) {
+    PBL_LOG(LOG_LEVEL_DEBUG, "MMC5603 probe failed; rv %d, result 0x%02x", rv, result);
+  } else {
+    PBL_LOG(LOG_LEVEL_DEBUG, "found the MMC5603NJ, setting to low power");
+    (void) prv_write_register(I2C_MMC5603NJ, MMC5603_CONTROL2, 0);
+  }
+
+  rv = prv_read_register(I2C_BMP390, BMP390_CHIP_ID, &result);
+  if (!rv || result != BMP390_CHIP_ID_VALUE) {
+    PBL_LOG(LOG_LEVEL_DEBUG, "BMP390 probe failed; rv %d, result 0x%02x", rv, result);
+  } else {
+    PBL_LOG(LOG_LEVEL_DEBUG, "found the BMP390, setting to low power");
+    (void) prv_write_register(I2C_BMP390, BMP390_PWR_CTRL, 0);
+  }
+  
+  rv = prv_read_register(I2C_LSM6D, LSM6D_WHO_AM_I, &result);
+  if (!rv || result != LSM6D_WHO_AM_I_VALUE) {
+    PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO probe failed; rv %d, result 0x%02x", rv, result);
+  } else {
+    PBL_LOG(LOG_LEVEL_DEBUG, "found the LSM6DSO, setting to lower power");
+    (void) prv_write_register(I2C_LSM6D, LSM6D_FUNC_CFG_ACCESS, 0);
+    (void) prv_write_register(I2C_LSM6D, LSM6D_CTRL1_XL, 0);
+    (void) prv_write_register(I2C_LSM6D, LSM6D_CTRL2_G, 0);
+    (void) prv_write_register(I2C_LSM6D, LSM6D_CTRL4_C, LSM6D_CTRL4_C_SLEEP_G);
+  }
 }
 
 void imu_power_up(void) {

--- a/src/fw/drivers/nrf5/pwm.c
+++ b/src/fw/drivers/nrf5/pwm.c
@@ -42,6 +42,8 @@ void pwm_set_duty_cycle(const PwmConfig *pwm, uint32_t duty_cycle) {
   pwm->state->value = pwm->state->resolution - duty_cycle;
   if (pwm->state->enabled)
     nrfx_pwm_simple_playback(&pwm->peripheral, &pwm->state->seq, 1, 0);
+  if (duty_cycle == 0)
+    nrfx_pwm_stop(&pwm->peripheral, 0);
 }
 
 void pwm_enable(const PwmConfig *pwm, bool enable) {


### PR DESCRIPTION
This doesn't seem to have much of a difference on Asterix, but it's good to rule these kinds of things out, I suppose, and it's not bad practice to have them anyway.