### PR TITLE
third_party/memfault: enable by default only on release mode

### DIFF
--- a/third_party/memfault/wscript
+++ b/third_party/memfault/wscript
@@ -9,7 +9,7 @@ def options(opt):
 def configure(conf):
     conf.env.memfault = conf.options.memfault
     if not conf.env.memfault:
-        conf.env.memfault = int(conf.is_asterix() or conf.is_obelix())
+        conf.env.memfault = int(conf.options.release and (conf.is_asterix() or conf.is_obelix()))
     else:
         conf.env.memfault = int(conf.env.memfault)
 


### PR DESCRIPTION
If needed in other builds, one can always set `--memfault=1` when configuring.