### PR TITLE
obelix add button driver

### DIFF
--- a/src/fw/board/board_sf32lb52.h
+++ b/src/fw/board/board_sf32lb52.h
@@ -22,6 +22,7 @@
 #include <stdbool.h>
 
 #include "bf0_hal_pinmux.h"
+#include "drivers/button_id.h"
 
 #define IRQ_PRIORITY_INVALID (1 << __NVIC_PRIO_BITS)
 
@@ -119,6 +120,20 @@ typedef struct {
   InputConfig dbgserial_int_gpio;
   OutputConfig lcd_com;
 } BoardConfig;
+
+typedef struct {
+  const char* name;
+  GPIO_TypeDef* const port;
+  uint8_t pin;
+  GPIOPuPd_TypeDef pull;
+  bool active_high;
+} ButtonConfig;
+
+typedef struct {
+  ButtonConfig buttons[NUM_BUTTONS];
+  GPT_TypeDef *timer;
+  IRQn_Type timer_irqn;
+} BoardConfigButton;
 
 typedef struct {
   //! Percentage for watch only mode

--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -20,6 +20,7 @@
 #include "bf0_hal_pmu.h"
 #include "bf0_hal_rcc.h"
 #include "board/board.h"
+#include "drivers/sf32lb52/debounced_button_definitions.h"
 #include "system/passert.h"
 
 
@@ -289,6 +290,18 @@ const BoardConfigPower BOARD_CONFIG_POWER = {
 const BoardConfig BOARD_CONFIG = {
   .backlight_on_percent = 100U,
 };
+
+const BoardConfigButton BOARD_CONFIG_BUTTON = {
+  .buttons = {
+    [BUTTON_ID_BACK]   = { "Back",   hwp_gpio1, 34, GPIO_PuPd_NOPULL, true },
+    [BUTTON_ID_UP]     = { "Up",     hwp_gpio1, 37, GPIO_PuPd_UP, false},
+    [BUTTON_ID_SELECT] = { "Select", hwp_gpio1, 36, GPIO_PuPd_UP, false},
+    [BUTTON_ID_DOWN]   = { "Down",   hwp_gpio1, 35, GPIO_PuPd_UP, false},
+  },
+  .timer = GPTIM1,
+  .timer_irqn = GPTIM1_IRQn,
+};
+IRQ_MAP(GPTIM1, debounced_button_irq_handler, GPTIM1);
 
 uint32_t BSP_GetOtpBase(void) {
   return MPI2_MEM_BASE;

--- a/src/fw/drivers/sf32lb52/button.c
+++ b/src/fw/drivers/sf32lb52/button.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 SiFli Technologies(Nanjing) Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "drivers/button.h"
+
+#include "board/board.h"
+#include "console/prompt.h"
+#include "drivers/periph_config.h"
+#include "drivers/gpio.h"
+#include "kernel/events.h"
+#include "system/passert.h"
+
+bool button_is_pressed(ButtonId id) {
+  const InputConfig config = {
+    .gpio = BOARD_CONFIG_BUTTON.buttons[id].port,
+    .gpio_pin = BOARD_CONFIG_BUTTON.buttons[id].pin,
+  };
+  uint32_t bit = gpio_input_read(&config);
+  return (BOARD_CONFIG_BUTTON.buttons[id].active_high) ? bit : !bit;
+}
+
+uint8_t button_get_state_bits(void) {
+  uint8_t button_state = 0x00;
+  for (int i = 0; i < NUM_BUTTONS; ++i) {
+    button_state |= (button_is_pressed(i) ? 0x01 : 0x00) << i;
+  }
+  return button_state;
+}
+
+void button_init(void) {
+  for (int i = 0; i < NUM_BUTTONS; ++i) {
+    const InputConfig config = {
+      .gpio = BOARD_CONFIG_BUTTON.buttons[i].port,
+      .gpio_pin = BOARD_CONFIG_BUTTON.buttons[i].pin,
+    };
+    gpio_input_init_pull_up_down(&config, BOARD_CONFIG_BUTTON.buttons[i].pull);
+  }
+}
+
+bool button_selftest(void) {
+  return button_get_state_bits() == 0;
+}
+
+void command_button_read(const char* button_id_str) {
+  int button = atoi(button_id_str);
+
+  if (button < 0 || button >= NUM_BUTTONS) {
+    prompt_send_response("Invalid button");
+    return;
+  }
+
+  if (button_is_pressed(button)) {
+    prompt_send_response("down");
+  } else {
+    prompt_send_response("up");
+  }
+}

--- a/src/fw/drivers/sf32lb52/debounced_button.c
+++ b/src/fw/drivers/sf32lb52/debounced_button.c
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2025 SiFli Technologies(Nanjing) Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "drivers/debounced_button.h"
+
+#include "board/board.h"
+#include "drivers/button.h"
+#include "drivers/exti.h"
+#include "drivers/gpio.h"
+#include "drivers/periph_config.h"
+#include "kernel/events.h"
+#include "kernel/util/stop.h"
+#include "system/bootbits.h"
+#include "system/reset.h"
+#include "util/bitset.h"
+#include "kernel/util/sleep.h"
+#include "bf0_hal_tim.h"
+
+#include "FreeRTOS.h"
+
+/* Timer period 1us, auto reload is 2ms. */
+#define TIMER_FREQUENCY_HZ    1000000
+#define TIMER_PERIOD_TICKS    2000
+
+#define RESET_BUTTONS ((1 << BUTTON_ID_SELECT) | (1 << BUTTON_ID_BACK))
+
+#define DEBOUNCE_SAMPLES_PER_SECOND (TIMER_FREQUENCY_HZ / TIMER_PERIOD_TICKS)
+
+// This reset-buttons-held timeout must be lower than the PMIC's back-button-reset timeout,
+// which is ~8-11s. The spacing between these timeouts should be large enough to avoid accidentally
+// shutting down the device when a customer is attempting to reset. Therefore the FW's
+// reset-buttons-held timeout is set to 5 seconds:
+#define RESET_THRESHOLD_SAMPLES (5 * DEBOUNCE_SAMPLES_PER_SECOND)
+
+// A button must be stable for 20 samples (40ms) to be accepted.
+static const uint32_t s_num_debounce_samples = 20;
+static GPT_HandleTypeDef s_tim_hdl = {0};
+
+static void prv_timer_handler(void);
+
+static void initialize_button_timer(void) {
+  s_tim_hdl.Instance = BOARD_CONFIG_BUTTON.timer;
+  s_tim_hdl.Init.Prescaler = HAL_RCC_GetPCLKFreq(CORE_ID_HCPU, 1) / TIMER_FREQUENCY_HZ - 1;
+  s_tim_hdl.core = CORE_ID_HCPU;
+  s_tim_hdl.Init.CounterMode = GPT_COUNTERMODE_UP;
+  s_tim_hdl.Init.RepetitionCounter = 0;
+  HAL_GPT_Base_Init(&s_tim_hdl);
+
+  /* Default NVIC priority group set in exit driver, group_2 */
+  HAL_NVIC_SetPriority(BOARD_CONFIG_BUTTON.timer_irqn, 3, 1);
+  HAL_NVIC_EnableIRQ(BOARD_CONFIG_BUTTON.timer_irqn);
+
+  __HAL_GPT_SET_AUTORELOAD(&s_tim_hdl, TIMER_PERIOD_TICKS);
+  __HAL_GPT_SET_MODE(&s_tim_hdl, GPT_OPMODE_REPETITIVE);
+}
+
+static bool prv_check_timer_enabled(void) {
+  return (HAL_GPT_Base_GetState(&s_tim_hdl) != HAL_GPT_STATE_READY);
+}
+
+static void disable_button_timer(void) {
+  if (prv_check_timer_enabled()) {
+    HAL_GPT_Base_Stop_IT(&s_tim_hdl);
+    stop_mode_enable(InhibitorButton);
+  }
+}
+
+static void prv_enable_button_timer(void) {
+  __disable_irq();
+  if (!prv_check_timer_enabled()) {
+    HAL_GPT_Base_Start_IT(&s_tim_hdl);
+    stop_mode_disable(InhibitorButton);
+  }
+  __enable_irq();
+}
+
+static void prv_button_interrupt_handler(bool *should_context_switch) {
+  prv_enable_button_timer();
+}
+
+void debounced_button_init(void) {
+  button_init();
+
+  for (int i = 0; i < NUM_BUTTONS; ++i) {
+    const ExtiConfig config = {
+      .peripheral = BOARD_CONFIG_BUTTON.buttons[i].port,
+      .gpio_pin = BOARD_CONFIG_BUTTON.buttons[i].pin
+    };
+    exti_configure_pin(config, ExtiTrigger_RisingFalling, prv_button_interrupt_handler);
+    exti_enable(config);
+  }
+
+  initialize_button_timer();
+
+  if (button_get_state_bits() != 0) {
+    prv_enable_button_timer();
+  }
+}
+
+void debounced_button_irq_handler(GPT_TypeDef *timer)
+{
+  if (__HAL_GPT_GET_FLAG(&s_tim_hdl, GPT_FLAG_UPDATE) != RESET) {
+    if (__HAL_GPT_GET_IT_SOURCE(&s_tim_hdl, GPT_IT_UPDATE) != RESET) {
+      __HAL_GPT_CLEAR_IT(&s_tim_hdl, GPT_IT_UPDATE);
+      prv_timer_handler();
+    }
+  }
+}
+
+static void prv_timer_handler(void) {
+  bool should_context_switch = pdFALSE;
+  bool can_disable_timer = true;
+
+  static uint32_t s_button_timers[NUM_BUTTONS] = {0, 0, 0, 0};
+  static uint32_t s_debounced_button_state = 0;
+
+  for (int i = 0; i < NUM_BUTTONS; ++i) {
+    bool debounced_button_state = bitset32_get(&s_debounced_button_state, i);
+    bool is_pressed = button_is_pressed(i);
+
+    if (is_pressed == debounced_button_state) {
+      s_button_timers[i] = 0;
+      continue;
+    }
+
+    can_disable_timer = false;
+
+    s_button_timers[i] += 1;
+
+    if (s_button_timers[i] == s_num_debounce_samples) {
+      s_button_timers[i] = 0;
+
+      bitset32_update(&s_debounced_button_state, i, is_pressed);
+
+      PebbleEvent e = {
+        .type = (is_pressed) ? PEBBLE_BUTTON_DOWN_EVENT : PEBBLE_BUTTON_UP_EVENT,
+        .button.button_id = i
+      };
+      should_context_switch = event_put_isr(&e);
+    }
+  }
+
+#if !defined(MANUFACTURING_FW)
+  // Now that s_debounced_button_state is updated, check to see if the user is holding down the reset
+  // combination.
+  static uint32_t s_hard_reset_timer = 0;
+  if ((s_debounced_button_state & RESET_BUTTONS) == RESET_BUTTONS) {
+    s_hard_reset_timer += 1;
+    can_disable_timer = false;
+
+    if (s_hard_reset_timer > RESET_THRESHOLD_SAMPLES) {
+      __disable_irq();
+
+      // If the UP button is held at the moment the timeout is hit, set the force-PRF bootbit:
+      const bool force_prf = (s_debounced_button_state & (1 << BUTTON_ID_UP));
+      if (force_prf) {
+        boot_bit_set(BOOT_BIT_FORCE_PRF);
+      }
+
+      RebootReason reason = {
+        .code = force_prf ? RebootReasonCode_PrfResetButtonsHeld :
+                            RebootReasonCode_ResetButtonsHeld
+      };
+      reboot_reason_set(&reason);
+
+      // Don't use system_reset here. This back door absolutely must work. Just hard reset.
+      system_hard_reset();
+    }
+  } else {
+    s_hard_reset_timer = 0;
+  }
+#endif
+
+  if (can_disable_timer) {
+    __disable_irq();
+    disable_button_timer();
+    __enable_irq();
+  }
+
+  portEND_SWITCHING_ISR(should_context_switch);
+}
+
+// Serial commands
+///////////////////////////////////////////////////////////
+void command_put_raw_button_event(const char* button_index, const char* is_button_down_event) {
+  PebbleEvent e;
+  int is_down = atoi(is_button_down_event);
+  int button = atoi(button_index);
+
+  if ((button < 0 || button > NUM_BUTTONS) || (is_down != 1 && is_down != 0)) {
+    return;
+  }
+  e.type = (is_down) ? PEBBLE_BUTTON_DOWN_EVENT : PEBBLE_BUTTON_UP_EVENT;
+  e.button.button_id = button;
+  event_put(&e);
+}

--- a/src/fw/drivers/sf32lb52/debounced_button_definitions.h
+++ b/src/fw/drivers/sf32lb52/debounced_button_definitions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Core Devices LLC
+ * Copyright 2025 SiFli Technologies(Nanjing) Co., Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,6 @@
 
 #pragma once
 
-#define BT_VENDOR_ID 0x0EEA
-#define BT_VENDOR_NAME "Core Devices LLC"
+#include "bf0_hal_tim.h"
 
-extern UARTDevice * const DBG_UART;
-#ifdef NIMBLE_HCI_SF32LB52_TRACE_BINARY
-extern UARTDevice * const HCI_TRACE_UART;
-#endif // NIMBLE_HCI_SF32LB52_TRACE_BINARY
-extern QSPIPort * const QSPI;
-extern QSPIFlash * const QSPI_FLASH;
-extern I2CBus *const I2C1_BUS;
-extern PwmConfig *const PWM1_CH1;
-extern DisplayJDIDevice *const DISPLAY;
-extern const BoardConfigPower BOARD_CONFIG_POWER;
-extern const BoardConfig BOARD_CONFIG;
-extern const BoardConfigButton BOARD_CONFIG_BUTTON;
+void debounced_button_irq_handler(GPT_TypeDef *timer);

--- a/src/fw/drivers/sf32lb52/gpio.c
+++ b/src/fw/drivers/sf32lb52/gpio.c
@@ -66,15 +66,8 @@ void gpio_output_init(const OutputConfig *pin_config, GPIOOType_TypeDef otype,
   HAL_GPIO_Init(pin_config->gpio, &GPIO_InitStruct);
 }
 
-void gpio_input_init(const InputConfig *pin_config) {
-  gpio_use(pin_config->gpio);
-  GPIO_InitTypeDef GPIO_InitStruct;
-  GPIO_InitStruct.Pin = pin_config->gpio_pin;
-  GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-
-  HAL_PIN_Set(PAD_PA00 + pin_config->gpio_pin, GPIO_A0 + pin_config->gpio_pin, PIN_NOPULL, 1);
-  HAL_GPIO_Init(pin_config->gpio, &GPIO_InitStruct);
+void gpio_input_init(const InputConfig *input_cfg) {
+  gpio_input_init_pull_up_down(input_cfg, GPIO_PuPd_NOPULL);
 }
 
 void gpio_input_init_pull_up_down(const InputConfig *input_cfg, GPIOPuPd_TypeDef pupd) {
@@ -85,12 +78,13 @@ void gpio_input_init_pull_up_down(const InputConfig *input_cfg, GPIOPuPd_TypeDef
   GPIO_InitStruct.Pull = GPIO_NOPULL;
 
   int flag = 0;
+  /* pullup/down is handled in pinmux hal. */
   if (pupd == GPIO_PuPd_UP) {
-    flag = GPIO_PULLUP;
+    flag = PIN_PULLUP;
   } else if (pupd == GPIO_PuPd_DOWN) {
-    flag = GPIO_PULLDOWN;
+    flag = PIN_PULLDOWN;
   } else {
-    WTF;
+    flag = PIN_NOPULL;
   }
 
   HAL_PIN_Set(PAD_PA00 + input_cfg->gpio_pin, GPIO_A0 + input_cfg->gpio_pin, flag, 1);

--- a/src/fw/drivers/wscript_build
+++ b/src/fw/drivers/wscript_build
@@ -523,16 +523,18 @@ elif mcu_family == 'NRF52840':
         ],
     )
 elif mcu_family == 'SF32LB52':
-    # FIXME(SF32LB52): provide working implementation
     bld.objects(
         name='driver_button',
         source=[
-            'stubs/button.c',
-            'stubs/debounced_button.c',
+            'sf32lb52/button.c',
+            'sf32lb52/debounced_button.c',
         ],
         use=[
             'driver_exti',
+            'driver_gpio',
+            'freertos',
             'fw_includes',
+            'hal_sifli',
         ],
     )
 


### PR DESCRIPTION
This add button and debounced_button driver for obelix board.

EDIT: 
~Below log show timer and gpio read is OK. Next step to check the exti function.~
Currently add button support for Sifli SF32LB52-DevKit-LCD board. Will add obelix new board support latter.

