### PR TITLE
Implement driver for Asterix's LSM6DSO IMU

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 [submodule "third_party/speex/speex"]
 	path = third_party/speex/speex
 	url = https://github.com/xiph/speex
+[submodule "third_party/hal_lsm6dso/lsm6dso-pid"]
+	path = third_party/hal_lsm6dso/lsm6dso-pid
+	url = https://github.com/STMicroelectronics/lsm6dso-pid.git

--- a/src/fw/board/boards/board_asterix.h
+++ b/src/fw/board/boards/board_asterix.h
@@ -59,6 +59,29 @@ static const BoardConfigActuator BOARD_CONFIG_VIBE = {
   .vsys_scale = 3300,
 };
 
+static const BoardConfigAccel BOARD_CONFIG_ACCEL = {
+  .accel_config = {
+    .axes_offsets[AXIS_X] = 1,
+    .axes_offsets[AXIS_Y] = 0,
+    .axes_offsets[AXIS_Z] = 2,
+    .axes_inverts[AXIS_X] = false,
+    .axes_inverts[AXIS_Y] = false,
+    .axes_inverts[AXIS_Z] = false,
+    // This will need calibration.
+    .shake_thresholds[AccelThresholdHigh] = 64,
+    .shake_thresholds[AccelThresholdLow] = 0xf,
+    .double_tap_threshold = 12500,
+  },
+  // Ideally we would configure both interrupt pins, but we have run out of GPIOTE channels.
+  // We will use INT1 (connected to pin 13) for accelerometer interrupts, and leave INT2 (pin 11) unused.
+  .accel_int_gpios = {
+    [0] = { .gpio = NRF5_GPIO_RESOURCE_EXISTS, .gpio_pin = NRF_GPIO_PIN_MAP(1, 13) },
+  },
+  .accel_ints = {
+    [0] = { .peripheral = NRFX_GPIOTE_INSTANCE(0), .channel = 7, .gpio_pin = NRF_GPIO_PIN_MAP(1, 13) },
+  },
+};
+
 extern UARTDevice * const DBG_UART;
 
 extern PwmState BACKLIGHT_PWM_STATE;

--- a/src/fw/drivers/imu/imu_asterix.c
+++ b/src/fw/drivers/imu/imu_asterix.c
@@ -1,10 +1,11 @@
 #include "board/board.h"
-
 #include "drivers/accel.h"
+#include "drivers/i2c.h"
 #include "drivers/imu.h"
+#include "drivers/imu/lsm6dso/lsm6dso.h"
 #include "drivers/spi.h"
 #include "kernel/util/delay.h"
-#include "drivers/i2c.h"
+#include "system/logging.h"
 
 #define MMC5603_PRODUCT_ID 0x39
 #define MMC5603_PRODUCT_ID_VALUE 0x10
@@ -13,17 +14,6 @@
 #define BMP390_CHIP_ID 0x00
 #define BMP390_CHIP_ID_VALUE 0x60
 #define BMP390_PWR_CTRL 0x1B
-
-#define LSM6D_FUNC_CFG_ACCESS 0x01
-
-#define LSM6D_WHO_AM_I 0x0F
-#define LSM6D_WHO_AM_I_VALUE 0x6C
-
-#define LSM6D_CTRL1_XL 0x10
-#define LSM6D_CTRL2_G 0x11
-#define LSM6D_CTRL4_C 0x13
-#define LSM6D_CTRL4_C_SLEEP_G 0x40
-
 
 
 static bool prv_read_register(I2CSlavePort *i2c, uint8_t register_address, uint8_t *result) {
@@ -63,23 +53,13 @@ void imu_init(void) {
     (void) prv_write_register(I2C_BMP390, BMP390_PWR_CTRL, 0);
   }
   
-  rv = prv_read_register(I2C_LSM6D, LSM6D_WHO_AM_I, &result);
-  if (!rv || result != LSM6D_WHO_AM_I_VALUE) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO probe failed; rv %d, result 0x%02x", rv, result);
-  } else {
-    PBL_LOG(LOG_LEVEL_DEBUG, "found the LSM6DSO, setting to lower power");
-    (void) prv_write_register(I2C_LSM6D, LSM6D_FUNC_CFG_ACCESS, 0);
-    (void) prv_write_register(I2C_LSM6D, LSM6D_CTRL1_XL, 0);
-    (void) prv_write_register(I2C_LSM6D, LSM6D_CTRL2_G, 0);
-    (void) prv_write_register(I2C_LSM6D, LSM6D_CTRL4_C, LSM6D_CTRL4_C_SLEEP_G);
-  }
+  lsm6dso_init();
 }
 
 void imu_power_up(void) {
-  // NYI
+  lsm6dso_power_up();
 }
 
 void imu_power_down(void) {
-  // NYI
+  lsm6dso_power_down();
 }
