### PR TITLE
ci: store loghash_dict as artifacts

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -59,6 +59,7 @@ jobs:
           path: |
             build/**/*.elf
             build/**/*.pbz
+            build/src/fw/tintin_fw_loghash_dict.json
 
       - name: Get Build ID
         id: build_id

--- a/.github/workflows/build-prf.yml
+++ b/.github/workflows/build-prf.yml
@@ -63,6 +63,7 @@ jobs:
           path: |
             build/**/*.elf
             build/**/*.pbz
+            build/prf/src/fw/tintin_fw_loghash_dict.json
 
       - name: Get Build ID
         id: build_id

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,7 @@ jobs:
           cp build/src/fw/tintin_fw.hex artifacts/firmware_${{ matrix.board }}_${{github.ref_name}}.hex
           cp build/src/fw/tintin_fw.elf artifacts/firmware_${{ matrix.board }}_${{github.ref_name}}.elf
           cp build/*.pbz artifacts
+          cp build/src/fw/tintin_fw_loghash_dict.json artifacts/firmware_${{ matrix.board }}_${{github.ref_name}}_loghash_dict.json
 
       - name: Get Build ID
         id: build_id
@@ -117,6 +118,7 @@ jobs:
           cp build/prf/src/fw/tintin_fw.hex artifacts/prf_${{ matrix.board }}_${{github.ref_name}}.hex
           cp build/prf/src/fw/tintin_fw.bin artifacts/prf_${{ matrix.board }}_${{github.ref_name}}.bin
           cp build/prf/*.pbz artifacts
+          cp build/src/fw/tintin_fw_loghash_dict.json artifacts/prf_${{ matrix.board }}_${{github.ref_name}}_loghash_dict.json
 
       - name: Get PRF Build ID
         id: prf_build_id


### PR DESCRIPTION
It sure would be nice to be able to console into a Pebble running a production firmware and see what's going on in there.