### PR TITLE
[FIRM-495] fw/voice: Fix voice assertion fails and races during startup and cancellation

### DIFF
--- a/src/fw/services/normal/voice/voice_speex.c
+++ b/src/fw/services/normal/voice/voice_speex.c
@@ -143,12 +143,21 @@ void voice_speex_deinit(void) {
 
   if (s_encoder.enc_state) {
     speex_encoder_destroy(s_encoder.enc_state);
+    s_encoder.enc_state = NULL;
   }
 
   speex_bits_destroy(&s_encoder.bits);
 
-  kernel_free(s_encoder.frame_buffer);
-  kernel_free(s_encoder.encoded_buffer);
+
+  if (s_encoder.frame_buffer) {
+    kernel_free(s_encoder.frame_buffer);
+    s_encoder.frame_buffer = NULL;
+  }
+
+  if (s_encoder.encoded_buffer) {
+    kernel_free(s_encoder.encoded_buffer);
+    s_encoder.encoded_buffer = NULL;
+  }
 
   memset(&s_encoder, 0, sizeof(s_encoder));
 }


### PR DESCRIPTION
I swear this microphone driver is gonna plague me till the end of time..
Fixes critical assertion failures in the voice service that occurred during startup and cancellation scenarios.

- Fixed PDM startup race that caused assertions when voice service started
- Implemented delayed Speex cleanup strategy to prevent heap corruption during resource cleanup
- Enhanced cancellation handling with state-specific logic for early vs recording vs post-recording cancellation
- Added session start protection to prevent race conditions between cleanup and new session start
- Improved error handling throughout the voice service state machine