-

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 Matthew Wardrop
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "drivers/accel.h"
+#include "lsm6dso_reg.h"
+
+#include "lsm6dso.h"
+
+// LSM6DSO configuration entrypoints
+
+void lsm6dso_init(void) {}
+
+void lsm6dso_power_up(void) {}
+
+void lsm6dso_power_down(void) {}
+
+// accel.h implementation
+
+const AccelDriverInfo ACCEL_DRIVER_INFO = {
+    .sample_interval_max = 1000000, // 1 second
+    .sample_interval_low_power = 100000, // 100 ms
+    .sample_interval_ui = 250000, // 250 ms
+    .sample_interval_game = 20000, // 20 ms
+    .sample_interval_min = 1000, // 1 ms
+};
+
+uint32_t accel_set_sampling_interval(uint32_t interval_us) {
+  return 0;
+}
+
+uint32_t accel_get_sampling_interval(void) {
+  return 0;
+}
+
+void accel_set_num_samples(uint32_t num_samples) {}
+
+int accel_peek(AccelDriverSample *data) {
+  data->timestamp_us = 0;
+  data->x = 0;
+  data->y = 0;
+  data->z = 0;
+  return 0;
+}
+
+void accel_enable_shake_detection(bool on) {}
+
+bool accel_get_shake_detection_enabled(void) {
+  return false;
+}
+
+void accel_enable_double_tap_detection(bool on) {}
+
+bool accel_get_double_tap_detection_enabled(void) {
+  return false;
+}
+
+void accel_set_shake_sensitivity_high(bool sensitivity_high) {}

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -21,6 +21,7 @@
 #include "drivers/rtc.h"
 #include "kernel/util/sleep.h"
 #include "system/logging.h"
+#include "util/math.h"
 #include "lsm6dso_reg.h"
 
 #include "lsm6dso.h"
@@ -34,6 +35,7 @@ static void prv_lsm6dso_mdelay(uint32_t ms);
 static void prv_lsm6dso_init(void);
 static void prv_lsm6dso_chase_target_state(void);
 static void prv_lsm6dso_configure_interrupts(void);
