### PR TITLE
 asterix: reenable RTC-driven FreeRTOS timer and allow sleep mode, but not STOP mode [FIRM-264]

### DIFF
--- a/src/fw/board/boards/board_asterix.c
+++ b/src/fw/board/boards/board_asterix.c
@@ -229,4 +229,7 @@ void board_init(void) {
   i2c_use(I2C_DA7212);
   i2c_write_block(I2C_DA7212, 2, da7212_powerdown);
   i2c_release(I2C_DA7212);
+  
+  // XXX: FIRM-264: stop mode breaks NimBLE
+  stop_mode_disable(InhibitorMain);
 }

--- a/src/fw/board/boards/board_asterix.h
+++ b/src/fw/board/boards/board_asterix.h
@@ -10,6 +10,7 @@
 #define BOARD_LSE_MODE RCC_LSE_Bypass
 
 #define BOARD_RTC_INST NRF_RTC1
+#define BOARD_RTC_IRQN RTC1_IRQn
 
 static const BoardConfig BOARD_CONFIG = {
   .ambient_light_dark_threshold = 100,

--- a/src/fw/console/prompt_commands.h
+++ b/src/fw/console/prompt_commands.h
@@ -626,7 +626,7 @@ static const Command s_prompt_commands[] = {
   // Firmware specific
   //{ "task-list", command_print_task_list, 0 },
 
-  //{ "cpustats", dump_current_runtime_stats, 0 },
+  { "cpustats", dump_current_runtime_stats, 0 },
   //{ "bt prefs get", command_get_remote_prefs, 0 },
   //{ "bt prefs del", command_del_remote_pref, 1 },
   //{ "bt sniff bounce", command_bt_sniff_bounce, 0 },

--- a/src/fw/drivers/rtc.h
+++ b/src/fw/drivers/rtc.h
@@ -117,4 +117,7 @@ const char* time_t_to_string(char* buffer, time_t t);
 
 #if MICRO_FAMILY_NRF5
 void rtc_irq_handler(void);
+void rtc_enable_synthetic_systick(void);
+void rtc_systick_pause(void);
+void rtc_systick_resume(void);
 #endif

--- a/src/fw/freertos_application.c
+++ b/src/fw/freertos_application.c
@@ -19,6 +19,7 @@
 #include "drivers/rtc.h"
 #include "drivers/task_watchdog.h"
 
+#include "console/prompt.h"
 #include "kernel/memory_layout.h"
 #include "kernel/pbl_malloc.h"
 #include "os/tick.h"
@@ -274,13 +275,22 @@ void dump_current_runtime_stats(void) {
   uint32_t tot_time = running_ms + sleep_ms + stop_ms;
 
   char buf[80];
-  dbgserial_putstr_fmt(buf, sizeof(buf), "Run:   %"PRIu32" ms (%"PRIu32" %%)",
-                       running_ms, (running_ms * 100) / tot_time);
-  dbgserial_putstr_fmt(buf, sizeof(buf), "Sleep: %"PRIu32" ms (%"PRIu32" %%)",
-                       sleep_ms, (sleep_ms * 100) / tot_time);
-  dbgserial_putstr_fmt(buf, sizeof(buf), "Stop:  %"PRIu32" ms (%"PRIu32" %%)",
-                       stop_ms, (stop_ms * 100) / tot_time);
-  dbgserial_putstr_fmt(buf, sizeof(buf), "Tot:   %"PRIu32" ms", tot_time);
+  snprintf(buf, sizeof(buf), "Run:   %"PRIu32" ms (%"PRIu32" %%)",
+           running_ms, (running_ms * 100) / tot_time);
+  prompt_send_response(buf);
+  snprintf(buf, sizeof(buf), "Sleep: %"PRIu32" ms (%"PRIu32" %%)",
+           sleep_ms, (sleep_ms * 100) / tot_time);
+  prompt_send_response(buf);
+  snprintf(buf, sizeof(buf), "Stop:  %"PRIu32" ms (%"PRIu32" %%)",
+           stop_ms, (stop_ms * 100) / tot_time);
+  prompt_send_response(buf);
+  snprintf(buf, sizeof(buf), "Tot:   %"PRIu32" ms", tot_time);
+  prompt_send_response(buf);
+  
+  uint32_t rtc_ticks = rtc_get_ticks();
+  uint32_t rtos_ticks = xTaskGetTickCount();
+  snprintf(buf, sizeof(buf), "RTC ticks: %"PRIu32", RTOS ticks: %"PRIu32, rtc_ticks, rtos_ticks);
+  prompt_send_response(buf);
 }
 
 void analytics_external_collect_cpu_stats(void) {

--- a/src/fw/freertos_application.c
+++ b/src/fw/freertos_application.c
@@ -112,6 +112,9 @@ extern void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime ) {
       // TODO: It would be nice if there was a clean way to actually 'suppress
       // ticks' while in sleep mode. If we figure that out, we would likely
       // need to update how this calculation works
+      //
+      // TODO(nrf5): systick is actually suppressed while in sleep mode!  so
+      // this calculation is bogus
       uint32_t systick_start = SysTick->VAL;
 
       power_tracking_start(PowerSystemMcuCoreSleep);
@@ -247,6 +250,14 @@ bool vPortCorrectTicks(void) {
   return need_context_switch;
 }
 
+bool vPortEnableTimer() {
+#if defined(MICRO_FAMILY_NRF5)
+  rtc_enable_synthetic_systick();
+  return true;
+#else
+  return false;
+#endif
+}
 
 // CPU analytics
 ///////////////////////////////////////////////////////////

--- a/src/fw/kernel/util/stop.c
+++ b/src/fw/kernel/util/stop.c
@@ -60,6 +60,7 @@ void enter_stop_mode(void) {
   dbgserial_enable_rx_exti();
 
   flash_power_down_for_stop_mode();
+  rtc_systick_pause();
 
   /* XXX(nrf5): LATER: have MPSL turn off HFCLK */
 
@@ -67,8 +68,8 @@ void enter_stop_mode(void) {
   do_wfi(); // Wait for Interrupt (enter sleep mode). Work around F2/F4 errata.
   __ISB(); // Let the pipeline catch up (force the WFI to activate before moving on).
 
+  rtc_systick_resume();
   flash_power_up_after_stop_mode();
-
 }
 #elif MICRO_FAMILY_SF32LB52
 void enter_stop_mode(void) {


### PR DESCRIPTION
This is the more aggressive of two PRs.  It disables stop mode, but not sleep mode.  This will cause a meaningful and substantial improvement in battery life, but there is also a chance that there will be Bluetooth regressions (if there are, at least it'll make sense to me; if not, I will be extremely puzzled about a data point from earlier today).  Bluetooth regressions are still recoverable from PRF.  It would be nice for internal watches to shake this down, at least.