### PR TITLE
feat: add alternative notification design option and related preferences

### DIFF
--- a/src/fw/applib/applib_malloc.json
+++ b/src/fw/applib/applib_malloc.json
@@ -230,7 +230,7 @@
         "_comment": "Generously padded because it's not feature complete yet (only 3.x)"
     }, {
         "name": "KinoLayer",
-        "size_3x_padding": 40,
+        "size_3x_padding": 36,
         "size_3x": 164,
         "dependencies": ["Layer", "KinoPlayer"],
         "_comment": "Generously padded because it's not feature complete yet (only 3.x)"
@@ -242,7 +242,7 @@
         "_comment": "Generously padded because it's not feature complete yet (only 3.x)"
     }, {
         "name": "ExpandableDialog",
-        "size_3x_padding": 48,
+        "size_3x_padding": 44,
         "size_3x": 1280,
         "dependencies": ["Dialog", "TextLayer", "ScrollLayer", "ActionBarLayer", "Layer"],
         "_comment": "Generously padded because it's not feature complete yet (only 3.x)"
@@ -254,7 +254,7 @@
         "_comment": "Generously padded because it's not feature complete yet (only 3.x)"
     }, {
         "name": "VoiceWindow",
-        "size_3x_padding": 40,
+        "size_3x_padding": 36,
         "size_3x": 2368,
         "dependencies": ["TranscriptionDialog", "Layer", "Layer", "StatusBarLayer", "TextLayer", 
                          "KinoLayer", "Window", "EventServiceInfo"],

--- a/src/fw/applib/graphics/gtypes.c
+++ b/src/fw/applib/graphics/gtypes.c
@@ -392,6 +392,13 @@ GColor8 gcolor_legible_over(GColor8 background_color) {
   return bright ? GColorBlack : GColorWhite;
 }
 
+GColor8 gcolor_invert(GColor8 color) {
+  // Invert the RGB components while keeping the alpha channel unchanged
+  return (GColor8) {
+    .argb = (color.argb & 0b11000000) | (~color.argb & 0b00111111)
+  };
+}
+
 BitmapInfo gbitmap_get_info(const GBitmap *bitmap) {
   if (!bitmap) {
     return (BitmapInfo) { 0 };

--- a/src/fw/applib/graphics/gtypes.h
+++ b/src/fw/applib/graphics/gtypes.h
@@ -99,6 +99,12 @@ GColor8 gcolor_get_grayscale(GColor8 color);
 //! @return A legible color for the given background color
 GColor8 gcolor_legible_over(GColor8 background_color);
 
+
+//! This method inverts a color.
+//! @param color The color to invert
+//! @return The inverted color
+GColor8 gcolor_invert(GColor8 color);
+
 //! @internal
 //! Returns true if the alpha channel of the given color is set to 0.
 bool gcolor_is_invisible(GColor8 color);

--- a/src/fw/applib/ui/kino/kino_layer.h
+++ b/src/fw/applib/ui/kino/kino_layer.h
@@ -37,6 +37,7 @@ struct KinoLayer {
   GAlign alignment;
   KinoLayerCallbacks callbacks;
   void *context;
+  bool invert_colors;
 };
 
 void kino_layer_init(KinoLayer *kino_layer, const GRect *frame);
@@ -50,11 +51,12 @@ void kino_layer_destroy(KinoLayer *kino_layer);
 Layer *kino_layer_get_layer(KinoLayer *kino_layer);
 
 void kino_layer_set_reel(KinoLayer *kino_layer, KinoReel *reel, bool take_ownership);
+void kino_layer_set_invert_colors(KinoLayer *kino_layer, bool invert);
 
 //! @internal
 void kino_layer_set_reel_with_resource(KinoLayer *kino_layer, uint32_t resource_id);
 void kino_layer_set_reel_with_resource_system(KinoLayer *kino_layer, ResAppNum app_num,
-                                              uint32_t resource_id);
+                                              uint32_t resource_id, bool invert);
 
 KinoReel *kino_layer_get_reel(KinoLayer *kino_layer);
 

--- a/src/fw/applib/ui/kino/kino_player.c
+++ b/src/fw/applib/ui/kino/kino_player.c
@@ -207,8 +207,13 @@ void kino_player_rewind(KinoPlayer *player) {
 }
 
 void kino_player_draw(KinoPlayer *player, GContext *ctx, GPoint offset) {
+  kino_player_draw_processed(player, ctx, offset, NULL);
+}
+
+void kino_player_draw_processed(KinoPlayer *player, GContext *ctx, GPoint offset,
+                                KinoReelProcessor *processor) {
   if (player && player->reel) {
-    kino_reel_draw(player->reel, ctx, offset);
+    kino_reel_draw_processed(player->reel, ctx, offset, processor);
   }
 }
 

--- a/src/fw/applib/ui/kino/kino_player.h
+++ b/src/fw/applib/ui/kino/kino_player.h
@@ -77,3 +77,6 @@ void kino_player_rewind(KinoPlayer *player);
 void kino_player_deinit(KinoPlayer *player);
 
 void kino_player_draw(KinoPlayer *player, GContext *ctx, GPoint offset);
+
+void kino_player_draw_processed(KinoPlayer *player, GContext *ctx, GPoint offset,
+                                KinoReelProcessor *processor);

--- a/src/fw/apps/system_apps/settings/settings_notifications.c
+++ b/src/fw/apps/system_apps/settings/settings_notifications.c
@@ -57,6 +57,7 @@ enum NotificationsItem {
 #endif
   NotificationsItemTextSize,
   NotificationsItemWindowTimeout,
+  NotificationsItemDesignStyle,
   NotificationsItem_Count,
 };
 
@@ -246,6 +247,38 @@ static void prv_window_timeout_menu_push(SettingsNotificationsData *data) {
       data);
 }
 
+// Design Style
+////////////////////////
+
+static const char *s_design_style_labels[] = {
+  /// Standard notification design option (default)
+  i18n_noop("Standard"),
+  /// Alternative notification design option
+  i18n_noop("Alternative"),
+};
+
+static int prv_design_style_get_selection_index(void) {
+  return alerts_preferences_get_notification_alternative_design() ? 1 : 0;
+}
+
+static void prv_design_style_menu_select(OptionMenu *option_menu, int selection, void *context) {
+  alerts_preferences_set_notification_alternative_design(selection == 1);
+  app_window_stack_remove(&option_menu->window, true /* animated */);
+}
+
+static void prv_design_style_menu_push(SettingsNotificationsData *data) {
+  const int index = prv_design_style_get_selection_index();
+  const OptionMenuCallbacks callbacks = {
+    .select = prv_design_style_menu_select,
+  };
+  /// Status bar title for the Notification Design Style settings screen
+  const char *title = i18n_noop("Style");
+  settings_option_menu_push(
+      title, OptionMenuContentType_SingleLine, index, &callbacks,
+      ARRAY_LENGTH(s_design_style_labels), true /* icons_enabled */, s_design_style_labels,
+      data);
+}
+
 // Menu Layer Callbacks
 ////////////////////////
 
@@ -290,6 +323,12 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
       subtitle = s_window_timeouts_labels[prv_window_timeout_get_selection_index()];
       break;
     }