+static void prv_lsm6dso_configure_double_tap(bool enable);
 static void prv_lsm6dso_interrupt_handler(bool *should_context_switch);
 static void prv_lsm6dso_process_interrupts(void);
 typedef struct {
@@ -74,6 +76,9 @@ typedef struct {
 lsm6dso_state_t s_lsm6dso_state = {0};
 lsm6dso_state_t s_lsm6dso_state_target = {0};
 static bool s_interrupts_pending = false;
+static uint32_t s_tap_threshold = 0x08;
+// TODO: Do something like: (but currently this doesn't work well)
+//    BOARD_CONFIG_ACCEL.accel_config.double_tap_threshold / 1250;  // 125 mg step at 4g range
 
 // LSM6DSO configuration entrypoints
 
@@ -128,10 +133,14 @@ bool accel_get_shake_detection_enabled(void) {
   return false;
 }
 
-void accel_enable_double_tap_detection(bool on) {}
+void accel_enable_double_tap_detection(bool on) {
+  PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: %s double tap detection.", on ? "Enabling" : "Disabling");
+  s_lsm6dso_state_target.double_tap_detection_enabled = on;
+  prv_lsm6dso_chase_target_state();
+}
 
 bool accel_get_double_tap_detection_enabled(void) {
-  return false;
+  return s_lsm6dso_state.double_tap_detection_enabled;
 }
 
 void accel_set_shake_sensitivity_high(bool sensitivity_high) {}
@@ -309,7 +318,7 @@ static void prv_lsm6dso_chase_target_state(void) {
   // Update double tap detection
   if (s_lsm6dso_state_target.double_tap_detection_enabled !=
       s_lsm6dso_state.double_tap_detection_enabled) {
-    // TODO: Configure the double tap thresholds.
+    prv_lsm6dso_configure_double_tap(s_lsm6dso_state_target.double_tap_detection_enabled);
     s_lsm6dso_state.double_tap_detection_enabled =
         s_lsm6dso_state_target.double_tap_detection_enabled;
     update_interrupts = true;
@@ -358,6 +367,33 @@ static void prv_lsm6dso_configure_interrupts(void) {
   }
 }
 
+void prv_lsm6dso_configure_double_tap(bool enable) {
+  if (enable) {
+    // Configure tap detection parameters
+    lsm6dso_tap_threshold_x_set(&lsm6dso_ctx, s_tap_threshold);  // Adjust threshold as needed
+    lsm6dso_tap_threshold_y_set(&lsm6dso_ctx, s_tap_threshold);
+    lsm6dso_tap_threshold_z_set(&lsm6dso_ctx, s_tap_threshold);
+
+    // Enable tap detection on all axes
+    lsm6dso_tap_detection_on_x_set(&lsm6dso_ctx, PROPERTY_ENABLE);
+    lsm6dso_tap_detection_on_y_set(&lsm6dso_ctx, PROPERTY_ENABLE);
+    lsm6dso_tap_detection_on_z_set(&lsm6dso_ctx, PROPERTY_ENABLE);
+
+    // Configure tap timing
+    lsm6dso_tap_shock_set(&lsm6dso_ctx, 0x03);  // Shock duration
+    lsm6dso_tap_quiet_set(&lsm6dso_ctx, 0x02);  // Quiet period
+    lsm6dso_tap_dur_set(&lsm6dso_ctx, 0x08);    // Double tap window
+
+    // Enable double tap recognition
+    lsm6dso_tap_mode_set(&lsm6dso_ctx, LSM6DSO_BOTH_SINGLE_DOUBLE);
+  } else {
+    // Disable tap detection
+    lsm6dso_tap_detection_on_x_set(&lsm6dso_ctx, PROPERTY_DISABLE);
+    lsm6dso_tap_detection_on_y_set(&lsm6dso_ctx, PROPERTY_DISABLE);
+    lsm6dso_tap_detection_on_z_set(&lsm6dso_ctx, PROPERTY_DISABLE);
+  }
+}
+
 static void prv_lsm6dso_interrupt_handler(bool *should_context_switch) {
   if (s_interrupts_pending) {  // avoid flooding the kernel queue
     return;
@@ -373,6 +409,30 @@ static void prv_lsm6dso_process_interrupts(void) {
 
   if (s_lsm6dso_state.num_samples > 0 && all_sources.drdy_xl) {
     prv_lsm6dso_read_samples();
+  }
+
+  if (all_sources.double_tap) {
+    PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Double tap interrupt triggered");
+    // Handle double tap detection
+    axis_t axis;
+    if (all_sources.tap_x) {
+      axis = X_AXIS;
+    } else if (all_sources.tap_y) {
+      axis = Y_AXIS;
+    } else if (all_sources.tap_z) {
+      axis = Z_AXIS;
+    } else {
+      PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: No tap axis detected");
+      return;  // No valid tap detected
+    }
+
+    uint8_t axis_offset = BOARD_CONFIG_ACCEL.accel_config.axes_offsets[axis];
+    uint8_t axis_direction = (BOARD_CONFIG_ACCEL.accel_config.axes_inverts[axis] ? -1 : 1) *
+                             (all_sources.tap_sign ? -1 : 1);
+
+    PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Double tap interrupt triggered; axis=%d, direction=%d",
+            axis_offset, axis_direction);
+    accel_cb_double_tap_detected(axis_offset, axis_direction);
   }
 }
 
@@ -396,6 +456,11 @@ static int32_t prv_lsm6dso_set_sampling_interval(uint32_t interval_us) {
   if (!s_lsm6dso_initialized) {
     PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Not initialized, cannot set sampling interval");
     return -1;
+  }
+
+  if (s_lsm6dso_state.double_tap_detection_enabled) {
+    interval_us =
+        MIN(interval_us, 2398);  // Max interval for shake/double tap detection to work reliably
   }
 
   odr_xl_interval_t odr_interval = prv_get_odr_for_interval(interval_us);

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -153,6 +153,11 @@ void accel_set_shake_sensitivity_high(bool sensitivity_high) {
   prv_lsm6dso_chase_target_state();
 }
 
+bool accel_run_selftest(void) {
+  // TODO: Implement  a sensible self-test for LSM6DSO 
+  return true;
+}
+
 // HAL context implementations
 
 static int32_t prv_lsm6dso_read(void *handle, uint8_t reg_addr, uint8_t *buffer,

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.h
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 Matthew Wardrop
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+//! Initialize the LSM6DSO accelerometer driver.
+void lsm6dso_init(void);
+
+//! Enter normal mode for the LSM6DSO accelerometer.
+void lsm6dso_power_up(void);
+
+//! Enter low-power mode for the LSM6DSO accelerometer.
+void lsm6dso_power_down(void);

--- a/src/fw/drivers/wscript_build
+++ b/src/fw/drivers/wscript_build
@@ -464,8 +464,20 @@ if bld.is_silk() and not bld.env.QEMU:
         ],
     )
 
-if bld.is_asterix() or bld.is_obelix():
-    # FIXME(ASTERIX,OBELIX): provide working implementation
+if bld.is_asterix():
+    bld.objects(
+        name='driver_lsm6dso',
+        source=[
+            'imu/lsm6dso/lsm6dso.c',
+        ],
+        use=[
+            'hal_lsm6dso',
+            'fw_includes',
+        ],
+    )
+
+if bld.is_obelix():
+    # FIXME(OBELIX): provide working implementation
     bld.objects(
         name='driver_lsm6dso',
         source=[

--- a/third_party/hal_lsm6dso/wscript
+++ b/third_party/hal_lsm6dso/wscript
@@ -1,0 +1,14 @@
+def build(bld):
+    lsm6dso_includes = [
+        'lsm6dso-pid'
+    ]
+
+    lsm6dso_sources = [
+        'lsm6dso-pid/lsm6dso_reg.c',
+    ]
+
+    bld.stlib(source=lsm6dso_sources,
+              includes=lsm6dso_includes,
+              export_includes=lsm6dso_includes,
+              target='hal_lsm6dso',
+              use=['pblibc'])

--- a/third_party/wscript
+++ b/third_party/wscript
@@ -35,4 +35,7 @@ def build(bld):
     if bld.env.bt_controller == 'cc2564x':
         bld.recurse('ti_bt_sp')
 
+    if bld.is_asterix():
+        bld.recurse('hal_lsm6dso')
+
     bld.recurse('memfault')


### PR DESCRIPTION
This patchset will implement full support for the LSM6DSO IMU found in Pebble 2 Duo (aka Asterix). IIUC, this is also the IMU found in Pebble Time 2 (aka Obelix), and so it should be straightforward to enable this driver for Obelix at some later point. Since I don't have Obelix hardware to play with, that is out of scope for this PR.

This PR is current in draft state, and will rebased as necessary to keep things clean (and for my own benefit, updated against latest main code).

**Current state**:

- [x] Accelerometer sampling.
- [x] Interrupt driven accelerometer updates.
- [x] Check and fix alignment and scaling of accelerometer axes (as defined [here](https://developer.rebble.io/developer.pebble.com/guides/events-and-services/accelerometer/index.html)).
- [ ] Use FIFO buffers on LSM6DSO when `n_samples` > 1.
- [x] Double tap detection.
- [x] (partial) Shake detection.
- [ ] Ignore tap interrupts when vibing.
- [ ] Sign off all commits.
- [ ] ...?

(This PR replaces my earlier exploratory work in #138, which I will now close).