### PR TITLE
fw/drivers/sf32lb52/qspi: flash support security registers

### DIFF
--- a/platform/platform_capabilities.py
+++ b/platform/platform_capabilities.py
@@ -299,6 +299,7 @@ board_capability_dicts = [
             'HAS_VIBE_SCORES',
             'HAS_WEATHER',
             'HAS_PUTBYTES_PREACKING',
+            'HAS_FLASH_OTP',
         },
     },
 ]

--- a/src/fw/drivers/flash/gd25q256e.c
+++ b/src/fw/drivers/flash/gd25q256e.c
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2025 Core Devices LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "board/board.h"
+#include "drivers/flash/flash_impl.h"
+#include "drivers/flash/qspi_flash.h"
+#include "drivers/flash/qspi_flash_part_definitions.h"
+#include "flash_region/flash_region.h"
+#include "system/passert.h"
+#include "system/status_codes.h"
+#include "util/math.h"
+#include "util/size.h"
+
+#define SF32LB52_COMPATIBLE
+#include <mcu.h>
+
+static bool s_protected;
+static FlashAddress s_protected_start;
+static FlashAddress s_protected_end;
+
+static const uint32_t prv_sec_regs[] = {
+  0x00001000,
+  0x00002000,
+  0x00003000,
+};
+
+static QSPIFlashPart QSPI_FLASH_PART = {
+    .instructions =
+        {
+            .fast_read = 0x0B,
+            .read2o = 0x3B,
+            .read2io = 0xBB,
+            .read4o = 0x6B,
+            .read4io = 0xEB,
+            .pp = 0x02,
+            .pp4o = 0x32,
+            .erase_sector_4k = 0x20,
+            .erase_block_64k = 0xD8,
+            .write_enable = 0x06,
+            .write_disable = 0x04,
+            .rdsr1 = 0x05,
+            .rdsr2 = 0x35,
+            .wrsr = 0x01,
+            .erase_suspend = 0x75,
+            .erase_resume = 0x7A,
+            .enter_low_power = 0xB9,
+            .exit_low_power = 0xAB,
+            .reset_enable = 0x66,
+            .reset = 0x99,
+            .qspi_id = 0x9F, /* single SPI ID */
+            .en4b = 0xB7,
+            .erase_sec = 0x44,
+            .program_sec = 0x42,
+            .read_sec = 0x48,
+        },
+    .status_bit_masks =
+        {
+            .busy = 1 << 0,
+            .write_enable = 1 << 1,
+        },
+    .flag_status_bit_masks =
+        {
+            .sec_lock = (1 << 5) | (1 << 4) | (1 << 3), /* SR2, page 12 */
+            .erase_suspend = 1 << 7, /* SR2 SUS1, page 14 */
+        },
+    .dummy_cycles =
+        {
+            .fast_read = 4,
+        },
+    .sec_registers = {
+        .sec_regs = prv_sec_regs,
+        .num_sec_regs = ARRAY_LENGTH(prv_sec_regs),
+        .sec_reg_size = 1024,
+    },
+    .supports_block_lock = false,
+    .reset_latency_ms = 12,
+    .suspend_to_read_latency_us = 20,
+    .standby_to_low_power_latency_us = 3,
+    .low_power_to_standby_latency_us = 20,
+    .supports_fast_read_ddr = false,
+    .qer_type = JESD216_DW15_QER_S2B1v1,
+    .qspi_id_value = 0x1940c8,
+    .size = 0x2000000, /* 32MB */
+    .name = "GD25Q256E",
+};
+
+static status_t prv_flash_check_protected(FlashAddress addr) {
+  if (!s_protected) {
+    return S_SUCCESS;
+  }
+
+  if (addr < s_protected_start || addr > s_protected_end) {
+    return S_SUCCESS;
+  }
+
+  return E_INVALID_OPERATION;
+}
+
+bool flash_check_whoami(void) { return qspi_flash_check_whoami(QSPI_FLASH); }
+
+FlashAddress flash_impl_get_sector_base_address(FlashAddress addr) {
+  return (addr & SECTOR_ADDR_MASK);
+}
+
+FlashAddress flash_impl_get_subsector_base_address(FlashAddress addr) {
+  return (addr & SUBSECTOR_ADDR_MASK);
+}
+
+void flash_impl_enable_write_protection(void) {}
+
+status_t flash_impl_write_protect(FlashAddress start_sector, FlashAddress end_sector) {
+  if (s_protected) {
+    return E_ERROR;
+  }
+
+  s_protected_start = start_sector;
+  s_protected_end = end_sector;
+  s_protected = true;
+
+  return S_SUCCESS;
+}
+
+status_t flash_impl_unprotect(void) {
+  if (!s_protected) {
+    return E_ERROR;
+  }
+
+  s_protected = false;
+
+  return S_SUCCESS;
+}
+
+status_t flash_impl_init(bool coredump_mode) {
+  qspi_flash_init(QSPI_FLASH, &QSPI_FLASH_PART, coredump_mode);
+  return S_SUCCESS;
+}
+
+status_t flash_impl_get_erase_status(void) { return qspi_flash_is_erase_complete(QSPI_FLASH); }
+
+status_t flash_impl_erase_subsector_begin(FlashAddress subsector_addr) {
+  status_t status;
+
+  status = prv_flash_check_protected(subsector_addr);
+  if (FAILED(status)) {
+    return status;
+  }
+
+  return qspi_flash_erase_begin(QSPI_FLASH, subsector_addr, true /* is_subsector */);
+}
+status_t flash_impl_erase_sector_begin(FlashAddress sector_addr) {
+  status_t status;
+
+  status = prv_flash_check_protected(sector_addr);
+  if (FAILED(status)) {
+    return status;
+  }
+
+  return qspi_flash_erase_begin(QSPI_FLASH, sector_addr, false /* !is_subsector */);
+}
+
+status_t flash_impl_erase_suspend(FlashAddress sector_addr) {
+  return qspi_flash_erase_suspend(QSPI_FLASH, sector_addr);
+}
+
+status_t flash_impl_erase_resume(FlashAddress sector_addr) {
+  qspi_flash_erase_resume(QSPI_FLASH, sector_addr);
+  return S_SUCCESS;
+}
+
+status_t flash_impl_read_sync(void *buffer_ptr, FlashAddress start_addr, size_t buffer_size) {
+  PBL_ASSERT(buffer_size > 0, "flash_impl_read_sync() called with 0 bytes to read");
+  qspi_flash_read_blocking(QSPI_FLASH, start_addr, buffer_ptr, buffer_size);
+  return S_SUCCESS;
+}
+
+int flash_impl_write_page_begin(const void *buffer, const FlashAddress start_addr, size_t len) {
+  status_t status;
+
+  status = prv_flash_check_protected(start_addr);
+  if (FAILED(status)) {
+    return status;
+  }
+
+  return qspi_flash_write_page_begin(QSPI_FLASH, buffer, start_addr, len);
+}
+
+status_t flash_impl_get_write_status(void) { return qspi_flash_get_write_status(QSPI_FLASH); }
+
+status_t flash_impl_enter_low_power_mode(void) {
+  qspi_flash_set_lower_power_mode(QSPI_FLASH, true);
+  return S_SUCCESS;
+}
+status_t flash_impl_exit_low_power_mode(void) {
+  qspi_flash_set_lower_power_mode(QSPI_FLASH, false);
+  return S_SUCCESS;
+}
+
+status_t flash_impl_set_burst_mode(bool burst_mode) {
+  // NYI
+  return S_SUCCESS;
+}
+
+status_t flash_impl_blank_check_sector(FlashAddress addr) {
+  return qspi_flash_blank_check(QSPI_FLASH, addr, false /* !is_subsector */);
+}
+status_t flash_impl_blank_check_subsector(FlashAddress addr) {
+  return qspi_flash_blank_check(QSPI_FLASH, addr, true /* is_subsector */);
+}
+
+uint32_t flash_impl_get_typical_sector_erase_duration_ms(void) { return 150; }
+
+uint32_t flash_impl_get_typical_subsector_erase_duration_ms(void) { return 50; }
+
+status_t flash_impl_read_security_register(uint32_t addr, uint8_t *val) {
+  return qspi_flash_read_security_register(QSPI_FLASH, addr, val);
+}
+
+status_t flash_impl_security_registers_are_locked(bool *locked) {
+  return qspi_flash_security_registers_are_locked(QSPI_FLASH, locked);
+}
+
+status_t flash_impl_erase_security_register(uint32_t addr) {
+  return qspi_flash_erase_security_register(QSPI_FLASH, addr);
+}
+
+status_t flash_impl_write_security_register(uint32_t addr, uint8_t val) {
+  return qspi_flash_write_security_register(QSPI_FLASH, addr, val);
+}
+
+const FlashSecurityRegisters *flash_impl_security_registers_info(void) {
+  return qspi_flash_security_registers_info(QSPI_FLASH);
+}
+
+#ifdef RECOVERY_FW
+status_t flash_impl_lock_security_registers(void) {
+  return qspi_flash_lock_security_registers(QSPI_FLASH);
+}
+#endif

