### PR TITLE
Expose standard BLE BAS service

### DIFF
--- a/src/bluetooth-fw/nimble/bas.c
+++ b/src/bluetooth-fw/nimble/bas.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 Core Devices LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bluetooth/bas.h"
+#include "services/bas/ble_svc_bas.h"
+
+void bt_driver_bas_handle_update(uint8_t percent) {
+  ble_svc_bas_battery_level_set(percent);
+}

--- a/src/bluetooth-fw/nimble/init.c
+++ b/src/bluetooth-fw/nimble/init.c
@@ -25,6 +25,7 @@
 #include <os/tick.h>
 #include <semphr.h>
 #include <services/dis/ble_svc_dis.h>
+#include <services/bas/ble_svc_bas.h>
 #include <services/gap/ble_svc_gap.h>
 #include <services/gatt/ble_svc_gatt.h>
 #include <stdlib.h>
@@ -115,6 +116,7 @@ bool bt_driver_start(BTDriverConfig *config) {
   ble_svc_gap_init();
   ble_svc_gatt_init();
   ble_svc_dis_init();
+  ble_svc_bas_init();
   pebble_pairing_service_init();
 
   ble_hs_sched_start();

--- a/src/bluetooth-fw/qemu/bas.c
+++ b/src/bluetooth-fw/qemu/bas.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 Core Devices LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bluetooth/bas.h"
+
+void bt_driver_bas_handle_update(uint8_t percent) {
+}

--- a/src/bluetooth-fw/stub/bas.c
+++ b/src/bluetooth-fw/stub/bas.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 Core Devices LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bluetooth/bas.h"
+
+void bt_driver_bas_handle_update(uint8_t percent) {
+}

--- a/src/fw/services/common/bluetooth/ble_bas.c
+++ b/src/fw/services/common/bluetooth/ble_bas.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 Core Devices LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "applib/event_service_client.h"
+#include "bluetooth/bas.h"
+#include "kernel/event_loop.h"
+#include "kernel/pebble_tasks.h"
+#include "syscall/syscall.h"
+
+static EventServiceInfo s_bas_evt;
+
+static void prv_execute_on_kernel_main(CallbackEventCallback cb) {
+  if (pebble_task_get_current() != PebbleTask_KernelMain) {
+    launcher_task_add_callback(cb, NULL);
+  } else {
+    cb(NULL);
+  }
+}
+
+static void prv_ble_bas_handle_event(PebbleEvent *e, void *context) {
+  const PebbleBatteryStateChangeEvent *const battery_state_event = &e->battery_state;
+
+  bt_driver_bas_handle_update(battery_state_event->new_state.charge_percent);
+}
+
+static void prv_start_ble_bas_kernel_main(void *unused) {
+  BatteryChargeState battery_state;
+
+  battery_state = sys_battery_get_charge_state();
+  bt_driver_bas_handle_update(battery_state.charge_percent);
+
+  s_bas_evt = (EventServiceInfo) {
+    .type = PEBBLE_BATTERY_STATE_CHANGE_EVENT,
+    .handler = prv_ble_bas_handle_event,
+  };
+
+  event_service_client_subscribe(&s_bas_evt);
+}
+
+static void prv_stop_ble_bas_kernel_main(void *unused) {
+  event_service_client_unsubscribe(&s_bas_evt);
+}
+
+void ble_bas_init(void) {
+  prv_execute_on_kernel_main(prv_start_ble_bas_kernel_main);
+}
+
+void ble_bas_deinit(void) {
+  prv_execute_on_kernel_main(prv_stop_ble_bas_kernel_main);
+}

--- a/src/fw/services/common/bluetooth/ble_bas.h
+++ b/src/fw/services/common/bluetooth/ble_bas.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Core Devices LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+void ble_bas_init(void);
+
+void ble_bas_deinit(void);

--- a/src/fw/services/common/bluetooth/bluetooth_ctl.c
+++ b/src/fw/services/common/bluetooth/bluetooth_ctl.c
@@ -33,6 +33,7 @@
 #include "os/mutex.h"
 #include "pebble_errors.h"
 #include "services/common/analytics/analytics.h"
+#include "services/common/bluetooth/ble_bas.h"
 #include "services/common/bluetooth/bluetooth_persistent_storage.h"
 #include "services/common/bluetooth/dis.h"
 #include "services/common/bluetooth/local_addr.h"
@@ -106,6 +107,7 @@ static void prv_comm_start(void) {
 #if CAPABILITY_HAS_BUILTIN_HRM
     ble_hrm_init();
 #endif
+    ble_bas_init();
     bt_pairability_init();
     analytics_stopwatch_stop(ANALYTICS_DEVICE_METRIC_BT_OFF_TIME);
   } else {
@@ -121,6 +123,7 @@ static void prv_comm_stop(void) {
     return;
   }
   stop_mode_disable(InhibitorCommMode);
+  ble_bas_deinit();
 #if CAPABILITY_HAS_BUILTIN_HRM
   ble_hrm_deinit();
 #endif

--- a/src/include/bluetooth/bas.h
+++ b/src/include/bluetooth/bas.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 Core Devices LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+//! Sends the battery measurement to all subscribed & connected devices.
+void bt_driver_bas_handle_update(uint8_t percent);

--- a/third_party/nimble/port/include/cc2564x/syscfg/syscfg.h
+++ b/third_party/nimble/port/include/cc2564x/syscfg/syscfg.h
@@ -45,7 +45,7 @@
 
 /*** Repository @syscfg info */
 #ifndef MYNEWT_VAL_REPO_HASH_SYSCFG
-#define MYNEWT_VAL_REPO_HASH_SYSCFG "c69c6b902649d3a2a0cb631a1bf77f9f26d198b6-dirty"
+#define MYNEWT_VAL_REPO_HASH_SYSCFG "3bdec47963cc638a2a9296673b24588381ecf196-dirty"
 #endif
 
 #ifndef MYNEWT_VAL_REPO_VERSION_SYSCFG
@@ -944,6 +944,19 @@
 #define MYNEWT_VAL_BLE_STORE_MAX_CCCDS (8)
 #endif
 
+/*** @apache-mynewt-nimble/nimble/host/services/bas */
+#ifndef MYNEWT_VAL_BLE_SVC_BAS_BATTERY_LEVEL_NOTIFY_ENABLE
+#define MYNEWT_VAL_BLE_SVC_BAS_BATTERY_LEVEL_NOTIFY_ENABLE (1)
+#endif
+
+#ifndef MYNEWT_VAL_BLE_SVC_BAS_BATTERY_LEVEL_READ_PERM
+#define MYNEWT_VAL_BLE_SVC_BAS_BATTERY_LEVEL_READ_PERM (0)
+#endif
+
+#ifndef MYNEWT_VAL_BLE_SVC_BAS_SYSINIT_STAGE
+#define MYNEWT_VAL_BLE_SVC_BAS_SYSINIT_STAGE (303)
+#endif
+
 /*** @apache-mynewt-nimble/nimble/host/services/dis */
 /* Overridden by app (defined by @apache-mynewt-nimble/nimble/host/services/dis) */
 #ifndef MYNEWT_VAL_BLE_SVC_DIS_DEFAULT_READ_PERM
@@ -1329,6 +1342,7 @@
 #define MYNEWT_PKG_apache_mynewt_core__util_rwlock 1
 #define MYNEWT_PKG_apache_mynewt_nimble__nimble 1
 #define MYNEWT_PKG_apache_mynewt_nimble__nimble_host 1
+#define MYNEWT_PKG_apache_mynewt_nimble__nimble_host_services_bas 1
 #define MYNEWT_PKG_apache_mynewt_nimble__nimble_host_services_dis 1
 #define MYNEWT_PKG_apache_mynewt_nimble__nimble_host_services_gap 1
 #define MYNEWT_PKG_apache_mynewt_nimble__nimble_host_services_gatt 1

--- a/third_party/nimble/port/include/nrf52/syscfg/syscfg.h
+++ b/third_party/nimble/port/include/nrf52/syscfg/syscfg.h
@@ -45,7 +45,7 @@
 
 /*** Repository @syscfg info */
 #ifndef MYNEWT_VAL_REPO_HASH_SYSCFG
-#define MYNEWT_VAL_REPO_HASH_SYSCFG "c69c6b902649d3a2a0cb631a1bf77f9f26d198b6-dirty"
+#define MYNEWT_VAL_REPO_HASH_SYSCFG "3bdec47963cc638a2a9296673b24588381ecf196-dirty"
 #endif
 
 #ifndef MYNEWT_VAL_REPO_VERSION_SYSCFG
@@ -2255,6 +2255,19 @@
 #define MYNEWT_VAL_BLE_STORE_MAX_CCCDS (8)
 #endif
 
+/*** @apache-mynewt-nimble/nimble/host/services/bas */
+#ifndef MYNEWT_VAL_BLE_SVC_BAS_BATTERY_LEVEL_NOTIFY_ENABLE
+#define MYNEWT_VAL_BLE_SVC_BAS_BATTERY_LEVEL_NOTIFY_ENABLE (1)
+#endif
+
+#ifndef MYNEWT_VAL_BLE_SVC_BAS_BATTERY_LEVEL_READ_PERM
+#define MYNEWT_VAL_BLE_SVC_BAS_BATTERY_LEVEL_READ_PERM (0)
+#endif
+
+#ifndef MYNEWT_VAL_BLE_SVC_BAS_SYSINIT_STAGE
+#define MYNEWT_VAL_BLE_SVC_BAS_SYSINIT_STAGE (303)
+#endif
+
 /*** @apache-mynewt-nimble/nimble/host/services/dis */
 /* Overridden by app (defined by @apache-mynewt-nimble/nimble/host/services/dis) */
 #ifndef MYNEWT_VAL_BLE_SVC_DIS_DEFAULT_READ_PERM
@@ -2738,6 +2751,7 @@
 #define MYNEWT_PKG_apache_mynewt_nimble__nimble_controller 1
 #define MYNEWT_PKG_apache_mynewt_nimble__nimble_drivers_nrf5x 1
 #define MYNEWT_PKG_apache_mynewt_nimble__nimble_host 1
+#define MYNEWT_PKG_apache_mynewt_nimble__nimble_host_services_bas 1
 #define MYNEWT_PKG_apache_mynewt_nimble__nimble_host_services_dis 1
 #define MYNEWT_PKG_apache_mynewt_nimble__nimble_host_services_gap 1
 #define MYNEWT_PKG_apache_mynewt_nimble__nimble_host_services_gatt 1

--- a/third_party/nimble/port/include/sf32lb52/syscfg/syscfg.h
+++ b/third_party/nimble/port/include/sf32lb52/syscfg/syscfg.h
@@ -45,7 +45,7 @@
 
 /*** Repository @syscfg info */
 #ifndef MYNEWT_VAL_REPO_HASH_SYSCFG
-#define MYNEWT_VAL_REPO_HASH_SYSCFG "c69c6b902649d3a2a0cb631a1bf77f9f26d198b6-dirty"
+#define MYNEWT_VAL_REPO_HASH_SYSCFG "3bdec47963cc638a2a9296673b24588381ecf196-dirty"
 #endif
 
 #ifndef MYNEWT_VAL_REPO_VERSION_SYSCFG
@@ -948,6 +948,19 @@
 #define MYNEWT_VAL_BLE_STORE_MAX_CCCDS (8)
 #endif
 
+/*** @apache-mynewt-nimble/nimble/host/services/bas */
+#ifndef MYNEWT_VAL_BLE_SVC_BAS_BATTERY_LEVEL_NOTIFY_ENABLE
+#define MYNEWT_VAL_BLE_SVC_BAS_BATTERY_LEVEL_NOTIFY_ENABLE (1)
+#endif
+
+#ifndef MYNEWT_VAL_BLE_SVC_BAS_BATTERY_LEVEL_READ_PERM
+#define MYNEWT_VAL_BLE_SVC_BAS_BATTERY_LEVEL_READ_PERM (0)
+#endif
+
+#ifndef MYNEWT_VAL_BLE_SVC_BAS_SYSINIT_STAGE
+#define MYNEWT_VAL_BLE_SVC_BAS_SYSINIT_STAGE (303)
+#endif
+
 /*** @apache-mynewt-nimble/nimble/host/services/dis */
 /* Overridden by app (defined by @apache-mynewt-nimble/nimble/host/services/dis) */
 #ifndef MYNEWT_VAL_BLE_SVC_DIS_DEFAULT_READ_PERM
@@ -1333,6 +1346,7 @@
 #define MYNEWT_PKG_apache_mynewt_core__util_rwlock 1
 #define MYNEWT_PKG_apache_mynewt_nimble__nimble 1
 #define MYNEWT_PKG_apache_mynewt_nimble__nimble_host 1
+#define MYNEWT_PKG_apache_mynewt_nimble__nimble_host_services_bas 1
 #define MYNEWT_PKG_apache_mynewt_nimble__nimble_host_services_dis 1
 #define MYNEWT_PKG_apache_mynewt_nimble__nimble_host_services_gap 1
 #define MYNEWT_PKG_apache_mynewt_nimble__nimble_host_services_gatt 1

--- a/third_party/nimble/syscfg/app/pkg.yml
+++ b/third_party/nimble/syscfg/app/pkg.yml
@@ -25,6 +25,7 @@ pkg.deps:
     - "@apache-mynewt-core/sys/log/stub"
     - "@apache-mynewt-core/sys/stats/stub"
     - "@apache-mynewt-nimble/nimble/host"
+    - "@apache-mynewt-nimble/nimble/host/services/bas"
     - "@apache-mynewt-nimble/nimble/host/services/gap"
     - "@apache-mynewt-nimble/nimble/host/services/gatt"
     - "@apache-mynewt-nimble/nimble/host/services/dis"

--- a/third_party/nimble/wscript
+++ b/third_party/nimble/wscript
@@ -44,6 +44,7 @@ def build(bld):
             'mynewt-nimble/nimble/src/*.c',
             'mynewt-nimble/nimble/host/src/*.c',
             'mynewt-nimble/nimble/host/util/src/*.c',
+            'mynewt-nimble/nimble/host/services/bas/src/*.c',
             'mynewt-nimble/nimble/host/services/gap/src/*.c',
             'mynewt-nimble/nimble/host/services/gatt/src/*.c',
             'mynewt-nimble/nimble/host/services/dis/src/*.c',


### PR DESCRIPTION
This can be used by the mobile app to show watch battery % in the device list or do whatever the app wants with this.