### PR TITLE
third_party/hal_sifli: switch to upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,7 +24,7 @@
 	url = https://github.com/MersenneTwister-Lab/TinyMT
 [submodule "third_party/hal_sifli/SiFli-SDK"]
 	path = third_party/hal_sifli/SiFli-SDK
-	url = https://github.com/coredevices/SiFli-SDK.git
+	url = https://github.com/OpenSiFli/SiFli-SDK.git
 [submodule "third_party/memfault/memfault-firmware-sdk"]
 	path = third_party/memfault/memfault-firmware-sdk
 	url = https://github.com/memfault/memfault-firmware-sdk.git


### PR DESCRIPTION
Upstream contains again all we need.