### PR TITLE
Fix for RTC reset causing step count to reset [FIRM-497]

### DIFF
--- a/src/fw/applib/health_service.c
+++ b/src/fw/applib/health_service.c
@@ -920,6 +920,9 @@ bool health_service_private_get_metric_history(HealthMetric metric, uint32_t his
 // ----------------------------------------------------------------------------------------------
 HealthServiceAccessibilityMask health_service_metric_accessible(
   HealthMetric metric, time_t time_start, time_t time_end) {
+  if (!activity_is_initialized()) {
+    return HealthServiceAccessibilityMaskNotAvailable;
+  }
   return health_service_metric_aggregate_averaged_accessible(metric, time_start, time_end,
                                                              prv_default_aggregation(metric),
                                                              HealthServiceTimeScopeOnce);
@@ -928,6 +931,9 @@ HealthServiceAccessibilityMask health_service_metric_accessible(
 // ----------------------------------------------------------------------------------------------
 HealthServiceAccessibilityMask health_service_metric_averaged_accessible(
   HealthMetric metric, time_t time_start, time_t time_end, HealthServiceTimeScope scope) {
+  if (!activity_is_initialized()) {
+    return HealthServiceAccessibilityMaskNotAvailable;
+  }
   return health_service_metric_aggregate_averaged_accessible(metric, time_start, time_end,
                                                              prv_default_aggregation(metric),
                                                              scope);
@@ -940,6 +946,9 @@ HealthServiceAccessibilityMask health_service_metric_aggregate_averaged_accessib
 #if !CAPABILITY_HAS_HEALTH_TRACKING
   return HealthServiceAccessibilityMaskNotSupported;
 #else
+  if (!activity_is_initialized()) {
+    return HealthServiceAccessibilityMaskNotAvailable;
+  }
   if (prv_is_heart_rate_metric(metric) && !sys_activity_prefs_heart_rate_is_enabled()) {
     return HealthServiceAccessibilityMaskNoPermission;
   }
@@ -977,6 +986,9 @@ HealthValue health_service_sum_today(HealthMetric metric) {
 #if !CAPABILITY_HAS_HEALTH_TRACKING
   return 0;
 #else
+  if (!activity_is_initialized()) {
+    return 0;
+  }
   const time_t today_midnight = sys_time_start_of_today();
   const time_t tomorrow_midnight = today_midnight + SECONDS_PER_DAY;
   return health_service_sum(metric, today_midnight, tomorrow_midnight);
@@ -986,6 +998,9 @@ HealthValue health_service_sum_today(HealthMetric metric) {
 
 // ----------------------------------------------------------------------------------------------
 HealthValue health_service_sum(HealthMetric metric, time_t time_start, time_t time_end) {
+  if (!activity_is_initialized()) {
+    return 0;
+  }
   return health_service_aggregate_averaged(metric, time_start, time_end, HealthAggregationSum,
                                            HealthServiceTimeScopeOnce);
 }
@@ -994,12 +1009,18 @@ HealthValue health_service_sum(HealthMetric metric, time_t time_start, time_t ti
 // Compute the sum of a metric, but averaged over multiple days.
 HealthValue health_service_sum_averaged(HealthMetric metric, time_t time_start, time_t time_end,
                                         HealthServiceTimeScope scope) {
+  if (!activity_is_initialized()) {
+    return 0;
+  }
   return health_service_aggregate_averaged(metric, time_start, time_end, HealthAggregationSum,
                                            scope);
 }
 
 // ----------------------------------------------------------------------------------------------
 HealthValue health_service_peek_current_value(HealthMetric metric) {
+  if (!activity_is_initialized()) {
+    return 0;
+  }
   time_t now_utc = sys_get_time();
   return health_service_aggregate_averaged(metric, now_utc, now_utc, HealthAggregationAvg,
                                            HealthServiceTimeScopeOnce);
@@ -1055,6 +1076,9 @@ HealthValue health_service_aggregate_averaged(HealthMetric metric, time_t time_s
 #if !CAPABILITY_HAS_HEALTH_TRACKING
   return 0;
 #else
+  if (!activity_is_initialized()) {
+    return 0;
+  }
   // Make sure this metric is supported by this type of aggregation
   if (!prv_metric_aggregation_implemented(metric, time_start, time_end, aggregation, scope)) {
     return 0;
@@ -1127,6 +1151,9 @@ bool health_service_events_subscribe(HealthEventHandler handler, void *context) 
 #if !CAPABILITY_HAS_HEALTH_TRACKING
   return false;
 #else
+  if (!activity_is_initialized()) {
+    return false;
+  }
   HealthServiceState *state = prv_get_state(true);
   if (!state) {
     return false;
@@ -1226,6 +1253,9 @@ bool health_service_set_heart_rate_sample_period(uint16_t interval_sec) {
 #if !CAPABILITY_HAS_BUILTIN_HRM
   return false;
 #else
+  if (!activity_is_initialized()) {
+    return false;
+  }
   if (!sys_activity_prefs_heart_rate_is_enabled()) {
     return false;
   }
@@ -1288,6 +1318,9 @@ uint32_t health_service_get_minute_history(HealthMinuteData *minute_data, uint32
 #if !CAPABILITY_HAS_HEALTH_TRACKING
   return false;
 #else
+  if (!activity_is_initialized()) {
+    return 0;
+  }
   if (!minute_data || max_records == 0 || !time_start) {
     return 0;
   }
@@ -1324,6 +1357,9 @@ HealthActivityMask health_service_peek_current_activities(void) {
 #if !CAPABILITY_HAS_HEALTH_TRACKING
   return HealthActivityNone;
 #else
+  if (!activity_is_initialized()) {
+    return HealthActivityNone;
+  }
   HealthValue sleep_state;
   if (!sys_activity_get_metric(ActivityMetricSleepState, 1, &sleep_state)) {
     return HealthActivityNone;
@@ -1368,6 +1404,9 @@ void health_service_activities_iterate(HealthActivityMask activity_mask,
 #if !CAPABILITY_HAS_HEALTH_TRACKING
   return;
 #else
+  if (!activity_is_initialized()) {
+    return;
+  }
   HealthServiceState *state = prv_get_state(true);
   if (!state->cache) {
     return;

--- a/src/fw/apps/system_apps/health/health.c
+++ b/src/fw/apps/system_apps/health/health.c
@@ -28,6 +28,7 @@
 #include "services/normal/activity/activity.h"
 #include "services/normal/activity/activity_private.h"
 #include "services/normal/timeline/timeline.h"
+#include "resource/resource_ids.auto.h"
 #include "system/logging.h"
 
 // Health app versions
@@ -110,6 +111,14 @@ static void prv_initialize(void) {
     static const char *msg = i18n_noop("Track your steps, sleep, and more!"
                                        " Enable Pebble Health in the mobile app.");
     health_tracking_ui_show_message(RESOURCE_ID_HEART_TINY, msg, true);
+    return;
+  }
+
+  if (!activity_is_initialized()) {
+    /// Health waiting for time sync
+    static const char *msg = i18n_noop("Health requires the time to be synced."
+                                       " Please connect your phone.");
+    health_tracking_ui_show_message(RESOURCE_ID_ALARM_CLOCK_TINY, msg, true);
     return;
   }
 

--- a/src/fw/apps/system_apps/workout/workout.c
+++ b/src/fw/apps/system_apps/workout/workout.c
@@ -36,6 +36,8 @@
 #include "services/normal/activity/health_util.h"
 #include "services/normal/activity/workout_service.h"
 #include "system/logging.h"
+#include "resource/resource_ids.auto.h"
+#include "popups/health_tracking_ui.h"
 
 #include <stdio.h>
 
@@ -196,6 +198,14 @@ void workout_push_summary_window(void) {
 // Initialization
 
 static void prv_init(void) {
+    if (!activity_is_initialized()) {
+    /// Workouts waiting for time sync
+    static const char *msg = i18n_noop("Workout requires the time to be synced."
+                                       " Please connect your phone.");
+    health_tracking_ui_show_message(RESOURCE_ID_ALARM_CLOCK_TINY, msg, true);
+    return;
+  }
+
   if (!activity_prefs_tracking_is_enabled()) {
     /// Health disabled text
     static const char *msg = i18n_noop("Enable Pebble Health in the mobile app to track workouts");

--- a/src/fw/services/normal/activity/activity.h
+++ b/src/fw/services/normal/activity/activity.h
@@ -283,6 +283,9 @@ typedef struct __attribute__((__packed__)) {
 //! @return true if successfully initialized
 bool activity_init(void);
 
+//! Returns true if the activity service is initialized
+bool activity_is_initialized(void);
+
 //! Start the activity tracking service. This starts sampling of the accelerometer
 //! @param test_mode if true, samples must be fed in using activity_feed_samples()
 //! @return true if successfully started

--- a/src/fw/services/normal/activity/insights_settings.c
+++ b/src/fw/services/normal/activity/insights_settings.c
@@ -157,6 +157,9 @@ static void prv_close_settings_and_unlock(SettingsFile *file) {
 }
 
 void activity_insights_settings_init(void) {
+  if (!activity_is_initialized()) {
+    return;
+  }
   // Create our mutex
   s_insight_settings_mutex = mutex_create();
 
@@ -184,6 +187,9 @@ void activity_insights_settings_init(void) {
 }
 
 uint16_t activity_insights_settings_get_version(void) {
+  if (!activity_is_initialized()) {
+    return ACTIVITY_INSIGHTS_SETTINGS_DEFAULT_VERSION;
+  }
   uint16_t version = ACTIVITY_INSIGHTS_SETTINGS_DEFAULT_VERSION;
   SettingsFile file;
   if (prv_open_settings_and_lock(&file)) {
@@ -199,6 +205,9 @@ uint16_t activity_insights_settings_get_version(void) {
 
 bool activity_insights_settings_read(const char *insight_name,
                                      ActivityInsightSettings *settings_out) {
+  if (!activity_is_initialized()) {
+    return false;
+  }
   bool rv = false;
   *settings_out = (ActivityInsightSettings) {};
 
@@ -237,6 +246,9 @@ close:
 
 bool activity_insights_settings_write(const char *insight_name,
                                       ActivityInsightSettings *settings) {
+  if (!activity_is_initialized()) {
+    return false;
+  }
   bool rv = false;
 
   SettingsFile file;
@@ -254,10 +266,16 @@ bool activity_insights_settings_write(const char *insight_name,
 }
 
 PFSCallbackHandle activity_insights_settings_watch(PFSFileChangedCallback callback) {
+  if (!activity_is_initialized()) {
+    return 0; // Return invalid handle
+  }
   return pfs_watch_file(ACTIVITY_INSIGHTS_SETTINGS_FILENAME, callback, FILE_CHANGED_EVENT_CLOSED,
                         NULL);
 }
 
 void activity_insights_settings_unwatch(PFSCallbackHandle cb_handle) {
+  if (!activity_is_initialized()) {
+    return;
+  }
   pfs_unwatch_file(cb_handle);
 }

--- a/src/fw/shell/normal/system_app_registry_list.json
+++ b/src/fw/shell/normal/system_app_registry_list.json
@@ -36,6 +36,8 @@
         "snowy",
         "spalding",
         "silk",
+        "asterix",
+        "obelix",
         "robert"
       ]
     },


### PR DESCRIPTION
Fixes https://github.com/coredevices/PebbleOS/issues/188 / FIRM-497

In order to fix the issue, we only initialize the activity service once the rtc is past 2010-01-01 (since Pebble was released in 2013 and I don't believe in time travel!)

I've added early returns to quite a bit of activity.c in order to allow pebble os to boot. (i have probably added a bit too many but better safe than sorry :P).
I've also added checks to health and workout so that they arent launchable until we have init'd.

The health service from applib provides dummy data until activity is initialized, so that stuff like kickstart (which I have added to asterix in this pr also) works :)