+    case NotificationsItemDesignStyle: {
+      /// String within Settings->Notifications that describes the notification design style
+      title = i18n_noop("Style");
+      subtitle = s_design_style_labels[prv_design_style_get_selection_index()];
+      break;
+    }
     default:
       WTF;
   }
@@ -323,6 +362,9 @@ static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
       break;
     case NotificationsItemWindowTimeout:
       prv_window_timeout_menu_push(data);
+      break;
+    case NotificationsItemDesignStyle:
+      prv_design_style_menu_push(data);
       break;
     default:
       WTF;

--- a/src/fw/apps/system_apps/timeline/peek_layer.c
+++ b/src/fw/apps/system_apps/timeline/peek_layer.c
@@ -185,8 +185,11 @@ static bool prv_is_dot_size(GSize size) {
   return (size.w <= UNFOLD_DOT_SIZE_PX && size.h <= UNFOLD_DOT_SIZE_PX);
 }
 
-void peek_layer_set_icon_with_size(PeekLayer *peek_layer, const TimelineResourceInfo *timeline_res,
-                                   TimelineResourceSize res_size, GRect icon_from) {
+void peek_layer_set_icon_with_size_invert(PeekLayer *peek_layer,
+                                          const TimelineResourceInfo *timeline_res,
+                                          TimelineResourceSize res_size, GRect icon_from,
+                                          bool invert) {
+  kino_layer_set_invert_colors(&peek_layer->kino_layer, invert);
   kino_layer_set_reel(&peek_layer->kino_layer, NULL, false);
 
   AppResourceInfo icon_res_info;
@@ -235,8 +238,19 @@ void peek_layer_set_icon_with_size(PeekLayer *peek_layer, const TimelineResource
   kino_layer_set_reel(&peek_layer->kino_layer, kino_reel, true);
 }
 
+void peek_layer_set_icon_with_size(PeekLayer *peek_layer, const TimelineResourceInfo *timeline_res,
+                                   TimelineResourceSize res_size, GRect icon_from) {
+  peek_layer_set_icon_with_size_invert(peek_layer, timeline_res, res_size, icon_from, false);
+}
+
 void peek_layer_set_icon(PeekLayer *peek_layer, const TimelineResourceInfo *timeline_res) {
   peek_layer_set_icon_with_size(peek_layer, timeline_res, TimelineResourceSizeLarge, GRectZero);
+}
+
+void peek_layer_set_icon_with_invert(PeekLayer *peek_layer,
+                                     const TimelineResourceInfo *timeline_res, bool invert) {
+  peek_layer_set_icon_with_size_invert(peek_layer, timeline_res, TimelineResourceSizeLarge,
+                                       GRectZero, invert);
 }
 
 //! This is called after both the scale to and the PDCS is complete

--- a/src/fw/apps/system_apps/timeline/peek_layer.h
+++ b/src/fw/apps/system_apps/timeline/peek_layer.h
@@ -79,6 +79,8 @@ void peek_layer_set_frame(PeekLayer *peek_layer, const GRect *frame);
 //! The peek layer will be primed with an unfold animation.
 //! The resource will begin as a dot until the peek layer is played.
 void peek_layer_set_icon(PeekLayer *peek_layer, const TimelineResourceInfo *timeline_res);
+void peek_layer_set_icon_with_invert(PeekLayer *peek_layer,
+                                     const TimelineResourceInfo *timeline_res, bool invert);
 void peek_layer_set_icon_with_size(PeekLayer *peek_layer, const TimelineResourceInfo *timeline_res,
                                    TimelineResourceSize res_size, GRect icon_from);
 

--- a/src/fw/popups/notifications/notification_window.c
+++ b/src/fw/popups/notifications/notification_window.c
@@ -49,6 +49,7 @@
 #include "services/normal/blob_db/reminder_db.h"
 #include "services/normal/notifications/alerts.h"
 #include "services/normal/notifications/alerts_preferences.h"
+#include "services/normal/notifications/alerts_preferences_private.h"
 #include "services/normal/notifications/alerts_private.h"
 #include "services/normal/notifications/ancs/ancs_filtering.h"
 #include "services/normal/notifications/do_not_disturb.h"
@@ -412,7 +413,12 @@ static void prv_show_peek_for_notification(NotificationWindowData *data, Uuid *i
     .app_id = &data->notification_app_id, // This is set earlier when we reload the layout
     .fallback_id = fallback_icon_id,
   };
+#if PBL_BW
+  const bool use_alternative_design = alerts_preferences_get_notification_alternative_design();
+  peek_layer_set_icon_with_invert(data->peek_layer, &data->peek_icon_info, use_alternative_design);
+#else
   peek_layer_set_icon(data->peek_layer, &data->peek_icon_info);
+#endif
   peek_layer_set_background_color(data->peek_layer, colors->bg_color);
 
   // This is so that only the banner of the swap_layer is sticking out from the bottom
@@ -1077,7 +1083,6 @@ static void prv_layout_did_appear_handler(SwapLayer *swap_layer, LayoutLayer *la
   kino_layer_play(&((NotificationLayout *)layout)->icon_layer);
 }
 
-#if PBL_COLOR
 static void prv_update_colors_handler(SwapLayer *swap_layer, GColor bg_color,
                                       bool status_bar_filled, void *context) {
   NotificationWindowData *data = context;
@@ -1086,7 +1091,6 @@ static void prv_update_colors_handler(SwapLayer *swap_layer, GColor bg_color,
   status_bar_layer_set_colors(&data->status_layer, PBL_IF_ROUND_ELSE(GColorClear, status_color),
                               gcolor_legible_over(status_color));
 }
-#endif
 
 static void prv_interaction_handler(SwapLayer *swap_layer, void *context) {
   NotificationWindowData *data = context;

--- a/src/fw/services/normal/notifications/alerts_preferences.c
+++ b/src/fw/services/normal/notifications/alerts_preferences.c
@@ -73,6 +73,9 @@ static uint32_t s_first_use_complete = 0;
 #define PREF_KEY_NOTIF_WINDOW_TIMEOUT "notifWindowTimeout"
 static uint32_t s_notif_window_timeout_ms = NOTIF_WINDOW_TIMEOUT_DEFAULT;
 
+#define PREF_KEY_NOTIF_DESIGN_STYLE "notifDesignStyle"
+static bool s_notification_alternative_design = false;  // true = alternative (black banner), false = standard (default)
+
 ///////////////////////////////////
 //! Legacy preference keys
 ///////////////////////////////////
@@ -285,6 +288,7 @@ void alerts_preferences_init(void) {
                s_dnd_schedule[WeekendSchedule].enabled);
   RESTORE_PREF(PREF_KEY_FIRST_USE_COMPLETE, s_first_use_complete);
   RESTORE_PREF(PREF_KEY_NOTIF_WINDOW_TIMEOUT, s_notif_window_timeout_ms);
+  RESTORE_PREF(PREF_KEY_NOTIF_DESIGN_STYLE, s_notification_alternative_design);
 #undef RESTORE_PREF
 
   prv_migrate_legacy_dnd_schedule(&file);
@@ -339,6 +343,15 @@ uint32_t alerts_preferences_get_notification_window_timeout_ms(void) {
 void alerts_preferences_set_notification_window_timeout_ms(uint32_t timeout_ms) {
   s_notif_window_timeout_ms = timeout_ms;
   SET_PREF(PREF_KEY_NOTIF_WINDOW_TIMEOUT, s_notif_window_timeout_ms);
+}
+
+bool alerts_preferences_get_notification_alternative_design(void) {
+  return s_notification_alternative_design;
+}
+
+void alerts_preferences_set_notification_alternative_design(bool alternative) {
+  s_notification_alternative_design = alternative;
+  SET_PREF(PREF_KEY_NOTIF_DESIGN_STYLE, s_notification_alternative_design);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/fw/services/normal/notifications/alerts_preferences_private.h
+++ b/src/fw/services/normal/notifications/alerts_preferences_private.h
@@ -44,6 +44,10 @@ uint32_t alerts_preferences_get_notification_window_timeout_ms(void);
 
 void alerts_preferences_set_notification_window_timeout_ms(uint32_t timeout_ms);
 
+bool alerts_preferences_get_notification_alternative_design(void);
+
+void alerts_preferences_set_notification_alternative_design(bool alternative);
+
 bool alerts_preferences_get_vibrate(void);
 
 void alerts_preferences_set_vibrate(bool enable);

--- a/src/fw/services/normal/timeline/layout_layer.c
+++ b/src/fw/services/normal/timeline/layout_layer.c
@@ -25,6 +25,7 @@
 #include "sports_layout.h"
 #include "weather_layout.h"
 
+#include "services/normal/notifications/alerts_preferences_private.h"
 #include "system/passert.h"
 #include "applib/ui/status_bar_layer.h"
 
@@ -56,10 +57,16 @@ static const LayoutColors s_default_colors = {
   .bg_color = { .argb = PBL_IF_COLOR_ELSE(GColorLightGrayARGB8, GColorWhiteARGB8) },
 };
 
-static const LayoutColors s_default_notification_colors = {
-  .primary_color = { .argb = GColorBlackARGB8 },
-  .secondary_color = { .argb = GColorBlackARGB8 },
-  .bg_color = { .argb = GColorLightGrayARGB8 },
+static const LayoutColors s_default_notification_colors_alternative = {
+    .primary_color = {.argb = GColorWhiteARGB8},
+    .secondary_color = {.argb = GColorBlackARGB8},
+    .bg_color = {.argb = GColorBlackARGB8},
+};
+
+static const LayoutColors s_default_notification_colors_standard = {
+    .primary_color = {.argb = GColorBlackARGB8},
+    .secondary_color = {.argb = GColorBlackARGB8},
+    .bg_color = {.argb = GColorLightGrayARGB8},
 };
 
 LayoutLayer *layout_create(LayoutId id, const LayoutLayerConfig *config) {
@@ -97,7 +104,12 @@ const LayoutColors *layout_get_colors(const LayoutLayer *layout) {
 }
 
 const LayoutColors *layout_get_notification_colors(const LayoutLayer *layout) {
-  return PBL_IF_COLOR_ELSE(layout_get_colors(layout), &s_default_notification_colors);
+#if PBL_COLOR
+  return layout_get_colors(layout);
+#else
+  const bool use_alternative_design = alerts_preferences_get_notification_alternative_design();
+  return use_alternative_design ? &s_default_notification_colors_alternative : &s_default_notification_colors_standard;
+#endif
 }
 
 void layout_set_mode(LayoutLayer *layout, LayoutLayerMode final_mode) {

--- a/src/fw/services/normal/timeline/swap_layer.c
+++ b/src/fw/services/normal/timeline/swap_layer.c
@@ -26,6 +26,7 @@
 #include "resource/resource_ids.auto.h"
 #include "services/normal/timeline/layout_layer.h"
 #include "services/normal/timeline/notification_layout.h"
+#include "services/normal/notifications/alerts_preferences_private.h"
 #include "kernel/ui/kernel_ui.h"
 #include "process_state/app_state/app_state.h"
 #include "system/logging.h"
@@ -204,6 +205,12 @@ static void prv_update_status_bar_color(SwapLayer *swap_layer) {
     color_status_bar = WITHIN(cur_frame->origin.y, -96, 66) || swap_layer->swap_in_progress;
 #endif
     bg_color = layout_get_colors(swap_layer->current)->bg_color;
+
+#if PBL_BW
+    // On a black and white display, use the appropriate status bar color based on design style
+    const bool use_alternative_design = alerts_preferences_get_notification_alternative_design();
+    bg_color = use_alternative_design ? GColorBlack : GColorLightGray;
+#endif
   }
 
   prv_update_colors(swap_layer, bg_color, color_status_bar);


### PR DESCRIPTION
This pull request introduces a new alternative notification style on black and white watches that can be changed to in settings ("old" design is still default)

https://github.com/user-attachments/assets/c5f4daf3-a10d-46ab-9a91-3579a1afe633


https://github.com/user-attachments/assets/3d2ee553-f1a3-413d-90b5-e76a4d2aaf2f

