### PR TITLE
Revert PR #98

### DIFF
--- a/src/fw/board/board_nrf5.h
+++ b/src/fw/board/board_nrf5.h
@@ -323,8 +323,7 @@ typedef struct {
   const OutputConfig on_ctrl;
   const nrf_gpio_pin_drive_t on_ctrl_otype;
 
-  const GpioteConfig extcomin_pin;
-  NRF_RTC_Type *const extcomin_rtc;
+  const PwmConfig extcomin;
 } BoardConfigSharpDisplay;
 
 typedef const struct DMARequest DMARequest;

--- a/src/fw/board/boards/board_asterix.h
+++ b/src/fw/board/boards/board_asterix.h
@@ -11,11 +11,6 @@
 #define BOARD_RTC_INST NRF_RTC1
 #define BOARD_RTC_IRQN RTC1_IRQn
 
-#define BOARD_WATCHDOG_RTC_INST NRF_RTC2
-#define BOARD_WATCHDOG_RTC_IRQN RTC2_IRQn
-#define BOARD_WATCHDOG_RTC_IRQHANDLER RTC2_IRQHandler
-#define BOARD_WATCHDOG_RTC_FREQUENCY 60 // Some boards may prefer 32768, but we reuse the RTC.TICK for the display
-
 static const BoardConfig BOARD_CONFIG = {
   .ambient_light_dark_threshold = 100,
   .ambient_k_delta_threshold = 30,

--- a/src/fw/board/boards/board_asterix.h
+++ b/src/fw/board/boards/board_asterix.h
@@ -8,12 +8,8 @@
 
 #define BOARD_LSE_MODE RCC_LSE_Bypass
 
-// RTC0 is used by NimBLE BLE_PHY
-
 #define BOARD_RTC_INST NRF_RTC1
 #define BOARD_RTC_IRQN RTC1_IRQn
-
-// RTC2 is used by display also
 
 #define BOARD_WATCHDOG_RTC_INST NRF_RTC2
 #define BOARD_WATCHDOG_RTC_IRQN RTC2_IRQn
@@ -232,6 +228,7 @@ static const BoardConfigActuator BOARD_CONFIG_BACKLIGHT = {
   },
 };
 
