### PR TITLE
waftools/openocd: when exiting openocd on nRF5, shut down the SWDAP to return to baseline power

### DIFF
--- a/wscript
+++ b/wscript
@@ -1692,6 +1692,10 @@ def force_flash(ctx):
     waftools.openocd.run_command(ctx, reset_cmd + 'init; stm32x unlock 0;', ignore_fail=True)
 
 
+class ResetDevice(BuildContext):
+    cmd = 'reset'
+    fun = 'reset'
+
 def reset(ctx):
     """resets a connected device"""
     waftools.openocd.run_command(ctx, 'init; reset;', expect=["found"])


### PR DESCRIPTION
On nRF5, `waf reset` and `waf flash` leave the board in a power-sucking mode with the SWDAP set to force-power mode and the CPU in debug-ready mode, pulling about 1.2mA extra, which makes it annoying and uncertain to debug power consumption.  Since we know how to make that stop, we do.  (Also, this leaves the breadcrumb around for doing this during a gdb session.)