### PR TITLE
boards/board_asterix: power down PWM1 on boot [FIRM-309]

### DIFF
--- a/src/fw/board/boards/board_asterix.c
+++ b/src/fw/board/boards/board_asterix.c
@@ -242,4 +242,6 @@ void board_init(void) {
   i2c_use(I2C_DA7212);
   i2c_write_block(I2C_DA7212, 2, da7212_powerdown);
   i2c_release(I2C_DA7212);
+
+  NRF_PWM1->ENABLE = 0; // Bootloader left this powered on.  We're done with it now, though; we use GPIOTE+PPI to toggle Vcom.
 }


### PR DESCRIPTION
We use GPIOTE and PPI now to toggle Vcom on asterix, which is much cheaper than PWM.  Unfortunately, the bootloader left PWM turned on, so it is sitting there demanding the PCLK, costing us power.  Turn it off on boot.