### PR TITLE
fw/services/voice: preserve teardown flag during reset

### DIFF
--- a/src/fw/services/normal/voice/voice.c
+++ b/src/fw/services/normal/voice/voice.c
@@ -169,7 +169,7 @@ static void prv_cancel_recording(void) {
 static void prv_reset(void) {
   s_state = SessionState_Idle;
   s_session_id = AUDIO_ENDPOINT_SESSION_INVALID_ID;
-  s_teardown_in_progress = false;
+  
 }
 
 static void prv_cancel_session(void) {


### PR DESCRIPTION
 Removes clearing of s_teardown_in_progress in prv_reset(). 
 
 Immediate user cancel (open dictation then close right away) could:

1. Set s_teardown_in_progress = true (cancel path)
2. Call prv_reset() (previously cleared the flag)
3. A pending setup/result timeout fires just after reset
4. Timeout handler no longer sees teardown flag, proceeds and hits an assert (Idle state unexpected) or operates on torn-down state.


I assume this race is the root cause of the observed assert failure. The repro was extremely intermittent, so this is a reasoned fix, not a definitively confirmed one.

