### PR TITLE
Fix building Pebble Packages

### DIFF
--- a/sdk/tools/pebble_package.py
+++ b/sdk/tools/pebble_package.py
@@ -53,11 +53,11 @@ class PebblePackage(object):
         else:
             self.package_files[name] = file_path
 
-    def pack(self, package_path=None):
+    def pack(self, package_path="."):
         with zipfile.ZipFile(os.path.join(package_path, self.package_filename), 'w') as zip_file:
             for filename, file_path in self.package_files.items():
                 zip_file.write(file_path, filename)
-            zip_file.comment = type(self).__name__
+            zip_file.comment = type(self).__name__.encode('utf-8')
 
     def unpack(self, package_path=''):
         try:

--- a/sdk/waftools/pebble_sdk_lib.py
+++ b/sdk/waftools/pebble_sdk_lib.py
@@ -13,6 +13,15 @@
 # limitations under the License.
 
 import json
+import sys
+import os
+
+# The wscript of a Pebble Package loads this module directly
+
+# waf loads this module from waflib/extras, which contains the file sdk_paths
+extras_dir = os.path.dirname(os.path.abspath(__file__))
+if extras_dir not in sys.path:
+    sys.path.insert(0, extras_dir)
 
 import sdk_paths
 


### PR DESCRIPTION
This fixes building Pebble Packages under Python 3. Before this, using existing Pebble Packages inside a project worked fine, but creators of Pebble Packages couldn't build their packages.