### PR TITLE
fw/vendor/jerryscript: disable RegExp built-in to save space

### DIFF
--- a/src/fw/vendor/jerryscript/wscript
+++ b/src/fw/vendor/jerryscript/wscript
@@ -182,6 +182,7 @@ def build(bld):
       'JERRY_BUILD_DATE': wrap_quotes(run_cmd('date +%d/%m/%Y')),
       'CONFIG_ECMA_NUMBER_TYPE': 'CONFIG_ECMA_NUMBER_FLOAT64',
       'CONFIG_DISABLE_PRINT_BUILTIN': '',
+      'CONFIG_DISABLE_REGEXP_BUILTIN': '1',  # Disable RegExp to save space
       'JERRY_DISABLE_HEAVY_DEBUG': '',
       'JERRY_ENABLE_SNAPSHOT_SAVE': '',
       'JERRY_ENABLE_ERROR_MESSAGES': '1',


### PR DESCRIPTION
Disabling RegEx in JerryScript increased my available size from 34525 to 51973 (thats about 17k more space)

I don't think any rocky.js app used RegEx ever so it wouldn't be a loss