### PR TITLE
kernel/stop: turn off dbgserial UART during stop on power-hungry platforms

### DIFF
--- a/src/fw/console/dbgserial_input.c
+++ b/src/fw/console/dbgserial_input.c
@@ -127,3 +127,22 @@ void dbgserial_set_rx_dma_enabled(bool enabled) {
     uart_stop_rx_dma(DBG_UART);
   }
 }
+
+#if MICRO_FAMILY_NRF5
+
+void dbgserial_disable_rx_dma_before_stop() {
+  // We will have an EXTI wake us if something happens.  We'll lose the
+  // first byte anyway, but probably we would have on STM32 also -- and
+  // anyway, Pulse will retransmit.
+  if (s_dma_enabled) {
+    uart_stop_rx_dma(DBG_UART);
+  }
+}
+
+void dbgserial_enable_rx_dma_after_stop() {
+  if (s_dma_enabled) {
+    uart_start_rx_dma(DBG_UART, s_dma_buffer, DMA_BUFFER_LENGTH);
+  }
+}
+
+#endif

--- a/src/fw/console/dbgserial_input.h
+++ b/src/fw/console/dbgserial_input.h
@@ -33,3 +33,8 @@ void dbgserial_enable_rx_exti(void);
 
 //! Enables/disables DMA-based receiving
 void dbgserial_set_rx_dma_enabled(bool enabled);
+
+#if MICRO_FAMILY_NRF5
+void dbgserial_disable_rx_dma_before_stop();
+void dbgserial_enable_rx_dma_after_stop();
+#endif

--- a/src/fw/drivers/nrf5/uart.c
+++ b/src/fw/drivers/nrf5/uart.c
@@ -356,7 +356,9 @@ void uart_start_rx_dma(UARTDevice *dev, void *buffer, uint32_t length) {
 }
 
 void uart_stop_rx_dma(UARTDevice *dev) {
+#ifdef DEBUG_UART
   PBL_LOG(LOG_LEVEL_INFO, "stop_rx_dma");
+#endif
   nrfx_uarte_rx_abort(&dev->periph, true, true);
   nrfx_timer_disable(&dev->counter);
 }

--- a/src/fw/kernel/util/stop.c
+++ b/src/fw/kernel/util/stop.c
@@ -26,6 +26,7 @@
 #include "mcu/interrupts.h"
 #include "services/common/analytics/analytics.h"
 #include "system/passert.h"
+#include "console/dbgserial_input.h"
 
 #define STM32F2_COMPATIBLE
 #define STM32F4_COMPATIBLE
@@ -58,6 +59,7 @@ static InhibitorTickProfile s_inhibitor_profile[InhibitorNumItems];
 #if MICRO_FAMILY_NRF5
 void enter_stop_mode(void) {
   dbgserial_enable_rx_exti();
+  dbgserial_disable_rx_dma_before_stop();
 
   rtc_systick_pause();
 
@@ -66,6 +68,8 @@ void enter_stop_mode(void) {
   __ISB(); // Let the pipeline catch up (force the WFI to activate before moving on).
 
   rtc_systick_resume();
+
+  dbgserial_enable_rx_dma_after_stop();
 }
 #elif MICRO_FAMILY_SF32LB52
 void enter_stop_mode(void) {

--- a/wscript
+++ b/wscript
@@ -341,10 +341,7 @@ def handle_configure_options(conf):
         conf.env.append_value('DEFINES', 'BOOTLOADER_TEST_STAGE1=0')
         conf.env.append_value('DEFINES', 'BOOTLOADER_TEST_STAGE2=0')
 
-    if (
-        not conf.options.no_pulse_everywhere and
-        (conf.options.mfg or not conf.options.release)
-    ):
+    if not conf.options.no_pulse_everywhere:
         conf.env.append_value('DEFINES', 'PULSE_EVERYWHERE=1')
 
 def _create_cm0_env(conf):


### PR DESCRIPTION
We can, in fact, have our cake and eat it too.  No need to choose between power consumption and debugging!