+extern PwmState DISPLAY_EXTCOMIN_STATE;
 static const BoardConfigSharpDisplay BOARD_CONFIG_DISPLAY = {
   .spi = NRFX_SPIM_INSTANCE(3),
 
@@ -241,11 +238,10 @@ static const BoardConfigSharpDisplay BOARD_CONFIG_DISPLAY = {
 
   .on_ctrl = { NRF5_GPIO_RESOURCE_EXISTS, NRF_GPIO_PIN_MAP(0, 4), true },
 
-  .extcomin_rtc = BOARD_WATCHDOG_RTC_INST,
-  .extcomin_pin = {
-    .peripheral = NRFX_GPIOTE_INSTANCE(0),
-    .channel = 7,
-    .gpio_pin = NRF_GPIO_PIN_MAP(1, 15),
+  .extcomin = {
+    .state = &DISPLAY_EXTCOMIN_STATE,
+    .output = { NRF5_GPIO_RESOURCE_EXISTS, NRF_GPIO_PIN_MAP(1, 15), true },
+    .peripheral = NRFX_PWM_INSTANCE(1),
   },
 };
 

--- a/src/fw/drivers/display/sharp_ls013b7dh01/sharp_ls013b7dh01_nrf5.c
+++ b/src/fw/drivers/display/sharp_ls013b7dh01/sharp_ls013b7dh01_nrf5.c
@@ -22,8 +22,6 @@
 
 #define NRF5_COMPATIBLE
 #include <mcu.h>
-#include <nrfx_ppi.h>
-#include <hal/nrf_rtc.h>
 
 #include "FreeRTOS.h"
 #include "task.h"
@@ -55,8 +53,6 @@ static SemaphoreHandle_t s_dma_update_in_progress_semaphore;
 
 static void prv_display_context_init(DisplayContext* context);
 static bool prv_do_dma_update(void);
-
-static const unsigned int DISPLAY_TOGGLE_HZ = 60;
 
 static void prv_enable_chip_select(void) {
   gpio_output_set(&BOARD_CONFIG_DISPLAY.cs, true);
@@ -158,46 +154,10 @@ void display_init(void) {
 
   prv_display_start();
 
-  // Set up the RTC to tick at 60Hz, like Zephyr does.  Some boards will
-  // reuse the WDT RTC for this.
-  if (BOARD_CONFIG_DISPLAY.extcomin_rtc == BOARD_WATCHDOG_RTC_INST) {
-    PBL_ASSERTN(DISPLAY_TOGGLE_HZ == BOARD_WATCHDOG_RTC_FREQUENCY);
-  }
-  nrf_rtc_prescaler_set(BOARD_CONFIG_DISPLAY.extcomin_rtc, NRF_RTC_FREQ_TO_PRESCALER(DISPLAY_TOGGLE_HZ));
-  nrf_rtc_task_trigger(BOARD_CONFIG_DISPLAY.extcomin_rtc, NRF_RTC_TASK_START);
-  nrf_rtc_event_enable(BOARD_CONFIG_DISPLAY.extcomin_rtc, NRF_RTC_EVENT_TICK);
-  
-  uint32_t event = nrf_rtc_event_address_get(BOARD_CONFIG_DISPLAY.extcomin_rtc, NRF_RTC_EVENT_TICK);
-  
-  // Set up a GPIOTE channel to toggle the EXTCOMIN pin.
-  nrfx_err_t err;
-
-  if (!nrfx_gpiote_init_check(&BOARD_CONFIG_DISPLAY.extcomin_pin.peripheral)) {
-    err = nrfx_gpiote_init(&BOARD_CONFIG_DISPLAY.extcomin_pin.peripheral, NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY);
-    PBL_ASSERTN(err == NRFX_SUCCESS);
-  }
-  
-  nrfx_gpiote_output_config_t out_cfg = {
-    .drive = NRF_GPIO_PIN_S0S1, 
-    .input_connect = NRF_GPIO_PIN_INPUT_DISCONNECT,
-    .pull = NRF_GPIO_PIN_NOPULL,
-  };
-  nrfx_gpiote_task_config_t task_cfg = {
-    .task_ch = BOARD_CONFIG_DISPLAY.extcomin_pin.channel,
-    .polarity = NRF_GPIOTE_POLARITY_TOGGLE,
-    .init_val = NRF_GPIOTE_INITIAL_VALUE_LOW,
-  };
-  err = nrfx_gpiote_output_configure(&BOARD_CONFIG_DISPLAY.extcomin_pin.peripheral, BOARD_CONFIG_DISPLAY.extcomin_pin.gpio_pin, &out_cfg, &task_cfg);
-  PBL_ASSERTN(err == NRFX_SUCCESS);
-  
-  uint32_t task = nrfx_gpiote_out_task_address_get(&BOARD_CONFIG_DISPLAY.extcomin_pin.peripheral, BOARD_CONFIG_DISPLAY.extcomin_pin.gpio_pin);
-  
-  // Wire the RTC TICK event to trigger the GPIOTE.
-  nrf_ppi_channel_t extcomin_channel;
-  err = nrfx_ppi_channel_alloc(&extcomin_channel);
-  PBL_ASSERTN(err == NRFX_SUCCESS);
-  nrfx_ppi_channel_assign(extcomin_channel, event, task);
-  nrfx_ppi_channel_enable(extcomin_channel);
+  // Generate PWM signal for EXTCOMIN (120Hz, ~100us pulse width)
+  pwm_init(&BOARD_CONFIG_DISPLAY.extcomin, 125000 / 120, 125000);
+  pwm_set_duty_cycle(&BOARD_CONFIG_DISPLAY.extcomin, (100U * 125000UL) / 1000000UL);
+  pwm_enable(&BOARD_CONFIG_DISPLAY.extcomin, true);
 
   s_initialized = true;
 }

--- a/src/fw/drivers/task_watchdog.c
+++ b/src/fw/drivers/task_watchdog.c
@@ -52,7 +52,6 @@
 
 #if MICRO_FAMILY_NRF5
 #include <hal/nrf_rtc.h>
-#include "board/board.h"
 #endif
 
 #define APP_THROTTLE_TIME_MS 300
@@ -74,7 +73,7 @@ static TimerID s_throttle_timer_id = TIMER_INVALID_ID;
 #define TIMER_INTERRUPT_HZ  2
 // The frequency to run the peripheral at
 #if MICRO_FAMILY_NRF5
-#define TIMER_CLOCK_HZ BOARD_WATCHDOG_RTC_FREQUENCY
+#define TIMER_CLOCK_HZ 32768
 #else
 #define TIMER_CLOCK_HZ 32000
 #endif
@@ -166,11 +165,11 @@ static void prv_log_failed_message(RebootReason *reboot_reason) {
 // The Timer ISR. This runs at super high priority (higher than configMAX_SYSCALL_INTERRUPT_PRIORITY), so
 // it is not safe to call ANY FreeRTOS functions from here.
 #if MICRO_FAMILY_NRF5
-void BOARD_WATCHDOG_RTC_IRQHANDLER(void) {
-  nrf_rtc_event_clear(BOARD_WATCHDOG_RTC_INST, NRF_RTC_EVENT_COMPARE_0);
-  nrf_rtc_task_trigger(BOARD_WATCHDOG_RTC_INST, NRF_RTC_TASK_CLEAR);
-  nrf_rtc_int_enable(BOARD_WATCHDOG_RTC_INST, NRF_RTC_INT_COMPARE0_MASK);
-  nrf_rtc_event_enable(BOARD_WATCHDOG_RTC_INST, NRF_RTC_EVENT_COMPARE_0);
+void RTC2_IRQHandler(void) {
+  nrf_rtc_event_clear(NRF_RTC2, NRF_RTC_EVENT_COMPARE_0);
+  nrf_rtc_task_trigger(NRF_RTC2, NRF_RTC_TASK_CLEAR);
+  nrf_rtc_int_enable(NRF_RTC2, NRF_RTC_INT_COMPARE0_MASK);
+  nrf_rtc_event_enable(NRF_RTC2, NRF_RTC_EVENT_COMPARE_0);
 
   s_ticks_since_successful_feed++;
   prv_task_watchdog_feed();
@@ -280,24 +279,20 @@ void WATCHDOG_FREERTOS_IRQHandler(void) {
 // which resets the watchdog timer if it detects that none of our watchable tasks are stuck.
 void task_watchdog_init(void) {
 #if MICRO_FAMILY_NRF5
-  // We use RTC2 as the WDT kicker; RTC1 is used by the OS RTC, and RTC0
-  // belongs to NimBLE.  Annoyingly, we're out of RTCs on nRF52, and we'd
-  // really like one more to use the TICK event to trigger the GPIOTE for
-  // VCOM, so we also reuse RTC2 for that, allowing the board to set the
-  // underlying RTC frequency.
-  nrf_rtc_prescaler_set(BOARD_WATCHDOG_RTC_INST, NRF_RTC_FREQ_TO_PRESCALER(BOARD_WATCHDOG_RTC_FREQUENCY));
+  // We use RTC2 as the WDT kicker; RTC1 is used by the OS RTC
+  nrf_rtc_prescaler_set(NRF_RTC2, NRF_RTC_FREQ_TO_PRESCALER(TIMER_CLOCK_HZ));
 
   // trigger compare interrupt at appropriate time
-  nrf_rtc_cc_set(BOARD_WATCHDOG_RTC_INST, 0, TIME_PERIOD);
-  nrf_rtc_event_clear(BOARD_WATCHDOG_RTC_INST, NRF_RTC_EVENT_COMPARE_0);
-  nrf_rtc_int_enable(BOARD_WATCHDOG_RTC_INST, NRF_RTC_INT_COMPARE0_MASK);
-  nrf_rtc_event_enable(BOARD_WATCHDOG_RTC_INST, NRF_RTC_EVENT_COMPARE_0);
+  nrf_rtc_cc_set(NRF_RTC2, 0, TIME_PERIOD);
+  nrf_rtc_event_clear(NRF_RTC2, NRF_RTC_EVENT_COMPARE_0);
+  nrf_rtc_int_enable(NRF_RTC2, NRF_RTC_INT_COMPARE0_MASK);
+  nrf_rtc_event_enable(NRF_RTC2, NRF_RTC_EVENT_COMPARE_0);
 
-  NVIC_SetPriority(BOARD_WATCHDOG_RTC_IRQN, TASK_WATCHDOG_PRIORITY);
-  NVIC_ClearPendingIRQ(BOARD_WATCHDOG_RTC_IRQN);
-  NVIC_EnableIRQ(BOARD_WATCHDOG_RTC_IRQN);
+  NVIC_SetPriority(RTC2_IRQn, TASK_WATCHDOG_PRIORITY);
+  NVIC_ClearPendingIRQ(RTC2_IRQn);
+  NVIC_EnableIRQ(RTC2_IRQn);
 
-  nrf_rtc_task_trigger(BOARD_WATCHDOG_RTC_INST, NRF_RTC_TASK_START);
+  nrf_rtc_task_trigger(NRF_RTC2, NRF_RTC_TASK_START);
 #elif MICRO_FAMILY_SF32LB52
 // TODO(SF32LB52): Add implementation
 #else
@@ -367,7 +362,7 @@ void task_watchdog_init(void) {
 
 static void task_watchdog_disable_interrupt() {
 #if MICRO_FAMILY_NRF5
-  NVIC_DisableIRQ(BOARD_WATCHDOG_RTC_IRQN);
+  NVIC_DisableIRQ(RTC2_IRQn);
 #elif MICRO_FAMILY_SF32LB52
 // TODO(SF32LB52): Add implementation
 #else
@@ -379,7 +374,7 @@ static void task_watchdog_disable_interrupt() {
 static void task_watchdog_enable_interrupt() {
   taskEXIT_CRITICAL();
 #if MICRO_FAMILY_NRF5
-  NVIC_EnableIRQ(BOARD_WATCHDOG_RTC_IRQN);
+  NVIC_EnableIRQ(RTC2_IRQn);
 #elif MICRO_FAMILY_SF32LB52
 // TODO(SF32LB52): Add implementation
 #else


### PR DESCRIPTION
This PR reverts #98, it looks like the VCOM toggle signal is no longer generated correctly.

TP30 before revert:

![Screenshot from 2025-07-09 12-56-20](https://github.com/user-attachments/assets/538b3add-474a-4ffe-983c-f5ac06b12b35)

After revert:

![Screenshot from 2025-07-09 12-53-49](https://github.com/user-attachments/assets/1f627c58-476d-4dab-8a43-d3a459e163dd)

FYI @jwise 