### PR TITLE
LSM6DSO: Avoid spurious events due to vibing

### DIFF
--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -89,8 +89,8 @@ static uint32_t s_last_vibe_detected = 0;
 // Maximum FIFO watermark supported by hardware (diff_fifo is 10 bits -> 0..1023)
 #define LSM6DSO_FIFO_MAX_WATERMARK 1023
 
-// Maximum allowed sampling interval (i.e., slowest rate, in microseconds)
-#define LSM6DSO_EVENT_MAX_INTERVAL_US 2398
+// Maximum allowed sampling interval for tap detection (i.e., slowest rate, in microseconds)
+#define LSM6DSO_TAP_DETECTION_MAX_INTERVAL_US 2398
 
 // Delay after detecting a vibe before shake/tap interrupts should be processed again
 #define LSM6DSO_VIBE_COOLDOWN_MS 50
@@ -627,7 +627,7 @@ static int32_t prv_lsm6dso_set_sampling_interval(uint32_t interval_us) {
   }
 
   if (s_lsm6dso_state.double_tap_detection_enabled) {
-    interval_us = MIN(interval_us, LSM6DSO_EVENT_MAX_INTERVAL_US);
+    interval_us = MIN(interval_us, LSM6DSO_TAP_DETECTION_MAX_INTERVAL_US);
   }
 
   odr_xl_interval_t odr_interval = prv_get_odr_for_interval(interval_us);

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -521,12 +521,11 @@ static void prv_lsm6dso_process_interrupts(void) {
   lsm6dso_all_sources_t all_sources;
   lsm6dso_all_sources_get(&lsm6dso_ctx, &all_sources);
 
+  // Collect accelerometer samples if requested
   if (s_lsm6dso_state.num_samples > 0 && all_sources.drdy_xl) {
     prv_lsm6dso_read_samples();
-  }
-  // FIFO watermark (or overrun/full) events when batching
-  if (s_lsm6dso_state.num_samples > 1 &&
-      (all_sources.fifo_th || all_sources.fifo_full || all_sources.fifo_ovr)) {
+  } else if (s_lsm6dso_state.num_samples > 1 &&
+             (all_sources.fifo_th || all_sources.fifo_full || all_sources.fifo_ovr)) {
     prv_lsm6dso_read_samples();
   }
 
@@ -536,6 +535,7 @@ static void prv_lsm6dso_process_interrupts(void) {
     return;
   }
 
+  // Process double tap events
   if (all_sources.double_tap) {
     PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Double tap interrupt triggered");
     // Handle double tap detection
@@ -583,6 +583,7 @@ static void prv_lsm6dso_process_interrupts(void) {
         bool invert = cfg->axes_inverts[axis];
         direction = (val >= 0 ? 1 : -1) * (invert ? -1 : 1);
       }
+      PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Shake detected; axis=%d, direction=%lu", axis, direction);
       accel_cb_shake_detected(axis, direction);
     }
   }


### PR DESCRIPTION
The main contribution of this patchset is to avoid vibing causing spurious events to be fired.

Otherwise, there are a few cleanups to aid future developers grokking the code.