--- a/src/fw/drivers/wscript_build
+++ b/src/fw/drivers/wscript_build
@@ -782,7 +782,7 @@ elif bld.is_obelix():
             'flash/flash_crc.c',
             'flash/flash_erase.c',
             'flash/cd_flash_driver.c',
-            'flash/py25q128ha.c',
+            'flash/gd25q256e.c',
         ],
         use=[
             'driver_qspi',

--- a/src/fw/flash_region/flash_region.h
+++ b/src/fw/flash_region/flash_region.h
@@ -44,7 +44,7 @@
 #elif PLATFORM_SNOWY || PLATFORM_SPALDING
 #include "flash_region_s29vs.h"
 #elif PLATFORM_OBELIX
-#include "flash_region_py25q128ha.h"
+#include "flash_region_gd25q256e.h"
 #endif
 
 // NOTE: The following functions are deprecated! New code should use the

--- a/src/fw/flash_region/flash_region_gd25q256e.h
+++ b/src/fw/flash_region/flash_region_gd25q256e.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 Core Devices LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#define PAGE_SIZE_BYTES (0x100)
+
+#define SECTOR_SIZE_BYTES (0x10000)
+#define SECTOR_ADDR_MASK (~(SECTOR_SIZE_BYTES - 1))
+
+#define SUBSECTOR_SIZE_BYTES (0x1000)
+#define SUBSECTOR_ADDR_MASK (~(SUBSECTOR_SIZE_BYTES - 1))
+
+#define FLASH_REGION_BASE_ADDRESS 0x12000000
+
+// A bit of preprocessor magic to help with automatically calculating flash region addresses
+//////////////////////////////////////////////////////////////////////////////
+
+#define FLASH_REGION_DEF(MACRO, arg)                                                        \
+  MACRO(PTABLE,                  0x0010000 /*    64K */, arg) /* 0x12000000 - 0x1200FFFF */ \
+  MACRO(BOOTLOADER,              0x0010000 /*    64K */, arg) /* 0x12010000 - 0x1201FFFF */ \
+  MACRO(FIRMWARE,                0x0300000 /*  3072K */, arg) /* 0x12020000 - 0x1231FFFF */ \
+  MACRO(FIRMWARE_SCRATCH,        0x0300000 /*  3072K */, arg) /* 0x12320000 - 0x1261FFFF */ \
+  MACRO(SYSTEM_RESOURCES_BANK_0, 0x0200000 /*  2048K */, arg) /* 0x12620000 - 0x1281FFFF */ \
+  MACRO(SYSTEM_RESOURCES_BANK_1, 0x0200000 /*  2048K */, arg) /* 0x12820000 - 0x12A1FFFF */ \
+  MACRO(SAFE_FIRMWARE,           0x0080000 /*   512K */, arg) /* 0x12A20000 - 0x12A9FFFF */ \
+  MACRO(FILESYSTEM,              0x1520000 /* 21632K */, arg) /* 0x12AA0000 - 0x13FBFFFF */ \
+  MACRO(RSVD1,                   0x000F000 /*    60K */, arg) /* 0x13FC0000 - 0x13FCEFFF */ \
+  MACRO(DEBUG_DB,                0x0020000 /*   128K */, arg) /* 0x13FCF000 - 0x13FEEFFF */ \
+  MACRO(RSVD2,                   0x000F000 /*    58K */, arg) /* 0x13FEF000 - 0x13FFDFFF */ \
+  MACRO(MFG_INFO,                0x0001000 /*     4K */, arg) /* 0x13FFE000 - 0x13FFEFFF */ \
+  MACRO(SHARED_PRF_STORAGE,      0x0001000 /*     4K */, arg) /* 0x13FFF000 - 0x13FFFFFF */
+
+#include "flash_region_def_helper.h"
+
+// Flash region _BEGIN and _END addresses
+//////////////////////////////////////////////////////////////////////////////
+
+#define FLASH_REGION_PTABLE_BEGIN FLASH_REGION_START_ADDR(PTABLE)
+#define FLASH_REGION_PTABLE_END FLASH_REGION_END_ADDR(PTABLE)
+
+#define FLASH_REGION_BOOTLOADER_BEGIN FLASH_REGION_START_ADDR(BOOTLOADER)
+#define FLASH_REGION_BOOTLOADER_END FLASH_REGION_END_ADDR(BOOTLOADER)
+
+#define FLASH_REGION_FIRMWARE_BEGIN FLASH_REGION_START_ADDR(FIRMWARE)
+#define FLASH_REGION_FIRMWARE_END FLASH_REGION_END_ADDR(FIRMWARE)
+
+#define FLASH_REGION_FIRMWARE_SCRATCH_BEGIN FLASH_REGION_START_ADDR(FIRMWARE_SCRATCH)
+#define FLASH_REGION_FIRMWARE_SCRATCH_END FLASH_REGION_END_ADDR(FIRMWARE_SCRATCH)
+
+#define FLASH_REGION_SYSTEM_RESOURCES_BANK_0_BEGIN FLASH_REGION_START_ADDR(SYSTEM_RESOURCES_BANK_0)
+#define FLASH_REGION_SYSTEM_RESOURCES_BANK_0_END FLASH_REGION_END_ADDR(SYSTEM_RESOURCES_BANK_0)
+
+#define FLASH_REGION_SYSTEM_RESOURCES_BANK_1_BEGIN FLASH_REGION_START_ADDR(SYSTEM_RESOURCES_BANK_1)
+#define FLASH_REGION_SYSTEM_RESOURCES_BANK_1_END FLASH_REGION_END_ADDR(SYSTEM_RESOURCES_BANK_1)
+
+#define FLASH_REGION_SAFE_FIRMWARE_BEGIN FLASH_REGION_START_ADDR(SAFE_FIRMWARE)
+#define FLASH_REGION_SAFE_FIRMWARE_END FLASH_REGION_END_ADDR(SAFE_FIRMWARE)
+
+#define FLASH_REGION_FILESYSTEM_BEGIN FLASH_REGION_START_ADDR(FILESYSTEM)
+#define FLASH_REGION_FILESYSTEM_END FLASH_REGION_END_ADDR(FILESYSTEM)
+#define FLASH_FILESYSTEM_BLOCK_SIZE SUBSECTOR_SIZE_BYTES
+
+#define FLASH_REGION_DEBUG_DB_BEGIN FLASH_REGION_START_ADDR(DEBUG_DB)
+#define FLASH_REGION_DEBUG_DB_END FLASH_REGION_END_ADDR(DEBUG_DB)
+#define FLASH_DEBUG_DB_BLOCK_SIZE SUBSECTOR_SIZE_BYTES
+
+#define FLASH_REGION_MFG_INFO_BEGIN FLASH_REGION_START_ADDR(MFG_INFO)
+#define FLASH_REGION_MFG_INFO_END FLASH_REGION_END_ADDR(MFG_INFO)
+
+#define FLASH_REGION_SHARED_PRF_STORAGE_BEGIN FLASH_REGION_START_ADDR(SHARED_PRF_STORAGE)
+#define FLASH_REGION_SHARED_PRF_STORAGE_END FLASH_REGION_END_ADDR(SHARED_PRF_STORAGE)
+
+#define BOARD_NOR_FLASH_SIZE FLASH_REGION_START_ADDR(_COUNT) - FLASH_REGION_BASE_ADDRESS
+
+// Static asserts to make sure everything worked out
+//////////////////////////////////////////////////////////////////////////////
+
+// make sure all the sizes are multiples of the subsector size (4k)
+FLASH_REGION_SIZE_CHECK(SUBSECTOR_SIZE_BYTES)
+
+// make sure the total size is what we expect (32mb)
+_Static_assert(BOARD_NOR_FLASH_SIZE == 0x2000000, "Flash size should be 32mb");


### PR DESCRIPTION
This add qspi flash security registers support for sf32lb52, flash region also updated

Fixes #14 
Fixes #85 