### PR TITLE
fw/services/common/accel_manager: fix use-after-free

### DIFF
--- a/src/fw/applib/accel_service_private.h
+++ b/src/fw/applib/accel_service_private.h
@@ -26,6 +26,7 @@ typedef struct AccelServiceState {
   AccelManagerState *manager_state;
   AccelSamplingRate sampling_rate;
   bool              deferred_free;
+  uint8_t           pending_events;
   uint16_t          samples_per_update;
   AccelRawData      *raw_data;   // of size samples_per_update
 

--- a/src/fw/services/common/accel_manager.h
+++ b/src/fw/services/common/accel_manager.h
@@ -58,8 +58,8 @@ AccelManagerState* sys_accel_manager_data_subscribe(
     AccelSamplingRate rate, AccelDataReadyCallback data_cb, void* context,
     PebbleTask handler_task);
 
-//! @return true if an unprocessed data event is outstanding
-bool sys_accel_manager_data_unsubscribe(AccelManagerState *state);
+//! @return number of outstanding unprocessed data events
+uint8_t sys_accel_manager_data_unsubscribe(AccelManagerState *state);
 
 //! Configured an existing subscription to use a given sample rate. Jitter-inducing subsampling
 //! may be used to accomplish the desired rate.

--- a/tests/stubs/stubs_accel_manager.h
+++ b/tests/stubs/stubs_accel_manager.h
@@ -22,8 +22,8 @@ AccelManagerState* sys_accel_manager_data_subscribe(
   return NULL;
 }
 
-bool sys_accel_manager_data_unsubscribe(AccelManagerState *state) {
-  return false;
+uint8_t sys_accel_manager_data_unsubscribe(AccelManagerState *state) {
+  return 0;
 }
 
 uint32_t accel_manager_set_jitterfree_sampling_rate(AccelManagerState *state, uint32_t min_rate_mhz) {

--- a/tests/stubs/stubs_syscalls.h
+++ b/tests/stubs/stubs_syscalls.h
@@ -61,8 +61,8 @@ GFont WEAK sys_font_get_system_font(const char *key) {
   return NULL;
 }
 
-bool WEAK sys_accel_manager_data_unsubscribe(AccelManagerState *state) {
-  return false;
+uint8_t WEAK sys_accel_manager_data_unsubscribe(AccelManagerState *state) {
+  return 0;
 }
 
 AppInstallId WEAK sys_process_manager_get_current_process_id(void) {


### PR DESCRIPTION
It looks like the Pebble accel manager came with a race that could occur when start/stopping activity tracking (this happens e.g. when plugging the charger).

The problem could occur if:

- prv_call_data_callback() is called for a state assigned to KernelBackground task (which defers to system task queue). At this point, event posted flag is set.
- Data from a previous event is consumed, so the event posted flag is cleared, ignoring if a new event was posted.
- Activity is stopped.
- Unsubscribe gets no pending events, so deferred free does not occur.
- Pending event comes and BOOM!

This patch uses a counter instead of a boolean for pending events, this way, producers increase and consumers decrease and so avoid clobbering a flag in case a new event is posted before the previous one is processed. Accelerometer service assumes that the same task that subscribes/unsubscribes is the one that does the processing, so no races can occur in state access.