### PR TITLE
src/fw/kernel: enable icache on nRF52, except when asleep

### DIFF
--- a/src/fw/board/boards/board_asterix.c
+++ b/src/fw/board/boards/board_asterix.c
@@ -186,6 +186,8 @@ void board_early_init(void) {
   nrf_gpio_pin_set(15);
   
   nrf_gpio_pin_set(16);
+ 
+  NRF_NVMC->ICACHECNF |= NVMC_ICACHECNF_CACHEEN_Msk;
 
   nrf_clock_lf_src_set(NRF_CLOCK, NRF_CLOCK_LFCLK_XTAL);
   nrf_clock_event_clear(NRF_CLOCK, NRF_CLOCK_EVENT_LFCLKSTARTED);


### PR DESCRIPTION
The NVMC on nRF52 has an instruction cache that is disabled by default. We would like to have it turned on when the CPU is running -- this improves performance, but more to the point, it improves performance per watt while running (and means that we can shut down the CPU sooner). Turn it on during init, and then turn it off when we go to sleep (it costs us as much as 200 uA of sleep current, otherwise!).