### PR TITLE
resources/normal/base/tzdata: Update timezone database

### DIFF
--- a/resources/normal/base/tzdata/timezones_olson.txt
+++ b/resources/normal/base/tzdata/timezones_olson.txt
@@ -1,3 +1,5 @@
+# tzdb data for Africa and environs
+
 # This file is in the public domain, so clarified as of
 # 2009-05-17 by Arthur David Olson.
 
@@ -6,15 +8,15 @@
 # tz@iana.org for general use in the future).  For more, please see
 # the file CONTRIBUTING in the tz distribution.
 
-# From Paul Eggert (2014-10-31):
+# From Paul Eggert (2018-05-27):
 #
 # Unless otherwise specified, the source for data through 1990 is:
 # Thomas G. Shanks and Rique Pottenger, The International Atlas (6th edition),
 # San Diego: ACS Publications, Inc. (2003).
 # Unfortunately this book contains many errors and cites no sources.
 #
-# Gwillim Law writes that a good source
-# for recent time zone data is the International Air Transport
+# Many years ago Gwillim Law wrote that a good source
+# for time zone data was the International Air Transport
 # Association's Standard Schedules Information Manual (IATA SSIM),
 # published semiannually.  Law sent in several helpful summaries
 # of the IATA's data after 1990.  Except where otherwise noted,
@@ -26,47 +28,44 @@
 #
 # For data circa 1899, a common source is:
 # Milne J. Civil time. Geogr J. 1899 Feb;13(2):173-94.
-# http://www.jstor.org/stable/1774359
+# https://www.jstor.org/stable/1774359
 #
-# A reliable and entertaining source about time zones is
-# Derek Howse, Greenwich time and longitude, Philip Wilson Publishers (1997).
+# For the 1911/1912 establishment of standard time in French possessions, see:
+# Société Française de Physique, Recueil de constantes physiques (1913),
+# page 752, 18b.
 #
+# European-style abbreviations are commonly used along the Mediterranean.
+# For sub-Saharan Africa abbreviations were less standardized.
 # Previous editions of this database used WAT, CAT, SAT, and EAT
-# for +0:00 through +3:00, respectively,
-# but Mark R V Murray reports that
-# 'SAST' is the official abbreviation for +2:00 in the country of South Africa,
-# 'CAT' is commonly used for +2:00 in countries north of South Africa, and
-# 'WAT' is probably the best name for +1:00, as the common phrase for
+# for UT +00 through +03, respectively,
+# but in 1997 Mark R V Murray reported that
+# 'SAST' is the official abbreviation for +02 in the country of South Africa,
+# 'CAT' is commonly used for +02 in countries north of South Africa, and
+# 'WAT' is probably the best name for +01, as the common phrase for
 # the area that includes Nigeria is "West Africa".
-# He has heard of "Western Sahara Time" for +0:00 but can find no reference.
 #
-# To make things confusing, 'WAT' seems to have been used for -1:00 long ago;
-# I'd guess that this was because people needed _some_ name for -1:00,
-# and at the time, far west Africa was the only major land area in -1:00.
-# This usage is now obsolete, as the last use of -1:00 on the African
-# mainland seems to have been 1976 in Western Sahara.
+# To summarize, the following abbreviations seemed to have some currency:
+#	 +00	GMT	Greenwich Mean Time
+#	 +02	CAT	Central Africa Time
+#	 +02	SAST	South Africa Standard Time
+# and Murray suggested the following abbreviation:
+#	 +01	WAT	West Africa Time
+# Murray's suggestion seems to have caught on in news reports and the like.
+# I vaguely recall 'WAT' also being used for -01 in the past but
+# cannot now come up with solid citations.
 #
-# To summarize, the following abbreviations seem to have some currency:
-#	-1:00	WAT	West Africa Time (no longer used)
-#	 0:00	GMT	Greenwich Mean Time
-#	 2:00	CAT	Central Africa Time
-#	 2:00	SAST	South Africa Standard Time
-# and Murray suggests the following abbreviation:
-#	 1:00	WAT	West Africa Time
-# I realize that this leads to 'WAT' being used for both -1:00 and 1:00
-# for times before 1976, but this is the best I can think of
-# until we get more information.
-#
-# I invented the following abbreviations; corrections are welcome!
-#	 2:00	WAST	West Africa Summer Time
-#	 2:30	BEAT	British East Africa Time (no longer used)
-#	 2:45	BEAUT	British East Africa Unified Time (no longer used)
-#	 3:00	CAST	Central Africa Summer Time (no longer used)
-#	 3:00	SAST	South Africa Summer Time (no longer used)
-#	 3:00	EAT	East Africa Time
+# I invented the following abbreviations in the 1990s:
+#	 +02	WAST	West Africa Summer Time
+#	 +03	CAST	Central Africa Summer Time
+#	 +03	SAST	South Africa Summer Time
+#	 +03	EAT	East Africa Time
+# 'EAT' seems to have caught on and is in current timestamps, and though
+# the other abbreviations are rarer and are only in past timestamps,
+# they are paired with better-attested non-DST abbreviations.
+# Corrections are welcome.
 
 # Algeria
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Algeria	1916	only	-	Jun	14	23:00s	1:00	S
 Rule	Algeria	1916	1919	-	Oct	Sun>=1	23:00s	0	-
 Rule	Algeria	1917	only	-	Mar	24	23:00s	1:00	S
@@ -89,10 +88,9 @@ Rule	Algeria	1978	only	-	Mar	24	 1:00	1:00	S
 Rule	Algeria	1978	only	-	Sep	22	 3:00	0	-
 Rule	Algeria	1980	only	-	Apr	25	 0:00	1:00	S
 Rule	Algeria	1980	only	-	Oct	31	 2:00	0	-
-# Shanks & Pottenger give 0:09:20 for Paris Mean Time; go with Howse's
-# more precise 0:09:21.
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Africa/Algiers	0:12:12 -	LMT	1891 Mar 15  0:01
+# See Europe/Paris for PMT-related transitions.
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Africa/Algiers	0:12:12 -	LMT	1891 Mar 16
 			0:09:21	-	PMT	1911 Mar 11 # Paris Mean Time
 			0:00	Algeria	WE%sT	1940 Feb 25  2:00
 			1:00	Algeria	CE%sT	1946 Oct  7
@@ -103,83 +101,60 @@ Zone	Africa/Algiers	0:12:12 -	LMT	1891 Mar 15  0:01
 			0:00	Algeria	WE%sT	1981 May
 			1:00	-	CET
 
-# Angola
-# Benin
-# See Africa/Lagos.
-
-# Botswana
-# See Africa/Maputo.
-
-# Burkina Faso
-# See Africa/Abidjan.
-
-# Burundi
-# See Africa/Maputo.
-
-# Cameroon
-# See Africa/Lagos.
-
-# Cape Verde
+# Cape Verde / Cabo Verde
 #
-# Shanks gives 1907 for the transition to CVT.
-# Perhaps the 1911-05-26 Portuguese decree
-# http://dre.pt/pdf1sdip/1911/05/12500/23132313.pdf
-# merely made it official?
+# From Tim Parenti (2024-07-01), per Paul Eggert (2018-02-16):
+# For timestamps before independence, see commentary for Europe/Lisbon.
+# Shanks gives 1907 instead for the transition to -02.
 #
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Atlantic/Cape_Verde -1:34:04 -	LMT	1907        # Praia
-			-2:00	-	CVT	1942 Sep
-			-2:00	1:00	CVST	1945 Oct 15
-			-2:00	-	CVT	1975 Nov 25  2:00
-			-1:00	-	CVT
-
-# Central African Republic
-# See Africa/Lagos.
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone Atlantic/Cape_Verde -1:34:04 -	LMT	1912 Jan 01  2:00u # Praia
+			-2:00	-	%z	1942 Sep
+			-2:00	1:00	%z	1945 Oct 15
+			-2:00	-	%z	1975 Nov 25  2:00
+			-1:00	-	%z
 
 # Chad
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Africa/Ndjamena	1:00:12 -	LMT	1912        # N'Djamena
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Africa/Ndjamena	1:00:12 -	LMT	1912 Jan  1 # N'Djamena
 			1:00	-	WAT	1979 Oct 14
 			1:00	1:00	WAST	1980 Mar  8
 			1:00	-	WAT
 
-# Comoros
-# See Africa/Nairobi.
+# Burkina Faso
+# Côte d'Ivoire (Ivory Coast)
+# The Gambia
+# Ghana
+# Guinea
+# Iceland
+# Mali
+# Mauritania
+# St Helena
+# Senegal
+# Sierra Leone
+# Togo
 
-# Democratic Republic of the Congo
-# See Africa/Lagos for the western part and Africa/Maputo for the eastern.
+# The other parts of the St Helena territory are similar:
+#	Tristan da Cunha: on GMT, say Whitman and the CIA
+#	Ascension: on GMT, say the USNO (1995-12-21) and the CIA
+#	Gough (scientific station since 1955; sealers wintered previously):
+#		on GMT, says the CIA
+#	Inaccessible, Nightingale: uninhabited
 
-# Republic of the Congo
-# See Africa/Lagos.
-
-# Côte d'Ivoire / Ivory Coast
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Africa/Abidjan	-0:16:08 -	LMT	1912
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Africa/Abidjan	-0:16:08 -	LMT	1912 Jan  1
 			 0:00	-	GMT
-Link Africa/Abidjan Africa/Bamako	# Mali
-Link Africa/Abidjan Africa/Banjul	# Gambia
-Link Africa/Abidjan Africa/Conakry	# Guinea
-Link Africa/Abidjan Africa/Dakar	# Senegal
-Link Africa/Abidjan Africa/Freetown	# Sierra Leone
-Link Africa/Abidjan Africa/Lome		# Togo
-Link Africa/Abidjan Africa/Nouakchott	# Mauritania
-Link Africa/Abidjan Africa/Ouagadougou	# Burkina Faso
-Link Africa/Abidjan Africa/Sao_Tome	# São Tomé and Príncipe
-Link Africa/Abidjan Atlantic/St_Helena	# St Helena
-
-# Djibouti
-# See Africa/Nairobi.
 
 ###############################################################################
 
 # Egypt
 
 # Milne says Cairo used 2:05:08.9, the local mean time of the Abbasizeh
-# observatory; round to nearest.  Milne also says that the official time for
+# observatory.  Milne also says that the official time for
 # Egypt was mean noon at the Great Pyramid, 2:04:30.5, but apparently this
 # did not apply to Cairo, Alexandria, or Port Said.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Egypt	1940	only	-	Jul	15	0:00	1:00	S
 Rule	Egypt	1940	only	-	Oct	 1	0:00	0	-
 Rule	Egypt	1941	only	-	Apr	15	0:00	1:00	S
@@ -224,7 +199,7 @@ Rule	Egypt	2006	only	-	Sep	21	24:00	0	-
 # saving time in Egypt will end in the night of 2007-09-06 to 2007-09-07.
 # From Jesper Nørgaard Welen (2007-08-15): [The following agree:]
 # http://www.nentjes.info/Bill/bill5.htm
-# http://www.timeanddate.com/worldclock/city.html?n=53
+# https://www.timeanddate.com/worldclock/city.html?n=53
 # From Steffen Thorsen (2007-09-04): The official information...:
 # http://www.sis.gov.eg/En/EgyptOnline/Miscellaneous/000002/0207000000000000001580.htm
 Rule	Egypt	2007	only	-	Sep	Thu>=1	24:00	0	-
@@ -262,8 +237,8 @@ Rule	Egypt	2007	only	-	Sep	Thu>=1	24:00	0	-
 # timeanddate[2] and another site I've found[3] also support that.
 #
 # [1] https://bugzilla.redhat.com/show_bug.cgi?id=492263
-# [2] http://www.timeanddate.com/worldclock/clockchange.html?n=53
-# [3] http://wwp.greenwichmeantime.com/time-zone/africa/egypt/
+# [2] https://www.timeanddate.com/worldclock/clockchange.html?n=53
+# [3] https://wwp.greenwichmeantime.com/time-zone/africa/egypt/
 
 # From Arthur David Olson (2009-04-20):
 # In 2009 (and for the next several years), Ramadan ends before the fourth
@@ -273,10 +248,10 @@ Rule	Egypt	2007	only	-	Sep	Thu>=1	24:00	0	-
 # From Steffen Thorsen (2009-08-11):
 # We have been able to confirm the August change with the Egyptian Cabinet
 # Information and Decision Support Center:
-# http://www.timeanddate.com/news/time/egypt-dst-ends-2009.html
+# https://www.timeanddate.com/news/time/egypt-dst-ends-2009.html
 #
 # The Middle East News Agency
-# http://www.mena.org.eg/index.aspx
+# https://www.mena.org.eg/index.aspx
 # also reports "Egypt starts winter time on August 21"
 # today in article numbered "71, 11/08/2009 12:25 GMT."
 # Only the title above is available without a subscription to their service,
@@ -313,20 +288,13 @@ Rule	Egypt	2007	only	-	Sep	Thu>=1	24:00	0	-
 # reproduced by other (more accessible) sites[, e.g.,]...
 # http://elgornal.net/news/news.aspx?id=4699258
 
-# From Paul Eggert (2014-06-04):
-# Sarah El Deeb and Lee Keath of AP report that the Egyptian government says
-# the change is because of blackouts in Cairo, even though Ahram Online (cited
-# above) says DST had no affect on electricity consumption.  There is
-# no information about when DST will end this fall.  See:
-# http://abcnews.go.com/International/wireStory/el-sissi-pushes-egyptians-line-23614833
-
 # From Steffen Thorsen (2015-04-08):
 # Egypt will start DST on midnight after Thursday, April 30, 2015.
 # This is based on a law (no 35) from May 15, 2014 saying it starts the last
 # Thursday of April....  Clocks will still be turned back for Ramadan, but
 # dates not yet announced....
 # http://almogaz.com/news/weird-news/2015/04/05/1947105 ...
-# http://www.timeanddate.com/news/time/egypt-starts-dst-2015.html
+# https://www.timeanddate.com/news/time/egypt-starts-dst-2015.html
 
 # From Ahmed Nazmy (2015-04-20):
 # Egypt's ministers cabinet just announced ... that it will cancel DST at
@@ -349,6 +317,14 @@ Rule	Egypt	2007	only	-	Sep	Thu>=1	24:00	0	-
 # From Mina Samuel (2016-07-04):
 # Egyptian government took the decision to cancel the DST,
 
+# From Ahmad ElDardiry (2023-03-01):
+# Egypt officially announced today that daylight savings will be
+# applied from last Friday of April to last Thursday of October.
+# From Paul Eggert (2023-03-01):
+# Assume transitions are at 00:00 and 24:00 respectively.
+# From Amir Adib (2023-03-07):
+# https://www.facebook.com/EgyptianCabinet/posts/638829614954129/
+
 Rule	Egypt	2008	only	-	Aug	lastThu	24:00	0	-
 Rule	Egypt	2009	only	-	Aug	20	24:00	0	-
 Rule	Egypt	2010	only	-	Aug	10	24:00	0	-
@@ -358,86 +334,112 @@ Rule	Egypt	2014	only	-	May	15	24:00	1:00	S
 Rule	Egypt	2014	only	-	Jun	26	24:00	0	-
 Rule	Egypt	2014	only	-	Jul	31	24:00	1:00	S
 Rule	Egypt	2014	only	-	Sep	lastThu	24:00	0	-
+Rule	Egypt	2023	max	-	Apr	lastFri	 0:00	1:00	S
+Rule	Egypt	2023	max	-	Oct	lastThu	24:00	0	-
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	2:05:08.9
 Zone	Africa/Cairo	2:05:09 -	LMT	1900 Oct
 			2:00	Egypt	EE%sT
 
-# Equatorial Guinea
-# See Africa/Lagos.
-
-# Eritrea
-# Ethiopia
-# See Africa/Nairobi.
-
-# Gabon
-# See Africa/Lagos.
-
-# Gambia
-# See Africa/Abidjan.
-
-# Ghana
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-# Whitman says DST was observed from 1931 to "the present";
-# Shanks & Pottenger say 1936 to 1942;
-# and September 1 to January 1 is given by:
-# Scott Keltie J, Epstein M (eds), The Statesman's Year-Book,
-# 57th ed. Macmillan, London (1920), OCLC 609408015, pp xxviii.
-# For lack of better info, assume DST was observed from 1920 to 1942.
-Rule	Ghana	1920	1942	-	Sep	 1	0:00	0:20	GHST
-Rule	Ghana	1920	1942	-	Dec	31	0:00	0	GMT
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Africa/Accra	-0:00:52 -	LMT	1918
-			 0:00	Ghana	%s
-
-# Guinea
-# See Africa/Abidjan.
-
 # Guinea-Bissau
 #
-# Shanks gives 1911-05-26 for the transition to WAT,
-# evidently confusing the date of the Portuguese decree
-# http://dre.pt/pdf1sdip/1911/05/12500/23132313.pdf
-# with the date that it took effect, namely 1912-01-01.
+# From Tim Parenti (2024-07-01), per Paul Eggert (2018-02-16):
+# For timestamps before independence, see commentary for Europe/Lisbon.
 #
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Africa/Bissau	-1:02:20 -	LMT	1912 Jan  1
-			-1:00	-	WAT	1975
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Africa/Bissau	-1:02:20 -	LMT	1912 Jan  1  1:00u
+			-1:00	-	%z	1975
 			 0:00	-	GMT
 
+# Comoros
+# Djibouti
+# Eritrea
+# Ethiopia
 # Kenya
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Africa/Nairobi	2:27:16	-	LMT	1928 Jul
-			3:00	-	EAT	1930
-			2:30	-	BEAT	1940
-			2:45	-	BEAUT	1960
-			3:00	-	EAT
-Link Africa/Nairobi Africa/Addis_Ababa	 # Ethiopia
-Link Africa/Nairobi Africa/Asmara	 # Eritrea
-Link Africa/Nairobi Africa/Dar_es_Salaam # Tanzania
-Link Africa/Nairobi Africa/Djibouti
-Link Africa/Nairobi Africa/Kampala	 # Uganda
-Link Africa/Nairobi Africa/Mogadishu	 # Somalia
-Link Africa/Nairobi Indian/Antananarivo	 # Madagascar
-Link Africa/Nairobi Indian/Comoro
-Link Africa/Nairobi Indian/Mayotte
+# Madagascar
+# Mayotte
+# Somalia
+# Tanzania
+# Uganda
 
-# Lesotho
-# See Africa/Johannesburg.
+# From P Chan (2020-10-24):
+#
+# The standard time of GMT+2:30 was adopted in the East Africa Protectorate....
+# [The Official Gazette, 1908-05-01, p 274]
+# https://books.google.com/books?id=e-cAC-sjPSEC&pg=PA274
+#
+# At midnight on 30 June 1928 the clocks throughout Kenya was put forward
+# half an hour by the Alteration of Time Ordinance, 1928.
+# https://gazettes.africa/archive/ke/1928/ke-government-gazette-dated-1928-05-11-no-28.pdf
+# [Ordinance No. 11 of 1928, The Official Gazette, 1928-06-26, p 813]
+# https://books.google.com/books?id=2S0S6os32ZUC&pg=PA813
+#
+# The 1928 ordinance was repealed by the Alteration of Time (repeal) Ordinance,
+# 1929 and the time was restored to GMT+2:30 at midnight on 4 January 1930.
+# [Ordinance No. 97 of 1929, The Official Gazette, 1929-12-31, p 2701]
+# https://books.google.com/books?id=_g18jIZQlwwC&pg=PA2701
+#
+# The Alteration of Time Ordinance, 1936 changed the time to GMT+2:45
+# and repealed the previous ordinance at midnight on 31 December 1936.
+# [The Official Gazette, 1936-07-21, p 705]
+# https://books.google.com/books?id=K7j41z0aC5wC&pg=PA705
+#
+# The Defence (Amendment of Laws No. 120) Regulations changed the time
+# to GMT+3 at midnight on 31 July 1942.
+# [Kenya Official Gazette Supplement No. 32, 1942-07-21, p 331]
+# https://books.google.com/books?hl=zh-TW&id=c_E-AQAAIAAJ&pg=PA331
+# The provision of the 1936 ordinance was not repealed and was later
+# incorporated in the Interpretation and General Clauses Ordinance in 1948.
+# Although it was overridden by the 1942 regulations.
+# [The Laws of Kenya in force on 1948-09-21, Title I, Chapter 1, 31]
+# https://dds.crl.edu/item/217517 (p.101)
+# In 1950 the Interpretation and General Clauses Ordinance was amended to adopt
+# GMT+3 permanently as the 1942 regulations were due to expire on 10 December.
+# https://books.google.com/books?id=jvR8mUDAwR0C&pg=PA787
+# [Ordinance No. 44 of 1950, Kenya Ordinances 1950, Vol. XXIX, p 294]
+# https://books.google.com/books?id=-_dQAQAAMAAJ&pg=PA294
+
+# From Paul Eggert (2020-10-24):
+# The 1908-05-01 announcement does not give an effective date,
+# so just say "1908 May".
+
+# From Paul Eggert (2018-09-11):
+# Unfortunately tzdb records only Western clock time in use in Ethiopia,
+# as the tzdb format is not up to properly recording a common Ethiopian
+# timekeeping practice that is based on solar time.  See:
+# Mortada D. If you have a meeting in Ethiopia, you'd better double
+# check the time. PRI's The World. 2015-01-30 15:15 -05.
+# https://www.pri.org/stories/2015-01-30/if-you-have-meeting-ethiopia-you-better-double-check-time
+
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Africa/Nairobi	2:27:16	-	LMT	1908 May
+			2:30	-	%z	1928 Jun 30 24:00
+			3:00	-	EAT	1930 Jan  4 24:00
+			2:30	-	%z	1936 Dec 31 24:00
+			2:45	-	%z	1942 Jul 31 24:00
+			3:00	-	EAT
 
 # Liberia
-# From Paul Eggert (2006-03-22):
-# In 1972 Liberia was the last country to switch
-# from a UTC offset that was not a multiple of 15 or 20 minutes.
-# Howse reports that it was in honor of their president's birthday.
-# Shank & Pottenger report the date as May 1, whereas Howse reports Jan;
-# go with Shanks & Pottenger.
-# For Liberia before 1972, Shanks & Pottenger report -0:44, whereas Howse and
-# Whitman each report -0:44:30; go with the more precise figure.
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+#
+# From Paul Eggert (2017-03-02):
+#
+# The Nautical Almanac for the Year 1970, p 264, is the source for -0:44:30.
+#
+# In 1972 Liberia was the last country to switch from a UT offset
+# that was not a multiple of 15 or 20 minutes.  The 1972 change was on
+# 1972-01-07, according to an entry dated 1972-01-04 on p 330 of:
+# Presidential Papers: First year of the administration of
+# President William R. Tolbert, Jr., July 23, 1971-July 31, 1972.
+# Monrovia: Executive Mansion.
+#
+# Use the abbreviation "MMT" before 1972, as the more accurate numeric
+# abbreviation "-004430" would be one byte over the POSIX limit.
+#
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Africa/Monrovia	-0:43:08 -	LMT	1882
 			-0:43:08 -	MMT	1919 Mar # Monrovia Mean Time
-			-0:44:30 -	LRT	1972 May # Liberia Time
+			-0:44:30 -	MMT	1972 Jan 7 # approximately MMT
 			 0:00	-	GMT
 
 ###############################################################################
@@ -446,11 +448,11 @@ Zone	Africa/Monrovia	-0:43:08 -	LMT	1882
 
 # From Even Scharning (2012-11-10):
 # Libya set their time one hour back at 02:00 on Saturday November 10.
-# http://www.libyaherald.com/2012/11/04/clocks-to-go-back-an-hour-on-saturday/
+# https://www.libyaherald.com/2012/11/04/clocks-to-go-back-an-hour-on-saturday/
 # Here is an official source [in Arabic]: http://ls.ly/fb6Yc
 #
 # Steffen Thorsen forwarded a translation (2012-11-10) in
-# http://mm.icann.org/pipermail/tz/2012-November/018451.html
+# https://mm.icann.org/pipermail/tz/2012-November/018451.html
 #
 # From Tim Parenti (2012-11-11):
 # Treat the 2012-11-10 change as a zone change from UTC+2 to UTC+1.
@@ -461,12 +463,12 @@ Zone	Africa/Monrovia	-0:43:08 -	LMT	1882
 # From Even Scharning (2013-10-25):
 # The scheduled end of DST in Libya on Friday, October 25, 2013 was
 # cancelled yesterday....
-# http://www.libyaherald.com/2013/10/24/correction-no-time-change-tomorrow/
+# https://www.libyaherald.com/2013/10/24/correction-no-time-change-tomorrow/
 #
 # From Paul Eggert (2013-10-25):
 # For now, assume they're reverting to the pre-2012 rules of permanent UT +02.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Libya	1951	only	-	Oct	14	2:00	1:00	S
 Rule	Libya	1952	only	-	Jan	 1	0:00	0	-
 Rule	Libya	1953	only	-	Oct	 9	2:00	1:00	S
@@ -484,7 +486,7 @@ Rule	Libya	1997	only	-	Apr	 4	0:00	1:00	S
 Rule	Libya	1997	only	-	Oct	 4	0:00	0	-
 Rule	Libya	2013	only	-	Mar	lastFri	1:00	1:00	S
 Rule	Libya	2013	only	-	Oct	lastFri	2:00	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Africa/Tripoli	0:52:44 -	LMT	1920
 			1:00	Libya	CE%sT	1959
 			2:00	-	EET	1982
@@ -497,16 +499,6 @@ Zone	Africa/Tripoli	0:52:44 -	LMT	1920
 			1:00	Libya	CE%sT	2013 Oct 25  2:00
 			2:00	-	EET
 
-# Madagascar
-# See Africa/Nairobi.
-
-# Malawi
-# See Africa/Maputo.
-
-# Mali
-# Mauritania
-# See Africa/Abidjan.
-
 # Mauritius
 
 # From Steffen Thorsen (2008-06-25):
@@ -514,7 +506,7 @@ Zone	Africa/Tripoli	0:52:44 -	LMT	1920
 # basis....
 # It seems that Mauritius observed daylight saving time from 1982-10-10 to
 # 1983-03-20 as well, but that was not successful....
-# http://www.timeanddate.com/news/time/mauritius-daylight-saving-time.html
+# https://www.timeanddate.com/news/time/mauritius-daylight-saving-time.html
 
 # From Alex Krivenyshev (2008-06-25):
 # http://economicdevelopment.gov.mu/portal/site/Mainhomepage/menuitem.a42b24128104d9845dabddd154508a0c/?content_id=0a7cee8b5d69a110VgnVCM1000000a04a8c0RCRD
@@ -578,33 +570,31 @@ Zone	Africa/Tripoli	0:52:44 -	LMT	1920
 # DST the coming summer...
 #
 # Some sources, in French:
-# http://www.defimedia.info/news/946/Rashid-Beebeejaun-:-%C2%AB-L%E2%80%99heure-d%E2%80%99%C3%A9t%C3%A9-ne-sera-pas-appliqu%C3%A9e-cette-ann%C3%A9e-%C2%BB
-# http://lexpress.mu/Story/3398~Beebeejaun---Les-objectifs-d-%C3%A9conomie-d-%C3%A9nergie-de-l-heure-d-%C3%A9t%C3%A9-ont-%C3%A9t%C3%A9-atteints-
+# http://www.defimedia.info/news/946/Rashid-Beebeejaun-:-«-L%E2%80%99heure-d%E2%80%99été-ne-sera-pas-appliquée-cette-année-»
+# http://lexpress.mu/Story/3398~Beebeejaun---Les-objectifs-d-économie-d-énergie-de-l-heure-d-été-ont-été-atteints-
 #
 # Our wrap-up:
-# http://www.timeanddate.com/news/time/mauritius-dst-will-not-repeat.html
+# https://www.timeanddate.com/news/time/mauritius-dst-will-not-repeat.html
 
 # From Arthur David Olson (2009-07-11):
 # The "mauritius-dst-will-not-repeat" wrapup includes this:
 # "The trial ended on March 29, 2009, when the clocks moved back by one hour
 # at 2am (or 02:00) local time..."
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule Mauritius	1982	only	-	Oct	10	0:00	1:00	S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule Mauritius	1982	only	-	Oct	10	0:00	1:00	-
 Rule Mauritius	1983	only	-	Mar	21	0:00	0	-
-Rule Mauritius	2008	only	-	Oct	lastSun	2:00	1:00	S
+Rule Mauritius	2008	only	-	Oct	lastSun	2:00	1:00	-
 Rule Mauritius	2009	only	-	Mar	lastSun	2:00	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Indian/Mauritius	3:50:00 -	LMT	1907 # Port Louis
-			4:00 Mauritius	MU%sT	# Mauritius Time
+			4:00 Mauritius	%z
 # Agalega Is, Rodriguez
 # no information; probably like Indian/Mauritius
 
-# Mayotte
-# See Africa/Nairobi.
 
 # Morocco
-# See the 'europe' file for Spanish Morocco (Africa/Ceuta).
+# See Africa/Ceuta for Spanish Morocco.
 
 # From Alex Krivenyshev (2008-05-09):
 # Here is an article that Morocco plan to introduce Daylight Saving Time between
@@ -614,7 +604,7 @@ Zone Indian/Mauritius	3:50:00 -	LMT	1907 # Port Louis
 # be one hour ahead of GMT between 1 June and 27 September, according to
 # Communication Minister and Government Spokesman, Khalid Naciri...."
 #
-# http://www.worldtimezone.net/dst_news/dst_news_morocco01.html
+# http://www.worldtimezone.com/dst_news/dst_news_morocco01.html
 # http://en.afrik.com/news11892.html
 
 # From Alex Krivenyshev (2008-05-09):
@@ -627,7 +617,7 @@ Zone Indian/Mauritius	3:50:00 -	LMT	1907 # Port Louis
 
 # From Patrice Scattolin (2008-05-09):
 # According to this article:
-# http://www.avmaroc.com/actualite/heure-dete-comment-a127896.html
+# https://www.avmaroc.com/actualite/heure-dete-comment-a127896.html
 # (and republished here: <http://www.actu.ma/heure-dete-comment_i127896_0.html>)
 # the changes occur at midnight:
 #
@@ -649,7 +639,7 @@ Zone Indian/Mauritius	3:50:00 -	LMT	1907 # Port Louis
 # posted in English).
 #
 # The following Google query will generate many relevant hits:
-# http://www.google.com/search?hl=en&q=Conseil+de+gouvernement+maroc+heure+avance&btnG=Search
+# https://www.google.com/search?hl=en&q=Conseil+de+gouvernement+maroc+heure+avance&btnG=Search
 
 # From Steffen Thorsen (2008-08-27):
 # Morocco will change the clocks back on the midnight between August 31
@@ -660,7 +650,7 @@ Zone Indian/Mauritius	3:50:00 -	LMT	1907 # Port Louis
 # http://www.menara.ma/fr/Actualites/Maroc/Societe/ci.retour_a_l_heure_gmt_a_partir_du_dimanche_31_aout_a_minuit_officiel_.default
 #
 # We have some further details posted here:
-# http://www.timeanddate.com/news/time/morocco-ends-dst-early-2008.html
+# https://www.timeanddate.com/news/time/morocco-ends-dst-early-2008.html
 
 # From Steffen Thorsen (2009-03-17):
 # Morocco will observe DST from 2009-06-01 00:00 to 2009-08-21 00:00 according
@@ -670,7 +660,7 @@ Zone Indian/Mauritius	3:50:00 -	LMT	1907 # Port Louis
 # (French)
 #
 # Our summary:
-# http://www.timeanddate.com/news/time/morocco-starts-dst-2009.html
+# https://www.timeanddate.com/news/time/morocco-starts-dst-2009.html
 
 # From Alexander Krivenyshev (2009-03-17):
 # Here is a link to official document from Royaume du Maroc Premier Ministre,
@@ -693,7 +683,7 @@ Zone Indian/Mauritius	3:50:00 -	LMT	1907 # Port Louis
 # http://www.lavieeco.com/actualites/4099-le-maroc-passera-a-l-heure-d-ete-gmt1-le-2-mai.html
 # (French)
 # Our page:
-# http://www.timeanddate.com/news/time/morocco-starts-dst-2010.html
+# https://www.timeanddate.com/news/time/morocco-starts-dst-2010.html
 
 # From Dan Abitol (2011-03-30):
 # ...Rules for Africa/Casablanca are the following (24h format)
@@ -710,9 +700,9 @@ Zone Indian/Mauritius	3:50:00 -	LMT	1907 # Port Louis
 # They said that the decision was already taken.
 #
 # More articles in the press
-# http://www.yabiladi.com/articles/details/5058/secret-l-heure-d-ete-maroc-leve.html
+# https://www.yabiladi.com/articles/details/5058/secret-l-heure-d-ete-maroc-leve.html
 # http://www.lematin.ma/Actualite/Express/Article.asp?id=148923
-# http://www.lavieeco.com/actualite/Le-Maroc-passe-sur-GMT%2B1-a-partir-de-dim
+# http://www.lavieeco.com/actualite/Le-Maroc-passe-sur-GMT+1-a-partir-de-dim
 
 # From Petr Machata (2011-03-30):
 # They have it written in English here:
@@ -727,7 +717,7 @@ Zone Indian/Mauritius	3:50:00 -	LMT	1907 # Port Louis
 # According to Infomédiaire web site from Morocco (infomediaire.ma),
 # on March 9, 2012, (in French) Heure légale:
 # Le Maroc adopte officiellement l'heure d'été
-# http://www.infomediaire.ma/news/maroc/heure-l%C3%A9gale-le-maroc-adopte-officiellement-lheure-d%C3%A9t%C3%A9
+# http://www.infomediaire.ma/news/maroc/heure-légale-le-maroc-adopte-officiellement-lheure-dété
 # Governing Council adopted draft decree, that Morocco DST starts on
 # the last Sunday of March (March 25, 2012) and ends on
 # last Sunday of September (September 30, 2012)
@@ -802,7 +792,7 @@ Zone Indian/Mauritius	3:50:00 -	LMT	1907 # Port Louis
 # 1433 (18 April 2012) and the decision of the Head of Government of
 # 16 N. 3-29-15 Chaaban 1435 (4 June 2015).
 # Source (french):
-# http://lnt.ma/le-maroc-reculera-dune-heure-le-dimanche-14-juin/
+# https://lnt.ma/le-maroc-reculera-dune-heure-le-dimanche-14-juin/
 #
 # From Milamber (2015-06-09):
 # http://www.mmsp.gov.ma/fr/actualites.aspx?id=863
@@ -811,21 +801,68 @@ Zone Indian/Mauritius	3:50:00 -	LMT	1907 # Port Louis
 # [The gov.ma announcement] would (probably) make the switch on 2015-07-19 go
 # from 03:00 to 04:00 rather than from 02:00 to 03:00, as in the patch....
 # I think the patch is correct and the quoted text is wrong; the text in
-# <http://lnt.ma/le-maroc-reculera-dune-heure-le-dimanche-14-juin/> agrees
+# <https://lnt.ma/le-maroc-reculera-dune-heure-le-dimanche-14-juin/> agrees
 # with the patch.
 
-# From Paul Eggert (2015-06-08):
-# For now, guess that later spring and fall transitions will use 2015's rules,
-# and guess that Morocco will switch to standard time at 03:00 the last
-# Sunday before Ramadan, and back to DST at 02:00 the first Sunday after
-# Ramadan.  To implement this, transition dates for 2016 through 2037 were
-# determined by running the following program under GNU Emacs 24.3, with the
-# results integrated by hand into the table below.
-# (let ((islamic-year 1437))
+# From Mohamed Essedik Najd (2018-10-26):
+# Today, a Moroccan government council approved the perpetual addition
+# of 60 minutes to the regular Moroccan timezone.
+# From Matt Johnson (2018-10-28):
+# http://www.sgg.gov.ma/Portals/1/BO/2018/BO_6720-bis_Ar.pdf
+#
+# From Maamar Abdelkader (2018-11-01):
+# We usually move clocks back the previous week end and come back to the +1
+# the week end after....  The government does not announce yet the decision
+# about this temporary change.  But it s 99% sure that it will be the case,
+# as in previous years.  An unofficial survey was done these days, showing
+# that 64% of asked people are ok for moving from +1 to +0 during Ramadan.
+# https://leconomiste.com/article/1035870-enquete-l-economiste-sunergia-64-des-marocains-plebiscitent-le-gmt-pendant-ramadan
+
+# From Naoufal Semlali (2019-04-16):
+# Morocco will be on GMT starting from Sunday, May 5th 2019 at 3am.
+# The switch to GMT+1 will occur on Sunday, June 9th 2019 at 2am....
+# http://fr.le360.ma/societe/voici-la-date-du-retour-a-lheure-legale-au-maroc-188222
+
+# From Semlali Naoufal (2020-04-14):
+# Following the announcement by the Moroccan government, the switch to
+# GMT time will take place on Sunday, April 19, 2020 from 3 a.m. and
+# the return to GMT+1 time will take place on Sunday, May 31, 2020 at 2 a.m....
+# https://maroc-diplomatique.net/maroc-le-retour-a-lheure-gmt-est-prevu-dimanche-prochain/
+# http://aujourdhui.ma/actualite/gmt1-retour-a-lheure-normale-dimanche-prochain-1
+#
+# From Milamber (2020-05-31)
+# In Morocco (where I live), the end of Ramadan (Arabic month) is followed by
+# the Eid al-Fitr, and concretely it's 1 or 2 day offs for the people (with
+# traditional visiting of family, big lunches/dinners, etc.).  So for this
+# year the astronomical calculations don't include the following 2 days off in
+# the calc.  These 2 days fall in a Sunday/Monday, so it's not acceptable by
+# people to have a time shift during these 2 days off.  Perhaps you can modify
+# the (predicted) rules for next years: if the end of Ramadan is a (probable)
+# Friday or Saturday (and so the 2 days off are on a weekend), the next time
+# shift will be the next weekend.
+#
+# From Milamber (2021-03-31, 2022-03-10):
+# https://www.mmsp.gov.ma/fr/actualites.aspx?id=2076
+# https://www.ecoactu.ma/horaires-administration-ramadan-gmtheure-gmt-a-partir-de-dimanche-27-mars/
+#
+# From Milamber (2023-03-14, 2023-03-15):
+# The return to legal GMT time will take place this Sunday, March 19 at 3 a.m.
+# ... the return to GMT+1 will be made on Sunday April 23, 2023 at 2 a.m.
+# https://www.mmsp.gov.ma/fr/actualites/passage-à-l%E2%80%99heure-gmt-à-partir-du-dimanche-19-mars-2023
+#
+# From Paul Eggert (2023-03-14):
+# For now, guess that in the future Morocco will fall back at 03:00
+# the last Sunday before Ramadan, and spring forward at 02:00 the
+# first Sunday after one day after Ramadan.  To implement this,
+# transition dates and times for 2019 through 2087 were determined by
+# running the following program under GNU Emacs 28.2.  (This algorithm
+# also produces the correct transition dates for 2016 through 2018,
+# though the times differ due to Morocco's time zone change in 2018.)
+# (let ((islamic-year 1440))
 #   (require 'cal-islam)
-#   (while (< islamic-year 1460)
+#   (while (< islamic-year 1511)
 #     (let ((a (calendar-islamic-to-absolute (list 9 1 islamic-year)))
-#           (b (calendar-islamic-to-absolute (list 10 1 islamic-year)))
+#           (b (+ 1 (calendar-islamic-to-absolute (list 10 1 islamic-year))))
 #           (sunday 0))
 #       (while (/= sunday (mod (setq a (1- a)) 7)))
 #       (while (/= sunday (mod b 7))
@@ -834,74 +871,207 @@ Zone Indian/Mauritius	3:50:00 -	LMT	1907 # Port Louis
 #       (setq b (calendar-gregorian-from-absolute b))
 #       (insert
 #        (format
-#         (concat "Rule\tMorocco\t%d\tonly\t-\t%s\t%2d\t 3:00\t0\t-\n"
-#                 "Rule\tMorocco\t%d\tonly\t-\t%s\t%2d\t 2:00\t1:00\tS\n")
+#         (concat "Rule\tMorocco\t%d\tonly\t-\t%s\t%2d\t 3:00\t-1:00\t-\n"
+#                 "Rule\tMorocco\t%d\tonly\t-\t%s\t%2d\t 2:00\t0\t-\n")
 #         (car (cdr (cdr a))) (calendar-month-name (car a) t) (car (cdr a))
 #         (car (cdr (cdr b))) (calendar-month-name (car b) t) (car (cdr b)))))
 #     (setq islamic-year (+ 1 islamic-year))))
 
-# RULE	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-
-Rule	Morocco	1939	only	-	Sep	12	 0:00	1:00	S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Morocco	1939	only	-	Sep	12	 0:00	1:00	-
 Rule	Morocco	1939	only	-	Nov	19	 0:00	0	-
-Rule	Morocco	1940	only	-	Feb	25	 0:00	1:00	S
+Rule	Morocco	1940	only	-	Feb	25	 0:00	1:00	-
 Rule	Morocco	1945	only	-	Nov	18	 0:00	0	-
-Rule	Morocco	1950	only	-	Jun	11	 0:00	1:00	S
+Rule	Morocco	1950	only	-	Jun	11	 0:00	1:00	-
 Rule	Morocco	1950	only	-	Oct	29	 0:00	0	-
-Rule	Morocco	1967	only	-	Jun	 3	12:00	1:00	S
+Rule	Morocco	1967	only	-	Jun	 3	12:00	1:00	-
 Rule	Morocco	1967	only	-	Oct	 1	 0:00	0	-
-Rule	Morocco	1974	only	-	Jun	24	 0:00	1:00	S
+Rule	Morocco	1974	only	-	Jun	24	 0:00	1:00	-
 Rule	Morocco	1974	only	-	Sep	 1	 0:00	0	-
-Rule	Morocco	1976	1977	-	May	 1	 0:00	1:00	S
+Rule	Morocco	1976	1977	-	May	 1	 0:00	1:00	-
 Rule	Morocco	1976	only	-	Aug	 1	 0:00	0	-
 Rule	Morocco	1977	only	-	Sep	28	 0:00	0	-
-Rule	Morocco	1978	only	-	Jun	 1	 0:00	1:00	S
+Rule	Morocco	1978	only	-	Jun	 1	 0:00	1:00	-
 Rule	Morocco	1978	only	-	Aug	 4	 0:00	0	-
-Rule	Morocco	2008	only	-	Jun	 1	 0:00	1:00	S
+Rule	Morocco	2008	only	-	Jun	 1	 0:00	1:00	-
 Rule	Morocco	2008	only	-	Sep	 1	 0:00	0	-
-Rule	Morocco	2009	only	-	Jun	 1	 0:00	1:00	S
+Rule	Morocco	2009	only	-	Jun	 1	 0:00	1:00	-
 Rule	Morocco	2009	only	-	Aug	21	 0:00	0	-
-Rule	Morocco	2010	only	-	May	 2	 0:00	1:00	S
+Rule	Morocco	2010	only	-	May	 2	 0:00	1:00	-
 Rule	Morocco	2010	only	-	Aug	 8	 0:00	0	-
-Rule	Morocco	2011	only	-	Apr	 3	 0:00	1:00	S
+Rule	Morocco	2011	only	-	Apr	 3	 0:00	1:00	-
 Rule	Morocco	2011	only	-	Jul	31	 0:00	0	-
-Rule	Morocco	2012	2013	-	Apr	lastSun	 2:00	1:00	S
+Rule	Morocco	2012	2013	-	Apr	lastSun	 2:00	1:00	-
 Rule	Morocco	2012	only	-	Jul	20	 3:00	0	-
-Rule	Morocco	2012	only	-	Aug	20	 2:00	1:00	S
+Rule	Morocco	2012	only	-	Aug	20	 2:00	1:00	-
 Rule	Morocco	2012	only	-	Sep	30	 3:00	0	-
 Rule	Morocco	2013	only	-	Jul	 7	 3:00	0	-
-Rule	Morocco	2013	only	-	Aug	10	 2:00	1:00	S
-Rule	Morocco	2013	max	-	Oct	lastSun	 3:00	0	-
-Rule	Morocco	2014	2021	-	Mar	lastSun	 2:00	1:00	S
+Rule	Morocco	2013	only	-	Aug	10	 2:00	1:00	-
+Rule	Morocco	2013	2018	-	Oct	lastSun	 3:00	0	-
+Rule	Morocco	2014	2018	-	Mar	lastSun	 2:00	1:00	-
 Rule	Morocco	2014	only	-	Jun	28	 3:00	0	-
-Rule	Morocco	2014	only	-	Aug	 2	 2:00	1:00	S
+Rule	Morocco	2014	only	-	Aug	 2	 2:00	1:00	-
 Rule	Morocco	2015	only	-	Jun	14	 3:00	0	-
-Rule	Morocco	2015	only	-	Jul	19	 2:00	1:00	S
+Rule	Morocco	2015	only	-	Jul	19	 2:00	1:00	-
 Rule	Morocco	2016	only	-	Jun	 5	 3:00	0	-
-Rule	Morocco	2016	only	-	Jul	10	 2:00	1:00	S
+Rule	Morocco	2016	only	-	Jul	10	 2:00	1:00	-
 Rule	Morocco	2017	only	-	May	21	 3:00	0	-
-Rule	Morocco	2017	only	-	Jul	 2	 2:00	1:00	S
+Rule	Morocco	2017	only	-	Jul	 2	 2:00	1:00	-
 Rule	Morocco	2018	only	-	May	13	 3:00	0	-
-Rule	Morocco	2018	only	-	Jun	17	 2:00	1:00	S
-Rule	Morocco	2019	only	-	May	 5	 3:00	0	-
-Rule	Morocco	2019	only	-	Jun	 9	 2:00	1:00	S
-Rule	Morocco	2020	only	-	Apr	19	 3:00	0	-
-Rule	Morocco	2020	only	-	May	24	 2:00	1:00	S
-Rule	Morocco	2021	only	-	Apr	11	 3:00	0	-
-Rule	Morocco	2021	only	-	May	16	 2:00	1:00	S
-Rule	Morocco	2022	only	-	May	 8	 2:00	1:00	S
-Rule	Morocco	2023	only	-	Apr	23	 2:00	1:00	S
-Rule	Morocco	2024	only	-	Apr	14	 2:00	1:00	S
-Rule	Morocco	2025	only	-	Apr	 6	 2:00	1:00	S
-Rule	Morocco	2026	max	-	Mar	lastSun	 2:00	1:00	S
-Rule	Morocco	2036	only	-	Oct	19	 3:00	0	-
-Rule	Morocco	2037	only	-	Oct	 4	 3:00	0	-
+Rule	Morocco	2018	only	-	Jun	17	 2:00	1:00	-
+Rule	Morocco	2019	only	-	May	 5	 3:00	-1:00	-
+Rule	Morocco	2019	only	-	Jun	 9	 2:00	0	-
+Rule	Morocco	2020	only	-	Apr	19	 3:00	-1:00	-
+Rule	Morocco	2020	only	-	May	31	 2:00	0	-
+Rule	Morocco	2021	only	-	Apr	11	 3:00	-1:00	-
+Rule	Morocco	2021	only	-	May	16	 2:00	0	-
+Rule	Morocco	2022	only	-	Mar	27	 3:00	-1:00	-
+Rule	Morocco	2022	only	-	May	 8	 2:00	0	-
+Rule	Morocco	2023	only	-	Mar	19	 3:00	-1:00	-
+Rule	Morocco	2023	only	-	Apr	23	 2:00	0	-
+Rule	Morocco	2024	only	-	Mar	10	 3:00	-1:00	-
+Rule	Morocco	2024	only	-	Apr	14	 2:00	0	-
+Rule	Morocco	2025	only	-	Feb	23	 3:00	-1:00	-
+Rule	Morocco	2025	only	-	Apr	 6	 2:00	0	-
+Rule	Morocco	2026	only	-	Feb	15	 3:00	-1:00	-
+Rule	Morocco	2026	only	-	Mar	22	 2:00	0	-
+Rule	Morocco	2027	only	-	Feb	 7	 3:00	-1:00	-
+Rule	Morocco	2027	only	-	Mar	14	 2:00	0	-
+Rule	Morocco	2028	only	-	Jan	23	 3:00	-1:00	-
+Rule	Morocco	2028	only	-	Mar	 5	 2:00	0	-
+Rule	Morocco	2029	only	-	Jan	14	 3:00	-1:00	-
+Rule	Morocco	2029	only	-	Feb	18	 2:00	0	-
+Rule	Morocco	2029	only	-	Dec	30	 3:00	-1:00	-
+Rule	Morocco	2030	only	-	Feb	10	 2:00	0	-
+Rule	Morocco	2030	only	-	Dec	22	 3:00	-1:00	-
+Rule	Morocco	2031	only	-	Jan	26	 2:00	0	-
+Rule	Morocco	2031	only	-	Dec	14	 3:00	-1:00	-
+Rule	Morocco	2032	only	-	Jan	18	 2:00	0	-
+Rule	Morocco	2032	only	-	Nov	28	 3:00	-1:00	-
+Rule	Morocco	2033	only	-	Jan	 9	 2:00	0	-
+Rule	Morocco	2033	only	-	Nov	20	 3:00	-1:00	-
+Rule	Morocco	2033	only	-	Dec	25	 2:00	0	-
+Rule	Morocco	2034	only	-	Nov	 5	 3:00	-1:00	-
+Rule	Morocco	2034	only	-	Dec	17	 2:00	0	-
+Rule	Morocco	2035	only	-	Oct	28	 3:00	-1:00	-
+Rule	Morocco	2035	only	-	Dec	 9	 2:00	0	-
+Rule	Morocco	2036	only	-	Oct	19	 3:00	-1:00	-
+Rule	Morocco	2036	only	-	Nov	23	 2:00	0	-
+Rule	Morocco	2037	only	-	Oct	 4	 3:00	-1:00	-
+Rule	Morocco	2037	only	-	Nov	15	 2:00	0	-
+Rule	Morocco	2038	only	-	Sep	26	 3:00	-1:00	-
+Rule	Morocco	2038	only	-	Oct	31	 2:00	0	-
+Rule	Morocco	2039	only	-	Sep	18	 3:00	-1:00	-
+Rule	Morocco	2039	only	-	Oct	23	 2:00	0	-
+Rule	Morocco	2040	only	-	Sep	 2	 3:00	-1:00	-
+Rule	Morocco	2040	only	-	Oct	14	 2:00	0	-
+Rule	Morocco	2041	only	-	Aug	25	 3:00	-1:00	-
+Rule	Morocco	2041	only	-	Sep	29	 2:00	0	-
+Rule	Morocco	2042	only	-	Aug	10	 3:00	-1:00	-
+Rule	Morocco	2042	only	-	Sep	21	 2:00	0	-
+Rule	Morocco	2043	only	-	Aug	 2	 3:00	-1:00	-
+Rule	Morocco	2043	only	-	Sep	13	 2:00	0	-
+Rule	Morocco	2044	only	-	Jul	24	 3:00	-1:00	-
+Rule	Morocco	2044	only	-	Aug	28	 2:00	0	-
+Rule	Morocco	2045	only	-	Jul	 9	 3:00	-1:00	-
+Rule	Morocco	2045	only	-	Aug	20	 2:00	0	-
+Rule	Morocco	2046	only	-	Jul	 1	 3:00	-1:00	-
+Rule	Morocco	2046	only	-	Aug	 5	 2:00	0	-
+Rule	Morocco	2047	only	-	Jun	23	 3:00	-1:00	-
+Rule	Morocco	2047	only	-	Jul	28	 2:00	0	-
+Rule	Morocco	2048	only	-	Jun	 7	 3:00	-1:00	-
+Rule	Morocco	2048	only	-	Jul	19	 2:00	0	-
+Rule	Morocco	2049	only	-	May	30	 3:00	-1:00	-
+Rule	Morocco	2049	only	-	Jul	 4	 2:00	0	-
+Rule	Morocco	2050	only	-	May	15	 3:00	-1:00	-
+Rule	Morocco	2050	only	-	Jun	26	 2:00	0	-
+Rule	Morocco	2051	only	-	May	 7	 3:00	-1:00	-
+Rule	Morocco	2051	only	-	Jun	18	 2:00	0	-
+Rule	Morocco	2052	only	-	Apr	28	 3:00	-1:00	-
+Rule	Morocco	2052	only	-	Jun	 2	 2:00	0	-
+Rule	Morocco	2053	only	-	Apr	13	 3:00	-1:00	-
+Rule	Morocco	2053	only	-	May	25	 2:00	0	-
+Rule	Morocco	2054	only	-	Apr	 5	 3:00	-1:00	-
+Rule	Morocco	2054	only	-	May	10	 2:00	0	-
+Rule	Morocco	2055	only	-	Mar	28	 3:00	-1:00	-
+Rule	Morocco	2055	only	-	May	 2	 2:00	0	-
+Rule	Morocco	2056	only	-	Mar	12	 3:00	-1:00	-
+Rule	Morocco	2056	only	-	Apr	23	 2:00	0	-
+Rule	Morocco	2057	only	-	Mar	 4	 3:00	-1:00	-
+Rule	Morocco	2057	only	-	Apr	 8	 2:00	0	-
+Rule	Morocco	2058	only	-	Feb	17	 3:00	-1:00	-
+Rule	Morocco	2058	only	-	Mar	31	 2:00	0	-
+Rule	Morocco	2059	only	-	Feb	 9	 3:00	-1:00	-
+Rule	Morocco	2059	only	-	Mar	23	 2:00	0	-
+Rule	Morocco	2060	only	-	Feb	 1	 3:00	-1:00	-
+Rule	Morocco	2060	only	-	Mar	 7	 2:00	0	-
+Rule	Morocco	2061	only	-	Jan	16	 3:00	-1:00	-
+Rule	Morocco	2061	only	-	Feb	27	 2:00	0	-
+Rule	Morocco	2062	only	-	Jan	 8	 3:00	-1:00	-
+Rule	Morocco	2062	only	-	Feb	12	 2:00	0	-
+Rule	Morocco	2062	only	-	Dec	31	 3:00	-1:00	-
+Rule	Morocco	2063	only	-	Feb	 4	 2:00	0	-
+Rule	Morocco	2063	only	-	Dec	16	 3:00	-1:00	-
+Rule	Morocco	2064	only	-	Jan	27	 2:00	0	-
+Rule	Morocco	2064	only	-	Dec	 7	 3:00	-1:00	-
+Rule	Morocco	2065	only	-	Jan	11	 2:00	0	-
+Rule	Morocco	2065	only	-	Nov	22	 3:00	-1:00	-
+Rule	Morocco	2066	only	-	Jan	 3	 2:00	0	-
+Rule	Morocco	2066	only	-	Nov	14	 3:00	-1:00	-
+Rule	Morocco	2066	only	-	Dec	26	 2:00	0	-
+Rule	Morocco	2067	only	-	Nov	 6	 3:00	-1:00	-
+Rule	Morocco	2067	only	-	Dec	11	 2:00	0	-
+Rule	Morocco	2068	only	-	Oct	21	 3:00	-1:00	-
+Rule	Morocco	2068	only	-	Dec	 2	 2:00	0	-
+Rule	Morocco	2069	only	-	Oct	13	 3:00	-1:00	-
+Rule	Morocco	2069	only	-	Nov	17	 2:00	0	-
+Rule	Morocco	2070	only	-	Oct	 5	 3:00	-1:00	-
+Rule	Morocco	2070	only	-	Nov	 9	 2:00	0	-
+Rule	Morocco	2071	only	-	Sep	20	 3:00	-1:00	-
+Rule	Morocco	2071	only	-	Nov	 1	 2:00	0	-
+Rule	Morocco	2072	only	-	Sep	11	 3:00	-1:00	-
+Rule	Morocco	2072	only	-	Oct	16	 2:00	0	-
+Rule	Morocco	2073	only	-	Aug	27	 3:00	-1:00	-
+Rule	Morocco	2073	only	-	Oct	 8	 2:00	0	-
+Rule	Morocco	2074	only	-	Aug	19	 3:00	-1:00	-
+Rule	Morocco	2074	only	-	Sep	30	 2:00	0	-
+Rule	Morocco	2075	only	-	Aug	11	 3:00	-1:00	-
+Rule	Morocco	2075	only	-	Sep	15	 2:00	0	-
+Rule	Morocco	2076	only	-	Jul	26	 3:00	-1:00	-
+Rule	Morocco	2076	only	-	Sep	 6	 2:00	0	-
+Rule	Morocco	2077	only	-	Jul	18	 3:00	-1:00	-
+Rule	Morocco	2077	only	-	Aug	22	 2:00	0	-
+Rule	Morocco	2078	only	-	Jul	10	 3:00	-1:00	-
+Rule	Morocco	2078	only	-	Aug	14	 2:00	0	-
+Rule	Morocco	2079	only	-	Jun	25	 3:00	-1:00	-
+Rule	Morocco	2079	only	-	Aug	 6	 2:00	0	-
+Rule	Morocco	2080	only	-	Jun	16	 3:00	-1:00	-
+Rule	Morocco	2080	only	-	Jul	21	 2:00	0	-
+Rule	Morocco	2081	only	-	Jun	 1	 3:00	-1:00	-
+Rule	Morocco	2081	only	-	Jul	13	 2:00	0	-
+Rule	Morocco	2082	only	-	May	24	 3:00	-1:00	-
+Rule	Morocco	2082	only	-	Jun	28	 2:00	0	-
+Rule	Morocco	2083	only	-	May	16	 3:00	-1:00	-
+Rule	Morocco	2083	only	-	Jun	20	 2:00	0	-
+Rule	Morocco	2084	only	-	Apr	30	 3:00	-1:00	-
+Rule	Morocco	2084	only	-	Jun	11	 2:00	0	-
+Rule	Morocco	2085	only	-	Apr	22	 3:00	-1:00	-
+Rule	Morocco	2085	only	-	May	27	 2:00	0	-
+Rule	Morocco	2086	only	-	Apr	14	 3:00	-1:00	-
+Rule	Morocco	2086	only	-	May	19	 2:00	0	-
+Rule	Morocco	2087	only	-	Mar	30	 3:00	-1:00	-
+Rule	Morocco	2087	only	-	May	11	 2:00	0	-
+# For dates after the somewhat-arbitrary cutoff of 2087, assume that
+# Morocco will no longer observe DST.  At some point this table will
+# need to be extended, though quite possibly Morocco will change the
+# rules first.
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Africa/Casablanca	-0:30:20 -	LMT	1913 Oct 26
-			 0:00	Morocco	WE%sT	1984 Mar 16
-			 1:00	-	CET	1986
-			 0:00	Morocco	WE%sT
+			 0:00	Morocco	%z	1984 Mar 16
+			 1:00	-	%z	1986
+			 0:00	Morocco	%z	2018 Oct 28  3:00
+			 1:00	Morocco	%z
 
 # Western Sahara
 #
@@ -915,30 +1085,56 @@ Zone Africa/Casablanca	-0:30:20 -	LMT	1913 Oct 26
 # since most of it was then controlled by Morocco.
 
 Zone Africa/El_Aaiun	-0:52:48 -	LMT	1934 Jan # El Aaiún
-			-1:00	-	WAT	1976 Apr 14
-			 0:00	Morocco	WE%sT
+			-1:00	-	%z	1976 Apr 14
+			 0:00	Morocco	%z	2018 Oct 28  3:00
+			 1:00	Morocco	%z
 
+# Botswana
+# Burundi
+# Democratic Republic of the Congo (eastern)
+# Malawi
 # Mozambique
+# Rwanda
+# Zambia
+# Zimbabwe
 #
-# Shanks gives 1903-03-01 for the transition to CAT.
-# Perhaps the 1911-05-26 Portuguese decree
-# http://dre.pt/pdf1sdip/1911/05/12500/23132313.pdf
-# merely made it official?
+# From Tim Parenti (2024-07-01):
+# For timestamps before Mozambique's independence, see commentary for
+# Europe/Lisbon.
 #
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Africa/Maputo	2:10:20 -	LMT	1903 Mar
+# From Paul Eggert (2024-05-24):
+# The London Gazette, 1903-04-03, page 2245, says that
+# as of 1903-03-03 a time ball at the port of Lourenço Marques
+# (as Maputo was then called) was dropped daily at 13:00:00 LMT,
+# corresponding to 22:49:41.7 GMT, so local time was +02:10:18.3.
+# Conversely, the newspaper South Africa, 1909-02-09, page 321,
+# says the port had just installed an apparatus that communicated
+# "from the controlling clock in the new Observatory at Reuben Point ...
+# exact mean South African time, i.e., 30 deg., or 2 hours East of Greenwich".
+# Although Shanks gives 1903-03-01 for the transition to CAT,
+# evidently the port transitioned to CAT after 1903-03-03 but before
+# the Portuguese legal transition of 1912-01-01 (see Europe/Lisbon commentary).
+# For lack of better info, list 1909 as the transition date.
+#
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	2:10:18.3
+Zone	Africa/Maputo	2:10:18 -	LMT	1909
 			2:00	-	CAT
-Link Africa/Maputo Africa/Blantyre	# Malawi
-Link Africa/Maputo Africa/Bujumbura	# Burundi
-Link Africa/Maputo Africa/Gaborone	# Botswana
-Link Africa/Maputo Africa/Harare	# Zimbabwe
-Link Africa/Maputo Africa/Kigali	# Rwanda
-Link Africa/Maputo Africa/Lubumbashi	# E Dem. Rep. of Congo
-Link Africa/Maputo Africa/Lusaka	# Zambia
 
 # Namibia
-# The 1994-04-03 transition is from Shanks & Pottenger.
-# Shanks & Pottenger report no DST after 1998-04; go with IATA.
+
+# From Arthur David Olson (2017-08-09):
+# The text of the "Namibia Time Act, 1994" is available online at
+# www.lac.org.na/laws/1994/811.pdf
+# and includes this nugget:
+# Notwithstanding the provisions of subsection (2) of section 1, the
+# first winter period after the commencement of this Act shall
+# commence at OOhOO on Monday 21 March 1994 and shall end at 02h00 on
+# Sunday 4 September 1994.
+
+# From Michael Deckers (2017-04-06):
+# ... both summer and winter time are called "standard"
+# (which differs from the use in Ireland) ...
 
 # From Petronella Sibeene (2007-03-30):
 # http://allafrica.com/stories/200703300178.html
@@ -949,136 +1145,220 @@ Link Africa/Maputo Africa/Lusaka	# Zambia
 # the country are close to 40 minutes earlier in sunrise than the rest
 # of the country.
 #
-# From Paul Eggert (2007-03-31):
-# Apparently the Caprivi Strip informally observes Botswana time, but
-# we have no details.  In the meantime people there can use Africa/Gaborone.
+# From Paul Eggert (2017-02-22):
+# Although the Zambezi Region (formerly known as Caprivi) informally
+# observes Botswana time, we have no details about historical practice.
+# In the meantime people there can use Africa/Gaborone.
+# See: Immanuel S. The Namibian. 2017-02-23.
+# https://www.namibian.com.na/51480/read/Time-change-divides-lawmakers
 
-# RULE	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Namibia	1994	max	-	Sep	Sun>=1	2:00	1:00	S
-Rule	Namibia	1995	max	-	Apr	Sun>=1	2:00	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# From Steffen Thorsen (2017-08-09):
+# Namibia is going to change their time zone to what is now their DST:
+# https://www.newera.com.na/2017/02/23/namibias-winter-time-might-be-repealed/
+# This video is from the government decision:
+# https://www.nbc.na/news/na-passes-namibia-time-bill-repealing-1994-namibia-time-act.8665
+# We have made the assumption so far that they will change their time zone at
+# the same time they would normally start DST, the first Sunday in September:
+# https://www.timeanddate.com/news/time/namibia-new-time-zone.html
+
+# From Paul Eggert (2017-04-09):
+# Before the change, summer and winter time were both standard time legally.
+# However in common parlance, winter time was considered to be DST.  See, e.g.:
+# http://www.nbc.na/news/namibias-winter-time-could-be-scrapped.2706
+# https://zone.my.na/news/times-are-changing-in-namibia
+# https://www.newera.com.na/2017/02/23/namibias-winter-time-might-be-repealed/
+# Use plain "WAT" and "CAT" for the time zone abbreviations, to be compatible
+# with Namibia's neighbors.
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+# Vanguard section, for zic and other parsers that support negative DST.
+Rule	Namibia	1994	only	-	Mar	21	0:00	-1:00	WAT
+Rule	Namibia	1994	2017	-	Sep	Sun>=1	2:00	0	CAT
+Rule	Namibia	1995	2017	-	Apr	Sun>=1	2:00	-1:00	WAT
+# Rearguard section, for parsers lacking negative DST; see ziguard.awk.
+#Rule	Namibia	1994	only	-	Mar	21	0:00	0	WAT
+#Rule	Namibia	1994	2017	-	Sep	Sun>=1	2:00	1:00	CAT
+#Rule	Namibia	1995	2017	-	Apr	Sun>=1	2:00	0	WAT
+# End of rearguard section.
+
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Africa/Windhoek	1:08:24 -	LMT	1892 Feb 8
-			1:30	-	SWAT	1903 Mar    # SW Africa Time
+			1:30	-	%z	1903 Mar
 			2:00	-	SAST	1942 Sep 20  2:00
 			2:00	1:00	SAST	1943 Mar 21  2:00
 			2:00	-	SAST	1990 Mar 21 # independence
-			2:00	-	CAT	1994 Apr  3
-			1:00	Namibia	WA%sT
+# Vanguard section, for zic and other parsers that support negative DST.
+			2:00	Namibia	%s
+# Rearguard section, for parsers lacking negative DST; see ziguard.awk.
+#			2:00	-	CAT	1994 Mar 21  0:00
+# From Paul Eggert (2017-04-07):
+# The official date of the 2017 rule change was 2017-10-24.  See:
+# http://www.lac.org.na/laws/annoSTAT/Namibian%20Time%20Act%209%20of%202017.pdf
+#			1:00	Namibia	%s	2017 Oct 24
+#			2:00	-	CAT
+# End of rearguard section.
 
+
+# Angola
+# Benin
+# Cameroon
+# Central African Republic
+# Democratic Republic of the Congo (western)
+# Republic of the Congo
+# Equatorial Guinea
+# Gabon
 # Niger
-# See Africa/Lagos.
-
 # Nigeria
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Africa/Lagos	0:13:36 -	LMT	1919 Sep
+
+# From P Chan (2020-12-03):
+# GMT was adopted as the standard time of Lagos on 1905-07-01.
+# Lagos Weekly Record, 1905-06-24, p 3
+# http://ddsnext.crl.edu/titles/31558#?c=0&m=668&s=0&cv=2&r=0&xywh=1446,5221,1931,1235
+# says "It is officially notified that on and after the 1st of July 1905
+# Greenwich Mean Solar Time will be adopted throughout the Colony and
+# Protectorate, and that it will be necessary to put all clocks 13 minutes and
+# 35 seconds back, recording local mean time."
+#
+# It seemed that Lagos returned to LMT on 1908-07-01.
+# [The Lagos Standard], 1908-07-01, p 5
+# http://ddsnext.crl.edu/titles/31556#?c=0&m=78&s=0&cv=4&r=0&xywh=-92,3590,3944,2523
+# says "Scarcely have the people become accustomed to this new time, when
+# another official notice has now appeared announcing that from and after the
+# 1st July next, return will be made to local mean time."
+#
+# From P Chan (2020-11-27):
+# On 1914-01-01, standard time of GMT+0:30 was adopted for the unified Nigeria.
+# Colonial Reports - Annual. No. 878. Nigeria. Report for 1914. (April 1916),
+# p 27
+# https://libsysdigi.library.illinois.edu/ilharvest/Africana/Books2011-05/3064634/3064634_1914/3064634_1914_opt.pdf#page=27
+# "On January 1st [1914], a universal standard time for Nigeria was adopted,
+# viz., half an hour fast on Greenwich mean time, corresponding to the meridian
+# 7° 30' E. long."
+# Lloyd's Register of Shipping (1915) says "Hitherto the time observed in Lagos
+# was the local mean time. On 1st January, 1914, standard time for the whole of
+# Nigeria was introduced ... Lagos time has been advanced about 16 minutes
+# accordingly."
+#
+# In 1919, standard time was changed to GMT+1.
+# Interpretation Ordinance (Cap 2)
+# The Laws of Nigeria, Containing the Ordinances of Nigeria, in Force on the
+# 1st Day of January, 1923, Vol.I [p 16]
+# https://books.google.com/books?id=BOMrAQAAMAAJ&pg=PA16
+# "The expression 'Standard time' means standard time as used in Nigeria:
+# namely, 60 minutes in advance of Greenwich mean time.  (As amended by 18 of
+# 1919, s. 2.)"
+# From Tim Parenti (2020-12-10):
+# The Lagos Weekly Record, 1919-09-20, p 3 details discussion on the first
+# reading of this Bill by the Legislative Council of the Colony of Nigeria on
+# Thursday 1919-08-28:
+# http://ddsnext.crl.edu/titles/31558?terms&item_id=303484#?m=1118&c=1&s=0&cv=2&r=0&xywh=1261,3408,2994,1915
+# "The proposal is that the Globe should be divided into twelve zones East and
+# West of Greenwich, of one hour each, Nigeria falling into the zone with a
+# standard of one hour fast on Greenwich Mean Time.  Nigeria standard time is
+# now 30 minutes in advance of Greenwich Mean Time ... according to the new
+# proposal, standard time will be advanced another 30 minutes".  It was further
+# proposed that the firing of the time guns likewise be adjusted by 30 minutes
+# to compensate.
+# From Tim Parenti (2020-12-10), per P Chan (2020-12-11):
+# The text of Ordinance 18 of 1919, published in Nigeria Gazette, Vol 6, No 52,
+# shows that the change was assented to the following day and took effect "on
+# the 1st day of September, 1919."
+# Nigeria Gazette and Supplements 1919 Jan-Dec, Reference: 73266B-40,
+# img 245-246
+# https://microform.digital/boa/collections/77/volumes/539/nigeria-lagos-1887-1919
+
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Africa/Lagos	0:13:35 -	LMT	1905 Jul  1
+			0:00	-	GMT	1908 Jul  1
+			0:13:35	-	LMT	1914 Jan  1
+			0:30	-	%z	1919 Sep  1
 			1:00	-	WAT
-Link Africa/Lagos Africa/Bangui	     # Central African Republic
-Link Africa/Lagos Africa/Brazzaville # Rep. of the Congo
-Link Africa/Lagos Africa/Douala	     # Cameroon
-Link Africa/Lagos Africa/Kinshasa    # Dem. Rep. of the Congo (west)
-Link Africa/Lagos Africa/Libreville  # Gabon
-Link Africa/Lagos Africa/Luanda	     # Angola
-Link Africa/Lagos Africa/Malabo	     # Equatorial Guinea
-Link Africa/Lagos Africa/Niamey	     # Niger
-Link Africa/Lagos Africa/Porto-Novo  # Benin
-
-# Réunion
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Indian/Reunion	3:41:52 -	LMT	1911 Jun # Saint-Denis
-			4:00	-	RET	# Réunion Time
-#
-# Crozet Islands also observes Réunion time; see the 'antarctica' file.
-#
-# Scattered Islands (Îles Éparses) administered from Réunion are as follows.
-# The following information about them is taken from
-# Îles Éparses (<http://www.outre-mer.gouv.fr/domtom/ile.htm>, 1997-07-22,
-# in French; no longer available as of 1999-08-17).
-# We have no info about their time zone histories.
-#
-# Bassas da India - uninhabited
-# Europa Island - inhabited from 1905 to 1910 by two families
-# Glorioso Is - inhabited until at least 1958
-# Juan de Nova - uninhabited
-# Tromelin - inhabited until at least 1958
-
-# Rwanda
-# See Africa/Maputo.
-
-# St Helena
-# See Africa/Abidjan.
-# The other parts of the St Helena territory are similar:
-#	Tristan da Cunha: on GMT, say Whitman and the CIA
-#	Ascension: on GMT, say the USNO (1995-12-21) and the CIA
-#	Gough (scientific station since 1955; sealers wintered previously):
-#		on GMT, says the CIA
-#	Inaccessible, Nightingale: uninhabited
 
 # São Tomé and Príncipe
-# Senegal
-# See Africa/Abidjan.
 
-# Seychelles
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Indian/Mahe	3:41:48 -	LMT	1906 Jun # Victoria
-			4:00	-	SCT	# Seychelles Time
-# From Paul Eggert (2001-05-30):
-# Aldabra, Farquhar, and Desroches, originally dependencies of the
-# Seychelles, were transferred to the British Indian Ocean Territory
-# in 1965 and returned to Seychelles control in 1976.  We don't know
-# whether this affected their time zone, so omit this for now.
-# Possibly the islands were uninhabited.
+# See Europe/Lisbon for info about the 1912 transition.
 
-# Sierra Leone
-# See Africa/Abidjan.
+# From Steffen Thorsen (2018-01-08):
+# Multiple sources tell that São Tomé changed from UTC to UTC+1 as
+# they entered the year 2018.
+# From Michael Deckers (2018-01-08):
+# the switch is from 01:00 to 02:00 ... [Decree No. 25/2017]
+# http://www.mnec.gov.st/index.php/publicacoes/documentos/file/90-decreto-lei-n-25-2017
 
-# Somalia
-# See Africa/Nairobi.
+# From Vadim Nasardinov (2018-12-29):
+# São Tomé and Príncipe is about to do the following on Jan 1, 2019:
+# https://www.stp-press.st/2018/12/05/governo-jesus-ja-decidiu-repor-hora-legal-sao-tomense/
+#
+# From Michael Deckers (2018-12-30):
+# https://www.legis-palop.org/download.jsp?idFile=102818
+# ... [The legal time of the country, which coincides with universal
+# coordinated time, will be reinstituted at 2 o'clock on day 1 of January, 2019.]
 
+Zone	Africa/Sao_Tome	 0:26:56 -	LMT	1884
+		#STDOFF	-0:36:44.68
+			-0:36:45 -	LMT	1912 Jan  1 00:00u # Lisbon MT
+			 0:00	-	GMT	2018 Jan  1 01:00
+			 1:00	-	WAT	2019 Jan  1 02:00
+			 0:00	-	GMT
+
+# Eswatini (Swaziland)
+# Lesotho
 # South Africa
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	SA	1942	1943	-	Sep	Sun>=15	2:00	1:00	-
 Rule	SA	1943	1944	-	Mar	Sun>=15	2:00	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Africa/Johannesburg 1:52:00 -	LMT	1892 Feb 8
 			1:30	-	SAST	1903 Mar
 			2:00	SA	SAST
-Link Africa/Johannesburg Africa/Maseru	   # Lesotho
-Link Africa/Johannesburg Africa/Mbabane    # Swaziland
 #
 # Marion and Prince Edward Is
 # scientific station since 1947
 # no information
 
 # Sudan
-#
+
 # From <http://www.sunanews.net/sn13jane.html>
 # Sudan News Agency (2000-01-13),
 # also reported by Michaël De Beukelaer-Dossche via Steffen Thorsen:
 # Clocks will be moved ahead for 60 minutes all over the Sudan as of noon
 # Saturday....  This was announced Thursday by Caretaker State Minister for
 # Manpower Abdul-Rahman Nur-Eddin.
+
+# From Ahmed Atyya, National Telecommunications Corp. (NTC), Sudan (2017-10-17):
+# ... the Republic of Sudan is going to change the time zone from (GMT+3:00)
+# to (GMT+ 2:00) starting from Wednesday 1 November 2017.
 #
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# From Paul Eggert (2017-10-18):
+# A scanned copy (in Arabic) of Cabinet Resolution No. 352 for the
+# year 2017 can be found as an attachment in email today from Yahia
+# Abdalla of NTC, archived at:
+# https://mm.icann.org/pipermail/tz/2017-October/025333.html
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Sudan	1970	only	-	May	 1	0:00	1:00	S
 Rule	Sudan	1970	1985	-	Oct	15	0:00	0	-
 Rule	Sudan	1971	only	-	Apr	30	0:00	1:00	S
 Rule	Sudan	1972	1985	-	Apr	lastSun	0:00	1:00	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Africa/Khartoum	2:10:08 -	LMT	1931
 			2:00	Sudan	CA%sT	2000 Jan 15 12:00
-			3:00	-	EAT
+			3:00	-	EAT	2017 Nov  1
+			2:00	-	CAT
 
 # South Sudan
-Link Africa/Khartoum Africa/Juba
 
-# Swaziland
-# See Africa/Johannesburg.
+# From Steffen Thorsen (2021-01-18):
+# "South Sudan will change its time zone by setting the clock back 1
+# hour on February 1, 2021...."
+# from https://eyeradio.org/south-sudan-adopts-new-time-zone-makuei/
 
-# Tanzania
-# See Africa/Nairobi.
-
-# Togo
-# See Africa/Abidjan.
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Africa/Juba	2:06:28 -	LMT	1931
+			2:00	Sudan	CA%sT	2000 Jan 15 12:00
+			3:00	-	EAT	2021 Feb  1 00:00
+			2:00	-	CAT
 
 # Tunisia
 
@@ -1107,11 +1387,11 @@ Link Africa/Khartoum Africa/Juba
 # According to several news sources, Tunisia will not observe DST this year.
 # (Arabic)
 # http://www.elbashayer.com/?page=viewn&nid=42546
-# http://www.babnet.net/kiwidetail-15295.asp
+# https://www.babnet.net/kiwidetail-15295.asp
 #
 # We have also confirmed this with the US embassy in Tunisia.
 # We have a wrap-up about this on the following page:
-# http://www.timeanddate.com/news/time/tunisia-cancels-dst-2009.html
+# https://www.timeanddate.com/news/time/tunisia-cancels-dst-2009.html
 
 # From Alexander Krivenyshev (2009-03-17):
 # Here is a link to Tunis Afrique Presse News Agency
@@ -1145,7 +1425,7 @@ Link Africa/Khartoum Africa/Juba
 # http://www.almadenahnews.com/newss/news.php?c=118&id=38036
 # http://www.worldtimezone.com/dst_news/dst_news_tunis02.html
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Tunisia	1939	only	-	Apr	15	23:00s	1:00	S
 Rule	Tunisia	1939	only	-	Nov	18	23:00s	0	-
 Rule	Tunisia	1940	only	-	Feb	25	23:00s	1:00	S
@@ -1172,20 +1452,13 @@ Rule	Tunisia	2005	only	-	Sep	30	 1:00s	0	-
 Rule	Tunisia	2006	2008	-	Mar	lastSun	 2:00s	1:00	S
 Rule	Tunisia	2006	2008	-	Oct	lastSun	 2:00s	0	-
 
-# Shanks & Pottenger give 0:09:20 for Paris Mean Time; go with Howse's
-# more precise 0:09:21.
-# Shanks & Pottenger say the 1911 switch was on Mar 9; go with Howse's Mar 11.
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# See Europe/Paris commentary for PMT-related transitions.
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Africa/Tunis	0:40:44 -	LMT	1881 May 12
 			0:09:21	-	PMT	1911 Mar 11 # Paris Mean Time
 			1:00	Tunisia	CE%sT
+# tzdb data for Antarctica and environs
 
-# Uganda
-# See Africa/Nairobi.
-
-# Zambia
-# Zimbabwe
-# See Africa/Maputo.
 # This file is in the public domain, so clarified as of
 # 2009-05-17 by Arthur David Olson.
 
@@ -1199,7 +1472,7 @@ Zone	Africa/Tunis	0:40:44 -	LMT	1881 May 12
 # for information.
 # Unless otherwise specified, we have no time zone information.
 
-# FORMAT is '-00' and GMTOFF is 0 for locations while uninhabited.
+# FORMAT is '-00' and STDOFF is 0 for locations while uninhabited.
 
 # Argentina - year-round bases
 # Belgrano II, Confin Coast, -770227-0343737, since 1972-02-05
@@ -1214,7 +1487,7 @@ Zone	Africa/Tunis	0:40:44 -	LMT	1881 May 12
 # Heard Island, McDonald Islands (uninhabited)
 #	previously sealers and scientific personnel wintered
 #	Margaret Turner reports
-#	http://web.archive.org/web/20021204222245/http://www.dstc.qut.edu.au/DST/marg/daylight.html
+#	https://web.archive.org/web/20021204222245/http://www.dstc.qut.edu.au/DST/marg/daylight.html
 #	(1999-09-30) that they're UT +05, with no DST;
 #	presumably this is when they have visitors.
 #
@@ -1235,7 +1508,7 @@ Zone	Africa/Tunis	0:40:44 -	LMT	1881 May 12
 # http://www.aad.gov.au/default.asp?casid=37079
 #
 # We have more background information here:
-# http://www.timeanddate.com/news/time/antarctica-new-times.html
+# https://www.timeanddate.com/news/time/antarctica-new-times.html
 
 # From Steffen Thorsen (2010-03-10):
 # We got these changes from the Australian Antarctic Division: ...
@@ -1250,31 +1523,57 @@ Zone	Africa/Tunis	0:40:44 -	LMT	1881 May 12
 # - Mawson station stays on UTC+5.
 #
 # Background:
-# http://www.timeanddate.com/news/time/antartica-time-changes-2010.html
+# https://www.timeanddate.com/news/time/antartica-time-changes-2010.html
 
 # From Steffen Thorsen (2016-10-28):
 # Australian Antarctica Division informed us that Casey changed time
 # zone to UTC+11 in "the morning of 22nd October 2016".
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Antarctica/Casey	0	-	-00	1969
-			8:00	-	+08	2009 Oct 18  2:00
-			11:00	-	+11	2010 Mar  5  2:00
-			8:00	-	+08	2011 Oct 28  2:00
-			11:00	-	+11	2012 Feb 21 17:00u
-			8:00	-	+08	2016 Oct 22
-			11:00	-	+11
+# From Steffen Thorsen (2020-10-02, as corrected):
+# Based on information we have received from the Australian Antarctic
+# Division, Casey station and Macquarie Island station will move to Tasmanian
+# daylight savings time on Sunday 4 October. This will take effect from 0001
+# hrs on Sunday 4 October 2020 and will mean Casey and Macquarie Island will
+# be on the same time zone as Hobart.  Some past dates too for this 3 hour
+# time change back and forth between UTC+8 and UTC+11 for Casey:
+# - 2018 Oct  7 4:00 - 2019 Mar 17 3:00 - 2019 Oct  4 3:00 - 2020 Mar  8 3:00
+# and now - 2020 Oct  4 0:01
+
+# From Paul Eggert (2023-12-20):
+# Transitions from 2021 on are taken from:
+# https://www.timeanddate.com/time/zone/antarctica/casey
+# retrieved at various dates.
+
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone Antarctica/Casey	 0	-	-00	1969
+			 8:00	-	%z	2009 Oct 18  2:00
+			11:00	-	%z	2010 Mar  5  2:00
+			 8:00	-	%z	2011 Oct 28  2:00
+			11:00	-	%z	2012 Feb 21 17:00u
+			 8:00	-	%z	2016 Oct 22
+			11:00	-	%z	2018 Mar 11  4:00
+			 8:00	-	%z	2018 Oct  7  4:00
+			11:00	-	%z	2019 Mar 17  3:00
+			 8:00	-	%z	2019 Oct  4  3:00
+			11:00	-	%z	2020 Mar  8  3:00
+			 8:00	-	%z	2020 Oct  4  0:01
+			11:00	-	%z	2021 Mar 14  0:00
+			 8:00	-	%z	2021 Oct  3  0:01
+			11:00	-	%z	2022 Mar 13  0:00
+			 8:00	-	%z	2022 Oct  2  0:01
+			11:00	-	%z	2023 Mar  9  3:00
+			 8:00	-	%z
 Zone Antarctica/Davis	0	-	-00	1957 Jan 13
-			7:00	-	+07	1964 Nov
+			7:00	-	%z	1964 Nov
 			0	-	-00	1969 Feb
-			7:00	-	+07	2009 Oct 18  2:00
-			5:00	-	+05	2010 Mar 10 20:00u
-			7:00	-	+07	2011 Oct 28  2:00
-			5:00	-	+05	2012 Feb 21 20:00u
-			7:00	-	+07
+			7:00	-	%z	2009 Oct 18  2:00
+			5:00	-	%z	2010 Mar 10 20:00u
+			7:00	-	%z	2011 Oct 28  2:00
+			5:00	-	%z	2012 Feb 21 20:00u
+			7:00	-	%z
 Zone Antarctica/Mawson	0	-	-00	1954 Feb 13
-			6:00	-	+06	2009 Oct 18  2:00
-			5:00	-	+05
+			6:00	-	%z	2009 Oct 18  2:00
+			5:00	-	%z
 # References:
 # Casey Weather (1998-02-26)
 # http://www.antdiv.gov.au/aad/exop/sfo/casey/casey_aws.html
@@ -1298,7 +1597,8 @@ Zone Antarctica/Mawson	0	-	-00	1954 Feb 13
 # O'Higgins, Antarctic Peninsula, -6319-05704, since 1948-02
 # Prat, -6230-05941
 # Villa Las Estrellas (a town), around the Frei base, since 1984-04-09
-# These locations have always used Santiago time; use TZ='America/Santiago'.
+# These locations employ Region of Magallanes time; use
+# TZ='America/Punta_Arenas'.
 
 # China - year-round bases
 # Great Wall, King George Island, -6213-05858, since 1985-02-20
@@ -1317,7 +1617,7 @@ Zone Antarctica/Mawson	0	-	-00	1954 Feb 13
 #
 # Alfred Faure, Possession Island, Crozet Islands, -462551+0515152, since 1964;
 #	sealing & whaling stations operated variously 1802/1911+;
-#	see Indian/Reunion.
+#	see Asia/Dubai.
 #
 # Martin-de-Viviès, Amsterdam Island, -374105+0773155, since 1950
 # Port-aux-Français, Kerguelen Islands, -492110+0701303, since 1951;
@@ -1326,25 +1626,15 @@ Zone Antarctica/Mawson	0	-	-00	1954 Feb 13
 # St Paul Island - near Amsterdam, uninhabited
 #	fishing stations operated variously 1819/1931
 #
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Indian/Kerguelen	0	-	-00	1950 # Port-aux-Français
-			5:00	-	+05
+# Kerguelen - see Indian/Maldives.
 #
 # year-round base in the main continent
-# Dumont d'Urville, Île des Pétrels, -6640+14001, since 1956-11
-# <http://en.wikipedia.org/wiki/Dumont_d'Urville_Station> (2005-12-05)
-#
-# Another base at Port-Martin, 50km east, began operation in 1947.
-# It was destroyed by fire on 1952-01-14.
-#
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Antarctica/DumontDUrville 0 -	-00	1947
-			10:00	-	+10	1952 Jan 14
-			0	-	-00	1956 Nov
-			10:00	-	+10
+# Dumont d'Urville - see Pacific/Port_Moresby.
 
 # France & Italy - year-round base
 # Concordia, -750600+1232000, since 2005
+# https://en.wikipedia.org/wiki/Concordia_Station
+# Can use Asia/Singapore, which it has agreed with since inception.
 
 # Germany - year-round base
 # Neumayer III, -704080-0081602, since 2009
@@ -1357,20 +1647,7 @@ Zone Antarctica/DumontDUrville 0 -	-00	1947
 # Zuchelli, Terra Nova Bay, -744140+1640647, since 1986
 
 # Japan - year-round bases
-# Syowa (also known as Showa), -690022+0393524, since 1957
-#
-# From Hideyuki Suzuki (1999-02-06):
-# In all Japanese stations, +0300 is used as the standard time.
-#
-# Syowa station, which is the first antarctic station of Japan,
-# was established on 1957-01-29.  Since Syowa station is still the main
-# station of Japan, it's appropriate for the principal location.
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Antarctica/Syowa	0	-	-00	1957 Jan 29
-			3:00	-	+03
-# See:
-# NIPR Antarctic Research Activities (1999-08-17)
-# http://www.nipr.ac.jp/english/ara01.html
+# See Asia/Riyadh.
 
 # S Korea - year-round base
 # Jang Bogo, Terra Nova Bay, -743700+1641205 since 2014
@@ -1408,14 +1685,14 @@ Zone Antarctica/Syowa	0	-	-00	1957 Jan 29
 # suggested by Bengt-Inge Larsson comment them out for now, and approximate
 # with only UTC and CEST.  Uncomment them when 2014b is more prevalent.
 #
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 #Rule	Troll	2005	max	-	Mar	 1	1:00u	1:00	+01
 Rule	Troll	2005	max	-	Mar	lastSun	1:00u	2:00	+02
 #Rule	Troll	2005	max	-	Oct	lastSun	1:00u	1:00	+01
 #Rule	Troll	2004	max	-	Nov	 7	1:00u	0:00	+00
 # Remove the following line when uncommenting the above '#Rule' lines.
 Rule	Troll	2004	max	-	Oct	lastSun	1:00u	0:00	+00
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Antarctica/Troll	0	-	-00	2005 Feb 12
 			0:00	Troll	%s
 
@@ -1455,10 +1732,29 @@ Zone Antarctica/Troll	0	-	-00	2005 Feb 12
 # changes during the year and does not necessarily correspond to mean
 # solar noon.  So the Vostok time might have been whatever the clocks
 # happened to be during their visit.  So we still don't really know what time
-# it is at Vostok.  But we'll guess +06.
+# it is at Vostok.
 #
+# From Zakhary V. Akulov (2023-12-17 22:00:48 +0700):
+# ... from December, 18, 2023 00:00 by my decision the local time of
+# the Antarctic research base Vostok will correspond to UTC+5.
+# (2023-12-19): We constantly interact with Progress base, with company who
+# builds new wintering station, with sledge convoys, with aviation - they all
+# use UTC+5. Besides, difference between Moscow time is just 2 hours now, not 4.
+# (2023-12-19, in response to the question "Has local time at Vostok
+# been UTC+6 ever since 1957, or has it changed before?"): No. At least
+# since my antarctic career start, 10 years ago, Vostok base has UTC+7.
+# (In response to a 2023-12-18 question "from 02:00 to 00:00 today"): This.
+#
+# From Paul Eggert (2023-12-18):
+# For lack of better info, guess Vostok was at +07 from founding through today,
+# except when closed.
+
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Antarctica/Vostok	0	-	-00	1957 Dec 16
-			6:00	-	+06
+			7:00	-	%z	1994 Feb
+			0	-	-00	1994 Nov
+			7:00	-	%z	2023 Dec 18  2:00
+			5:00	-	%z
 
 # S Africa - year-round bases
 # Marion Island, -4653+03752
@@ -1489,9 +1785,9 @@ Zone Antarctica/Vostok	0	-	-00	1957 Dec 16
 # From Paul Eggert (2002-10-22)
 # <http://webexhibits.org/daylightsaving/g.html> says Rothera is -03 all year.
 #
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Antarctica/Rothera	0	-	-00	1976 Dec  1
-			-3:00	-	-03
+			-3:00	-	%z
 
 # Uruguay - year round base
 # Artigas, King George Island, -621104-0585107
@@ -1510,7 +1806,7 @@ Zone Antarctica/Rothera	0	-	-00	1976 Dec  1
 # but that he found it more convenient to keep GMT+12
 # as supplies for the station were coming from McMurdo Sound,
 # which was on GMT+12 because New Zealand was on GMT+12 all year
-# at that time (1957).  (Source: Siple's book 90 Degrees South.)
+# at that time (1957).  (Source: Siple's book 90° South.)
 #
 # From Susan Smith
 # http://www.cybertours.com/whs/pole10.html
@@ -1524,7 +1820,9 @@ Zone Antarctica/Rothera	0	-	-00	1976 Dec  1
 # we have to go around and set them back 5 minutes or so.
 # Maybe if we let them run fast all of the time, we'd get to leave here sooner!!
 #
-# See 'australasia' for Antarctica/McMurdo.
+# See Pacific/Auckland.
+# tzdb data for Asia and environs
+
 # This file is in the public domain, so clarified as of
 # 2009-05-17 by Arthur David Olson.
 
@@ -1533,15 +1831,15 @@ Zone Antarctica/Rothera	0	-	-00	1976 Dec  1
 # tz@iana.org for general use in the future).  For more, please see
 # the file CONTRIBUTING in the tz distribution.
 
-# From Paul Eggert (2015-08-08):
+# From Paul Eggert (2019-07-11):
 #
 # Unless otherwise specified, the source for data through 1990 is:
 # Thomas G. Shanks and Rique Pottenger, The International Atlas (6th edition),
 # San Diego: ACS Publications, Inc. (2003).
 # Unfortunately this book contains many errors and cites no sources.
 #
-# Gwillim Law writes that a good source
-# for recent time zone data is the International Air Transport
+# Many years ago Gwillim Law wrote that a good source
+# for time zone data was the International Air Transport
 # Association's Standard Schedules Information Manual (IATA SSIM),
 # published semiannually.  Law sent in several helpful summaries
 # of the IATA's data after 1990.  Except where otherwise noted,
@@ -1553,38 +1851,33 @@ Zone Antarctica/Rothera	0	-	-00	1976 Dec  1
 #
 # For data circa 1899, a common source is:
 # Milne J. Civil time. Geogr J. 1899 Feb;13(2):173-94.
-# http://www.jstor.org/stable/1774359
+# https://www.jstor.org/stable/1774359
 #
 # For Russian data circa 1919, a source is:
 # Byalokoz EL. New Counting of Time in Russia since July 1, 1919.
 # (See the 'europe' file for a fuller citation.)
 #
-# A reliable and entertaining source about time zones is
-# Derek Howse, Greenwich time and longitude, Philip Wilson Publishers (1997).
-#
-# I invented the abbreviations marked '*' in the following table;
-# the rest are from earlier versions of this file, or from other sources.
-# Corrections are welcome!
+# The following alphabetic abbreviations appear in these tables
+# (corrections are welcome):
 #	     std  dst
 #	     LMT	Local Mean Time
 #	2:00 EET  EEST	Eastern European Time
 #	2:00 IST  IDT	Israel
-#	3:00 AST  ADT	Arabia*
-#	3:30 IRST IRDT	Iran*
-#	4:00 GST	Gulf*
 #	5:30 IST	India
-#	7:00 ICT	Indochina, most times and locations*
 #	7:00 WIB	west Indonesia (Waktu Indonesia Barat)
 #	8:00 WITA	central Indonesia (Waktu Indonesia Tengah)
 #	8:00 CST	China
-#	8:00 IDT	Indochina, 1943-45, 1947-55, 1960-75 (some locations)*
-#	8:00 JWST	Western Standard Time (Japan, 1896/1937)*
-#	8:30 KST  KDT	Korea when at +0830*
-#	9:00 JCST	Central Standard Time (Japan, 1896/1937)
+#	8:00 HKT  HKST	Hong Kong (HKWT* for Winter Time in late 1941)
+#	8:00 PST  PDT*	Philippines
+#	8:30 KST  KDT	Korea when at +0830
 #	9:00 WIT	east Indonesia (Waktu Indonesia Timur)
 #	9:00 JST  JDT	Japan
 #	9:00 KST  KDT	Korea when at +09
-#	9:30 ACST	Australian Central Standard Time
+# *I invented the abbreviations HKWT and PDT; see below.
+# Otherwise, these tables typically use numeric abbreviations like +03
+# and +0330 for integer hour and minute UT offsets.  Although earlier
+# editions invented alphabetic time zone abbreviations for every
+# offset, this did not reflect common practice.
 #
 # See the 'europe' file for Russia and Turkey in Asia.
 
@@ -1592,29 +1885,29 @@ Zone Antarctica/Rothera	0	-	-00	1976 Dec  1
 # Incorporates data for Singapore from Robert Elz' asia 1.1, as well as
 # additional information from Tom Yap, Sun Microsystems Intercontinental
 # Technical Support (including a page from the Official Airline Guide -
-# Worldwide Edition).  The names for time zones are guesses.
+# Worldwide Edition).
 
 ###############################################################################
 
 # These rules are stolen from the 'europe' file.
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	EUAsia	1981	max	-	Mar	lastSun	 1:00u	1:00	S
 Rule	EUAsia	1979	1995	-	Sep	lastSun	 1:00u	0	-
 Rule	EUAsia	1996	max	-	Oct	lastSun	 1:00u	0	-
-Rule E-EurAsia	1981	max	-	Mar	lastSun	 0:00	1:00	S
+Rule E-EurAsia	1981	max	-	Mar	lastSun	 0:00	1:00	-
 Rule E-EurAsia	1979	1995	-	Sep	lastSun	 0:00	0	-
 Rule E-EurAsia	1996	max	-	Oct	lastSun	 0:00	0	-
-Rule RussiaAsia	1981	1984	-	Apr	1	 0:00	1:00	S
+Rule RussiaAsia	1981	1984	-	Apr	1	 0:00	1:00	-
 Rule RussiaAsia	1981	1983	-	Oct	1	 0:00	0	-
 Rule RussiaAsia	1984	1995	-	Sep	lastSun	 2:00s	0	-
-Rule RussiaAsia	1985	2011	-	Mar	lastSun	 2:00s	1:00	S
-Rule RussiaAsia	1996	2011	-	Oct	lastSun	 2:00s	0	-
+Rule RussiaAsia	1985	2010	-	Mar	lastSun	 2:00s	1:00	-
+Rule RussiaAsia	1996	2010	-	Oct	lastSun	 2:00s	0	-
 
 # Afghanistan
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Kabul	4:36:48 -	LMT	1890
-			4:00	-	AFT	1945
-			4:30	-	AFT
+			4:00	-	%z	1945
+			4:30	-	%z
 
 # Armenia
 # From Paul Eggert (2006-03-22):
@@ -1641,13 +1934,17 @@ Zone	Asia/Kabul	4:36:48 -	LMT	1890
 # or
 # (brief)
 # http://www.worldtimezone.com/dst_news/dst_news_armenia03.html
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule Armenia	2011	only	-	Mar	lastSun	 2:00s	1:00	-
+Rule Armenia	2011	only	-	Oct	lastSun	 2:00s	0	-
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Yerevan	2:58:00 -	LMT	1924 May  2
-			3:00	-	+03	1957 Mar
-			4:00 RussiaAsia +04/+05	1991 Mar 31  2:00s
-			3:00 RussiaAsia	+03/+04	1995 Sep 24  2:00s
-			4:00	-	+04	1997
-			4:00 RussiaAsia	+04/+05
+			3:00	-	%z	1957 Mar
+			4:00 RussiaAsia %z	1991 Mar 31  2:00s
+			3:00 RussiaAsia	%z	1995 Sep 24  2:00s
+			4:00	-	%z	1997
+			4:00 RussiaAsia	%z	2011
+			4:00	Armenia	%z
 
 # Azerbaijan
 
@@ -1659,24 +1956,21 @@ Zone	Asia/Yerevan	2:58:00 -	LMT	1924 May  2
 # From Steffen Thorsen (2016-03-17):
 # ... the Azerbaijani Cabinet of Ministers has cancelled switching to
 # daylight saving time....
-# http://www.azernews.az/azerbaijan/94137.html
+# https://www.azernews.az/azerbaijan/94137.html
 # http://vestnikkavkaza.net/news/Azerbaijani-Cabinet-of-Ministers-cancels-daylight-saving-time.html
 # http://en.apa.az/xeber_azerbaijan_abolishes_daylight_savings_ti_240862.html
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Azer	1997	2015	-	Mar	lastSun	 4:00	1:00	S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Azer	1997	2015	-	Mar	lastSun	 4:00	1:00	-
 Rule	Azer	1997	2015	-	Oct	lastSun	 5:00	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Baku	3:19:24 -	LMT	1924 May  2
-			3:00	-	+03	1957 Mar
-			4:00 RussiaAsia +04/+05	1991 Mar 31  2:00s
-			3:00 RussiaAsia	+03/+04	1992 Sep lastSun  2:00s
-			4:00	-	+04	1996
-			4:00	EUAsia	+04/+05	1997
-			4:00	Azer	+04/+05
-
-# Bahrain
-# See Asia/Qatar.
+			3:00	-	%z	1957 Mar
+			4:00 RussiaAsia %z	1991 Mar 31  2:00s
+			3:00 RussiaAsia	%z	1992 Sep lastSun  2:00s
+			4:00	-	%z	1996
+			4:00	EUAsia	%z	1997
+			4:00	Azer	%z
 
 # Bangladesh
 # From Alexander Krivenyshev (2009-05-13):
@@ -1700,11 +1994,11 @@ Zone	Asia/Baku	3:19:24 -	LMT	1924 May  2
 # the 19th and 20th, and they have not set the end date yet.
 #
 # Some sources:
-# http://in.reuters.com/article/southAsiaNews/idINIndia-40017620090601
+# https://in.reuters.com/article/southAsiaNews/idINIndia-40017620090601
 # http://bdnews24.com/details.php?id=85889&cid=2
 #
 # Our wrap-up:
-# http://www.timeanddate.com/news/time/bangladesh-daylight-saving-2009.html
+# https://www.timeanddate.com/news/time/bangladesh-daylight-saving-2009.html
 
 # From A. N. M. Kamrus Saadat (2009-06-15):
 # Finally we've got the official mail regarding DST start time where DST start
@@ -1750,25 +2044,24 @@ Zone	Asia/Baku	3:19:24 -	LMT	1924 May  2
 # http://www.thedailystar.net/newDesign/latest_news.php?nid=22817
 # http://www.worldtimezone.com/dst_news/dst_news_bangladesh06.html
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Dhaka	2009	only	-	Jun	19	23:00	1:00	S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Dhaka	2009	only	-	Jun	19	23:00	1:00	-
 Rule	Dhaka	2009	only	-	Dec	31	24:00	0	-
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Dhaka	6:01:40 -	LMT	1890
 			5:53:20	-	HMT	1941 Oct    # Howrah Mean Time?
-			6:30	-	BURT	1942 May 15 # Burma Time
-			5:30	-	IST	1942 Sep
-			6:30	-	BURT	1951 Sep 30
-			6:00	-	DACT	1971 Mar 26 # Dacca Time
-			6:00	-	BDT	2009
-			6:00	Dhaka	BD%sT
+			6:30	-	%z	1942 May 15
+			5:30	-	%z	1942 Sep
+			6:30	-	%z	1951 Sep 30
+			6:00	-	%z	2009
+			6:00	Dhaka	%z
 
 # Bhutan
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Thimphu	5:58:36 -	LMT	1947 Aug 15 # or Thimbu
-			5:30	-	IST	1987 Oct
-			6:00	-	BTT	# Bhutan Time
+			5:30	-	%z	1987 Oct
+			6:00	-	%z
 
 # British Indian Ocean Territory
 # Whitman and the 1995 CIA time zone map say 5:00, but the
@@ -1776,33 +2069,154 @@ Zone	Asia/Thimphu	5:58:36 -	LMT	1947 Aug 15 # or Thimbu
 # We have no information as to when standard time was introduced;
 # assume it occurred in 1907, the same year as Mauritius (which
 # then contained the Chagos Archipelago).
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Indian/Chagos	4:49:40	-	LMT	1907
-			5:00	-	IOT	1996 # BIOT Time
-			6:00	-	IOT
+			5:00	-	%z	1996
+			6:00	-	%z
 
-# Brunei
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Asia/Brunei	7:39:40 -	LMT	1926 Mar # Bandar Seri Begawan
-			7:30	-	BNT	1933
-			8:00	-	BNT
-
-# Burma / Myanmar
+# Cocos (Keeling) Islands
+# Myanmar (Burma)
 
 # Milne says 6:24:40 was the meridian of the time ball observatory at Rangoon.
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Asia/Yangon	6:24:40 -	LMT	1880        # or Rangoon
-			6:24:40	-	RMT	1920        # Rangoon Mean Time?
-			6:30	-	BURT	1942 May    # Burma Time
-			9:00	-	JST	1945 May  3
-			6:30	-	MMT	# Myanmar Time
+# From Paul Eggert (2017-04-20):
+# Page 27 of Reed & Low (cited for Asia/Kolkata) says "Rangoon local time is
+# used upon the railways and telegraphs of Burma, and is 6h. 24m. 47s. ahead
+# of Greenwich."  This refers to the period before Burma's transition to +0630,
+# a transition for which Shanks is the only source.
 
-# Cambodia
-# See Asia/Bangkok.
-
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Asia/Yangon	6:24:47 -	LMT	1880        # or Rangoon
+			6:24:47	-	RMT	1920        # Rangoon local time
+			6:30	-	%z	1942 May
+			9:00	-	%z	1945 May  3
+			6:30	-	%z
 
 # China
+
+# From Phake Nick (2020-04-15):
+# According to this news report:
+# http://news.sina.com.cn/c/2004-09-01/19524201403.shtml
+# on April 11, 1919, newspaper in Shanghai said clocks in Shanghai will spring
+# forward for an hour starting from midnight of that Saturday. The report did
+# not mention what happened in Shanghai thereafter, but it mentioned that a
+# similar trial in Tianjin which ended at October 1st as citizens are told to
+# recede the clock on September 30 from 12:00pm to 11:00pm. The trial at
+# Tianjin got terminated in 1920.
+#
+# From Paul Eggert (2020-04-15):
+# The Returns of Trade and Trade Reports, page 711, says "Daylight saving was
+# given a trial during the year, and from the 12th April to the 1st October
+# the clocks were all set one hour ahead of sun time.  Though the scheme was
+# generally esteemed a success, it was announced early in 1920 that it would
+# not be repeated."
+#
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Shang	1919	only	-	Apr	12	24:00	1:00	D
+Rule	Shang	1919	only	-	Sep	30	24:00	0	S
+
+# From Paul Eggert (2018-10-02):
+# The following comes from Table 1 of:
+# Li Yu. Research on the daylight saving movement in 1940s Shanghai.
+# Nanjing Journal of Social Sciences. 2014;(2):144-50.
+# http://oversea.cnki.net/kns55/detail.aspx?dbname=CJFD2014&filename=NJSH201402020
+# The table lists dates only; I am guessing 00:00 and 24:00 transition times.
+# Also, the table lists the planned end of DST in 1949, but the corresponding
+# zone line cuts this off on May 28, when the Communists took power.
+
+# From Phake Nick (2020-04-15):
+#
+# For the history of time in Shanghai between 1940-1942, the situation is
+# actually slightly more complex than the table [below]....  At the time,
+# there were three different authorities in Shanghai, including Shanghai
+# International Settlement, a settlement established by western countries with
+# its own westernized form of government, Shanghai French Concession, similar
+# to the international settlement but is controlled by French, and then the
+# rest of the city of Shanghai, which have already been controlled by Japanese
+# force through a puppet local government (Wang Jingwei regime).  It was
+# additionally complicated by the circumstances that, according to the 1940s
+# Shanghai summer time essay cited in the database, some
+# departments/businesses/people in the Shanghai city itself during that time
+# period, refused to change their clock and instead only changed their opening
+# hours.
+#
+# For example, as quoted in the article, in 1940, other than the authority
+# itself, power, tram, bus companies, cinema, department stores, and other
+# public service organizations have all decided to follow the summer time and
+# spring forward the clock.  On the other hand, the custom office refused to
+# spring forward the clock because of worry on mechanical wear to the physical
+# clock, postal office refused to spring forward because of disruption to
+# business and log-keeping, although they did changed their office hour to
+# match rest of the city.  So is travel agents, and also weather
+# observatory.  It is said both time standards had their own supporters in the
+# city at the time, those who prefer new time standard would have moved their
+# clock while those who prefer the old time standard would keep their clock
+# unchange, and there were different clocks that use different time standard
+# in the city at the time for people who use different time standard to adjust
+# their clock to their preferred time.
+#
+# a. For the 1940 May 31 spring forward, the essay [says] ... "Hong
+# Kong government implemented the spring forward in the same time on
+# the same date as Shanghai".
+#
+# b. For the 1940 fall back, it was said that they initially intended to do
+# so on September 30 00:59 at night, however they postponed it to October 12
+# after discussion with relevant parties. However schools restored to the
+# original schedule ten days earlier.
+#
+# c. For the 1941 spring forward, it is said to start from March 15
+# "following the previous year's method", and in addition to that the essay
+# cited an announcement in 1941 from the Wang regime which said the Special
+# City of Shanghai under Wang regime control will follow the DST rule set by
+# the Settlements, irrespective of the original DST plan announced by the Wang
+# regime for other area under its control(April 1 to September 30). (no idea
+# to situation before that announcement)
+#
+# d. For the 1941 fall back, it was said that the fall back would occurs at
+# the end of September (A newspaper headline cited by the essay, published on
+# October 1, 1941, have the headlines which said "French Concession would
+# rewind to the old clock this morning), but it ultimately didn't happen due
+# to disagreement between the international settlement authority and the
+# French concession authority, and the fall back ultimately occurred on
+# November 1.
+#
+# e. In 1941 December, Japan have officially started war with the United
+# States and the United Kingdom, and in Shanghai they have marched into the
+# international settlement, taken over its control
+#
+# f. For the 1942 spring forward, the essay said that the spring forward
+# started on January 31. It said this time the custom office and postal
+# department will also change their clocks, unlike before.
+#
+# g. The essay itself didn't cover any specific changes thereafter until the
+# end of the war, it quoted a November 1942 command from the government of the
+# Wang regime, which claim the daylight saving time applies year round during
+# the war. However, the essay ambiguously said the period is "February 1 to
+# September 30", which I don't really understand what is the meaning of such
+# period in the context of year round implementation here.. More researches
+# might be needed to show exactly what happened during that period of time.
+
+# From Phake Nick (2020-04-15):
+# According to a Japanese tour bus pamphlet in Nanjing area believed to be
+# from around year 1941: http://www.tt-museum.jp/tairiku_0280_nan1941.html ,
+# the schedule listed was in the format of Japanese time.  Which indicate some
+# use of the Japanese time (instead of syncing by DST) might have occurred in
+# the Yangtze river delta area during that period of time although the scope
+# of such use will need to be investigated to determine.
+#
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Shang	1940	only	-	Jun	 1	 0:00	1:00	D
+Rule	Shang	1940	only	-	Oct	12	24:00	0	S
+Rule	Shang	1941	only	-	Mar	15	 0:00	1:00	D
+Rule	Shang	1941	only	-	Nov	 1	24:00	0	S
+Rule	Shang	1942	only	-	Jan	31	 0:00	1:00	D
+Rule	Shang	1945	only	-	Sep	 1	24:00	0	S
+Rule	Shang	1946	only	-	May	15	 0:00	1:00	D
+Rule	Shang	1946	only	-	Sep	30	24:00	0	S
+Rule	Shang	1947	only	-	Apr	15	 0:00	1:00	D
+Rule	Shang	1947	only	-	Oct	31	24:00	0	S
+Rule	Shang	1948	1949	-	May	 1	 0:00	1:00	D
+Rule	Shang	1948	1949	-	Sep	30	24:00	0	S #plan
 
 # From Guy Harris:
 # People's Republic of China.  Yes, they really have only one time zone.
@@ -1830,18 +2244,33 @@ Zone	Asia/Yangon	6:24:40 -	LMT	1880        # or Rangoon
 # time - sort of", Los Angeles Times, 1986-05-05 ... [says] that China began
 # observing daylight saving time in 1986.
 
-# From Paul Eggert (2014-06-30):
-# Shanks & Pottenger have China switching to a single time zone in 1980, but
-# this doesn't seem to be correct.  They also write that China observed summer
-# DST from 1986 through 1991, which seems to match the above commentary, so
-# go with them for DST rules as follows:
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Shang	1940	only	-	Jun	 3	0:00	1:00	D
-Rule	Shang	1940	1941	-	Oct	 1	0:00	0	S
-Rule	Shang	1941	only	-	Mar	16	0:00	1:00	D
-Rule	PRC	1986	only	-	May	 4	0:00	1:00	D
-Rule	PRC	1986	1991	-	Sep	Sun>=11	0:00	0	S
-Rule	PRC	1987	1991	-	Apr	Sun>=10	0:00	1:00	D
+# From P Chan (2018-05-07):
+# The start and end time of DST in China [from 1986 on] should be 2:00
+# (i.e. 2:00 to 3:00 at the start and 2:00 to 1:00 at the end)....
+# Government notices about summer time:
+#
+# 1986-04-12 http://www.zj.gov.cn/attach/zfgb/198608.pdf p.21-22
+# (To establish summer time from 1986. On 4 May, set the clocks ahead one hour
+# at 2 am. On 14 September, set the clocks backward one hour at 2 am.)
+#
+# 1987-02-15 http://www.gov.cn/gongbao/shuju/1987/gwyb198703.pdf p.114
+# (Summer time in 1987 to start from 12 April until 13 September)
+#
+# 1987-09-09 http://www.gov.cn/gongbao/shuju/1987/gwyb198721.pdf p.709
+# (From 1988, summer time to start from 2 am of the first Sunday of mid-April
+# until 2 am of the first Sunday of mid-September)
+#
+# 1992-03-03 http://www.gov.cn/gongbao/shuju/1992/gwyb199205.pdf p.152
+# (To suspend summer time from 1992)
+#
+# The first page of People's Daily on 12 April 1988 stating that summer time
+# to begin on 17 April.
+# http://data.people.com.cn/pic/101p/1988/04/1988041201.jpg
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	PRC	1986	only	-	May	 4	 2:00	1:00	D
+Rule	PRC	1986	1991	-	Sep	Sun>=11	 2:00	0	S
+Rule	PRC	1987	1991	-	Apr	Sun>=11	 2:00	1:00	D
 
 # From Anthony Fok (2001-12-20):
 # BTW, I did some research on-line and found some info regarding these five
@@ -1850,7 +2279,7 @@ Rule	PRC	1987	1991	-	Apr	Sun>=10	0:00	1:00	D
 #
 # From Jesper Nørgaard Welen (2006-07-14):
 # I have investigated the timezones around 1970 on the
-# http://www.astro.com/atlas site [with provinces and county
+# https://www.astro.com/atlas site [with provinces and county
 # boundaries summarized below]....  A few other exceptions were two
 # counties on the Sichuan side of the Xizang-Sichuan border,
 # counties Dege and Baiyu which lies on the Sichuan side and are
@@ -1859,14 +2288,15 @@ Rule	PRC	1987	1991	-	Apr	Sun>=10	0:00	1:00	D
 # (could be true), for the moment I am assuming that those two
 # counties are mistakes in the astro.com data.
 
-# From Paul Eggert (2014-06-30):
+# From Paul Eggert (2017-01-05):
 # Alois Treindl kindly sent me translations of the following two sources:
 #
 # (1)
-# Guo Qingsheng (National Time-Service Center, CAS, Xi'an 710600, China)
+# Guo Qing-sheng (National Time-Service Center, CAS, Xi'an 710600, China)
 # Beijing Time at the Beginning of the PRC
 # China Historical Materials of Science and Technology
-# (Zhongguo ke ji shi liao, 中国科技史料), Vol. 24, No. 1 (2003)
+# (Zhongguo ke ji shi liao, 中国科技史料). 2003;24(1):5-9.
+# http://oversea.cnki.net/kcms/detail/detail.aspx?filename=ZGKS200301000&dbname=CJFD2003
 # It gives evidence that at the beginning of the PRC, Beijing time was
 # officially apparent solar time!  However, Guo also says that the
 # evidence is dubious, as the relevant institute of astronomy had not
@@ -1917,28 +2347,26 @@ Rule	PRC	1987	1991	-	Apr	Sun>=10	0:00	1:00	D
 # mainly observed in coastal areas), the five zones were:
 #
 # Changbai Time ("Long-white Time", Long-white = Heilongjiang area) UT +08:30
-# Asia/Harbin (currently a link to Asia/Shanghai)
+# Now part of Asia/Shanghai; its pre-1970 times are not recorded here.
 # Heilongjiang (except Mohe county), Jilin
 #
 # Zhongyuan Time ("Central plain Time") UT +08
-# Asia/Shanghai
+# Now part of Asia/Shanghai.
 # most of China
-# This currently represents most other zones as well,
-# as apparently these regions have been the same since 1970.
-# Milne gives 8:05:43.2 for Xujiahui Observatory time; round to nearest.
+# Milne gives 8:05:43.2 for Xujiahui Observatory time....
 # Guo says Shanghai switched to UT +08 "from the end of the 19th century".
 #
-# Long-shu Time (probably due to Long and Shu being two names of the area) UT +07
-# Asia/Chongqing (currently a link to Asia/Shanghai)
+# Long-shu Time (probably as Long and Shu were two names of the area) UT +07
+# Now part of Asia/Shanghai; its pre-1970 times are not recorded here.
 # Guangxi, Guizhou, Hainan, Ningxia, Sichuan, Shaanxi, and Yunnan;
-# most of Gansu; west Inner Mongolia; west Qinghai; and the Guangdong
+# most of Gansu; west Inner Mongolia; east Qinghai; and the Guangdong
 # counties Deqing, Enping, Kaiping, Luoding, Taishan, Xinxing,
 # Yangchun, Yangjiang, Yu'nan, and Yunfu.
 #
 # Xin-zang Time ("Xinjiang-Tibet Time") UT +06
-# Asia/Urumqi
-# This currently represents Kunlun Time as well,
-# as apparently the two regions have been the same since 1970.
+# This region is now part of either Asia/Urumqi or Asia/Shanghai with
+# current boundaries uncertain; times before 1970 for areas that
+# disagree with Ürümqi or Shanghai are not recorded here.
 # The Gansu counties Aksay, Anxi, Dunhuang, Subei; west Qinghai;
 # the Guangdong counties  Xuwen, Haikang, Suixi, Lianjiang,
 # Zhanjiang, Wuchuan, Huazhou, Gaozhou, Maoming, Dianbai, and Xinyi;
@@ -1949,7 +2377,7 @@ Rule	PRC	1987	1991	-	Apr	Sun>=10	0:00	1:00	D
 # Fukang, Kuitun, Kumukuli, Miquan, Qitai, and Turfan.
 #
 # Kunlun Time UT +05:30
-# Asia/Kashgar (currently a link to Asia/Urumqi)
+# This region is now in the same status as Xin-zang Time (see above).
 # West Tibet, including Pulan, Aheqi, Shufu, Shule;
 # West Xinjiang, including Aksu, Atushi, Yining, Hetian, Cele, Luopu, Nileke,
 # Zhaosu, Tekesi, Gongliu, Chabuchaer, Huocheng, Bole, Pishan, Suiding,
@@ -2004,7 +2432,7 @@ Rule	PRC	1987	1991	-	Apr	Sun>=10	0:00	1:00	D
 
 # From David Cochrane (2014-03-26):
 # Just a confirmation that Ürümqi time was implemented in Ürümqi on 1 Feb 1986:
-# http://content.time.com/time/magazine/article/0,9171,960684,00.html
+# https://content.time.com/time/magazine/article/0,9171,960684,00.html
 
 # From Luther Ma (2014-04-22):
 # I have interviewed numerous people of various nationalities and from
@@ -2042,20 +2470,20 @@ Rule	PRC	1987	1991	-	Apr	Sun>=10	0:00	1:00	D
 # that the sort of users who prefer Asia/Urumqi now typically ignored the
 # +08 mandate back then.
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 # Beijing time, used throughout China; represented by Shanghai.
+		#STDOFF	8:05:43.2
 Zone	Asia/Shanghai	8:05:43	-	LMT	1901
-			8:00	Shang	C%sT	1949
+			8:00	Shang	C%sT	1949 May 28
 			8:00	PRC	C%sT
 # Xinjiang time, used by many in western China; represented by Ürümqi / Ürümchi
 # / Wulumuqi.  (Please use Asia/Shanghai if you prefer Beijing time.)
 Zone	Asia/Urumqi	5:50:20	-	LMT	1928
-			6:00	-	XJT
+			6:00	-	%z
 
+# Hong Kong
 
-# Hong Kong (Xianggang)
-
-# Milne gives 7:36:41.7; round this.
+# Milne gives 7:36:41.7.
 
 # From Lee Yiu Chung (2009-10-24):
 # I found there are some mistakes for the...DST rule for Hong
@@ -2063,27 +2491,134 @@ Zone	Asia/Urumqi	5:50:20	-	LMT	1928
 # it is not [an] observatory, but the official meteorological agency of HK,
 # and also serves as the official timing agency), there are some missing
 # and incorrect rules. Although the exact switch over time is missing, I
-# think 3:30 is correct. The official DST record for Hong Kong can be
-# obtained from
-# http://www.hko.gov.hk/gts/time/Summertime.htm
+# think 3:30 is correct.
 
-# From Arthur David Olson (2009-10-28):
+# From Phake Nick (2018-10-27):
+# According to Singaporean newspaper
+# http://eresources.nlb.gov.sg/newspapers/Digitised/Article/singfreepresswk19041102-1.2.37
+# the day that Hong Kong start using GMT+8 should be Oct 30, 1904.
+#
+# From Paul Eggert (2018-11-17):
+# Hong Kong had a time ball near the Marine Police Station, Tsim Sha Tsui.
+# "The ball was raised manually each day and dropped at exactly 1pm
+# (except on Sundays and Government holidays)."
+# Dyson AD. From Time Ball to Atomic Clock. Hong Kong Government. 1983.
+# <https://www.hko.gov.hk/publica/gen_pub/timeball_atomic_clock.pdf>
+# "From 1904 October 30 the time-ball at Hong Kong has been dropped by order
+# of the Governor of the Colony at 17h 0m 0s G.M.T., which is 23m 18s.14 in
+# advance of 1h 0m 0s of Hong Kong mean time."
+# Hollis HP. Universal Time, Longitudes, and Geodesy. Mon Not R Astron Soc.
+# 1905-02-10;65(4):405-6. https://doi.org/10.1093/mnras/65.4.382
+#
+# From Joseph Myers (2018-11-18):
+# An astronomer before 1925 referring to GMT would have been using the old
+# astronomical convention where the day started at noon, not midnight.
+#
+# From Steve Allen (2018-11-17):
+# Meteorological Observations made at the Hongkong Observatory in the year 1904
+# page 4 <https://books.google.com/books?id=kgw5AQAAMAAJ&pg=RA4-PA4>
+# ... the log of drop times in Table II shows that on Sunday 1904-10-30 the
+# ball was dropped.  So that looks like a special case drop for the sake
+# of broadcasting the new local time.
+#
+# From Phake Nick (2018-11-18):
+# According to The Hong Kong Weekly Press, 1904-10-29, p.324, the
+# governor of Hong Kong at the time stated that "We are further desired to
+# make it known that the change will be effected by firing the gun and by the
+# dropping of the Ball at 23min. 18sec. before one."
+# From Paul Eggert (2018-11-18):
+# See <https://mmis.hkpl.gov.hk> for this; unfortunately Flash is required.
+
+# From Phake Nick (2018-10-26):
+# I went to check microfilm records stored at Hong Kong Public Library....
+# on September 30 1941, according to Ta Kung Pao (Hong Kong edition), it was
+# stated that fallback would occur on the next day (the 1st)'s "03:00 am (Hong
+# Kong Time 04:00 am)" and the clock will fall back for a half hour. (03:00
+# probably refer to the time commonly used in mainland China at the time given
+# the paper's background) ... the sunrise/sunset time given by South China
+# Morning Post for October 1st was indeed moved by half an hour compares to
+# before.  After that, in December, the battle to capture Hong Kong started and
+# the library doesn't seems to have any record stored about press during that
+# period of time.  Some media resumed publication soon after that within the
+# same month, but there were not much information about time there.  Later they
+# started including a radio program guide when they restored radio service,
+# explicitly mentioning it use Tokyo standard time, and later added a note
+# saying it's half an hour ahead of the old Hong Kong standard time, and it
+# also seems to indicate that Hong Kong was not using GMT+8 when it was
+# captured by Japan.
+#
+# Image of related sections on newspaper:
+# * 1941-09-30, Ta Kung Pao (Hong Kong), "Winter Time start tomorrow".
+#   https://i.imgur.com/6waY51Z.jpg (Chinese)
+# * 1941-09-29, South China Morning Post, Information on sunrise/sunset
+#   time and other things for September 30 and October 1.
+#   https://i.imgur.com/kCiUR78.jpg
+# * 1942-02-05. The Hong Kong News, Radio Program Guide.
+#   https://i.imgur.com/eVvDMzS.jpg
+# * 1941-06-14. Hong Kong Daily Press, Daylight Saving from 3am Tomorrow.
+#   https://i.imgur.com/05KkvtC.png
+# * 1941-09-30, Hong Kong Daily Press, Winter Time Warning.
+#   https://i.imgur.com/dge4kFJ.png
+
+# From Paul Eggert (2019-07-11):
+# "Hong Kong winter time" is considered to be daylight saving.
+# "Hong Kong had adopted daylight saving on June 15 as a wartime measure,
+# clocks moving forward one hour until October 1, when they would be put back
+# by just half an hour for 'Hong Kong Winter time', so that daylight saving
+# operated year round." -- Low Z. The longest day: when wartime Hong Kong
+# introduced daylight saving. South China Morning Post. 2019-06-28.
+# https://www.scmp.com/magazines/post-magazine/short-reads/article/3016281/longest-day-when-wartime-hong-kong-introduced
+
+# From P Chan (2018-12-31):
+# * According to the Hong Kong Daylight-Saving Regulations, 1941, the
+#   1941 spring-forward transition was at 03:00.
+#	http://sunzi.lib.hku.hk/hkgro/view/g1941/304271.pdf
+#	http://sunzi.lib.hku.hk/hkgro/view/g1941/305516.pdf
+# * According to some articles from South China Morning Post, +08 was
+#   resumed on 1945-11-18 at 02:00.
+#	https://i.imgur.com/M2IsZ3c.png
+#	https://i.imgur.com/iOPqrVo.png
+#	https://i.imgur.com/fffcGDs.png
+# * Some newspapers ... said the 1946 spring-forward transition was on
+#   04-21 at 00:00.  The Kung Sheung Evening News 1946-04-20 (Chinese)
+#	https://i.imgur.com/ZSzent0.png
+#	https://mmis.hkpl.gov.hk///c/portal/cover?c=QF757YsWv5%2FH7zGe%2FKF%2BFLYsuqGhRBfe p.4
+#   The Kung Sheung Daily News 1946-04-21 (Chinese)
+#	https://i.imgur.com/7ecmRlcm.png
+#	https://mmis.hkpl.gov.hk///c/portal/cover?c=QF757YsWv5%2BQBGt1%2BwUj5qG2GqtwR3Wh p.4
+# * According to the Summer Time Ordinance (1946), the fallback
+#   transitions between 1946 and 1952 were at 03:30 Standard Time (+08)
+#	http://oelawhk.lib.hku.hk/archive/files/bb74b06a74d5294620a15de560ab33c6.pdf
+# * Some other laws and regulations related to DST from 1953 to 1979
+#   Summer Time Ordinance 1953
+#	https://i.imgur.com/IOlJMav.jpg
+#   Summer Time (Amendment) Ordinance 1965
+#	https://i.imgur.com/8rofeLa.jpg
+#   Interpretation and General Clauses Ordinance (1966)
+#	https://i.imgur.com/joy3msj.jpg
+#   Emergency (Summer Time) Regulation 1973 <https://i.imgur.com/OpRWrKz.jpg>
+#   Interpretation and General Clauses (Amendment) Ordinance 1977
+#	https://i.imgur.com/RaNqnc4.jpg
+#   Resolution of the Legislative Council passed on 9 May 1979
+#	https://www.legco.gov.hk/yr78-79/english/lc_sitg/hansard/h790509.pdf#page=39
+
+# From Paul Eggert (2020-04-15):
 # Here are the dates given at
-# http://www.hko.gov.hk/gts/time/Summertime.htm
-# as of 2009-10-28:
+# https://www.hko.gov.hk/en/gts/time/Summertime.htm
+# as of 2020-02-10:
 # Year        Period
-# 1941        1 Apr to 30 Sep
+# 1941        15 Jun to 30 Sep
 # 1942        Whole year
 # 1943        Whole year
 # 1944        Whole year
 # 1945        Whole year
 # 1946        20 Apr to 1 Dec
-# 1947        13 Apr to 30 Dec
+# 1947        13 Apr to 30 Nov
 # 1948        2 May to 31 Oct
 # 1949        3 Apr to 30 Oct
 # 1950        2 Apr to 29 Oct
 # 1951        1 Apr to 28 Oct
-# 1952        6 Apr to 25 Oct
+# 1952        6 Apr to 2 Nov
 # 1953        5 Apr to 1 Nov
 # 1954        21 Mar to 31 Oct
 # 1955        20 Mar to 6 Nov
@@ -2112,37 +2647,32 @@ Zone	Asia/Urumqi	5:50:20	-	LMT	1928
 # 1978        Nil
 # 1979        13 May to 21 Oct
 # 1980 to Now Nil
-# The page does not give start or end times of day.
-# The page does not give a start date for 1942.
-# The page does not givw an end date for 1945.
-# The Japanese occupation of Hong Kong began on 1941-12-25.
-# The Japanese surrender of Hong Kong was signed 1945-09-15.
-# For lack of anything better, use start of those days as the transition times.
+# The page does not give times of day for transitions,
+# or dates for the 1942 and 1945 transitions.
+# The Japanese occupation of Hong Kong began 1941-12-25.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	HK	1941	only	-	Apr	1	3:30	1:00	S
-Rule	HK	1941	only	-	Sep	30	3:30	0	-
-Rule	HK	1946	only	-	Apr	20	3:30	1:00	S
-Rule	HK	1946	only	-	Dec	1	3:30	0	-
-Rule	HK	1947	only	-	Apr	13	3:30	1:00	S
-Rule	HK	1947	only	-	Dec	30	3:30	0	-
-Rule	HK	1948	only	-	May	2	3:30	1:00	S
-Rule	HK	1948	1951	-	Oct	lastSun	3:30	0	-
-Rule	HK	1952	only	-	Oct	25	3:30	0	-
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	HK	1946	only	-	Apr	21	0:00	1:00	S
+Rule	HK	1946	only	-	Dec	1	3:30s	0	-
+Rule	HK	1947	only	-	Apr	13	3:30s	1:00	S
+Rule	HK	1947	only	-	Nov	30	3:30s	0	-
+Rule	HK	1948	only	-	May	2	3:30s	1:00	S
+Rule	HK	1948	1952	-	Oct	Sun>=28	3:30s	0	-
 Rule	HK	1949	1953	-	Apr	Sun>=1	3:30	1:00	S
-Rule	HK	1953	only	-	Nov	1	3:30	0	-
+Rule	HK	1953	1964	-	Oct	Sun>=31	3:30	0	-
 Rule	HK	1954	1964	-	Mar	Sun>=18	3:30	1:00	S
-Rule	HK	1954	only	-	Oct	31	3:30	0	-
-Rule	HK	1955	1964	-	Nov	Sun>=1	3:30	0	-
 Rule	HK	1965	1976	-	Apr	Sun>=16	3:30	1:00	S
 Rule	HK	1965	1976	-	Oct	Sun>=16	3:30	0	-
 Rule	HK	1973	only	-	Dec	30	3:30	1:00	S
-Rule	HK	1979	only	-	May	Sun>=8	3:30	1:00	S
-Rule	HK	1979	only	-	Oct	Sun>=16	3:30	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Asia/Hong_Kong	7:36:42 -	LMT	1904 Oct 30
-			8:00	HK	HK%sT	1941 Dec 25
-			9:00	-	JST	1945 Sep 15
+Rule	HK	1979	only	-	May	13	3:30	1:00	S
+Rule	HK	1979	only	-	Oct	21	3:30	0	-
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	7:36:41.7
+Zone	Asia/Hong_Kong	7:36:42 -	LMT	1904 Oct 29 17:00u
+			8:00	-	HKT	1941 Jun 15  3:00
+			8:00	1:00	HKST	1941 Oct  1  4:00
+			8:00	0:30	HKWT	1941 Dec 25
+			9:00	-	JST	1945 Nov 18  2:00
 			8:00	HK	HK%sT
 
 ###############################################################################
@@ -2161,7 +2691,7 @@ Zone	Asia/Hong_Kong	7:36:42 -	LMT	1904 Oct 30
 # (both in Okinawa) adopt the Western Standard Time which is based on
 # 120E. The adoption began from Jan 1, 1896. The original text can be
 # found on Wikisource:
-# http://ja.wikisource.org/wiki/標準時ニ關スル件_(公布時)
+# https://ja.wikisource.org/wiki/標準時ニ關スル件_(公布時)
 # ... This could be the first adoption of time zone in Taiwan, because
 # during the Qing Dynasty, it seems that there was no time zone
 # declared officially.
@@ -2172,17 +2702,17 @@ Zone	Asia/Hong_Kong	7:36:42 -	LMT	1904 Oct 30
 # time", in which abolished the adoption of Western Standard Time in
 # western islands (listed above), which means the whole Japan
 # territory, including later occupations, adopt Japan Central Time
-# (UTC+9). The adoption began on Oct 1, 1937. The original text can
+# (UT+9). The adoption began on Oct 1, 1937. The original text can
 # be found on Wikisource:
-# http://ja.wikisource.org/wiki/明治二十八年勅令第百六十七號標準時ニ關スル件中改正ノ件
+# https://ja.wikisource.org/wiki/明治二十八年勅令第百六十七號標準時ニ關スル件中改正ノ件
 #
-# That is, the time zone of Taipei switched to UTC+9 on Oct 1, 1937.
+# That is, the time zone of Taipei switched to UT+9 on Oct 1, 1937.
 
 # From Yu-Cheng Chuang (2014-07-02):
-# I've found more evidence about when the time zone was switched from UTC+9
-# back to UTC+8 after WW2.  I believe it was on Sep 21, 1945.  In a document
+# I've found more evidence about when the time zone was switched from UT+9
+# back to UT+8 after WW2.  I believe it was on Sep 21, 1945.  In a document
 # during Japanese era [1] in which the officer told the staff to change time
-# zone back to Western Standard Time (UTC+8) on Sep 21.  And in another
+# zone back to Western Standard Time (UT+8) on Sep 21.  And in another
 # history page of National Cheng Kung University [2], on Sep 21 there is a
 # note "from today, switch back to Western Standard Time".  From these two
 # materials, I believe that the time zone change happened on Sep 21.  And
@@ -2249,7 +2779,7 @@ Zone	Asia/Hong_Kong	7:36:42 -	LMT	1904 Oct 30
 # until 1945-09-21 at 01:00, overriding Shanks & Pottenger.
 # Likewise, use Yu-Cheng Chuang's data for DST in Taiwan.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Taiwan	1946	only	-	May	15	0:00	1:00	D
 Rule	Taiwan	1946	only	-	Oct	1	0:00	0	S
 Rule	Taiwan	1947	only	-	Apr	15	0:00	1:00	D
@@ -2266,33 +2796,149 @@ Rule	Taiwan	1974	1975	-	Oct	1	0:00	0	S
 Rule	Taiwan	1979	only	-	Jul	1	0:00	1:00	D
 Rule	Taiwan	1979	only	-	Oct	1	0:00	0	S
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 # Taipei or Taibei or T'ai-pei
 Zone	Asia/Taipei	8:06:00 -	LMT	1896 Jan  1
-			8:00	-	JWST	1937 Oct  1
+			8:00	-	CST	1937 Oct  1
 			9:00	-	JST	1945 Sep 21  1:00
 			8:00	Taiwan	C%sT
 
 # Macau (Macao, Aomen)
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Macau	1961	1962	-	Mar	Sun>=16	3:30	1:00	S
-Rule	Macau	1961	1964	-	Nov	Sun>=1	3:30	0	-
-Rule	Macau	1963	only	-	Mar	Sun>=16	0:00	1:00	S
-Rule	Macau	1964	only	-	Mar	Sun>=16	3:30	1:00	S
-Rule	Macau	1965	only	-	Mar	Sun>=16	0:00	1:00	S
-Rule	Macau	1965	only	-	Oct	31	0:00	0	-
-Rule	Macau	1966	1971	-	Apr	Sun>=16	3:30	1:00	S
-Rule	Macau	1966	1971	-	Oct	Sun>=16	3:30	0	-
-Rule	Macau	1972	1974	-	Apr	Sun>=15	0:00	1:00	S
-Rule	Macau	1972	1973	-	Oct	Sun>=15	0:00	0	-
-Rule	Macau	1974	1977	-	Oct	Sun>=15	3:30	0	-
-Rule	Macau	1975	1977	-	Apr	Sun>=15	3:30	1:00	S
-Rule	Macau	1978	1980	-	Apr	Sun>=15	0:00	1:00	S
-Rule	Macau	1978	1980	-	Oct	Sun>=15	0:00	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Asia/Macau	7:34:20 -	LMT	1912 Jan  1
-			8:00	Macau	MO%sT	1999 Dec 20 # return to China
-			8:00	PRC	C%sT
+#
+# From P Chan (2018-05-10):
+# * LegisMac
+#   http://legismac.safp.gov.mo/legismac/descqry/Descqry.jsf?lang=pt
+#   A database for searching titles of legal documents of Macau in
+#   Chinese and Portuguese.  The term "HORÁRIO DE VERÃO" can be used for
+#   searching decrees about summer time.
+# * Archives of Macao
+#   http://www.archives.gov.mo/en/bo/
+#   It contains images of old official gazettes.
+# * The Macao Meteorological and Geophysical Bureau have a page listing the
+#   summer time history.  But it is not complete and has some mistakes.
+#   http://www.smg.gov.mo/smg/geophysics/e_t_Summer%20Time.htm
+# Macau adopted GMT+8 on 30 Oct 1904 to follow Hong Kong.  Clocks were
+# advanced by 25 minutes and 50 seconds.  Which means the LMT used was
+# +7:34:10.  As stated in the "Portaria No. 204" dated 21 October 1904
+# and published in the Official Gazette on 29 October 1904.
+# http://igallery.icm.gov.mo/Images/Archives/BO/MO_AH_PUB_BO_1904_10/MO_AH_PUB_BO_1904_10_00025_Grey.JPG
+#
+# Therefore the 1911 decree of Portugal did not change time in Macau.
+#
+# From LegisMac, here is a list of decrees that changed the time ...
+# [Decree Gazette-no. date; titles omitted in this quotation]
+#	DIL 732 BOCM 51 1941.12.20
+#	DIL 764 BOCM 9S 1942.04.30
+#	DIL 781 BOCM 21 1942.10.10
+#	PT 3434 BOCM 8S 1943.04.17
+#	PT 3504 BOCM 20 1943.09.25
+#	PT 3843 BOCM 39 1945.09.29
+#	PT 3961 BOCM 17 1946.04.27
+#	PT 4026 BOCM 39 1946.09.28
+#	PT 4153 BOCM 16 1947.04.10
+#	PT 4271 BOCM 48 1947.11.29
+#	PT 4374 BOCM 18 1948.05.01
+#	PT 4465 BOCM 44 1948.10.30
+#	PT 4590 BOCM 14 1949.04.02
+#	PT 4666 BOCM 44 1949.10.29
+#	PT 4771 BOCM 12 1950.03.25
+#	PT 4838 BOCM 43 1950.10.28
+#	PT 4946 BOCM 12 1951.03.24
+#	PT 5025 BO 43 1951.10.27
+#	PT 5149 BO 14 1952.04.05
+#	PT 5251 BO 43 1952.10.25
+#	PT 5366 BO 13 1953.03.28
+#	PT 5444 BO 44 1953.10.31
+#	PT 5540 BO 12 1954.03.20
+#	PT 5589 BO 44 1954.10.30
+#	PT 5676 BO 12 1955.03.19
+#	PT 5739 BO 45 1955.11.05
+#	PT 5823 BO 11 1956.03.17
+#	PT 5891 BO 44 1956.11.03
+#	PT 5981 BO 12 1957.03.23
+#	PT 6064 BO 43 1957.10.26
+#	PT 6172 BO 12 1958.03.22
+#	PT 6243 BO 43 1958.10.25
+#	PT 6341 BO 12 1959.03.21
+#	PT 6411 BO 43 1959.10.24
+#	PT 6514 BO 11 1960.03.12
+#	PT 6584 BO 44 1960.10.29
+#	PT 6721 BO 10 1961.03.11
+#	PT 6815 BO 43 1961.10.28
+#	PT 6947 BO 10 1962.03.10
+#	PT 7080 BO 43 1962.10.27
+#	PT 7218 BO 12 1963.03.23
+#	PT 7340 BO 43 1963.10.26
+#	PT 7491 BO 11 1964.03.14
+#	PT 7664 BO 43 1964.10.24
+#	PT 7846 BO 15 1965.04.10
+#	PT 7979 BO 42 1965.10.16
+#	PT 8146 BO 15 1966.04.09
+#	PT 8252 BO 41 1966.10.08
+#	PT 8429 BO 15 1967.04.15
+#	PT 8540 BO 41 1967.10.14
+#	PT 8735 BO 15 1968.04.13
+#	PT 8860 BO 41 1968.10.12
+#	PT 9035 BO 16 1969.04.19
+#	PT 9156 BO 42 1969.10.18
+#	PT 9328 BO 15 1970.04.11
+#	PT 9418 BO 41 1970.10.10
+#	PT 9587 BO 14 1971.04.03
+#	PT 9702 BO 41 1971.10.09
+#	PT 38-A/72 BO 14 1972.04.01
+#	PT 126-A/72 BO 41 1972.10.07
+#	PT 61/73 BO 14 1973.04.07
+#	PT 182/73 BO 40 1973.10.06
+#	PT 282/73 BO 51 1973.12.22
+#	PT 177/74 BO 41 1974.10.12
+#	PT 51/75 BO 15 1975.04.12
+#	PT 173/75 BO 41 1975.10.11
+#	PT 67/76/M BO 14 1976.04.03
+#	PT 169/76/M BO 41 1976.10.09
+#	PT 78/79/M BO 19 1979.05.12
+#	PT 166/79/M BO 42 1979.10.20
+# Note that DIL 732 does not belong to "HORÁRIO DE VERÃO" according to
+# LegisMac.... Note that between 1942 and 1945, the time switched
+# between GMT+9 and GMT+10.  Also in 1965 and 1965 the DST ended at 2:30am.
+
+# From Paul Eggert (2018-05-10):
+# The 1904 decree says that Macau changed from the meridian of
+# Fortaleza do Monte, presumably the basis for the 7:34:10 for LMT.
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Macau	1942	1943	-	Apr	30	23:00	1:00	-
+Rule	Macau	1942	only	-	Nov	17	23:00	0	-
+Rule	Macau	1943	only	-	Sep	30	23:00	0	S
+Rule	Macau	1946	only	-	Apr	30	23:00s	1:00	D
+Rule	Macau	1946	only	-	Sep	30	23:00s	0	S
+Rule	Macau	1947	only	-	Apr	19	23:00s	1:00	D
+Rule	Macau	1947	only	-	Nov	30	23:00s	0	S
+Rule	Macau	1948	only	-	May	 2	23:00s	1:00	D
+Rule	Macau	1948	only	-	Oct	31	23:00s	0	S
+Rule	Macau	1949	1950	-	Apr	Sat>=1	23:00s	1:00	D
+Rule	Macau	1949	1950	-	Oct	lastSat	23:00s	0	S
+Rule	Macau	1951	only	-	Mar	31	23:00s	1:00	D
+Rule	Macau	1951	only	-	Oct	28	23:00s	0	S
+Rule	Macau	1952	1953	-	Apr	Sat>=1	23:00s	1:00	D
+Rule	Macau	1952	only	-	Nov	 1	23:00s	0	S
+Rule	Macau	1953	1954	-	Oct	lastSat	23:00s	0	S
+Rule	Macau	1954	1956	-	Mar	Sat>=17	23:00s	1:00	D
+Rule	Macau	1955	only	-	Nov	 5	23:00s	0	S
+Rule	Macau	1956	1964	-	Nov	Sun>=1	03:30	0	S
+Rule	Macau	1957	1964	-	Mar	Sun>=18	03:30	1:00	D
+Rule	Macau	1965	1973	-	Apr	Sun>=16	03:30	1:00	D
+Rule	Macau	1965	1966	-	Oct	Sun>=16	02:30	0	S
+Rule	Macau	1967	1976	-	Oct	Sun>=16	03:30	0	S
+Rule	Macau	1973	only	-	Dec	30	03:30	1:00	D
+Rule	Macau	1975	1976	-	Apr	Sun>=16	03:30	1:00	D
+Rule	Macau	1979	only	-	May	13	03:30	1:00	D
+Rule	Macau	1979	only	-	Oct	Sun>=16	03:30	0	S
+
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Asia/Macau	7:34:10 -	LMT	1904 Oct 30
+			8:00	-	CST	1941 Dec 21 23:00
+			9:00	Macau	%z	1945 Sep 30 24:00
+			8:00	Macau	C%sT
 
 
 ###############################################################################
@@ -2311,7 +2957,13 @@ Zone	Asia/Macau	7:34:20 -	LMT	1912 Jan  1
 # Looks like the time zone split in Cyprus went through last night.
 # http://cyprus-mail.com/2016/10/30/cyprus-new-division-two-time-zones-now-reality/
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# From Paul Eggert (2017-10-18):
+# Northern Cyprus will reinstate winter time on October 29, thus
+# staying in sync with the rest of Cyprus.  See: Anastasiou A.
+# Cyprus to remain united in time.  Cyprus Mail 2017-10-17.
+# https://cyprus-mail.com/2017/10/17/cyprus-remain-united-time/
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Cyprus	1975	only	-	Apr	13	0:00	1:00	S
 Rule	Cyprus	1975	only	-	Oct	12	0:00	0	-
 Rule	Cyprus	1976	only	-	May	15	0:00	1:00	S
@@ -2321,18 +2973,15 @@ Rule	Cyprus	1977	only	-	Sep	25	0:00	0	-
 Rule	Cyprus	1978	only	-	Oct	2	0:00	0	-
 Rule	Cyprus	1979	1997	-	Sep	lastSun	0:00	0	-
 Rule	Cyprus	1981	1998	-	Mar	lastSun	0:00	1:00	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Nicosia	2:13:28 -	LMT	1921 Nov 14
 			2:00	Cyprus	EE%sT	1998 Sep
 			2:00	EUAsia	EE%sT
 Zone	Asia/Famagusta	2:15:48	-	LMT	1921 Nov 14
 			2:00	Cyprus	EE%sT	1998 Sep
 			2:00	EUAsia	EE%sT	2016 Sep  8
-			3:00	-	+03
-
-# Classically, Cyprus belongs to Asia; e.g. see Herodotus, Histories, I.72.
-# However, for various reasons many users expect to find it under Europe.
-Link	Asia/Nicosia	Europe/Nicosia
+			3:00	-	%z	2017 Oct 29 1:00u
+			2:00	EUAsia	EE%sT
 
 # Georgia
 # From Paul Eggert (1994-11-19):
@@ -2369,26 +3018,33 @@ Link	Asia/Nicosia	Europe/Nicosia
 # Byalokoz 1919 says Georgia was 2:59:11.
 # Go with Byalokoz.
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Tbilisi	2:59:11 -	LMT	1880
 			2:59:11	-	TBMT	1924 May  2 # Tbilisi Mean Time
-			3:00	-	+03	1957 Mar
-			4:00 RussiaAsia +04/+05	1991 Mar 31  2:00s
-			3:00 RussiaAsia +03/+04	1992
-			3:00 E-EurAsia	+03/+04	1994 Sep lastSun
-			4:00 E-EurAsia	+04/+05	1996 Oct lastSun
-			4:00	1:00	+05	1997 Mar lastSun
-			4:00 E-EurAsia	+04/+05	2004 Jun 27
-			3:00 RussiaAsia	+03/+04	2005 Mar lastSun  2:00
-			4:00	-	+04
+			3:00	-	%z	1957 Mar
+			4:00 RussiaAsia %z	1991 Mar 31  2:00s
+			3:00 RussiaAsia %z	1992
+			3:00 E-EurAsia	%z	1994 Sep lastSun
+			4:00 E-EurAsia	%z	1996 Oct lastSun
+			4:00	1:00	%z	1997 Mar lastSun
+			4:00 E-EurAsia	%z	2004 Jun 27
+			3:00 RussiaAsia	%z	2005 Mar lastSun  2:00
+			4:00	-	%z
 
 # East Timor
+
+# From Tim Parenti (2024-07-01):
+# The 1912-01-01 transition occurred at 00:00 new time, per the 1911-05-24
+# Portuguese decree (see Europe/Lisbon).  A provision in article 5(c) of the
+# decree prescribed that Timor "will keep counting time in harmony with
+# neighboring foreign colonies, [for] as long as they do not adopt the time
+# that belongs to them in [the Washington Convention] system."
 
 # See Indonesia for the 1945 transition.
 
 # From João Carrascalão, brother of the former governor of East Timor, in
 # East Timor may be late for its millennium
-# <http://etan.org/et99c/december/26-31/30ETMAY.htm> (1999-12-26/31):
+# <https://etan.org/et99c/december/26-31/30ETMAY.htm> (1999-12-26/31):
 # Portugal tried to change the time forward in 1974 because the sun
 # rises too early but the suggestion raised a lot of problems with the
 # Timorese and I still don't think it would work today because it
@@ -2406,32 +3062,82 @@ Zone	Asia/Tbilisi	2:59:11 -	LMT	1880
 # which will be permanent, with no seasonal adjustment, will happen at
 # midnight on Saturday, September 16.
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Asia/Dili	8:22:20 -	LMT	1912 Jan  1
-			8:00	-	TLT	1942 Feb 21 23:00 # E Timor Time
-			9:00	-	JST	1945 Sep 23
-			9:00	-	TLT	1976 May  3
-			8:00	-	WITA	2000 Sep 17  0:00
-			9:00	-	TLT
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Asia/Dili	8:22:20 -	LMT	1911 Dec 31 16:00u
+			8:00	-	%z	1942 Feb 21 23:00
+			9:00	-	%z	1976 May  3
+			8:00	-	%z	2000 Sep 17  0:00
+			9:00	-	%z
 
 # India
 
+# British astronomer Henry Park Hollis disliked India Standard Time's offset:
+# "A new time system has been proposed for India, Further India, and Burmah.
+# The scheme suggested is that the times of the meridians 5½ and 6½ hours
+# east of Greenwich should be adopted in these territories.  No reason is
+# given why hourly meridians five hours and six hours east should not be
+# chosen; a plan which would bring the time of India into harmony with
+# that of almost the whole of the civilised world."
+# Hollis HP. Universal Time, Longitudes, and Geodesy. Mon Not R Astron Soc.
+# 1905-02-10;65(4):405-6. https://doi.org/10.1093/mnras/65.4.382
+
 # From Ian P. Beacock, in "A brief history of (modern) time", The Atlantic
-# http://www.theatlantic.com/technology/archive/2015/12/the-creation-of-modern-time/421419/
+# https://www.theatlantic.com/technology/archive/2015/12/the-creation-of-modern-time/421419/
 # (2015-12-22):
 # In January 1906, several thousand cotton-mill workers rioted on the
 # outskirts of Bombay....  They were protesting the proposed abolition of
 # local time in favor of Indian Standard Time....  Journalists called this
 # dispute the "Battle of the Clocks."  It lasted nearly half a century.
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Asia/Kolkata	5:53:28 -	LMT	1880        # Kolkata
-			5:53:20	-	HMT	1941 Oct    # Howrah Mean Time?
-			6:30	-	BURT	1942 May 15 # Burma Time
+# From Paul Eggert (2017-04-20):
+# Good luck trying to nail down old timekeeping records in India.
+# "... in the nineteenth century ... Madras Observatory took its magnetic
+# measurements on Göttingen time, its meteorological measurements on Madras
+# (local) time, dropped its time ball on Greenwich (ocean navigator's) time,
+# and distributed civil (local time)." -- Bartky IR. Selling the true time:
+# 19th-century timekeeping in america. Stanford U Press (2000), 247 note 19.
+# "A more potent cause of resistance to the general adoption of the present
+# standard time lies in the fact that it is Madras time.  The citizen of
+# Bombay, proud of being 'primus in Indis' and of Calcutta, equally proud of
+# his city being the Capital of India, and - for a part of the year - the Seat
+# of the Supreme Government, alike look down on Madras, and refuse to change
+# the time they are using, for that of what they regard as a benighted
+# Presidency; while Madras, having for long given the standard time to the
+# rest of India, would resist the adoption of any other Indian standard in its
+# place." -- Oldham RD. On Time in India: a suggestion for its improvement.
+# Proceedings of the Asiatic Society of Bengal (April 1899), 49-55.
+#
+# "In 1870 ... Madras time - 'now used by the telegraph and regulated from the
+# only government observatory' - was suggested as a standard railway time,
+# first to be adopted on the Great Indian Peninsular Railway (GIPR)....
+# Calcutta, Bombay, and Karachi, were to be allowed to continue with their
+# local time for civil purposes." - Prasad R. Tracks of Change: Railways and
+# Everyday Life in Colonial India. Cambridge University Press (2016), 145.
+#
+# Reed S, Low F. The Indian Year Book 1936-37. Bennett, Coleman, pp 27-8.
+# https://archive.org/details/in.ernet.dli.2015.282212
+# This lists +052110 as Madras local time used in railways, and says that on
+# 1906-01-01 railways and telegraphs in India switched to +0530.  Some
+# municipalities retained their former time, and the time in Calcutta
+# continued to depend on whether you were at the railway station or at
+# government offices.  Government time was at +055320 (according to Shanks) or
+# at +0554 (according to the Indian Year Book).  Railway time is more
+# appropriate for our purposes, as it was better documented, it is what we do
+# elsewhere (e.g., Europe/London before 1880), and after 1906 it was
+# consistent in the region now identified by Asia/Kolkata.  So, use railway
+# time for 1870-1941.  Shanks is our only (and dubious) source for the
+# 1941-1945 data.
+
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Asia/Kolkata	5:53:28 -	LMT	1854 Jun 28 # Kolkata
+			5:53:20	-	HMT	1870	    # Howrah Mean Time?
+			5:21:10	-	MMT	1906 Jan  1 # Madras local time
+			5:30	-	IST	1941 Oct
+			5:30	1:00	%z	1942 May 15
 			5:30	-	IST	1942 Sep
-			5:30	1:00	IST	1945 Oct 15
+			5:30	1:00	%z	1945 Oct 15
 			5:30	-	IST
-# The following are like Asia/Kolkata:
+# Since 1970 the following are like Asia/Kolkata:
 #	Andaman Is
 #	Lakshadweep (Laccadive, Minicoy and Amindivi Is)
 #	Nicobar Is
@@ -2440,7 +3146,7 @@ Zone	Asia/Kolkata	5:53:28 -	LMT	1880        # Kolkata
 #
 # From Paul Eggert (2014-09-06):
 # The 1876 Report of the Secretary of the [US] Navy, p 306 says that Batavia
-# civil time was 7:07:12.5; round to even for Jakarta.
+# civil time was 7:07:12.5.
 #
 # From Gwillim Law (2001-05-28), overriding Shanks & Pottenger:
 # http://www.sumatera-inc.com/go_to_invest/about_indonesia.asp#standtime
@@ -2474,43 +3180,159 @@ Zone	Asia/Kolkata	5:53:28 -	LMT	1880        # Kolkata
 # WITA - +08 - Waktu Indonesia Tengah (Indonesia central time)
 # WIT  - +09 - Waktu Indonesia Timur (Indonesia eastern time)
 #
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 # Java, Sumatra
+		#STDOFF	7:07:12.5
 Zone Asia/Jakarta	7:07:12 -	LMT	1867 Aug 10
 # Shanks & Pottenger say the next transition was at 1924 Jan 1 0:13,
 # but this must be a typo.
-			7:07:12	-	BMT	1923 Dec 31 23:47:12 # Batavia
-			7:20	-	JAVT	1932 Nov    # Java Time
-			7:30	-	WIB	1942 Mar 23
-			9:00	-	JST	1945 Sep 23
-			7:30	-	WIB	1948 May
-			8:00	-	WIB	1950 May
-			7:30	-	WIB	1964
+			7:07:12	-	BMT	1923 Dec 31 16:40u # Batavia
+			7:20	-	%z	1932 Nov
+			7:30	-	%z	1942 Mar 23
+			9:00	-	%z	1945 Sep 23
+			7:30	-	%z	1948 May
+			8:00	-	%z	1950 May
+			7:30	-	%z	1964
 			7:00	-	WIB
 # west and central Borneo
 Zone Asia/Pontianak	7:17:20	-	LMT	1908 May
 			7:17:20	-	PMT	1932 Nov    # Pontianak MT
-			7:30	-	WIB	1942 Jan 29
-			9:00	-	JST	1945 Sep 23
-			7:30	-	WIB	1948 May
-			8:00	-	WIB	1950 May
-			7:30	-	WIB	1964
+			7:30	-	%z	1942 Jan 29
+			9:00	-	%z	1945 Sep 23
+			7:30	-	%z	1948 May
+			8:00	-	%z	1950 May
+			7:30	-	%z	1964
 			8:00	-	WITA	1988 Jan  1
 			7:00	-	WIB
 # Sulawesi, Lesser Sundas, east and south Borneo
 Zone Asia/Makassar	7:57:36 -	LMT	1920
 			7:57:36	-	MMT	1932 Nov    # Macassar MT
-			8:00	-	WITA	1942 Feb  9
-			9:00	-	JST	1945 Sep 23
+			8:00	-	%z	1942 Feb  9
+			9:00	-	%z	1945 Sep 23
 			8:00	-	WITA
 # Maluku Islands, West Papua, Papua
 Zone Asia/Jayapura	9:22:48 -	LMT	1932 Nov
-			9:00	-	WIT	1944 Sep  1
-			9:30	-	ACST	1964
+			9:00	-	%z	1944 Sep  1
+			9:30	-	%z	1964
 			9:00	-	WIT
 
 # Iran
 
+# From Roozbeh Pournader (2022-05-30):
+# Here's an order from the Cabinet to the rest of the government to switch to
+# Tehran time, which is mentioned to be already at +03:30:
+# https://qavanin.ir/Law/TreeText/180138
+# Just in case that goes away, I also saved a copy at archive.org:
+# https://web.archive.org/web/20220530111940/https://qavanin.ir/Law/TreeText/180138
+# Here's my translation:
+#
+# "Circular on Matching the Hours of Governmental and Official Circles
+# in Provinces
+# Approved 1314/03/22 [=1935-06-13]
+# According to the ruling of the Honorable Cabinet, it is ordered that from
+# now on in all internal provinces of the country, governmental and official
+# circles set their time to match Tehran time (three hours and half before
+# Greenwich)....
+#
+# I still haven't found out when Tehran itself switched to +03:30....
+#
+# From Paul Eggert (2022-06-05):
+# Although the above says Tehran was at +03:30 before 1935-06-13, we don't
+# know when it switched to +03:30.  For now, use 1935-06-13 as the switch date.
+# Although most likely wrong, we have no better info.
+
+# From Roozbeh Pournader (2022-06-01):
+# This is from Kayhan newspaper, one of the major Iranian newspapers, from
+# March 20, 1978, page 2:
+#
+# "Pull the clocks 60 minutes forward
+# As we informed before, from the fourth day of the month Farvardin of the
+# new year [=1978-03-24], clocks will be pulled forward, and people's daily
+# work and life program will start one hour earlier than the current program.
+# On the 1st day of the month Farvardin of this year [=1977-03-21], they had
+# pulled the clocks forward by one hour, but in the month of Mehr
+# [=1977-09-23], the clocks were pulled back by 30 minutes.
+# In this way, from the 4th day of the month Farvardin, clocks will be ahead
+# of the previous years by one hour and a half.
+# According to the new program, during the night of 4th of Farvardin, when
+# the midnight, meaning 24 o'clock is announced, the hands of the clock must
+# be pulled forward by one hour and thus consider midnight 1 o'clock in the
+# forenoon."
+#
+# This implies that in September 1977, when the daylight savings time was
+# done with, Iran didn't go back to +03:30, but immediately to +04:00.
+#
+#
+# This is from the major Iranian newspaper Ettela'at, dated [1978-08-03]...,
+# page 32. It looks like they decided to get the clocks back to +4:00
+# just in time for Ramadan that year:
+#
+# "Tomorrow Night, Pull the Clocks Back by One Hour
+# At 1 o'clock in the forenoon of Saturday 14 Mordad [=1978-08-05], the
+# clocks will be pulled one hour back and instead of 1 o'clock in the
+# forenoon, Radio Iran will announce 24 o'clock.
+# This decision was made in the Cabinet of Ministers meeting of 25 Tir
+# [=1978-07-16], [...]
+# At the beginning of the year 2537 [=March 1978: Iran was using a different
+# year number for a few years then, based on the Coronation of Cyrus the
+# Great], the country's official time was pulled forward by one hour and now
+# the official time is one hour and a half ahead compared to last year,
+# because in Farvardin of last year [=March 1977], the official time was
+# pulled forward one hour and this continued until the second half of last
+# year [=September 1977] until in the second half of last year the official
+# time was pulled back half an hour and that half hour still remains."
+#
+# This matches the time of the true noon published in the newspapers, as they
+# clearly go from +05:00 to +04:00 after that date (which happened during a
+# long weekend in Iran).
+
+# From Roozbeh Pournader (2022-05-31):
+# [Movahedi S. Cultural preconceptions of time: Can we use operational time
+# to meddle in God's Time? Comp Stud Soc Hist. 1985;27(3):385-400]
+# https://www.jstor.org/stable/178704
+# Here's the quotes from the paper:
+# 1. '"Iran's official time keeper moved the clock one hour forward as from
+# March 22, 1977 (Farvardin 2, 2536) to make maximum use of daylight and save
+# in energy consumption. Thus Iran joined such other countries as Britain in
+# observing what is known as 'daylight saving.' The proposal was originally
+# put forward by the Ministry of Energy, in no way having any influence on
+# observing religious ceremonies. Moving time one hour forward in summer
+# means that at 11:00 o'clock on March 21, the official time was set as
+# midnight March 22. Then September 24 will actually begin one hour later
+# than the end of September 23 [...]." Iran's time base thus continued to be
+# Greenwich Mean Time plus three and one-half hours (plus four and one-half
+# hours in summer).'
+#
+# The article sources this from Iran Almanac and Book of Facts, 1977, Tehran:
+# Echo of Iran, which is on Google Books at
+# https://www.google.com/books/edition/Iran_Almanac_and_Book_of_Facts/9ybVAAAAMAAJ.
+# (I confirmed it by searching for snippets.)
+#
+# 2. "After the fall of the shah, the revolutionary government returned to
+# daylight-saving time (DST) on 26 May 1979."
+#
+# This seems to have been announced just one day in advance, on 25 May 1979.
+#
+# The change in 1977 clearly seems to be the first daylight savings effort in
+# Iran. But the article doesn't mention what happened in 1978 (which was
+# still during the shah's government), or how things continued in 1979
+# onwards (which was during the Islamic Republic).
+
+# From Francis Santoni (2022-06-01):
+# for Iran and 1977 the effective change is only 20 October
+# (UIT No. 143 17.XI.1977) and not 23 September (UIT No. 141 13.IX.1977).
+# UIT is the Operational Bulletin of International Telecommunication Union.
+
+# From Roozbeh Pournader (2025-03-18):
+# ... the exact time of Iran's transition from +0400 to +0330 ... was Friday
+# 1357/8/19 AP=1978-11-10. Here's a newspaper clip from the Ettela'at
+# newspaper, dated 1357/8/14 AP=1978-11-05, translated from Persian
+# (at https://w.wiki/DUEY):
+#	Following the government's decision about returning the official time
+#	to the previous status, the spokesperson for the Ministry of Energy
+#	announced today: At the hour 24 of Friday 19th of Aban (=1978-11-10),
+#	the country's time will be pulled back half an hour.
+#
 # From Roozbeh Pournader (2003-03-15):
 # This is an English translation of what I just found (originally in Persian).
 # The Gregorian dates in brackets are mine:
@@ -2538,8 +3360,6 @@ Zone Asia/Jayapura	9:22:48 -	LMT	1932 Nov
 # for at least the last 5 years.  Before that, for a few years, the
 # date used was the first Thursday night of Farvardin and the last
 # Thursday night of Shahrivar, but I can't give exact dates....
-# I have also changed the abbreviations to what is considered correct
-# here in Iran, IRST for regular time and IRDT for daylight saving time.
 #
 # From Roozbeh Pournader (2005-04-05):
 # The text of the Iranian law, in effect since 1925, clearly mentions
@@ -2547,12 +3367,12 @@ Zone Asia/Jayapura	9:22:48 -	LMT	1932 Nov
 # leap year calculation involved.  There has never been any serious
 # plan to change that law....
 #
-# From Paul Eggert (2006-03-22):
-# Go with Shanks & Pottenger before Sept. 1991, and with Pournader thereafter.
-# I used Ed Reingold's cal-persia in GNU Emacs 21.2 to check Persian dates,
-# stopping after 2037 when 32-bit time_t's overflow.
-# That cal-persia used Birashk's approximation, which disagrees with the solar
-# calendar predictions for the year 2025, so I corrected those dates by hand.
+# From Paul Eggert (2022-06-30):
+# Go with Pournader for 1935 through spring 1979, and for timestamps
+# after August 1991; go with with Shanks & Pottenger for other timestamps.
+# Go with Santoni's citation of the UIT for fall 1977, as 20 October 1977
+# is 28 Mehr 1356, consistent with the "Mehr" in Pournader's source.
+# Assume that the UIT's "1930" is UTC, i.e., 24:00 local time.
 #
 # From Oscar van Vlijmen (2005-03-30), writing about future
 # discrepancies between cal-persia and the Iranian calendar:
@@ -2575,7 +3395,7 @@ Zone Asia/Jayapura	9:22:48 -	LMT	1932 Nov
 # From Reuters (2007-09-16), with a heads-up from Jesper Nørgaard Welen:
 # ... the Guardian Council ... approved a law on Sunday to re-introduce
 # daylight saving time ...
-# http://uk.reuters.com/article/oilRpt/idUKBLA65048420070916
+# https://uk.reuters.com/article/oilRpt/idUKBLA65048420070916
 #
 # From Roozbeh Pournader (2007-11-05):
 # This is quoted from Official Gazette of the Islamic Republic of
@@ -2586,69 +3406,62 @@ Zone Asia/Jayapura	9:22:48 -	LMT	1932 Nov
 # be changed back to its previous state on the 24 hours of the
 # thirtieth day of Shahrivar.
 #
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Iran	1978	1980	-	Mar	21	0:00	1:00	D
-Rule	Iran	1978	only	-	Oct	21	0:00	0	S
-Rule	Iran	1979	only	-	Sep	19	0:00	0	S
-Rule	Iran	1980	only	-	Sep	23	0:00	0	S
-Rule	Iran	1991	only	-	May	 3	0:00	1:00	D
-Rule	Iran	1992	1995	-	Mar	22	0:00	1:00	D
-Rule	Iran	1991	1995	-	Sep	22	0:00	0	S
-Rule	Iran	1996	only	-	Mar	21	0:00	1:00	D
-Rule	Iran	1996	only	-	Sep	21	0:00	0	S
-Rule	Iran	1997	1999	-	Mar	22	0:00	1:00	D
-Rule	Iran	1997	1999	-	Sep	22	0:00	0	S
-Rule	Iran	2000	only	-	Mar	21	0:00	1:00	D
-Rule	Iran	2000	only	-	Sep	21	0:00	0	S
-Rule	Iran	2001	2003	-	Mar	22	0:00	1:00	D
-Rule	Iran	2001	2003	-	Sep	22	0:00	0	S
-Rule	Iran	2004	only	-	Mar	21	0:00	1:00	D
-Rule	Iran	2004	only	-	Sep	21	0:00	0	S
-Rule	Iran	2005	only	-	Mar	22	0:00	1:00	D
-Rule	Iran	2005	only	-	Sep	22	0:00	0	S
-Rule	Iran	2008	only	-	Mar	21	0:00	1:00	D
-Rule	Iran	2008	only	-	Sep	21	0:00	0	S
-Rule	Iran	2009	2011	-	Mar	22	0:00	1:00	D
-Rule	Iran	2009	2011	-	Sep	22	0:00	0	S
-Rule	Iran	2012	only	-	Mar	21	0:00	1:00	D
-Rule	Iran	2012	only	-	Sep	21	0:00	0	S
-Rule	Iran	2013	2015	-	Mar	22	0:00	1:00	D
-Rule	Iran	2013	2015	-	Sep	22	0:00	0	S
-Rule	Iran	2016	only	-	Mar	21	0:00	1:00	D
-Rule	Iran	2016	only	-	Sep	21	0:00	0	S
-Rule	Iran	2017	2019	-	Mar	22	0:00	1:00	D
-Rule	Iran	2017	2019	-	Sep	22	0:00	0	S
-Rule	Iran	2020	only	-	Mar	21	0:00	1:00	D
-Rule	Iran	2020	only	-	Sep	21	0:00	0	S
-Rule	Iran	2021	2023	-	Mar	22	0:00	1:00	D
-Rule	Iran	2021	2023	-	Sep	22	0:00	0	S
-Rule	Iran	2024	only	-	Mar	21	0:00	1:00	D
-Rule	Iran	2024	only	-	Sep	21	0:00	0	S
-Rule	Iran	2025	2027	-	Mar	22	0:00	1:00	D
-Rule	Iran	2025	2027	-	Sep	22	0:00	0	S
-Rule	Iran	2028	2029	-	Mar	21	0:00	1:00	D
-Rule	Iran	2028	2029	-	Sep	21	0:00	0	S
-Rule	Iran	2030	2031	-	Mar	22	0:00	1:00	D
-Rule	Iran	2030	2031	-	Sep	22	0:00	0	S
-Rule	Iran	2032	2033	-	Mar	21	0:00	1:00	D
-Rule	Iran	2032	2033	-	Sep	21	0:00	0	S
-Rule	Iran	2034	2035	-	Mar	22	0:00	1:00	D
-Rule	Iran	2034	2035	-	Sep	22	0:00	0	S
+# From Ali Mirjamali (2022-05-10):
+# Official IR News Agency announcement: irna.ir/xjJ3TT
+# ...
+# Highlights: DST will be cancelled for the next Iranian year 1402
+# (i.e 2023-March-21) and forthcoming years.
 #
-# The following rules are approximations starting in the year 2038.
-# These are the best post-2037 approximations available, given the
-# restrictions of a single rule using a Gregorian-based data format.
-# At some point this table will need to be extended, though quite
-# possibly Iran will change the rules first.
-Rule	Iran	2036	max	-	Mar	21	0:00	1:00	D
-Rule	Iran	2036	max	-	Sep	21	0:00	0	S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+# Work around a bug in zic 2022a and earlier.
+Rule	Iran	1910	only	-	Jan	 1	00:00	0	-
+#
+Rule	Iran	1977	only	-	Mar	21	23:00	1:00	-
+Rule	Iran	1977	only	-	Oct	20	24:00	0	-
+Rule	Iran	1978	only	-	Mar	24	24:00	1:00	-
+Rule	Iran	1978	only	-	Aug	 5	01:00	0	-
+Rule	Iran	1979	only	-	May	26	24:00	1:00	-
+Rule	Iran	1979	only	-	Sep	18	24:00	0	-
+Rule	Iran	1980	only	-	Mar	20	24:00	1:00	-
+Rule	Iran	1980	only	-	Sep	22	24:00	0	-
+Rule	Iran	1991	only	-	May	 2	24:00	1:00	-
+Rule	Iran	1992	1995	-	Mar	21	24:00	1:00	-
+Rule	Iran	1991	1995	-	Sep	21	24:00	0	-
+Rule	Iran	1996	only	-	Mar	20	24:00	1:00	-
+Rule	Iran	1996	only	-	Sep	20	24:00	0	-
+Rule	Iran	1997	1999	-	Mar	21	24:00	1:00	-
+Rule	Iran	1997	1999	-	Sep	21	24:00	0	-
+Rule	Iran	2000	only	-	Mar	20	24:00	1:00	-
+Rule	Iran	2000	only	-	Sep	20	24:00	0	-
+Rule	Iran	2001	2003	-	Mar	21	24:00	1:00	-
+Rule	Iran	2001	2003	-	Sep	21	24:00	0	-
+Rule	Iran	2004	only	-	Mar	20	24:00	1:00	-
+Rule	Iran	2004	only	-	Sep	20	24:00	0	-
+Rule	Iran	2005	only	-	Mar	21	24:00	1:00	-
+Rule	Iran	2005	only	-	Sep	21	24:00	0	-
+Rule	Iran	2008	only	-	Mar	20	24:00	1:00	-
+Rule	Iran	2008	only	-	Sep	20	24:00	0	-
+Rule	Iran	2009	2011	-	Mar	21	24:00	1:00	-
+Rule	Iran	2009	2011	-	Sep	21	24:00	0	-
+Rule	Iran	2012	only	-	Mar	20	24:00	1:00	-
+Rule	Iran	2012	only	-	Sep	20	24:00	0	-
+Rule	Iran	2013	2015	-	Mar	21	24:00	1:00	-
+Rule	Iran	2013	2015	-	Sep	21	24:00	0	-
+Rule	Iran	2016	only	-	Mar	20	24:00	1:00	-
+Rule	Iran	2016	only	-	Sep	20	24:00	0	-
+Rule	Iran	2017	2019	-	Mar	21	24:00	1:00	-
+Rule	Iran	2017	2019	-	Sep	21	24:00	0	-
+Rule	Iran	2020	only	-	Mar	20	24:00	1:00	-
+Rule	Iran	2020	only	-	Sep	20	24:00	0	-
+Rule	Iran	2021	2022	-	Mar	21	24:00	1:00	-
+Rule	Iran	2021	2022	-	Sep	21	24:00	0	-
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Tehran	3:25:44	-	LMT	1916
-			3:25:44	-	TMT	1946     # Tehran Mean Time
-			3:30	-	IRST	1977 Nov
-			4:00	Iran	IR%sT	1979
-			3:30	Iran	IR%sT
+			3:25:44	-	TMT	1935 Jun 13 # Tehran Mean Time
+			3:30	Iran	%z	1977 Oct 20 24:00
+			4:00	Iran	%z	1978 Nov 10 24:00
+			3:30	Iran	%z
 
 
 # Iraq
@@ -2674,30 +3487,34 @@ Zone	Asia/Tehran	3:25:44	-	LMT	1916
 # http://www.aswataliraq.info/look/article.tpl?id=2047&IdLanguage=17&IdPublication=4&NrArticle=71743&NrIssue=1&NrSection=10
 #
 # We have published a short article in English about the change:
-# http://www.timeanddate.com/news/time/iraq-dumps-daylight-saving.html
+# https://www.timeanddate.com/news/time/iraq-dumps-daylight-saving.html
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Iraq	1982	only	-	May	1	0:00	1:00	D
-Rule	Iraq	1982	1984	-	Oct	1	0:00	0	S
-Rule	Iraq	1983	only	-	Mar	31	0:00	1:00	D
-Rule	Iraq	1984	1985	-	Apr	1	0:00	1:00	D
-Rule	Iraq	1985	1990	-	Sep	lastSun	1:00s	0	S
-Rule	Iraq	1986	1990	-	Mar	lastSun	1:00s	1:00	D
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Iraq	1982	only	-	May	1	0:00	1:00	-
+Rule	Iraq	1982	1984	-	Oct	1	0:00	0	-
+Rule	Iraq	1983	only	-	Mar	31	0:00	1:00	-
+Rule	Iraq	1984	1985	-	Apr	1	0:00	1:00	-
+Rule	Iraq	1985	1990	-	Sep	lastSun	1:00s	0	-
+Rule	Iraq	1986	1990	-	Mar	lastSun	1:00s	1:00	-
 # IATA SSIM (1991/1996) says Apr 1 12:01am UTC; guess the ':01' is a typo.
 # Shanks & Pottenger say Iraq did not observe DST 1992/1997; ignore this.
 #
-Rule	Iraq	1991	2007	-	Apr	 1	3:00s	1:00	D
-Rule	Iraq	1991	2007	-	Oct	 1	3:00s	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+Rule	Iraq	1991	2007	-	Apr	 1	3:00s	1:00	-
+Rule	Iraq	1991	2007	-	Oct	 1	3:00s	0	-
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Baghdad	2:57:40	-	LMT	1890
 			2:57:36	-	BMT	1918     # Baghdad Mean Time?
-			3:00	-	AST	1982 May
-			3:00	Iraq	A%sT
+			3:00	-	%z	1982 May
+			3:00	Iraq	%z
 
 
 ###############################################################################
 
 # Israel
+
+# For more info about the motivation for DST in Israel, see:
+# Barak Y. Israel's Daylight Saving Time controversy. Israel Affairs.
+# 2020-08-11. https://doi.org/10.1080/13537121.2020.1806564
 
 # From Ephraim Silverberg (2001-01-11):
 #
@@ -2719,53 +3536,210 @@ Zone	Asia/Baghdad	2:57:40	-	LMT	1890
 # high on my favorite-country list (and not only because my wife's
 # family is from India).
 
-# From Shanks & Pottenger:
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Zion	1940	only	-	Jun	 1	0:00	1:00	D
-Rule	Zion	1942	1944	-	Nov	 1	0:00	0	S
-Rule	Zion	1943	only	-	Apr	 1	2:00	1:00	D
-Rule	Zion	1944	only	-	Apr	 1	0:00	1:00	D
-Rule	Zion	1945	only	-	Apr	16	0:00	1:00	D
-Rule	Zion	1945	only	-	Nov	 1	2:00	0	S
-Rule	Zion	1946	only	-	Apr	16	2:00	1:00	D
-Rule	Zion	1946	only	-	Nov	 1	0:00	0	S
-Rule	Zion	1948	only	-	May	23	0:00	2:00	DD
-Rule	Zion	1948	only	-	Sep	 1	0:00	1:00	D
-Rule	Zion	1948	1949	-	Nov	 1	2:00	0	S
-Rule	Zion	1949	only	-	May	 1	0:00	1:00	D
-Rule	Zion	1950	only	-	Apr	16	0:00	1:00	D
-Rule	Zion	1950	only	-	Sep	15	3:00	0	S
-Rule	Zion	1951	only	-	Apr	 1	0:00	1:00	D
-Rule	Zion	1951	only	-	Nov	11	3:00	0	S
-Rule	Zion	1952	only	-	Apr	20	2:00	1:00	D
-Rule	Zion	1952	only	-	Oct	19	3:00	0	S
-Rule	Zion	1953	only	-	Apr	12	2:00	1:00	D
-Rule	Zion	1953	only	-	Sep	13	3:00	0	S
-Rule	Zion	1954	only	-	Jun	13	0:00	1:00	D
-Rule	Zion	1954	only	-	Sep	12	0:00	0	S
-Rule	Zion	1955	only	-	Jun	11	2:00	1:00	D
-Rule	Zion	1955	only	-	Sep	11	0:00	0	S
-Rule	Zion	1956	only	-	Jun	 3	0:00	1:00	D
-Rule	Zion	1956	only	-	Sep	30	3:00	0	S
-Rule	Zion	1957	only	-	Apr	29	2:00	1:00	D
-Rule	Zion	1957	only	-	Sep	22	0:00	0	S
-Rule	Zion	1974	only	-	Jul	 7	0:00	1:00	D
-Rule	Zion	1974	only	-	Oct	13	0:00	0	S
-Rule	Zion	1975	only	-	Apr	20	0:00	1:00	D
-Rule	Zion	1975	only	-	Aug	31	0:00	0	S
-Rule	Zion	1985	only	-	Apr	14	0:00	1:00	D
-Rule	Zion	1985	only	-	Sep	15	0:00	0	S
-Rule	Zion	1986	only	-	May	18	0:00	1:00	D
-Rule	Zion	1986	only	-	Sep	 7	0:00	0	S
-Rule	Zion	1987	only	-	Apr	15	0:00	1:00	D
-Rule	Zion	1987	only	-	Sep	13	0:00	0	S
+# From P Chan (2020-10-27), with corrections:
+#
+# 1940-1946 Supplement No. 2 to the Palestine Gazette
+# # issue page  Order No.   dated      start        end         note
+# 1 1010  729  67 of 1940 1940-05-22 1940-05-31* 1940-09-30* revoked by #2
+# 2 1013  758  73 of 1940 1940-05-31 1940-05-31  1940-09-30
+# 3 1055 1574 196 of 1940 1940-11-06 1940-11-16  1940-12-31
+# 4 1066 1811 208 of 1940 1940-12-17 1940-12-31  1941-12-31
+# 5 1156 1967 116 of 1941 1941-12-16 1941-12-31  1942-12-31* amended by #6
+# 6 1228 1608  86 of 1942 1942-10-14 1941-12-31  1942-10-31
+# 7 1256  279  21 of 1943 1943-03-18 1943-03-31  1943-10-31
+# 8 1323  249  19 of 1944 1944-03-13 1944-03-31  1944-10-31
+# 9 1402  328  20 of 1945 1945-04-05 1945-04-15  1945-10-31
+#10 1487  596  14 of 1946 1946-04-04 1946-04-15  1946-10-31
+#
+# 1948 Iton Rishmi (Official Gazette of the Provisional Government)
+# #    issue    page   dated      start       end
+#11 2             7 1948-05-20 1948-05-22 1948-10-31*
+#	^This moved timezone to +04, replaced by #12 from 1948-08-31 24:00 GMT.
+#12 17 (Annex B) 84 1948-08-22 1948-08-31 1948-10-31
+#
+# 1949-2000 Kovetz HaTakanot (Collection of Regulations)
+# # issue page  dated      start       end            note
+#13    6  133 1949-03-23 1949-04-30  1949-10-31
+#14   80  755 1950-03-17 1950-04-15  1950-09-14
+#15  164  782 1951-03-22 1951-03-31  1951-09-29* amended by #16
+#16  206 1940 1951-09-23 ----------  1951-10-22* amended by #17
+#17  212   78 1951-10-19 ----------  1951-11-10
+#18  254  652 1952-03-03 1952-04-19  1952-09-27* amended by #19
+#19  300   11 1952-09-15 ----------  1952-10-18
+#20  348  817 1953-03-03 1953-04-11  1953-09-12
+#21  420  385 1954-02-17 1954-06-12  1954-09-11
+#22  497  548 1955-01-14 1955-06-11  1955-09-10
+#23  591  608 1956-03-12 1956-06-02  1956-09-29
+#24  680  957 1957-02-08 1957-04-27  1957-09-21
+#25 3192 1418 1974-06-28 1974-07-06  1974-10-12
+#26 3322 1389 1975-04-03 1975-04-19  1975-08-30
+#27 4146 2089 1980-07-15 1980-08-02  1980-09-13
+#28 4604 1081 1984-02-22 1984-05-05* 1984-08-25* revoked by #29
+#29 4619 1312 1984-04-06 1984-05-05  1984-08-25
+#30 4744  475 1984-12-23 1985-04-13  1985-09-14* amended by #31
+#31 4851 1848 1985-08-18 ----------  1985-08-31
+#32 4932  899 1986-04-22 1986-05-17  1986-09-06
+#33 5013  580 1987-02-15 1987-04-18* 1987-08-22* revoked by #34
+#34 5021  744 1987-03-30 1987-04-14  1987-09-12
+#35 5096  659 1988-02-14 1988-04-09  1988-09-03
+#36 5167  514 1989-02-03 1989-04-29  1989-09-02
+#37 5248  375 1990-01-23 1990-03-24  1990-08-25
+#38 5335  612 1991-02-10 1991-03-09* 1991-08-31	 amended by #39
+#			 1992-03-28  1992-09-05
+#39 5339  709 1991-03-04 1991-03-23  ----------
+#40 5506  503 1993-02-18 1993-04-02  1993-09-05
+#			 1994-04-01  1994-08-28
+#			 1995-03-31  1995-09-03
+#41 5731  438 1996-01-01 1996-03-14  1996-09-15
+#			 1997-03-13* 1997-09-18* overridden by 1997 Temp Prov
+#			 1998-03-19* 1998-09-17* revoked by #42
+#42 5853 1243 1997-09-18 1998-03-19  1998-09-05
+#43 5937   77 1998-10-18 1999-04-02  1999-09-03
+#			 2000-04-14* 2000-09-15* revoked by #44
+#			 2001-04-13* 2001-09-14* revoked by #44
+#44 6024   39 2000-03-14 2000-04-14  2000-10-22* overridden by 2000 Temp Prov
+#			 2001-04-06* 2001-10-10* overridden by 2000 Temp Prov
+#			 2002-03-29* 2002-10-29* overridden by 2000 Temp Prov
+#
+# These are laws enacted by the Knesset since the Minister could only alter the
+# transition dates at least six months in advanced under the 1992 Law.
+#				dated		start		end
+# 1997 Temporary Provisions	1997-03-06	1997-03-20	1997-09-13
+# 2000 Temporary Provisions	2000-07-28	----------	2000-10-06
+#						2001-04-09	2001-09-24
+#						2002-03-29	2002-10-07
+#						2003-03-28	2003-10-03
+#						2004-04-07	2004-09-22
+# Note:
+# Transition times in 1940-1957 (#1-#24) were midnight GMT,
+# in 1974-1998 (#25-#42 and the 1997 Temporary Provisions) were midnight,
+# in 1999-April 2000 (#43,#44) were 02:00,
+# in the 2000 Temporary Provisions were 01:00.
+#
+# -----------------------------------------------------------------------------
+# Links:
+# 1 https://findit.library.yale.edu/images_layout/view?parentoid=15537490&increment=687
+# 2 https://findit.library.yale.edu/images_layout/view?parentoid=15537490&increment=716
+# 3 https://findit.library.yale.edu/images_layout/view?parentoid=15537491&increment=721
+# 4 https://findit.library.yale.edu/images_layout/view?parentoid=15537491&increment=958
+# 5 https://findit.library.yale.edu/images_layout/view?parentoid=15537502&increment=558
+# 6 https://findit.library.yale.edu/images_layout/view?parentoid=15537511&increment=105
+# 7 https://findit.library.yale.edu/images_layout/view?parentoid=15537516&increment=278
+# 8 https://findit.library.yale.edu/images_layout/view?parentoid=15537522&increment=248
+# 9 https://findit.library.yale.edu/images_layout/view?parentoid=15537530&increment=329
+#10 https://findit.library.yale.edu/images_layout/view?parentoid=15537537&increment=601
+#11 https://www.nevo.co.il/law_word/law12/er-002.pdf#page=3
+#12 https://www.nevo.co.il/law_word/law12/er-017-t2.pdf#page=4
+#13 https://www.nevo.co.il/law_word/law06/tak-0006.pdf#page=3
+#14 https://www.nevo.co.il/law_word/law06/tak-0080.pdf#page=7
+#15 https://www.nevo.co.il/law_word/law06/tak-0164.pdf#page=10
+#16 https://www.nevo.co.il/law_word/law06/tak-0206.pdf#page=4
+#17 https://www.nevo.co.il/law_word/law06/tak-0212.pdf#page=2
+#18 https://www.nevo.co.il/law_word/law06/tak-0254.pdf#page=4
+#19 https://www.nevo.co.il/law_word/law06/tak-0300.pdf#page=5
+#20 https://www.nevo.co.il/law_word/law06/tak-0348.pdf#page=3
+#21 https://www.nevo.co.il/law_word/law06/tak-0420.pdf#page=5
+#22 https://www.nevo.co.il/law_word/law06/tak-0497.pdf#page=10
+#23 https://www.nevo.co.il/law_word/law06/tak-0591.pdf#page=6
+#24 https://www.nevo.co.il/law_word/law06/tak-0680.pdf#page=3
+#25 https://www.nevo.co.il/law_word/law06/tak-3192.pdf#page=2
+#26 https://www.nevo.co.il/law_word/law06/tak-3322.pdf#page=5
+#27 https://www.nevo.co.il/law_word/law06/tak-4146.pdf#page=2
+#28 https://www.nevo.co.il/law_word/law06/tak-4604.pdf#page=7
+#29 https://www.nevo.co.il/law_word/law06/tak-4619.pdf#page=2
+#30 https://www.nevo.co.il/law_word/law06/tak-4744.pdf#page=11
+#31 https://www.nevo.co.il/law_word/law06/tak-4851.pdf#page=2
+#32 https://www.nevo.co.il/law_word/law06/tak-4932.pdf#page=19
+#33 https://www.nevo.co.il/law_word/law06/tak-5013.pdf#page=8
+#34 https://www.nevo.co.il/law_word/law06/tak-5021.pdf#page=8
+#35 https://www.nevo.co.il/law_word/law06/tak-5096.pdf#page=3
+#36 https://www.nevo.co.il/law_word/law06/tak-5167.pdf#page=2
+#37 https://www.nevo.co.il/law_word/law06/tak-5248.pdf#page=7
+#38 https://www.nevo.co.il/law_word/law06/tak-5335.pdf#page=6
+#39 https://www.nevo.co.il/law_word/law06/tak-5339.pdf#page=7
+#40 https://www.nevo.co.il/law_word/law06/tak-5506.pdf#page=19
+#41 https://www.nevo.co.il/law_word/law06/tak-5731.pdf#page=2
+#42 https://www.nevo.co.il/law_word/law06/tak-5853.pdf#page=3
+#43 https://www.nevo.co.il/law_word/law06/tak-5937.pdf#page=9
+#44 https://www.nevo.co.il/law_word/law06/tak-6024.pdf#page=4
+#
+# Time Determination (Temporary Provisions) Law, 1997
+# https://www.nevo.co.il/law_html/law19/p201_003.htm
+#
+# Time Determination (Temporary Provisions) Law, 2000
+# https://www.nevo.co.il/law_html/law19/p201_004.htm
+#
+# Time Determination Law, 1992 and amendments
+# https://www.nevo.co.il/law_html/law01/p201_002.htm
+# https://main.knesset.gov.il/Activity/Legislation/Laws/Pages/LawPrimary.aspx?lawitemid=2001174
+
+# From Paul Eggert (2020-10-27):
+# Several of the midnight transitions mentioned above are ambiguous;
+# are they 00:00, 00:00s, 24:00, or 24:00s?  When resolving these ambiguities,
+# try to minimize changes from previous tzdb versions, for lack of better info.
+# Commentary from previous versions is included below, to help explain this.
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Zion	1940	only	-	May	31	24:00u	1:00	D
+Rule	Zion	1940	only	-	Sep	30	24:00u	0	S
+Rule	Zion	1940	only	-	Nov	16	24:00u	1:00	D
+Rule	Zion	1942	1946	-	Oct	31	24:00u	0	S
+Rule	Zion	1943	1944	-	Mar	31	24:00u	1:00	D
+Rule	Zion	1945	1946	-	Apr	15	24:00u	1:00	D
+Rule	Zion	1948	only	-	May	22	24:00u	2:00	DD
+Rule	Zion	1948	only	-	Aug	31	24:00u	1:00	D
+Rule	Zion	1948	1949	-	Oct	31	24:00u	0	S
+Rule	Zion	1949	only	-	Apr	30	24:00u	1:00	D
+Rule	Zion	1950	only	-	Apr	15	24:00u	1:00	D
+Rule	Zion	1950	only	-	Sep	14	24:00u	0	S
+Rule	Zion	1951	only	-	Mar	31	24:00u	1:00	D
+Rule	Zion	1951	only	-	Nov	10	24:00u	0	S
+Rule	Zion	1952	only	-	Apr	19	24:00u	1:00	D
+Rule	Zion	1952	only	-	Oct	18	24:00u	0	S
+Rule	Zion	1953	only	-	Apr	11	24:00u	1:00	D
+Rule	Zion	1953	only	-	Sep	12	24:00u	0	S
+Rule	Zion	1954	only	-	Jun	12	24:00u	1:00	D
+Rule	Zion	1954	only	-	Sep	11	24:00u	0	S
+Rule	Zion	1955	only	-	Jun	11	24:00u	1:00	D
+Rule	Zion	1955	only	-	Sep	10	24:00u	0	S
+Rule	Zion	1956	only	-	Jun	 2	24:00u	1:00	D
+Rule	Zion	1956	only	-	Sep	29	24:00u	0	S
+Rule	Zion	1957	only	-	Apr	27	24:00u	1:00	D
+Rule	Zion	1957	only	-	Sep	21	24:00u	0	S
+Rule	Zion	1974	only	-	Jul	 6	24:00	1:00	D
+Rule	Zion	1974	only	-	Oct	12	24:00	0	S
+Rule	Zion	1975	only	-	Apr	19	24:00	1:00	D
+Rule	Zion	1975	only	-	Aug	30	24:00	0	S
+
+# From Alois Treindl (2019-03-06):
+# http://www.moin.gov.il/Documents/שעון%20קיץ/clock-50-years-7-2014.pdf
+# From Isaac Starkman (2019-03-06):
+# Summer time was in that period in 1980 and 1984, see
+# https://www.ynet.co.il/articles/0,7340,L-3951073,00.html
+# You can of course read it in translation.
+# I checked the local newspapers for that years.
+# It started on midnight and end at 01.00 am.
+# From Paul Eggert (2019-03-06):
+# Also see this thread about the moin.gov.il URL:
+# https://mm.icann.org/pipermail/tz/2018-November/027194.html
+Rule	Zion	1980	only	-	Aug	 2	24:00s	1:00	D
+Rule	Zion	1980	only	-	Sep	13	24:00s	0	S
+Rule	Zion	1984	only	-	May	 5	24:00s	1:00	D
+Rule	Zion	1984	only	-	Aug	25	24:00s	0	S
+
+Rule	Zion	1985	only	-	Apr	13	24:00	1:00	D
+Rule	Zion	1985	only	-	Aug	31	24:00	0	S
+Rule	Zion	1986	only	-	May	17	24:00	1:00	D
+Rule	Zion	1986	only	-	Sep	 6	24:00	0	S
+Rule	Zion	1987	only	-	Apr	14	24:00	1:00	D
+Rule	Zion	1987	only	-	Sep	12	24:00	0	S
 
 # From Avigdor Finkelstein (2014-03-05):
 # I check the Parliament (Knesset) records and there it's stated that the
 # [1988] transition should take place on Saturday night, when the Sabbath
 # ends and changes to Sunday.
-Rule	Zion	1988	only	-	Apr	10	0:00	1:00	D
-Rule	Zion	1988	only	-	Sep	 4	0:00	0	S
+Rule	Zion	1988	only	-	Apr	 9	24:00	1:00	D
+Rule	Zion	1988	only	-	Sep	 3	24:00	0	S
 
 # From Ephraim Silverberg
 # (1997-03-04, 1998-03-16, 1998-12-28, 2000-01-17, 2000-07-25, 2004-12-22,
@@ -2794,15 +3768,15 @@ Rule	Zion	1988	only	-	Sep	 4	0:00	0	S
 # (except in 2002) is three nights before Yom Kippur [Day of Atonement]
 # (the eve of the 7th of Tishrei in the lunar Hebrew calendar).
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Zion	1989	only	-	Apr	30	0:00	1:00	D
-Rule	Zion	1989	only	-	Sep	 3	0:00	0	S
-Rule	Zion	1990	only	-	Mar	25	0:00	1:00	D
-Rule	Zion	1990	only	-	Aug	26	0:00	0	S
-Rule	Zion	1991	only	-	Mar	24	0:00	1:00	D
-Rule	Zion	1991	only	-	Sep	 1	0:00	0	S
-Rule	Zion	1992	only	-	Mar	29	0:00	1:00	D
-Rule	Zion	1992	only	-	Sep	 6	0:00	0	S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Zion	1989	only	-	Apr	29	24:00	1:00	D
+Rule	Zion	1989	only	-	Sep	 2	24:00	0	S
+Rule	Zion	1990	only	-	Mar	24	24:00	1:00	D
+Rule	Zion	1990	only	-	Aug	25	24:00	0	S
+Rule	Zion	1991	only	-	Mar	23	24:00	1:00	D
+Rule	Zion	1991	only	-	Aug	31	24:00	0	S
+Rule	Zion	1992	only	-	Mar	28	24:00	1:00	D
+Rule	Zion	1992	only	-	Sep	 5	24:00	0	S
 Rule	Zion	1993	only	-	Apr	 2	0:00	1:00	D
 Rule	Zion	1993	only	-	Sep	 5	0:00	0	S
 
@@ -2810,7 +3784,7 @@ Rule	Zion	1993	only	-	Sep	 5	0:00	0	S
 # Ministry of Interior, Jerusalem, Israel.  The spokeswoman can be reached by
 # calling the office directly at 972-2-6701447 or 972-2-6701448.
 
-# Rule	NAME    FROM    TO      TYPE    IN      ON      AT      SAVE    LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Zion	1994	only	-	Apr	 1	0:00	1:00	D
 Rule	Zion	1994	only	-	Aug	28	0:00	0	S
 Rule	Zion	1995	only	-	Mar	31	0:00	1:00	D
@@ -2830,11 +3804,11 @@ Rule	Zion	1995	only	-	Sep	 3	0:00	0	S
 #
 #       where YYYY is the relevant year.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Zion	1996	only	-	Mar	15	0:00	1:00	D
-Rule	Zion	1996	only	-	Sep	16	0:00	0	S
-Rule	Zion	1997	only	-	Mar	21	0:00	1:00	D
-Rule	Zion	1997	only	-	Sep	14	0:00	0	S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Zion	1996	only	-	Mar	14	24:00	1:00	D
+Rule	Zion	1996	only	-	Sep	15	24:00	0	S
+Rule	Zion	1997	only	-	Mar	20	24:00	1:00	D
+Rule	Zion	1997	only	-	Sep	13	24:00	0	S
 Rule	Zion	1998	only	-	Mar	20	0:00	1:00	D
 Rule	Zion	1998	only	-	Sep	 6	0:00	0	S
 Rule	Zion	1999	only	-	Apr	 2	2:00	1:00	D
@@ -2853,7 +3827,7 @@ Rule	Zion	1999	only	-	Sep	 3	2:00	0	S
 #
 #	ftp://ftp.cs.huji.ac.il/pub/tz/announcements/2000-2004.ps.gz
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Zion	2000	only	-	Apr	14	2:00	1:00	D
 Rule	Zion	2000	only	-	Oct	 6	1:00	0	S
 Rule	Zion	2001	only	-	Apr	 9	1:00	1:00	D
@@ -2875,48 +3849,32 @@ Rule	Zion	2004	only	-	Sep	22	1:00	0	S
 #
 #	ftp://ftp.cs.huji.ac.il/pub/tz/announcements/2005+beyond.ps
 
-# From Paul Eggert (2012-10-26):
-# I used Ephraim Silverberg's dst-israel.el program
-# <ftp://ftp.cs.huji.ac.il/pub/tz/software/dst-israel.el> (2005-02-20)
-# along with Ed Reingold's cal-hebrew in GNU Emacs 21.4,
-# to generate the transitions from 2005 through 2012.
-# (I replaced "lastFri" with "Fri>=26" by hand.)
-# The spring transitions all correspond to the following Rule:
-#
-# Rule	Zion	2005	2012	-	Mar	Fri>=26	2:00	1:00	D
-#
-# but older zic implementations (e.g., Solaris 8) do not support
-# "Fri>=26" to mean April 1 in years like 2005, so for now we list the
-# springtime transitions explicitly.
-
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Zion	2005	only	-	Apr	 1	2:00	1:00	D
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Zion	2005	2012	-	Apr	Fri<=1	2:00	1:00	D
 Rule	Zion	2005	only	-	Oct	 9	2:00	0	S
-Rule	Zion	2006	2010	-	Mar	Fri>=26	2:00	1:00	D
 Rule	Zion	2006	only	-	Oct	 1	2:00	0	S
 Rule	Zion	2007	only	-	Sep	16	2:00	0	S
 Rule	Zion	2008	only	-	Oct	 5	2:00	0	S
 Rule	Zion	2009	only	-	Sep	27	2:00	0	S
 Rule	Zion	2010	only	-	Sep	12	2:00	0	S
-Rule	Zion	2011	only	-	Apr	 1	2:00	1:00	D
 Rule	Zion	2011	only	-	Oct	 2	2:00	0	S
-Rule	Zion	2012	only	-	Mar	Fri>=26	2:00	1:00	D
 Rule	Zion	2012	only	-	Sep	23	2:00	0	S
 
-# From Ephraim Silverberg (2013-06-27):
-# On June 23, 2013, the Israeli government approved changes to the
-# Time Decree Law.  The next day, the changes passed the First Reading
-# in the Knesset.  The law is expected to pass the Second and Third
-# (final) Readings by the beginning of September 2013.
-#
-# As of 2013, DST starts at 02:00 on the Friday before the last Sunday
-# in March.  DST ends at 02:00 on the last Sunday of October.
+# From Ephraim Silverberg (2020-10-26):
+# The current time law (2013) from the State of Israel can be viewed
+# (in Hebrew) at:
+# ftp://ftp.cs.huji.ac.il/pub/tz/israel/announcements/2013+law.pdf
+# It translates to:
+# Every year, in the period from the Friday before the last Sunday in
+# the month of March at 02:00 a.m. until the last Sunday of the month
+# of October at 02:00 a.m., Israel Time will be advanced an additional
+# hour such that it will be UTC+3.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Zion	2013	max	-	Mar	Fri>=23	2:00	1:00	D
 Rule	Zion	2013	max	-	Oct	lastSun	2:00	0	S
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Jerusalem	2:20:54 -	LMT	1880
 			2:20:40	-	JMT	1918 # Jerusalem Mean Time?
 			2:00	Zion	I%sT
@@ -2928,6 +3886,47 @@ Zone	Asia/Jerusalem	2:20:54 -	LMT	1880
 # Japan
 
 # '9:00' and 'JST' is from Guy Harris.
+
+# From Paul Eggert (2020-01-19):
+# Starting in the 7th century, Japan generally followed an ancient Chinese
+# timekeeping system that divided night and day into six hours each,
+# with hour length depending on season.  In 1873 the government
+# started requiring the use of a Western style 24-hour clock.  See:
+# Yulia Frumer, "Making Time: Astronomical Time Measurement in Tokugawa Japan"
+# <https://www.worldcat.org/oclc/1043907065>.  As the tzdb code and
+# data support only 24-hour clocks, its tables model timestamps before
+# 1873 using Western-style local mean time.
+
+# From Hideyuki Suzuki (1998-11-09):
+# 'Tokyo' usually stands for the former location of Tokyo Astronomical
+# Observatory: 139° 44' 40.90" E (9h 18m 58.727s), 35° 39' 16.0" N.
+# This data is from 'Rika Nenpyou (Chronological Scientific Tables) 1996'
+# edited by National Astronomical Observatory of Japan....
+# JST (Japan Standard Time) has been used since 1888-01-01 00:00 (JST).
+# The law is enacted on 1886-07-07.
+
+# From Hideyuki Suzuki (1998-11-16):
+# The ordinance No. 51 (1886) established "standard time" in Japan,
+# which stands for the time on 135° E.
+# In the ordinance No. 167 (1895), "standard time" was renamed to "central
+# standard time".  And the same ordinance also established "western standard
+# time", which stands for the time on 120° E....  But "western standard
+# time" was abolished in the ordinance No. 529 (1937).  In the ordinance No.
+# 167, there is no mention regarding for what place western standard time is
+# standard....
+#
+# I wrote "ordinance" above, but I don't know how to translate.
+# In Japanese it's "chokurei", which means ordinance from emperor.
+
+# From Yu-Cheng Chuang (2013-07-12):
+# ...the Meiji Emperor announced Ordinance No. 167 of Meiji Year 28 "The clause
+# about standard time" ... The adoption began from Jan 1, 1896.
+# https://ja.wikisource.org/wiki/標準時ニ關スル件_(公布時)
+#
+# ...the Showa Emperor announced Ordinance No. 529 of Showa Year 12 ... which
+# means the whole Japan territory, including later occupations, adopt Japan
+# Central Time (UT+9). The adoption began on Oct 1, 1937.
+# https://ja.wikisource.org/wiki/明治二十八年勅令第百六十七號標準時ニ關スル件中改正ノ件
 
 # From Paul Eggert (1995-03-06):
 # Today's _Asahi Evening News_ (page 4) reports that Japan had
@@ -2945,56 +3944,44 @@ Zone	Asia/Jerusalem	2:20:54 -	LMT	1880
 # of the Japanese wanted to scrap daylight-saving time, as opposed to 30% who
 # wanted to keep it.)
 
-# From Paul Eggert (2006-03-22):
-# Shanks & Pottenger write that DST in Japan during those years was as follows:
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Japan	1948	only	-	May	Sun>=1	2:00	1:00	D
-Rule	Japan	1948	1951	-	Sep	Sat>=8	2:00	0	S
-Rule	Japan	1949	only	-	Apr	Sun>=1	2:00	1:00	D
-Rule	Japan	1950	1951	-	May	Sun>=1	2:00	1:00	D
-# but the only locations using it (for birth certificates, presumably, since
-# their audience is astrologers) were US military bases.  For now, assume
-# that for most purposes daylight-saving time was observed; otherwise, what
-# would have been the point of the 1951 poll?
+# From Takayuki Nikai (2018-01-19):
+# The source of information is Japanese law.
+# http://www.shugiin.go.jp/internet/itdb_housei.nsf/html/houritsu/00219480428029.htm
+# http://www.shugiin.go.jp/internet/itdb_housei.nsf/html/houritsu/00719500331039.htm
+# ... In summary, it is written as follows.  From 24:00 on the first Saturday
+# in May, until 0:00 on the day after the second Saturday in September.
 
-# From Hideyuki Suzuki (1998-11-09):
-# 'Tokyo' usually stands for the former location of Tokyo Astronomical
-# Observatory: 139 degrees 44' 40.90" E (9h 18m 58.727s),
-# 35 degrees 39' 16.0" N.
-# This data is from 'Rika Nenpyou (Chronological Scientific Tables) 1996'
-# edited by National Astronomical Observatory of Japan....
-# JST (Japan Standard Time) has been used since 1888-01-01 00:00 (JST).
-# The law is enacted on 1886-07-07.
-
-# From Hideyuki Suzuki (1998-11-16):
-# The ordinance No. 51 (1886) established "standard time" in Japan,
-# which stands for the time on 135 degrees E.
-# In the ordinance No. 167 (1895), "standard time" was renamed to "central
-# standard time".  And the same ordinance also established "western standard
-# time", which stands for the time on 120 degrees E....  But "western standard
-# time" was abolished in the ordinance No. 529 (1937).  In the ordinance No.
-# 167, there is no mention regarding for what place western standard time is
-# standard....
+# From Phake Nick (2018-09-27):
+# [T]he webpage authored by National Astronomical Observatory of Japan
+# https://eco.mtk.nao.ac.jp/koyomi/wiki/BBFEB9EF2FB2C6BBFEB9EF.html
+# ... mentioned that using Showa 23 (year 1948) as example, 13pm of September
+# 11 in summer time will equal to 0am of September 12 in standard time.
+# It cited a document issued by the Liaison Office which briefly existed
+# during the postwar period of Japan, where the detail on implementation
+# of the summer time is described in the document.
+# https://eco.mtk.nao.ac.jp/koyomi/wiki/BBFEB9EF2FB2C6BBFEB9EFB2C6BBFEB9EFA4CEBCC2BBDCA4CBA4C4A4A4A4C6.pdf
+# The text in the document do instruct a fall back to occur at
+# September 11, 13pm in summer time, while ordinary citizens can
+# change the clock before they sleep.
 #
-# I wrote "ordinance" above, but I don't know how to translate.
-# In Japanese it's "chokurei", which means ordinance from emperor.
+# From Paul Eggert (2018-09-27):
+# This instruction is equivalent to "Sat>=8 25:00", so use that.  zic treats
+# it like "Sun>=9 01:00", which is not quite the same but is the best we can
+# do in any POSIX or C platform.  The "25:00" assumes zic from 2007 or later,
+# which should be safe now.
 
-# From Yu-Cheng Chuang (2013-07-12):
-# ...the Meiji Emperor announced Ordinance No. 167 of Meiji Year 28 "The clause
-# about standard time" ... The adoption began from Jan 1, 1896.
-# http://ja.wikisource.org/wiki/標準時ニ關スル件_(公布時)
-#
-# ...the Showa Emperor announced Ordinance No. 529 of Showa Year 12 ... which
-# means the whole Japan territory, including later occupations, adopt Japan
-# Central Time (UTC+9). The adoption began on Oct 1, 1937.
-# http://ja.wikisource.org/wiki/明治二十八年勅令第百六十七號標準時ニ關スル件中改正ノ件
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Japan	1948	only	-	May	Sat>=1	24:00	1:00	D
+Rule	Japan	1948	1951	-	Sep	Sat>=8	25:00	0	S
+Rule	Japan	1949	only	-	Apr	Sat>=1	24:00	1:00	D
+Rule	Japan	1950	1951	-	May	Sat>=1	24:00	1:00	D
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Tokyo	9:18:59	-	LMT	1887 Dec 31 15:00u
-			9:00	-	JST	1896 Jan  1
-			9:00	-	JCST	1937 Oct  1
 			9:00	Japan	J%sT
-# Since 1938, all Japanese possessions have been like Asia/Tokyo.
+# Since 1938, all Japanese possessions have been like Asia/Tokyo,
+# except that Truk (Chuuk), Ponape (Pohnpei), and Jaluit (Kosrae) did not
+# switch from +10 to +09 until 1941-04-01; see the 'australasia' file.
 
 # Jordan
 #
@@ -3051,7 +4038,7 @@ Zone	Asia/Tokyo	9:18:59	-	LMT	1887 Dec 31 15:00u
 # Official, in Arabic:
 # http://www.petra.gov.jo/public_news/Nws_NewsDetails.aspx?Menu_ID=&Site_Id=2&lang=1&NewsID=133230&CatID=14
 # ... Our background/permalink about it
-# http://www.timeanddate.com/news/time/jordan-reverses-dst-decision.html
+# https://www.timeanddate.com/news/time/jordan-reverses-dst-decision.html
 # ...
 # http://www.petra.gov.jo/Public_News/Nws_NewsDetails.aspx?lang=2&site_id=1&NewsID=133313&Type=P
 # ... says midnight for the coming one and 1:00 for the ones in the future
@@ -3060,7 +4047,26 @@ Zone	Asia/Tokyo	9:18:59	-	LMT	1887 Dec 31 15:00u
 # From Paul Eggert (2013-12-11):
 # As Steffen suggested, consider the past 21-month experiment to be DST.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# From Steffen Thorsen (2021-09-24):
+# The Jordanian Government announced yesterday that they will start DST
+# in February instead of March:
+# https://petra.gov.jo/Include/InnerPage.jsp?ID=37683&lang=en&name=en_news (English)
+# https://petra.gov.jo/Include/InnerPage.jsp?ID=189969&lang=ar&name=news (Arabic)
+# From the Arabic version, it seems to say it would be at midnight
+# (assume 24:00) on the last Thursday in February, starting from 2022.
+
+# From Issam Al-Zuwairi (2022-10-05):
+# The Council of Ministers in Jordan decided Wednesday 5th October 2022,
+# that daylight saving time (DST) will be throughout the year....
+#
+# From Brian Inglis (2022-10-06):
+# https://petra.gov.jo/Include/InnerPage.jsp?ID=45567&lang=en&name=en_news
+#
+# From Paul Eggert (2022-10-05):
+# Like Syria, model this as a transition from EEST +03 (DST) to plain +03
+# (non-DST) at the point where DST would otherwise have ended.
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Jordan	1973	only	-	Jun	6	0:00	1:00	S
 Rule	Jordan	1973	1975	-	Oct	1	0:00	0	-
 Rule	Jordan	1974	1977	-	May	1	0:00	1:00	S
@@ -3090,11 +4096,13 @@ Rule	Jordan	2004	only	-	Oct	15	0:00s	0	-
 Rule	Jordan	2005	only	-	Sep	lastFri	0:00s	0	-
 Rule	Jordan	2006	2011	-	Oct	lastFri	0:00s	0	-
 Rule	Jordan	2013	only	-	Dec	20	0:00	0	-
-Rule	Jordan	2014	max	-	Mar	lastThu	24:00	1:00	S
-Rule	Jordan	2014	max	-	Oct	lastFri	0:00s	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+Rule	Jordan	2014	2021	-	Mar	lastThu	24:00	1:00	S
+Rule	Jordan	2014	2022	-	Oct	lastFri	0:00s	0	-
+Rule	Jordan	2022	only	-	Feb	lastThu	24:00	1:00	S
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Amman	2:23:44 -	LMT	1931
-			2:00	Jordan	EE%sT
+			2:00	Jordan	EE%sT	2022 Oct 28 0:00s
+			3:00	-	%z
 
 
 # Kazakhstan
@@ -3110,12 +4118,12 @@ Zone	Asia/Amman	2:23:44 -	LMT	1931
 # was "blended" with the Central zone.  Therefore, Kazakhstan now has
 # two time zones, and difference between them is one hour.  The zone
 # closer to UTC is the former Western zone (probably still called the
-# same), encompassing four provinces in the west: Aqtobe, Atyrau,
-# Mangghystau, and West Kazakhstan.  The other zone encompasses
+# same), encompassing four provinces in the west: Aqtöbe, Atyraū,
+# Mangghystaū, and West Kazakhstan.  The other zone encompasses
 # everything else....  I guess that would make Kazakhstan time zones
 # de jure UTC+5 and UTC+6 respectively.
 
-# From Stepan Golosunov (2016-03-27) ([*] means see later comments below):
+# From Stepan Golosunov (2016-03-27):
 # Review of the linked documents from http://adilet.zan.kz/
 # produced the following data for post-1991 Kazakhstan:
 #
@@ -3133,8 +4141,8 @@ Zone	Asia/Amman	2:23:44 -	LMT	1931
 # text.
 #
 # According to Izvestia newspaper No. 68 (23334) from 1991-03-20
-# (page 6; available at http://libinfo.org/newsr/newsr2574.djvu via
-# http://libinfo.org/index.php?id=58564) on 1991-03-31 at 2:00 during
+# -- page 6; available at http://libinfo.org/newsr/newsr2574.djvu via
+# http://libinfo.org/index.php?id=58564 -- on 1991-03-31 at 2:00 during
 # transition to "summer" time:
 # Republic of Georgia, Latvian SSR, Lithuanian SSR, SSR Moldova,
 # Estonian SSR; Komi ASSR; Kaliningrad oblast; Nenets autonomous okrug
@@ -3150,7 +4158,7 @@ Zone	Asia/Amman	2:23:44 -	LMT	1931
 # Apparently there were last minute changes. Apparently Kazakh act No. 170
 # was one of such changes.
 #
-# https://ru.wikipedia.org/wiki/Декретное время
+# https://ru.wikipedia.org/wiki/Декретное_время
 # claims that Sovetskaya Rossiya newspaper on 1991-03-29 published that
 # Nenets autonomous okrug, Komi and Kazakhstan (excluding Uralsk oblast)
 # were to not move clocks and Uralsk oblast was to move clocks
@@ -3161,7 +4169,7 @@ Zone	Asia/Amman	2:23:44 -	LMT	1931
 #
 # This implies that on 1991-03-31 Asia/Oral remained on +04/+05 while
 # the rest of Kazakhstan switched from +06/+07 to +05/06 or from +05/06
-# to +04/+05. It's unclear how Kzyl-Orda oblast moved into the fifth
+# to +04/+05. It's unclear how Qyzylorda oblast moved into the fifth
 # time belt. (By switching from +04/+05 to +05/+06 on 1991-09-29?) ...
 #
 # 1. Act of the Cabinet of Ministers of the Republic of Kazakhstan
@@ -3174,25 +4182,25 @@ Zone	Asia/Amman	2:23:44 -	LMT	1931
 # on the whole territory of Kazakhstan 1 hour forward on 1992-01-19 at
 # 2:00, specified DST rules.  It acknowledged that Kazakhstan was
 # located in the fourth and the fifth time belts and specified the
-# border between them to be located east of Kustanay and Aktyubinsk
-# oblasts (notably including Turgai and Kzyl-Orda oblasts into the fifth
+# border between them to be located east of Qostanay and Aktyubinsk
+# oblasts (notably including Turgai and Qyzylorda oblasts into the fifth
 # time belt).
 #
 # This means switch on 1992-01-19 at 2:00 from +04/+05 to +05/+06 for
-# Asia/Aqtau, Asia/Aqtobe, Asia/Oral, Atyrau and Kustanay oblasts; from
-# +05/+06 to +06/+07 for Asia/Almaty and Asia/Qyzylorda (and Arkalyk) [*]....
+# Asia/Aqtau, Asia/Aqtobe, Asia/Oral, Atyraū and Qostanay oblasts; from
+# +05/+06 to +06/+07 for Asia/Almaty and Asia/Qyzylorda (and Arkalyk)....
 #
 # 2. Act of the Cabinet of Ministers of the Republic of Kazakhstan
 # from 1992-03-27 No. 284
 # http://adilet.zan.kz/rus/docs/P920000284_
-# cancels extra hour ("decree time") for Uralsk and Kzyl-Orda oblasts
+# cancels extra hour ("decree time") for Uralsk and Qyzylorda oblasts
 # since the last Sunday of March 1992, while keeping them in the fourth
 # and the fifth time belts respectively.
 #
 # 3. Order of the Prime Minister of the Republic of Kazakhstan
 # from 1994-09-23 No. 384
 # http://adilet.zan.kz/rus/docs/R940000384_
-# cancels the extra hour ("decree time") on the territory of Mangystau
+# cancels the extra hour ("decree time") on the territory of Mangghystaū
 # oblast since the last Sunday of September 1994 (saying that time on
 # the territory would correspond to the third time belt as a
 # result)....
@@ -3206,14 +4214,11 @@ Zone	Asia/Amman	2:23:44 -	LMT	1931
 # 5. Act of the Government of the Republic of Kazakhstan
 # from 1999-03-26 No. 305
 # http://adilet.zan.kz/rus/docs/P990000305_
-# cancels the extra hour ("decree time") for Atyrau oblast since the
+# cancels the extra hour ("decree time") for Atyraū oblast since the
 # last Sunday of March 1999 while retaining the oblast in the fourth
 # time belt.
 #
-# This means change from +05/+06 to +04/+05.
-#
-# There is no zone for Atyrau currently (listed under Asia/Aqtau in
-# zone1970.tab).[*]
+# This means change from +05/+06 to +04/+05....
 #
 # 6. Act of the Government of the Republic of Kazakhstan
 # from 2000-11-23 No. 1749
@@ -3223,10 +4228,10 @@ Zone	Asia/Amman	2:23:44 -	LMT	1931
 # The only changes I noticed are in definition of the border between the
 # fourth and the fifth time belts.  They account for changes in spelling
 # and administrative division (splitting of Turgai oblast in 1997
-# probably changed time in territories incorporated into Kostanay oblast
-# (including Arkalyk) from +06/+07 to +05/+06) and move Kyzylorda oblast
+# probably changed time in territories incorporated into Qostanay oblast
+# (including Arkalyk) from +06/+07 to +05/+06) and move Qyzylorda oblast
 # from being in the fifth time belt and not using decree time into the
-# fourth time belt (no change in practice).[*]
+# fourth time belt (no change in practice).
 #
 # 7. Act of the Government of the Republic of Kazakhstan
 # from 2003-12-29 No. 1342
@@ -3236,7 +4241,7 @@ Zone	Asia/Amman	2:23:44 -	LMT	1931
 # 8. Act of the Government of the Republic of Kazakhstan
 # from 2004-07-20 No. 775
 # http://adilet.zan.kz/rus/archive/docs/P040000775_/20.07.2004
-# modified the 2000-11-23 act to move Kostanay and Kyzylorda oblasts into
+# modified the 2000-11-23 act to move Qostanay and Qyzylorda oblasts into
 # the fifth time belt and add Aktobe oblast to the list of regions not
 # using extra hour ("decree time"), leaving Kazakhstan with only 2 time
 # zones (+04/+05 and +06/+07).  The changes were to be implemented
@@ -3248,14 +4253,14 @@ Zone	Asia/Amman	2:23:44 -	LMT	1931
 # http://adilet.zan.kz/rus/docs/P040001059_
 # modified the 2000-11-23 act to remove exceptions from the "decree time"
 # (leaving Kazakhstan in +05/+06 and +06/+07 zones), amended the
-# 2004-07-20 act to implement changes for Atyrau, West Kazakhstan,
-# Kostanay, Kyzylorda and Mangystau oblasts by not moving clocks
-# during the 2014 transition to "winter" time.
+# 2004-07-20 act to implement changes for Atyraū, West Kazakhstan,
+# Qostanay, Qyzylorda and Mangghystaū oblasts by not moving clocks
+# during the 2004 transition to "winter" time.
 #
-# This means transition from +04/+05 to +05/+06 for Atyrau oblast (no
+# This means transition from +04/+05 to +05/+06 for Atyraū oblast (no
 # zone currently), Asia/Oral, Asia/Aqtau and transition from +05/+06 to
-# +06/+07 for Kostanay oblast (Kostanay and Arkalyk, no zones currently)
-# and Asia/Qyzylorda on 2004-10-31 at 3:00....[*]
+# +06/+07 for Qostanay oblast (Qostanay and Arkalyk, no zones currently)
+# and Asia/Qyzylorda on 2004-10-31 at 3:00....
 #
 # 10. Act of the Government of the Republic of Kazakhstan
 # from 2005-03-15 No. 231
@@ -3271,76 +4276,125 @@ Zone	Asia/Amman	2:23:44 -	LMT	1931
 # Kazakh 1992-01-13 act appears to provide the same rules and 1992-03-27
 # act was to be enacted on the last Sunday of March 1992.
 
-# From Paul Eggert (2016-04-15):
-# The tables below should reflect Stepan Golosunov's remarks above,
-# except for the items marked "[*]" which I haven't gotten to yet.
-# It looks like we will need new zones Asia/Atyrau and Asia/Qostanay
-# to handle changes from 1992 through 2004 that we did not previously
-# know about.
-
+# From Stepan Golosunov (2016-11-08):
+# Turgai reorganization should affect only southern part of Qostanay
+# oblast.  Which should probably be separated into Asia/Arkalyk zone.
+# (There were also 1970, 1988 and 1990 Turgai oblast reorganizations
+# according to wikipedia.)
 #
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# [For Qostanay] http://www.ng.kz/gazeta/195/hranit/
+# suggests that clocks were to be moved 40 minutes backwards on
+# 1920-01-01 to the fourth time belt.  But I do not understand
+# how that could happen....
+#
+# [For Atyrau and Oral] 1919 decree
+# (http://www.worldtimezone.com/dst_news/dst_news_russia-1919-02-08.html
+# and in Byalokoz) lists Ural river (plus 10 versts on its left bank) in
+# the third time belt (before 1930 this means +03).
+
+# From Alexander Konzurovski (2018-12-20):
+# (Asia/Qyzylorda) is changing its time zone from UTC+6 to UTC+5
+# effective December 21st, 2018....
+# http://adilet.zan.kz/rus/docs/P1800000817 (russian language).
+
+# From Zhanbolat Raimbekov (2024-01-19):
+# Kazakhstan (all parts) switching to UTC+5 on March 1, 2024
+# https://www.gov.kz/memleket/entities/mti/press/news/details/688998?lang=ru
+# [in Russian]
+# (2024-01-20): https://primeminister.kz/ru/decisions/19012024-20
+#
+# From Alexander Krivenyshev (2024-01-19):
+# According to a different news and the official web site for the Ministry of
+# Trade and Integration of the Republic of Kazakhstan:
+# https://en.inform.kz/news/kazakhstan-to-switch-to-single-hour-zone-mar-1-54ad0b/
+
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 #
 # Almaty (formerly Alma-Ata), representing most locations in Kazakhstan
-# This includes KZ-AKM, KZ-ALA, KZ-ALM, KZ-AST, KZ-BAY, KZ-VOS, KZ-ZHA,
-# KZ-KAR, KZ-SEV, KZ-PAV, and KZ-YUZ.
+# This includes Abai/Abay (ISO 3166-2 code KZ-10), Aqmola/Akmola (KZ-11),
+# Almaty (KZ-19), Almaty city (KZ-75), Astana city (KZ-71),
+# East Kazakhstan (KZ-63), Jambyl/Zhambyl (KZ-31), Jetisu/Zhetysu (KZ-33),
+# Karaganda (KZ-35), North Kazakhstan (KZ-59), Pavlodar (KZ-55),
+# Shymkent city (KZ-79), Turkistan (KZ-61), and Ulytau (KZ-62).
 Zone	Asia/Almaty	5:07:48 -	LMT	1924 May  2 # or Alma-Ata
-			5:00	-	+05	1930 Jun 21
-			6:00 RussiaAsia +06/+07	1991 Mar 31  2:00s
-			5:00 RussiaAsia	+05/+06	1992 Jan 19  2:00s
-			6:00 RussiaAsia	+06/+07	2004 Oct 31  2:00s
-			6:00	-	+06
-# Qyzylorda (aka Kyzylorda, Kizilorda, Kzyl-Orda, etc.) (KZ-KZY)
+			5:00	-	%z	1930 Jun 21
+			6:00 RussiaAsia %z	1991 Mar 31  2:00s
+			5:00 RussiaAsia	%z	1992 Jan 19  2:00s
+			6:00 RussiaAsia	%z	2004 Oct 31  2:00s
+			6:00	-	%z	2024 Mar  1  0:00
+			5:00	-	%z
+# Qyzylorda (aka Kyzylorda, Kizilorda, Kzyl-Orda, etc.) (KZ-43)
 Zone	Asia/Qyzylorda	4:21:52 -	LMT	1924 May  2
-			4:00	-	+04	1930 Jun 21
-			5:00	-	+05	1981 Apr  1
-			5:00	1:00	+06	1981 Oct  1
-			6:00	-	+06	1982 Apr  1
-			5:00 RussiaAsia	+05/+06	1991 Mar 31  2:00s
-			4:00 RussiaAsia	+04/+05	1991 Sep 29  2:00s
-			5:00 RussiaAsia	+05/+06	1992 Jan 19  2:00s
-			6:00 RussiaAsia	+06/+07	1992 Mar 29  2:00s
-			5:00 RussiaAsia	+05/+06	2004 Oct 31  2:00s
-			6:00	-	+06
-# Aqtobe (aka Aktobe, formerly Aktyubinsk) (KZ-AKT)
+			4:00	-	%z	1930 Jun 21
+			5:00	-	%z	1981 Apr  1
+			5:00	1:00	%z	1981 Oct  1
+			6:00	-	%z	1982 Apr  1
+			5:00 RussiaAsia	%z	1991 Mar 31  2:00s
+			4:00 RussiaAsia	%z	1991 Sep 29  2:00s
+			5:00 RussiaAsia	%z	1992 Jan 19  2:00s
+			6:00 RussiaAsia	%z	1992 Mar 29  2:00s
+			5:00 RussiaAsia	%z	2004 Oct 31  2:00s
+			6:00	-	%z	2018 Dec 21  0:00
+			5:00	-	%z
+# Qostanay (aka Kostanay, Kustanay) (KZ-39)
+# The 1991/2 rules are unclear partly because of the 1997 Turgai
+# reorganization.
+Zone	Asia/Qostanay	4:14:28 -	LMT	1924 May  2
+			4:00	-	%z	1930 Jun 21
+			5:00	-	%z	1981 Apr  1
+			5:00	1:00	%z	1981 Oct  1
+			6:00	-	%z	1982 Apr  1
+			5:00 RussiaAsia	%z	1991 Mar 31  2:00s
+			4:00 RussiaAsia	%z	1992 Jan 19  2:00s
+			5:00 RussiaAsia	%z	2004 Oct 31  2:00s
+			6:00	-	%z	2024 Mar  1  0:00
+			5:00	-	%z
+# Aqtöbe (aka Aktobe, formerly Aktyubinsk) (KZ-15)
 Zone	Asia/Aqtobe	3:48:40	-	LMT	1924 May  2
-			4:00	-	+04	1930 Jun 21
-			5:00	-	+05	1981 Apr  1
-			5:00	1:00	+06	1981 Oct  1
-			6:00	-	+06	1982 Apr  1
-			5:00 RussiaAsia	+05/+06	1991 Mar 31  2:00s
-			4:00 RussiaAsia	+04/+05	1992 Jan 19  2:00s
-			5:00 RussiaAsia	+05/+06	2004 Oct 31  2:00s
-			5:00	-	+05
-# Qostanay (KZ-KUS)
-
-# Mangghystau (KZ-MAN)
+			4:00	-	%z	1930 Jun 21
+			5:00	-	%z	1981 Apr  1
+			5:00	1:00	%z	1981 Oct  1
+			6:00	-	%z	1982 Apr  1
+			5:00 RussiaAsia	%z	1991 Mar 31  2:00s
+			4:00 RussiaAsia	%z	1992 Jan 19  2:00s
+			5:00 RussiaAsia	%z	2004 Oct 31  2:00s
+			5:00	-	%z
+# Mangghystaū (KZ-47)
 # Aqtau was not founded until 1963, but it represents an inhabited region,
-# so include time stamps before 1963.
+# so include timestamps before 1963.
 Zone	Asia/Aqtau	3:21:04	-	LMT	1924 May  2
-			4:00	-	+04	1930 Jun 21
-			5:00	-	+05	1963
-			5:00	-	+05	1981 Oct  1
-			6:00	-	+06	1982 Apr  1
-			5:00 RussiaAsia	+05/+06	1991 Mar 31  2:00s
-			4:00 RussiaAsia	+04/+05	1992 Jan 19  2:00s
-			5:00 RussiaAsia	+05/+06	1994 Sep 25  2:00s
-			4:00 RussiaAsia	+04/+05	2004 Oct 31  2:00s
-			5:00	-	+05
-
-# West Kazakhstan (KZ-ZAP)
+			4:00	-	%z	1930 Jun 21
+			5:00	-	%z	1981 Oct  1
+			6:00	-	%z	1982 Apr  1
+			5:00 RussiaAsia	%z	1991 Mar 31  2:00s
+			4:00 RussiaAsia	%z	1992 Jan 19  2:00s
+			5:00 RussiaAsia	%z	1994 Sep 25  2:00s
+			4:00 RussiaAsia	%z	2004 Oct 31  2:00s
+			5:00	-	%z
+# Atyraū (KZ-23) is like Mangghystaū except it switched from
+# +04/+05 to +05/+06 in spring 1999, not fall 1994.
+Zone	Asia/Atyrau	3:27:44	-	LMT	1924 May  2
+			3:00	-	%z	1930 Jun 21
+			5:00	-	%z	1981 Oct  1
+			6:00	-	%z	1982 Apr  1
+			5:00 RussiaAsia	%z	1991 Mar 31  2:00s
+			4:00 RussiaAsia	%z	1992 Jan 19  2:00s
+			5:00 RussiaAsia	%z	1999 Mar 28  2:00s
+			4:00 RussiaAsia	%z	2004 Oct 31  2:00s
+			5:00	-	%z
+# West Kazakhstan (KZ-27)
 # From Paul Eggert (2016-03-18):
 # The 1989 transition is from USSR act No. 227 (1989-03-14).
 Zone	Asia/Oral	3:25:24	-	LMT	1924 May  2 # or Ural'sk
-			4:00	-	+04	1930 Jun 21
-			5:00	-	+05	1981 Apr  1
-			5:00	1:00	+06	1981 Oct  1
-			6:00	-	+06	1982 Apr  1
-			5:00 RussiaAsia	+05/+06	1989 Mar 26  2:00s
-			4:00 RussiaAsia	+04/+05	1992 Jan 19  2:00s
-			5:00 RussiaAsia	+05/+06	1992 Mar 29  2:00s
-			4:00 RussiaAsia	+04/+05	2004 Oct 31  2:00s
-			5:00	-	+05
+			3:00	-	%z	1930 Jun 21
+			5:00	-	%z	1981 Apr  1
+			5:00	1:00	%z	1981 Oct  1
+			6:00	-	%z	1982 Apr  1
+			5:00 RussiaAsia	%z	1989 Mar 26  2:00s
+			4:00 RussiaAsia	%z	1992 Jan 19  2:00s
+			5:00 RussiaAsia	%z	1992 Mar 29  2:00s
+			4:00 RussiaAsia	%z	2004 Oct 31  2:00s
+			5:00	-	%z
 
 # Kyrgyzstan (Kirgizstan)
 # Transitions through 1991 are from Shanks & Pottenger.
@@ -3354,18 +4408,18 @@ Zone	Asia/Oral	3:25:24	-	LMT	1924 May  2 # or Ural'sk
 # Our government cancels daylight saving time 6th of August 2005.
 # From 2005-08-12 our GMT-offset is +6, w/o any daylight saving.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Kyrgyz	1992	1996	-	Apr	Sun>=7	0:00s	1:00	S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Kyrgyz	1992	1996	-	Apr	Sun>=7	0:00s	1:00	-
 Rule	Kyrgyz	1992	1996	-	Sep	lastSun	0:00	0	-
-Rule	Kyrgyz	1997	2005	-	Mar	lastSun	2:30	1:00	S
+Rule	Kyrgyz	1997	2005	-	Mar	lastSun	2:30	1:00	-
 Rule	Kyrgyz	1997	2004	-	Oct	lastSun	2:30	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Bishkek	4:58:24 -	LMT	1924 May  2
-			5:00	-	+05	1930 Jun 21
-			6:00 RussiaAsia +06/+07	1991 Mar 31  2:00s
-			5:00 RussiaAsia	+05/+06	1991 Aug 31  2:00
-			5:00	Kyrgyz	+05/+06	2005 Aug 12
-			6:00	-	+06
+			5:00	-	%z	1930 Jun 21
+			6:00 RussiaAsia %z	1991 Mar 31  2:00s
+			5:00 RussiaAsia	%z	1991 Aug 31  2:00
+			5:00	Kyrgyz	%z	2005 Aug 12
+			6:00	-	%z
 
 ###############################################################################
 
@@ -3378,9 +4432,9 @@ Zone	Asia/Bishkek	4:58:24 -	LMT	1924 May  2
 # between 1987 and 1988 ...
 
 # From Sanghyuk Jung (2014-10-29):
-# http://mm.icann.org/pipermail/tz/2014-October/021830.html
+# https://mm.icann.org/pipermail/tz/2014-October/021830.html
 # According to the Korean Wikipedia
-# http://ko.wikipedia.org/wiki/한국_표준시
+# https://ko.wikipedia.org/wiki/한국_표준시
 # [oldid=12896437 2014-09-04 08:03 UTC]
 # DST in Republic of Korea was as follows....  And I checked old
 # newspapers in Korean, all articles correspond with data in Wikipedia.
@@ -3388,21 +4442,43 @@ Zone	Asia/Bishkek	4:58:24 -	LMT	1924 May  2
 # started at June 1 in that year.  For another example, the article in
 # 1988 said that DST started at 2:00 AM in that year.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	ROK	1948	only	-	Jun	 1	0:00	1:00	D
-Rule	ROK	1948	only	-	Sep	13	0:00	0	S
-Rule	ROK	1949	only	-	Apr	 3	0:00	1:00	D
-Rule	ROK	1949	1951	-	Sep	Sun>=8	0:00	0	S
-Rule	ROK	1950	only	-	Apr	 1	0:00	1:00	D
-Rule	ROK	1951	only	-	May	 6	0:00	1:00	D
-Rule	ROK	1955	only	-	May	 5	0:00	1:00	D
-Rule	ROK	1955	only	-	Sep	 9	0:00	0	S
-Rule	ROK	1956	only	-	May	20	0:00	1:00	D
-Rule	ROK	1956	only	-	Sep	30	0:00	0	S
-Rule	ROK	1957	1960	-	May	Sun>=1	0:00	1:00	D
-Rule	ROK	1957	1960	-	Sep	Sun>=18	0:00	0	S
-Rule	ROK	1987	1988	-	May	Sun>=8	2:00	1:00	D
-Rule	ROK	1987	1988	-	Oct	Sun>=8	3:00	0	S
+# From Phake Nick (2018-10-27):
+# 1. According to official announcement from Korean government, the DST end
+# date in South Korea should be
+# 1955-09-08 without specifying time
+# http://theme.archives.go.kr/next/common/viewEbook.do?singleData=N&archiveEventId=0027977557
+# 1956-09-29 without specifying time
+# http://theme.archives.go.kr/next/common/viewEbook.do?singleData=N&archiveEventId=0027978341
+# 1957-09-21 24 o'clock
+# http://theme.archives.go.kr/next/common/viewEbook.do?singleData=N&archiveEventId=0027979690#3
+# 1958-09-20 24 o'clock
+# http://theme.archives.go.kr/next/common/viewEbook.do?singleData=N&archiveEventId=0027981189
+# 1959-09-19 24 o'clock
+# http://theme.archives.go.kr/next/common/viewEbook.do?singleData=N&archiveEventId=0027982974#2
+# 1960-09-17 24 o'clock
+# http://theme.archives.go.kr/next/common/viewEbook.do?singleData=N&archiveEventId=0028044104
+# ...
+# 2.... https://namu.wiki/w/대한민국%20표준시 ... [says]
+# when Korea was using GMT+8:30 as standard time, the international
+# aviation/marine/meteorological industry in the country refused to
+# follow and continued to use GMT+9:00 for interoperability.
+
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	ROK	1948	only	-	Jun	 1	 0:00	1:00	D
+Rule	ROK	1948	only	-	Sep	12	24:00	0	S
+Rule	ROK	1949	only	-	Apr	 3	 0:00	1:00	D
+Rule	ROK	1949	1951	-	Sep	Sat>=7	24:00	0	S
+Rule	ROK	1950	only	-	Apr	 1	 0:00	1:00	D
+Rule	ROK	1951	only	-	May	 6	 0:00	1:00	D
+Rule	ROK	1955	only	-	May	 5	 0:00	1:00	D
+Rule	ROK	1955	only	-	Sep	 8	24:00	0	S
+Rule	ROK	1956	only	-	May	20	 0:00	1:00	D
+Rule	ROK	1956	only	-	Sep	29	24:00	0	S
+Rule	ROK	1957	1960	-	May	Sun>=1	 0:00	1:00	D
+Rule	ROK	1957	1960	-	Sep	Sat>=17	24:00	0	S
+Rule	ROK	1987	1988	-	May	Sun>=8	 2:00	1:00	D
+Rule	ROK	1987	1988	-	Oct	Sun>=8	 3:00	0	S
 
 # From Paul Eggert (2016-08-23):
 # The Korean Wikipedia entry gives the following sources for UT offsets:
@@ -3435,32 +4511,74 @@ Rule	ROK	1987	1988	-	Oct	Sun>=8	3:00	0	S
 # There is no common English-language abbreviation for this time zone.
 # Use KST, as that's what we already use for 1954-1961 in ROK.
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# From Kang Seonghoon (2018-04-29):
+# North Korea will revert its time zone from UTC+8:30 (PYT; Pyongyang
+# Time) back to UTC+9 (KST; Korea Standard Time).
+#
+# From Seo Sanghyeon (2018-04-30):
+# Rodong Sinmun 2018-04-30 announced Pyongyang Time transition plan.
+# https://www.nknews.org/kcna/wp-content/uploads/sites/5/2018/04/rodong-2018-04-30.pdf
+# ... the transition date is 2018-05-05 ...  Citation should be Decree
+# No. 2232 of April 30, 2018, of the Presidium of the Supreme People's
+# Assembly, as published in Rodong Sinmun.
+# From Tim Parenti (2018-04-29):
+# It appears to be the front page story at the top in the right-most column.
+#
+# From Paul Eggert (2018-05-04):
+# The BBC reported that the transition was from 23:30 to 24:00 today.
+# https://www.bbc.com/news/world-asia-44010705
+
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Seoul	8:27:52	-	LMT	1908 Apr  1
 			8:30	-	KST	1912 Jan  1
-			9:00	-	JCST	1937 Oct  1
 			9:00	-	JST	1945 Sep  8
-			9:00	-	KST	1954 Mar 21
+			9:00	ROK	K%sT	1954 Mar 21
 			8:30	ROK	K%sT	1961 Aug 10
 			9:00	ROK	K%sT
 Zone	Asia/Pyongyang	8:23:00 -	LMT	1908 Apr  1
 			8:30	-	KST	1912 Jan  1
-			9:00	-	JCST	1937 Oct  1
 			9:00	-	JST	1945 Aug 24
 			9:00	-	KST	2015 Aug 15 00:00
-			8:30	-	KST
-
-###############################################################################
-
-# Kuwait
-# See Asia/Riyadh.
-
-# Laos
-# See Asia/Bangkok.
+			8:30	-	KST	2018 May  4 23:30
+			9:00	-	KST
 
 
 # Lebanon
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+#
+# From Saadallah Itani (2023-03-23):
+# Lebanon ... announced today delay of Spring forward from March 25 to April 20.
+#
+# From Paul Eggert (2023-03-27):
+# This announcement was by the Lebanese caretaker prime minister Najib Mikati.
+# https://www.mtv.com.lb/en/News/Local/1352516/lebanon-postpones-daylight-saving-time-adoption
+# A video was later leaked to the media of parliament speaker Nabih Berri
+# asking Mikati to postpone DST to aid observance of Ramadan, Mikati objecting
+# that this would cause problems such as scheduling airline flights, to which
+# Berri interjected, "What flights?"
+#
+# The change was controversial and led to a partly-sectarian divide.
+# Many Lebanese institutions, including the education ministry, the Maronite
+# church, and two news channels LCBI and MTV, ignored the announcement and
+# went ahead with the long-scheduled spring-forward on March 25/26, some
+# arguing that the prime minister had not followed the law because the change
+# had not been approved by the cabinet.  Google went with the announcement;
+# Apple ignored it.  At least one bank followed the announcement for its doors,
+# but ignored the announcement in internal computer systems.
+# Beirut international airport listed two times for each departure.
+# Dan Azzi wrote "My view is that this whole thing is a Dumb and Dumber movie."
+# Eventually the prime minister backed down, said the cabinet had decided to
+# stick with its 1998 decision, and that DST would begin midnight March 29/30.
+# https://www.nna-leb.gov.lb/en/miscellaneous/604093/lebanon-has-two-times-of-day-amid-daylight-savings
+# https://www.cnbc.com/2023/03/27/lebanon-in-two-different-time-zones-as-government-disagrees-on-daylight-savings.html
+#
+# Although we could model the chaos with two Zones, that would likely cause
+# more trouble than it would cure.  Since so many manual clocks and
+# computer-based timestamps ignored the announcement, stick with official
+# cabinet resolutions in the data while recording the prime minister's
+# announcement as a comment.  This is how we treated a similar situation in
+# Rio de Janeiro in spring 1993.
+#
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Lebanon	1920	only	-	Mar	28	0:00	1:00	S
 Rule	Lebanon	1920	only	-	Oct	25	0:00	0	-
 Rule	Lebanon	1921	only	-	Apr	3	0:00	1:00	S
@@ -3485,45 +4603,39 @@ Rule	Lebanon	1992	only	-	Oct	4	0:00	0	-
 Rule	Lebanon	1993	max	-	Mar	lastSun	0:00	1:00	S
 Rule	Lebanon	1993	1998	-	Sep	lastSun	0:00	0	-
 Rule	Lebanon	1999	max	-	Oct	lastSun	0:00	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# This one-time rule, announced by the prime minister first for April 21
+# then for March 30, is commented out for reasons described above.
+#Rule	Lebanon	2023	only	-	Mar	30	0:00	1:00	S
+
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Beirut	2:22:00 -	LMT	1880
 			2:00	Lebanon	EE%sT
 
-# Malaysia
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	NBorneo	1935	1941	-	Sep	14	0:00	0:20	TS # one-Third Summer
+# Brunei
+# Malaysia (eastern)
+#
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	NBorneo	1935	1941	-	Sep	14	0:00	0:20	-
 Rule	NBorneo	1935	1941	-	Dec	14	0:00	0	-
 #
-# peninsular Malaysia
-# taken from Mok Ly Yng (2003-10-30)
-# http://www.math.nus.edu.sg/aslaksen/teaching/timezone.html
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Asia/Kuala_Lumpur	6:46:46 -	LMT	1901 Jan  1
-			6:55:25	-	SMT	1905 Jun  1 # Singapore M.T.
-			7:00	-	MALT	1933 Jan  1 # Malaya Time
-			7:00	0:20	MALST	1936 Jan  1
-			7:20	-	MALT	1941 Sep  1
-			7:30	-	MALT	1942 Feb 16
-			9:00	-	JST	1945 Sep 12
-			7:30	-	MALT	1982 Jan  1
-			8:00	-	MYT	# Malaysia Time
+# For peninsular Malaysia see Asia/Singapore.
+#
 # Sabah & Sarawak
 # From Paul Eggert (2014-08-12):
 # The data entries here are mostly from Shanks & Pottenger, but the 1942, 1945
 # and 1982 transition dates are from Mok Ly Yng.
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Asia/Kuching	7:21:20	-	LMT	1926 Mar
-			7:30	-	BORT	1933        # Borneo Time
-			8:00	NBorneo	BOR%sT	1942 Feb 16
-			9:00	-	JST	1945 Sep 12
-			8:00	-	BORT	1982 Jan  1
-			8:00	-	MYT
+			7:30	-	%z	1933
+			8:00 NBorneo	%z	1942 Feb 16
+			9:00	-	%z	1945 Sep 12
+			8:00	-	%z
 
 # Maldives
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Indian/Maldives	4:54:00 -	LMT	1880 # Male
-			4:54:00	-	MMT	1960 # Male Mean Time
-			5:00	-	MVT	# Maldives Time
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Indian/Maldives	4:54:00 -	LMT	1880 # Malé
+			4:54:00	-	MMT	1960 # Malé Mean Time
+			5:00	-	%z
 
 # Mongolia
 
@@ -3605,7 +4717,7 @@ Zone	Indian/Maldives	4:54:00 -	LMT	1880 # Male
 # +08:00 instead. Different sources appear to disagree with the tz
 # database on this, e.g.:
 #
-# http://www.timeanddate.com/worldclock/city.html?n=1026
+# https://www.timeanddate.com/worldclock/city.html?n=1026
 # http://www.worldtimeserver.com/current_time_in_MN.aspx
 #
 # both say GMT+08:00.
@@ -3625,9 +4737,37 @@ Zone	Indian/Maldives	4:54:00 -	LMT	1880 # Male
 
 # From Arthur David Olson (2008-05-19):
 # Assume that Choibalsan is indeed offset by 8:00.
-# XXX--in the absence of better information, assume that transition
-# was at the start of 2008-03-31 (the day of Steffen Thorsen's report);
-# this is almost surely wrong.
+
+# From Heitor David Pinto (2024-06-23):
+# Sources about time zones in Mongolia seem to list one of two conflicting
+# configurations.  The first configuration, mentioned in a comment to the TZ
+# database in 1999, citing a Mongolian government website, lists the provinces
+# of Bayan-Ölgii, Khovd and Uvs in UTC+7, and the rest of the country in
+# UTC+8.  The second configuration, mentioned in a comment to the database in
+# 2001, lists Bayan-Ölgii, Khovd, Uvs, Govi-Altai and Zavkhan in UTC+7, Dornod
+# and Sükhbaatar in UTC+9, and the rest of the country in UTC+8.
+#
+# The first configuration is still mentioned by several Mongolian travel
+# agencies:
+# https://www.adventurerider.mn/en/page/about_mongolia
+# http://www.naturetours.mn/nt/mongolia.php
+# https://www.newjuulchin.mn/web/content/7506?unique=fa24a0f6e96e022a3578ee5195ac879638c734ce
+#
+# It also matches these flight schedules in 2013:
+# http://web.archive.org/web/20130722023600/https://www.hunnuair.com/en/timetabled
+# The flight times imply that the airports of Uliastai (Zavkhan), Choibalsan
+# (Dornod) and Altai (Govi-Altai) are in the same time zone as Ulaanbaatar,
+# and Khovd is one hour behind....
+#
+# The second configuration was mentioned by an official of the Mongolian
+# standards agency in an interview in 2014: https://ikon.mn/n/9v6
+# And it's still listed by the Mongolian aviation agency:
+# https://ais.mn/files/aip/eAIP/2023-12-25/html/eSUP/ZM-eSUP-23-04-en-MN.html
+#
+# ... I believe that the first configuration is what is actually observed in
+# Mongolia and has been so all along, at least since 1999.  The second
+# configuration closely matches the ideal time zone boundaries at 97.5° E and
+# 112.5° E but it doesn't seem to be used in practice.
 
 # From Ganbold Tsagaankhuu (2015-03-10):
 # It seems like yesterday Mongolian Government meeting has concluded to use
@@ -3636,8 +4776,8 @@ Zone	Indian/Maldives	4:54:00 -	LMT	1880 # Male
 # September daylight saving time ends.  Source:
 # http://zasag.mn/news/view/8969
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Mongol	1983	1984	-	Apr	1	0:00	1:00	S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Mongol	1983	1984	-	Apr	1	0:00	1:00	-
 Rule	Mongol	1983	only	-	Oct	1	0:00	0	-
 # Shanks & Pottenger and IATA SSIM say 1990s switches occurred at 00:00,
 # but McDow says the 2001 switches occurred at 02:00.  Also, IATA SSIM
@@ -3650,40 +4790,34 @@ Rule	Mongol	1983	only	-	Oct	1	0:00	0	-
 # correction of 02:00 (in the previous edition) not being done correctly
 # in the latest edition; so ignore it for now.
 
-Rule	Mongol	1985	1998	-	Mar	lastSun	0:00	1:00	S
+# From Ganbold Tsagaankhuu (2017-02-09):
+# Mongolian Government meeting has concluded today to cancel daylight
+# saving time adoption in Mongolia.  Source: http://zasag.mn/news/view/16192
+
+Rule	Mongol	1985	1998	-	Mar	lastSun	0:00	1:00	-
 Rule	Mongol	1984	1998	-	Sep	lastSun	0:00	0	-
 # IATA SSIM (1999-09) says Mongolia no longer observes DST.
-Rule	Mongol	2001	only	-	Apr	lastSat	2:00	1:00	S
+Rule	Mongol	2001	only	-	Apr	lastSat	2:00	1:00	-
 Rule	Mongol	2001	2006	-	Sep	lastSat	2:00	0	-
-Rule	Mongol	2002	2006	-	Mar	lastSat	2:00	1:00	S
-Rule	Mongol	2015	max	-	Mar	lastSat	2:00	1:00	S
-Rule	Mongol	2015	max	-	Sep	lastSat	0:00	0	-
+Rule	Mongol	2002	2006	-	Mar	lastSat	2:00	1:00	-
+Rule	Mongol	2015	2016	-	Mar	lastSat	2:00	1:00	-
+Rule	Mongol	2015	2016	-	Sep	lastSat	0:00	0	-
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 # Hovd, a.k.a. Chovd, Dund-Us, Dzhargalant, Khovd, Jirgalanta
 Zone	Asia/Hovd	6:06:36 -	LMT	1905 Aug
-			6:00	-	HOVT	1978     # Hovd Time
-			7:00	Mongol	HOV%sT
+			6:00	-	%z	1978
+			7:00	Mongol	%z
 # Ulaanbaatar, a.k.a. Ulan Bataar, Ulan Bator, Urga
 Zone	Asia/Ulaanbaatar 7:07:32 -	LMT	1905 Aug
-			7:00	-	ULAT	1978     # Ulaanbaatar Time
-			8:00	Mongol	ULA%sT
-# Choibalsan, a.k.a. Bajan Tümen, Bajan Tumen, Chojbalsan,
-# Choybalsan, Sanbejse, Tchoibalsan
-Zone	Asia/Choibalsan	7:38:00 -	LMT	1905 Aug
-			7:00	-	ULAT	1978
-			8:00	-	ULAT	1983 Apr
-			9:00	Mongol	CHO%sT	2008 Mar 31 # Choibalsan Time
-			8:00	Mongol	CHO%sT
+			7:00	-	%z	1978
+			8:00	Mongol	%z
 
 # Nepal
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Kathmandu	5:41:16 -	LMT	1920
-			5:30	-	IST	1986
-			5:45	-	NPT	# Nepal Time
-
-# Oman
-# See Asia/Dubai.
+			5:30	-	%z	1986
+			5:45	-	%z
 
 # Pakistan
 
@@ -3731,8 +4865,8 @@ Zone	Asia/Kathmandu	5:41:16 -	LMT	1920
 # help reduce load shedding by approving the closure of commercial centres at
 # 9pm and moving clocks forward by one hour for the next three months. ...."
 #
-# http://www.worldtimezone.net/dst_news/dst_news_pakistan01.html
-# http://www.dailytimes.com.pk/default.asp?page=2008%5C05%5C15%5Cstory_15-5-2008_pg1_4
+# http://www.worldtimezone.com/dst_news/dst_news_pakistan01.html
+# http://www.dailytimes.com.pk/default.asp?page=2008\05\15\story_15-5-2008_pg1_4
 
 # From Arthur David Olson (2008-05-19):
 # XXX--midnight transitions is a guess; 2008 only is a guess.
@@ -3797,7 +4931,7 @@ Zone	Asia/Kathmandu	5:41:16 -	LMT	1920
 #
 # We have confirmed this year's end date with both with the Ministry of
 # Water and Power and the Pakistan Electric Power Company:
-# http://www.timeanddate.com/news/time/pakistan-ends-dst09.html
+# https://www.timeanddate.com/news/time/pakistan-ends-dst09.html
 
 # From Christoph Göhre (2009-10-01):
 # [T]he German Consulate General in Karachi reported me today that Pakistan
@@ -3820,19 +4954,19 @@ Zone	Asia/Kathmandu	5:41:16 -	LMT	1920
 # "People laud PM's announcement to end DST"
 # http://www.app.com.pk/en_/index.php?option=com_content&task=view&id=99374&Itemid=2
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule Pakistan	2002	only	-	Apr	Sun>=2	0:00	1:00	S
 Rule Pakistan	2002	only	-	Oct	Sun>=2	0:00	0	-
 Rule Pakistan	2008	only	-	Jun	1	0:00	1:00	S
 Rule Pakistan	2008	2009	-	Nov	1	0:00	0	-
 Rule Pakistan	2009	only	-	Apr	15	0:00	1:00	S
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Karachi	4:28:12 -	LMT	1907
-			5:30	-	IST	1942 Sep
-			5:30	1:00	IST	1945 Oct 15
-			5:30	-	IST	1951 Sep 30
-			5:00	-	KART	1971 Mar 26 # Karachi Time
+			5:30	-	%z	1942 Sep
+			5:30	1:00	%z	1945 Oct 15
+			5:30	-	%z	1951 Sep 30
+			5:00	-	%z	1971 Mar 26
 			5:00 Pakistan	PK%sT	# Pakistan Time
 
 # Palestine
@@ -3979,7 +5113,7 @@ Zone	Asia/Karachi	4:28:12 -	LMT	1907
 #
 # We are not sure if Gaza will do the same, last year they had a different
 # end date, we will keep this page updated:
-# http://www.timeanddate.com/news/time/westbank-gaza-dst-2009.html
+# https://www.timeanddate.com/news/time/westbank-gaza-dst-2009.html
 
 # From Alexander Krivenyshev (2009-09-02):
 # Seems that Gaza Strip will go back to Winter Time same date as West Bank.
@@ -4017,7 +5151,7 @@ Zone	Asia/Karachi	4:28:12 -	LMT	1907
 # the clocks were set back one hour at 2010-08-11 00:00:00 local time in
 # Gaza and the West Bank.
 # Some more background info:
-# http://www.timeanddate.com/news/time/westbank-gaza-end-dst-2010.html
+# https://www.timeanddate.com/news/time/westbank-gaza-end-dst-2010.html
 
 # From Steffen Thorsen (2011-08-26):
 # Gaza and the West Bank did go back to standard time in the beginning of
@@ -4027,7 +5161,7 @@ Zone	Asia/Karachi	4:28:12 -	LMT	1907
 #
 # http://www.maannews.net/eng/ViewDetails.aspx?ID=416217
 # Additional info:
-# http://www.timeanddate.com/news/time/palestine-dst-2011.html
+# https://www.timeanddate.com/news/time/palestine-dst-2011.html
 
 # From Alexander Krivenyshev (2011-08-27):
 # According to the article in The Jerusalem Post:
@@ -4037,7 +5171,7 @@ Zone	Asia/Karachi	4:28:12 -	LMT	1907
 # The Hamas government said on Saturday that it won't observe summertime after
 # the Muslim feast of Id al-Fitr, which begins on Tuesday..."
 # ...
-# http://www.jpost.com/MiddleEast/Article.aspx?id=235650
+# https://www.jpost.com/MiddleEast/Article.aspx?id=235650
 # http://www.worldtimezone.com/dst_news/dst_news_gazastrip05.html
 # The rules for Egypt are stolen from the 'africa' file.
 
@@ -4055,17 +5189,17 @@ Zone	Asia/Karachi	4:28:12 -	LMT	1907
 # Some of many sources in Arabic:
 # http://www.samanews.com/index.php?act=Show&id=122638
 #
-# http://safa.ps/details/news/74352/%D8%A8%D8%AF%D8%A1-%D8%A7%D9%84%D8%AA%D9%88%D9%82%D9%8A%D8%AA-%D8%A7%D9%84%D8%B5%D9%8A%D9%81%D9%8A-%D8%A8%D8%A7%D9%84%D8%B6%D9%81%D8%A9-%D9%88%D8%BA%D8%B2%D8%A9-%D9%84%D9%8A%D9%84%D8%A9-%D8%A7%D9%84%D8%AC%D9%85%D8%B9%D8%A9.html
+# http://safa.ps/details/news/74352/بدء-التوقيت-الصيفي-بالضفة-وغزة-ليلة-الجمعة.html
 #
 # Our brief summary:
-# http://www.timeanddate.com/news/time/gaza-west-bank-dst-2012.html
+# https://www.timeanddate.com/news/time/gaza-west-bank-dst-2012.html
 
 # From Steffen Thorsen (2013-03-26):
 # The following news sources tells that Palestine will "start daylight saving
 # time from midnight on Friday, March 29, 2013" (translated).
 # [These are in Arabic and are for Gaza and for Ramallah, respectively.]
 # http://www.samanews.com/index.php?act=Show&id=154120
-# http://safa.ps/details/news/99844/%D8%B1%D8%A7%D9%85-%D8%A7%D9%84%D9%84%D9%87-%D8%A8%D8%AF%D8%A1-%D8%A7%D9%84%D8%AA%D9%88%D9%82%D9%8A%D8%AA-%D8%A7%D9%84%D8%B5%D9%8A%D9%81%D9%8A-29-%D8%A7%D9%84%D8%AC%D8%A7%D8%B1%D9%8A.html
+# http://safa.ps/details/news/99844/رام-الله-بدء-التوقيت-الصيفي-29-الجاري.html
 
 # From Steffen Thorsen (2013-09-24):
 # The Gaza and West Bank are ending DST Thursday at midnight
@@ -4078,11 +5212,11 @@ Zone	Asia/Karachi	4:28:12 -	LMT	1907
 
 # From Steffen Thorsen (2015-03-03):
 # Sources such as http://www.alquds.com/news/article/view/id/548257
-# and http://www.raya.ps/ar/news/890705.html say Palestine areas will
+# and https://www.raya.ps/ar/news/890705.html say Palestine areas will
 # start DST on 2015-03-28 00:00 which is one day later than expected.
 #
 # From Paul Eggert (2015-03-03):
-# http://www.timeanddate.com/time/change/west-bank/ramallah?year=2014
+# https://www.timeanddate.com/time/change/west-bank/ramallah?year=2014
 # says that the fall 2014 transition was Oct 23 at 24:00.
 
 # From Hannah Kreitem (2016-03-09):
@@ -4090,26 +5224,127 @@ Zone	Asia/Karachi	4:28:12 -	LMT	1907
 # [Google translation]: "The Council also decided to start daylight
 # saving in Palestine as of one o'clock on Saturday morning,
 # 2016-03-26, to provide the clock 60 minutes ahead."
-#
-# From Paul Eggert (2016-03-12):
-# Predict spring transitions on March's last Saturday at 01:00 from now on.
 
 # From Sharef Mustafa (2016-10-19):
 # [T]he Palestinian cabinet decision (Mar 8th 2016) published on
 # http://www.palestinecabinet.gov.ps/WebSite/Upload/Decree/GOV_17/16032016134830.pdf
 # states that summer time will end on Oct 29th at 01:00.
-#
-# From Tim Parenti (2016-10-19):
-# Predict fall transitions on October's last Saturday at 01:00 from now on.
-# This is consistent with the 2016 transition as well as our spring
-# predictions.
-#
-# From Paul Eggert (2016-10-19):
-# It's also consistent with predictions in the following URLs today:
-# http://www.timeanddate.com/time/change/gaza-strip/gaza
-# http://www.timeanddate.com/time/change/west-bank/hebron
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# From Sharef Mustafa (2018-03-16):
+# Palestine summer time will start on Mar 24th 2018 ...
+# http://www.palestinecabinet.gov.ps/Website/AR/NDecrees/ViewFile.ashx?ID=e7a42ab7-ee23-435a-b9c8-a4f7e81f3817
+
+# From Even Scharning (2019-03-23):
+# http://pnn.ps/news/401130
+# http://palweather.ps/ar/node/50136.html
+#
+# From Sharif Mustafa (2019-03-26):
+# The Palestinian cabinet announced today that the switch to DST will
+# be on Fri Mar 29th 2019 by advancing the clock by 60 minutes.
+# http://palestinecabinet.gov.ps/Website/AR/NDecrees/ViewFile.ashx?ID=e54e9ea1-50ee-4137-84df-0d6c78da259b
+#
+# From Even Scharning (2019-04-10):
+# Our source in Palestine said it happened Friday 29 at 00:00 local time....
+
+# From Sharef Mustafa (2019-10-18):
+# Palestine summer time will end on midnight Oct 26th 2019 ...
+#
+# From Steffen Thorsen (2020-10-20):
+# Some sources such as these say, and display on clocks, that DST ended at
+# midnight last year...
+# https://www.amad.ps/ar/post/320006
+#
+# From Tim Parenti (2020-10-20):
+# The report of the Palestinian Cabinet meeting of 2019-10-14 confirms
+# a decision on (translated): "The start of the winter time in Palestine, by
+# delaying the clock by sixty minutes, starting from midnight on Friday /
+# Saturday corresponding to 26/10/2019."
+# http://www.palestinecabinet.gov.ps/portal/meeting/details/43948
+
+# From Sharef Mustafa (2020-10-20):
+# As per the palestinian cabinet announcement yesterday , the day light saving
+# shall [end] on Oct 24th 2020 at 01:00AM by delaying the clock by 60 minutes.
+# http://www.palestinecabinet.gov.ps/portal/Meeting/Details/51584
+
+# From Pierre Cashon (2020-10-20):
+# The summer time this year started on March 28 at 00:00.
+# https://wafa.ps/ar_page.aspx?id=GveQNZa872839351758aGveQNZ
+# http://www.palestinecabinet.gov.ps/portal/meeting/details/50284
+# The winter time in 2015 started on October 23 at 01:00.
+# https://wafa.ps/ar_page.aspx?id=CgpCdYa670694628582aCgpCdY
+# http://www.palestinecabinet.gov.ps/portal/meeting/details/27583
+
+# From P Chan (2021-10-18):
+# http://wafa.ps/Pages/Details/34701
+# Palestine winter time will start from midnight 2021-10-29 (Thursday-Friday).
+#
+# From Heba Hemad, Palestine Ministry of Telecom & IT (2021-10-20):
+# ... winter time will begin in Palestine from Friday 10-29, 01:00 AM
+# by 60 minutes backwards.
+#
+# From Tim Parenti (2021-10-25), per Paul Eggert (2021-10-24):
+# Guess future fall transitions at 01:00 on the Friday preceding October's
+# last Sunday (i.e., Fri>=23), as this is more consistent with recent practice.
+
+# From Heba Hamad (2022-03-10):
+# summer time will begin in Palestine from Sunday 03-27-2022, 00:00 AM.
+
+# From Heba Hamad (2022-08-30):
+# winter time will begin in Palestine from Saturday 10-29, 02:00 AM by
+# 60 minutes backwards.  Also the state of Palestine adopted the summer
+# and winter time for the years: 2023,2024,2025,2026 ...
+# https://mm.icann.org/pipermail/tz/attachments/20220830/9f024566/Time-0001.pdf
+# (2022-08-31): ... the Saturday before the last Sunday in March and October
+# at 2:00 AM ,for the years from 2023 to 2026.
+# (2022-09-05): https://mtit.pna.ps/Site/New/1453
+
+# From Heba Hamad (2023-03-22):
+# ... summer time will begin in Palestine from Saturday 04-29-2023,
+# 02:00 AM by 60 minutes forward.
+# From Heba Hemad (2023-10-09):
+# ... winter time will begin in Palestine from Saturday 10-28-2023,
+# 02:00 AM by 60 minutes back.
+#
+# From Heba Hamad (2024-01-25):
+# the summer time for the years 2024,2025 will begin in Palestine
+# from Saturday at 02:00 AM by 60 minutes forward as shown below:
+# year date
+# 2024 2024-04-20
+# 2025 2025-04-12
+#
+# From Paul Eggert (2024-01-25):
+# For now, guess that spring and fall transitions will normally
+# continue to use 2022's rules, that during DST Palestine will switch
+# to standard time at 02:00 the last Saturday before Ramadan and back
+# to DST at 02:00 the second Saturday after Ramadan, and that
+# if the normal spring-forward or fall-back transition occurs during
+# Ramadan the former is delayed and the latter advanced.
+# To implement this, I predicted Ramadan-oriented transition dates for
+# 2026 through 2086 by running the following program under GNU Emacs 29.2,
+# with the results integrated by hand into the table below.
+# Predictions after 2086 are approximated without Ramadan.
+#
+# (let ((islamic-year 1447))
+#   (require 'cal-islam)
+#   (while (< islamic-year 1510)
+#     (let ((a (calendar-islamic-to-absolute (list 9 1 islamic-year)))
+#           (b (+ 1 (calendar-islamic-to-absolute (list 10 1 islamic-year))))
+#           (saturday 6))
+#       (while (/= saturday (mod (setq a (1- a)) 7)))
+#       (while (/= saturday (mod b 7))
+#         (setq b (1+ b)))
+#       (setq b (+ 7 b))
+#       (setq a (calendar-gregorian-from-absolute a))
+#       (setq b (calendar-gregorian-from-absolute b))
+#       (insert
+#        (format
+#         (concat "Rule Palestine\t%d\tonly\t-\t%s\t%2d\t2:00\t0\t-\n"
+#                 "Rule Palestine\t%d\tonly\t-\t%s\t%2d\t2:00\t1:00\tS\n")
+#         (car (cdr (cdr a))) (calendar-month-name (car a) t) (car (cdr a))
+#         (car (cdr (cdr b))) (calendar-month-name (car b) t) (car (cdr b)))))
+#     (setq islamic-year (+ 1 islamic-year))))
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule EgyptAsia	1957	only	-	May	10	0:00	1:00	S
 Rule EgyptAsia	1957	1958	-	Oct	 1	0:00	0	-
 Rule EgyptAsia	1958	only	-	May	 1	0:00	1:00	S
@@ -4123,10 +5358,10 @@ Rule Palestine	2004	only	-	Oct	 1	1:00	0	-
 Rule Palestine	2005	only	-	Oct	 4	2:00	0	-
 Rule Palestine	2006	2007	-	Apr	 1	0:00	1:00	S
 Rule Palestine	2006	only	-	Sep	22	0:00	0	-
-Rule Palestine	2007	only	-	Sep	Thu>=8	2:00	0	-
+Rule Palestine	2007	only	-	Sep	13	2:00	0	-
 Rule Palestine	2008	2009	-	Mar	lastFri	0:00	1:00	S
 Rule Palestine	2008	only	-	Sep	 1	0:00	0	-
-Rule Palestine	2009	only	-	Sep	Fri>=1	1:00	0	-
+Rule Palestine	2009	only	-	Sep	 4	1:00	0	-
 Rule Palestine	2010	only	-	Mar	26	0:00	1:00	S
 Rule Palestine	2010	only	-	Aug	11	0:00	0	-
 Rule Palestine	2011	only	-	Apr	 1	0:01	1:00	S
@@ -4135,15 +5370,102 @@ Rule Palestine	2011	only	-	Aug	30	0:00	1:00	S
 Rule Palestine	2011	only	-	Sep	30	0:00	0	-
 Rule Palestine	2012	2014	-	Mar	lastThu	24:00	1:00	S
 Rule Palestine	2012	only	-	Sep	21	1:00	0	-
-Rule Palestine	2013	only	-	Sep	Fri>=21	0:00	0	-
-Rule Palestine	2014	2015	-	Oct	Fri>=21	0:00	0	-
-Rule Palestine	2015	only	-	Mar	lastFri	24:00	1:00	S
-Rule Palestine	2016	max	-	Mar	lastSat	1:00	1:00	S
-Rule Palestine	2016	max	-	Oct	lastSat	1:00	0	-
+Rule Palestine	2013	only	-	Sep	27	0:00	0	-
+Rule Palestine	2014	only	-	Oct	24	0:00	0	-
+Rule Palestine	2015	only	-	Mar	28	0:00	1:00	S
+Rule Palestine	2015	only	-	Oct	23	1:00	0	-
+Rule Palestine	2016	2018	-	Mar	Sat<=30	1:00	1:00	S
+Rule Palestine	2016	2018	-	Oct	Sat<=30	1:00	0	-
+Rule Palestine	2019	only	-	Mar	29	0:00	1:00	S
+Rule Palestine	2019	only	-	Oct	Sat<=30	0:00	0	-
+Rule Palestine	2020	2021	-	Mar	Sat<=30	0:00	1:00	S
+Rule Palestine	2020	only	-	Oct	24	1:00	0	-
+Rule Palestine	2021	only	-	Oct	29	1:00	0	-
+Rule Palestine	2022	only	-	Mar	27	0:00	1:00	S
+Rule Palestine	2022	2035	-	Oct	Sat<=30	2:00	0	-
+Rule Palestine	2023	only	-	Apr	29	2:00	1:00	S
+Rule Palestine	2024	only	-	Apr	20	2:00	1:00	S
+Rule Palestine	2025	only	-	Apr	12	2:00	1:00	S
+Rule Palestine	2026	2054	-	Mar	Sat<=30	2:00	1:00	S
+Rule Palestine	2036	only	-	Oct	18	2:00	0	-
+Rule Palestine	2037	only	-	Oct	10	2:00	0	-
+Rule Palestine	2038	only	-	Sep	25	2:00	0	-
+Rule Palestine	2039	only	-	Sep	17	2:00	0	-
+Rule Palestine	2040	only	-	Sep	 1	2:00	0	-
+Rule Palestine	2040	only	-	Oct	20	2:00	1:00	S
+Rule Palestine	2040	2067	-	Oct	Sat<=30	2:00	0	-
+Rule Palestine	2041	only	-	Aug	24	2:00	0	-
+Rule Palestine	2041	only	-	Oct	 5	2:00	1:00	S
+Rule Palestine	2042	only	-	Aug	16	2:00	0	-
+Rule Palestine	2042	only	-	Sep	27	2:00	1:00	S
+Rule Palestine	2043	only	-	Aug	 1	2:00	0	-
+Rule Palestine	2043	only	-	Sep	19	2:00	1:00	S
+Rule Palestine	2044	only	-	Jul	23	2:00	0	-
+Rule Palestine	2044	only	-	Sep	 3	2:00	1:00	S
+Rule Palestine	2045	only	-	Jul	15	2:00	0	-
+Rule Palestine	2045	only	-	Aug	26	2:00	1:00	S
+Rule Palestine	2046	only	-	Jun	30	2:00	0	-
+Rule Palestine	2046	only	-	Aug	18	2:00	1:00	S
+Rule Palestine	2047	only	-	Jun	22	2:00	0	-
+Rule Palestine	2047	only	-	Aug	 3	2:00	1:00	S
+Rule Palestine	2048	only	-	Jun	 6	2:00	0	-
+Rule Palestine	2048	only	-	Jul	25	2:00	1:00	S
+Rule Palestine	2049	only	-	May	29	2:00	0	-
+Rule Palestine	2049	only	-	Jul	10	2:00	1:00	S
+Rule Palestine	2050	only	-	May	21	2:00	0	-
+Rule Palestine	2050	only	-	Jul	 2	2:00	1:00	S
+Rule Palestine	2051	only	-	May	 6	2:00	0	-
+Rule Palestine	2051	only	-	Jun	24	2:00	1:00	S
+Rule Palestine	2052	only	-	Apr	27	2:00	0	-
+Rule Palestine	2052	only	-	Jun	 8	2:00	1:00	S
+Rule Palestine	2053	only	-	Apr	12	2:00	0	-
+Rule Palestine	2053	only	-	May	31	2:00	1:00	S
+Rule Palestine	2054	only	-	Apr	 4	2:00	0	-
+Rule Palestine	2054	only	-	May	23	2:00	1:00	S
+Rule Palestine	2055	only	-	May	 8	2:00	1:00	S
+Rule Palestine	2056	only	-	Apr	29	2:00	1:00	S
+Rule Palestine	2057	only	-	Apr	14	2:00	1:00	S
+Rule Palestine	2058	only	-	Apr	 6	2:00	1:00	S
+Rule Palestine	2059	max	-	Mar	Sat<=30	2:00	1:00	S
+Rule Palestine	2068	only	-	Oct	20	2:00	0	-
+Rule Palestine	2069	only	-	Oct	12	2:00	0	-
+Rule Palestine	2070	only	-	Oct	 4	2:00	0	-
+Rule Palestine	2071	only	-	Sep	19	2:00	0	-
+Rule Palestine	2072	only	-	Sep	10	2:00	0	-
+Rule Palestine	2072	only	-	Oct	22	2:00	1:00	S
+Rule Palestine	2072	max	-	Oct	Sat<=30	2:00	0	-
+Rule Palestine	2073	only	-	Sep	 2	2:00	0	-
+Rule Palestine	2073	only	-	Oct	14	2:00	1:00	S
+Rule Palestine	2074	only	-	Aug	18	2:00	0	-
+Rule Palestine	2074	only	-	Oct	 6	2:00	1:00	S
+Rule Palestine	2075	only	-	Aug	10	2:00	0	-
+Rule Palestine	2075	only	-	Sep	21	2:00	1:00	S
+Rule Palestine	2076	only	-	Jul	25	2:00	0	-
+Rule Palestine	2076	only	-	Sep	12	2:00	1:00	S
+Rule Palestine	2077	only	-	Jul	17	2:00	0	-
+Rule Palestine	2077	only	-	Sep	 4	2:00	1:00	S
+Rule Palestine	2078	only	-	Jul	 9	2:00	0	-
+Rule Palestine	2078	only	-	Aug	20	2:00	1:00	S
+Rule Palestine	2079	only	-	Jun	24	2:00	0	-
+Rule Palestine	2079	only	-	Aug	12	2:00	1:00	S
+Rule Palestine	2080	only	-	Jun	15	2:00	0	-
+Rule Palestine	2080	only	-	Jul	27	2:00	1:00	S
+Rule Palestine	2081	only	-	Jun	 7	2:00	0	-
+Rule Palestine	2081	only	-	Jul	19	2:00	1:00	S
+Rule Palestine	2082	only	-	May	23	2:00	0	-
+Rule Palestine	2082	only	-	Jul	11	2:00	1:00	S
+Rule Palestine	2083	only	-	May	15	2:00	0	-
+Rule Palestine	2083	only	-	Jun	26	2:00	1:00	S
+Rule Palestine	2084	only	-	Apr	29	2:00	0	-
+Rule Palestine	2084	only	-	Jun	17	2:00	1:00	S
+Rule Palestine	2085	only	-	Apr	21	2:00	0	-
+Rule Palestine	2085	only	-	Jun	 9	2:00	1:00	S
+Rule Palestine	2086	only	-	Apr	13	2:00	0	-
+Rule Palestine	2086	only	-	May	25	2:00	1:00	S
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Gaza	2:17:52	-	LMT	1900 Oct
-			2:00	Zion	EET	1948 May 15
+			2:00	Zion	EET/EEST 1948 May 15
 			2:00 EgyptAsia	EE%sT	1967 Jun  5
 			2:00	Zion	I%sT	1996
 			2:00	Jordan	EE%sT	1999
@@ -4156,7 +5478,7 @@ Zone	Asia/Gaza	2:17:52	-	LMT	1900 Oct
 			2:00 Palestine	EE%sT
 
 Zone	Asia/Hebron	2:20:23	-	LMT	1900 Oct
-			2:00	Zion	EET	1948 May 15
+			2:00	Zion	EET/EEST 1948 May 15
 			2:00 EgyptAsia	EE%sT	1967 Jun  5
 			2:00	Zion	I%sT	1996
 			2:00	Jordan	EE%sT	1999
@@ -4166,58 +5488,159 @@ Zone	Asia/Hebron	2:20:23	-	LMT	1900 Oct
 # no information
 
 # Philippines
+
+# From Paul Eggert (2024-01-21):
+# The Spanish initially used American (west-of-Greenwich) time.
+# It is unknown what time Manila kept when the British occupied it from
+# 1762-10-06 through 1764-04; for now assume it kept American time.
 # On 1844-08-16, Narciso Clavería, governor-general of the
 # Philippines, issued a proclamation announcing that 1844-12-30 was to
 # be immediately followed by 1845-01-01; see R.H. van Gent's
 # History of the International Date Line
-# http://www.staff.science.uu.nl/~gent0113/idl/idl_philippines.htm
-# The rest of the data entries are from Shanks & Pottenger.
+# https://webspace.science.uu.nl/~gent0113/idl/idl_philippines.htm
 
-# From Jesper Nørgaard Welen (2006-04-26):
-# ... claims that Philippines had DST last time in 1990:
-# http://story.philippinetimes.com/p.x/ct/9/id/145be20cc6b121c0/cid/3e5bbccc730d258c/
-# [a story dated 2006-04-25 by Cris Larano of Dow Jones Newswires,
-# but no details]
-
-# From Paul Eggert (2014-08-14):
-# The following source says DST may be instituted November-January and again
-# March-June, but this is not definite.  It also says DST was last proclaimed
-# during the Ramos administration (1992-1998); but again, no details.
-# Carcamo D. PNoy urged to declare use of daylight saving time.
-# Philippine Star 2014-08-05
-# http://www.philstar.com/headlines/2014/08/05/1354152/pnoy-urged-declare-use-daylight-saving-time
-
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Phil	1936	only	-	Nov	1	0:00	1:00	S
-Rule	Phil	1937	only	-	Feb	1	0:00	0	-
-Rule	Phil	1954	only	-	Apr	12	0:00	1:00	S
-Rule	Phil	1954	only	-	Jul	1	0:00	0	-
-Rule	Phil	1978	only	-	Mar	22	0:00	1:00	S
-Rule	Phil	1978	only	-	Sep	21	0:00	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Asia/Manila	-15:56:00 -	LMT	1844 Dec 31
-			8:04:00 -	LMT	1899 May 11
-			8:00	Phil	PH%sT	1942 May
-			9:00	-	JST	1944 Nov
-			8:00	Phil	PH%sT
-
-# Qatar
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Asia/Qatar	3:26:08 -	LMT	1920     # Al Dawhah / Doha
-			4:00	-	GST	1972 Jun
-			3:00	-	AST
-Link Asia/Qatar Asia/Bahrain
-
-# Saudi Arabia
+# From P Chan (2021-05-10):
+# Here's a fairly comprehensive article in Japanese:
+#	https://wiki.suikawiki.org/n/Philippine%20Time
+# (2021-05-16):
+# According to the references listed in the article,
+# the periods that the Philippines (Manila) observed DST or used +9 are:
 #
-# From Paul Eggert (2014-07-15):
+# 1936-10-31 24:00 to 1937-01-15 24:00
+#	(Proclamation No. 104, Proclamation No. 126)
+# 1941-12-15 24:00 to 1945-11-30 24:00
+#	(Proclamation No. 789, Proclamation No. 20)
+# 1954-04-11 24:00 to 1954-06-04 24:00
+#	(Proclamation No. 13, Proclamation No. 33)
+# 1977-03-27 24:00 to 1977-09-21 24:00
+#	(Proclamation No. 1629, Proclamation No. 1641)
+# 1990-05-21 00:00 to 1990-07-28 24:00
+#	(National Emergency Memorandum Order No. 17, Executive Order No. 415)
+#
+# Proclamation No. 104 ... October 30, 1936
+#  https://www.officialgazette.gov.ph/1936/10/30/proclamation-no-104-s-1936/
+# Proclamation No. 126 ... January 15, 1937
+#  https://www.officialgazette.gov.ph/1937/01/15/proclamation-no-126-s-1937/
+# Proclamation No. 789 ... December 13, 1941
+#  https://www.officialgazette.gov.ph/1941/12/13/proclamation-no-789-s-1941/
+# Proclamation No. 20 ... November 11, 1945
+#  https://www.officialgazette.gov.ph/1945/11/11/proclamation-no-20-s-1945/
+# Proclamation No. 13 ... April 6, 1954
+#  https://www.officialgazette.gov.ph/1954/04/06/proclamation-no-13-s-1954/
+# Proclamation No. 33 ... June 3, 1954
+#  https://www.officialgazette.gov.ph/1954/06/03/proclamation-no-33-s-1954/
+# Proclamation No. 1629 ... March 25, 1977
+#  https://www.officialgazette.gov.ph/1977/03/25/proclamation-no-1629-s-1977/
+# Proclamation No. 1641 ...May 26, 1977
+#  https://www.officialgazette.gov.ph/1977/05/26/proclamation-no-1641-s-1977/
+# National Emergency Memorandum Order No. 17 ... May 2, 1990
+#  https://www.officialgazette.gov.ph/1990/05/02/national-emergency-memorandum-order-no-17-s-1990/
+# Executive Order No. 415 ... July 20, 1990
+#  https://www.officialgazette.gov.ph/1990/07/20/executive-order-no-415-s-1990/
+#
+# During WWII, Proclamation No. 789 fixed two periods of DST. The first period
+# was set to continue only until January 31, 1942. But Manila was occupied by
+# the Japanese earlier in the month....
+#
+# For the date of the adoption of standard time, Shank[s] gives 1899-05-11.
+# The article is not able to state the basis of that. I guess it was based on
+# a US War Department Circular issued on that date.
+#	https://books.google.com/books?id=JZ1PAAAAYAAJ&pg=RA3-PA8
+#
+# However, according to other sources, standard time was adopted on
+# 1899-09-06.  Also, the LMT was GMT+8:03:52
+#	https://books.google.com/books?id=MOYIAQAAIAAJ&pg=PA521
+#	https://books.google.com/books?id=lSnqqatpYikC&pg=PA21
+#
+# From Paul Eggert (2024-09-05):
+# The penultimate URL in P Chan's email refers to page 521 of
+# Selga M, The Time Service in the Philippines.
+# Proc Pan-Pacific Science Congress. Vol. 1 (1923), 519-532.
+# It says, "The change from the meridian 120° 58' 04" to the 120th implied a
+# change of 3 min. 52s.26 in time; consequently on 6th September, 1899,
+# Manila Observatory gave the noon signal 3 min. 52s.26 later than before".
+#
+# Wikipedia says the US declared Manila liberated on March 4, 1945;
+# this doesn't affect clocks, just our time zone abbreviation and DST flag.
+
+# From Paul Goyette (2018-06-15) with URLs updated by Guy Harris (2024-02-15):
+# In the Philippines, there is a national law, Republic Act No. 10535
+# which declares the official time here as "Philippine Standard Time".
+# The act [1] even specifies use of PST as the abbreviation, although
+# the FAQ provided by PAGASA [2] uses the "acronym PhST to distinguish
+# it from the Pacific Standard Time (PST)."
+# [1] https://www.officialgazette.gov.ph/2013/05/15/republic-act-no-10535/
+# [2] https://prsd.pagasa.dost.gov.ph/index.php/28-astronomy/302-philippine-standard-time
+#
+# From Paul Eggert (2018-06-19):
+# I surveyed recent news reports, and my impression is that "PST" is
+# more popular among reliable English-language news sources.  This is
+# not just a measure of Google hit counts: it's also the sizes and
+# influence of the sources.  There is no current abbreviation for DST,
+# so use "PDT", the usual American style.
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Phil	1936	only	-	Oct	31	24:00	1:00	D
+Rule	Phil	1937	only	-	Jan	15	24:00	0	S
+Rule	Phil	1941	only	-	Dec	15	24:00	1:00	D
+# The following three rules were canceled by Japan:
+#Rule	Phil	1942	only	-	Jan	31	24:00	0	S
+#Rule	Phil	1942	only	-	Mar	 1	 0:00	1:00	D
+#Rule	Phil	1942	only	-	Jun	30	24:00	0	S
+Rule	Phil	1945	only	-	Nov	30	24:00	0	S
+Rule	Phil	1954	only	-	Apr	11	24:00	1:00	D
+Rule	Phil	1954	only	-	Jun	 4	24:00	0	S
+Rule	Phil	1977	only	-	Mar	27	24:00	1:00	D
+Rule	Phil	1977	only	-	Sep	21	24:00	0	S
+Rule	Phil	1990	only	-	May	21	 0:00	1:00	D
+Rule	Phil	1990	only	-	Jul	28	24:00	0	S
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Asia/Manila	-15:56:08 -	LMT	1844 Dec 31
+			8:03:52 -	LMT	1899 Sep  6  4:00u
+			8:00	Phil	P%sT	1942 Feb 11 24:00
+			9:00	-	JST	1945 Mar  4
+			8:00	Phil	P%sT
+
+# Bahrain
+# Qatar
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Asia/Qatar	3:26:08 -	LMT	1920     # Al Dawhah / Doha
+			4:00	-	%z	1972 Jun
+			3:00	-	%z
+
+# Kuwait
+# Saudi Arabia
+# Yemen
+#
+# Japan's year-round bases in Antarctica match this since 1970.
+#
+# From Paul Eggert (2018-08-29):
 # Time in Saudi Arabia and other countries in the Arabian peninsula was not
-# standardized until relatively recently; we don't know when, and possibly it
+# standardized until 1968 or so; we don't know exactly when, and possibly it
 # has never been made official.  Richard P Hunt, in "Islam city yielding to
 # modern times", New York Times (1961-04-09), p 20, wrote that only airlines
 # observed standard time, and that people in Jeddah mostly observed quasi-solar
 # time, doing so by setting their watches at sunrise to 6 o'clock (or to 12
 # o'clock for "Arab" time).
+#
+# Timekeeping differed depending on who you were and which part of Saudi
+# Arabia you were in.  In 1969, Elias Antar wrote that although a common
+# practice had been to set one's watch to 12:00 (i.e., midnight) at sunset -
+# which meant that the time on one side of a mountain could differ greatly from
+# the time on the other side - many foreigners set their watches to 6pm
+# instead, while airlines instead used UTC +03 (except in Dhahran, where they
+# used UTC +04), Aramco used UTC +03 with DST, and the Trans-Arabian Pipe Line
+# Company used Aramco time in eastern Saudi Arabia and airline time in western.
+# (The American Military Aid Advisory Group used plain UTC.)  Antar writes,
+# "A man named Higgins, so the story goes, used to run a local power
+# station. One day, the whole thing became too much for Higgins and he
+# assembled his staff and laid down the law. 'I've had enough of this,' he
+# shrieked. 'It is now 12 o'clock Higgins Time, and from now on this station is
+# going to run on Higgins Time.' And so, until last year, it did."  See:
+# Antar E. Dinner at When? Saudi Aramco World, 1969 March/April. 2-3.
+# http://archive.aramcoworld.com/issue/196902/dinner.at.when.htm
+# Also see: Antar EN. Arabian flying is confusing.
+# Port Angeles (WA) Evening News. 1965-03-10. page 3.
 #
 # The TZ database cannot represent quasi-solar time; airline time is the best
 # we can do.  The 1946 foreign air news digest of the U.S. Civil Aeronautics
@@ -4228,28 +5651,26 @@ Link Asia/Qatar Asia/Bahrain
 #
 # Shanks & Pottenger also state that until 1968-05-01 Saudi Arabia had two
 # time zones; the other zone, at UT +04, was in the far eastern part of
-# the country.  Ignore this, as it's before our 1970 cutoff.
+# the country.  Presumably this is documenting airline time.  Ignore this,
+# as it's before our 1970 cutoff.
 #
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Riyadh	3:06:52 -	LMT	1947 Mar 14
-			3:00	-	AST
-Link Asia/Riyadh Asia/Aden	# Yemen
-Link Asia/Riyadh Asia/Kuwait
+			3:00	-	%z
 
 # Singapore
 # taken from Mok Ly Yng (2003-10-30)
-# http://www.math.nus.edu.sg/aslaksen/teaching/timezone.html
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# https://web.archive.org/web/20190822231045/http://www.math.nus.edu.sg/~mathelmr/teaching/timezone.html
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Singapore	6:55:25 -	LMT	1901 Jan  1
 			6:55:25	-	SMT	1905 Jun  1 # Singapore M.T.
-			7:00	-	MALT	1933 Jan  1 # Malaya Time
-			7:00	0:20	MALST	1936 Jan  1
-			7:20	-	MALT	1941 Sep  1
-			7:30	-	MALT	1942 Feb 16
-			9:00	-	JST	1945 Sep 12
-			7:30	-	MALT	1965 Aug  9 # independence
-			7:30	-	SGT	1982 Jan  1 # Singapore Time
-			8:00	-	SGT
+			7:00	-	%z	1933 Jan  1
+			7:00	0:20	%z	1936 Jan  1
+			7:20	-	%z	1941 Sep  1
+			7:30	-	%z	1942 Feb 16
+			9:00	-	%z	1945 Sep 12
+			7:30	-	%z	1981 Dec 31 16:00u
+			8:00	-	%z
 
 # Spratly Is
 # no information
@@ -4295,7 +5716,7 @@ Zone	Asia/Singapore	6:55:25 -	LMT	1901 Jan  1
 # standard time is SLST.
 #
 # From Paul Eggert (2016-10-18):
-# "SLST" seems to be reasonably recent and rarely-used outside time
+# "SLST" seems to be reasonably recent and rarely used outside time
 # zone nerd sources.  I searched Google News and found three uses of
 # it in the International Business Times of India in February and
 # March of this year when discussing cricket match times, but nothing
@@ -4304,19 +5725,19 @@ Zone	Asia/Singapore	6:55:25 -	LMT	1901 Jan  1
 # even worse.  For now, let's use a numeric abbreviation; we can
 # switch to "SLST" if it catches on.
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Colombo	5:19:24 -	LMT	1880
 			5:19:32	-	MMT	1906        # Moratuwa Mean Time
-			5:30	-	+0530	1942 Jan  5
-			5:30	0:30	+0530/+06 1942 Sep
-			5:30	1:00	+0530/+0630 1945 Oct 16  2:00
-			5:30	-	+0530	1996 May 25  0:00
-			6:30	-	+0630	1996 Oct 26  0:30
-			6:00	-	+06	2006 Apr 15  0:30
-			5:30	-	+0530
+			5:30	-	%z	1942 Jan  5
+			5:30	0:30	%z	1942 Sep
+			5:30	1:00	%z	1945 Oct 16  2:00
+			5:30	-	%z	1996 May 25  0:00
+			6:30	-	%z	1996 Oct 26  0:30
+			6:00	-	%z	2006 Apr 15  0:30
+			5:30	-	%z
 
 # Syria
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Syria	1920	1923	-	Apr	Sun>=15	2:00	1:00	S
 Rule	Syria	1920	1923	-	Oct	Sun>=1	2:00	0	-
 Rule	Syria	1962	only	-	Apr	29	2:00	1:00	S
@@ -4435,7 +5856,7 @@ Rule	Syria	2007	only	-	Nov	 Fri>=1	0:00	0	-
 # We have not found any sources saying anything about when DST ends this year.
 #
 # Our summary
-# http://www.timeanddate.com/news/time/syria-dst-starts-march-27-2009.html
+# https://www.timeanddate.com/news/time/syria-dst-starts-march-27-2009.html
 
 # From Steffen Thorsen (2009-10-27):
 # The Syrian Arab News Network on 2009-09-29 reported that Syria will
@@ -4462,72 +5883,87 @@ Rule	Syria	2007	only	-	Nov	 Fri>=1	0:00	0	-
 # http://www.sana.sy/ara/2/2012/03/26/408215.htm
 #
 # Our brief summary:
-# http://www.timeanddate.com/news/time/syria-dst-2012.html
+# https://www.timeanddate.com/news/time/syria-dst-2012.html
 
-# From Arthur David Olson (2012-03-27):
-# Assume last Friday in March going forward XXX.
+# From Steffen Thorsen (2022-10-05):
+# Syria is adopting year-round DST, starting this autumn....
+# From https://www.enabbaladi.net/archives/607812
+# "This [the decision] came after the weekly government meeting today,
+# Tuesday 4 October ..."
+#
+# From Paul Eggert (2022-10-05):
+# Like Jordan, model this as a transition from EEST +03 (DST) to plain +03
+# (non-DST) at the point where DST would otherwise have ended.
 
 Rule	Syria	2008	only	-	Apr	Fri>=1	0:00	1:00	S
 Rule	Syria	2008	only	-	Nov	1	0:00	0	-
 Rule	Syria	2009	only	-	Mar	lastFri	0:00	1:00	S
 Rule	Syria	2010	2011	-	Apr	Fri>=1	0:00	1:00	S
-Rule	Syria	2012	max	-	Mar	lastFri	0:00	1:00	S
-Rule	Syria	2009	max	-	Oct	lastFri	0:00	0	-
+Rule	Syria	2012	2022	-	Mar	lastFri	0:00	1:00	S
+Rule	Syria	2009	2022	-	Oct	lastFri	0:00	0	-
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Damascus	2:25:12 -	LMT	1920 # Dimashq
-			2:00	Syria	EE%sT
+			2:00	Syria	EE%sT	2022 Oct 28 0:00
+			3:00	-	%z
 
 # Tajikistan
 # From Shanks & Pottenger.
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Dushanbe	4:35:12 -	LMT	1924 May  2
-			5:00	-	+05	1930 Jun 21
-			6:00 RussiaAsia +06/+07	1991 Mar 31  2:00s
-			5:00	1:00	+05/+06	1991 Sep  9  2:00s
-			5:00	-	+05
+			5:00	-	%z	1930 Jun 21
+			6:00 RussiaAsia %z	1991 Mar 31  2:00s
+			5:00	1:00	%z	1991 Sep  9  2:00s
+			5:00	-	%z
 
+# Cambodia
+# Christmas I
+# Laos
 # Thailand
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Vietnam (northern)
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Bangkok	6:42:04	-	LMT	1880
 			6:42:04	-	BMT	1920 Apr # Bangkok Mean Time
-			7:00	-	ICT
-Link Asia/Bangkok Asia/Phnom_Penh	# Cambodia
-Link Asia/Bangkok Asia/Vientiane	# Laos
+			7:00	-	%z
 
 # Turkmenistan
 # From Shanks & Pottenger.
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Ashgabat	3:53:32 -	LMT	1924 May  2 # or Ashkhabad
-			4:00	-	+04	1930 Jun 21
-			5:00 RussiaAsia	+05/+06	1991 Mar 31  2:00
-			4:00 RussiaAsia	+04/+05	1992 Jan 19  2:00
-			5:00	-	+05
+			4:00	-	%z	1930 Jun 21
+			5:00 RussiaAsia	%z	1991 Mar 31  2:00
+			4:00 RussiaAsia	%z	1992 Jan 19  2:00
+			5:00	-	%z
 
+# Oman
+# Réunion
+# Seychelles
 # United Arab Emirates
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+#
+# The Crozet Is also observe Réunion time; see the 'antarctica' file.
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Dubai	3:41:12 -	LMT	1920
-			4:00	-	GST
-Link Asia/Dubai Asia/Muscat	# Oman
+			4:00	-	%z
 
 # Uzbekistan
 # Byalokoz 1919 says Uzbekistan was 4:27:53.
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Samarkand	4:27:53 -	LMT	1924 May  2
-			4:00	-	+04	1930 Jun 21
-			5:00	-	+05	1981 Apr  1
-			5:00	1:00	+06	1981 Oct  1
-			6:00	-	+06	1982 Apr  1
-			5:00 RussiaAsia	+05/+06	1992
-			5:00	-	+05
-# Milne says Tashkent was 4:37:10.8; round to nearest.
+			4:00	-	%z	1930 Jun 21
+			5:00	-	%z	1981 Apr  1
+			5:00	1:00	%z	1981 Oct  1
+			6:00	-	%z	1982 Apr  1
+			5:00 RussiaAsia	%z	1992
+			5:00	-	%z
+# Milne says Tashkent was 4:37:10.8.
+		#STDOFF	4:37:10.8
 Zone	Asia/Tashkent	4:37:11 -	LMT	1924 May  2
-			5:00	-	+05	1930 Jun 21
-			6:00 RussiaAsia	+06/+07	1991 Mar 31  2:00
-			5:00 RussiaAsia	+05/+06	1992
-			5:00	-	+05
+			5:00	-	%z	1930 Jun 21
+			6:00 RussiaAsia	%z	1991 Mar 31  2:00
+			5:00 RussiaAsia	%z	1992
+			5:00	-	%z
 
-# Vietnam
+# Vietnam (southern)
 
 # From Paul Eggert (2014-10-04):
 # Milne gives 7:16:56 for the meridian of Saigon in 1899, as being
@@ -4539,20 +5975,21 @@ Zone	Asia/Tashkent	4:37:11 -	LMT	1924 May  2
 # The English-language name of Vietnam's most populous city is "Ho Chi Minh
 # City"; use Ho_Chi_Minh below to avoid a name of more than 14 characters.
 
-# From Paul Eggert (2014-10-21) after a heads-up from Trần Ngọc Quân:
+# From Paul Eggert (2024-01-14) after a 2014 heads-up from Trần Ngọc Quân
+# and a 2024-01-14 heads-up from Đoàn Trần Công Danh:
 # Trần Tiến Bình's authoritative book "Lịch Việt Nam: thế kỷ XX-XXI (1901-2100)"
 # (Nhà xuất bản Văn Hoá - Thông Tin, Hanoi, 2005), pp 49-50,
 # is quoted verbatim in:
 # http://www.thoigian.com.vn/?mPage=P80D01
 # is translated by Brian Inglis in:
-# http://mm.icann.org/pipermail/tz/2014-October/021654.html
+# https://mm.icann.org/pipermail/tz/2014-October/021654.html
 # and is the basis for the information below.
 #
 # The 1906 transition was effective July 1 and standardized Indochina to
-# Phù Liễn Observatory, legally 104 deg. 17'17" east of Paris.
+# Phù Liễn Observatory, legally 104° 17' 17" east of Paris.
 # It's unclear whether this meant legal Paris Mean Time (00:09:21) or
-# the Paris Meridian (2 deg. 20'14.03" E); the former yields 07:06:30.1333...
-# and the latter 07:06:29.333... so either way it rounds to 07:06:30,
+# the Paris Meridian; for now guess the former and round the exact
+# 07:06:30.1333... to 07:06:30.13 as the legal spec used 66 2/3 ms precision.
 # which is used below even though the modern-day Phù Liễn Observatory
 # is closer to 07:06:31.  Abbreviate Phù Liễn Mean Time as PLMT.
 #
@@ -4560,7 +5997,7 @@ Zone	Asia/Tashkent	4:37:11 -	LMT	1924 May  2
 # and in South Vietnam in particular (after 1954):
 # To 07:00 on 1911-05-01.
 # To 08:00 on 1942-12-31 at 23:00.
-# To 09:00 in 1945-03-14 at 23:00.
+# To 09:00 on 1945-03-14 at 23:00.
 # To 07:00 on 1945-09-02 in Vietnam.
 # To 08:00 on 1947-04-01 in French-controlled Indochina.
 # To 07:00 on 1955-07-01 in South Vietnam.
@@ -4569,29 +6006,61 @@ Zone	Asia/Tashkent	4:37:11 -	LMT	1924 May  2
 #
 # Trần cites the following sources; it's unclear which supplied the info above.
 #
-# Hoàng Xuân Hãn: "Lịch và lịch Việt Nam". Tập san Khoa học Xã hội,
-# No. 9, Paris, February 1982.
+#   Hoàng Xuân Hãn: "Lịch và lịch Việt Nam". Tập san Khoa học Xã hội,
+#   No. 9, Paris, February 1982.
 #
-# Lê Thành Lân: "Lịch và niên biểu lịch sử hai mươi thế kỷ (0001-2010)",
-# NXB Thống kê, Hanoi, 2000.
+#   Lê Thành Lân: "Lịch và niên biểu lịch sử hai mươi thế kỷ (0001-2010)",
+#   NXB Thống kê, Hanoi, 2000.
 #
-# Lê Thành Lân: "Lịch hai thế kỷ (1802-2010) và các lịch vĩnh cửu",
-# NXB Thuận Hoá, Huế, 1995.
+#   Lê Thành Lân: "Lịch hai thế kỷ (1802-2010) và các lịch vĩnh cửu",
+#   NXB Thuận Hoá, Huế, 1995.
+#
+# Here is the decision for the September 1945 transition:
+# Võ Nguyên Giáp, Việt Nam Dân Quốc Công Báo, No. 1 (1945-09-29), page 13
+# http://baochi.nlv.gov.vn/baochi/cgi-bin/baochi?a=d&d=JwvzO19450929.2.5&dliv=none
+# It says that on 1945-09-01 at 24:00, Vietnam moved back two hours, to +07.
+# It also mentions a 1945-03-29 decree (by a Japanese Governor-General)
+# to set the time zone to +09, but does not say whether that decree
+# merely legalized an earlier change to +09.
+#
+# July 1955 transition:
+# Ngô Đình Diệm, Công Báo Việt Nam, No. 92 (1955-07-02), page 1780-1781
+# Ordinance (Dụ) No. 46 (1955-06-25)
+# http://ddsnext.crl.edu/titles/32341#?c=0&m=29&s=0&cv=4&r=0&xywh=-89%2C342%2C1724%2C1216
+# It says that on 1955-07-01 at 01:00, South Vietnam moved back 1 hour (to +07).
+#
+# December 1959 transition:
+# Ngô Đình Diệm, Công Báo Việt Nam Cộng Hòa, 1960 part 1 (1960-01-02), page 62
+# Decree (Sắc lệnh) No. 362-TTP (1959-12-30)
+# http://ddsnext.crl.edu/titles/32341#?c=0&m=138&s=0&cv=793&r=0&xywh=-54%2C1504%2C1705%2C1202
+# It says that on 1959-12-31 at 23:00, South Vietnam moved forward 1 hour (to +08).
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Asia/Ho_Chi_Minh	7:06:40 -	LMT	1906 Jul  1
-			7:06:30	-	PLMT	1911 May  1
-			7:00	-	ICT	1942 Dec 31 23:00
-			8:00	-	IDT	1945 Mar 14 23:00
-			9:00	-	JST	1945 Sep  2
-			7:00	-	ICT	1947 Apr  1
-			8:00	-	IDT	1955 Jul  1
-			7:00	-	ICT	1959 Dec 31 23:00
-			8:00	-	IDT	1975 Jun 13
-			7:00	-	ICT
 
-# Yemen
-# See Asia/Riyadh.
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	7:06:30.13
+Zone Asia/Ho_Chi_Minh	7:06:30 -	LMT	1906 Jul  1
+			7:06:30	-	PLMT	1911 May  1 # Phù Liễn MT
+			7:00	-	%z	1942 Dec 31 23:00
+			8:00	-	%z	1945 Mar 14 23:00
+			9:00	-	%z	1945 Sep  1 24:00
+			7:00	-	%z	1947 Apr  1
+			8:00	-	%z	1955 Jul  1 01:00
+			7:00	-	%z	1959 Dec 31 23:00
+			8:00	-	%z	1975 Jun 13
+			7:00	-	%z
+
+# From Paul Eggert (2019-02-19):
+#
+# The Ho Chi Minh entry suffices for most purposes as it agrees with all of
+# Vietnam since 1975-06-13.  Presumably clocks often changed in south Vietnam
+# in the early 1970s as locations changed hands during the war; however the
+# details are unknown and would likely be too voluminous for this database.
+#
+# For timestamps in north Vietnam back to 1970 (the tzdb cutoff),
+# use Asia/Bangkok; see the VN entries in the file zone1970.tab.
+# For timestamps before 1970, see Asia/Hanoi in the file 'backzone'.
+# tzdb data for Australasia and environs, and for much of the Pacific
+
 # This file is in the public domain, so clarified as of
 # 2009-05-17 by Arthur David Olson.
 
@@ -4605,26 +6074,23 @@ Zone Asia/Ho_Chi_Minh	7:06:40 -	LMT	1906 Jul  1
 
 # Please see the notes below for the controversy about "EST" versus "AEST" etc.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Aus	1917	only	-	Jan	 1	0:01	1:00	D
-Rule	Aus	1917	only	-	Mar	25	2:00	0	S
-Rule	Aus	1942	only	-	Jan	 1	2:00	1:00	D
-Rule	Aus	1942	only	-	Mar	29	2:00	0	S
-Rule	Aus	1942	only	-	Sep	27	2:00	1:00	D
-Rule	Aus	1943	1944	-	Mar	lastSun	2:00	0	S
-Rule	Aus	1943	only	-	Oct	 3	2:00	1:00	D
-# Go with Whitman and the Australian National Standards Commission, which
-# says W Australia didn't use DST in 1943/1944.  Ignore Whitman's claim that
-# 1944/1945 was just like 1943/1944.
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Aus	1917	only	-	Jan	 1	2:00s	1:00	D
+Rule	Aus	1917	only	-	Mar	lastSun	2:00s	0	S
+Rule	Aus	1942	only	-	Jan	 1	2:00s	1:00	D
+Rule	Aus	1942	only	-	Mar	lastSun	2:00s	0	S
+Rule	Aus	1942	only	-	Sep	27	2:00s	1:00	D
+Rule	Aus	1943	1944	-	Mar	lastSun	2:00s	0	S
+Rule	Aus	1943	only	-	Oct	 3	2:00s	1:00	D
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 # Northern Territory
 Zone Australia/Darwin	 8:43:20 -	LMT	1895 Feb
 			 9:00	-	ACST	1899 May
 			 9:30	Aus	AC%sT
 # Western Australia
 #
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	AW	1974	only	-	Oct	lastSun	2:00s	1:00	D
 Rule	AW	1975	only	-	Mar	Sun>=1	2:00s	0	S
 Rule	AW	1983	only	-	Oct	lastSun	2:00s	1:00	D
@@ -4638,8 +6104,8 @@ Zone Australia/Perth	 7:43:24 -	LMT	1895 Dec
 			 8:00	Aus	AW%sT	1943 Jul
 			 8:00	AW	AW%sT
 Zone Australia/Eucla	 8:35:28 -	LMT	1895 Dec
-			 8:45	Aus	ACW%sT	1943 Jul
-			 8:45	AW	ACW%sT
+			 8:45	Aus	%z	1943 Jul
+			 8:45	AW	%z
 
 # Queensland
 #
@@ -4662,7 +6128,7 @@ Zone Australia/Eucla	 8:35:28 -	LMT	1895 Dec
 # applies to all of the Whitsundays.
 # http://www.australia.gov.au/about-australia/australian-story/austn-islands
 #
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	AQ	1971	only	-	Oct	lastSun	2:00s	1:00	D
 Rule	AQ	1972	only	-	Feb	lastSun	2:00s	0	S
 Rule	AQ	1989	1991	-	Oct	lastSun	2:00s	1:00	D
@@ -4678,7 +6144,7 @@ Zone Australia/Lindeman  9:55:56 -	LMT	1895
 			10:00	Holiday	AE%sT
 
 # South Australia
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	AS	1971	1985	-	Oct	lastSun	2:00s	1:00	D
 Rule	AS	1986	only	-	Oct	19	2:00s	1:00	D
 Rule	AS	1987	2007	-	Oct	lastSun	2:00s	1:00	D
@@ -4694,7 +6160,7 @@ Rule	AS	2006	only	-	Apr	2	2:00s	0	S
 Rule	AS	2007	only	-	Mar	lastSun	2:00s	0	S
 Rule	AS	2008	max	-	Apr	Sun>=1	2:00s	0	S
 Rule	AS	2008	max	-	Oct	Sun>=1	2:00s	1:00	D
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Australia/Adelaide	9:14:20 -	LMT	1895 Feb
 			9:00	-	ACST	1899 May
 			9:30	Aus	AC%sT	1971
@@ -4706,9 +6172,13 @@ Zone Australia/Adelaide	9:14:20 -	LMT	1895 Feb
 # http://www.bom.gov.au/climate/averages/tables/dst_times.shtml
 # says King Island didn't observe DST from WWII until late 1971.
 #
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	AT	1916	only	-	Oct	Sun>=1	2:00s	1:00	D
+Rule	AT	1917	only	-	Mar	lastSun	2:00s	0	S
+Rule	AT	1917	1918	-	Oct	Sun>=22	2:00s	1:00	D
+Rule	AT	1918	1919	-	Mar	Sun>=1	2:00s	0	S
 Rule	AT	1967	only	-	Oct	Sun>=1	2:00s	1:00	D
-Rule	AT	1968	only	-	Mar	lastSun	2:00s	0	S
+Rule	AT	1968	only	-	Mar	Sun>=29	2:00s	0	S
 Rule	AT	1968	1985	-	Oct	lastSun	2:00s	1:00	D
 Rule	AT	1969	1971	-	Mar	Sun>=8	2:00s	0	S
 Rule	AT	1972	only	-	Feb	lastSun	2:00s	0	S
@@ -4726,20 +6196,14 @@ Rule	AT	2001	max	-	Oct	Sun>=1	2:00s	1:00	D
 Rule	AT	2006	only	-	Apr	Sun>=1	2:00s	0	S
 Rule	AT	2007	only	-	Mar	lastSun	2:00s	0	S
 Rule	AT	2008	max	-	Apr	Sun>=1	2:00s	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Australia/Hobart	9:49:16	-	LMT	1895 Sep
-			10:00	-	AEST	1916 Oct  1  2:00
-			10:00	1:00	AEDT	1917 Feb
+			10:00	AT	AE%sT	1919 Oct 24
 			10:00	Aus	AE%sT	1967
-			10:00	AT	AE%sT
-Zone Australia/Currie	9:35:28	-	LMT	1895 Sep
-			10:00	-	AEST	1916 Oct  1  2:00
-			10:00	1:00	AEDT	1917 Feb
-			10:00	Aus	AE%sT	1971 Jul
 			10:00	AT	AE%sT
 
 # Victoria
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	AV	1971	1985	-	Oct	lastSun	2:00s	1:00	D
 Rule	AV	1972	only	-	Feb	lastSun	2:00s	0	S
 Rule	AV	1973	1985	-	Mar	Sun>=1	2:00s	0	S
@@ -4754,13 +6218,13 @@ Rule	AV	2006	only	-	Apr	Sun>=1	2:00s	0	S
 Rule	AV	2007	only	-	Mar	lastSun	2:00s	0	S
 Rule	AV	2008	max	-	Apr	Sun>=1	2:00s	0	S
 Rule	AV	2008	max	-	Oct	Sun>=1	2:00s	1:00	D
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Australia/Melbourne 9:39:52 -	LMT	1895 Feb
 			10:00	Aus	AE%sT	1971
 			10:00	AV	AE%sT
 
 # New South Wales
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	AN	1971	1985	-	Oct	lastSun	2:00s	1:00	D
 Rule	AN	1972	only	-	Feb	27	2:00s	0	S
 Rule	AN	1973	1981	-	Mar	Sun>=1	2:00s	0	S
@@ -4777,7 +6241,7 @@ Rule	AN	2006	only	-	Apr	Sun>=1	2:00s	0	S
 Rule	AN	2007	only	-	Mar	lastSun	2:00s	0	S
 Rule	AN	2008	max	-	Apr	Sun>=1	2:00s	0	S
 Rule	AN	2008	max	-	Oct	Sun>=1	2:00s	1:00	D
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Australia/Sydney	10:04:52 -	LMT	1895 Feb
 			10:00	Aus	AE%sT	1971
 			10:00	AN	AE%sT
@@ -4789,24 +6253,25 @@ Zone Australia/Broken_Hill 9:25:48 -	LMT	1895 Feb
 			9:30	AS	AC%sT
 
 # Lord Howe Island
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	LH	1981	1984	-	Oct	lastSun	2:00	1:00	D
-Rule	LH	1982	1985	-	Mar	Sun>=1	2:00	0	S
-Rule	LH	1985	only	-	Oct	lastSun	2:00	0:30	D
-Rule	LH	1986	1989	-	Mar	Sun>=15	2:00	0	S
-Rule	LH	1986	only	-	Oct	19	2:00	0:30	D
-Rule	LH	1987	1999	-	Oct	lastSun	2:00	0:30	D
-Rule	LH	1990	1995	-	Mar	Sun>=1	2:00	0	S
-Rule	LH	1996	2005	-	Mar	lastSun	2:00	0	S
-Rule	LH	2000	only	-	Aug	lastSun	2:00	0:30	D
-Rule	LH	2001	2007	-	Oct	lastSun	2:00	0:30	D
-Rule	LH	2006	only	-	Apr	Sun>=1	2:00	0	S
-Rule	LH	2007	only	-	Mar	lastSun	2:00	0	S
-Rule	LH	2008	max	-	Apr	Sun>=1	2:00	0	S
-Rule	LH	2008	max	-	Oct	Sun>=1	2:00	0:30	D
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	LH	1981	1984	-	Oct	lastSun	2:00	1:00	-
+Rule	LH	1982	1985	-	Mar	Sun>=1	2:00	0	-
+Rule	LH	1985	only	-	Oct	lastSun	2:00	0:30	-
+Rule	LH	1986	1989	-	Mar	Sun>=15	2:00	0	-
+Rule	LH	1986	only	-	Oct	19	2:00	0:30	-
+Rule	LH	1987	1999	-	Oct	lastSun	2:00	0:30	-
+Rule	LH	1990	1995	-	Mar	Sun>=1	2:00	0	-
+Rule	LH	1996	2005	-	Mar	lastSun	2:00	0	-
+Rule	LH	2000	only	-	Aug	lastSun	2:00	0:30	-
+Rule	LH	2001	2007	-	Oct	lastSun	2:00	0:30	-
+Rule	LH	2006	only	-	Apr	Sun>=1	2:00	0	-
+Rule	LH	2007	only	-	Mar	lastSun	2:00	0	-
+Rule	LH	2008	max	-	Apr	Sun>=1	2:00	0	-
+Rule	LH	2008	max	-	Oct	Sun>=1	2:00	0:30	-
 Zone Australia/Lord_Howe 10:36:20 -	LMT	1895 Feb
 			10:00	-	AEST	1981 Mar
-			10:30	LH	LH%sT
+			10:30	LH	%z	1985 Jul
+			10:30	LH	%z
 
 # Australian miscellany
 #
@@ -4843,21 +6308,9 @@ Zone Antarctica/Macquarie 0	-	-00	1899 Nov
 			10:00	Aus	AE%sT	1919 Apr  1  0:00s
 			0	-	-00	1948 Mar 25
 			10:00	Aus	AE%sT	1967
-			10:00	AT	AE%sT	2010 Apr  4  3:00
-			11:00	-	MIST	# Macquarie I Standard Time
-
-# Christmas
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Indian/Christmas	7:02:52 -	LMT	1895 Feb
-			7:00	-	CXT	# Christmas Island Time
-
-# Cocos (Keeling) Is
-# These islands were ruled by the Ross family from about 1830 to 1978.
-# We don't know when standard time was introduced; for now, we guess 1900.
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Indian/Cocos	6:27:40	-	LMT	1900
-			6:30	-	CCT	# Cocos Islands Time
-
+			10:00	AT	AE%sT	2010
+			10:00	1:00	AEDT	2011
+			10:00	AT	AE%sT
 
 # Fiji
 
@@ -4886,7 +6339,7 @@ Zone	Indian/Cocos	6:27:40	-	LMT	1900
 # http://www.fiji.gov.fj/index.php?option=com_content&view=article&id=1096:3310-cabinet-approves-change-in-daylight-savings-dates&catid=49:cabinet-releases&Itemid=166
 #
 # A bit more background info here:
-# http://www.timeanddate.com/news/time/fiji-dst-ends-march-2010.html
+# https://www.timeanddate.com/news/time/fiji-dst-ends-march-2010.html
 
 # From Alexander Krivenyshev (2010-10-24):
 # According to Radio Fiji and Fiji Times online, Fiji will end DST 3
@@ -4931,7 +6384,7 @@ Zone	Indian/Cocos	6:27:40	-	LMT	1900
 
 # From Steffen Thorsen (2013-01-10):
 # Fiji will end DST on 2014-01-19 02:00:
-# http://www.fiji.gov.fj/Media-Center/Press-Releases/DAYLIGHT-SAVINGS-TO-END-THIS-MONTH-%281%29.aspx
+# http://www.fiji.gov.fj/Media-Center/Press-Releases/DAYLIGHT-SAVINGS-TO-END-THIS-MONTH-(1).aspx
 
 # From Ken Rylander (2014-10-20):
 # DST will start Nov. 2 this year.
@@ -4950,108 +6403,210 @@ Zone	Indian/Cocos	6:27:40	-	LMT	1900
 # clocks go forward an hour at 2am to 3am....  Daylight Saving will
 # end at 3.00am on Sunday 15th January 2017."
 
-# From Paul Eggert (2016-10-03):
-# For now, guess DST from 02:00 the first Sunday in November to
-# 03:00 the third Sunday in January.  Although ad hoc, it matches
-# transitions since late 2014 and seems more likely to match future
-# practice than guessing no DST.
+# From Paul Eggert (2017-08-21):
+# Dominic Fok writes (2017-08-20) that DST ends 2018-01-14, citing
+# Extraordinary Government of Fiji Gazette Supplement No. 21 (2017-08-27),
+# [Legal Notice No. 41] of an order of the previous day by J Usamate.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Fiji	1998	1999	-	Nov	Sun>=1	2:00	1:00	S
+# From Raymond Kumar (2018-07-13):
+# http://www.fijitimes.com/government-approves-2018-daylight-saving/
+# ... The daylight saving period will end at 3am on Sunday January 13, 2019.
+
+# From Paul Eggert (2019-08-06):
+# Today Raymond Kumar reported the Government of Fiji Gazette Supplement No. 27
+# (2019-08-02) said that Fiji observes DST "commencing at 2.00 am on
+# Sunday, 10 November 2019 and ending at 3.00 am on Sunday, 12 January 2020."
+# For now, guess DST from 02:00 the second Sunday in November to 03:00
+# the first Sunday on or after January 12.  January transitions reportedly
+# depend on when school terms start.  Although the guess is ad hoc, it matches
+# transitions planned this year and seems more likely to match future practice
+# than guessing no DST.
+# From Michael Deckers (2019-08-06):
+# https://www.laws.gov.fj/LawsAsMade/downloadfile/848
+
+# From Raymond Kumar (2020-10-08):
+# [DST in Fiji] is from December 20th 2020, till 17th January 2021.
+# From Alan Mintz (2020-10-08):
+# https://www.laws.gov.fj/LawsAsMade/GetFile/1071
+# From Tim Parenti (2020-10-08):
+# https://www.fijivillage.com/news/Daylight-saving-from-Dec-20th-this-year-to-Jan-17th-2021-8rf4x5/
+# "Minister for Employment, Parveen Bala says they had never thought of
+# stopping daylight saving. He says it was just to decide on when it should
+# start and end.  Bala says it is a short period..."
+#
+# From Tim Parenti (2021-10-11), per Jashneel Kumar (2021-10-11) and P Chan
+# (2021-10-12):
+# https://www.fiji.gov.fj/Media-Centre/Speeches/English/PM-BAINIMARAMA-S-COVID-19-ANNOUNCEMENT-10-10-21
+# https://www.fbcnews.com.fj/news/covid-19/curfew-moved-back-to-11pm/
+# In a 2021-10-10 speech concerning updated Covid-19 mitigation measures in
+# Fiji, prime minister Josaia Voreqe "Frank" Bainimarama announced the
+# suspension of DST for the 2021/2022 season: "Given that we are in the process
+# of readjusting in the midst of so many changes, we will also put Daylight
+# Savings Time on hold for this year. It will also make the reopening of
+# scheduled commercial air service much smoother if we don't have to be
+# concerned shifting arrival and departure times, which may look like a simple
+# thing but requires some significant logistical adjustments domestically and
+# internationally."
+
+# From Shalvin Narayan (2022-10-27):
+# Please note that there will not be any daylight savings time change
+# in Fiji for 2022-2023....
+# https://www.facebook.com/FijianGovernment/posts/pfbid0mmWVTYmTibn66ybpFda75pDcf34SSpoSaskJW5gXwaKo5Sgc7273Q4fXWc6kQV6Hl
+
+# From Almaz Mingaleev (2023-10-06):
+# Cabinet approved the suspension of Daylight Saving and appropriate
+# legislative changes will be considered including the repeal of the
+# Daylight Saving Act 1998
+# https://www.fiji.gov.fj/Media-Centre/Speeches/English/CABINET-DECISIONS-3-OCTOBER-2023
+#
+# From Paul Eggert (2023-10-06):
+# For now, assume DST is suspended indefinitely.
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Fiji	1998	1999	-	Nov	Sun>=1	2:00	1:00	-
 Rule	Fiji	1999	2000	-	Feb	lastSun	3:00	0	-
-Rule	Fiji	2009	only	-	Nov	29	2:00	1:00	S
+Rule	Fiji	2009	only	-	Nov	29	2:00	1:00	-
 Rule	Fiji	2010	only	-	Mar	lastSun	3:00	0	-
-Rule	Fiji	2010	2013	-	Oct	Sun>=21	2:00	1:00	S
+Rule	Fiji	2010	2013	-	Oct	Sun>=21	2:00	1:00	-
 Rule	Fiji	2011	only	-	Mar	Sun>=1	3:00	0	-
 Rule	Fiji	2012	2013	-	Jan	Sun>=18	3:00	0	-
 Rule	Fiji	2014	only	-	Jan	Sun>=18	2:00	0	-
-Rule	Fiji	2014	max	-	Nov	Sun>=1	2:00	1:00	S
-Rule	Fiji	2015	max	-	Jan	Sun>=15	3:00	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+Rule	Fiji	2014	2018	-	Nov	Sun>=1	2:00	1:00	-
+Rule	Fiji	2015	2021	-	Jan	Sun>=12	3:00	0	-
+Rule	Fiji	2019	only	-	Nov	Sun>=8	2:00	1:00	-
+Rule	Fiji	2020	only	-	Dec	20	2:00	1:00	-
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Fiji	11:55:44 -	LMT	1915 Oct 26 # Suva
-			12:00	Fiji	FJ%sT	# Fiji Time
+			12:00	Fiji	%z
 
 # French Polynesia
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Pacific/Gambier	 -8:59:48 -	LMT	1912 Oct # Rikitea
-			 -9:00	-	GAMT	# Gambier Time
-Zone	Pacific/Marquesas -9:18:00 -	LMT	1912 Oct
-			 -9:30	-	MART	# Marquesas Time
-Zone	Pacific/Tahiti	 -9:58:16 -	LMT	1912 Oct # Papeete
-			-10:00	-	TAHT	# Tahiti Time
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Pacific/Gambier	 -8:59:48 -	LMT	1912 Oct  1 # Rikitea
+			 -9:00	-	%z
+Zone	Pacific/Marquesas -9:18:00 -	LMT	1912 Oct  1
+			 -9:30	-	%z
+Zone	Pacific/Tahiti	 -9:58:16 -	LMT	1912 Oct  1 # Papeete
+			-10:00	-	%z
 # Clipperton (near North America) is administered from French Polynesia;
 # it is uninhabited.
 
+
 # Guam
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# N Mariana Is
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+# http://guamlegislature.com/Public_Laws_5th/PL05-025.pdf
+# http://documents.guam.gov/wp-content/uploads/E.O.-59-7-Guam-Daylight-Savings-Time-May-6-1959.pdf
+Rule	Guam	1959	only	-	Jun	27	2:00	1:00	D
+# http://documents.guam.gov/wp-content/uploads/E.O.-61-5-Revocation-of-Daylight-Saving-Time-and-Restoratio.pdf
+Rule	Guam	1961	only	-	Jan	29	2:00	0	S
+# http://documents.guam.gov/wp-content/uploads/E.O.-67-13-Guam-Daylight-Savings-Time.pdf
+Rule	Guam	1967	only	-	Sep	 1	2:00	1:00	D
+# http://documents.guam.gov/wp-content/uploads/E.O.-69-2-Repeal-of-Guam-Daylight-Saving-Time.pdf
+Rule	Guam	1969	only	-	Jan	26	0:01	0	S
+# http://documents.guam.gov/wp-content/uploads/E.O.-69-10-Guam-Daylight-Saving-Time.pdf
+Rule	Guam	1969	only	-	Jun	22	2:00	1:00	D
+Rule	Guam	1969	only	-	Aug	31	2:00	0	S
+# http://documents.guam.gov/wp-content/uploads/E.O.-70-10-Guam-Daylight-Saving-Time.pdf
+# http://documents.guam.gov/wp-content/uploads/E.O.-70-30-End-of-Guam-Daylight-Saving-Time.pdf
+# http://documents.guam.gov/wp-content/uploads/E.O.-71-5-Guam-Daylight-Savings-Time.pdf
+Rule	Guam	1970	1971	-	Apr	lastSun	2:00	1:00	D
+Rule	Guam	1970	1971	-	Sep	Sun>=1	2:00	0	S
+# http://documents.guam.gov/wp-content/uploads/E.O.-73-28.-Guam-Day-light-Saving-Time.pdf
+Rule	Guam	1973	only	-	Dec	16	2:00	1:00	D
+# http://documents.guam.gov/wp-content/uploads/E.O.-74-7-Guam-Daylight-Savings-Time-Rescinded.pdf
+Rule	Guam	1974	only	-	Feb	24	2:00	0	S
+# http://documents.guam.gov/wp-content/uploads/E.O.-76-13-Daylight-Savings-Time.pdf
+Rule	Guam	1976	only	-	May	26	2:00	1:00	D
+# http://documents.guam.gov/wp-content/uploads/E.O.-76-25-Revocation-of-E.O.-76-13.pdf
+Rule	Guam	1976	only	-	Aug	22	2:01	0	S
+# http://documents.guam.gov/wp-content/uploads/E.O.-77-4-Daylight-Savings-Time.pdf
+Rule	Guam	1977	only	-	Apr	24	2:00	1:00	D
+# http://documents.guam.gov/wp-content/uploads/E.O.-77-18-Guam-Standard-Time.pdf
+Rule	Guam	1977	only	-	Aug	28	2:00	0	S
+
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Guam	-14:21:00 -	LMT	1844 Dec 31
 			 9:39:00 -	LMT	1901        # Agana
-			10:00	-	GST	2000 Dec 23 # Guam
+			10:00	-	GST	1941 Dec 10 # Guam
+			 9:00	-	%z	1944 Jul 31
+			10:00	Guam	G%sT	2000 Dec 23
 			10:00	-	ChST	# Chamorro Standard Time
-Link Pacific/Guam Pacific/Saipan # N Mariana Is
 
-# Kiribati
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+
+# Kiribati (Gilbert Is)
+# Marshall Is
+# Tuvalu
+# Wake
+# Wallis & Futuna
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Tarawa	 11:32:04 -	LMT	1901 # Bairiki
-			 12:00	-	GILT	# Gilbert Is Time
-Zone Pacific/Enderbury	-11:24:20 -	LMT	1901
-			-12:00	-	PHOT	1979 Oct # Phoenix Is Time
-			-11:00	-	PHOT	1995
-			 13:00	-	PHOT
-Zone Pacific/Kiritimati	-10:29:20 -	LMT	1901
-			-10:40	-	LINT	1979 Oct # Line Is Time
-			-10:00	-	LINT	1995
-			 14:00	-	LINT
+			 12:00	-	%z
 
-# N Mariana Is
-# See Pacific/Guam.
+# Kiribati (except Gilbert Is)
+# See Pacific/Tarawa for the Gilbert Is.
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone Pacific/Kanton	  0	-	-00	1937 Aug 31
+			-12:00	-	%z	1979 Oct
+			-11:00	-	%z	1994 Dec 31
+			 13:00	-	%z
+Zone Pacific/Kiritimati	-10:29:20 -	LMT	1901
+			-10:40	-	%z	1979 Oct
+			-10:00	-	%z	1994 Dec 31
+			 14:00	-	%z
 
 # Marshall Is
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Pacific/Majuro	11:24:48 -	LMT	1901
-			11:00	-	MHT	1969 Oct # Marshall Islands Time
-			12:00	-	MHT
-Zone Pacific/Kwajalein	11:09:20 -	LMT	1901
-			11:00	-	MHT	1969 Oct
-			-12:00	-	KWAT	1993 Aug 20 # Kwajalein Time
-			12:00	-	MHT
+# See Pacific/Tarawa for most locations.
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone Pacific/Kwajalein	 11:09:20 -	LMT	1901
+			 11:00	-	%z	1937
+			 10:00	-	%z	1941 Apr  1
+			  9:00	-	%z	1944 Feb  6
+			 11:00	-	%z	1969 Oct
+			-12:00	-	%z	1993 Aug 20 24:00
+			 12:00	-	%z
 
 # Micronesia
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Pacific/Chuuk	10:07:08 -	LMT	1901
-			10:00	-	CHUT	# Chuuk Time
-Zone Pacific/Pohnpei	10:32:52 -	LMT	1901 # Kolonia
-			11:00	-	PONT	# Pohnpei Time
-Zone Pacific/Kosrae	10:51:56 -	LMT	1901
-			11:00	-	KOST	1969 Oct # Kosrae Time
-			12:00	-	KOST	1999
-			11:00	-	KOST
+# For Chuuk and Yap see Pacific/Port_Moresby.
+# For Pohnpei see Pacific/Guadalcanal.
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone Pacific/Kosrae	-13:08:04 -	LMT	1844 Dec 31
+			 10:51:56 -	LMT	1901
+			 11:00	-	%z	1914 Oct
+			  9:00	-	%z	1919 Feb  1
+			 11:00	-	%z	1937
+			 10:00	-	%z	1941 Apr  1
+			  9:00	-	%z	1945 Aug
+			 11:00	-	%z	1969 Oct
+			 12:00	-	%z	1999
+			 11:00	-	%z
 
 # Nauru
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Nauru	11:07:40 -	LMT	1921 Jan 15 # Uaobe
-			11:30	-	NRT	1942 Mar 15 # Nauru Time
-			9:00	-	JST	1944 Aug 15
-			11:30	-	NRT	1979 May
-			12:00	-	NRT
+			11:30	-	%z	1942 Aug 29
+			 9:00	-	%z	1945 Sep  8
+			11:30	-	%z	1979 Feb 10  2:00
+			12:00	-	%z
 
 # New Caledonia
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	NC	1977	1978	-	Dec	Sun>=1	0:00	1:00	S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	NC	1977	1978	-	Dec	Sun>=1	0:00	1:00	-
 Rule	NC	1978	1979	-	Feb	27	0:00	0	-
-Rule	NC	1996	only	-	Dec	 1	2:00s	1:00	S
+Rule	NC	1996	only	-	Dec	 1	2:00s	1:00	-
 # Shanks & Pottenger say the following was at 2:00; go with IATA.
 Rule	NC	1997	only	-	Mar	 2	2:00s	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Noumea	11:05:48 -	LMT	1912 Jan 13 # Nouméa
-			11:00	NC	NC%sT
+			11:00	NC	%z
 
 
 ###############################################################################
 
 # New Zealand
+# McMurdo Station and Scott Base in Antarctica use Auckland time.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	NZ	1927	only	-	Nov	 6	2:00	1:00	S
 Rule	NZ	1928	only	-	Mar	 4	2:00	0	M
 Rule	NZ	1928	1933	-	Oct	Sun>=8	2:00	0:30	S
@@ -5059,36 +6614,36 @@ Rule	NZ	1929	1933	-	Mar	Sun>=15	2:00	0	M
 Rule	NZ	1934	1940	-	Apr	lastSun	2:00	0	M
 Rule	NZ	1934	1940	-	Sep	lastSun	2:00	0:30	S
 Rule	NZ	1946	only	-	Jan	 1	0:00	0	S
-# Since 1957 Chatham has been 45 minutes ahead of NZ, but there's no
-# convenient single notation for the date and time of this transition
-# so we must duplicate the Rule lines.
+# Since 1957 Chatham has been 45 minutes ahead of NZ, but until 2018a
+# there was no documented single notation for the date and time of this
+# transition.  Duplicate the Rule lines for now, to give the 2018a change
+# time to percolate out.
 Rule	NZ	1974	only	-	Nov	Sun>=1	2:00s	1:00	D
-Rule	Chatham	1974	only	-	Nov	Sun>=1	2:45s	1:00	D
+Rule	Chatham	1974	only	-	Nov	Sun>=1	2:45s	1:00	-
 Rule	NZ	1975	only	-	Feb	lastSun	2:00s	0	S
-Rule	Chatham	1975	only	-	Feb	lastSun	2:45s	0	S
+Rule	Chatham	1975	only	-	Feb	lastSun	2:45s	0	-
 Rule	NZ	1975	1988	-	Oct	lastSun	2:00s	1:00	D
-Rule	Chatham	1975	1988	-	Oct	lastSun	2:45s	1:00	D
+Rule	Chatham	1975	1988	-	Oct	lastSun	2:45s	1:00	-
 Rule	NZ	1976	1989	-	Mar	Sun>=1	2:00s	0	S
-Rule	Chatham	1976	1989	-	Mar	Sun>=1	2:45s	0	S
+Rule	Chatham	1976	1989	-	Mar	Sun>=1	2:45s	0	-
 Rule	NZ	1989	only	-	Oct	Sun>=8	2:00s	1:00	D
-Rule	Chatham	1989	only	-	Oct	Sun>=8	2:45s	1:00	D
+Rule	Chatham	1989	only	-	Oct	Sun>=8	2:45s	1:00	-
 Rule	NZ	1990	2006	-	Oct	Sun>=1	2:00s	1:00	D
-Rule	Chatham	1990	2006	-	Oct	Sun>=1	2:45s	1:00	D
+Rule	Chatham	1990	2006	-	Oct	Sun>=1	2:45s	1:00	-
 Rule	NZ	1990	2007	-	Mar	Sun>=15	2:00s	0	S
-Rule	Chatham	1990	2007	-	Mar	Sun>=15	2:45s	0	S
+Rule	Chatham	1990	2007	-	Mar	Sun>=15	2:45s	0	-
 Rule	NZ	2007	max	-	Sep	lastSun	2:00s	1:00	D
-Rule	Chatham	2007	max	-	Sep	lastSun	2:45s	1:00	D
+Rule	Chatham	2007	max	-	Sep	lastSun	2:45s	1:00	-
 Rule	NZ	2008	max	-	Apr	Sun>=1	2:00s	0	S
-Rule	Chatham	2008	max	-	Apr	Sun>=1	2:45s	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+Rule	Chatham	2008	max	-	Apr	Sun>=1	2:45s	0	-
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Auckland	11:39:04 -	LMT	1868 Nov  2
 			11:30	NZ	NZ%sT	1946 Jan  1
 			12:00	NZ	NZ%sT
-Zone Pacific/Chatham	12:13:48 -	LMT	1868 Nov  2
-			12:15	-	CHAST	1946 Jan  1
-			12:45	Chatham	CHA%sT
 
-Link Pacific/Auckland Antarctica/McMurdo
+Zone Pacific/Chatham	12:13:48 -	LMT	1868 Nov  2
+			12:15	-	%z	1946 Jan  1
+			12:45	Chatham	%z
 
 # Auckland Is
 # uninhabited; Māori and Moriori, colonial settlers, pastoralists, sealers,
@@ -5101,45 +6656,88 @@ Link Pacific/Auckland Antarctica/McMurdo
 # was probably like Pacific/Auckland
 
 # Cook Is
-# From Shanks & Pottenger:
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Cook	1978	only	-	Nov	12	0:00	0:30	HS
+#
+# From Alexander Krivenyshev (2021-03-24):
+# In 1899 the Cook Islands celebrated Christmas twice to correct the calendar.
+# According to the old books, missionaries were unaware of
+# the International Date line, when they came from Sydney.
+# Thus the Cook Islands were one day ahead....
+# http://nzetc.victoria.ac.nz/tm/scholarly/tei-KloDisc-t1-body-d18.html
+# ... Appendix to the Journals of the House of Representatives, 1900
+# https://atojs.natlib.govt.nz/cgi-bin/atojs?a=d&d=AJHR1900-I.2.1.2.3
+# (page 20)
+#
+# From Michael Deckers (2021-03-24):
+# ... in the Cook Island Act of 1915-10-11, online at
+# http://www.paclii.org/ck/legis/ck-nz_act/cia1915132/
+# "651. The hour of the day shall in each of the islands included in the
+#  Cook Islands be determined in accordance with the meridian of that island."
+# so that local (mean?) time was still used in Rarotonga (and Niue) in 1915.
+# This was changed in the Cook Island Amendment Act of 1952-10-16 ...
+# http://www.paclii.org/ck/legis/ck-nz_act/ciaa1952212/
+# "651 (1) The hour of the day in each of the islands included in the Cook
+#  Islands, other than Niue, shall be determined as if each island were
+#  situated on the meridian one hundred and fifty-seven degrees thirty minutes
+#  West of Greenwich.  (2) The hour of the day in the Island of Niue shall be
+#  determined as if that island were situated on the meridian one hundred and
+#  seventy degrees West of Greenwich."
+# This act does not state when it takes effect, so one has to assume it
+# applies since 1952-10-16.  But there is the possibility that the act just
+# legalized prior existing practice, as we had seen with the Guernsey law of
+# 1913-06-18 for the switch in 1909-04-19.
+#
+# From Paul Eggert (2021-03-24):
+# Transitions after 1952 are from Shanks & Pottenger.
+#
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Cook	1978	only	-	Nov	12	0:00	0:30	-
 Rule	Cook	1979	1991	-	Mar	Sun>=1	0:00	0	-
-Rule	Cook	1979	1990	-	Oct	lastSun	0:00	0:30	HS
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Pacific/Rarotonga	-10:39:04 -	LMT	1901        # Avarua
-			-10:30	-	CKT	1978 Nov 12 # Cook Is Time
-			-10:00	Cook	CK%sT
+Rule	Cook	1979	1990	-	Oct	lastSun	0:00	0:30	-
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone Pacific/Rarotonga	13:20:56 -	LMT	1899 Dec 26 # Avarua
+			-10:39:04 -	LMT	1952 Oct 16
+			-10:30	-	%z	1978 Nov 12
+			-10:00	Cook	%z
 
 ###############################################################################
 
 
 # Niue
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Pacific/Niue	-11:19:40 -	LMT	1901        # Alofi
-			-11:20	-	NUT	1951        # Niue Time
-			-11:30	-	NUT	1978 Oct  1
-			-11:00	-	NUT
+# See Pacific/Rarotonga comments for 1952 transition.
+#
+# From Tim Parenti (2021-09-13):
+# Consecutive contemporaneous editions of The Air Almanac listed -11:20 for
+# Niue as of Apr 1964 but -11 as of Aug 1964:
+#   Apr 1964: https://books.google.com/books?id=_1So677Y5vUC&pg=SL1-PA23
+#   Aug 1964: https://books.google.com/books?id=MbJloqd-zyUC&pg=SL1-PA23
+# Without greater specificity, guess 1964-07-01 for this transition.
+
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Pacific/Niue	-11:19:40 -	LMT	1952 Oct 16	# Alofi
+			-11:20	-	%z	1964 Jul
+			-11:00	-	%z
 
 # Norfolk
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Norfolk	11:11:52 -	LMT	1901 # Kingston
-			11:12	-	NMT	1951 # Norfolk Mean Time
-			11:30	-	NFT	1974 Oct 27 02:00 # Norfolk T.
-			11:30	1:00	NFST	1975 Mar  2 02:00
-			11:30	-	NFT	2015 Oct  4 02:00
-			11:00	-	NFT
+			11:12	-	%z	1951
+			11:30	-	%z	1974 Oct 27 02:00s
+			11:30	1:00	%z	1975 Mar  2 02:00s
+			11:30	-	%z	2015 Oct  4 02:00s
+			11:00	-	%z	2019 Jul
+			11:00	AN	%z
 
 # Palau (Belau)
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Pacific/Palau	8:57:56 -	LMT	1901 # Koror
-			9:00	-	PWT	# Palau Time
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone Pacific/Palau	-15:02:04 -	LMT	1844 Dec 31	# Koror
+			  8:57:56 -	LMT	1901
+			  9:00	-	%z
 
 # Papua New Guinea
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Port_Moresby 9:48:40 -	LMT	1880
 			9:48:32	-	PMMT	1895 # Port Moresby Mean Time
-			10:00	-	PGT	# Papua New Guinea Time
+			10:00	-	%z
 #
 # From Paul Eggert (2014-10-13):
 # Base the Bougainville entry on the Arawa-Kieta region, which appears to have
@@ -5150,34 +6748,32 @@ Zone Pacific/Port_Moresby 9:48:40 -	LMT	1880
 # The World War II entries below are instead based on Arawa-Kieta.
 # The Japanese occupied Kieta in July 1942,
 # according to the Pacific War Online Encyclopedia
-# http://pwencycl.kgbudge.com/B/o/Bougainville.htm
+# https://pwencycl.kgbudge.com/B/o/Bougainville.htm
 # and seem to have controlled it until their 1945-08-21 surrender.
 #
 # The Autonomous Region of Bougainville switched from UT +10 to +11
-# on 2014-12-28 at 02:00.  They call +11 "Bougainville Standard Time";
-# abbreviate this as BST.  See:
+# on 2014-12-28 at 02:00.  They call +11 "Bougainville Standard Time".
+# See:
 # http://www.bougainville24.com/bougainville-issues/bougainville-gets-own-timezone/
 #
 Zone Pacific/Bougainville 10:22:16 -	LMT	1880
 			 9:48:32 -	PMMT	1895
-			10:00	-	PGT	1942 Jul
-			 9:00	-	JST	1945 Aug 21
-			10:00	-	PGT	2014 Dec 28  2:00
-			11:00	-	BST
+			10:00	-	%z	1942 Jul
+			 9:00	-	%z	1945 Aug 21
+			10:00	-	%z	2014 Dec 28  2:00
+			11:00	-	%z
 
 # Pitcairn
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Pitcairn	-8:40:20 -	LMT	1901        # Adamstown
-			-8:30	-	PNT	1998 Apr 27  0:00
-			-8:00	-	PST	# Pitcairn Standard Time
+			-8:30	-	%z	1998 Apr 27  0:00
+			-8:00	-	%z
 
 # American Samoa
-Zone Pacific/Pago_Pago	 12:37:12 -	LMT	1879 Jul  5
+# Midway
+Zone Pacific/Pago_Pago	 12:37:12 -	LMT	1892 Jul  5
 			-11:22:48 -	LMT	1911
-			-11:00	-	NST	1967 Apr    # N=Nome
-			-11:00	-	BST	1983 Nov 30 # B=Bering
 			-11:00	-	SST	            # S=Samoa
-Link Pacific/Pago_Pago Pacific/Midway # in US minor outlying islands
 
 # Samoa (formerly and also known as Western Samoa)
 
@@ -5190,11 +6786,11 @@ Link Pacific/Pago_Pago Pacific/Midway # in US minor outlying islands
 # Sunday of April 2011."
 #
 # Background info:
-# http://www.timeanddate.com/news/time/samoa-dst-plan-2009.html
+# https://www.timeanddate.com/news/time/samoa-dst-plan-2009.html
 #
 # Samoa's Daylight Saving Time Act 2009 is available here, but does not
 # contain any dates:
-# http://www.parliament.gov.ws/documents/acts/Daylight%20Saving%20Act%20%202009%20%28English%29%20-%20Final%207-7-091.pdf
+# http://www.parliament.gov.ws/documents/acts/Daylight%20Saving%20Act%20%202009%20(English)%20-%20Final%207-7-091.pdf
 
 # From Laupue Raymond Hughes (2010-10-07):
 # Please see
@@ -5246,27 +6842,31 @@ Link Pacific/Pago_Pago Pacific/Midway # in US minor outlying islands
 # From Paul Eggert (2014-07-08):
 # That web page currently lists transitions for 2012/3 and 2013/4.
 # Assume the pattern instituted in 2012 will continue indefinitely.
+#
+# From Geoffrey D. Bennett (2021-09-20):
+# https://www.mcil.gov.ws/storage/2021/09/MCIL-Scan_20210920_120553.pdf
+# DST has been cancelled for this year.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	WS	2010	only	-	Sep	lastSun	0:00	1	D
-Rule	WS	2011	only	-	Apr	Sat>=1	4:00	0	S
-Rule	WS	2011	only	-	Sep	lastSat	3:00	1	D
-Rule	WS	2012	max	-	Apr	Sun>=1	4:00	0	S
-Rule	WS	2012	max	-	Sep	lastSun	3:00	1	D
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Pacific/Apia	 12:33:04 -	LMT	1879 Jul  5
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	WS	2010	only	-	Sep	lastSun	0:00	1	-
+Rule	WS	2011	only	-	Apr	Sat>=1	4:00	0	-
+Rule	WS	2011	only	-	Sep	lastSat	3:00	1	-
+Rule	WS	2012	2021	-	Apr	Sun>=1	4:00	0	-
+Rule	WS	2012	2020	-	Sep	lastSun	3:00	1	-
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone Pacific/Apia	 12:33:04 -	LMT	1892 Jul  5
 			-11:26:56 -	LMT	1911
-			-11:30	-	WSST	1950
-			-11:00	WS	S%sT	2011 Dec 29 24:00 # S=Samoa
-			 13:00	WS	WS%sT
+			-11:30	-	%z	1950
+			-11:00	WS	%z	2011 Dec 29 24:00
+			 13:00	WS	%z
 
 # Solomon Is
 # excludes Bougainville, for which see Papua New Guinea
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Pacific/Guadalcanal 10:39:48 -	LMT	1912 Oct # Honiara
-			11:00	-	SBT	# Solomon Is Time
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone Pacific/Guadalcanal 10:39:48 -	LMT	1912 Oct  1 # Honiara
+			11:00	-	%z
 
-# Tokelau Is
+# Tokelau
 #
 # From Gwillim Law (2011-12-29)
 # A correspondent informed me that Tokelau, like Samoa, will be skipping
@@ -5275,39 +6875,34 @@ Zone Pacific/Guadalcanal 10:39:48 -	LMT	1912 Oct # Honiara
 # From Steffen Thorsen (2012-07-25)
 # ... we double checked by calling hotels and offices based in Tokelau asking
 # about the time there, and they all told a time that agrees with UTC+13....
-# Shanks says UTC-10 from 1901 [but] ... there is a good chance the change
-# actually was to UTC-11 back then.
+# Shanks says UT-10 from 1901 [but] ... there is a good chance the change
+# actually was to UT-11 back then.
 #
 # From Paul Eggert (2012-07-25)
 # A Google Books snippet of Appendix to the Journals of the House of
 # Representatives of New Zealand, Session 1948,
-# <http://books.google.com/books?id=ZaVCAQAAIAAJ>, page 65, says Tokelau
+# <https://books.google.com/books?id=ZaVCAQAAIAAJ>, page 65, says Tokelau
 # was "11 hours slow on G.M.T."  Go with Thorsen and assume Shanks & Pottenger
 # are off by an hour starting in 1901.
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Fakaofo	-11:24:56 -	LMT	1901
-			-11:00	-	TKT	2011 Dec 30 # Tokelau Time
-			13:00	-	TKT
+			-11:00	-	%z	2011 Dec 30
+			13:00	-	%z
 
 # Tonga
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Tonga	1999	only	-	Oct	 7	2:00s	1:00	S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Tonga	1999	only	-	Oct	 7	2:00s	1:00	-
 Rule	Tonga	2000	only	-	Mar	19	2:00s	0	-
-Rule	Tonga	2000	2001	-	Nov	Sun>=1	2:00	1:00	S
+Rule	Tonga	2000	2001	-	Nov	Sun>=1	2:00	1:00	-
 Rule	Tonga	2001	2002	-	Jan	lastSun	2:00	0	-
-Rule	Tonga	2016	max	-	Nov	Sun>=1	2:00	1:00	S
-Rule	Tonga	2017	max	-	Jan	Sun>=15	3:00	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Pacific/Tongatapu	12:19:20 -	LMT	1901
-			12:20	-	+1220	1941
-			13:00	-	+13	1999
-			13:00	Tonga	+13/+14
-
-# Tuvalu
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Pacific/Funafuti	11:56:52 -	LMT	1901
-			12:00	-	TVT	# Tuvalu Time
+Rule	Tonga	2016	only	-	Nov	Sun>=1	2:00	1:00	-
+Rule	Tonga	2017	only	-	Jan	Sun>=15	3:00	0	-
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone Pacific/Tongatapu	12:19:12 -	LMT	1945 Sep 10
+			12:20	-	%z	1961
+			13:00	-	%z	1999
+			13:00	Tonga	%z
 
 
 # US minor outlying islands
@@ -5331,10 +6926,11 @@ Zone Pacific/Funafuti	11:56:52 -	LMT	1901
 
 # Johnston
 #
-# From Paul Eggert (2014-03-11):
+# From Paul Eggert (2017-02-10):
 # Sometimes Johnston kept Hawaii time, and sometimes it was an hour behind.
 # Details are uncertain.  We have no data for Johnston after 1970, so
-# treat it like Hawaii for now.
+# treat it like Hawaii for now.  Since Johnston is now uninhabited,
+# its link to Pacific/Honolulu is in the 'backward' file.
 #
 # In his memoirs of June 6th to October 4, 1945
 # <http://www.315bw.org/Herb_Bach.htm> (2005), Herbert C. Bach writes,
@@ -5350,44 +6946,52 @@ Zone Pacific/Funafuti	11:56:52 -	LMT	1901
 # Operation Fishbowl shot (Tightrope, 1962-11-04).... [See] Herman Hoerlin,
 # "The United States High-Altitude Test Experience: A Review Emphasizing the
 # Impact on the Environment", Los Alamos LA-6405, Oct 1976.
-# http://www.fas.org/sgp/othergov/doe/lanl/docs1/00322994.pdf
+# https://www.fas.org/sgp/othergov/doe/lanl/docs1/00322994.pdf
 # See the table on page 4 where he lists GMT and local times for the tests; a
 # footnote for the JI tests reads that local time is "JI time = Hawaii Time
 # Minus One Hour".
-#
-# See 'northamerica' for Pacific/Johnston.
 
 # Kingman
 # uninhabited
 
-# Midway
-# See Pacific/Pago_Pago.
-
 # Palmyra
 # uninhabited since World War II; was probably like Pacific/Kiritimati
 
-# Wake
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Pacific/Wake	11:06:28 -	LMT	1901
-			12:00	-	WAKT	# Wake Time
-
 
 # Vanuatu
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Vanuatu	1983	only	-	Sep	25	0:00	1:00	S
-Rule	Vanuatu	1984	1991	-	Mar	Sun>=23	0:00	0	-
-Rule	Vanuatu	1984	only	-	Oct	23	0:00	1:00	S
-Rule	Vanuatu	1985	1991	-	Sep	Sun>=23	0:00	1:00	S
-Rule	Vanuatu	1992	1993	-	Jan	Sun>=23	0:00	0	-
-Rule	Vanuatu	1992	only	-	Oct	Sun>=23	0:00	1:00	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Pacific/Efate	11:13:16 -	LMT	1912 Jan 13 # Vila
-			11:00	Vanuatu	VU%sT	# Vanuatu Time
 
-# Wallis and Futuna
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Pacific/Wallis	12:15:20 -	LMT	1901
-			12:00	-	WFT	# Wallis & Futuna Time
+# From P Chan (2020-11-27):
+# Joint Daylight Saving Regulation No 59 of 1973
+# New Hebrides Condominium Gazette No 336. December 1973
+# http://www.paclii.org/vu/other/VUNHGovGaz//1973/11.pdf#page=15
+#
+# Joint Daylight Saving (Repeal) Regulation No 10 of 1974
+# New Hebrides Condominium Gazette No 336. March 1974
+# http://www.paclii.org/vu/other/VUNHGovGaz//1974/3.pdf#page=11
+#
+# Summer Time Act No. 35 of 1982 [commenced 1983-09-01]
+# http://www.paclii.org/vu/other/VUGovGaz/1982/32.pdf#page=48
+#
+# Summer Time Act (Cap 157)
+# Laws of the Republic of Vanuatu Revised Edition 1988
+# http://www.paclii.org/cgi-bin/sinodisp/vu/legis/consol_act1988/sta147/sta147.html
+#
+# Summer Time (Amendment) Act No. 6 of 1991 [commenced 1991-11-11]
+# http://www.paclii.org/vu/legis/num_act/sta1991227/
+#
+# Summer Time (Repeal) Act No. 4 of 1993 [commenced 1993-05-03]
+# http://www.paclii.org/vu/other/VUGovGaz/1993/15.pdf#page=59
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Vanuatu	1973	only	-	Dec	22	12:00u	1:00	-
+Rule	Vanuatu	1974	only	-	Mar	30	12:00u	0	-
+Rule	Vanuatu	1983	1991	-	Sep	Sat>=22	24:00	1:00	-
+Rule	Vanuatu	1984	1991	-	Mar	Sat>=22	24:00	0	-
+Rule	Vanuatu	1992	1993	-	Jan	Sat>=22	24:00	0	-
+Rule	Vanuatu	1992	only	-	Oct	Sat>=22	24:00	1:00	-
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Pacific/Efate	11:13:16 -	LMT	1912 Jan 13 # Vila
+			11:00	Vanuatu	%z
 
 ###############################################################################
 
@@ -5398,15 +7002,15 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # tz@iana.org for general use in the future).  For more, please see
 # the file CONTRIBUTING in the tz distribution.
 
-# From Paul Eggert (2014-10-31):
+# From Paul Eggert (2018-11-18):
 #
 # Unless otherwise specified, the source for data through 1990 is:
 # Thomas G. Shanks and Rique Pottenger, The International Atlas (6th edition),
 # San Diego: ACS Publications, Inc. (2003).
 # Unfortunately this book contains many errors and cites no sources.
 #
-# Gwillim Law writes that a good source
-# for recent time zone data is the International Air Transport
+# Many years ago Gwillim Law wrote that a good source
+# for time zone data was the International Air Transport
 # Association's Standard Schedules Information Manual (IATA SSIM),
 # published semiannually.  Law sent in several helpful summaries
 # of the IATA's data after 1990.  Except where otherwise noted,
@@ -5418,33 +7022,29 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 #
 # For data circa 1899, a common source is:
 # Milne J. Civil time. Geogr J. 1899 Feb;13(2):173-94.
-# http://www.jstor.org/stable/1774359
+# https://www.jstor.org/stable/1774359
+#
+# For the 1911/1912 establishment of standard time in French possessions, see:
+# Société Française de Physique, Recueil de constantes physiques (1913),
+# page 752, 18b.
 #
 # A reliable and entertaining source about time zones is
 # Derek Howse, Greenwich time and longitude, Philip Wilson Publishers (1997).
 #
-# I invented the abbreviations marked '*' in the following table;
-# the rest are from earlier versions of this file, or from other sources.
+# I invented the abbreviation marked "*".
+# The following abbreviations are from other sources.
 # Corrections are welcome!
 #		std	dst
 #		LMT		Local Mean Time
 #	  8:00	AWST	AWDT	Western Australia
-#	  8:45	ACWST	ACWDT	Central Western Australia*
-#	  9:00	JST		Japan
 #	  9:30	ACST	ACDT	Central Australia
 #	 10:00	AEST	AEDT	Eastern Australia
+#	 10:00	GST	GDT*	Guam through 2000
 #	 10:00	ChST		Chamorro
-#	 10:30	LHST	LHDT	Lord Howe*
-#	 11:00	BST		Bougainville*
 #	 11:30	NZMT	NZST	New Zealand through 1945
 #	 12:00	NZST	NZDT	New Zealand 1946-present
-#	 12:15	CHAST		Chatham through 1945*
-#	 12:45	CHAST	CHADT	Chatham 1946-present*
-#	 13:00	WSST	WSDT	(western) Samoa 2011-present*
-#	-11:30	WSST		Western Samoa through 1950*
 #	-11:00	SST		Samoa
 #	-10:00	HST		Hawaii
-#	- 8:00	PST		Pitcairn*
 #
 # See the 'northamerica' file for Hawaii.
 # See the 'southamerica' file for Easter I and the Galápagos Is.
@@ -5465,6 +7065,25 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # about fading curtains and crazed farm animals."
 # Electronic Journal of Australian and New Zealand History (1997-03-03)
 # http://www.jcu.edu.au/aff/history/reviews/davison.htm
+
+# From P Chan (2020-11-20):
+# Daylight Saving Act 1916 (No. 40 of 1916) [1916-12-21, commenced 1917-01-01]
+# http://classic.austlii.edu.au/au/legis/cth/num_act/dsa1916401916192/
+#
+# Daylight Saving Repeal Act 1917 (No. 35 of 1917) [1917-09-25]
+# http://classic.austlii.edu.au/au/legis/cth/num_act/dsra1917351917243/
+#
+# Statutory Rules 1941, No. 323 [1941-12-24]
+# https://www.legislation.gov.au/Details/C1941L00323
+#
+# Statutory Rules 1942, No. 392 [1942-09-10]
+# https://www.legislation.gov.au/Details/C1942L00392
+#
+# Statutory Rules 1943, No. 241 [1943-09-29]
+# https://www.legislation.gov.au/Details/C1943L00241
+#
+# All transition times should be 02:00 standard time.
+
 
 # From Paul Eggert (2005-12-08):
 # Implementation Dates of Daylight Saving Time within Australia
@@ -5574,7 +7193,7 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 #   AEST ACST AWST AEDT ACDT
 #
 #   Parliamentary Library (2008-11-10)
-#   http://www.aph.gov.au/binaries/library/pubs/rp/2008-09/09rp14.pdf
+#   https://www.aph.gov.au/binaries/library/pubs/rp/2008-09/09rp14.pdf
 #   EST CST WST preferred for standard time; AEST AEDT ACST ACDT also used
 #
 #   The Transport Safety Bureau has an extensive series of accident reports,
@@ -5610,13 +7229,13 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 #
 # NSW (including LHI and Broken Hill):
 # Standard Time Act 1987 (updated 1995-04-04)
-# http://www.austlii.edu.au/au/legis/nsw/consol_act/sta1987137/index.html
+# https://www.austlii.edu.au/au/legis/nsw/consol_act/sta1987137/index.html
 # ACT
 # Standard Time and Summer Time Act 1972
-# http://www.austlii.edu.au/au/legis/act/consol_act/stasta1972279/index.html
+# https://www.austlii.edu.au/au/legis/act/consol_act/stasta1972279/index.html
 # SA
 # Standard Time Act, 1898
-# http://www.austlii.edu.au/au/legis/sa/consol_act/sta1898137/index.html
+# https://www.austlii.edu.au/au/legis/sa/consol_act/sta1898137/index.html
 
 # From David Grosz (2005-06-13):
 # It was announced last week that Daylight Saving would be extended by
@@ -5681,52 +7300,25 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # The 1992 ending date used in the rules is a best guess;
 # it matches what was used in the past.
 
-# The Australian Bureau of Meteorology FAQ
-# http://www.bom.gov.au/faq/faqgen.htm
-# (1999-09-27) writes that Giles Meteorological Station uses
-# South Australian time even though it's located in Western Australia.
-
-# Queensland
-# From George Shepherd via Simon Woodhead via Robert Elz (1991-03-06):
-# #   The state of QUEENSLAND.. [ Courtesy Qld. Dept Premier Econ&Trade Devel ]
-# #						[ Dec 1990 ]
-# ...
-# Zone	Australia/Queensland	10:00	AQ	%sST
-# ...
-# Rule	AQ	1971	only	-	Oct	lastSun	2:00	1:00	D
-# Rule	AQ	1972	only	-	Feb	lastSun	3:00	0	E
-# Rule	AQ	1989	max	-	Oct	lastSun	2:00	1:00	D
-# Rule	AQ	1990	max	-	Mar	Sun>=1	3:00	0	E
-
-# From Bradley White (1989-12-24):
-# "Australia/Queensland" now observes daylight time (i.e. from
-# October 1989).
-
-# From Bradley White (1991-03-04):
-# A recent excerpt from an Australian newspaper...
-# ...Queensland...[has] agreed to end daylight saving
-# at 3am tomorrow (March 3)...
-
-# From John Mackin (1991-03-06):
-# I can certainly confirm for my part that Daylight Saving in NSW did in fact
-# end on Sunday, 3 March.  I don't know at what hour, though.  (It surprised
-# me.)
-
-# From Bradley White (1992-03-08):
-# ...there was recently a referendum in Queensland which resulted
-# in the experimental daylight saving system being abandoned. So, ...
-# ...
-# Rule	QLD	1989	1991	-	Oct	lastSun	2:00	1:00	D
-# Rule	QLD	1990	1992	-	Mar	Sun>=1	3:00	0	S
-# ...
-
-# From Arthur David Olson (1992-03-08):
-# The chosen rules the union of the 1971/1972 change and the 1989-1992 changes.
-
 # From Christopher Hunt (2006-11-21), after an advance warning
 # from Jesper Nørgaard Welen (2006-11-01):
 # WA are trialing DST for three years.
 # http://www.parliament.wa.gov.au/parliament/bills.nsf/9A1B183144403DA54825721200088DF1/$File/Bill175-1B.pdf
+
+# From Paul Eggert (2018-04-01):
+# The Guardian Express of Perth, Australia reported today that the
+# government decided to advance the clocks permanently on January 1,
+# 2019, from UT +08 to UT +09.  The article noted that an exemption
+# would be made for people aged 61 and over, who "can apply in writing
+# to have the extra hour of sunshine removed from their area."  See:
+# Daylight saving coming to WA in 2019. Guardian Express. 2018-04-01.
+# https://www.communitynews.com.au/guardian-express/news/exclusive-daylight-savings-coming-wa-summer-2018/
+# [The article ends with "Today's date is April 1."]
+
+# The Australian Bureau of Meteorology FAQ
+# http://www.bom.gov.au/faq/faqgen.htm
+# (1999-09-27) writes that Giles Meteorological Station uses
+# South Australian time even though it's located in Western Australia.
 
 # From Rives McDow (2002-04-09):
 # The most interesting region I have found consists of three towns on the
@@ -5763,10 +7355,79 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # in WA or its introduction in SA had anything to do with the genesis
 # of this time zone.  My hunch is that it's been around since well
 # before 1975.  I remember seeing it noted on road maps decades ago.
+#
+# From Gilmore Davidson (2019-04-08):
+# https://www.abc.net.au/news/2019-04-08/this-remote-stretch-of-desert-has-its-own-custom-time-zone/10981000
+# ... include[s] a rough description of the geographical boundaries...
+# "The time zone exists for about 340 kilometres and takes in the tiny
+# roadhouse communities of Cocklebiddy, Madura, Eucla and Border Village."
+# ... and an indication that the zone has definitely been in existence
+# since before the 1970 cut-off of the database ...
+# From Paul Eggert (2019-05-17):
+# That ABC Esperance story by Christien de Garis also says:
+#    Although the Central Western Time Zone is not officially recognised (your
+#    phones won't automatically change), there is a sign instructing you which
+#    way to wind your clocks 45 minutes and scrawled underneath one of them in
+#    Texta is the word: 'Why'?
+#    "Good question," Mr Pike said.
+#    "I don't even know that, and it's been going for over 50 years."
 
 # From Paul Eggert (2006-12-15):
 # For lack of better info, assume the tradition dates back to the
 # introduction of standard time in 1895.
+
+# From Stuart Bishop (2024-11-12):
+# An article discussing the in-use but technically unofficial timezones
+# in the Western Australian portion of the Nullarbor Plain.
+# https://www.abc.net.au/news/2024-11-22/outback-wa-properties-strange-time-zones/104542494
+# From Paul Eggert (2024-11-12):
+# As the article says, the Eyre Bird Observatory and nearby sheep stations
+# can use Tokyo time.  Other possibilities include Asia/Chita, Asia/Seoul,
+# and Asia/Jayapura.
+
+# Queensland
+
+# From Paul Eggert (2018-02-26):
+# I lack access to the following source for Queensland DST:
+# Pearce C. History of daylight saving time in Queensland.
+# Queensland Hist J. 2017 Aug;23(6):389-403
+# https://search.informit.com.au/documentSummary;dn=994682348436426;res=IELHSS
+
+# From George Shepherd via Simon Woodhead via Robert Elz (1991-03-06):
+# #   The state of QUEENSLAND.. [ Courtesy Qld. Dept Premier Econ&Trade Devel ]
+# #						[ Dec 1990 ]
+# ...
+# Zone	Australia/Queensland	10:00	AQ	%sST
+# ...
+# Rule	AQ	1971	only	-	Oct	lastSun	2:00	1:00	D
+# Rule	AQ	1972	only	-	Feb	lastSun	3:00	0	E
+# Rule	AQ	1989	max	-	Oct	lastSun	2:00	1:00	D
+# Rule	AQ	1990	max	-	Mar	Sun>=1	3:00	0	E
+
+# From Bradley White (1989-12-24):
+# "Australia/Queensland" now observes daylight time (i.e. from
+# October 1989).
+
+# From Bradley White (1991-03-04):
+# A recent excerpt from an Australian newspaper...
+# ...Queensland...[has] agreed to end daylight saving
+# at 3am tomorrow (March 3)...
+
+# From John Mackin (1991-03-06):
+# I can certainly confirm for my part that Daylight Saving in NSW did in fact
+# end on Sunday, 3 March.  I don't know at what hour, though.  (It surprised
+# me.)
+
+# From Bradley White (1992-03-08):
+# ...there was recently a referendum in Queensland which resulted
+# in the experimental daylight saving system being abandoned. So, ...
+# ...
+# Rule	QLD	1989	1991	-	Oct	lastSun	2:00	1:00	D
+# Rule	QLD	1990	1992	-	Mar	Sun>=1	3:00	0	S
+# ...
+
+# From Arthur David Olson (1992-03-08):
+# The chosen rules the union of the 1971/1972 change and the 1989-1992 changes.
 
 
 # southeast Australia
@@ -5825,6 +7486,27 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # See "southeast Australia" above for 2008 and later.
 
 # Tasmania
+
+# From P Chan (2020-11-20):
+# Tasmania observed DST in 1916-1919.
+#
+# Daylight Saving Act, 1916 (7 Geo V, No 2) [1916-09-22]
+# http://classic.austlii.edu.au/au/legis/tas/num_act/tdsa19167gvn2267/
+#
+# Daylight Saving Amendment Act, 1917 (8 Geo V, No 5) [1917-10-01]
+# http://classic.austlii.edu.au/au/legis/tas/num_act/tdsaa19178gvn5347/
+#
+# Daylight Saving Act Repeal Act, 1919 (10 Geo V, No 9) [1919-10-24]
+# http://classic.austlii.edu.au/au/legis/tas/num_act/tdsara191910gvn9339/
+#
+# King Island is mentioned in the 1967 Act but not the 1968 Act.
+# Therefore it possibly observed DST from 1968/69.
+#
+# Daylight Saving Act 1967 (No. 33 of 1967) [1967-09-22]
+# http://classic.austlii.edu.au/au/legis/tas/num_act/dsa196733o1967211/
+#
+# Daylight Saving Act 1968 (No. 42 of 1968) [1968-10-15]
+# http://classic.austlii.edu.au/au/legis/tas/num_act/dsa196842o1968211/
 
 # The rules for 1967 through 1991 were reported by George Shepherd
 # via Simon Woodhead via Robert Elz (1991-03-06):
@@ -5911,7 +7593,7 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # http://abc.net.au/news/regionals/neweng/monthly/regeng-22jul1999-1.htm
 # (1999-07-22).  For now, we'll wait to see if this really happens.
 #
-# Victoria will following NSW.  See:
+# Victoria will follow NSW.  See:
 # Vic to extend daylight saving (1999-07-28)
 # http://abc.net.au/local/news/olympics/1999/07/item19990728112314_1.htm
 #
@@ -6014,7 +7696,7 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # the ACT for all 52 weeks of the year...
 #
 # We have a wrap-up here:
-# http://www.timeanddate.com/news/time/south-australia-extends-dst.html
+# https://www.timeanddate.com/news/time/south-australia-extends-dst.html
 ###############################################################################
 
 # New Zealand
@@ -6052,7 +7734,7 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 #
 # From Paul Eggert (2006-03-22):
 # The Department of Internal Affairs (DIA) maintains a brief history,
-# as does Carol Squires; see tz-link.htm for the full references.
+# as does Carol Squires; see tz-link.html for the full references.
 # Use these sources in preference to Shanks & Pottenger.
 #
 # For Chatham, IATA SSIM (1991/1999) gives the NZ rules but with
@@ -6068,7 +7750,7 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # From Paul Eggert (2014-07-14):
 # Chatham Island time was formally standardized on 1957-01-01 by
 # New Zealand's Standard Time Amendment Act 1956 (1956-10-26).
-# http://www.austlii.edu.au/nz/legis/hist_act/staa19561956n100244.pdf
+# https://www.austlii.edu.au/nz/legis/hist_act/staa19561956n100244.pdf
 # According to Google Books snippet view, a speaker in the New Zealand
 # parliamentary debates in 1956 said "Clause 78 makes provision for standard
 # time in the Chatham Islands.  The time there is 45 minutes in advance of New
@@ -6079,6 +7761,42 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # not observe New Zealand's prewar DST.
 
 ###############################################################################
+
+
+# Bonin (Ogasawara) Islands and Marcus Island (Minami-Tori-shima)
+
+# From Wakaba (2019-01-28) via Phake Nick:
+# National Diet Library of Japan has several reports by Japanese Government
+# officers that describe the time used in islands when they visited there.
+# According to them (and other sources such as newspapers), standard time UTC
+# + 10 (JST + 1) and DST UTC + 11 (JST + 2) was used until its return to Japan
+# at 1968-06-26 00:00 JST.  The exact periods of DST are still unknown.
+# I guessed Guam, Mariana, and Bonin and Marcus districts might have
+# synchronized their DST periods, but reports imply they had their own
+# decisions, i.e. there were three or more different time zones....
+#
+# https://wiki.suikawiki.org/n/小笠原諸島の標準時
+
+# From Phake Nick (2019-02-12):
+# Because their last time change to return to Japanese time when they returned
+# to Japanese rule was right before 1970, ... per the current tz database
+# rule, the information doesn't warrant creation of a new timezone for Bonin
+# Islands itself and is thus as an anecdotal note for interest purpose only.
+# ... [The abovementioned link] described some special timekeeping phenomenon
+# regarding Marcus island, another remote island currently owned by Japanese
+# in the same administrative unit as Bonin Islands.  Many reports claim that
+# the American coastal guard on the American quarter of the island use its own
+# coastal guard time, and most sources describe the time as UTC+11, being two
+# hours faster than JST used by some Japanese personnel on the island.  Some
+# sites describe it as same as Wake Island/Guam time although it would be
+# incorrect to be same as Guam.  And then in a few Japanese governmental
+# report from 1980s (from National Institute of Information and Communications
+# Technology) regarding the construction of VLBI facility on the Marcus
+# Island, it claimed that there are three time standards being used on the
+# island at the time which include not just JST (UTC+9) or [US]CG time
+# (UTC+11) but also a JMSDF time (UTC+10) (Japan Maritime Self-Defense
+# Force).  Unfortunately there are no other sources that mentioned such time
+# and there are also no information on things like how the time was used.
 
 
 # Fiji
@@ -6113,38 +7831,92 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # "declared it the same day [throughout] the country as of Jan. 1, 1995"
 # as part of the competition to be first into the 21st century.
 
+# From Kerry Shetline (2018-02-03):
+# December 31 was the day that was skipped, so that the transition
+# would be from Friday December 30, 1994 to Sunday January 1, 1995.
+# From Paul Eggert (2018-02-04):
+# One source for this is page 202 of: Bartky IR. One Time Fits All:
+# The Campaigns for Global Uniformity (2007).
+
+# Kanton
+
+# From Paul Eggert (2021-05-27):
+# Kiribati's +13 timezone is represented by Kanton, its only populated
+# island.  (It was formerly spelled "Canton", but Gilbertese lacks "C".)
+# Kanton was settled on 1937-08-31 by two British radio operators
+# <https://history.state.gov/historicaldocuments/frus1937v02/d94>;
+# Americans came the next year and built an airfield, partly to
+# establish airline service and perhaps partly anticipating the
+# next war.  Aside from the war, the airfield was used by commercial
+# airlines until long-range jets became standard; although currently
+# for emergency use only, China says it is considering rebuilding the
+# airfield for high-end niche tourism.  Kanton has about two dozen
+# people, caretakers who rotate in from the rest of Kiribati in 2-5
+# year shifts, and who use some of the leftover structures
+# <http://pipa.neaq.org/2012/06/images-of-kanton-island.html>.
 
 # Kwajalein
 
-# In comp.risks 14.87 (26 August 1993), Peter Neumann writes:
-# I wonder what happened in Kwajalein, where there was NO Friday,
-# 1993-08-20.  Thursday night at midnight Kwajalein switched sides with
-# respect to the International Date Line, to rejoin its fellow islands,
-# going from 11:59 p.m. Thursday to 12:00 m. Saturday in a blink.
+# From an AP article (1993-08-22):
+# "The nearly 3,000 Americans living on this remote Pacific atoll have a good
+# excuse for not remembering Saturday night: there wasn't one.  Residents were
+# going to bed Friday night and waking up Sunday morning because at midnight
+# -- 8 A.M. Eastern daylight time on Saturday -- Kwajalein was jumping from
+# one side of the international date line to the other."
+# "In Marshall Islands, Friday is followed by Sunday", NY Times. 1993-08-22.
+# https://www.nytimes.com/1993/08/22/world/in-marshall-islands-friday-is-followed-by-sunday.html
+
+# From Paul Eggert (2022-03-31):
+# Phake Nick (2018-10-27) noted <https://wiki.suikawiki.org/n/南洋群島の標準時>'s
+# citation of a 1993 AP article published in the New York Times saying
+# Kwajalein synchronized its day with the US mainland about 40 years earlier.
+# However the AP article is vague and possibly wrong about this.  The article
+# says the earlier switch was "about 40 years ago when the United States
+# Army established a missile test range here".  However, the Kwajalein Test
+# Center was established on 1960-10-01 and was run by the US Navy.  It was
+# transferred to the US Army on 1964-07-01.  See "Seize the High Ground"
+# <https://history.army.mil/html/books/070/70-88-1/cmhPub_70-88-1.pdf>.
+# Given that Shanks was right on the money about the 1993 change, I'm inclined
+# to take Shanks's word for the 1969 change unless we find better evidence.
 
 
 # N Mariana Is, Guam
 
+# From Phake Nick (2018-10-27):
+# Guam Island was briefly annexed by Japan during ... year 1941-1944 ...
+# however there are no detailed information about what time it use during that
+# period.  It would probably be reasonable to assume Guam use GMT+9 during
+# that period of time like the surrounding area.
+
+# From Paul Eggert (2023-01-23):
 # Howse writes (p 153) "The Spaniards, on the other hand, reached the
 # Philippines and the Ladrones from America," and implies that the Ladrones
 # (now called the Marianas) kept American date for quite some time.
 # For now, we assume the Ladrones switched at the same time as the Philippines;
 # see Asia/Manila.
-
+#
+# Use 1941-12-10 and 1944-07-31 for Guam WWII transitions, as the rough start
+# and end of Japanese control of Agana.  We don't know whether the Northern
+# Marianas followed Guam's DST rules from 1959 through 1977; for now, assume
+# they did as that avoids the need for a separate zone due to our 1970 cutoff.
+#
 # US Public Law 106-564 (2000-12-23) made UT +10 the official standard time,
-# under the name "Chamorro Standard Time".  There is no official abbreviation,
+# under the name "Chamorro standard time".  There is no official abbreviation,
 # but Congressman Robert A. Underwood, author of the bill that became law,
 # wrote in a press release (2000-12-27) that he will seek the use of "ChST".
 
+# See also the commentary for Micronesia.
 
-# Micronesia
 
-# Alan Eugene Davis writes (1996-03-16),
-# "I am certain, having lived there for the past decade, that 'Truk'
-# (now properly known as Chuuk) ... is in the time zone GMT+10."
-#
-# Shanks & Pottenger write that Truk switched from UT +10 to +11
-# on 1978-10-01; ignore this for now.
+# Marshall Is
+# See the commentary for Micronesia.
+
+
+# Micronesia (and nearby)
+
+# From Paul Eggert (2018-11-18):
+# Like the Ladrones (see Guam commentary), assume the Spanish East Indies
+# kept American time until the Philippines switched at the end of 1844.
 
 # From Paul Eggert (1999-10-29):
 # The Federated States of Micronesia Visitors Board writes in
@@ -6152,6 +7924,95 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # http://www.fsmgov.org/info/clocks.html
 # that Truk and Yap are UT +10, and Ponape and Kosrae are +11.
 # We don't know when Kosrae switched from +12; assume January 1 for now.
+
+# From Phake Nick (2018-10-27):
+#
+# From a Japanese wiki site https://wiki.suikawiki.org/n/南洋群島の標準時
+# ...
+# For "Southern Islands" (modern region of Mariana + Palau + Federation of
+# Micronesia + Marshall Islands):
+#
+# A 1906 Japanese magazine shown the Caroline Islands and Mariana Islands
+# who was occupied by Germany at the time as GMT+10, together with the like
+# of German New Guinea.  However there is a marking saying it have not been
+# implemented (yet).  No further information after that were found.
+#
+# Japan invaded those islands in 1914, and records shows that they were
+# instructed to use JST at the time.
+#
+# 1915 January telecommunication record on the Jaluit Atoll shows they use
+# the meridian of 170E as standard time (GMT+11:20), which is similar to the
+# longitude of the atoll.
+# 1915 February record say the 170E standard time is to be used until
+# February 9 noon, and after February 9 noon they are to use JST.
+# However these are time used within the Japanese Military at the time and
+# probably does not reflect the time used by local resident at the time (that
+# is if they keep their own time back then)
+#
+# In January 1919 the occupying force issued a command that split the area
+# into three different timezone with meridian of 135E, 150E, 165E (JST+0, +1,
+# +2), and the command was to become effective from February 1 of the same
+# year.  Despite the target of the command is still only for the occupying
+# force itself, further publication have described the time as the standard
+# time for the occupied area and thus it can probably be seen as such.
+#  * Area that use meridian of 135E: Palau and Yap civil administration area
+#    (Southern Islands Western Standard Time)
+#  * Area that use meridian of 150E: Truk (Chuuk) and Saipan civil
+#    administration area (Southern Islands Central Standard Time)
+#  * Area that use meridian of 165E: Ponape (Pohnpei) and Jaluit civil
+#    administration area (Southern Islands Eastern Standard Time).
+#  * In the next few years Japanese occupation of those islands have been
+#    formalized via League of Nation Mandate (South Pacific Mandate) and formal
+#    governance structure have been established, these district [become
+#    subprefectures] and timezone classification have been inherited as standard
+#    time of the area.
+#  * Saipan subprefecture include Mariana islands (exclude Guam which was
+#    occupied by America at the time), Palau and Yap subprefecture rule the
+#    Western Caroline Islands with 137E longitude as border, Truk and Ponape
+#    subprefecture rule the Eastern Caroline Islands with 154E as border, Ponape
+#    subprefecture also rule part of Marshall Islands to the west of 164E
+#    starting from (1918?) and Jaluit subprefecture rule the rest of the
+#    Marshall Islands.
+#
+# And then in year 1937, an announcement was made to change the time in the
+# area into 2 timezones:
+#  * Area that use meridian of 135E: area administered by Palau, Yap and
+#    Saipan subprefecture (Southern Islands Western Standard Time)
+#  * Area that use meridian of 150E: area administered by Truk (Chuuk),
+#    Ponape (Pohnpei) and Jaluit subprefecture (Southern Islands Eastern
+#    Standard Time)
+#
+# Another announcement issued in 1941 say that on April 1 that year,
+# standard time of the Southern Islands would be changed to use the meridian
+# of 135E (GMT+9), and thus abolishing timezone different within the area.
+#
+# Then Pacific theater of WWII started and Japan slowly lose control on the
+# island.  The webpage I linked above contain no information during this
+# period of time....
+#
+# After the end of WWII, in 1946 February, a document written by the
+# (former?) Japanese military personnel describe there are 3 hours time
+# different between Caroline islands time/Wake island time and the Chungking
+# time, which would mean the time being used there at the time was GMT+10.
+#
+# After that, the area become Trust Territories of the Pacific Islands
+# under American administration from year 1947.  The site listed some
+# American/International books/maps/publications about time used in those
+# area during this period of time but they doesn't seems to be reliable
+# information so it would be the best if someone know where can more reliable
+# information can be found.
+#
+#
+# From Paul Eggert (2018-11-18):
+#
+# For the above, use vague dates like "1914" and "1945" for transitions that
+# plausibly exist but for which the details are not known.  The information
+# for Wake is too sketchy to act on.
+#
+# The 1906 GMT+10 info about German-controlled islands might not have been
+# done, so omit it from the data for now.
+#
+# The Jaluit info governs Kwajalein.
 
 
 # Midway
@@ -6170,6 +8031,29 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # started DST on June 3.  Possibly DST was observed other years
 # in Midway, but we have no record of it.
 
+# Nauru
+
+# From Phake Nick (2018-10-31):
+# Currently, the tz database say Nauru use LMT until 1921, and then
+# switched to GMT+11:30 for the next two decades.
+# However, a number of timezone map published in America/Japan back then
+# showed its timezone as GMT+11 per https://wiki.suikawiki.org/n/ナウルの標準時
+# And it would also be nice if the 1921 transition date could be sourced.
+# ...
+# The "Nauru Standard Time Act 1978 Time Change"
+# http://ronlaw.gov.nr/nauru_lpms/files/gazettes/4b23a17d2030150404db7a5fa5872f52.pdf#page=3
+# based on "Nauru Standard Time Act 1978 Time Change"
+# http://www.paclii.org/nr/legis/num_act/nsta1978207/ defined that "Nauru
+# Alternative Time" (GMT+12) should be in effect from 1979 Feb.
+#
+# From Paul Eggert (2018-11-19):
+# The 1921-01-15 introduction of standard time is in Shanks; it is also in
+# "Standard Time Throughout the World", US National Bureau of Standards (1935),
+# page 3, which does not give the UT offset.  In response to a comment by
+# Phake Nick I set the Nauru time of occupation by Japan to
+# 1942-08-29/1945-09-08 by using dates from:
+# https://en.wikipedia.org/wiki/Japanese_occupation_of_Nauru
+
 # Norfolk
 
 # From Alexander Krivenyshev (2015-09-23):
@@ -6178,12 +8062,24 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # ... at 12.30 am (by legal time in New South Wales) on 4 October 2015.
 # http://www.norfolkisland.gov.nf/nia/MediaRelease/Media%20Release%20Norfolk%20Island%20Standard%20Time%20Change.pdf
 
-# From Paul Eggert (2015-09-23):
+# From Paul Eggert (2019-08-28):
 # Transitions before 2015 are from timeanddate.com, which consulted
 # the Norfolk Island Museum and the Australian Bureau of Meteorology's
 # Norfolk Island station, and found no record of Norfolk observing DST
 # other than in 1974/5.  See:
-# http://www.timeanddate.com/time/australia/norfolk-island.html
+# https://www.timeanddate.com/time/australia/norfolk-island.html
+# However, disagree with timeanddate about the 1975-03-02 transition;
+# timeanddate has 02:00 but 02:00s corresponds to what the NSW law said
+# (thanks to Michael Deckers).
+
+# Norfolk started observing Australian DST in spring 2019.
+# From Kyle Czech (2019-08-13):
+# https://www.legislation.gov.au/Details/F2018L01702
+# From Michael Deckers (2019-08-14):
+# https://www.legislation.gov.au/Details/F2019C00010
+
+# Palau
+# See commentary for Micronesia.
 
 # Pitcairn
 
@@ -6205,17 +8101,19 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 
 # From Howie Phelps (1999-11-10), who talked to a Pitcairner via shortwave:
 # Betty Christian told me yesterday that their local time is the same as
-# Pacific Standard Time. They used to be 1/2 hour different from us here in
+# Pacific Standard Time. They used to be ½ hour different from us here in
 # Sacramento but it was changed a couple of years ago.
 
 
 # (Western) Samoa and American Samoa
 
-# Howse writes (p 153, citing p 10 of the 1883-11-18 New York Herald)
-# that in 1879 the King of Samoa decided to change
+# Howse writes (p 153) that after the 1879 standardization on Antipodean
+# time by the British governor of Fiji, the King of Samoa decided to change
 # "the date in his kingdom from the Antipodean to the American system,
 # ordaining - by a masterpiece of diplomatic flattery - that
 # the Fourth of July should be celebrated twice in that year."
+# This happened in 1892, according to the Evening News (Sydney) of 1892-07-20.
+# https://webspace.science.uu.nl/~gent0113/idl/idl_alaska_samoa.htm
 
 # Although Shanks & Pottenger says they both switched to UT -11:30
 # in 1911, and to -11 in 1950. many earlier sources give -11
@@ -6226,7 +8124,19 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # day in 2011.  Assume also that the Samoas follow the US and New
 # Zealand's "ST"/"DT" style of daylight-saving abbreviations.
 
+
 # Tonga
+
+# From Paul Eggert (2021-03-04):
+# In 1943 "The standard time kept is 12 hrs. 19 min. 12 sec. fast
+# on Greenwich mean time." according to the Admiralty's Hydrographic
+# Dept., Pacific Islands Pilot, Vol. II, 7th ed., 1943, p 360.
+
+# From Michael Deckers (2021-03-03):
+# [Ian R Bartky: "One Time Fits All: The Campaigns for Global Uniformity".
+# Stanford University Press. 2007. p. 255]:
+# On 10 September 1945 Tonga adopted a standard time 12 hours,
+# 20 minutes in advance of Greenwich.
 
 # From Paul Eggert (1996-01-22):
 # Today's _Wall Street Journal_ (p 1) reports that "Tonga has been plotting
@@ -6241,7 +8151,7 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # 12 hours and 20 minutes ahead of GMT.  When New Zealand adjusted its
 # standard time in 1940s, Tonga had the choice of subtracting from its
 # local time to come on the same standard time as New Zealand or of
-# advancing its time to maintain the differential of 13 degrees
+# advancing its time to maintain the differential of 13°
 # (approximately 50 minutes ahead of New Zealand time).
 #
 # Because His Majesty King Tāufaʻāhau Tupou IV, then Crown Prince
@@ -6256,9 +8166,26 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # The Crown Prince, presented an unanswerable argument: "Remember that
 # on the World Day of Prayer, you would be the first people on Earth
 # to say your prayers in the morning."
-
-# From Paul Eggert (2006-03-22):
-# Shanks & Pottenger say the transition was on 1968-10-01; go with Mundell.
+#
+# From Tim Parenti (2021-09-13), per Paul Eggert (2006-03-22) and Michael
+# Deckers (2021-03-03):
+# Mundell places the transition from +12:20 to +13 in 1941, while Shanks &
+# Pottenger say the transition was on 1968-10-01.
+#
+# The Air Almanac published contemporaneous tables of standard times,
+# which listed +12:20 as of Nov 1960 and +13 as of Mar 1961:
+#   Nov 1960: https://books.google.com/books?id=bVgtWM6kPZUC&pg=SL1-PA19
+#   Mar 1961: https://books.google.com/books?id=W2nItAul4g0C&pg=SL1-PA19
+# (Thanks to P Chan for pointing us toward these sources.)
+# This agrees with Bartky, who writes that "since 1961 [Tonga's] official time
+# has been thirteen hours in advance of Greenwich time" (p. 202) and further
+# writes in an endnote that this was because "the legislation was amended" on
+# 1960-10-19. (p. 255)
+#
+# Without greater specificity, presume that Bartky and the Air Almanac point to
+# a 1961-01-01 transition, as Tāufaʻāhau Tupou IV was still Crown Prince in
+# 1961 and this still jives with the gist of Mundell's telling, and go with
+# this over Shanks & Pottenger.
 
 # From Eric Ulevik (1999-05-03):
 # Tonga's director of tourism, who is also secretary of the National Millennium
@@ -6320,22 +8247,14 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # Assume Tonga will observe DST from the first Sunday in November at 02:00
 # through the third Sunday in January at 03:00, like Fiji, for now.
 
-# Wake
-
-# From Vernice Anderson, Personal Secretary to Philip Jessup,
-# US Ambassador At Large (oral history interview, 1971-02-02):
+# From David Wade (2017-10-18):
+# In August government was dissolved by the King.  The current prime minister
+# continued in office in care taker mode.  It is easy to see that few
+# decisions will be made until elections 16th November.
 #
-# Saturday, the 14th [of October, 1950] - ...  The time was all the
-# more confusing at that point, because we had crossed the
-# International Date Line, thus getting two Sundays.  Furthermore, we
-# discovered that Wake Island had two hours of daylight saving time
-# making calculation of time in Washington difficult if not almost
-# impossible.
-#
-# http://www.trumanlibrary.org/wake/meeting.htm
+# From Paul Eggert (2017-10-18):
+# For now, guess that DST is discontinued.  That's what the IATA is guessing.
 
-# From Paul Eggert (2003-03-23):
-# We have no other report of DST in Wake Island, so omit this info for now.
 
 ###############################################################################
 
@@ -6360,27 +8279,23 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # an international standard, there are some places on the high seas where the
 # correct date is ambiguous.
 
-# From Wikipedia <http://en.wikipedia.org/wiki/Time_zone> (2005-08-31):
-# Before 1920, all ships kept local apparent time on the high seas by setting
-# their clocks at night or at the morning sight so that, given the ship's
-# speed and direction, it would be 12 o'clock when the Sun crossed the ship's
-# meridian (12 o'clock = local apparent noon).  During 1917, at the
-# Anglo-French Conference on Time-keeping at Sea, it was recommended that all
-# ships, both military and civilian, should adopt hourly standard time zones
-# on the high seas.  Whenever a ship was within the territorial waters of any
-# nation it would use that nation's standard time.  The captain was permitted
-# to change his ship's clocks at a time of his choice following his ship's
-# entry into another zone time - he often chose midnight.  These zones were
-# adopted by all major fleets between 1920 and 1925 but not by many
-# independent merchant ships until World War II.
+# From Wikipedia <https://en.wikipedia.org/wiki/Nautical_time> (2023-01-23):
+# The nautical time zone system is analogous to the terrestrial time zone
+# system for use on high seas.  Under the system time changes are required for
+# changes of longitude in one-hour steps.  The one-hour step corresponds to a
+# time zone width of 15° longitude.  The 15° gore that is offset from GMT or
+# UT1 (not UTC) by twelve hours is bisected by the nautical date line into two
+# 7°30' gores that differ from GMT by ±12 hours.  A nautical date line is
+# implied but not explicitly drawn on time zone maps.  It follows the 180th
+# meridian except where it is interrupted by territorial waters adjacent to
+# land, forming gaps: it is a pole-to-pole dashed line.
 
-# From Paul Eggert, using references suggested by Oscar van Vlijmen
-# (2005-03-20):
-#
-# The American Practical Navigator (2002)
-# http://pollux.nss.nima.mil/pubs/pubs_j_apn_sections.html?rid=187
-# talks only about the 180-degree meridian with respect to ships in
-# international waters; it ignores the international date line.
+# From Paul Eggert (2023-01-23):
+# The American Practical Navigator <https://msi.nga.mil/Publications/APN>,
+# 2019 edition, merely says that the International Date Line
+# "coincides with the 180th meridian over most of its length."
+# tzdb data for Europe and environs
+
 # This file is in the public domain, so clarified as of
 # 2009-05-17 by Arthur David Olson.
 
@@ -6389,15 +8304,15 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # tz@iana.org for general use in the future).  For more, please see
 # the file CONTRIBUTING in the tz distribution.
 
-# From Paul Eggert (2014-10-31):
+# From Paul Eggert (2017-02-10):
 #
 # Unless otherwise specified, the source for data through 1990 is:
 # Thomas G. Shanks and Rique Pottenger, The International Atlas (6th edition),
 # San Diego: ACS Publications, Inc. (2003).
 # Unfortunately this book contains many errors and cites no sources.
 #
-# Gwillim Law writes that a good source
-# for recent time zone data is the International Air Transport
+# Many years ago Gwillim Law wrote that a good source
+# for time zone data was the International Air Transport
 # Association's Standard Schedules Information Manual (IATA SSIM),
 # published semiannually.  Law sent in several helpful summaries
 # of the IATA's data after 1990.  Except where otherwise noted,
@@ -6420,14 +8335,14 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 #	[PDF] (1914-03)
 #
 #	Milne J. Civil time. Geogr J. 1899 Feb;13(2):173-94
-#	<http://www.jstor.org/stable/1774359>.  He writes:
+#	<https://www.jstor.org/stable/1774359>.  He writes:
 #	"It is requested that corrections and additions to these tables
 #	may be sent to Mr. John Milne, Royal Geographical Society,
 #	Savile Row, London."  Nowadays please email them to tz@iana.org.
 #
 #	Byalokoz EL. New Counting of Time in Russia since July 1, 1919.
 #	This Russian-language source was consulted by Vladimir Karpinsky; see
-#	http://mm.icann.org/pipermail/tz/2014-August/021320.html
+#	https://mm.icann.org/pipermail/tz/2014-August/021320.html
 #	The full Russian citation is:
 #	Бялокоз, Евгений Людвигович. Новый счет времени в течении суток
 #	введенный декретом Совета народных комиссаров для всей России с 1-го
@@ -6439,29 +8354,26 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 #	History of Summer Time
 #	<http://pcdsh01.on.br/HISTHV.htm>
 #	(1998-09-21, in Portuguese)
-
 #
 # I invented the abbreviations marked '*' in the following table;
-# the rest are from earlier versions of this file, or from other sources.
-# Corrections are welcome!
-#                   std dst  2dst
-#                   LMT           Local Mean Time
-#       -4:00       AST ADT       Atlantic
-#       -3:00       WGT WGST      Western Greenland*
-#       -1:00       EGT EGST      Eastern Greenland*
-#        0:00       GMT BST  BDST Greenwich, British Summer
-#        0:00       GMT IST       Greenwich, Irish Summer
-#        0:00       WET WEST WEMT Western Europe
-#        0:19:32.13 AMT NST       Amsterdam, Netherlands Summer (1835-1937)*
-#        0:20       NET NEST      Netherlands (1937-1940)*
-#        1:00       BST           British Standard (1968-1971)
-#        1:00       CET CEST CEMT Central Europe
-#        1:00:14    SET           Swedish (1879-1899)*
-#        2:00       EET EEST      Eastern Europe
-#        3:00       MSK MSD       Moscow
+# the rest are variants of the "xMT" pattern for a city's mean time,
+# or are from other sources.  Corrections are welcome!
+#                   std  dst  2dst
+#                   LMT             Local Mean Time
+#       -4:00       AST  ADT        Atlantic
+#        0:00       GMT  BST  BDST  Greenwich, British Summer
+#        0:00       GMT  IST        Greenwich, Irish Summer
+#        0:00       WET  WEST WEMT  Western Europe
+#        1:00       BST             British Standard (1968-1971)
+#        1:00       IST  GMT        Irish Standard (1968-) with winter DST
+#        1:00       CET  CEST CEMT  Central Europe
+#        1:00:14    SET             Swedish (1879-1899)
+#        1:36:34    RMT* LST*       Riga, Latvian Summer (1880-1926)*
+#        2:00       EET  EEST       Eastern Europe
+#        3:00       MSK  MSD  MDST* Moscow
 
-# From Peter Ilieve (1994-12-04),
-# The original six [EU members]: Belgium, France, (West) Germany, Italy,
+# From Peter Ilieve (1994-12-04), re EEC/EC/EU members:
+# The original six: Belgium, France, (West) Germany, Italy,
 # Luxembourg, the Netherlands.
 # Plus, from 1 Jan 73: Denmark, Ireland, United Kingdom.
 # Plus, from 1 Jan 81: Greece.
@@ -6502,10 +8414,10 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # along the towpath within a few yards of it.'
 #
 # I have a one inch to one mile map of London and my estimate of the stone's
-# position is 51 degrees 28' 30" N, 0 degrees 18' 45" W. The longitude should
-# be within about +-2". The Ordnance Survey grid reference is TQ172761.
+# position is 51° 28' 30" N, 0° 18' 45" W. The longitude should
+# be within about ±2". The Ordnance Survey grid reference is TQ172761.
 #
-# [This yields GMTOFF = -0:01:15 for London LMT in the 18th century.]
+# [This yields STDOFF = -0:01:15 for London LMT in the 18th century.]
 
 # From Paul Eggert (1993-11-18):
 #
@@ -6543,7 +8455,7 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # after-hours daylight in which to pursue his research.
 # In 1895 he presented a paper to the Wellington Philosophical Society
 # that proposed a two-hour daylight-saving shift.  See:
-# Hudson GV. On seasonal time-adjustment in countries south of lat. 30 deg.
+# Hudson GV. On seasonal time-adjustment in countries south of lat. 30°.
 # Transactions and Proceedings of the New Zealand Institute. 1895;28:734
 # http://rsnz.natlib.govt.nz/volume/rsnz_28/rsnz_28_00_006110.html
 # Although some interest was expressed in New Zealand, his proposal
@@ -6573,7 +8485,7 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # foundations of civilization throughout the world.
 #	-- "A Silent Toast to William Willett", Pictorial Weekly;
 #	republished in Finest Hour (Spring 2002) 1(114):26
-#	http://www.winstonchurchill.org/images/finesthour/Vol.01%20No.114.pdf
+#	https://www.winstonchurchill.org/publications/finest-hour/finest-hour-114/a-silent-toast-to-william-willett-by-winston-s-churchill
 
 # From Paul Eggert (2015-08-08):
 # The OED Supplement says that the English originally said "Daylight Saving"
@@ -6611,8 +8523,8 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # official designation; the reply of the 21st was that there wasn't
 # but he couldn't think of anything better than the "Double British
 # Summer Time" that the BBC had been using informally.
-# http://www.polyomino.org.uk/british-time/bbc-19410418.png
-# http://www.polyomino.org.uk/british-time/ho-19410421.png
+# https://www.polyomino.org.uk/british-time/bbc-19410418.png
+# https://www.polyomino.org.uk/british-time/ho-19410421.png
 
 # From Sir Alexander Maxwell in the above-mentioned letter (1941-04-21):
 # [N]o official designation has as far as I know been adopted for the time
@@ -6629,13 +8541,13 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # the history of summer time legislation in the United Kingdom.
 # Since 1998 Joseph S. Myers has been updating
 # and extending this list, which can be found in
-# http://www.polyomino.org.uk/british-time/
+# https://www.polyomino.org.uk/british-time/
 
 # From Joseph S. Myers (1998-01-06):
 #
 # The legal time in the UK outside of summer time is definitely GMT, not UTC;
 # see Lord Tanlaw's speech
-# http://www.publications.parliament.uk/pa/ld199798/ldhansrd/vo970611/text/70611-10.htm#70611-10_head0
+# https://www.publications.parliament.uk/pa/ld199798/ldhansrd/vo970611/text/70611-10.htm#70611-10_head0
 # (Lords Hansard 11 June 1997 columns 964 to 976).
 
 # From Paul Eggert (2006-03-22):
@@ -6664,16 +8576,30 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # The following claim by Shanks & Pottenger is possible though doubtful;
 # we'll ignore it for now.
 #     * Dublin's 1971-10-31 switch was at 02:00, even though London's was 03:00.
+
+# From Paul Eggert (2017-12-04):
 #
-#
-# Whitman says Dublin Mean Time was -0:25:21, which is more precise than
-# Shanks & Pottenger.
-# Perhaps this was Dunsink Observatory Time, as Dunsink Observatory
-# (8 km NW of Dublin's center) seemingly was to Dublin as Greenwich was
-# to London.  For example:
+# Dunsink Observatory (8 km NW of Dublin's center) was to Dublin as
+# Greenwich was to London.  For example:
 #
 #   "Timeball on the ballast office is down.  Dunsink time."
 #   -- James Joyce, Ulysses
+#
+# The abbreviation DMT stood for "Dublin Mean Time" or "Dunsink Mean Time";
+# this being Ireland, opinions differed.
+#
+# Whitman says Dublin/Dunsink Mean Time was UT-00:25:21, which agrees
+# with measurements of recent visitors to the Meridian Room of Dunsink
+# Observatory; see Malone D. Dunsink and timekeeping. 2016-01-24.
+# <https://www.maths.tcd.ie/~dwmalone/time/dunsink.html>.  Malone
+# writes that the Nautical Almanac listed UT-00:25:22 until 1896, when
+# it moved to UT-00:25:21.1 (I confirmed that the 1893 edition used
+# the former and the 1896 edition used the latter).  Evidently the
+# news of this change propagated slowly, as Milne 1899 still lists
+# UT-00:25:22 and cites the International Telegraph Bureau.  As it is
+# not clear that there was any practical significance to the change
+# from UT-00:25:22 to UT-00:25:21.1 in civil timekeeping, omit this
+# transition for now and just use the latter value.
 
 # "Countess Markievicz ... claimed that the [1916] abolition of Dublin Mean Time
 # was among various actions undertaken by the 'English' government that
@@ -6681,7 +8607,7 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # Irish 'public feeling (was) outraged by forcing of English time on us'."
 # -- Parsons M. Dublin lost its time zone - and 25 minutes - after 1916 Rising.
 # Irish Times 2014-10-27.
-# http://www.irishtimes.com/news/politics/dublin-lost-its-time-zone-and-25-minutes-after-1916-rising-1.1977411
+# https://www.irishtimes.com/news/politics/dublin-lost-its-time-zone-and-25-minutes-after-1916-rising-1.1977411
 
 # From Joseph S. Myers (2005-01-26):
 # Irish laws are available online at <http://www.irishstatutebook.ie>.
@@ -6733,8 +8659,30 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # regulations. I spoke this morning with the Secretary of the Department of
 # Justice (tel +353 1 678 9711) who confirmed to me that the correct name is
 # "Irish Summer Time", abbreviated to "IST".
+#
+# From Paul Eggert (2017-12-07):
+# The 1996 anonymous contributor's goal was to determine the correct
+# abbreviation for summer time in Dublin and so the contributor
+# focused on the "IST", not on the "Irish Summer Time".  Though the
+# "IST" was correct, the "Irish Summer Time" appears to have been an
+# error, as Ireland's Standard Time (Amendment) Act, 1971 states that
+# standard time in Ireland remains at UT +01 and is observed in
+# summer, and that Greenwich mean time is observed in winter.  (Thanks
+# to Derick Rethans for pointing out the error.)  That is, when
+# Ireland amended the 1968 act that established UT +01 as Irish
+# Standard Time, it left standard time unchanged and established GMT
+# as a negative daylight saving time in winter.  So, in this database
+# IST stands for Irish Summer Time for timestamps before 1968, and for
+# Irish Standard Time after that.  See:
+# http://www.irishstatutebook.ie/eli/1971/act/17/enacted/en/print
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Michael Deckers (2017-06-01) gave the following URLs for Ireland's
+# Summer Time Act, 1925 and Summer Time Orders, 1926 and 1947:
+# http://www.irishstatutebook.ie/eli/1925/act/8/enacted/en/print
+# http://www.irishstatutebook.ie/eli/1926/sro/919/made/en/print
+# http://www.irishstatutebook.ie/eli/1947/sro/71/made/en/print
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 # Summer Time Act, 1916
 Rule	GB-Eire	1916	only	-	May	21	2:00s	1:00	BST
 Rule	GB-Eire	1916	only	-	Oct	 1	2:00s	0	GMT
@@ -6846,39 +8794,69 @@ Rule	GB-Eire 1990	1995	-	Oct	Sun>=22	1:00u	0	GMT
 #
 # Use Europe/London for Jersey, Guernsey, and the Isle of Man.
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Europe/London	-0:01:15 -	LMT	1847 Dec  1  0:00s
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Europe/London	-0:01:15 -	LMT	1847 Dec  1
 			 0:00	GB-Eire	%s	1968 Oct 27
 			 1:00	-	BST	1971 Oct 31  2:00u
 			 0:00	GB-Eire	%s	1996
 			 0:00	EU	GMT/BST
-Link	Europe/London	Europe/Jersey
-Link	Europe/London	Europe/Guernsey
-Link	Europe/London	Europe/Isle_of_Man
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Europe/Dublin	-0:25:00 -	LMT	1880 Aug  2
-			-0:25:21 -	DMT	1916 May 21  2:00
+# From Paul Eggert (2018-02-15):
+# In January 2018 we discovered that the negative SAVE values in the
+# Eire rules cause problems with tests for ICU:
+# https://mm.icann.org/pipermail/tz/2018-January/025825.html
+# and with tests for OpenJDK:
+# https://mm.icann.org/pipermail/tz/2018-January/025822.html
+#
+# To work around this problem, the build procedure can translate the
+# following data into two forms, one with negative SAVE values and the
+# other form with a traditional approximation for Irish timestamps
+# after 1971-10-31 02:00 UTC; although this approximation has tm_isdst
+# flags that are reversed, its UTC offsets are correct and this often
+# suffices....
+#
+# The following is like GB-Eire and EU, except with standard time in
+# summer and negative daylight saving time in winter.  It is for when
+# negative SAVE values are used.
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Eire	1971	only	-	Oct	31	 2:00u	-1:00	-
+Rule	Eire	1972	1980	-	Mar	Sun>=16	 2:00u	0	-
+Rule	Eire	1972	1980	-	Oct	Sun>=23	 2:00u	-1:00	-
+Rule	Eire	1981	max	-	Mar	lastSun	 1:00u	0	-
+Rule	Eire	1981	1989	-	Oct	Sun>=23	 1:00u	-1:00	-
+Rule	Eire	1990	1995	-	Oct	Sun>=22	 1:00u	-1:00	-
+Rule	Eire	1996	max	-	Oct	lastSun	 1:00u	-1:00	-
+
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	-0:25:21.1
+Zone	Europe/Dublin	-0:25:21 -	LMT	1880 Aug  2
+			-0:25:21 -	DMT	1916 May 21  2:00s
 			-0:25:21 1:00	IST	1916 Oct  1  2:00s
 			 0:00	GB-Eire	%s	1921 Dec  6 # independence
-			 0:00	GB-Eire	GMT/IST	1940 Feb 25  2:00
-			 0:00	1:00	IST	1946 Oct  6  2:00
-			 0:00	-	GMT	1947 Mar 16  2:00
-			 0:00	1:00	IST	1947 Nov  2  2:00
-			 0:00	-	GMT	1948 Apr 18  2:00
+			 0:00	GB-Eire	GMT/IST	1940 Feb 25  2:00s
+			 0:00	1:00	IST	1946 Oct  6  2:00s
+			 0:00	-	GMT	1947 Mar 16  2:00s
+			 0:00	1:00	IST	1947 Nov  2  2:00s
+			 0:00	-	GMT	1948 Apr 18  2:00s
 			 0:00	GB-Eire	GMT/IST	1968 Oct 27
-			 1:00	-	IST	1971 Oct 31  2:00u
-			 0:00	GB-Eire	GMT/IST	1996
-			 0:00	EU	GMT/IST
+# Vanguard section, for zic and other parsers that support negative DST.
+			 1:00	Eire	IST/GMT
+# Rearguard section, for parsers lacking negative DST; see ziguard.awk.
+#			 1:00	-	IST	1971 Oct 31  2:00u
+#			 0:00	GB-Eire	GMT/IST	1996
+#			 0:00	EU	GMT/IST
+# End of rearguard section.
+
 
 ###############################################################################
 
 # Europe
 
-# EU rules are for the European Union, previously known as the EC, EEC,
-# Common Market, etc.
+# The following rules are for the European Union and for its
+# predecessor organization, the European Communities.
+# For brevity they are called "EU rules" elsewhere in this file.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	EU	1977	1980	-	Apr	Sun>=1	 1:00u	1:00	S
 Rule	EU	1977	only	-	Sep	lastSun	 1:00u	0	-
 Rule	EU	1978	only	-	Oct	 1	 1:00u	0	-
@@ -6918,13 +8896,13 @@ Rule	C-Eur	1944	only	-	Oct	 2	 2:00s	0	-
 # corrected in version 2008d). The circumstantial evidence is simply the
 # tz database itself, as seen below:
 #
-# Zone Europe/Paris 0:09:21 - LMT 1891 Mar 15  0:01
+# Zone Europe/Paris ...
 #    0:00 France WE%sT 1945 Sep 16  3:00
 #
-# Zone Europe/Monaco 0:29:32 - LMT 1891 Mar 15
+# Zone Europe/Monaco ...
 #    0:00 France WE%sT 1945 Sep 16  3:00
 #
-# Zone Europe/Belgrade 1:22:00 - LMT 1884
+# Zone Europe/Belgrade ...
 #    1:00 1:00 CEST 1945 Sep 16  2:00s
 #
 # Rule France 1945 only - Sep 16  3:00 0 -
@@ -6970,7 +8948,7 @@ Rule	E-Eur	1996	max	-	Oct	lastSun	 0:00	0	-
 #
 # The 1917-1921 decree URLs are from Alexander Belopolsky (2016-08-23).
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Russia	1917	only	-	Jul	 1	23:00	1:00	MST  # Moscow Summer Time
 #
 # Decree No. 142 (1917-12-22) http://istmat.info/node/28137
@@ -7011,7 +8989,7 @@ Rule	Russia	1996	2010	-	Oct	lastSun	 2:00s	0	-
 # Council of Ministers of the USSR from 1989-03-14 No. 227.
 #
 # I did not find full texts of these acts.  For the 1989 one we have
-# title at http://base.garant.ru/70754136/ :
+# title at https://base.garant.ru/70754136/ :
 # "About change in calculation of time on the territories of
 # Lithuanian SSR, Latvian SSR and Estonian SSR, Astrakhan,
 # Kaliningrad, Kirov, Kuybyshev, Ulyanovsk and Uralsk oblasts".
@@ -7042,19 +9020,11 @@ Rule	Russia	1996	2010	-	Oct	lastSun	 2:00s	0	-
 # http://bmockbe.ru/events/?ID=7583
 #
 # Medvedev signed a law on the calculation of the time (in russian):
-# http://www.regnum.ru/news/polit/1413906.html
+# https://www.regnum.ru/news/polit/1413906.html
 
 # From Arthur David Olson (2011-06-15):
 # Take "abolishing daylight saving time" to mean that time is now considered
 # to be standard.
-
-# These are for backward compatibility with older versions.
-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	WET		0:00	EU	WE%sT
-Zone	CET		1:00	C-Eur	CE%sT
-Zone	MET		1:00	C-Eur	ME%sT
-Zone	EET		2:00	EU	EE%sT
 
 # Previous editions of this database used abbreviations like MET DST
 # for Central European Summer Time, but this didn't agree with common usage.
@@ -7084,7 +9054,7 @@ Zone	EET		2:00	EU	EE%sT
 
 
 # Albania
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Albania	1940	only	-	Jun	16	0:00	1:00	S
 Rule	Albania	1942	only	-	Nov	 2	3:00	0	-
 Rule	Albania	1943	only	-	Mar	29	2:00	1:00	S
@@ -7110,14 +9080,14 @@ Rule	Albania	1982	only	-	Oct	 3	0:00	0	-
 Rule	Albania	1983	only	-	Apr	18	0:00	1:00	S
 Rule	Albania	1983	only	-	Oct	 1	0:00	0	-
 Rule	Albania	1984	only	-	Apr	 1	0:00	1:00	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Tirane	1:19:20 -	LMT	1914
 			1:00	-	CET	1940 Jun 16
 			1:00	Albania	CE%sT	1984 Jul
 			1:00	EU	CE%sT
 
 # Andorra
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Andorra	0:06:04 -	LMT	1901
 			0:00	-	WET	1946 Sep 30
 			1:00	-	CET	1985 Mar 31  2:00
@@ -7134,16 +9104,21 @@ Zone	Europe/Andorra	0:06:04 -	LMT	1901
 # Shanks & Pottenger give 02:00, the BEV 00:00.  Go with the BEV,
 # and guess 02:00 for 1945-04-12.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# From Alois Treindl (2019-07-22):
+# In 1946 the end of DST was on Monday, 7 October 1946, at 3:00 am.
+# Shanks had this right.  Source: Die Weltpresse, 5. Oktober 1946, page 5.
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Austria	1920	only	-	Apr	 5	2:00s	1:00	S
 Rule	Austria	1920	only	-	Sep	13	2:00s	0	-
 Rule	Austria	1946	only	-	Apr	14	2:00s	1:00	S
-Rule	Austria	1946	1948	-	Oct	Sun>=1	2:00s	0	-
+Rule	Austria	1946	only	-	Oct	 7	2:00s	0	-
+Rule	Austria	1947	1948	-	Oct	Sun>=1	2:00s	0	-
 Rule	Austria	1947	only	-	Apr	 6	2:00s	1:00	S
 Rule	Austria	1948	only	-	Apr	18	2:00s	1:00	S
 Rule	Austria	1980	only	-	Apr	 6	0:00	1:00	S
 Rule	Austria	1980	only	-	Sep	28	0:00	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Vienna	1:05:21 -	LMT	1893 Apr
 			1:00	C-Eur	CE%sT	1920
 			1:00	Austria	CE%sT	1940 Apr  1  2:00s
@@ -7169,13 +9144,13 @@ Zone	Europe/Vienna	1:05:21 -	LMT	1893 Apr
 # Sources (Russian language):
 # http://www.belta.by/ru/all_news/society/V-Belarusi-otmenjaetsja-perexod-na-sezonnoe-vremja_i_572952.html
 # http://naviny.by/rubrics/society/2011/09/16/ic_articles_116_175144/
-# http://news.tut.by/society/250578.html
+# https://news.tut.by/society/250578.html
 #
 # From Alexander Bokovoy (2014-10-09):
 # Belarussian government decided against changing to winter time....
 # http://eng.belta.by/all_news/society/Belarus-decides-against-adjusting-time-in-Russias-wake_i_76335.html
 #
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Minsk	1:50:16 -	LMT	1880
 			1:50	-	MMT	1924 May  2 # Minsk Mean Time
 			2:00	-	EET	1930 Jun 21
@@ -7184,23 +9159,45 @@ Zone	Europe/Minsk	1:50:16 -	LMT	1880
 			3:00	Russia	MSK/MSD	1990
 			3:00	-	MSK	1991 Mar 31  2:00s
 			2:00	Russia	EE%sT	2011 Mar 27  2:00s
-			3:00	-	+03
+			3:00	-	%z
 
 # Belgium
+# Luxembourg
+# Netherlands
 #
-# From Paul Eggert (1997-07-02):
+# From Michael Deckers (2019-08-25):
+# The exposition in the web page
+# https://www.bestor.be/wiki/index.php/Voyager_dans_le_temps._L%E2%80%99introduction_de_la_norme_de_Greenwich_en_Belgique
+# gives several contemporary sources from which one can conclude that
+# the switch in Europe/Brussels on 1892-05-01 was from 00:17:30 to 00:00:00.
+#
+# From Paul Eggert (2019-08-28):
+# This quote helps explain the late-1914 situation:
+#   In early November 1914, the Germans imposed the time zone used in central
+#   Europe and forced the inhabitants to set their watches and public clocks
+#   sixty minutes ahead.  Many were reluctant to accept "German time" and
+#   continued to use "Belgian time" among themselves.  Reflecting the spirit of
+#   resistance that arose in the population, a song made fun of this change....
+# The song ended:
+#   Putting your clock forward
+#   Will but hasten the happy hour
+#   When we kick out the Boches!
+# See: Pluvinage G. Brussels on German time. Cahiers Bruxellois -
+# Brusselse Cahiers. 2014;XLVI(1E):15-38.
+# https://www.cairn.info/revue-cahiers-bruxellois-2014-1E-page-15.htm
+#
+# Entries from 1914 through 1917 are taken from "De tijd in België"
+# <https://www.astro.oma.be/GENERAL/INFO/nli001a.html>.
 # Entries from 1918 through 1991 are taken from:
 #	Annuaire de L'Observatoire Royal de Belgique,
 #	Avenue Circulaire, 3, B-1180 BRUXELLES, CLVIIe année, 1991
 #	(Imprimerie HAYEZ, s.p.r.l., Rue Fin, 4, 1080 BRUXELLES, MCMXC),
 #	pp 8-9.
-# LMT before 1892 was 0:17:30, according to the official journal of Belgium:
-#	Moniteur Belge, Samedi 30 Avril 1892, N.121.
-# Thanks to Pascal Delmoitie for these references.
+# Thanks to Pascal Delmoitie for the 1918/1991 references.
 # The 1918 rules are listed for completeness; they apply to unoccupied Belgium.
 # Assume Brussels switched to WET in 1918 when the armistice took effect.
 #
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Belgium	1918	only	-	Mar	 9	 0:00s	1:00	S
 Rule	Belgium	1918	1919	-	Oct	Sat>=1	23:00s	0	-
 Rule	Belgium	1919	only	-	Mar	 1	23:00s	1:00	S
@@ -7239,9 +9236,9 @@ Rule	Belgium	1945	only	-	Apr	 2	 2:00s	1:00	S
 Rule	Belgium	1945	only	-	Sep	16	 2:00s	0	-
 Rule	Belgium	1946	only	-	May	19	 2:00s	1:00	S
 Rule	Belgium	1946	only	-	Oct	 7	 2:00s	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Brussels	0:17:30 -	LMT	1880
-			0:17:30	-	BMT	1892 May  1 12:00  # Brussels MT
+			0:17:30	-	BMT	1892 May  1 00:17:30
 			0:00	-	WET	1914 Nov  8
 			1:00	-	CET	1916 May  1  0:00
 			1:00	C-Eur	CE%sT	1918 Nov 11 11:00u
@@ -7250,9 +9247,6 @@ Zone	Europe/Brussels	0:17:30 -	LMT	1880
 			1:00	Belgium	CE%sT	1977
 			1:00	EU	CE%sT
 
-# Bosnia and Herzegovina
-# See Europe/Belgrade.
-
 # Bulgaria
 #
 # From Plamen Simenov via Steffen Thorsen (1999-09-09):
@@ -7260,13 +9254,13 @@ Zone	Europe/Brussels	0:17:30 -	LMT	1880
 # EET -> EETDST is in 03:00 Local time in last Sunday of March ...
 # EETDST -> EET is in 04:00 Local time in last Sunday of October
 #
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Bulg	1979	only	-	Mar	31	23:00	1:00	S
 Rule	Bulg	1979	only	-	Oct	 1	 1:00	0	-
 Rule	Bulg	1980	1982	-	Apr	Sat>=1	23:00	1:00	S
 Rule	Bulg	1980	only	-	Sep	29	 1:00	0	-
 Rule	Bulg	1981	only	-	Sep	27	 2:00	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Sofia	1:33:16 -	LMT	1880
 			1:56:56	-	IMT	1894 Nov 30 # Istanbul MT?
 			2:00	-	EET	1942 Nov  2  3:00
@@ -7278,96 +9272,80 @@ Zone	Europe/Sofia	1:33:16 -	LMT	1880
 			2:00	E-Eur	EE%sT	1997
 			2:00	EU	EE%sT
 
-# Croatia
-# See Europe/Belgrade.
-
 # Cyprus
 # Please see the 'asia' file for Asia/Nicosia.
 
-# Czech Republic
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Czech	1945	only	-	Apr	 8	2:00s	1:00	S
-Rule	Czech	1945	only	-	Nov	18	2:00s	0	-
+# Czech Republic (Czechia)
+# Slovakia
+#
+# From Ivan Benovic (2024-01-30):
+# https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/1946/54/
+# (This is an official link to the Czechoslovak Summer Time Act of
+# March 8, 1946 that authorizes the Czechoslovak government to set the
+# exact dates of change to summer time and back to Central European Time.
+# The act also implicitly confirms Central European Time as the
+# official time zone of Czechoslovakia and currently remains in force
+# in both the Czech Republic and Slovakia.)
+# https://www.psp.cz/eknih/1945pns/tisky/t0216_00.htm
+# (This is a link to the original legislative proposal dating back to
+# February 22, 1946. The accompanying memorandum to the proposal says
+# that an advisory committee on European railroad transportation that
+# met in Brussels in October 1945 decided that the change of time
+# should be carried out in all participating countries in a strictly
+# coordinated manner....)
+#
+# From Paul Eggert (2024-01-30):
+# The source for Czech data is: Kdy začíná a končí letní čas.
+# https://kalendar.beda.cz/kdy-zacina-a-konci-letni-cas
+# Its main text disagrees with its quoted sources only in 1918,
+# where the main text says spring and autumn transitions
+# occurred at 02:00 and 03:00 respectively (as usual),
+# whereas the 1918 source "Oznámení o zavedení letního času v roce 1918"
+# says transitions were at 01:00 and 02:00 respectively.
+# As the 1918 source appears to be a humorous piece, and it is
+# unlikely that Prague would have disagreed with its neighbors by an hour,
+# go with the main text for now.
+#
+# We know of no English-language name for historical Czech winter time;
+# abbreviate it as "GMT", as it happened to be GMT.
+#
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Czech	1945	only	-	Apr	Mon>=1	2:00s	1:00	S
+Rule	Czech	1945	only	-	Oct	 1	2:00s	0	-
 Rule	Czech	1946	only	-	May	 6	2:00s	1:00	S
 Rule	Czech	1946	1949	-	Oct	Sun>=1	2:00s	0	-
-Rule	Czech	1947	only	-	Apr	20	2:00s	1:00	S
-Rule	Czech	1948	only	-	Apr	18	2:00s	1:00	S
+Rule	Czech	1947	1948	-	Apr	Sun>=15	2:00s	1:00	S
 Rule	Czech	1949	only	-	Apr	 9	2:00s	1:00	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Prague	0:57:44 -	LMT	1850
 			0:57:44	-	PMT	1891 Oct    # Prague Mean Time
-			1:00	C-Eur	CE%sT	1944 Sep 17  2:00s
+			1:00	C-Eur	CE%sT	1945 May  9
+			1:00	Czech	CE%sT	1946 Dec  1  3:00
+# Vanguard section, for zic and other parsers that support negative DST.
+			1:00	-1:00	GMT	1947 Feb 23  2:00
+# Rearguard section, for parsers lacking negative DST; see ziguard.awk.
+#			0:00	-	GMT	1947 Feb 23  2:00
+# End of rearguard section.
 			1:00	Czech	CE%sT	1979
 			1:00	EU	CE%sT
-# Use Europe/Prague also for Slovakia.
 
-# Denmark, Faroe Islands, and Greenland
-
-# From Jesper Nørgaard Welen (2005-04-26):
-# http://www.hum.aau.dk/~poe/tid/tine/DanskTid.htm says that the law
-# [introducing standard time] was in effect from 1894-01-01....
-# The page http://www.retsinfo.dk/_GETDOCI_/ACCN/A18930008330-REGL
-# confirms this, and states that the law was put forth 1893-03-29.
-#
-# The EU treaty with effect from 1973:
-# http://www.retsinfo.dk/_GETDOCI_/ACCN/A19722110030-REGL
-#
-# This provoked a new law from 1974 to make possible summer time changes
-# in subsequent decrees with the law
-# http://www.retsinfo.dk/_GETDOCI_/ACCN/A19740022330-REGL
-#
-# It seems however that no decree was set forward until 1980.  I have
-# not found any decree, but in another related law, the effecting DST
-# changes are stated explicitly to be from 1980-04-06 at 02:00 to
-# 1980-09-28 at 02:00.  If this is true, this differs slightly from
-# the EU rule in that DST runs to 02:00, not 03:00.  We don't know
-# when Denmark began using the EU rule correctly, but we have only
-# confirmation of the 1980-time, so I presume it was correct in 1981:
-# The law is about the management of the extra hour, concerning
-# working hours reported and effect on obligatory-rest rules (which
-# was suspended on that night):
-# http://www.retsinfo.dk/_GETDOCI_/ACCN/C19801120554-REGL
-
-# From Jesper Nørgaard Welen (2005-06-11):
-# The Herning Folkeblad (1980-09-26) reported that the night between
-# Saturday and Sunday the clock is set back from three to two.
-
-# From Paul Eggert (2005-06-11):
-# Hence the "02:00" of the 1980 law refers to standard time, not
-# wall-clock time, and so the EU rules were in effect in 1980.
-
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Denmark	1916	only	-	May	14	23:00	1:00	S
-Rule	Denmark	1916	only	-	Sep	30	23:00	0	-
-Rule	Denmark	1940	only	-	May	15	 0:00	1:00	S
-Rule	Denmark	1945	only	-	Apr	 2	 2:00s	1:00	S
-Rule	Denmark	1945	only	-	Aug	15	 2:00s	0	-
-Rule	Denmark	1946	only	-	May	 1	 2:00s	1:00	S
-Rule	Denmark	1946	only	-	Sep	 1	 2:00s	0	-
-Rule	Denmark	1947	only	-	May	 4	 2:00s	1:00	S
-Rule	Denmark	1947	only	-	Aug	10	 2:00s	0	-
-Rule	Denmark	1948	only	-	May	 9	 2:00s	1:00	S
-Rule	Denmark	1948	only	-	Aug	 8	 2:00s	0	-
-#
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Europe/Copenhagen	 0:50:20 -	LMT	1890
-			 0:50:20 -	CMT	1894 Jan  1 # Copenhagen MT
-			 1:00	Denmark	CE%sT	1942 Nov  2  2:00s
-			 1:00	C-Eur	CE%sT	1945 Apr  2  2:00
-			 1:00	Denmark	CE%sT	1980
-			 1:00	EU	CE%sT
+# Faroe Is
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Atlantic/Faroe	-0:27:04 -	LMT	1908 Jan 11 # Tórshavn
 			 0:00	-	WET	1981
 			 0:00	EU	WE%sT
+
+# Greenland
 #
 # From Paul Eggert (2004-10-31):
 # During World War II, Germany maintained secret manned weather stations in
 # East Greenland and Franz Josef Land, but we don't know their time zones.
 # My source for this is Wilhelm Dege's book mentioned under Svalbard.
 #
-# From Paul Eggert (2006-03-22):
-# Greenland joined the EU as part of Denmark, obtained home rule on 1979-05-01,
-# and left the EU on 1985-02-01.  It therefore should have been using EU
+# From Paul Eggert (2017-12-10):
+# Greenland joined the European Communities as part of Denmark,
+# obtained home rule on 1979-05-01, and left the European Communities
+# on 1985-02-01.  It therefore should have been using EU
 # rules at least through 1984.  Shanks & Pottenger say Scoresbysund and Godthåb
 # used C-Eur rules after 1980, but IATA SSIM (1991/1996) says they use EU
 # rules since at least 1991.  Assume EU rules since 1980.
@@ -7436,8 +9414,47 @@ Zone Atlantic/Faroe	-0:27:04 -	LMT	1908 Jan 11 # Tórshavn
 # "National Park" by Executive Order:
 # http://naalakkersuisut.gl/~/media/Nanoq/Files/Attached%20Files/Engelske-tekster/Legislation/Executive%20Order%20National%20Park.rtf
 # It is their only National Park.
+
+# From Jonas Nyrup (2022-11-24):
+# On last Saturday in October 2023 when DST ends America/Nuuk will switch
+# from -03/-02 to -02/-01
+# https://sermitsiaq.ag/forslagtidsforskel-danmark-mindskes-sommertid-beholdes
+# ...
+# https://sermitsiaq.ag/groenland-skifte-tidszone-trods-bekymringer
 #
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# From Jürgen Appel (2022-11-25):
+# https://ina.gl/samlinger/oversigt-over-samlinger/samling/dagsordener/dagsorden.aspx?lang=da&day=24-11-2022
+#
+# From Thomas M. Steenholdt (2022-12-02):
+# - The bill to move America/Nuuk from UTC-03 to UTC-02 passed.
+# - The bill to stop observing DST did not (Greenland will stop observing DST
+#   when EU does).
+# Details on the implementation are here (section 6):
+# https://ina.gl/dvd/EM%202022/pdf/media/2553529/pkt17_em2022_tidens_bestemmelse_bem_da.pdf
+# This is how the change will be implemented:
+# 1. The shift *to* DST in 2023 happens as normal.
+# 2. The shift *from* DST in 2023 happens as normal, but coincides with the
+#    shift to UTC-02 normaltime (people will not change their clocks here).
+# 3. After this, DST is still observed, but as -02/-01 instead of -03/-02.
+#
+# From Múte Bourup Egede via Jógvan Svabo Samuelsen (2023-03-15):
+# Greenland will not switch to Daylight Saving Time this year, 2023,
+# because the standard time for Greenland will change from UTC -3 to UTC -2.
+# However, Greenland will change to Daylight Saving Time again in 2024
+# and onwards.
+
+# From Jule Dabars (2023-10-29):
+# https://www.dr.dk/nyheder/seneste/i-nat-skal-uret-stilles-en-time-tilbage-men-foerste-gang-sker-det-ikke-i-groenland
+# with a link to that page:
+# https://naalakkersuisut.gl/Nyheder/2023/10/2710_sommertid
+# ... Ittoqqortoormiit joins the time of Nuuk at March 2024.
+# What would mean that America/Scoresbysund would either be in -01 year round
+# or in -02/-01 like America/Nuuk, but no longer in -01/+00.
+#
+# From Paul Eggert (2023-10-29):
+# For now, assume it will be like America/Nuuk.
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Thule	1991	1992	-	Mar	lastSun	2:00	1:00	D
 Rule	Thule	1991	1992	-	Sep	lastSun	2:00	0	S
 Rule	Thule	1993	2006	-	Apr	Sun>=1	2:00	1:00	D
@@ -7445,19 +9462,25 @@ Rule	Thule	1993	2006	-	Oct	lastSun	2:00	0	S
 Rule	Thule	2007	max	-	Mar	Sun>=8	2:00	1:00	D
 Rule	Thule	2007	max	-	Nov	Sun>=1	2:00	0	S
 #
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Danmarkshavn -1:14:40 -	LMT	1916 Jul 28
-			-3:00	-	WGT	1980 Apr  6  2:00
-			-3:00	EU	WG%sT	1996
+			-3:00	-	%z	1980 Apr  6  2:00
+			-3:00	EU	%z	1996
 			0:00	-	GMT
+#
+# Use the old name Scoresbysund, as the current name Ittoqqortoormiit
+# exceeds tzdb's 14-letter limit and has no common English abbreviation.
 Zone America/Scoresbysund -1:27:52 -	LMT	1916 Jul 28 # Ittoqqortoormiit
-			-2:00	-	CGT	1980 Apr  6  2:00
-			-2:00	C-Eur	CG%sT	1981 Mar 29
-			-1:00	EU	EG%sT
-Zone America/Godthab	-3:26:56 -	LMT	1916 Jul 28 # Nuuk
-			-3:00	-	WGT	1980 Apr  6  2:00
-			-3:00	EU	WG%sT
-Zone America/Thule	-4:35:08 -	LMT	1916 Jul 28 # Pituffik air base
+			-2:00	-	%z	1980 Apr  6  2:00
+			-2:00	C-Eur	%z	1981 Mar 29
+			-1:00	EU	%z	2024 Mar 31
+			-2:00	EU	%z
+Zone America/Nuuk	-3:26:56 -	LMT	1916 Jul 28 # Godthåb
+			-3:00	-	%z	1980 Apr  6  2:00
+			-3:00	EU	%z	2023 Mar 26  1:00u
+			-2:00	-	%z	2023 Oct 29  1:00u
+			-2:00	EU	%z
+Zone America/Thule	-4:35:08 -	LMT	1916 Jul 28 # Pituffik
 			-4:00	Thule	A%sT
 
 # Estonia
@@ -7490,7 +9513,7 @@ Zone America/Thule	-4:35:08 -	LMT	1916 Jul 28 # Pituffik air base
 # for their standard and summer times. He says no, they use "suveaeg"
 # (summer time) and "talveaeg" (winter time).
 
-# From The Baltic Times <http://www.baltictimes.com/> (1999-09-09)
+# From The Baltic Times <https://www.baltictimes.com/> (1999-09-09)
 # via Steffen Thorsen:
 # This year will mark the last time Estonia shifts to summer time,
 # a council of the ruling coalition announced Sept. 6....
@@ -7511,7 +9534,7 @@ Zone America/Thule	-4:35:08 -	LMT	1916 Jul 28 # Pituffik air base
 # From Urmet Jänes (2002-03-28):
 # The legislative reference is Government decree No. 84 on 2002-02-21.
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Tallinn	1:39:00	-	LMT	1880
 			1:39:00	-	TMT	1918 Feb    # Tallinn Mean Time
 			1:00	C-Eur	CE%sT	1919 Jul
@@ -7542,7 +9565,7 @@ Zone	Europe/Tallinn	1:39:00	-	LMT	1880
 # This is documented in Heikki Oja: Aikakirja 2007, published by The Almanac
 # Office of University of Helsinki, ISBN 952-10-3221-9, available online (in
 # Finnish) at
-# http://almanakka.helsinki.fi/aikakirja/Aikakirja2007kokonaan.pdf
+# https://almanakka.helsinki.fi/aikakirja/Aikakirja2007kokonaan.pdf
 #
 # Page 105 (56 in PDF version) has a handy table of all past daylight savings
 # transitions. It is easy enough to interpret without Finnish skills.
@@ -7555,7 +9578,7 @@ Zone	Europe/Tallinn	1:39:00	-	LMT	1880
 
 # From Konstantin Hyppönen (2014-06-13):
 # [Heikki Oja's book Aikakirja 2013]
-# http://almanakka.helsinki.fi/images/aikakirja/Aikakirja2013kokonaan.pdf
+# https://almanakka.helsinki.fi/images/aikakirja/Aikakirja2013kokonaan.pdf
 # pages 104-105, including a scan from a newspaper published on Apr 2 1942
 # say that ... [o]n Apr 2 1942, 24 o'clock (which means Apr 3 1942,
 # 00:00), clocks were moved one hour forward. The newspaper
@@ -7565,26 +9588,23 @@ Zone	Europe/Tallinn	1:39:00	-	LMT	1880
 # From Paul Eggert (2014-06-14):
 # Go with Oja over Shanks.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Finland	1942	only	-	Apr	2	24:00	1:00	S
 Rule	Finland	1942	only	-	Oct	4	1:00	0	-
 Rule	Finland	1981	1982	-	Mar	lastSun	2:00	1:00	S
 Rule	Finland	1981	1982	-	Sep	lastSun	3:00	0	-
 
-# Milne says Helsinki (Helsingfors) time was 1:39:49.2 (official document);
-# round to nearest.
+# Milne says Helsinki (Helsingfors) time was 1:39:49.2 (official document).
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	1:39:49.2
 Zone	Europe/Helsinki	1:39:49 -	LMT	1878 May 31
 			1:39:49	-	HMT	1921 May    # Helsinki Mean Time
 			2:00	Finland	EE%sT	1983
 			2:00	EU	EE%sT
 
-# Åland Is
-Link	Europe/Helsinki	Europe/Mariehamn
-
-
 # France
+# Monaco
 
 # From Ciro Discepolo (2000-12-20):
 #
@@ -7597,10 +9617,58 @@ Link	Europe/Helsinki	Europe/Mariehamn
 # Françoise Gauquelin, Problèmes de l'heure résolus en astrologie,
 # Guy Trédaniel, Paris 1987
 
+# From Michael Deckers (2020-06-11):
+# the law of 1891 <https://gallica.bnf.fr/ark:/12148/bpt6k64415343.texteImage>
+# was published on 1891-03-15, so it could only take force on 1891-03-16.
+
+# From Michael Deckers (2020-06-10):
+# Le Gaulois, 1911-03-11, page 1/6, online at
+# https://www.retronews.fr/societe/echo-de-presse/2018/01/29/1911-change-lheure-de-paris
+# ... [ Instantly, all pressure driven clock dials halted...  Nine minutes and
+#       twenty-one seconds later the hands resumed their circular motion. ]
+# There are also precise reports about how the change was prepared in train
+# stations: all the publicly visible clocks stopped at midnight railway time
+# (or were covered), only the chief of service had a watch, labeled
+# "Heure ancienne", that he kept running until it reached 00:04:21, when
+# he announced "Heure nouvelle".  See the "Le Petit Journal 1911-03-11".
+# https://gallica.bnf.fr/ark:/12148/bpt6k6192911/f1.item.zoom
+#
+# From Michael Deckers (2020-06-12):
+# That "all French clocks stopped" for 00:09:21 is a misreading of French
+# newspapers; this sort of adjustment applies only to certain
+# remote-controlled clocks ("pendules pneumatiques", of which there existed
+# perhaps a dozen in Paris, and which simply could not be set back remotely),
+# but not to all the clocks in all French towns and villages.  For instance,
+# the following story in the "Courrier de Saône-et-Loire" 1911-03-11, page 2:
+# only works if legal time was stepped back (was not monotone): ...
+#   [One can observe that children who had been born at midnight less 5
+#    minutes and who had died at midnight of the old time, would turn out to
+#    be dead before being born, time having been set back and having
+#    suppressed 9 minutes and 25 seconds of their existence, that is, more
+#    than they could spend.]
+#
+# From Paul Eggert (2020-06-12):
+# French time in railway stations was legally five minutes behind civil time,
+# which explains why railway "old time" ran to 00:04:21 instead of to 00:09:21.
+# The law's text (which Michael Deckers noted is at
+# <https://gallica.bnf.fr/ark:/12148/bpt6k2022333z/f2>) says only that
+# at 1911-03-11 00:00 legal time was that of Paris mean time delayed by
+# nine minutes and twenty-one seconds, and does not say how the
+# transition from Paris mean time was to occur.
+#
+# tzdb has no way to represent stopped clocks.  As the railway practice
+# was to keep a watch running on "old time" to decide when to restart
+# the other clocks, this could be modeled as a transition for "old time" at
+# 00:09:21.  However, since the law was ambiguous and clocks outside railway
+# stations were probably done haphazardly with the popular impression being
+# that the transition was done at 00:00 "old time", simply leave the time
+# blank; this causes zic to default to 00:00 "old time" which is good enough.
+# Do something similar for the 1891-03-16 transition.  There are similar
+# problems in Algiers, Monaco and Tunis.
 
 #
 # Shank & Pottenger seem to use '24:00' ambiguously; resolve it with Whitman.
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	France	1916	only	-	Jun	14	23:00s	1:00	S
 Rule	France	1916	1919	-	Oct	Sun>=1	23:00s	0	-
 Rule	France	1917	only	-	Mar	24	23:00s	1:00	S
@@ -7660,13 +9728,11 @@ Rule	France	1945	only	-	Sep	16	 3:00	0	-
 # go with Excoffier's 28/3/76 0hUT and 25/9/76 23hUT.
 Rule	France	1976	only	-	Mar	28	 1:00	1:00	S
 Rule	France	1976	only	-	Sep	26	 1:00	0	-
-# Shanks & Pottenger give 0:09:20 for Paris Mean Time, and Whitman 0:09:05,
-# but Howse quotes the actual French legislation as saying 0:09:21.
-# Go with Howse.  Howse writes that the time in France was officially based
+# Howse writes that the time in France was officially based
 # on PMT-0:09:21 until 1978-08-09, when the time base finally switched to UTC.
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Europe/Paris	0:09:21 -	LMT	1891 Mar 15  0:01
-			0:09:21	-	PMT	1911 Mar 11  0:01 # Paris MT
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Europe/Paris	0:09:21 -	LMT	1891 Mar 16
+			0:09:21	-	PMT	1911 Mar 11 # Paris Mean Time
 # Shanks & Pottenger give 1940 Jun 14 0:00; go with Excoffier and Le Corre.
 			0:00	France	WE%sT	1940 Jun 14 23:00
 # Le Corre says Paris stuck with occupied-France time after the liberation;
@@ -7676,16 +9742,19 @@ Zone	Europe/Paris	0:09:21 -	LMT	1891 Mar 15  0:01
 			1:00	France	CE%sT	1977
 			1:00	EU	CE%sT
 
+# Denmark
 # Germany
+# Norway
+# Sweden
 
 # From Markus Kuhn (1998-09-29):
 # The German time zone web site by the Physikalisch-Technische
 # Bundesanstalt contains DST information back to 1916.
-# [See tz-link.htm for the URL.]
+# [See tz-link.html for the URL.]
 
 # From Jörg Schilling (2002-10-23):
 # In 1945, Berlin was switched to Moscow Summer time (GMT+4) by
-# http://www.dhm.de/lemo/html/biografien/BersarinNikolai/
+# https://www.dhm.de/lemo/html/biografien/BersarinNikolai/
 # General [Nikolai] Bersarin.
 
 # From Paul Eggert (2003-03-08):
@@ -7694,14 +9763,61 @@ Zone	Europe/Paris	0:09:21 -	LMT	1891 Mar 15  0:01
 # However, Moscow did not observe daylight saving in 1945, so
 # this was equivalent to UT +03, not +04.
 
+# Svalbard & Jan Mayen
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# From Steffen Thorsen (2001-05-01):
+# Although I could not find it explicitly, it seems that Jan Mayen and
+# Svalbard have been using the same time as Norway at least since the
+# time they were declared as parts of Norway.  Svalbard was declared
+# as a part of Norway by law of 1925-07-17 no 11, section 4 and Jan
+# Mayen by law of 1930-02-27 no 2, section 2. (From
+# <http://www.lovdata.no/all/nl-19250717-011.html> and
+# <http://www.lovdata.no/all/nl-19300227-002.html>).  The law/regulation
+# for normal/standard time in Norway is from 1894-06-29 no 1 (came
+# into operation on 1895-01-01) and Svalbard/Jan Mayen seem to be a
+# part of this law since 1925/1930. (From
+# <http://www.lovdata.no/all/nl-18940629-001.html>) I have not been
+# able to find if Jan Mayen used a different time zone (e.g. -0100)
+# before 1930. Jan Mayen has only been "inhabited" since 1921 by
+# Norwegian meteorologists and maybe used the same time as Norway ever
+# since 1921.  Svalbard (Arctic/Longyearbyen) has been inhabited since
+# before 1895, and therefore probably changed the local time somewhere
+# between 1895 and 1925 (inclusive).
+
+# From Paul Eggert (2013-09-04):
+#
+# Actually, Jan Mayen was never occupied by Germany during World War II,
+# so it must have diverged from Oslo time during the war, as Oslo was
+# keeping Berlin time.
+#
+# <https://www.jan-mayen.no/history.htm> says that the meteorologists
+# burned down their station in 1940 and left the island, but returned in
+# 1941 with a small Norwegian garrison and continued operations despite
+# frequent air attacks from Germans.  In 1943 the Americans established a
+# radiolocating station on the island, called "Atlantic City".  Possibly
+# the UT offset changed during the war, but I think it unlikely that
+# Jan Mayen used German daylight-saving rules.
+#
+# Svalbard is more complicated, as it was raided in August 1941 by an
+# Allied party that evacuated the civilian population to England (says
+# <http://www.bartleby.com/65/sv/Svalbard.html>).  The Svalbard FAQ
+# <http://www.svalbard.com/SvalbardFAQ.html> says that the Germans were
+# expelled on 1942-05-14.  However, small parties of Germans did return,
+# and according to Wilhelm Dege's book "War North of 80" (1954)
+# http://www.ucalgary.ca/UofC/departments/UP/1-55238/1-55238-110-2.html
+# the German armed forces at the Svalbard weather station code-named
+# Haudegen did not surrender to the Allies until September 1945.
+#
+# All these events predate our cutoff date of 1970, so use Europe/Berlin
+# for these regions.
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Germany	1946	only	-	Apr	14	2:00s	1:00	S
 Rule	Germany	1946	only	-	Oct	 7	2:00s	0	-
 Rule	Germany	1947	1949	-	Oct	Sun>=1	2:00s	0	-
-# http://www.ptb.de/de/org/4/44/441/salt.htm says the following transition
-# occurred at 3:00 MEZ, not the 2:00 MEZ given in Shanks & Pottenger.
-# Go with the PTB.
+# https://www.ptb.de/cms/en/ptb/fachabteilungen/abt4/fb-44/ag-441/realisation-of-legal-time-in-germany/dst-and-midsummer-dst-in-germany-until-1979.html
+# says the following transition occurred at 3:00 MEZ, not the 2:00 MEZ
+# given in Shanks & Pottenger. Go with the PTB.
 Rule	Germany	1947	only	-	Apr	 6	3:00s	1:00	S
 Rule	Germany	1947	only	-	May	11	2:00s	2:00	M
 Rule	Germany	1947	only	-	Jun	29	3:00	1:00	S
@@ -7712,27 +9828,12 @@ Rule SovietZone	1945	only	-	May	24	2:00	2:00	M # Midsummer
 Rule SovietZone	1945	only	-	Sep	24	3:00	1:00	S
 Rule SovietZone	1945	only	-	Nov	18	2:00s	0	-
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Berlin	0:53:28 -	LMT	1893 Apr
 			1:00	C-Eur	CE%sT	1945 May 24  2:00
 			1:00 SovietZone	CE%sT	1946
 			1:00	Germany	CE%sT	1980
 			1:00	EU	CE%sT
-
-# From Tobias Conradi (2011-09-12):
-# Büsingen <http://www.buesingen.de>, surrounded by the Swiss canton
-# Schaffhausen, did not start observing DST in 1980 as the rest of DE
-# (West Germany at that time) and DD (East Germany at that time) did.
-# DD merged into DE, the area is currently covered by code DE in ISO 3166-1,
-# which in turn is covered by the zone Europe/Berlin.
-#
-# Source for the time in Büsingen 1980:
-# http://www.srf.ch/player/video?id=c012c029-03b7-4c2b-9164-aa5902cd58d3
-
-# From Arthur David Olson (2012-03-03):
-# Büsingen and Zurich have shared clocks since 1970.
-
-Link	Europe/Zurich	Europe/Busingen
 
 # Georgia
 # Please see the "asia" file for Asia/Tbilisi.
@@ -7740,14 +9841,14 @@ Link	Europe/Zurich	Europe/Busingen
 # is in Europe.  Our reference location Tbilisi is in the Asian part.
 
 # Gibraltar
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Europe/Gibraltar	-0:21:24 -	LMT	1880 Aug  2  0:00s
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone Europe/Gibraltar	-0:21:24 -	LMT	1880 Aug  2
 			0:00	GB-Eire	%s	1957 Apr 14  2:00
 			1:00	-	CET	1982
 			1:00	EU	CE%sT
 
 # Greece
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 # Whitman gives 1932 Jul 5 - Nov 1; go with Shanks & Pottenger.
 Rule	Greece	1932	only	-	Jul	 7	0:00	1:00	S
 Rule	Greece	1932	only	-	Sep	 1	0:00	0	-
@@ -7771,110 +9872,89 @@ Rule	Greece	1979	only	-	Apr	 1	9:00	1:00	S
 Rule	Greece	1979	only	-	Sep	29	2:00	0	-
 Rule	Greece	1980	only	-	Apr	 1	0:00	1:00	S
 Rule	Greece	1980	only	-	Sep	28	0:00	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Athens	1:34:52 -	LMT	1895 Sep 14
 			1:34:52	-	AMT	1916 Jul 28  0:01 # Athens MT
 			2:00	Greece	EE%sT	1941 Apr 30
 			1:00	Greece	CE%sT	1944 Apr  4
 			2:00	Greece	EE%sT	1981
 			# Shanks & Pottenger say it switched to C-Eur in 1981;
-			# go with EU instead, since Greece joined it on Jan 1.
+			# go with EU rules instead, since Greece joined Jan 1.
 			2:00	EU	EE%sT
 
 # Hungary
-# From Paul Eggert (2014-07-15):
-# Dates for 1916-1945 are taken from:
-# Oross A. Jelen a múlt jövője: a nyári időszámítás Magyarországon 1916-1945.
-# National Archives of Hungary (2012-10-29).
-# http://mnl.gov.hu/a_het_dokumentuma/a_nyari_idoszamitas_magyarorszagon_19161945.html
-# This source does not always give times, which are taken from Shanks
-# & Pottenger (which disagree about the dates).
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Hungary	1918	only	-	Apr	 1	 3:00	1:00	S
-Rule	Hungary	1918	only	-	Sep	16	 3:00	0	-
-Rule	Hungary	1919	only	-	Apr	15	 3:00	1:00	S
-Rule	Hungary	1919	only	-	Nov	24	 3:00	0	-
+
+# From Michael Deckers (2020-06-09):
+# an Austrian encyclopedia of railroads of 1913, online at
+# http://www.zeno.org/Roell-1912/A/Eisenbahnzeit
+# says that the switch [to CET] happened on 1890-11-01.
+
+# From Géza Nyáry (2020-06-07):
+# Data for 1918-1983 are based on the archive database of Library Hungaricana.
+# The dates are collected from original, scanned governmental orders,
+# bulletins, instructions and public press.
+# [See URLs below.]
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+# https://library.hungaricana.hu/hu/view/OGYK_RT_1918/?pg=238
+# https://library.hungaricana.hu/hu/view/OGYK_RT_1919/?pg=808
+# https://library.hungaricana.hu/hu/view/OGYK_RT_1920/?pg=201
+Rule	Hungary	1918	1919	-	Apr	15	 2:00	1:00	S
+Rule	Hungary	1918	1920	-	Sep	Mon>=15	 3:00	0	-
+Rule	Hungary	1920	only	-	Apr	 5	 2:00	1:00	S
+# https://library.hungaricana.hu/hu/view/OGYK_RT_1945/?pg=882
 Rule	Hungary	1945	only	-	May	 1	23:00	1:00	S
-Rule	Hungary	1945	only	-	Nov	 1	 0:00	0	-
+Rule	Hungary	1945	only	-	Nov	 1	 1:00	0	-
+# https://library.hungaricana.hu/hu/view/Delmagyarorszag_1946_03/?pg=49
 Rule	Hungary	1946	only	-	Mar	31	 2:00s	1:00	S
-Rule	Hungary	1946	1949	-	Oct	Sun>=1	 2:00s	0	-
+# https://library.hungaricana.hu/hu/view/Delmagyarorszag_1946_09/?pg=54
+Rule	Hungary	1946	only	-	Oct	 7	 2:00	0	-
+# https://library.hungaricana.hu/hu/view/KulfBelfHirek_1947_04_1__001-123/?pg=90
+# https://library.hungaricana.hu/hu/view/DunantuliNaplo_1947_09/?pg=128
+# https://library.hungaricana.hu/hu/view/KulfBelfHirek_1948_03_3__001-123/?pg=304
+# https://library.hungaricana.hu/hu/view/Zala_1948_09/?pg=64
+# https://library.hungaricana.hu/hu/view/SatoraljaujhelyiLeveltar_ZempleniNepujsag_1948/?pg=53
+# https://library.hungaricana.hu/hu/view/SatoraljaujhelyiLeveltar_ZempleniNepujsag_1948/?pg=160
+# https://library.hungaricana.hu/hu/view/UjSzo_1949_01-04/?pg=102
+# https://library.hungaricana.hu/hu/view/KeletMagyarorszag_1949_03/?pg=96
+# https://library.hungaricana.hu/hu/view/Delmagyarorszag_1949_09/?pg=94
 Rule	Hungary	1947	1949	-	Apr	Sun>=4	 2:00s	1:00	S
-Rule	Hungary	1950	only	-	Apr	17	 2:00s	1:00	S
-Rule	Hungary	1950	only	-	Oct	23	 2:00s	0	-
-Rule	Hungary	1954	1955	-	May	23	 0:00	1:00	S
-Rule	Hungary	1954	1955	-	Oct	 3	 0:00	0	-
-Rule	Hungary	1956	only	-	Jun	Sun>=1	 0:00	1:00	S
-Rule	Hungary	1956	only	-	Sep	lastSun	 0:00	0	-
-Rule	Hungary	1957	only	-	Jun	Sun>=1	 1:00	1:00	S
-Rule	Hungary	1957	only	-	Sep	lastSun	 3:00	0	-
-Rule	Hungary	1980	only	-	Apr	 6	 1:00	1:00	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Europe/Budapest	1:16:20 -	LMT	1890 Oct
+Rule	Hungary	1947	1949	-	Oct	Sun>=1	 2:00s	0	-
+# https://library.hungaricana.hu/hu/view/DTT_KOZL_TanacsokKozlonye_1954/?pg=513
+Rule	Hungary	1954	only	-	May	23	 0:00	1:00	S
+Rule	Hungary	1954	only	-	Oct	 3	 0:00	0	-
+# https://library.hungaricana.hu/hu/view/DTT_KOZL_TanacsokKozlonye_1955/?pg=398
+Rule	Hungary	1955	only	-	May	22	 2:00	1:00	S
+Rule	Hungary	1955	only	-	Oct	 2	 3:00	0	-
+# https://library.hungaricana.hu/hu/view/HevesMegyeiNepujsag_1956_06/?pg=0
+# https://library.hungaricana.hu/hu/view/EszakMagyarorszag_1956_06/?pg=6
+# https://library.hungaricana.hu/hu/view/SzolnokMegyeiNeplap_1957_04/?pg=120
+# https://library.hungaricana.hu/hu/view/PestMegyeiHirlap_1957_09/?pg=143
+Rule	Hungary	1956	1957	-	Jun	Sun>=1	 2:00	1:00	S
+Rule	Hungary	1956	1957	-	Sep	lastSun	 3:00	0	-
+# https://library.hungaricana.hu/hu/view/DTT_KOZL_TanacsokKozlonye_1980/?pg=189
+Rule	Hungary	1980	only	-	Apr	 6	 0:00	1:00	S
+Rule	Hungary	1980	only	-	Sep	28	 1:00	0	-
+# https://library.hungaricana.hu/hu/view/DTT_KOZL_TanacsokKozlonye_1980/?pg=1227
+# https://library.hungaricana.hu/hu/view/Delmagyarorszag_1981_01/?pg=79
+# https://library.hungaricana.hu/hu/view/DTT_KOZL_TanacsokKozlonye_1982/?pg=115
+# https://library.hungaricana.hu/hu/view/DTT_KOZL_TanacsokKozlonye_1983/?pg=85
+Rule	Hungary	1981	1983	-	Mar	lastSun	 0:00	1:00	S
+Rule	Hungary	1981	1983	-	Sep	lastSun	 1:00	0	-
+#
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Europe/Budapest	1:16:20 -	LMT	1890 Nov  1
 			1:00	C-Eur	CE%sT	1918
-			1:00	Hungary	CE%sT	1941 Apr  8
+# https://library.hungaricana.hu/hu/view/OGYK_RT_1941/?pg=1204
+# https://library.hungaricana.hu/hu/view/OGYK_RT_1942/?pg=3955
+			1:00	Hungary	CE%sT	1941 Apr  7 23:00
 			1:00	C-Eur	CE%sT	1945
-			1:00	Hungary	CE%sT	1980 Sep 28  2:00s
+			1:00	Hungary	CE%sT	1984
 			1:00	EU	CE%sT
 
-# Iceland
-#
-# From Adam David (1993-11-06):
-# The name of the timezone in Iceland for system / mail / news purposes is GMT.
-#
-# (1993-12-05):
-# This material is paraphrased from the 1988 edition of the University of
-# Iceland Almanak.
-#
-# From January 1st, 1908 the whole of Iceland was standardised at 1 hour
-# behind GMT. Previously, local mean solar time was used in different parts
-# of Iceland, the almanak had been based on Reykjavik mean solar time which
-# was 1 hour and 28 minutes behind GMT.
-#
-# "first day of winter" referred to [below] means the first day of the 26 weeks
-# of winter, according to the old icelandic calendar that dates back to the
-# time the norsemen first settled Iceland.  The first day of winter is always
-# Saturday, but is not dependent on the Julian or Gregorian calendars.
-#
-# (1993-12-10):
-# I have a reference from the Oxford Icelandic-English dictionary for the
-# beginning of winter, which ties it to the ecclesiastical calendar (and thus
-# to the julian/gregorian calendar) over the period in question.
-#	the winter begins on the Saturday next before St. Luke's day
-#	(old style), or on St. Luke's day, if a Saturday.
-# St. Luke's day ought to be traceable from ecclesiastical sources. "old style"
-# might be a reference to the Julian calendar as opposed to Gregorian, or it
-# might mean something else (???).
-#
-# From Paul Eggert (2014-11-22):
-# The information below is taken from the 1988 Almanak; see
-# http://www.almanak.hi.is/klukkan.html
-#
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Iceland	1917	1919	-	Feb	19	23:00	1:00	S
-Rule	Iceland	1917	only	-	Oct	21	 1:00	0	-
-Rule	Iceland	1918	1919	-	Nov	16	 1:00	0	-
-Rule	Iceland	1921	only	-	Mar	19	23:00	1:00	S
-Rule	Iceland	1921	only	-	Jun	23	 1:00	0	-
-Rule	Iceland	1939	only	-	Apr	29	23:00	1:00	S
-Rule	Iceland	1939	only	-	Oct	29	 2:00	0	-
-Rule	Iceland	1940	only	-	Feb	25	 2:00	1:00	S
-Rule	Iceland	1940	1941	-	Nov	Sun>=2	 1:00s	0	-
-Rule	Iceland	1941	1942	-	Mar	Sun>=2	 1:00s	1:00	S
-# 1943-1946 - first Sunday in March until first Sunday in winter
-Rule	Iceland	1943	1946	-	Mar	Sun>=1	 1:00s	1:00	S
-Rule	Iceland	1942	1948	-	Oct	Sun>=22	 1:00s	0	-
-# 1947-1967 - first Sunday in April until first Sunday in winter
-Rule	Iceland	1947	1967	-	Apr	Sun>=1	 1:00s	1:00	S
-# 1949 and 1967 Oct transitions delayed by 1 week
-Rule	Iceland	1949	only	-	Oct	30	 1:00s	0	-
-Rule	Iceland	1950	1966	-	Oct	Sun>=22	 1:00s	0	-
-Rule	Iceland	1967	only	-	Oct	29	 1:00s	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Atlantic/Reykjavik	-1:28	-	LMT	1908
-			-1:00	Iceland	IS%sT	1968 Apr  7  1:00s
-			 0:00	-	GMT
-
 # Italy
+# San Marino
+# Vatican City
 #
 # From Paul Eggert (2001-03-06):
 # Sicily and Sardinia each had their own time zones from 1866 to 1893,
@@ -7882,6 +9962,25 @@ Zone Atlantic/Reykjavik	-1:28	-	LMT	1908
 # During World War II, German-controlled Italy used German time.
 # But these events all occurred before the 1970 cutoff,
 # so record only the time in Rome.
+#
+# From Stephen Trainor (2019-05-06):
+# http://www.ac-ilsestante.it/MERIDIANE/ora_legale/ORA_LEGALE_ESTIVA_IN_ITALIA.htm
+# ... the [1866] law went into effect on 12 December 1866, rather than
+# the date of the decree (22 Sep 1866)
+# https://web.archive.org/web/20070824155341/http://www.iav.it/planetario/didastro/didastro/english.htm
+# ... "In Italy in 1866 there were 6 railway times (Torino, Verona, Firenze,
+# Roma, Napoli, Palermo). On that year it was decided to unify them, adopting
+# the average time of Rome (even if this city was not yet part of the
+# kingdom).  On the 12th December 1866, on the starting of the winter time
+# table, it took effect in the railways, the post office and the telegraph,
+# not only for the internal service but also for the public....  Milano set
+# the public watches on the Rome time on the same day (12th December 1866),
+# Torino and Bologna on the 1st January 1867, Venezia the 1st May 1880 and the
+# last city was Cagliari in 1886."
+#
+# From Luigi Rosa (2019-05-07):
+# this is the scan of the decree:
+# http://www.radiomarconi.com/marconi/filopanti/1866c.jpg
 #
 # From Michael Deckers (2016-10-24):
 # http://www.ac-ilsestante.it/MERIDIANE/ora_legale quotes a law of 1893-08-10
@@ -7893,6 +9992,7 @@ Zone Atlantic/Reykjavik	-1:28	-	LMT	1908
 # The authoritative source for time in Italy is the national metrological
 # institute, which has a summary page of historical DST data at
 # http://www.inrim.it/res/tf/ora_legale_i.shtml
+# [now at http://oldsite.inrim.it/res/tf/ora_legale_i.shtml as of 2017]
 # (2016-10-24):
 # http://www.renzobaldini.it/le-ore-legali-in-italia/
 # has still different data for 1944.  It divides Italy in two, as
@@ -7907,14 +10007,24 @@ Zone Atlantic/Reykjavik	-1:28	-	LMT	1908
 # advanced to sixty minutes later starting at hour two on 1944-04-02; ...
 # Starting at hour three on the date 1944-09-17 standard time will be resumed.
 #
-# From Paul Eggert (2016-10-27):
+# From Alois Treindl (2019-07-02):
+# I spent 6 Euros to buy two archive copies of Il Messaggero, a Roman paper,
+# for 1 and 2 April 1944.  The edition of 2 April has this note: "Tonight at 2
+# am, put forward the clock by one hour.  Remember that in the night between
+# today and Monday the 'ora legale' will come in force again."  That makes it
+# clear that in Rome the change was on Monday, 3 April 1944 at 2 am.
+#
+# From Paul Eggert (2021-10-05):
 # Go with INRiM for DST rules, except as corrected by Inglis for 1944
 # for the Kingdom of Italy.  This is consistent with Renzo Baldini.
-# Model Rome's occupation by using using C-Eur rules from 1943-09-10
+# Model Rome's occupation by using C-Eur rules from 1943-09-10
 # to 1944-06-04; although Rome was an open city during this period, it
-# was effectively controlled by Germany.
+# was effectively controlled by Germany.  Using C-Eur is consistent
+# with Treindl's comment about Rome in April 1944, as the "Rule Italy"
+# lines during German occupation do not affect Europe/Rome
+# (though they do affect Europe/Malta).
 #
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Italy	1916	only	-	Jun	 3	24:00	1:00	S
 Rule	Italy	1916	1917	-	Sep	30	24:00	0	-
 Rule	Italy	1917	only	-	Mar	31	24:00	1:00	S
@@ -7956,16 +10066,13 @@ Rule	Italy	1976	only	-	May	30	 0:00s	1:00	S
 Rule	Italy	1977	1979	-	May	Sun>=22	 0:00s	1:00	S
 Rule	Italy	1978	only	-	Oct	 1	 0:00s	0	-
 Rule	Italy	1979	only	-	Sep	30	 0:00s	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Europe/Rome	0:49:56 -	LMT	1866 Sep 22
-			0:49:56	-	RMT	1893 Oct 31 23:49:56 # Rome Mean
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Europe/Rome	0:49:56 -	LMT	1866 Dec 12
+			0:49:56	-	RMT	1893 Oct 31 23:00u # Rome Mean
 			1:00	Italy	CE%sT	1943 Sep 10
 			1:00	C-Eur	CE%sT	1944 Jun  4
 			1:00	Italy	CE%sT	1980
 			1:00	EU	CE%sT
-
-Link	Europe/Rome	Europe/Vatican
-Link	Europe/Rome	Europe/San_Marino
 
 # Latvia
 
@@ -8024,7 +10131,7 @@ Link	Europe/Rome	Europe/San_Marino
 # urged Lithuania and Estonia to adopt a similar time policy, but it
 # appears that they will not do so....
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Latvia	1989	1996	-	Mar	lastSun	 2:00s	1:00	S
 Rule	Latvia	1989	1996	-	Sep	lastSun	 2:00s	0	-
 
@@ -8032,7 +10139,7 @@ Rule	Latvia	1989	1996	-	Sep	lastSun	 2:00s	0	-
 # Byalokoz 1919 says Latvia was 1:36:34.
 # Go with Byalokoz.
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Riga	1:36:34	-	LMT	1880
 			1:36:34	-	RMT	1918 Apr 15  2:00 # Riga MT
 			1:36:34	1:00	LST	1918 Sep 16  3:00 # Latvian ST
@@ -8048,24 +10155,6 @@ Zone	Europe/Riga	1:36:34	-	LMT	1880
 			2:00	EU	EE%sT	2000 Feb 29
 			2:00	-	EET	2001 Jan  2
 			2:00	EU	EE%sT
-
-# Liechtenstein
-
-# From Paul Eggert (2013-09-09):
-# Shanks & Pottenger say Vaduz is like Zurich.
-
-# From Alois Treindl (2013-09-18):
-# http://www.eliechtensteinensia.li/LIJ/1978/1938-1978/1941.pdf
-# ... confirms on p. 6 that Liechtenstein followed Switzerland in 1941 and 1942.
-# I ... translate only the last two paragraphs:
-#    ... during second world war, in the years 1941 and 1942, Liechtenstein
-#    introduced daylight saving time, adapting to Switzerland.  From 1943 on
-#    central European time was in force throughout the year.
-#    From a report of the duke's government to the high council,
-#    regarding the introduction of a time law, of 31 May 1977.
-
-Link Europe/Zurich Europe/Vaduz
-
 
 # Lithuania
 
@@ -8102,7 +10191,7 @@ Link Europe/Zurich Europe/Vaduz
 # http://www.lrvk.lt/nut/11/n1749.htm
 
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Vilnius	1:41:16	-	LMT	1880
 			1:24:00	-	WMT	1917        # Warsaw Mean Time
 			1:35:36	-	KMT	1919 Oct 10 # Kaunas Mean Time
@@ -8119,51 +10208,12 @@ Zone	Europe/Vilnius	1:41:16	-	LMT	1880
 			2:00	-	EET	2003 Jan  1
 			2:00	EU	EE%sT
 
-# Luxembourg
-# Whitman disagrees with most of these dates in minor ways;
-# go with Shanks & Pottenger.
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Lux	1916	only	-	May	14	23:00	1:00	S
-Rule	Lux	1916	only	-	Oct	 1	 1:00	0	-
-Rule	Lux	1917	only	-	Apr	28	23:00	1:00	S
-Rule	Lux	1917	only	-	Sep	17	 1:00	0	-
-Rule	Lux	1918	only	-	Apr	Mon>=15	 2:00s	1:00	S
-Rule	Lux	1918	only	-	Sep	Mon>=15	 2:00s	0	-
-Rule	Lux	1919	only	-	Mar	 1	23:00	1:00	S
-Rule	Lux	1919	only	-	Oct	 5	 3:00	0	-
-Rule	Lux	1920	only	-	Feb	14	23:00	1:00	S
-Rule	Lux	1920	only	-	Oct	24	 2:00	0	-
-Rule	Lux	1921	only	-	Mar	14	23:00	1:00	S
-Rule	Lux	1921	only	-	Oct	26	 2:00	0	-
-Rule	Lux	1922	only	-	Mar	25	23:00	1:00	S
-Rule	Lux	1922	only	-	Oct	Sun>=2	 1:00	0	-
-Rule	Lux	1923	only	-	Apr	21	23:00	1:00	S
-Rule	Lux	1923	only	-	Oct	Sun>=2	 2:00	0	-
-Rule	Lux	1924	only	-	Mar	29	23:00	1:00	S
-Rule	Lux	1924	1928	-	Oct	Sun>=2	 1:00	0	-
-Rule	Lux	1925	only	-	Apr	 5	23:00	1:00	S
-Rule	Lux	1926	only	-	Apr	17	23:00	1:00	S
-Rule	Lux	1927	only	-	Apr	 9	23:00	1:00	S
-Rule	Lux	1928	only	-	Apr	14	23:00	1:00	S
-Rule	Lux	1929	only	-	Apr	20	23:00	1:00	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Europe/Luxembourg	0:24:36 -	LMT	1904 Jun
-			1:00	Lux	CE%sT	1918 Nov 25
-			0:00	Lux	WE%sT	1929 Oct  6  2:00s
-			0:00	Belgium	WE%sT	1940 May 14  3:00
-			1:00	C-Eur	WE%sT	1944 Sep 18  3:00
-			1:00	Belgium	CE%sT	1977
-			1:00	EU	CE%sT
-
-# Macedonia
-# See Europe/Belgrade.
-
 # Malta
 #
 # From Paul Eggert (2016-10-21):
 # Assume 1900-1972 was like Rome, overriding Shanks.
 #
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Malta	1973	only	-	Mar	31	0:00s	1:00	S
 Rule	Malta	1973	only	-	Sep	29	0:00s	0	-
 Rule	Malta	1974	only	-	Apr	21	0:00s	1:00	S
@@ -8171,8 +10221,8 @@ Rule	Malta	1974	only	-	Sep	16	0:00s	0	-
 Rule	Malta	1975	1979	-	Apr	Sun>=15	2:00	1:00	S
 Rule	Malta	1975	1980	-	Sep	Sun>=15	2:00	0	-
 Rule	Malta	1980	only	-	Mar	31	2:00	1:00	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Europe/Malta	0:58:04 -	LMT	1893 Nov  2  0:00s # Valletta
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Europe/Malta	0:58:04 -	LMT	1893 Nov  2 # Valletta
 			1:00	Italy	CE%sT	1973 Mar 31
 			1:00	Malta	CE%sT	1981
 			1:00	EU	CE%sT
@@ -8225,22 +10275,22 @@ Zone	Europe/Malta	0:58:04 -	LMT	1893 Nov  2  0:00s # Valletta
 # Following Moldova and neighboring Ukraine- Transnistria (Pridnestrovie)-
 # Tiraspol will go back to winter time on October 30, 2011.
 # News from Moldova (in russian):
-# http://ru.publika.md/link_317061.html
+# https://ru.publika.md/link_317061.html
 
 # From Roman Tudos (2015-07-02):
 # http://lex.justice.md/index.php?action=view&view=doc&lang=1&id=355077
 # From Paul Eggert (2015-07-01):
 # The abovementioned official link to IGO1445-868/2014 states that
 # 2014-10-26's fallback transition occurred at 03:00 local time.  Also,
-# http://www.trm.md/en/social/la-30-martie-vom-trece-la-ora-de-vara
+# https://www.trm.md/en/social/la-30-martie-vom-trece-la-ora-de-vara
 # says the 2014-03-30 spring-forward transition was at 02:00 local time.
 # Guess that since 1997 Moldova has switched one hour before the EU.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Moldova	1997	max	-	Mar	lastSun	 2:00	1:00	S
 Rule	Moldova	1997	max	-	Oct	lastSun	 3:00	0	-
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Chisinau	1:55:20 -	LMT	1880
 			1:55	-	CMT	1918 Feb 15 # Chisinau MT
 			1:44:24	-	BMT	1931 Jul 24 # Bucharest MT
@@ -8253,166 +10303,12 @@ Zone	Europe/Chisinau	1:55:20 -	LMT	1880
 # See Romania commentary for the guessed 1997 transition to EU rules.
 			2:00	Moldova	EE%sT
 
-# Monaco
-# Shanks & Pottenger give 0:09:20 for Paris Mean Time; go with Howse's
-# more precise 0:09:21.
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Europe/Monaco	0:29:32 -	LMT	1891 Mar 15
-			0:09:21	-	PMT	1911 Mar 11 # Paris Mean Time
-			0:00	France	WE%sT	1945 Sep 16  3:00
-			1:00	France	CE%sT	1977
-			1:00	EU	CE%sT
-
-# Montenegro
-# See Europe/Belgrade.
-
-# Netherlands
-
-# Howse writes that the Netherlands' railways used GMT between 1892 and 1940,
-# but for other purposes the Netherlands used Amsterdam mean time.
-
-# However, Robert H. van Gent writes (2001-04-01):
-# Howse's statement is only correct up to 1909. From 1909-05-01 (00:00:00
-# Amsterdam mean time) onwards, the whole of the Netherlands (including
-# the Dutch railways) was required by law to observe Amsterdam mean time
-# (19 minutes 32.13 seconds ahead of GMT). This had already been the
-# common practice (except for the railways) for many decades but it was
-# not until 1909 when the Dutch government finally defined this by law.
-# On 1937-07-01 this was changed to 20 minutes (exactly) ahead of GMT and
-# was generally known as Dutch Time ("Nederlandse Tijd").
-#
-# (2001-04-08):
-# 1892-05-01 was the date when the Dutch railways were by law required to
-# observe GMT while the remainder of the Netherlands adhered to the common
-# practice of following Amsterdam mean time.
-#
-# (2001-04-09):
-# In 1835 the authorities of the province of North Holland requested the
-# municipal authorities of the towns and cities in the province to observe
-# Amsterdam mean time but I do not know in how many cases this request was
-# actually followed.
-#
-# From 1852 onwards the Dutch telegraph offices were by law required to
-# observe Amsterdam mean time. As the time signals from the observatory of
-# Leiden were also distributed by the telegraph system, I assume that most
-# places linked up with the telegraph (and railway) system automatically
-# adopted Amsterdam mean time.
-#
-# Although the early Dutch railway companies initially observed a variety
-# of times, most of them had adopted Amsterdam mean time by 1858 but it
-# was not until 1866 when they were all required by law to observe
-# Amsterdam mean time.
-
-# The data entries before 1945 are taken from
-# http://www.staff.science.uu.nl/~gent0113/wettijd/wettijd.htm
-
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Neth	1916	only	-	May	 1	0:00	1:00	NST	# Netherlands Summer Time
-Rule	Neth	1916	only	-	Oct	 1	0:00	0	AMT	# Amsterdam Mean Time
-Rule	Neth	1917	only	-	Apr	16	2:00s	1:00	NST
-Rule	Neth	1917	only	-	Sep	17	2:00s	0	AMT
-Rule	Neth	1918	1921	-	Apr	Mon>=1	2:00s	1:00	NST
-Rule	Neth	1918	1921	-	Sep	lastMon	2:00s	0	AMT
-Rule	Neth	1922	only	-	Mar	lastSun	2:00s	1:00	NST
-Rule	Neth	1922	1936	-	Oct	Sun>=2	2:00s	0	AMT
-Rule	Neth	1923	only	-	Jun	Fri>=1	2:00s	1:00	NST
-Rule	Neth	1924	only	-	Mar	lastSun	2:00s	1:00	NST
-Rule	Neth	1925	only	-	Jun	Fri>=1	2:00s	1:00	NST
-# From 1926 through 1939 DST began 05-15, except that it was delayed by a week
-# in years when 05-15 fell in the Pentecost weekend.
-Rule	Neth	1926	1931	-	May	15	2:00s	1:00	NST
-Rule	Neth	1932	only	-	May	22	2:00s	1:00	NST
-Rule	Neth	1933	1936	-	May	15	2:00s	1:00	NST
-Rule	Neth	1937	only	-	May	22	2:00s	1:00	NST
-Rule	Neth	1937	only	-	Jul	 1	0:00	1:00	S
-Rule	Neth	1937	1939	-	Oct	Sun>=2	2:00s	0	-
-Rule	Neth	1938	1939	-	May	15	2:00s	1:00	S
-Rule	Neth	1945	only	-	Apr	 2	2:00s	1:00	S
-Rule	Neth	1945	only	-	Sep	16	2:00s	0	-
-#
-# Amsterdam Mean Time was +00:19:32.13 exactly, but the .13 is omitted
-# below because the current format requires GMTOFF to be an integer.
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Europe/Amsterdam	0:19:32 -	LMT	1835
-			0:19:32	Neth	%s	1937 Jul  1
-			0:20	Neth	NE%sT	1940 May 16  0:00 # Dutch Time
-			1:00	C-Eur	CE%sT	1945 Apr  2  2:00
-			1:00	Neth	CE%sT	1977
-			1:00	EU	CE%sT
-
-# Norway
-# http://met.no/met/met_lex/q_u/sommertid.html (2004-01) agrees with Shanks &
-# Pottenger.
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Norway	1916	only	-	May	22	1:00	1:00	S
-Rule	Norway	1916	only	-	Sep	30	0:00	0	-
-Rule	Norway	1945	only	-	Apr	 2	2:00s	1:00	S
-Rule	Norway	1945	only	-	Oct	 1	2:00s	0	-
-Rule	Norway	1959	1964	-	Mar	Sun>=15	2:00s	1:00	S
-Rule	Norway	1959	1965	-	Sep	Sun>=15	2:00s	0	-
-Rule	Norway	1965	only	-	Apr	25	2:00s	1:00	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Europe/Oslo	0:43:00 -	LMT	1895 Jan  1
-			1:00	Norway	CE%sT	1940 Aug 10 23:00
-			1:00	C-Eur	CE%sT	1945 Apr  2  2:00
-			1:00	Norway	CE%sT	1980
-			1:00	EU	CE%sT
-
-# Svalbard & Jan Mayen
-
-# From Steffen Thorsen (2001-05-01):
-# Although I could not find it explicitly, it seems that Jan Mayen and
-# Svalbard have been using the same time as Norway at least since the
-# time they were declared as parts of Norway.  Svalbard was declared
-# as a part of Norway by law of 1925-07-17 no 11, section 4 and Jan
-# Mayen by law of 1930-02-27 no 2, section 2. (From
-# <http://www.lovdata.no/all/nl-19250717-011.html> and
-# <http://www.lovdata.no/all/nl-19300227-002.html>).  The law/regulation
-# for normal/standard time in Norway is from 1894-06-29 no 1 (came
-# into operation on 1895-01-01) and Svalbard/Jan Mayen seem to be a
-# part of this law since 1925/1930. (From
-# <http://www.lovdata.no/all/nl-18940629-001.html>) I have not been
-# able to find if Jan Mayen used a different time zone (e.g. -0100)
-# before 1930. Jan Mayen has only been "inhabited" since 1921 by
-# Norwegian meteorologists and maybe used the same time as Norway ever
-# since 1921.  Svalbard (Arctic/Longyearbyen) has been inhabited since
-# before 1895, and therefore probably changed the local time somewhere
-# between 1895 and 1925 (inclusive).
-
-# From Paul Eggert (2013-09-04):
-#
-# Actually, Jan Mayen was never occupied by Germany during World War II,
-# so it must have diverged from Oslo time during the war, as Oslo was
-# keeping Berlin time.
-#
-# <http://home.no.net/janmayen/history.htm> says that the meteorologists
-# burned down their station in 1940 and left the island, but returned in
-# 1941 with a small Norwegian garrison and continued operations despite
-# frequent air attacks from Germans.  In 1943 the Americans established a
-# radiolocating station on the island, called "Atlantic City".  Possibly
-# the UT offset changed during the war, but I think it unlikely that
-# Jan Mayen used German daylight-saving rules.
-#
-# Svalbard is more complicated, as it was raided in August 1941 by an
-# Allied party that evacuated the civilian population to England (says
-# <http://www.bartleby.com/65/sv/Svalbard.html>).  The Svalbard FAQ
-# <http://www.svalbard.com/SvalbardFAQ.html> says that the Germans were
-# expelled on 1942-05-14.  However, small parties of Germans did return,
-# and according to Wilhelm Dege's book "War North of 80" (1954)
-# http://www.ucalgary.ca/UofC/departments/UP/1-55238/1-55238-110-2.html
-# the German armed forces at the Svalbard weather station code-named
-# Haudegen did not surrender to the Allies until September 1945.
-#
-# All these events predate our cutoff date of 1970, so use Europe/Oslo
-# for these regions.
-Link	Europe/Oslo	Arctic/Longyearbyen
-
 # Poland
 
 # The 1919 dates and times can be found in Tygodnik Urzędowy nr 1 (1919-03-20),
 # <http://www.wbc.poznan.pl/publication/32156> pp 1-2.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Poland	1918	1919	-	Sep	16	2:00s	0	-
 Rule	Poland	1919	only	-	Apr	15	2:00s	1:00	S
 Rule	Poland	1944	only	-	Apr	 3	2:00s	1:00	S
@@ -8423,7 +10319,7 @@ Rule	Poland	1945	only	-	Apr	29	0:00	1:00	S
 Rule	Poland	1945	only	-	Nov	 1	0:00	0	-
 # For 1946 on the source is Kazimierz Borkowski,
 # Toruń Center for Astronomy, Dept. of Radio Astronomy, Nicolaus Copernicus U.,
-# http://www.astro.uni.torun.pl/~kb/Artykuly/U-PA/Czas2.htm#tth_tAb1
+# https://www.astro.uni.torun.pl/~kb/Artykuly/U-PA/Czas2.htm#tth_tAb1
 # Thanks to Przemysław Augustyniak (2005-05-28) for this reference.
 # He also gives these further references:
 # Mon Pol nr 13, poz 162 (1995) <http://www.abc.com.pl/serwis/mp/1995/0162.htm>
@@ -8442,7 +10338,7 @@ Rule	Poland	1959	1961	-	Oct	Sun>=1	1:00s	0	-
 Rule	Poland	1960	only	-	Apr	 3	1:00s	1:00	S
 Rule	Poland	1961	1964	-	May	lastSun	1:00s	1:00	S
 Rule	Poland	1962	1964	-	Sep	lastSun	1:00s	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Warsaw	1:24:00 -	LMT	1880
 			1:24:00	-	WMT	1915 Aug  5 # Warsaw Mean Time
 			1:00	C-Eur	CE%sT	1918 Sep 16  3:00
@@ -8454,14 +10350,220 @@ Zone	Europe/Warsaw	1:24:00 -	LMT	1880
 			1:00	EU	CE%sT
 
 # Portugal
+
+# From Tim Parenti (2024-07-01), per Alois Treindl (2021-02-07) and Michael
+# Deckers (2021-02-10):
+# http://oal.ul.pt/documentos/2018/01/hl1911a2018.pdf/
+# The Astronomical Observatory of Lisbon has published a list detailing the
+# historical transitions in legal time within continental Portugal.  It
+# directly references many decrees and ordinances which are, in turn,
+# referenced below.  They can be viewed in the public archives of the Diário da
+# República (until 1976-04-09 known as the Diário do Govêrno) at
+# https://dre.pt/ (in Portuguese).
 #
-# From Paul Eggert (2014-08-11), after a heads-up from Stephen Colebourne:
-# According to a Portuguese decree (1911-05-26)
-# http://dre.pt/pdf1sdip/1911/05/12500/23132313.pdf
-# Lisbon was at -0:36:44.68, but switched to GMT on 1912-01-01 at 00:00.
-# Round the old offset to -0:36:45.  This agrees with Willett but disagrees
-# with Shanks, who says the transition occurred on 1911-05-24 at 00:00 for
-# Europe/Lisbon, Atlantic/Azores, and Atlantic/Madeira.
+# Most of the Rules below have been updated simply to match the Observatory's
+# listing for continental (mainland) Portugal.  Although there are over 50
+# referenced decrees and ordinances, only the handful with comments below have
+# been verified against the text, typically to provide additional confidence
+# wherever dates provided by Whitman and Shanks & Pottenger had disagreed.
+# See further below for the Azores and Madeira.
+
+# From Tim Parenti (2024-07-01), per Paul Eggert (2014-08-11), after a
+# heads-up from Stephen Colebourne:
+# According to a 1911-05-24 Portuguese decree, Lisbon was at -0:36:44.68, but
+# switched to GMT on 1912-01-01 at 00:00.
+# https://dre.pt/dr/detalhe/decreto/593090
+# https://dre.pt/application/conteudo/593090
+# The decree made legal time throughout Portugal and her possessions
+# "subordinate to the Greenwich meridian, according to the principle adopted at
+# the Washington Convention in 1884" and eliminated the "difference of five
+# minutes between the internal and external clocks of railway stations".
+#
+# The decree was gazetted in the 1911-05-30 issue of Diário do Govêrno, and is
+# considered to be dated 1911-05-24 by that issue's summary; however, the text
+# of the decree itself is dated 1911-05-26.  The Diário da República website
+# notes the discrepancy, but later laws and the Observatory all seem to refer
+# to this decree by the 1911-05-24 date.
+#
+# From Michael Deckers (2018-02-15):
+# article 5 [of the 1911 decree; Deckers's translation] ...:
+# These dispositions shall enter into force at the instant at which,
+# according to the 2nd article, the civil day January 1, 1912 begins,
+# all clocks therefore having to be advanced or set back correspondingly ...
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+# From Tim Parenti (2024-07-01), per Paul Eggert (1999-01-30):
+# DSH writes in their history that Decreto 1469 of 1915-03-30 established
+# summer time and that, "despite" this, the change to the clocks was not done
+# every year, depending on what Spain did, because of railroad schedules.
+# In fact, that decree had nothing to do with DST; rather, it regulated the
+# sending of time signals.  But we do see linkage to Spain in the 1920s below.
+# https://dre.pt/dr/detalhe/decreto/1469-1915-285721
+# https://dre.pt/application/conteudo/285721
+#
+# According to the Observatory, standard time was first advanced by Decreto
+# 2433 of 1916-06-09 and restored by Decreto 2712 of 1916-10-28.  While Whitman
+# gives 1916-10-31 for the latter transition, Shanks & Pottenger agrees more
+# closely with the decree, which stated that its provision "will start sixty
+# minutes after the end of 31 October, according to the current time," i.e.,
+# 01:00 on 1 November.
+# https://dre.pt/dr/detalhe/decreto/2433-1916-267192
+# https://dre.pt/application/conteudo/267192
+# https://dre.pt/dr/detalhe/decreto/2712-1916-590937
+# https://dre.pt/application/conteudo/590937
+Rule	Port	1916	only	-	Jun	17	23:00	1:00	S
+Rule	Port	1916	only	-	Nov	 1	 1:00	0	-
+# From Tim Parenti (2024-07-01):
+# Article 7 of Decreto 2922 of 1916-12-30 stated that "the legal time will be
+# advanced by sixty minutes from 1 March to 31 October."  Per Article 15, this
+# came into force from 1917-01-01.  Just before the first fall back, Decreto
+# 3446 of 1917-10-11 changed the annual end date to 14 October.
+# https://dre.pt/dr/detalhe/decreto/2922-1916-261894
+# https://dre.pt/application/conteudo/261894
+# https://dre.pt/dr/detalhe/decreto/3446-1917-495161
+# https://dre.pt/application/conteudo/495161
+# This annual change was revoked by Decreto 8038 of 1922-02-18.
+# https://dre.pt/dr/detalhe/decreto/8038-1922-569751
+# https://dre.pt/application/conteudo/569751
+Rule	Port	1917	1921	-	Mar	 1	 0:00	1:00	S
+Rule	Port	1917	1921	-	Oct	14	24:00	0	-
+# From Tim Parenti (2024-07-01):
+# Decreto 9592 of 1924-04-14 noted that "France maintains the advance of legal
+# time in the summer and Spain has now adopted it for the first time" and
+# considered "that the absence of similar measures would cause serious
+# difficulties for international rail connections with consequent repercussions
+# on domestic service hours..." along with "inconvenient analogues...for postal
+# and telegraph services."  Summer time would be in effect from 17 April to 4
+# October, with the spring change explicitly specified by bringing clocks
+# forward from 16 April 23:00.
+# https://dre.pt/dr/detalhe/decreto/9592-1924-652133
+# https://dre.pt/application/conteudo/652133
+#
+# Decreto 10700, issued 1925-04-16, noted that Spain had not continued summer
+# time, declared that "the current legal hour prior to 17 April remains
+# unchanged from that day forward", and revoked legislation to the contrary,
+# just a day before summer time would have otherwise resumed.
+# https://dre.pt/dr/detalhe/decreto/10700-1925-437826
+# https://dre.pt/application/conteudo/437826
+Rule	Port	1924	only	-	Apr	16	23:00s	1:00	S
+Rule	Port	1924	only	-	Oct	 4	23:00s	0	-
+Rule	Port	1926	only	-	Apr	17	23:00s	1:00	S
+Rule	Port	1926	1929	-	Oct	Sat>=1	23:00s	0	-
+Rule	Port	1927	only	-	Apr	 9	23:00s	1:00	S
+Rule	Port	1928	only	-	Apr	14	23:00s	1:00	S
+Rule	Port	1929	only	-	Apr	20	23:00s	1:00	S
+Rule	Port	1931	only	-	Apr	18	23:00s	1:00	S
+# Whitman gives 1931 Oct 8; go with Shanks & Pottenger.
+Rule	Port	1931	1932	-	Oct	Sat>=1	23:00s	0	-
+Rule	Port	1932	only	-	Apr	 2	23:00s	1:00	S
+Rule	Port	1934	only	-	Apr	 7	23:00s	1:00	S
+# Whitman gives 1934 Oct 5; go with Shanks & Pottenger.
+# Note: The 1935 law specified 10-06 00:00, not 10-05 24:00, but the following
+# is equivalent and more succinct.
+Rule	Port	1934	1938	-	Oct	Sat>=1	23:00s	0	-
+# Shanks & Pottenger give 1935 Apr 30; go with Whitman.
+Rule	Port	1935	only	-	Mar	30	23:00s	1:00	S
+Rule	Port	1936	only	-	Apr	18	23:00s	1:00	S
+# Whitman gives 1937 Apr 2; go with Shanks & Pottenger.
+Rule	Port	1937	only	-	Apr	 3	23:00s	1:00	S
+Rule	Port	1938	only	-	Mar	26	23:00s	1:00	S
+Rule	Port	1939	only	-	Apr	15	23:00s	1:00	S
+# Whitman gives 1939 Oct 7; go with Shanks & Pottenger.
+Rule	Port	1939	only	-	Nov	18	23:00s	0	-
+# From Tim Parenti (2024-07-01):
+# Portaria 9465 of 1940-02-17 advanced clocks from Saturday 1940-02-24 23:00.
+# The clocks were restored by Portaria 9658, issued Monday 1940-10-07,
+# effective from 24:00 that very night, which agrees with Shanks & Pottenger;
+# Whitman gives Saturday 1940-10-05 instead.
+# https://dre.pt/dr/detalhe/portaria/9465-1940-189096
+# https://dre.pt/application/conteudo/189096
+# https://dre.pt/dr/detalhe/portaria/9658-1940-196729
+# https://dre.pt/application/conteudo/196729
+Rule	Port	1940	only	-	Feb	24	23:00s	1:00	S
+Rule	Port	1940	only	-	Oct	 7	23:00s	0	-
+Rule	Port	1941	only	-	Apr	 5	23:00s	1:00	S
+Rule	Port	1941	only	-	Oct	 5	23:00s	0	-
+Rule	Port	1942	1945	-	Mar	Sat>=8	23:00s	1:00	S
+Rule	Port	1942	only	-	Apr	25	22:00s	2:00	M # Midsummer
+Rule	Port	1942	only	-	Aug	15	22:00s	1:00	S
+Rule	Port	1942	1945	-	Oct	Sat>=24	23:00s	0	-
+Rule	Port	1943	only	-	Apr	17	22:00s	2:00	M
+Rule	Port	1943	1945	-	Aug	Sat>=25	22:00s	1:00	S
+Rule	Port	1944	1945	-	Apr	Sat>=21	22:00s	2:00	M
+Rule	Port	1946	only	-	Apr	Sat>=1	23:00s	1:00	S
+Rule	Port	1946	only	-	Oct	Sat>=1	23:00s	0	-
+# From Tim Parenti (2024-07-01), per Alois Treindl (2021-02-07):
+# The Astronomical Observatory of Lisbon cites Portaria 11767 of 1947-03-28 for
+# 1947 and Portaria 12286 of 1948-02-19 for 1948.
+# https://dre.pt/dr/detalhe/portaria/11767-1947-414787
+# https://dre.pt/application/conteudo/414787
+# https://dre.pt/dr/detalhe/portaria/12286-1948-152953
+# https://dre.pt/application/conteudo/152953
+#
+# Although the latter ordinance explicitly had the 1948-10-03 transition
+# scheduled for 02:00 rather than 03:00 as had been used in 1947, Decreto-Lei
+# 37048 of 1948-09-07 recognized "that it is advisable to definitely set...the
+# 'summer time' regime", and fixed the fall transition at 03:00 moving forward.
+# https://dre.pt/dr/detalhe/decreto-lei/37048-1948-373810
+# https://dre.pt/application/conteudo/373810
+# While the Observatory only cites this act for 1949-1965 and not for 1948, it
+# does not appear to have had any provision delaying its effect, so assume that
+# it overrode the prior ordinance for 1948-10-03.
+#
+# Whitman says DST was not observed in 1950 and gives Oct lastSun for 1952 on.
+# The Observatory, however, agrees with Shanks & Pottenger that 1950 was not an
+# exception and that Oct Sun>=1 was maintained through 1965.
+Rule	Port	1947	1966	-	Apr	Sun>=1	 2:00s	1:00	S
+Rule	Port	1947	1965	-	Oct	Sun>=1	 2:00s	0	-
+# From Tim Parenti (2024-07-01):
+# Decreto-Lei 47233 of 1966-10-01 considered that the "duality" in time was
+# "the cause of serious disturbances" and noted that "the countries with which
+# we have the most frequent contacts...have already adopted" a solution
+# coinciding with the extant "summer time".  It established that the former
+# "summer time" would apply year-round on the mainland and adjacent islands
+# with immediate effect, as the fall back would have otherwise occurred later
+# that evening.
+# https://dre.pt/dr/detalhe/decreto-lei/47233-1966-293729
+# Model this by changing zones without changing clocks at the
+# previously-appointed fall back time.
+#
+# Decreto-Lei 309/76 of 1976-04-27 acknowledged that those international
+# contacts had returned to adopting seasonal times, and considered that the
+# year-round advancement "entails considerable sacrifices for the vast majority
+# of the working population during the winter months", including morning
+# visibility concerns for schoolchildren.  It specified, beginning 1976-09-26
+# 01:00, an annual return to UT+00 on the mainland from 00:00 UT on Sep lastSun
+# to 00:00 UT on Mar lastSun (unless the latter date fell on Easter, in which
+# case it was to be brought forward to the preceding Sunday).  It also assigned
+# the Permanent Time Commission to study and propose revisions for the Azores
+# and Madeira, neither of which resumed DST until 1982 (as described further
+# below).
+# https://dre.pt/dr/detalhe/decreto-lei/309-1976-502063
+Rule	Port	1976	only	-	Sep	lastSun	 1:00	0	-
+Rule	Port	1977	only	-	Mar	lastSun	 0:00s	1:00	S
+Rule	Port	1977	only	-	Sep	lastSun	 0:00s	0	-
+# From Tim Parenti (2024-07-01):
+# Beginning in 1978, rather than triggering the Easter rule of the 1976 decree
+# (Easter fell on 1978-03-26), Article 5 was used instead, which allowed DST
+# dates to be changed by order of the Minister of Education and Scientific
+# Research, upon consultation with the Permanent Time Commission, "whenever
+# considered convenient."  As such, a series of one-off ordinances were
+# promulgated for the mainland in 1978 through 1980, after which the 1976
+# decree naturally came back into force from 1981.
+Rule	Port	1978	1980	-	Apr	Sun>=1	 1:00s	1:00	S
+Rule	Port	1978	only	-	Oct	 1	 1:00s	0	-
+Rule	Port	1979	1980	-	Sep	lastSun	 1:00s	0	-
+Rule	Port	1981	1986	-	Mar	lastSun	 0:00s	1:00	S
+Rule	Port	1981	1985	-	Sep	lastSun	 0:00s	0	-
+# From Tim Parenti (2024-07-01):
+# Decreto-Lei 44-B/86 of 1986-03-07 switched mainland Portugal's transition
+# times from 0:00s to 1:00u to harmonize with the EEC from 1986-03-30.
+# https://dre.pt/dr/detalhe/decreto-lei/44-b-1986-628280
+# (Transitions of 1:00s as previously reported and used by the W-Eur rules,
+# though equivalent, appear to have been fiction here.)  Madeira continued to
+# use 0:00s for spring 1986 before joining with the mainland using 1:00u in the
+# fall; meanwhile, in the Azores the two were equivalent, so the law specifying
+# 0:00s wasn't touched until 1992.  (See below for more on the islands.)
 #
 # From Rui Pedro Salgueiro (1992-11-12):
 # Portugal has recently (September, 27) changed timezone
@@ -8474,95 +10576,111 @@ Zone	Europe/Warsaw	1:24:00 -	LMT	1880
 # From Paul Eggert (1996-11-12):
 # IATA SSIM (1991-09) reports several 1991-09 and 1992-09 transitions
 # at 02:00u, not 01:00u.  Assume that these are typos.
-# IATA SSIM (1991/1992) reports that the Azores were at -1:00.
-# IATA SSIM (1993-02) says +0:00; later issues (through 1996-09) say -1:00.
-# Guess that the Azores changed to EU rules in 1992 (since that's when Portugal
-# harmonized with the EU), and that they stayed +0:00 that winter.
 #
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-# DSH writes that despite Decree 1,469 (1915), the change to the clocks was not
-# done every year, depending on what Spain did, because of railroad schedules.
-# Go with Shanks & Pottenger.
-Rule	Port	1916	only	-	Jun	17	23:00	1:00	S
-# Whitman gives 1916 Oct 31; go with Shanks & Pottenger.
-Rule	Port	1916	only	-	Nov	 1	 1:00	0	-
-Rule	Port	1917	only	-	Feb	28	23:00s	1:00	S
-Rule	Port	1917	1921	-	Oct	14	23:00s	0	-
-Rule	Port	1918	only	-	Mar	 1	23:00s	1:00	S
-Rule	Port	1919	only	-	Feb	28	23:00s	1:00	S
-Rule	Port	1920	only	-	Feb	29	23:00s	1:00	S
-Rule	Port	1921	only	-	Feb	28	23:00s	1:00	S
-Rule	Port	1924	only	-	Apr	16	23:00s	1:00	S
-Rule	Port	1924	only	-	Oct	14	23:00s	0	-
-Rule	Port	1926	only	-	Apr	17	23:00s	1:00	S
-Rule	Port	1926	1929	-	Oct	Sat>=1	23:00s	0	-
-Rule	Port	1927	only	-	Apr	 9	23:00s	1:00	S
-Rule	Port	1928	only	-	Apr	14	23:00s	1:00	S
-Rule	Port	1929	only	-	Apr	20	23:00s	1:00	S
-Rule	Port	1931	only	-	Apr	18	23:00s	1:00	S
-# Whitman gives 1931 Oct 8; go with Shanks & Pottenger.
-Rule	Port	1931	1932	-	Oct	Sat>=1	23:00s	0	-
-Rule	Port	1932	only	-	Apr	 2	23:00s	1:00	S
-Rule	Port	1934	only	-	Apr	 7	23:00s	1:00	S
-# Whitman gives 1934 Oct 5; go with Shanks & Pottenger.
-Rule	Port	1934	1938	-	Oct	Sat>=1	23:00s	0	-
-# Shanks & Pottenger give 1935 Apr 30; go with Whitman.
-Rule	Port	1935	only	-	Mar	30	23:00s	1:00	S
-Rule	Port	1936	only	-	Apr	18	23:00s	1:00	S
-# Whitman gives 1937 Apr 2; go with Shanks & Pottenger.
-Rule	Port	1937	only	-	Apr	 3	23:00s	1:00	S
-Rule	Port	1938	only	-	Mar	26	23:00s	1:00	S
-Rule	Port	1939	only	-	Apr	15	23:00s	1:00	S
-# Whitman gives 1939 Oct 7; go with Shanks & Pottenger.
-Rule	Port	1939	only	-	Nov	18	23:00s	0	-
-Rule	Port	1940	only	-	Feb	24	23:00s	1:00	S
-# Shanks & Pottenger give 1940 Oct 7; go with Whitman.
-Rule	Port	1940	1941	-	Oct	 5	23:00s	0	-
-Rule	Port	1941	only	-	Apr	 5	23:00s	1:00	S
-Rule	Port	1942	1945	-	Mar	Sat>=8	23:00s	1:00	S
-Rule	Port	1942	only	-	Apr	25	22:00s	2:00	M # Midsummer
-Rule	Port	1942	only	-	Aug	15	22:00s	1:00	S
-Rule	Port	1942	1945	-	Oct	Sat>=24	23:00s	0	-
-Rule	Port	1943	only	-	Apr	17	22:00s	2:00	M
-Rule	Port	1943	1945	-	Aug	Sat>=25	22:00s	1:00	S
-Rule	Port	1944	1945	-	Apr	Sat>=21	22:00s	2:00	M
-Rule	Port	1946	only	-	Apr	Sat>=1	23:00s	1:00	S
-Rule	Port	1946	only	-	Oct	Sat>=1	23:00s	0	-
-Rule	Port	1947	1949	-	Apr	Sun>=1	 2:00s	1:00	S
-Rule	Port	1947	1949	-	Oct	Sun>=1	 2:00s	0	-
-# Shanks & Pottenger say DST was observed in 1950; go with Whitman.
-# Whitman gives Oct lastSun for 1952 on; go with Shanks & Pottenger.
-Rule	Port	1951	1965	-	Apr	Sun>=1	 2:00s	1:00	S
-Rule	Port	1951	1965	-	Oct	Sun>=1	 2:00s	0	-
-Rule	Port	1977	only	-	Mar	27	 0:00s	1:00	S
-Rule	Port	1977	only	-	Sep	25	 0:00s	0	-
-Rule	Port	1978	1979	-	Apr	Sun>=1	 0:00s	1:00	S
-Rule	Port	1978	only	-	Oct	 1	 0:00s	0	-
-Rule	Port	1979	1982	-	Sep	lastSun	 1:00s	0	-
-Rule	Port	1980	only	-	Mar	lastSun	 0:00s	1:00	S
-Rule	Port	1981	1982	-	Mar	lastSun	 1:00s	1:00	S
-Rule	Port	1983	only	-	Mar	lastSun	 2:00s	1:00	S
-#
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	-0:36:44.68
 Zone	Europe/Lisbon	-0:36:45 -	LMT	1884
-			-0:36:45 -	LMT	1912 Jan  1 # Lisbon Mean Time
-			 0:00	Port	WE%sT	1966 Apr  3  2:00
+			-0:36:45 -	LMT	1912 Jan  1  0:00u # Lisbon MT
+			 0:00	Port	WE%sT	1966 Oct  2  2:00s
 			 1:00	-	CET	1976 Sep 26  1:00
-			 0:00	Port	WE%sT	1983 Sep 25  1:00s
-			 0:00	W-Eur	WE%sT	1992 Sep 27  1:00s
+			 0:00	Port	WE%sT	1986
+			 0:00	EU	WE%sT	1992 Sep 27  1:00u
 			 1:00	EU	CE%sT	1996 Mar 31  1:00u
 			 0:00	EU	WE%sT
+
+# From Tim Parenti (2024-07-01):
+# For the Azores and Madeira, legislation was followed from the laws currently
+# in force as listed at:
+# https://oal.ul.pt/hora-legal/legislacao/
+# working backward through references of revocation and abrogation to
+# Decreto-Lei 47233 of 1966-10-01, the last time DST was abolished across the
+# mainland and its adjacent islands.  Because of that reference, it is
+# therefore assumed that DST rules in the islands prior to 1966 were like that
+# of the mainland, though most legislation of the time didn't explicitly
+# specify DST practices for the islands.
 Zone Atlantic/Azores	-1:42:40 -	LMT	1884        # Ponta Delgada
-			-1:54:32 -	HMT	1912 Jan  1 # Horta Mean Time
-			-2:00	Port	AZO%sT	1966 Apr  3  2:00  # Azores Time
-			-1:00	Port	AZO%sT	1983 Sep 25  1:00s
-			-1:00	W-Eur	AZO%sT	1992 Sep 27  1:00s
-			 0:00	EU	WE%sT	1993 Mar 28  1:00u
-			-1:00	EU	AZO%sT
+			-1:54:32 -	HMT	1912 Jan  1  2:00u # Horta MT
+# Vanguard section, for zic and other parsers that support %z.
+			-2:00	Port	%z	1966 Oct  2  2:00s
+# From Tim Parenti (2024-07-01):
+# While Decreto-Lei 309/76 of 1976-04-27 reintroduced DST on the mainland by
+# falling back on 1976-09-26, it assigned the Permanent Time Commission to
+# study and propose revisions for the Azores and Madeira.  Decreto Regional
+# 9/77/A of 1977-05-17 affirmed that "the legal time remained unchanged in the
+# Azores" at UT-1, and would remain there year-round.
+# https://dre.pt/dr/detalhe/decreto-regional/9-1977-252066
+#
+# Decreto Regional 2/82/A, published 1982-03-02, adopted DST in the same
+# fashion as the mainland used at the time.
+# https://dre.pt/dr/detalhe/decreto-regional/2-1982-599965
+# Though transitions in the Azores officially remained at 0:00s through 1992,
+# this was equivalent to the EU-style 1:00u adopted by the mainland in 1986, so
+# model it as such.
+			-1:00	-	%z	1982 Mar 28  0:00s
+			-1:00	Port	%z	1986
+# Rearguard section, for parsers lacking %z; see ziguard.awk.
+#			-2:00	Port	-02/-01	1942 Apr 25 22:00s
+#			-2:00	Port	+00	1942 Aug 15 22:00s
+#			-2:00	Port	-02/-01	1943 Apr 17 22:00s
+#			-2:00	Port	+00	1943 Aug 28 22:00s
+#			-2:00	Port	-02/-01	1944 Apr 22 22:00s
+#			-2:00	Port	+00	1944 Aug 26 22:00s
+#			-2:00	Port	-02/-01	1945 Apr 21 22:00s
+#			-2:00	Port	+00	1945 Aug 25 22:00s
+#			-2:00	Port	-02/-01	1966 Oct  2  2:00s
+#			-1:00	-	-01	1982 Mar 28  0:00s
+#			-1:00	Port	-01/+00	1986
+# End of rearguard section.
+#
+# From Paul Eggert (1996-11-12):
+# IATA SSIM (1991/1992) reports that the Azores were at -1:00.
+# IATA SSIM (1993-02) says +0:00; later issues (through 1996-09) say -1:00.
+#
+# From Tim Parenti (2024-07-01):
+# After mainland Portugal had shifted forward an hour from 1992-09-27, Decreto
+# Legislativo Regional 29/92/A of 1992-12-23 sought to "reduce the time
+# difference" by shifting the Azores forward as well from 1992-12-27.  Just six
+# months later, this was revoked by Decreto Legislativo Regional 9/93/A, citing
+# "major changes in work habits and way of life."  Though the revocation didn't
+# give a transition time, it was signed Wednesday 1993-06-16; assume it took
+# effect later that evening, and that an EU-style spring forward (to +01) was
+# still observed in the interim on 1993-03-28.
+# https://dre.pt/dr/detalhe/decreto-legislativo-regional/29-1992-621553
+# https://dre.pt/dr/detalhe/decreto-legislativo-regional/9-1993-389633
+			-1:00	EU	%z	1992 Dec 27  1:00s
+			 0:00	EU	WE%sT	1993 Jun 17  1:00u
+			-1:00	EU	%z
+
 Zone Atlantic/Madeira	-1:07:36 -	LMT	1884        # Funchal
-			-1:07:36 -	FMT	1912 Jan  1 # Funchal Mean Time
-			-1:00	Port	MAD%sT	1966 Apr  3  2:00 # Madeira Time
-			 0:00	Port	WE%sT	1983 Sep 25  1:00s
+			-1:07:36 -	FMT	1912 Jan  1  1:00u # Funchal MT
+# Vanguard section, for zic and other parsers that support %z.
+			-1:00	Port	%z	1966 Oct  2  2:00s
+# Rearguard section, for parsers lacking %z; see ziguard.awk.
+#			-1:00	Port	-01/+00	1942 Apr 25 22:00s
+#			-1:00	Port	+01	1942 Aug 15 22:00s
+#			-1:00	Port	-01/+00	1943 Apr 17 22:00s
+#			-1:00	Port	+01	1943 Aug 28 22:00s
+#			-1:00	Port	-01/+00	1944 Apr 22 22:00s
+#			-1:00	Port	+01	1944 Aug 26 22:00s
+#			-1:00	Port	-01/+00	1945 Apr 21 22:00s
+#			-1:00	Port	+01	1945 Aug 25 22:00s
+#			-1:00	Port	-01/+00	1966 Oct  2  2:00s
+# End of rearguard section.
+#
+# From Tim Parenti (2024-07-01):
+# Decreto Regional 5/82/M, published 1982-04-03, established DST transitions at
+# 0:00u, which for Madeira is equivalent to the mainland's rules (0:00s) at the
+# time.  It came into effect the day following its publication, Sunday
+# 1982-04-04, thus resuming Madeira's DST practice about a week later than the
+# mainland and the Azores.
+# https://dre.pt/dr/detalhe/decreto-regional/5-1982-608273
+#
+# Decreto Legislativo Regional 18/86/M, published 1986-10-01, adopted EU-style
+# rules (1:00u) and entered into immediate force after being signed on
+# 1986-07-31.
+# https://dre.pt/dr/detalhe/decreto-legislativo-regional/18-1986-221705
+			 0:00	-	WET	1982 Apr  4
+			 0:00	Port	WE%sT	1986 Jul 31
 			 0:00	EU	WE%sT
 
 # Romania
@@ -8574,7 +10692,7 @@ Zone Atlantic/Madeira	-1:07:36 -	LMT	1884        # Funchal
 # assume that Romania and Moldova switched to EU rules in 1997,
 # the same year as Bulgaria.
 #
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Romania	1932	only	-	May	21	 0:00s	1:00	S
 Rule	Romania	1932	1939	-	Oct	Sun>=1	 0:00s	0	-
 Rule	Romania	1933	1939	-	Apr	Sun>=2	 0:00s	1:00	S
@@ -8584,7 +10702,7 @@ Rule	Romania	1980	only	-	Apr	 5	23:00	1:00	S
 Rule	Romania	1980	only	-	Sep	lastSun	 1:00	0	-
 Rule	Romania	1991	1993	-	Mar	lastSun	 0:00s	1:00	S
 Rule	Romania	1991	1993	-	Sep	lastSun	 0:00s	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Europe/Bucharest	1:44:24 -	LMT	1891 Oct
 			1:44:24	-	BMT	1931 Jul 24 # Bucharest MT
 			2:00	Romania	EE%sT	1981 Mar 29  2:00s
@@ -8621,7 +10739,7 @@ Zone Europe/Bucharest	1:44:24 -	LMT	1891 Oct
 # 2011 No. 725" and contains no other dates or "effective date" information.
 #
 # Another source is
-# http://www.rg.ru/2011/09/06/chas-zona-dok.html
+# https://rg.ru/2011/09/06/chas-zona-dok.html
 # which, according to translate.google.com, begins "Resolution of the
 # Government of the Russian Federation on August 31, 2011 N 725" and also
 # contains "Date first official publication: September 6, 2011 Posted on:
@@ -8629,7 +10747,7 @@ Zone Europe/Bucharest	1:44:24 -	LMT	1891 Oct
 # does not contain any "effective date" information.
 #
 # Another source is
-# http://en.wikipedia.org/wiki/Oymyakonsky_District#cite_note-RuTime-7
+# https://en.wikipedia.org/wiki/Oymyakonsky_District#cite_note-RuTime-7
 # which, in note 8, contains "Resolution No. 725 of August 31, 2011...
 # Effective as of after 7 days following the day of the official publication"
 # but which does not contain any reference to September 6, 2011.
@@ -8654,7 +10772,7 @@ Zone Europe/Bucharest	1:44:24 -	LMT	1891 Oct
 # the State Duma has approved ... the draft bill on returning to
 # winter time standard and return Russia 11 time zones.  The new
 # regulations will come into effect on October 26, 2014 at 02:00 ...
-# http://asozd2.duma.gov.ru/main.nsf/%28Spravka%29?OpenAgent&RN=431985-6&02
+# http://asozd2.duma.gov.ru/main.nsf/(Spravka)?OpenAgent&RN=431985-6&02
 # Here is a link where we put together table (based on approved Bill N
 # 431985-6) with proposed 11 Russian time zones and corresponding
 # areas/cities/administrative centers in the Russian Federation (in English):
@@ -8665,7 +10783,7 @@ Zone Europe/Bucharest	1:44:24 -	LMT	1891 Oct
 # http://itar-tass.com/obschestvo/1333711
 # http://www.pravo.gov.ru:8080/page.aspx?111660
 # http://www.kremlin.ru/acts/46279
-# From October 26, 2014 the new Russian time zone map will looks like this:
+# From October 26, 2014 the new Russian time zone map will look like this:
 # http://www.worldtimezone.com/dst_news/dst_news_russia-map-2014-07.html
 
 # From Paul Eggert (2006-03-22):
@@ -8707,22 +10825,52 @@ Zone Europe/Bucharest	1:44:24 -	LMT	1891 Oct
 # administratively part of Sakhalin oblast', they appear to have
 # remained on UTC+11 along with Magadan.
 
+# From Marat Nigametzianov (2018-07-16):
+# this is link to order from 1956 about timezone in USSR
+# http://astro.uni-altai.ru/~orion/blog/2011/11/novyie-granitsyi-chasovyih-poyasov-v-sssr/
+#
+# From Paul Eggert (2018-07-16):
+# Perhaps someone could translate the above-mentioned link and use it
+# to correct our data for the ex-Soviet Union.  It cites the following:
+# «Поясное время и новые границы часовых поясов» / сост. П.Н. Долгов,
+# отв. ред. Г.Д. Бурдун - М: Комитет стандартов, мер и измерительных
+# приборов при Совете Министров СССР, Междуведомственная комиссия
+# единой службы времени, 1956 г.
+# This book looks like it would be a helpful resource for the Soviet
+# Union through 1956.  Although a copy was in the Scientific Library
+# of Tomsk State University, I have not been able to track down a copy nearby.
+#
+# From Stepan Golosunov (2018-07-21):
+# http://astro.uni-altai.ru/~orion/blog/2015/05/center-reforma-ischisleniya-vremeni-br-na-territorii-sssr-v-1957-godu-center/
+# says that the 1956 decision to change time belts' borders was not
+# implemented as planned in 1956 and the change happened in 1957.
+# There is also the problem that actual time zones were different from
+# the official time belts (and from many time belts' maps) as there were
+# numerous exceptions to application of time belt rules.  For example,
+# https://ru.wikipedia.org/wiki/Московское_время#Перемещение_границы_применения_московского_времени_на_восток
+# says that by 1962 there were many regions in the 3rd time belt that
+# were on Moscow time, referring to a 1962 map.  By 1989 number of such
+# exceptions grew considerably.
+
 # From Tim Parenti (2014-07-06):
 # The comments detailing the coverage of each Russian zone are meant to assist
 # with maintenance only and represent our best guesses as to which regions
 # are covered by each zone.  They are not meant to be taken as an authoritative
 # listing.  The region codes listed come from
-# http://en.wikipedia.org/w/?title=Federal_subjects_of_Russia&oldid=611810498
+# https://en.wikipedia.org/w/?title=Federal_subjects_of_Russia&oldid=611810498
 # and are used for convenience only; no guarantees are made regarding their
 # future stability.  ISO 3166-2:RU codes are also listed for first-level
 # divisions where available.
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-
-
 # From Tim Parenti (2014-07-03):
 # Europe/Kaliningrad covers...
 # 39	RU-KGD	Kaliningrad Oblast
+
+# From Paul Eggert (2019-07-25):
+# Although Shanks lists 1945-01-01 as the date for transition from
+# +01/+02 to +02/+03, more likely this is a placeholder.  Guess that
+# the transition occurred at 1945-04-10 00:00, which is about when
+# Königsberg surrendered to Soviet troops.  (Thanks to Alois Treindl.)
 
 # From Paul Eggert (2016-03-18):
 # The 1989 transition is from USSR act No. 227 (1989-03-14).
@@ -8740,11 +10888,11 @@ Zone Europe/Bucharest	1:44:24 -	LMT	1891 Oct
 # Moscow on 1991-11-03, switched to Moscow-1 on 1992-01-19.
 
 Zone Europe/Kaliningrad	 1:22:00 -	LMT	1893 Apr
-			 1:00	C-Eur	CE%sT	1945
-			 2:00	Poland	CE%sT	1946
+			 1:00	C-Eur	CE%sT	1945 Apr 10
+			 2:00	Poland	EE%sT	1946 Apr  7
 			 3:00	Russia	MSK/MSD	1989 Mar 26  2:00s
 			 2:00	Russia	EE%sT	2011 Mar 27  2:00s
-			 3:00	-	+03	2014 Oct 26  2:00s
+			 3:00	-	%z	2014 Oct 26  2:00s
 			 2:00	-	EET
 
 
@@ -8877,12 +11025,30 @@ Zone Europe/Kaliningrad	 1:22:00 -	LMT	1893 Apr
 # http://www.kaliningradka.ru/site_pc/cherez/index.php?ELEMENT_ID=40091
 # says that Kaliningrad decided not to be an exception 2 days before the
 # 1991-03-31 switch and one person at
-# http://izhevsk.ru/forum_light_message/50/682597-m8369040.html
+# https://izhevsk.ru/forum_light_message/50/682597-m8369040.html
 # says he remembers that Samara opted out of the 1992-01-19 exception
 # 2 days before the switch.
 #
+# From Alois Treindl (2022-02-15):
+# the Russian wikipedia page
+# https://ru.wikipedia.org/wiki/Московское_время#Перемещение_границы_применения_московского_времени_на_восток
+# contains the sentence (in Google translation) "In the autumn of
+# 1981, Arkhangelsk, Vologda, Yaroslavl, Ivanovo, Vladimir, Ryazan,
+# Lipetsk, Voronezh, Rostov-on-Don, Krasnodar and regions to the east
+# of those named (about 30 in total) parted ways with Moscow time.
+# However, the convenience of common time with Moscow turned out to be
+# decisive - in 1982, these regions again switched to Moscow time."
+# Shanks International atlas has similar information, and also the
+# Russian book Zaitsev A., Kutalev D. A new astrologer's reference
+# book. Coordinates of cities and time corrections, - The World of
+# Urania, 2012 (Russian: Зайцев А., Куталёв Д., Новый справочник
+# астролога. Координаты городов и временные поправки).
+# To me it seems that an extra zone is needed, which starts with LMT
+# util 1919, later follows Moscow since 1930, but deviates from it
+# between 1 October 1981 until 1 April 1982.
 #
-# From Paul Eggert (2016-03-18):
+#
+# From Paul Eggert (2022-02-15):
 # Given the above, we appear to be missing some Zone entries for the
 # chaotic early 1980s in Russia.  It's not clear what these entries
 # should be.  For now, sweep this under the rug and just document the
@@ -8890,13 +11056,13 @@ Zone Europe/Kaliningrad	 1:22:00 -	LMT	1893 Apr
 
 # From Vladimir Karpinsky (2014-07-08):
 # LMT in Moscow (before Jul 3, 1916) is 2:30:17, that was defined by Moscow
-# Observatory (coordinates: 55 deg. 45'29.70", 37 deg. 34'05.30")....
+# Observatory (coordinates: 55° 45' 29.70", 37° 34' 05.30")....
 # LMT in Moscow since Jul 3, 1916 is 2:31:01 as a result of new standard.
 # (The info is from the book by Byalokoz ... p. 18.)
 # The time in St. Petersburg as capital of Russia was defined by
 # Pulkov observatory, near St. Petersburg.  In 1916 LMT Moscow
 # was synchronized with LMT St. Petersburg (+30 minutes), (Pulkov observatory
-# coordinates: 59 deg. 46'18.70", 30 deg. 19'40.70") so 30 deg. 19'40.70" >
+# coordinates: 59° 46' 18.70", 30° 19' 40.70") so 30° 19' 40.70" >
 # 2h01m18.7s = 2:01:19.  LMT Moscow = LMT St.Petersburg + 30m 2:01:19 + 0:30 =
 # 2:31:19 ...
 #
@@ -8919,10 +11085,8 @@ Zone Europe/Moscow	 2:30:17 -	LMT	1880
 			 3:00	-	MSK
 
 
-# From Tim Parenti (2014-07-03):
-# Europe/Simferopol covers...
-# **	****	Crimea, Republic of
-# **	****	Sevastopol
+# From Paul Eggert (2016-12-06):
+# Europe/Simferopol covers Crimea.
 
 Zone Europe/Simferopol	 2:16:24 -	LMT	1880
 			 2:16	-	SMT	1924 May  2 # Simferopol Mean T
@@ -8931,31 +11095,34 @@ Zone Europe/Simferopol	 2:16:24 -	LMT	1880
 			 1:00	C-Eur	CE%sT	1944 Apr 13
 			 3:00	Russia	MSK/MSD	1990
 			 3:00	-	MSK	1990 Jul  1  2:00
-			 2:00	-	EET	1992
+			 2:00	-	EET	1992 Mar 20
 # Central Crimea used Moscow time 1994/1997.
 #
-# From Paul Eggert (2006-03-22):
-# The _Economist_ (1994-05-28, p 45) reports that central Crimea switched
-# from Kiev to Moscow time sometime after the January 1994 elections.
+# From Paul Eggert (2022-07-21):
+# The _Economist_ (1994-05-28, p 45) reported that central Crimea switched
+# from Kyiv to Moscow time sometime after the January 1994 elections.
 # Shanks (1999) says "date of change uncertain", but implies that it happened
 # sometime between the 1994 DST switches.  Shanks & Pottenger simply say
 # 1994-09-25 03:00, but that can't be right.  For now, guess it
-# changed in May.
-			 2:00	E-Eur	EE%sT	1994 May
-# From IATA SSIM (1994/1997), which also says that Kerch is still like Kiev.
-			 3:00	E-Eur	MSK/MSD	1996 Mar 31  0:00s
+# changed in May.  This change evidently didn't last long; see below.
+			 2:00	C-Eur	EE%sT	1994 May
+# From IATA SSIM (1994/1997), which also said that Kerch is still like Kyiv.
+			 3:00	C-Eur	MSK/MSD	1996 Mar 31  0:00s
 			 3:00	1:00	MSD	1996 Oct 27  3:00s
-# IATA SSIM (1997-09) says Crimea switched to EET/EEST.
+# IATA SSIM (1997-09) said Crimea switched to EET/EEST.
 # Assume it happened in March by not changing the clocks.
-			 3:00	Russia	MSK/MSD	1997
 			 3:00	-	MSK	1997 Mar lastSun  1:00u
 # From Alexander Krivenyshev (2014-03-17):
 # time change at 2:00 (2am) on March 30, 2014
-# http://vz.ru/news/2014/3/17/677464.html
-# From Paul Eggert (2014-03-30):
-# Simferopol and Sevastopol reportedly changed their central town clocks
-# late the previous day, but this appears to have been ceremonial
-# and the discrepancies are small enough to not worry about.
+# https://vz.ru/news/2014/3/17/677464.html
+# From Tim Parenti (2022-07-01), per Paul Eggert (2014-03-30):
+# The clocks at the railway station in Simferopol were put forward from 22:00
+# to 24:00 the previous day in a "symbolic ceremony"; however, per
+# contemporaneous news reports, "ordinary Crimeans [made] the daylight savings
+# time switch at 2am" on Sunday.
+# https://www.business-standard.com/article/pti-stories/crimea-to-set-clocks-to-russia-time-114033000014_1.html
+# https://www.reuters.com/article/us-ukraine-crisis-crimea-time/crimea-switches-to-moscow-time-amid-incorporation-frenzy-idUKBREA2S0LT20140329
+# https://www.bbc.com/news/av/world-europe-26806583
 			 2:00	EU	EE%sT	2014 Mar 30  2:00
 			 4:00	-	MSK	2014 Oct 26  2:00s
 			 3:00	-	MSK
@@ -8975,30 +11142,74 @@ Zone Europe/Simferopol	 2:16:24 -	LMT	1880
 # http://publication.pravo.gov.ru/Document/View/0001201602150056
 
 Zone Europe/Astrakhan	 3:12:12 -	LMT	1924 May
-			 3:00	-	+03	1930 Jun 21
-			 4:00	Russia	+04/+05	1989 Mar 26  2:00s
-			 3:00	Russia	+03/+04	1991 Mar 31  2:00s
-			 4:00	-	+04	1992 Mar 29  2:00s
-			 3:00	Russia	+03/+04	2011 Mar 27  2:00s
-			 4:00	-	+04	2014 Oct 26  2:00s
-			 3:00	-	+03	2016 Mar 27  2:00s
-			 4:00	-	+04
+			 3:00	-	%z	1930 Jun 21
+			 4:00	Russia	%z	1989 Mar 26  2:00s
+			 3:00	Russia	%z	1991 Mar 31  2:00s
+			 4:00	-	%z	1992 Mar 29  2:00s
+			 3:00	Russia	%z	2011 Mar 27  2:00s
+			 4:00	-	%z	2014 Oct 26  2:00s
+			 3:00	-	%z	2016 Mar 27  2:00s
+			 4:00	-	%z
 
-# From Paul Eggert (2016-03-18):
+# From Paul Eggert (2016-11-11):
 # Europe/Volgograd covers:
 # 34	RU-VGG	Volgograd Oblast
-# 64	RU-SAR	Saratov Oblast
 # The 1988 transition is from USSR act No. 5 (1988-01-04).
 
+# From Alexander Fetisov (2018-09-20):
+# Volgograd region in southern Russia (Europe/Volgograd) change
+# timezone from UTC+3 to UTC+4 from 28oct2018.
+# http://sozd.parliament.gov.ru/bill/452878-7
+#
+# From Stepan Golosunov (2018-10-11):
+# The law has been published today on
+# http://publication.pravo.gov.ru/Document/View/0001201810110037
+
+# From Alexander Krivenyshev (2020-11-27):
+# The State Duma approved (Nov 24, 2020) the transition of the Volgograd
+# region to the Moscow time zone....
+# https://sozd.duma.gov.ru/bill/1012130-7
+#
+# From Stepan Golosunov (2020-12-05):
+# Currently proposed text for the second reading (expected on December 8) ...
+# changes the date to December 27. https://v1.ru/text/gorod/2020/12/04/69601031/
+#
+# From Stepan Golosunov (2020-12-22):
+# The law was published today on
+# http://publication.pravo.gov.ru/Document/View/0001202012220002
+
 Zone Europe/Volgograd	 2:57:40 -	LMT	1920 Jan  3
-			 3:00	-	+03	1930 Jun 21
-			 4:00	-	+04	1961 Nov 11
-			 4:00	Russia	+04/+05	1988 Mar 27  2:00s
-			 3:00	Russia	+03/+04	1991 Mar 31  2:00s
-			 4:00	-	+04	1992 Mar 29  2:00s
-			 3:00	Russia	+03/+04	2011 Mar 27  2:00s
-			 4:00	-	+04	2014 Oct 26  2:00s
-			 3:00	-	+03
+			 3:00	-	%z	1930 Jun 21
+			 4:00	-	%z	1961 Nov 11
+			 4:00	Russia	%z	1988 Mar 27  2:00s
+			 3:00	Russia	MSK/MSD	1991 Mar 31  2:00s
+			 4:00	-	%z	1992 Mar 29  2:00s
+			 3:00	Russia	MSK/MSD	2011 Mar 27  2:00s
+			 4:00	-	MSK	2014 Oct 26  2:00s
+			 3:00	-	MSK	2018 Oct 28  2:00s
+			 4:00	-	%z	2020 Dec 27  2:00s
+			 3:00	-	MSK
+
+# From Paul Eggert (2016-11-11):
+# Europe/Saratov covers:
+# 64	RU-SAR	Saratov Oblast
+
+# From Yuri Konotopov (2016-11-11):
+# Dec 4, 2016 02:00 UTC+3....  Saratov Region's local time will be ... UTC+4.
+# From Stepan Golosunov (2016-11-11):
+# ... Byalokoz listed Saratov on 03:04:18.
+# From Stepan Golosunov (2016-11-22):
+# http://publication.pravo.gov.ru/Document/View/0001201611220031
+
+Zone Europe/Saratov	 3:04:18 -	LMT	1919 Jul  1  0:00u
+			 3:00	-	%z	1930 Jun 21
+			 4:00	Russia	%z	1988 Mar 27  2:00s
+			 3:00	Russia	%z	1991 Mar 31  2:00s
+			 4:00	-	%z	1992 Mar 29  2:00s
+			 3:00	Russia	%z	2011 Mar 27  2:00s
+			 4:00	-	%z	2014 Oct 26  2:00s
+			 3:00	-	%z	2016 Dec  4  2:00s
+			 4:00	-	%z
 
 # From Paul Eggert (2016-03-18):
 # Europe/Kirov covers:
@@ -9006,13 +11217,13 @@ Zone Europe/Volgograd	 2:57:40 -	LMT	1920 Jan  3
 # The 1989 transition is from USSR act No. 227 (1989-03-14).
 #
 Zone Europe/Kirov	 3:18:48 -	LMT	1919 Jul  1  0:00u
-			 3:00	-	+03	1930 Jun 21
-			 4:00	Russia	+04/+05	1989 Mar 26  2:00s
-			 3:00	Russia	+03/+04	1991 Mar 31  2:00s
-			 4:00	-	+04	1992 Mar 29  2:00s
-			 3:00	Russia	+03/+04	2011 Mar 27  2:00s
-			 4:00	-	+04	2014 Oct 26  2:00s
-			 3:00	-	+03
+			 3:00	-	%z	1930 Jun 21
+			 4:00	Russia	%z	1989 Mar 26  2:00s
+			 3:00	Russia	MSK/MSD	1991 Mar 31  2:00s
+			 4:00	-	%z	1992 Mar 29  2:00s
+			 3:00	Russia	MSK/MSD	2011 Mar 27  2:00s
+			 4:00	-	MSK	2014 Oct 26  2:00s
+			 3:00	-	MSK
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2001-08-25):
 # Europe/Samara covers...
@@ -9024,15 +11235,15 @@ Zone Europe/Kirov	 3:18:48 -	LMT	1919 Jul  1  0:00u
 # The 1989 transition is from USSR act No. 227 (1989-03-14).
 
 Zone Europe/Samara	 3:20:20 -	LMT	1919 Jul  1  0:00u
-			 3:00	-	+03	1930 Jun 21
-			 4:00	-	+04	1935 Jan 27
-			 4:00	Russia	+04/+05	1989 Mar 26  2:00s
-			 3:00	Russia	+03/+04	1991 Mar 31  2:00s
-			 2:00	Russia	+02/+03	1991 Sep 29  2:00s
-			 3:00	-	+03	1991 Oct 20  3:00
-			 4:00	Russia	+04/+05	2010 Mar 28  2:00s
-			 3:00	Russia	+03/+04	2011 Mar 27  2:00s
-			 4:00	-	+04
+			 3:00	-	%z	1930 Jun 21
+			 4:00	-	%z	1935 Jan 27
+			 4:00	Russia	%z	1989 Mar 26  2:00s
+			 3:00	Russia	%z	1991 Mar 31  2:00s
+			 2:00	Russia	%z	1991 Sep 29  2:00s
+			 3:00	-	%z	1991 Oct 20  3:00
+			 4:00	Russia	%z	2010 Mar 28  2:00s
+			 3:00	Russia	%z	2011 Mar 27  2:00s
+			 4:00	-	%z
 
 # From Paul Eggert (2016-03-18):
 # Europe/Ulyanovsk covers:
@@ -9048,14 +11259,14 @@ Zone Europe/Samara	 3:20:20 -	LMT	1919 Jul  1  0:00u
 # http://publication.pravo.gov.ru/Document/View/0001201603090051
 
 Zone Europe/Ulyanovsk	 3:13:36 -	LMT	1919 Jul  1  0:00u
-			 3:00	-	+03	1930 Jun 21
-			 4:00	Russia	+04/+05	1989 Mar 26  2:00s
-			 3:00	Russia	+03/+04	1991 Mar 31  2:00s
-			 2:00	Russia	+02/+03	1992 Jan 19  2:00s
-			 3:00	Russia	+03/+04	2011 Mar 27  2:00s
-			 4:00	-	+04	2014 Oct 26  2:00s
-			 3:00	-	+03	2016 Mar 27  2:00s
-			 4:00	-	+04
+			 3:00	-	%z	1930 Jun 21
+			 4:00	Russia	%z	1989 Mar 26  2:00s
+			 3:00	Russia	%z	1991 Mar 31  2:00s
+			 2:00	Russia	%z	1992 Jan 19  2:00s
+			 3:00	Russia	%z	2011 Mar 27  2:00s
+			 4:00	-	%z	2014 Oct 26  2:00s
+			 3:00	-	%z	2016 Mar 27  2:00s
+			 4:00	-	%z
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2001-08-25):
 # Asia/Yekaterinburg covers...
@@ -9072,19 +11283,20 @@ Zone Europe/Ulyanovsk	 3:13:36 -	LMT	1919 Jul  1  0:00u
 # Note: Effective 2005-12-01, (59) Perm Oblast and (81) Komi-Permyak
 # Autonomous Okrug merged to form (90, RU-PER) Perm Krai.
 
-# Milne says Yekaterinburg was 4:02:32.9; round to nearest.
+# Milne says Yekaterinburg was 4:02:32.9.
 # Byalokoz 1919 says its provincial time was based on Perm, at 3:45:05.
 # Assume it switched on 1916-07-03, the time of the new standard.
 # The 1919 and 1930 transitions are from Shanks.
 
+		#STDOFF	 4:02:32.9
 Zone Asia/Yekaterinburg	 4:02:33 -	LMT	1916 Jul  3
 			 3:45:05 -	PMT	1919 Jul 15  4:00
-			 4:00	-	+04	1930 Jun 21
-			 5:00	Russia	+05/+06	1991 Mar 31  2:00s
-			 4:00	Russia	+04/+05	1992 Jan 19  2:00s
-			 5:00	Russia	+05/+06	2011 Mar 27  2:00s
-			 6:00	-	+06	2014 Oct 26  2:00s
-			 5:00	-	+05
+			 4:00	-	%z	1930 Jun 21
+			 5:00	Russia	%z	1991 Mar 31  2:00s
+			 4:00	Russia	%z	1992 Jan 19  2:00s
+			 5:00	Russia	%z	2011 Mar 27  2:00s
+			 6:00	-	%z	2014 Oct 26  2:00s
+			 5:00	-	%z
 
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2001-08-25):
@@ -9094,12 +11306,12 @@ Zone Asia/Yekaterinburg	 4:02:33 -	LMT	1916 Jul  3
 # Byalokoz 1919 says Omsk was 4:53:30.
 
 Zone Asia/Omsk		 4:53:30 -	LMT	1919 Nov 14
-			 5:00	-	+05	1930 Jun 21
-			 6:00	Russia	+06/+07	1991 Mar 31  2:00s
-			 5:00	Russia	+05/+06	1992 Jan 19  2:00s
-			 6:00	Russia	+06/+07	2011 Mar 27  2:00s
-			 7:00	-	+07	2014 Oct 26  2:00s
-			 6:00	-	+06
+			 5:00	-	%z	1930 Jun 21
+			 6:00	Russia	%z	1991 Mar 31  2:00s
+			 5:00	Russia	%z	1992 Jan 19  2:00s
+			 6:00	Russia	%z	2011 Mar 27  2:00s
+			 7:00	-	%z	2014 Oct 26  2:00s
+			 6:00	-	%z
 
 # From Paul Eggert (2016-02-22):
 # Asia/Barnaul covers:
@@ -9114,11 +11326,11 @@ Zone Asia/Omsk		 4:53:30 -	LMT	1919 Nov 14
 # suggests that Altai Republic transitioned to Moscow+3 on
 # 1995-05-28.
 #
-# http://regnum.ru/news/society/1957270.html
+# https://regnum.ru/news/society/1957270.html
 # has some historical data for Altai Krai:
-# before 1957: west part on UTC+6, east on UTC+7
-# after 1957: UTC+7
-# since 1995: UTC+6
+# before 1957: west part on UT+6, east on UT+7
+# after 1957: UT+7
+# since 1995: UT+6
 # http://barnaul.rusplt.ru/index/pochemu_altajskij_kraj_okazalsja_v_neprivychnom_chasovom_pojase-17648.html
 # confirms that and provides more details including 1995-05-28 transition date.
 
@@ -9132,14 +11344,14 @@ Zone Asia/Omsk		 4:53:30 -	LMT	1919 Nov 14
 # http://publication.pravo.gov.ru/Document/View/0001201603090038
 
 Zone Asia/Barnaul	 5:35:00 -	LMT	1919 Dec 10
-			 6:00	-	+06	1930 Jun 21
-			 7:00	Russia	+07/+08	1991 Mar 31  2:00s
-			 6:00	Russia	+06/+07	1992 Jan 19  2:00s
-			 7:00	Russia	+07/+08	1995 May 28
-			 6:00	Russia	+06/+07	2011 Mar 27  2:00s
-			 7:00	-	+07	2014 Oct 26  2:00s
-			 6:00	-	+06	2016 Mar 27  2:00s
-			 7:00	-	+07
+			 6:00	-	%z	1930 Jun 21
+			 7:00	Russia	%z	1991 Mar 31  2:00s
+			 6:00	Russia	%z	1992 Jan 19  2:00s
+			 7:00	Russia	%z	1995 May 28
+			 6:00	Russia	%z	2011 Mar 27  2:00s
+			 7:00	-	%z	2014 Oct 26  2:00s
+			 6:00	-	%z	2016 Mar 27  2:00s
+			 7:00	-	%z
 
 # From Paul Eggert (2016-03-18):
 # Asia/Novosibirsk covers:
@@ -9153,14 +11365,14 @@ Zone Asia/Barnaul	 5:35:00 -	LMT	1919 Dec 10
 # http://publication.pravo.gov.ru/Document/View/0001201607040064
 
 Zone Asia/Novosibirsk	 5:31:40 -	LMT	1919 Dec 14  6:00
-			 6:00	-	+06	1930 Jun 21
-			 7:00	Russia	+07/+08	1991 Mar 31  2:00s
-			 6:00	Russia	+06/+07	1992 Jan 19  2:00s
-			 7:00	Russia	+07/+08	1993 May 23 # say Shanks & P.
-			 6:00	Russia	+06/+07	2011 Mar 27  2:00s
-			 7:00	-	+07	2014 Oct 26  2:00s
-			 6:00	-	+06	2016 Jul 24  2:00s
-			 7:00	-	+07
+			 6:00	-	%z	1930 Jun 21
+			 7:00	Russia	%z	1991 Mar 31  2:00s
+			 6:00	Russia	%z	1992 Jan 19  2:00s
+			 7:00	Russia	%z	1993 May 23 # say Shanks & P.
+			 6:00	Russia	%z	2011 Mar 27  2:00s
+			 7:00	-	%z	2014 Oct 26  2:00s
+			 6:00	-	%z	2016 Jul 24  2:00s
+			 7:00	-	%z
 
 # From Paul Eggert (2016-03-18):
 # Asia/Tomsk covers:
@@ -9205,14 +11417,14 @@ Zone Asia/Novosibirsk	 5:31:40 -	LMT	1919 Dec 14  6:00
 # http://publication.pravo.gov.ru/Document/View/0001201604260048
 
 Zone	Asia/Tomsk	 5:39:51 -	LMT	1919 Dec 22
-			 6:00	-	+06	1930 Jun 21
-			 7:00	Russia	+07/+08	1991 Mar 31  2:00s
-			 6:00	Russia	+06/+07	1992 Jan 19  2:00s
-			 7:00	Russia	+07/+08	2002 May  1  3:00
-			 6:00	Russia	+06/+07	2011 Mar 27  2:00s
-			 7:00	-	+07	2014 Oct 26  2:00s
-			 6:00	-	+06	2016 May 29  2:00s
-			 7:00	-	+07
+			 6:00	-	%z	1930 Jun 21
+			 7:00	Russia	%z	1991 Mar 31  2:00s
+			 6:00	Russia	%z	1992 Jan 19  2:00s
+			 7:00	Russia	%z	2002 May  1  3:00
+			 6:00	Russia	%z	2011 Mar 27  2:00s
+			 7:00	-	%z	2014 Oct 26  2:00s
+			 6:00	-	%z	2016 May 29  2:00s
+			 7:00	-	%z
 
 
 # From Tim Parenti (2014-07-03):
@@ -9243,12 +11455,12 @@ Zone	Asia/Tomsk	 5:39:51 -	LMT	1919 Dec 22
 # realigning itself with KRAT.
 
 Zone Asia/Novokuznetsk	 5:48:48 -	LMT	1924 May  1
-			 6:00	-	+06	1930 Jun 21
-			 7:00	Russia	+07/+08	1991 Mar 31  2:00s
-			 6:00	Russia	+06/+07	1992 Jan 19  2:00s
-			 7:00	Russia	+07/+08	2010 Mar 28  2:00s
-			 6:00	Russia	+06/+07	2011 Mar 27  2:00s
-			 7:00	-	+07
+			 6:00	-	%z	1930 Jun 21
+			 7:00	Russia	%z	1991 Mar 31  2:00s
+			 6:00	Russia	%z	1992 Jan 19  2:00s
+			 7:00	Russia	%z	2010 Mar 28  2:00s
+			 6:00	Russia	%z	2011 Mar 27  2:00s
+			 7:00	-	%z
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2001-08-25):
 # Asia/Krasnoyarsk covers...
@@ -9262,12 +11474,12 @@ Zone Asia/Novokuznetsk	 5:48:48 -	LMT	1924 May  1
 # Byalokoz 1919 says Krasnoyarsk was 6:11:26.
 
 Zone Asia/Krasnoyarsk	 6:11:26 -	LMT	1920 Jan  6
-			 6:00	-	+06	1930 Jun 21
-			 7:00	Russia	+07/+08	1991 Mar 31  2:00s
-			 6:00	Russia	+06/+07	1992 Jan 19  2:00s
-			 7:00	Russia	+07/+08	2011 Mar 27  2:00s
-			 8:00	-	+08	2014 Oct 26  2:00s
-			 7:00	-	+07
+			 6:00	-	%z	1930 Jun 21
+			 7:00	Russia	%z	1991 Mar 31  2:00s
+			 6:00	Russia	%z	1992 Jan 19  2:00s
+			 7:00	Russia	%z	2011 Mar 27  2:00s
+			 8:00	-	%z	2014 Oct 26  2:00s
+			 7:00	-	%z
 
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2001-08-25):
@@ -9284,12 +11496,12 @@ Zone Asia/Krasnoyarsk	 6:11:26 -	LMT	1920 Jan  6
 
 Zone Asia/Irkutsk	 6:57:05 -	LMT	1880
 			 6:57:05 -	IMT	1920 Jan 25 # Irkutsk Mean Time
-			 7:00	-	+07	1930 Jun 21
-			 8:00	Russia	+08/+09	1991 Mar 31  2:00s
-			 7:00	Russia	+07/+08	1992 Jan 19  2:00s
-			 8:00	Russia	+08/+09	2011 Mar 27  2:00s
-			 9:00	-	+09	2014 Oct 26  2:00s
-			 8:00	-	+08
+			 7:00	-	%z	1930 Jun 21
+			 8:00	Russia	%z	1991 Mar 31  2:00s
+			 7:00	Russia	%z	1992 Jan 19  2:00s
+			 8:00	Russia	%z	2011 Mar 27  2:00s
+			 9:00	-	%z	2014 Oct 26  2:00s
+			 8:00	-	%z
 
 
 # From Tim Parenti (2014-07-06):
@@ -9306,13 +11518,13 @@ Zone Asia/Irkutsk	 6:57:05 -	LMT	1880
 # http://publication.pravo.gov.ru/Document/View/0001201512300107
 
 Zone Asia/Chita	 7:33:52 -	LMT	1919 Dec 15
-			 8:00	-	+08	1930 Jun 21
-			 9:00	Russia	+09/+10	1991 Mar 31  2:00s
-			 8:00	Russia	+08/+09	1992 Jan 19  2:00s
-			 9:00	Russia	+09/+10	2011 Mar 27  2:00s
-			10:00	-	+10	2014 Oct 26  2:00s
-			 8:00	-	+08	2016 Mar 27  2:00
-			 9:00	-	+09
+			 8:00	-	%z	1930 Jun 21
+			 9:00	Russia	%z	1991 Mar 31  2:00s
+			 8:00	Russia	%z	1992 Jan 19  2:00s
+			 9:00	Russia	%z	2011 Mar 27  2:00s
+			10:00	-	%z	2014 Oct 26  2:00s
+			 8:00	-	%z	2016 Mar 27  2:00
+			 9:00	-	%z
 
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2009-11-29):
@@ -9352,12 +11564,12 @@ Zone Asia/Chita	 7:33:52 -	LMT	1919 Dec 15
 # Byalokoz 1919 says Yakutsk was 8:38:58.
 
 Zone Asia/Yakutsk	 8:38:58 -	LMT	1919 Dec 15
-			 8:00	-	+08	1930 Jun 21
-			 9:00	Russia	+09/+10	1991 Mar 31  2:00s
-			 8:00	Russia	+08/+09	1992 Jan 19  2:00s
-			 9:00	Russia	+09/+10	2011 Mar 27  2:00s
-			10:00	-	+10	2014 Oct 26  2:00s
-			 9:00	-	+09
+			 8:00	-	%z	1930 Jun 21
+			 9:00	Russia	%z	1991 Mar 31  2:00s
+			 8:00	Russia	%z	1992 Jan 19  2:00s
+			 9:00	Russia	%z	2011 Mar 27  2:00s
+			10:00	-	%z	2014 Oct 26  2:00s
+			 9:00	-	%z
 
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2009-11-29):
@@ -9375,12 +11587,12 @@ Zone Asia/Yakutsk	 8:38:58 -	LMT	1919 Dec 15
 # Go with Byalokoz.
 
 Zone Asia/Vladivostok	 8:47:31 -	LMT	1922 Nov 15
-			 9:00	-	+09	1930 Jun 21
-			10:00	Russia	+10/+11	1991 Mar 31  2:00s
-			 9:00	Russia	+09/+10	1992 Jan 19  2:00s
-			10:00	Russia	+10/+11	2011 Mar 27  2:00s
-			11:00	-	+11	2014 Oct 26  2:00s
-			10:00	-	+10
+			 9:00	-	%z	1930 Jun 21
+			10:00	Russia	%z	1991 Mar 31  2:00s
+			 9:00	Russia	%z	1992 Jan 19  2:00s
+			10:00	Russia	%z	2011 Mar 27  2:00s
+			11:00	-	%z	2014 Oct 26  2:00s
+			10:00	-	%z
 
 
 # From Tim Parenti (2014-07-03):
@@ -9388,8 +11600,8 @@ Zone Asia/Vladivostok	 8:47:31 -	LMT	1922 Nov 15
 # 14-28	****	Tomponsky District
 # 14-30	****	Ust-Maysky District
 
-# From Arthur David Olson (2012-05-09):
-# Tomponskij and Ust'-Majskij switched from Vladivostok time to Yakutsk time
+# From Arthur David Olson (2022-03-21):
+# Tomponsky and Ust-Maysky switched from Vladivostok time to Yakutsk time
 # in 2011.
 
 # From Paul Eggert (2012-11-25):
@@ -9398,14 +11610,14 @@ Zone Asia/Vladivostok	 8:47:31 -	LMT	1922 Nov 15
 # This transition is no doubt wrong, but we have no better info.
 
 Zone Asia/Khandyga	 9:02:13 -	LMT	1919 Dec 15
-			 8:00	-	+08	1930 Jun 21
-			 9:00	Russia	+09/+10	1991 Mar 31  2:00s
-			 8:00	Russia	+08/+09	1992 Jan 19  2:00s
-			 9:00	Russia	+09/+10	2004
-			10:00	Russia	+10/+11	2011 Mar 27  2:00s
-			11:00	-	+11	2011 Sep 13  0:00s # Decree 725?
-			10:00	-	+10	2014 Oct 26  2:00s
-			 9:00	-	+09
+			 8:00	-	%z	1930 Jun 21
+			 9:00	Russia	%z	1991 Mar 31  2:00s
+			 8:00	Russia	%z	1992 Jan 19  2:00s
+			 9:00	Russia	%z	2004
+			10:00	Russia	%z	2011 Mar 27  2:00s
+			11:00	-	%z	2011 Sep 13  0:00s # Decree 725?
+			10:00	-	%z	2014 Oct 26  2:00s
+			 9:00	-	%z
 
 
 # From Tim Parenti (2014-07-03):
@@ -9421,14 +11633,14 @@ Zone Asia/Khandyga	 9:02:13 -	LMT	1919 Dec 15
 
 # The Zone name should be Asia/Yuzhno-Sakhalinsk, but that's too long.
 Zone Asia/Sakhalin	 9:30:48 -	LMT	1905 Aug 23
-			 9:00	-	+09	1945 Aug 25
-			11:00	Russia	+11/+12	1991 Mar 31  2:00s # Sakhalin T
-			10:00	Russia	+10/+11	1992 Jan 19  2:00s
-			11:00	Russia	+11/+12	1997 Mar lastSun  2:00s
-			10:00	Russia	+10/+11	2011 Mar 27  2:00s
-			11:00	-	+11	2014 Oct 26  2:00s
-			10:00	-	+10	2016 Mar 27  2:00s
-			11:00	-	+11
+			 9:00	-	%z	1945 Aug 25
+			11:00	Russia	%z	1991 Mar 31  2:00s # Sakhalin T
+			10:00	Russia	%z	1992 Jan 19  2:00s
+			11:00	Russia	%z	1997 Mar lastSun  2:00s
+			10:00	Russia	%z	2011 Mar 27  2:00s
+			11:00	-	%z	2014 Oct 26  2:00s
+			10:00	-	%z	2016 Mar 27  2:00s
+			11:00	-	%z
 
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2009-11-29):
@@ -9451,13 +11663,13 @@ Zone Asia/Sakhalin	 9:30:48 -	LMT	1905 Aug 23
 # http://publication.pravo.gov.ru/Document/View/0001201604050038
 
 Zone Asia/Magadan	10:03:12 -	LMT	1924 May  2
-			10:00	-	+10	1930 Jun 21 # Magadan Time
-			11:00	Russia	+11/+12	1991 Mar 31  2:00s
-			10:00	Russia	+10/+11	1992 Jan 19  2:00s
-			11:00	Russia	+11/+12	2011 Mar 27  2:00s
-			12:00	-	+12	2014 Oct 26  2:00s
-			10:00	-	+10	2016 Apr 24  2:00s
-			11:00	-	+11
+			10:00	-	%z	1930 Jun 21 # Magadan Time
+			11:00	Russia	%z	1991 Mar 31  2:00s
+			10:00	Russia	%z	1992 Jan 19  2:00s
+			11:00	Russia	%z	2011 Mar 27  2:00s
+			12:00	-	%z	2014 Oct 26  2:00s
+			10:00	-	%z	2016 Apr 24  2:00s
+			11:00	-	%z
 
 
 # From Tim Parenti (2014-07-06):
@@ -9488,8 +11700,8 @@ Zone Asia/Magadan	10:03:12 -	LMT	1924 May  2
 # districts, but have very similar populations.  In fact, Wikipedia currently
 # lists them both as having 3528 people, exactly 1668 males and 1860 females
 # each!  (Yikes!)
-# http://en.wikipedia.org/w/?title=Srednekolymsky_District&oldid=603435276
-# http://en.wikipedia.org/w/?title=Verkhnekolymsky_District&oldid=594378493
+# https://en.wikipedia.org/w/?title=Srednekolymsky_District&oldid=603435276
+# https://en.wikipedia.org/w/?title=Verkhnekolymsky_District&oldid=594378493
 # Assume this is a mistake, albeit an amusing one.
 #
 # Looking at censuses, the populations of the two municipalities seem to have
@@ -9502,20 +11714,20 @@ Zone Asia/Magadan	10:03:12 -	LMT	1924 May  2
 # Go with Srednekolymsk.
 
 Zone Asia/Srednekolymsk	10:14:52 -	LMT	1924 May  2
-			10:00	-	+10	1930 Jun 21
-			11:00	Russia	+11/+12	1991 Mar 31  2:00s
-			10:00	Russia	+10/+11	1992 Jan 19  2:00s
-			11:00	Russia	+11/+12	2011 Mar 27  2:00s
-			12:00	-	+12	2014 Oct 26  2:00s
-			11:00	-	+11
+			10:00	-	%z	1930 Jun 21
+			11:00	Russia	%z	1991 Mar 31  2:00s
+			10:00	Russia	%z	1992 Jan 19  2:00s
+			11:00	Russia	%z	2011 Mar 27  2:00s
+			12:00	-	%z	2014 Oct 26  2:00s
+			11:00	-	%z
 
 
 # From Tim Parenti (2014-07-03):
 # Asia/Ust-Nera covers parts of (14, RU-SA) Sakha (Yakutia) Republic:
 # 14-22	****	Oymyakonsky District
 
-# From Arthur David Olson (2012-05-09):
-# Ojmyakonskij [and the Kuril Islands] switched from
+# From Arthur David Olson (2022-03-21):
+# Oymyakonsky and the Kuril Islands switched from
 # Magadan time to Vladivostok time in 2011.
 #
 # From Tim Parenti (2014-07-06), per Alexander Krivenyshev (2014-07-02):
@@ -9525,14 +11737,14 @@ Zone Asia/Srednekolymsk	10:14:52 -	LMT	1924 May  2
 # UTC+12 since at least then, too.
 
 Zone Asia/Ust-Nera	 9:32:54 -	LMT	1919 Dec 15
-			 8:00	-	+08	1930 Jun 21
-			 9:00	Russia	+09/+10	1981 Apr  1
-			11:00	Russia	+11/+12	1991 Mar 31  2:00s
-			10:00	Russia	+10/+11	1992 Jan 19  2:00s
-			11:00	Russia	+11/+12	2011 Mar 27  2:00s
-			12:00	-	+12	2011 Sep 13  0:00s # Decree 725?
-			11:00	-	+11	2014 Oct 26  2:00s
-			10:00	-	+10
+			 8:00	-	%z	1930 Jun 21
+			 9:00	Russia	%z	1981 Apr  1
+			11:00	Russia	%z	1991 Mar 31  2:00s
+			10:00	Russia	%z	1992 Jan 19  2:00s
+			11:00	Russia	%z	2011 Mar 27  2:00s
+			12:00	-	%z	2011 Sep 13  0:00s # Decree 725?
+			11:00	-	%z	2014 Oct 26  2:00s
+			10:00	-	%z
 
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2001-08-25):
@@ -9545,12 +11757,12 @@ Zone Asia/Ust-Nera	 9:32:54 -	LMT	1919 Dec 15
 # The Zone name should be Asia/Petropavlovsk-Kamchatski or perhaps
 # Asia/Petropavlovsk-Kamchatsky, but these are too long.
 Zone Asia/Kamchatka	10:34:36 -	LMT	1922 Nov 10
-			11:00	-	+11	1930 Jun 21
-			12:00	Russia	+12/+13	1991 Mar 31  2:00s
-			11:00	Russia	+11/+12	1992 Jan 19  2:00s
-			12:00	Russia	+12/+13	2010 Mar 28  2:00s
-			11:00	Russia	+11/+12	2011 Mar 27  2:00s
-			12:00	-	+12
+			11:00	-	%z	1930 Jun 21
+			12:00	Russia	%z	1991 Mar 31  2:00s
+			11:00	Russia	%z	1992 Jan 19  2:00s
+			12:00	Russia	%z	2010 Mar 28  2:00s
+			11:00	Russia	%z	2011 Mar 27  2:00s
+			12:00	-	%z
 
 
 # From Tim Parenti (2014-07-03):
@@ -9558,20 +11770,22 @@ Zone Asia/Kamchatka	10:34:36 -	LMT	1922 Nov 10
 # 87	RU-CHU	Chukotka Autonomous Okrug
 
 Zone Asia/Anadyr	11:49:56 -	LMT	1924 May  2
-			12:00	-	+12	1930 Jun 21
-			13:00	Russia	+13/+14	1982 Apr  1  0:00s
-			12:00	Russia	+12/+13	1991 Mar 31  2:00s
-			11:00	Russia	+11/+12	1992 Jan 19  2:00s
-			12:00	Russia	+12/+13	2010 Mar 28  2:00s
-			11:00	Russia	+11/+12	2011 Mar 27  2:00s
-			12:00	-	+12
+			12:00	-	%z	1930 Jun 21
+			13:00	Russia	%z	1982 Apr  1  0:00s
+			12:00	Russia	%z	1991 Mar 31  2:00s
+			11:00	Russia	%z	1992 Jan 19  2:00s
+			12:00	Russia	%z	2010 Mar 28  2:00s
+			11:00	Russia	%z	2011 Mar 27  2:00s
+			12:00	-	%z
 
-
-# San Marino
-# See Europe/Rome.
-
+# Bosnia & Herzegovina
+# Croatia
+# Kosovo
+# Montenegro
+# North Macedonia
 # Serbia
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Slovenia
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Belgrade	1:22:00	-	LMT	1884
 			1:00	-	CET	1941 Apr 18 23:00
 			1:00	C-Eur	CE%sT	1945
@@ -9582,60 +11796,81 @@ Zone	Europe/Belgrade	1:22:00	-	LMT	1884
 # Shanks & Pottenger don't give as much detail, so go with Koželj.
 			1:00	-	CET	1982 Nov 27
 			1:00	EU	CE%sT
-Link Europe/Belgrade Europe/Ljubljana	# Slovenia
-Link Europe/Belgrade Europe/Podgorica	# Montenegro
-Link Europe/Belgrade Europe/Sarajevo	# Bosnia and Herzegovina
-Link Europe/Belgrade Europe/Skopje	# Macedonia
-Link Europe/Belgrade Europe/Zagreb	# Croatia
-
-# Slovakia
-Link Europe/Prague Europe/Bratislava
-
-# Slovenia
-# See Europe/Belgrade.
 
 # Spain
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-# For 1917-1919 Whitman gives Apr Sat>=1 - Oct Sat>=1;
-# go with Shanks & Pottenger.
-Rule	Spain	1917	only	-	May	 5	23:00s	1:00	S
-Rule	Spain	1917	1919	-	Oct	 6	23:00s	0	-
-Rule	Spain	1918	only	-	Apr	15	23:00s	1:00	S
-Rule	Spain	1919	only	-	Apr	 5	23:00s	1:00	S
-# Whitman gives 1921 Feb 28 - Oct 14; go with Shanks & Pottenger.
-Rule	Spain	1924	only	-	Apr	16	23:00s	1:00	S
-# Whitman gives 1924 Oct 14; go with Shanks & Pottenger.
-Rule	Spain	1924	only	-	Oct	 4	23:00s	0	-
-Rule	Spain	1926	only	-	Apr	17	23:00s	1:00	S
-# Whitman says no DST in 1929; go with Shanks & Pottenger.
-Rule	Spain	1926	1929	-	Oct	Sat>=1	23:00s	0	-
-Rule	Spain	1927	only	-	Apr	 9	23:00s	1:00	S
-Rule	Spain	1928	only	-	Apr	14	23:00s	1:00	S
-Rule	Spain	1929	only	-	Apr	20	23:00s	1:00	S
-# Whitman gives 1937 Jun 16, 1938 Apr 16, 1940 Apr 13;
-# go with Shanks & Pottenger.
-Rule	Spain	1937	only	-	May	22	23:00s	1:00	S
-Rule	Spain	1937	1939	-	Oct	Sat>=1	23:00s	0	-
-Rule	Spain	1938	only	-	Mar	22	23:00s	1:00	S
-Rule	Spain	1939	only	-	Apr	15	23:00s	1:00	S
-Rule	Spain	1940	only	-	Mar	16	23:00s	1:00	S
-# Whitman says no DST 1942-1945; go with Shanks & Pottenger.
-Rule	Spain	1942	only	-	May	 2	22:00s	2:00	M # Midsummer
-Rule	Spain	1942	only	-	Sep	 1	22:00s	1:00	S
-Rule	Spain	1943	1946	-	Apr	Sat>=13	22:00s	2:00	M
-Rule	Spain	1943	only	-	Oct	 3	22:00s	1:00	S
-Rule	Spain	1944	only	-	Oct	10	22:00s	1:00	S
-Rule	Spain	1945	only	-	Sep	30	 1:00	1:00	S
-Rule	Spain	1946	only	-	Sep	30	 0:00	0	-
+#
+# From Paul Eggert (2016-12-14):
+#
+# The source for Europe/Madrid before 2013 is:
+# Planesas P. La hora oficial en España y sus cambios.
+# Anuario del Observatorio Astronómico de Madrid (2013, in Spanish).
+# http://astronomia.ign.es/rknowsys-theme/images/webAstro/paginas/documentos/Anuario/lahoraoficialenespana.pdf
+# As this source says that historical time in the Canaries is obscure,
+# and it does not discuss Ceuta, stick with Shanks for now for that data.
+#
+# In the 1918 and 1919 fallback transitions in Spain, the clock for
+# the hour-longer day officially kept going after midnight, so that
+# the repeated instances of that day's 00:00 hour were 24 hours apart,
+# with a fallback transition from the second occurrence of 00:59... to
+# the next day's 00:00.  Our data format cannot represent this
+# directly, and instead repeats the first hour of the next day, with a
+# fallback transition from the next day's 00:59... to 00:00.
+
+# From Michael Deckers (2016-12-15):
+# The Royal Decree of 1900-07-26 quoted by Planesas, online at
+# https://www.boe.es/datos/pdfs/BOE//1900/209/A00383-00384.pdf
+# says in its article 5 (my translation):
+# These dispositions will enter into force beginning with the
+# instant at which, according to the time indicated in article 1,
+# the 1st day of January of 1901 will begin.
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Spain	1918	only	-	Apr	15	23:00	1:00	S
+Rule	Spain	1918	1919	-	Oct	 6	24:00s	0	-
+Rule	Spain	1919	only	-	Apr	 6	23:00	1:00	S
+Rule	Spain	1924	only	-	Apr	16	23:00	1:00	S
+Rule	Spain	1924	only	-	Oct	 4	24:00s	0	-
+Rule	Spain	1926	only	-	Apr	17	23:00	1:00	S
+Rule	Spain	1926	1929	-	Oct	Sat>=1	24:00s	0	-
+Rule	Spain	1927	only	-	Apr	 9	23:00	1:00	S
+Rule	Spain	1928	only	-	Apr	15	 0:00	1:00	S
+Rule	Spain	1929	only	-	Apr	20	23:00	1:00	S
+# Republican Spain during the civil war; it controlled Madrid until 1939-03-28.
+Rule	Spain	1937	only	-	Jun	16	23:00	1:00	S
+Rule	Spain	1937	only	-	Oct	 2	24:00s	0	-
+Rule	Spain	1938	only	-	Apr	 2	23:00	1:00	S
+Rule	Spain	1938	only	-	Apr	30	23:00	2:00	M
+Rule	Spain	1938	only	-	Oct	 2	24:00	1:00	S
+# The following rules are for unified Spain again.
+#
+# Planesas does not say what happened in Madrid between its fall on
+# 1939-03-28 and the Nationalist spring-forward transition on
+# 1939-04-15.  For lack of better info, assume Madrid's clocks did not
+# change during that period.
+#
+# The first rule is commented out, as it is redundant for Republican Spain.
+#Rule	Spain	1939	only	-	Apr	15	23:00	1:00	S
+Rule	Spain	1939	only	-	Oct	 7	24:00s	0	-
+Rule	Spain	1942	only	-	May	 2	23:00	1:00	S
+Rule	Spain	1942	only	-	Sep	 1	 1:00	0	-
+Rule	Spain	1943	1946	-	Apr	Sat>=13	23:00	1:00	S
+Rule	Spain	1943	1944	-	Oct	Sun>=1	 1:00	0	-
+Rule	Spain	1945	1946	-	Sep	lastSun	 1:00	0	-
 Rule	Spain	1949	only	-	Apr	30	23:00	1:00	S
-Rule	Spain	1949	only	-	Sep	30	 1:00	0	-
-Rule	Spain	1974	1975	-	Apr	Sat>=13	23:00	1:00	S
+Rule	Spain	1949	only	-	Oct	 2	 1:00	0	-
+Rule	Spain	1974	1975	-	Apr	Sat>=12	23:00	1:00	S
 Rule	Spain	1974	1975	-	Oct	Sun>=1	 1:00	0	-
 Rule	Spain	1976	only	-	Mar	27	23:00	1:00	S
 Rule	Spain	1976	1977	-	Sep	lastSun	 1:00	0	-
-Rule	Spain	1977	1978	-	Apr	 2	23:00	1:00	S
-Rule	Spain	1978	only	-	Oct	 1	 1:00	0	-
-# The following rules are copied from Morocco from 1967 through 1978.
+Rule	Spain	1977	only	-	Apr	 2	23:00	1:00	S
+Rule	Spain	1978	only	-	Apr	 2	 2:00s	1:00	S
+Rule	Spain	1978	only	-	Oct	 1	 2:00s	0	-
+# Nationalist Spain during the civil war
+#Rule NatSpain	1937	only	-	May	22	23:00	1:00	S
+#Rule NatSpain	1937	1938	-	Oct	Sat>=1	24:00s	0	-
+#Rule NatSpain	1938	only	-	Mar	26	23:00	1:00	S
+# The following rules are copied from Morocco from 1967 through 1978,
+# except with "S" letters.
 Rule SpainAfrica 1967	only	-	Jun	 3	12:00	1:00	S
 Rule SpainAfrica 1967	only	-	Oct	 1	 0:00	0	-
 Rule SpainAfrica 1974	only	-	Jun	24	 0:00	1:00	S
@@ -9645,87 +11880,38 @@ Rule SpainAfrica 1976	only	-	Aug	 1	 0:00	0	-
 Rule SpainAfrica 1977	only	-	Sep	28	 0:00	0	-
 Rule SpainAfrica 1978	only	-	Jun	 1	 0:00	1:00	S
 Rule SpainAfrica 1978	only	-	Aug	 4	 0:00	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Europe/Madrid	-0:14:44 -	LMT	1901 Jan  1  0:00s
-			 0:00	Spain	WE%sT	1946 Sep 30
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	Europe/Madrid	-0:14:44 -	LMT	1901 Jan  1  0:00u
+			 0:00	Spain	WE%sT	1940 Mar 16 23:00
 			 1:00	Spain	CE%sT	1979
 			 1:00	EU	CE%sT
-Zone	Africa/Ceuta	-0:21:16 -	LMT	1901
+Zone	Africa/Ceuta	-0:21:16 -	LMT	1901 Jan  1  0:00u
 			 0:00	-	WET	1918 May  6 23:00
 			 0:00	1:00	WEST	1918 Oct  7 23:00
 			 0:00	-	WET	1924
 			 0:00	Spain	WE%sT	1929
+			 0:00	-	WET	1967 # Help zishrink.awk.
 			 0:00 SpainAfrica WE%sT	1984 Mar 16
 			 1:00	-	CET	1986
 			 1:00	EU	CE%sT
 Zone	Atlantic/Canary	-1:01:36 -	LMT	1922 Mar # Las Palmas de Gran C.
-			-1:00	-	CANT	1946 Sep 30  1:00 # Canaries T
+			-1:00	-	%z	1946 Sep 30  1:00
 			 0:00	-	WET	1980 Apr  6  0:00s
 			 0:00	1:00	WEST	1980 Sep 28  1:00u
 			 0:00	EU	WE%sT
 # IATA SSIM (1996-09) says the Canaries switch at 2:00u, not 1:00u.
 # Ignore this for now, as the Canaries are part of the EU.
 
-# Sweden
 
-# From Ivan Nilsson (2001-04-13), superseding Shanks & Pottenger:
-#
-# The law "Svensk författningssamling 1878, no 14" about standard time in 1879:
-# From the beginning of 1879 (that is 01-01 00:00) the time for all
-# places in the country is "the mean solar time for the meridian at
-# three degrees, or twelve minutes of time, to the west of the
-# meridian of the Observatory of Stockholm".  The law is dated 1878-05-31.
-#
-# The observatory at that time had the meridian 18 degrees 03' 30"
-# eastern longitude = 01:12:14 in time.  Less 12 minutes gives the
-# national standard time as 01:00:14 ahead of GMT....
-#
-# About the beginning of CET in Sweden. The lawtext ("Svensk
-# författningssamling 1899, no 44") states, that "from the beginning
-# of 1900... ... the same as the mean solar time for the meridian at
-# the distance of one hour of time from the meridian of the English
-# observatory at Greenwich, or at 12 minutes 14 seconds to the west
-# from the meridian of the Observatory of Stockholm". The law is dated
-# 1899-06-16.  In short: At 1900-01-01 00:00:00 the new standard time
-# in Sweden is 01:00:00 ahead of GMT.
-#
-# 1916: The lawtext ("Svensk författningssamling 1916, no 124") states
-# that "1916-05-15 is considered to begin one hour earlier". It is
-# pretty obvious that at 05-14 23:00 the clocks are set to 05-15 00:00....
-# Further the law says, that "1916-09-30 is considered to end one hour later".
-#
-# The laws regulating [DST] are available on the site of the Swedish
-# Parliament beginning with 1985 - the laws regulating 1980/1984 are
-# not available on the site (to my knowledge they are only available
-# in Swedish): <http://www.riksdagen.se/english/work/sfst.asp> (type
-# "sommartid" without the quotes in the field "Fritext" and then click
-# the Sök-button).
-#
-# (2001-05-13):
-#
-# I have now found a newspaper stating that at 1916-10-01 01:00
-# summertime the church-clocks etc were set back one hour to show
-# 1916-10-01 00:00 standard time.  The article also reports that some
-# people thought the switch to standard time would take place already
-# at 1916-10-01 00:00 summer time, but they had to wait for another
-# hour before the event took place.
-#
-# Source: The newspaper "Dagens Nyheter", 1916-10-01, page 7 upper left.
-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Europe/Stockholm	1:12:12 -	LMT	1879 Jan  1
-			1:00:14	-	SET	1900 Jan  1 # Swedish Time
-			1:00	-	CET	1916 May 14 23:00
-			1:00	1:00	CEST	1916 Oct  1  1:00
-			1:00	-	CET	1980
-			1:00	EU	CE%sT
-
+# Germany (Busingen enclave)
+# Liechtenstein
 # Switzerland
+#
 # From Howse:
 # By the end of the 18th century clocks and watches became commonplace
 # and their performance improved enormously.  Communities began to keep
 # mean time in preference to apparent time - Geneva from 1780 ....
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 # From Whitman (who writes "Midnight?"):
 # Rule	Swiss	1940	only	-	Nov	 2	0:00	1:00	S
 # Rule	Swiss	1940	only	-	Dec	31	0:00	0	-
@@ -9779,8 +11965,8 @@ Zone Europe/Stockholm	1:12:12 -	LMT	1879 Jan  1
 #
 # From Alois Treindl (2013-09-11):
 # The Federal regulations say
-# http://www.admin.ch/opc/de/classified-compilation/20071096/index.html
-# ... the meridian for Bern mean time ... is 7 degrees 26' 22.50".
+# https://www.admin.ch/opc/de/classified-compilation/20071096/index.html
+# ... the meridian for Bern mean time ... is 7° 26' 22.50".
 # Expressed in time, it is 0h29m45.5s.
 
 # From Pierre-Yves Berger (2013-09-11):
@@ -9790,8 +11976,8 @@ Zone Europe/Stockholm	1:12:12 -	LMT	1879 Jan  1
 # but if no one is present after 11 at night, could be postponed until one
 # hour before the beginning of service.
 
-# From Paul Eggert (2013-09-11):
-# Round BMT to the nearest even second, 0:29:46.
+# From Paul Eggert (2024-05-24):
+# Express BMT as 0:29:45.500, approximately the same precision 7° 26' 22.50".
 #
 # We can find no reliable source for Shanks's assertion that all of Switzerland
 # except Geneva switched to Bern Mean Time at 00:00 on 1848-09-12.  This book:
@@ -9812,35 +11998,104 @@ Zone Europe/Stockholm	1:12:12 -	LMT	1879 Jan  1
 # 1853-07-16, though it probably occurred at some other date in Zurich, and
 # legal civil time probably changed at still some other transition date.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# From Tobias Conradi (2011-09-12):
+# Büsingen <http://www.buesingen.de>, surrounded by the Swiss canton
+# Schaffhausen, did not start observing DST in 1980 as the rest of DE
+# (West Germany at that time) and DD (East Germany at that time) did.
+# DD merged into DE, the area is currently covered by code DE in ISO 3166-1,
+# which in turn is covered by the zone Europe/Berlin.
+#
+# Source for the time in Büsingen 1980:
+# http://www.srf.ch/player/video?id=c012c029-03b7-4c2b-9164-aa5902cd58d3
+#
+# From Arthur David Olson (2012-03-03):
+# Büsingen and Zurich have shared clocks since 1970.
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Swiss	1941	1942	-	May	Mon>=1	1:00	1:00	S
 Rule	Swiss	1941	1942	-	Oct	Mon>=1	2:00	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Zurich	0:34:08 -	LMT	1853 Jul 16 # See above comment.
+		#STDOFF	0:29:45.500
 			0:29:46	-	BMT	1894 Jun    # Bern Mean Time
 			1:00	Swiss	CE%sT	1981
 			1:00	EU	CE%sT
 
 # Turkey
 
+# From Alois Treindl (2019-08-12):
+# http://www.astrolojidergisi.com/yazsaati.htm has researched the time zone
+# history of Turkey, based on newspaper archives and official documents.
+# From Paul Eggert (2019-08-28):
+# That source (Oya Vulaş, "Türkiye'de Yaz Saati Uygulamaları")
+# is used for 1940/1972, where it seems more reliable than our other
+# sources.
+
+# From Kıvanç Yazan (2019-08-12):
+# http://www.resmigazete.gov.tr/arsiv/14539.pdf#page=24
+# 1973-06-03 01:00 -> 02:00, 1973-11-04 02:00 -> 01:00
+#
+# http://www.resmigazete.gov.tr/arsiv/14829.pdf#page=1
+# 1974-03-31 02:00 -> 03:00, 1974-11-03 02:00 -> 01:00
+#
+# http://www.resmigazete.gov.tr/arsiv/15161.pdf#page=1
+# 1975-03-22 02:00 -> 03:00, 1975-11-02 02:00 -> 01:00
+#
+# http://www.resmigazete.gov.tr/arsiv/15535_1.pdf#page=1
+# 1976-03-21 02:00 -> 03:00, 1976-10-31 02:00 -> 01:00
+#
+# http://www.resmigazete.gov.tr/arsiv/15778.pdf#page=5
+# 1977-04-03 02:00 -> 03:00, 1977-10-16 02:00 -> 01:00,
+# 1978-04-02 02:00 -> 03:00 (not applied, see below)
+# 1978-10-15 02:00 -> 01:00 (not applied, see below)
+# 1979-04-01 02:00 -> 03:00 (not applied, see below)
+# 1979-10-14 02:00 -> 01:00 (not applied, see below)
+#
+# http://www.resmigazete.gov.tr/arsiv/16245.pdf#page=17
+# This cancels the previous decision, and repeats it only for 1978.
+# 1978-04-02 02:00 -> 03:00, 1978-10-15 02:00 -> 01:00
+# (not applied due to standard TZ change below)
+#
+# http://www.resmigazete.gov.tr/arsiv/16331.pdf#page=3
+# This decision changes the default longitude for Turkish time zone from 30
+# degrees East to 45 degrees East.  This means a standard TZ change, from +2
+# to +3.  This is published & applied on 1978-06-29.  At that time, Turkey was
+# already on summer time (already on 45E).  Hence, this new law just meant an
+# "continuous summer time".  Note that this was reversed in a few years.
+#
+# http://www.resmigazete.gov.tr/arsiv/18119_1.pdf#page=1
+# 1983-07-31 02:00 -> 03:00 (note that this jumps TZ to +4)
+# 1983-10-02 02:00 -> 01:00 (back to +3)
+#
+# http://www.resmigazete.gov.tr/arsiv/18561.pdf (page 1 and 34)
+# At this time, Turkey is still on +3 with no spring-forward on early
+# 1984.  This decision is published on 10/31/1984.  Page 1 declares
+# the decision of reverting the "default longitude change".  So the
+# standard time should go back to +3 (30E).  And page 34 explains when
+# that will happen: 1984-11-01 02:00 -> 01:00.  You can think of this
+# as "end of continuous summer time, change of standard time zone".
+#
+# http://www.resmigazete.gov.tr/arsiv/18713.pdf#page=1
+# 1985-04-20 01:00 -> 02:00, 1985-09-28 02:00 -> 01:00
+
 # From Kıvanç Yazan (2016-09-25):
 # 1) For 1986-2006, DST started at 01:00 local and ended at 02:00 local, with
 #    no exceptions.
 # 2) 1994's lastSun was overridden with Mar 20 ...
 # Here are official papers:
-# http://www.resmigazete.gov.tr/arsiv/19032.pdf  - page 2 for 1986
-# http://www.resmigazete.gov.tr/arsiv/19400.pdf  - page 4 for 1987
-# http://www.resmigazete.gov.tr/arsiv/19752.pdf  - page 15 for 1988
-# http://www.resmigazete.gov.tr/arsiv/20102.pdf  - page 6 for 1989
-# http://www.resmigazete.gov.tr/arsiv/20464.pdf  - page 1 for 1990 - 1992
-# http://www.resmigazete.gov.tr/arsiv/21531.pdf  - page 15 for 1993 - 1995
-# http://www.resmigazete.gov.tr/arsiv/21879.pdf  - page 1 for overriding 1994
-# http://www.resmigazete.gov.tr/arsiv/22588.pdf  - page 1 for 1996, 1997
-# http://www.resmigazete.gov.tr/arsiv/23286.pdf  - page 10 for 1998 - 2000
+# http://www.resmigazete.gov.tr/arsiv/19032.pdf#page=2 for 1986
+# http://www.resmigazete.gov.tr/arsiv/19400.pdf#page=4 for 1987
+# http://www.resmigazete.gov.tr/arsiv/19752.pdf#page=15 for 1988
+# http://www.resmigazete.gov.tr/arsiv/20102.pdf#page=6 for 1989
+# http://www.resmigazete.gov.tr/arsiv/20464.pdf#page=1 for 1990 - 1992
+# http://www.resmigazete.gov.tr/arsiv/21531.pdf#page=15 for 1993 - 1995
+# http://www.resmigazete.gov.tr/arsiv/21879.pdf#page=1 for overriding 1994
+# http://www.resmigazete.gov.tr/arsiv/22588.pdf#page=1 for 1996, 1997
+# http://www.resmigazete.gov.tr/arsiv/23286.pdf#page=10 for 1998 - 2000
 # http://www.resmigazete.gov.tr/eskiler/2001/03/20010324.htm#2  - for 2001
 # http://www.resmigazete.gov.tr/eskiler/2002/03/20020316.htm#2  - for 2002-2006
 # From Paul Eggert (2016-09-25):
-# Prefer the above sources to Shanks & Pottenger for time stamps after 1985.
+# Prefer the above sources to Shanks & Pottenger for timestamps after 1985.
 
 # From Steffen Thorsen (2007-03-09):
 # Starting 2007 though, it seems that they are adopting EU's 1:00 UTC
@@ -9856,9 +12111,9 @@ Zone	Europe/Zurich	0:34:08 -	LMT	1853 Jul 16 # See above comment.
 # According to the articles linked below, Turkey will change into summer
 # time zone (GMT+3) on March 28, 2011 at 3:00 a.m. instead of March 27.
 # This change is due to a nationwide exam on 27th.
-# http://www.worldbulletin.net/?aType=haber&ArticleID=70872
+# https://www.worldbulletin.net/?aType=haber&ArticleID=70872
 # Turkish:
-# http://www.hurriyet.com.tr/ekonomi/17230464.asp?gid=373
+# https://www.hurriyet.com.tr/yaz-saati-uygulamasi-bir-gun-ileri-alindi-17230464
 
 # From Faruk Pasin (2014-02-14):
 # The DST for Turkey has been changed for this year because of the
@@ -9895,7 +12150,18 @@ Zone	Europe/Zurich	0:34:08 -	LMT	1853 Jul 16 # See above comment.
 # The change is permanent, so this is the new standard time in Turkey.
 # It takes effect today, which is not much notice.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# From Kıvanç Yazan (2017-10-28):
+# Turkey will go back to Daylight Saving Time starting 2018-10.
+# http://www.resmigazete.gov.tr/eskiler/2017/10/20171028-5.pdf
+#
+# From Even Scharning (2017-11-08):
+# ... today it was announced that the DST will become "continuous":
+# http://www.hurriyet.com.tr/son-dakika-yaz-saati-uygulamasi-surekli-hale-geldi-40637482
+# From Paul Eggert (2017-11-08):
+# Although Google Translate misfires on that source, it looks like
+# Turkey reversed last month's decision, and so will stay at +03.
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Turkey	1916	only	-	May	 1	0:00	1:00	S
 Rule	Turkey	1916	only	-	Oct	 1	0:00	0	-
 Rule	Turkey	1920	only	-	Mar	28	0:00	1:00	S
@@ -9909,56 +12175,46 @@ Rule	Turkey	1922	only	-	Oct	 8	0:00	0	-
 Rule	Turkey	1924	only	-	May	13	0:00	1:00	S
 Rule	Turkey	1924	1925	-	Oct	 1	0:00	0	-
 Rule	Turkey	1925	only	-	May	 1	0:00	1:00	S
-Rule	Turkey	1940	only	-	Jun	30	0:00	1:00	S
-Rule	Turkey	1940	only	-	Oct	 5	0:00	0	-
+Rule	Turkey	1940	only	-	Jul	 1	0:00	1:00	S
+Rule	Turkey	1940	only	-	Oct	 6	0:00	0	-
 Rule	Turkey	1940	only	-	Dec	 1	0:00	1:00	S
 Rule	Turkey	1941	only	-	Sep	21	0:00	0	-
 Rule	Turkey	1942	only	-	Apr	 1	0:00	1:00	S
-# Whitman omits the next two transition and gives 1945 Oct 1;
-# go with Shanks & Pottenger.
-Rule	Turkey	1942	only	-	Nov	 1	0:00	0	-
-Rule	Turkey	1945	only	-	Apr	 2	0:00	1:00	S
 Rule	Turkey	1945	only	-	Oct	 8	0:00	0	-
 Rule	Turkey	1946	only	-	Jun	 1	0:00	1:00	S
 Rule	Turkey	1946	only	-	Oct	 1	0:00	0	-
 Rule	Turkey	1947	1948	-	Apr	Sun>=16	0:00	1:00	S
-Rule	Turkey	1947	1950	-	Oct	Sun>=2	0:00	0	-
+Rule	Turkey	1947	1951	-	Oct	Sun>=2	0:00	0	-
 Rule	Turkey	1949	only	-	Apr	10	0:00	1:00	S
-Rule	Turkey	1950	only	-	Apr	19	0:00	1:00	S
+Rule	Turkey	1950	only	-	Apr	16	0:00	1:00	S
 Rule	Turkey	1951	only	-	Apr	22	0:00	1:00	S
-Rule	Turkey	1951	only	-	Oct	 8	0:00	0	-
+# DST for 15 months; unusual but we'll let it pass.
 Rule	Turkey	1962	only	-	Jul	15	0:00	1:00	S
-Rule	Turkey	1962	only	-	Oct	 8	0:00	0	-
+Rule	Turkey	1963	only	-	Oct	30	0:00	0	-
 Rule	Turkey	1964	only	-	May	15	0:00	1:00	S
 Rule	Turkey	1964	only	-	Oct	 1	0:00	0	-
-Rule	Turkey	1970	1972	-	May	Sun>=2	0:00	1:00	S
-Rule	Turkey	1970	1972	-	Oct	Sun>=2	0:00	0	-
 Rule	Turkey	1973	only	-	Jun	 3	1:00	1:00	S
-Rule	Turkey	1973	only	-	Nov	 4	3:00	0	-
+Rule	Turkey	1973	1976	-	Oct	Sun>=31	2:00	0	-
 Rule	Turkey	1974	only	-	Mar	31	2:00	1:00	S
-Rule	Turkey	1974	only	-	Nov	 3	5:00	0	-
-Rule	Turkey	1975	only	-	Mar	30	0:00	1:00	S
-Rule	Turkey	1975	1976	-	Oct	lastSun	0:00	0	-
-Rule	Turkey	1976	only	-	Jun	 1	0:00	1:00	S
-Rule	Turkey	1977	1978	-	Apr	Sun>=1	0:00	1:00	S
-Rule	Turkey	1977	only	-	Oct	16	0:00	0	-
-Rule	Turkey	1979	1980	-	Apr	Sun>=1	3:00	1:00	S
-Rule	Turkey	1979	1982	-	Oct	Mon>=11	0:00	0	-
-Rule	Turkey	1981	1982	-	Mar	lastSun	3:00	1:00	S
-Rule	Turkey	1983	only	-	Jul	31	0:00	1:00	S
-Rule	Turkey	1983	only	-	Oct	 2	0:00	0	-
-Rule	Turkey	1985	only	-	Apr	20	0:00	1:00	S
-Rule	Turkey	1985	only	-	Sep	28	0:00	0	-
+Rule	Turkey	1975	only	-	Mar	22	2:00	1:00	S
+Rule	Turkey	1976	only	-	Mar	21	2:00	1:00	S
+Rule	Turkey	1977	1978	-	Apr	Sun>=1	2:00	1:00	S
+Rule	Turkey	1977	1978	-	Oct	Sun>=15	2:00	0	-
+Rule	Turkey	1978	only	-	Jun	29	0:00	0	-
+Rule	Turkey	1983	only	-	Jul	31	2:00	1:00	S
+Rule	Turkey	1983	only	-	Oct	 2	2:00	0	-
+Rule	Turkey	1985	only	-	Apr	20	1:00s	1:00	S
+Rule	Turkey	1985	only	-	Sep	28	1:00s	0	-
 Rule	Turkey	1986	1993	-	Mar	lastSun	1:00s	1:00	S
 Rule	Turkey	1986	1995	-	Sep	lastSun	1:00s	0	-
 Rule	Turkey	1994	only	-	Mar	20	1:00s	1:00	S
 Rule	Turkey	1995	2006	-	Mar	lastSun	1:00s	1:00	S
 Rule	Turkey	1996	2006	-	Oct	lastSun	1:00s	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Istanbul	1:55:52 -	LMT	1880
 			1:56:56	-	IMT	1910 Oct # Istanbul Mean Time?
-			2:00	Turkey	EE%sT	1978 Oct 15
-			3:00	Turkey	+03/+04	1985 Apr 20
+			2:00	Turkey	EE%sT	1978 Jun 29
+			3:00	Turkey	%z	1984 Nov  1  2:00
 			2:00	Turkey	EE%sT	2007
 			2:00	EU	EE%sT	2011 Mar 27  1:00u
 			2:00	-	EET	2011 Mar 28  1:00u
@@ -9967,11 +12223,27 @@ Zone	Europe/Istanbul	1:55:52 -	LMT	1880
 			2:00	EU	EE%sT	2015 Oct 25  1:00u
 			2:00	1:00	EEST	2015 Nov  8  1:00u
 			2:00	EU	EE%sT	2016 Sep  7
-			3:00	-	+03
-Link	Europe/Istanbul	Asia/Istanbul	# Istanbul is in both continents.
+			3:00	-	%z
 
 # Ukraine
 #
+# From Alois Treindl (2014-03-01):
+# REGULATION A N O V A on March 20, 1992 N 139 ...  means that from
+# 1992 on, Ukraine had DST with begin time at 02:00 am, on last Sunday
+# in March, and end time 03:00 am, last Sunday in September....
+# CABINET OF MINISTERS OF UKRAINE RESOLUTION on May 13, 1996 N 509
+# "On the order of computation time on the territory of Ukraine" ....
+# As this cabinet decision is from May 1996, it seems likely that the
+# transition in March 1996, which predates it, was still at 2:00 am
+# and not at 3:00 as would have been under EU rules.
+# This is why I have set the change to EU rules into May 1996,
+# so that the change in March is stil covered by the Ukraine rule.
+# The next change in October 1996 happened under EU rules.
+#
+# From Paul Eggert (2022-08-27):
+# For now, assume that Ukraine's zones all followed the same rules,
+# except that Crimea switched to Moscow time in 1994 as described elsewhere.
+
 # From Igor Karpov, who works for the Ukrainian Ministry of Justice,
 # via Garrett Wollman (2003-01-27):
 # BTW, I've found the official document on this matter. It's government
@@ -9994,7 +12266,7 @@ Link	Europe/Istanbul	Asia/Istanbul	# Istanbul is in both continents.
 # http://www.segodnya.ua/news/14290482.html
 #
 # Deputies cancelled the winter time (in Russian)
-# http://www.pravda.com.ua/rus/news/2011/09/20/6600616/
+# https://www.pravda.com.ua/rus/news/2011/09/20/6600616/
 #
 # From Philip Pizzey (2011-10-18):
 # Today my Ukrainian colleagues have informed me that the
@@ -10011,7 +12283,7 @@ Link	Europe/Istanbul	Asia/Istanbul	# Istanbul is in both continents.
 # The law documents themselves are at
 # http://w1.c1.rada.gov.ua/pls/zweb_n/webproc4_1?id=&pf3511=41484
 
-# From Vladimir in Moscow via Alois Treindl re Kiev time 1991/2 (2014-02-28):
+# From Vladimir in Moscow via Alois Treindl re Kyiv time 1991/2 (2014-02-28):
 # First in Ukraine they changed Time zone from UTC+3 to UTC+2 with DST:
 #       03 25 1990 02:00 -03.00 1       Time Zone 3 with DST
 #       07 01 1990 02:00 -02.00 1       Time Zone 2 with DST
@@ -10039,49 +12311,16 @@ Link	Europe/Istanbul	Asia/Istanbul	# Istanbul is in both continents.
 # * Ukrainian Government's Resolution of 20.03.1992, No. 139.
 # http://www.uazakon.com/documents/date_8u/pg_grcasa.htm
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-# Most of Ukraine since 1970 has been like Kiev.
-# "Kyiv" is the transliteration of the Ukrainian name, but
-# "Kiev" is more common in English.
-Zone Europe/Kiev	2:02:04 -	LMT	1880
-			2:02:04	-	KMT	1924 May  2 # Kiev Mean Time
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone Europe/Kyiv	2:02:04 -	LMT	1880
+			2:02:04	-	KMT	1924 May  2 # Kyiv Mean Time
 			2:00	-	EET	1930 Jun 21
 			3:00	-	MSK	1941 Sep 20
 			1:00	C-Eur	CE%sT	1943 Nov  6
 			3:00	Russia	MSK/MSD	1990 Jul  1  2:00
 			2:00	1:00	EEST	1991 Sep 29  3:00
-			2:00	E-Eur	EE%sT	1995
+			2:00	C-Eur	EE%sT	1996 May 13
 			2:00	EU	EE%sT
-# Ruthenia used CET 1990/1991.
-# "Uzhhorod" is the transliteration of the Rusyn/Ukrainian pronunciation, but
-# "Uzhgorod" is more common in English.
-Zone Europe/Uzhgorod	1:29:12 -	LMT	1890 Oct
-			1:00	-	CET	1940
-			1:00	C-Eur	CE%sT	1944 Oct
-			1:00	1:00	CEST	1944 Oct 26
-			1:00	-	CET	1945 Jun 29
-			3:00	Russia	MSK/MSD	1990
-			3:00	-	MSK	1990 Jul  1  2:00
-			1:00	-	CET	1991 Mar 31  3:00
-			2:00	-	EET	1992
-			2:00	E-Eur	EE%sT	1995
-			2:00	EU	EE%sT
-# Zaporozh'ye and eastern Lugansk oblasts observed DST 1990/1991.
-# "Zaporizhia" is the transliteration of the Ukrainian name, but
-# "Zaporozh'ye" is more common in English.  Use the common English
-# spelling, except omit the apostrophe as it is not allowed in
-# portable Posix file names.
-Zone Europe/Zaporozhye	2:20:40 -	LMT	1880
-			2:20	-	CUT	1924 May  2 # Central Ukraine T
-			2:00	-	EET	1930 Jun 21
-			3:00	-	MSK	1941 Aug 25
-			1:00	C-Eur	CE%sT	1943 Oct 25
-			3:00	Russia	MSK/MSD	1991 Mar 31  2:00
-			2:00	E-Eur	EE%sT	1995
-			2:00	EU	EE%sT
-
-# Vatican City
-# See Europe/Rome.
 
 ###############################################################################
 
@@ -10156,15 +12395,16 @@ Zone Europe/Zaporozhye	2:20:40 -	LMT	1880
 # ...
 # Monaco: has same DST as France.
 # ...
+# tzdb data for ships at sea and other miscellany
+
 # This file is in the public domain, so clarified as of
 # 2009-05-17 by Arthur David Olson.
 
-# These entries are mostly present for historical reasons, so that
-# people in areas not otherwise covered by the tz files could "zic -l"
-# to a time zone that was right for their area.  These days, the
-# tz files cover almost all the inhabited world, and the only practical
-# need now for the entries that are not on UTC are for ships at sea
-# that cannot use POSIX TZ settings.
+# These entries are for uses not otherwise covered by the tz database.
+# Their main practical use is for platforms like Android that lack
+# support for POSIX proleptic TZ strings.  On such platforms these entries
+# can be useful if the timezone database is wrong or if a ship or
+# aircraft at sea is not in a timezone.
 
 # Starting with POSIX 1003.1-2001, the entries below are all
 # unnecessary as settings for the TZ environment variable.  E.g.,
@@ -10173,23 +12413,23 @@ Zone Europe/Zaporozhye	2:20:40 -	LMT	1880
 # Do not use a POSIX TZ setting like TZ='GMT+4', which is four hours
 # behind GMT but uses the completely misleading abbreviation "GMT".
 
-Zone	Etc/GMT		0	-	GMT
+# The following zone is used by tzcode functions like gmtime,
+# which load the "UTC" file to handle seconds properly.
 Zone	Etc/UTC		0	-	UTC
-Zone	Etc/UCT		0	-	UCT
+
+# Functions like gmtime load the "GMT" file to handle leap seconds properly.
+# Vanguard section, which works with most .zi parsers.
+#Zone	GMT		0	-	GMT
+# Rearguard section, for TZUpdater 2.3.2 and earlier.
+Zone	Etc/GMT		0	-	GMT
 
 # The following link uses older naming conventions,
 # but it belongs here, not in the file 'backward',
-# as functions like gmtime load the "GMT" file to handle leap seconds properly.
-# We want this to work even on installations that omit the other older names.
+# as it is needed for tzcode releases through 2022a,
+# where functions like gmtime load "GMT" instead of the "Etc/UTC".
+# We want this to work even on installations that omit 'backward'.
 Link	Etc/GMT				GMT
-
-Link	Etc/UTC				Etc/Universal
-Link	Etc/UTC				Etc/Zulu
-
-Link	Etc/GMT				Etc/Greenwich
-Link	Etc/GMT				Etc/GMT-0
-Link	Etc/GMT				Etc/GMT+0
-Link	Etc/GMT				Etc/GMT0
+# End of rearguard section.
 
 # Be consistent with POSIX TZ settings in the Zone names,
 # even though this is the opposite of what many people expect.
@@ -10208,32 +12448,38 @@ Link	Etc/GMT				Etc/GMT0
 # so we moved the names into the Etc subdirectory.
 # Also, the time zone abbreviations are now compatible with %z.
 
-Zone	Etc/GMT-14	14	-	+14
-Zone	Etc/GMT-13	13	-	+13
-Zone	Etc/GMT-12	12	-	+12
-Zone	Etc/GMT-11	11	-	+11
-Zone	Etc/GMT-10	10	-	+10
-Zone	Etc/GMT-9	9	-	+09
-Zone	Etc/GMT-8	8	-	+08
-Zone	Etc/GMT-7	7	-	+07
-Zone	Etc/GMT-6	6	-	+06
-Zone	Etc/GMT-5	5	-	+05
-Zone	Etc/GMT-4	4	-	+04
-Zone	Etc/GMT-3	3	-	+03
-Zone	Etc/GMT-2	2	-	+02
-Zone	Etc/GMT-1	1	-	+01
-Zone	Etc/GMT+1	-1	-	-01
-Zone	Etc/GMT+2	-2	-	-02
-Zone	Etc/GMT+3	-3	-	-03
-Zone	Etc/GMT+4	-4	-	-04
-Zone	Etc/GMT+5	-5	-	-05
-Zone	Etc/GMT+6	-6	-	-06
-Zone	Etc/GMT+7	-7	-	-07
-Zone	Etc/GMT+8	-8	-	-08
-Zone	Etc/GMT+9	-9	-	-09
-Zone	Etc/GMT+10	-10	-	-10
-Zone	Etc/GMT+11	-11	-	-11
-Zone	Etc/GMT+12	-12	-	-12
+# There is no "Etc/Unknown" entry, as CLDR says that "Etc/Unknown"
+# corresponds to an unknown or invalid time zone, and things would get
+# confusing if Etc/Unknown were made valid here.
+
+Zone	Etc/GMT-14	14	-	%z
+Zone	Etc/GMT-13	13	-	%z
+Zone	Etc/GMT-12	12	-	%z
+Zone	Etc/GMT-11	11	-	%z
+Zone	Etc/GMT-10	10	-	%z
+Zone	Etc/GMT-9	9	-	%z
+Zone	Etc/GMT-8	8	-	%z
+Zone	Etc/GMT-7	7	-	%z
+Zone	Etc/GMT-6	6	-	%z
+Zone	Etc/GMT-5	5	-	%z
+Zone	Etc/GMT-4	4	-	%z
+Zone	Etc/GMT-3	3	-	%z
+Zone	Etc/GMT-2	2	-	%z
+Zone	Etc/GMT-1	1	-	%z
+Zone	Etc/GMT+1	-1	-	%z
+Zone	Etc/GMT+2	-2	-	%z
+Zone	Etc/GMT+3	-3	-	%z
+Zone	Etc/GMT+4	-4	-	%z
+Zone	Etc/GMT+5	-5	-	%z
+Zone	Etc/GMT+6	-6	-	%z
+Zone	Etc/GMT+7	-7	-	%z
+Zone	Etc/GMT+8	-8	-	%z
+Zone	Etc/GMT+9	-9	-	%z
+Zone	Etc/GMT+10	-10	-	%z
+Zone	Etc/GMT+11	-11	-	%z
+Zone	Etc/GMT+12	-12	-	%z
+# tzdb data for North and Central America and environs
+
 # This file is in the public domain, so clarified as of
 # 2009-05-17 by Arthur David Olson.
 
@@ -10261,9 +12507,12 @@ Zone	Etc/GMT+12	-12	-	-12
 # in New York City (1869-10).  His 1870 proposal was based on Washington, DC,
 # but in 1872-05 he moved the proposed origin to Greenwich.
 
-# From Paul Eggert (2016-09-21):
+# From Paul Eggert (2024-11-18):
 # Dowd's proposal left many details unresolved, such as where to draw
-# lines between time zones.  The key individual who made time zones
+# lines between time zones.  Sandford Fleming of the Canadian Pacific Railway
+# argued for Dowd's proposal in 1876, and Cleveland Abbe of the American
+# Meteorology Society published a report in 1879 recommending four US time
+# zones based on GMT.  However, the key individual who made time zones
 # work in the US was William Frederick Allen - railway engineer,
 # managing editor of the Travelers' Guide, and secretary of the
 # General Time Convention, a railway standardization group.  Allen
@@ -10272,10 +12521,9 @@ Zone	Etc/GMT+12	-12	-	-12
 # to the General Time Convention on 1883-04-11, saying that his plan
 # meant "local time would be practically abolished" - a plus for
 # railway scheduling.  By the next convention on 1883-10-11 nearly all
-# railroads had agreed and it took effect on 1883-11-18 at 12:00.
-# That Sunday was called the "day of two noons", as the eastern parts
-# of the new zones observed noon twice.  Allen witnessed the
-# transition in New York City, writing:
+# railroads had agreed and it took effect on 1883-11-18.  That Sunday
+# was called the "day of two noons", as some locations observed noon
+# twice.  Allen witnessed the transition in New York City, writing:
 #
 #   I heard the bells of St. Paul's strike on the old time.  Four
 #   minutes later, obedient to the electrical signal from the Naval
@@ -10285,7 +12533,7 @@ Zone	Etc/GMT+12	-12	-	-12
 #
 # Most of the US soon followed suit.  See:
 # Bartky IR. The adoption of standard time. Technol Cult 1989 Jan;30(1):25-56.
-# http://dx.doi.org/10.2307/3105430
+# https://dx.doi.org/10.2307/3105430
 
 # From Paul Eggert (2005-04-16):
 # That 1883 transition occurred at 12:00 new time, not at 12:00 old time.
@@ -10321,17 +12569,40 @@ Zone	Etc/GMT+12	-12	-	-12
 # For more about the first ten years of DST in the United States, see
 # Robert Garland, Ten years of daylight saving from the Pittsburgh standpoint
 # (Carnegie Library of Pittsburgh, 1927).
-# http://www.clpgh.org/exhibit/dst.html
+# https://web.archive.org/web/20160517155308/http://www.clpgh.org/exhibit/dst.html
 #
 # Shanks says that DST was called "War Time" in the US in 1918 and 1919.
 # However, DST was imposed by the Standard Time Act of 1918, which
 # was the first nationwide legal time standard, and apparently
 # time was just called "Standard Time" or "Daylight Saving Time".
 
-# From Arthur David Olson:
-# US Daylight Saving Time ended on the last Sunday of *October* in 1974.
-# See, for example, the front page of the Saturday, 1974-10-26
-# and Sunday, 1974-10-27 editions of the Washington Post.
+# From Paul Eggert (2019-06-04):
+# Here is the legal basis for the US federal rules.
+# * Public Law 65-106 (1918-03-19) implemented standard and daylight saving
+#   time for the first time across the US, springing forward on March's last
+#   Sunday and falling back on October's last Sunday.
+#   https://www.loc.gov/law/help/statutes-at-large/65th-congress/session-2/c65s2ch24.pdf
+# * Public Law 66-40 (1919-08-20) repealed DST on October 1919's last Sunday.
+#   https://www.loc.gov/law/help/statutes-at-large/66th-congress/session-1/c66s1ch51.pdf
+# * Public Law 77-403 (1942-01-20) started wartime DST on 1942-02-09.
+#   https://www.loc.gov/law/help/statutes-at-large/77th-congress/session-2/c77s2ch7.pdf
+# * Public Law 79-187 (1945-09-25) ended wartime DST on 1945-09-30.
+#   https://www.loc.gov/law/help/statutes-at-large/79th-congress/session-1/c79s1ch388.pdf
+# * Public Law 89-387 (1966-04-13) reinstituted a national standard for DST,
+#   from April's last Sunday to October's last Sunday, effective 1967.
+#   https://www.govinfo.gov/content/pkg/STATUTE-80/pdf/STATUTE-80-Pg107.pdf
+# * Public Law 93-182 (1973-12-15) moved the 1974 spring-forward to 01-06.
+#   https://www.govinfo.gov/content/pkg/STATUTE-87/pdf/STATUTE-87-Pg707.pdf
+# * Public Law 93-434 (1974-10-05) moved the 1975 spring-forward to
+#   February's last Sunday.
+#   https://www.govinfo.gov/content/pkg/STATUTE-88/pdf/STATUTE-88-Pg1209.pdf
+# * Public Law 99-359 (1986-07-08) moved the spring-forward to April's first
+#   Sunday.
+#   https://www.govinfo.gov/content/pkg/STATUTE-100/pdf/STATUTE-100-Pg764.pdf
+# * Public Law 109-58 (2005-08-08), effective 2007, moved the spring-forward
+#   to March's second Sunday and the fall-back to November's first Sunday.
+#   https://www.govinfo.gov/content/pkg/PLAW-109publ58/pdf/PLAW-109publ58.pdf
+# All transitions are at 02:00 local time.
 
 # From Arthur David Olson:
 # Before the Uniform Time Act of 1966 took effect in 1967, observance of
@@ -10341,10 +12612,13 @@ Zone	Etc/GMT+12	-12	-	-12
 # Last night I heard part of a rebroadcast of a 1945 Arch Oboler radio drama.
 # In the introduction, Oboler spoke of "Eastern Peace Time."
 # An AltaVista search turned up:
-# http://rowayton.org/rhs/hstaug45.html
+# https://web.archive.org/web/20000926032210/http://rowayton.org/rhs/hstaug45.html
 # "When the time is announced over the radio now, it is 'Eastern Peace
 # Time' instead of the old familiar 'Eastern War Time.'  Peace is wonderful."
 # (August 1945) by way of confirmation.
+#
+# From Paul Eggert (2017-09-23):
+# This was the V-J Day issue of the Clamdigger, a Rowayton, CT newsletter.
 
 # From Joseph Gallant citing
 # George H. Douglas, _The Early Days of Radio Broadcasting_ (1987):
@@ -10379,56 +12653,20 @@ Zone	Etc/GMT+12	-12	-	-12
 # U.S. government action.  So even though the "US" rules have changed
 # in the latest release, other countries won't be affected.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	US	1918	1919	-	Mar	lastSun	2:00	1:00	D
 Rule	US	1918	1919	-	Oct	lastSun	2:00	0	S
 Rule	US	1942	only	-	Feb	9	2:00	1:00	W # War
 Rule	US	1945	only	-	Aug	14	23:00u	1:00	P # Peace
-Rule	US	1945	only	-	Sep	lastSun	2:00	0	S
+Rule	US	1945	only	-	Sep	30	2:00	0	S
 Rule	US	1967	2006	-	Oct	lastSun	2:00	0	S
 Rule	US	1967	1973	-	Apr	lastSun	2:00	1:00	D
 Rule	US	1974	only	-	Jan	6	2:00	1:00	D
-Rule	US	1975	only	-	Feb	23	2:00	1:00	D
+Rule	US	1975	only	-	Feb	lastSun	2:00	1:00	D
 Rule	US	1976	1986	-	Apr	lastSun	2:00	1:00	D
 Rule	US	1987	2006	-	Apr	Sun>=1	2:00	1:00	D
 Rule	US	2007	max	-	Mar	Sun>=8	2:00	1:00	D
 Rule	US	2007	max	-	Nov	Sun>=1	2:00	0	S
-
-# From Arthur David Olson, 2005-12-19
-# We generate the files specified below to guard against old files with
-# obsolete information being left in the time zone binary directory.
-# We limit the list to names that have appeared in previous versions of
-# this time zone package.
-# We do these as separate Zones rather than as Links to avoid problems if
-# a particular place changes whether it observes DST.
-# We put these specifications here in the northamerica file both to
-# increase the chances that they'll actually get compiled and to
-# avoid the need to duplicate the US rules in another file.
-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	EST		 -5:00	-	EST
-Zone	MST		 -7:00	-	MST
-Zone	HST		-10:00	-	HST
-Zone	EST5EDT		 -5:00	US	E%sT
-Zone	CST6CDT		 -6:00	US	C%sT
-Zone	MST7MDT		 -7:00	US	M%sT
-Zone	PST8PDT		 -8:00	US	P%sT
-
-# From Bob Devine (1988-01-28):
-# ...Alaska (and Hawaii) had the timezone names changed in 1967.
-#    old			 new
-#    Pacific Standard Time(PST)  -same-
-#    Yukon Standard Time(YST)    -same-
-#    Central Alaska S.T. (CAT)   Alaska-Hawaii St[an]dard Time (AHST)
-#    Nome Standard Time (NT)     Bering Standard Time (BST)
-#
-# ...Alaska's timezone lines were redrawn in 1983 to give only 2 tz.
-#    The YST zone now covers nearly all of the state, AHST just part
-#    of the Aleutian islands.   No DST.
-
-# From Paul Eggert (1995-12-19):
-# The tables below use 'NST', not 'NT', for Nome Standard Time.
-# I invented 'CAWT' for Central Alaska War Time.
 
 # From U. S. Naval Observatory (1989-01-19):
 # USA  EASTERN       5 H  BEHIND UTC    NEW YORK, WASHINGTON
@@ -10486,15 +12724,31 @@ Zone	PST8PDT		 -8:00	US	P%sT
 #	Samoa standard time
 # The law doesn't give abbreviations.
 #
-# From Paul Eggert (2000-01-08), following a heads-up from Rives McDow:
-# Public law 106-564 (2000-12-23) introduced ... "Chamorro Standard Time"
+# From Paul Eggert (2016-12-19):
+# Here are URLs for the 1918 and 1966 legislation:
+# http://uscode.house.gov/statviewer.htm?volume=40&page=451
+# http://uscode.house.gov/statviewer.htm?volume=80&page=108
+# Although the 1918 names were officially "United States Standard
+# Eastern Time" and similarly for "Central", "Mountain", "Pacific",
+# and "Alaska", in practice "Standard" was placed just before "Time",
+# as codified in 1966.  In practice, Alaska time was abbreviated "AST"
+# before 1968.  Summarizing the 1967 name changes:
+#	1918 names			1967 names
+#  -08	Standard Pacific Time (PST)	Pacific standard time (PST)
+#  -09	(unofficial) Yukon (YST)	Yukon standard time (YST)
+#  -10	Standard Alaska Time (AST)	Alaska-Hawaii standard time (AHST)
+#  -11	(unofficial) Nome (NST)		Bering standard time (BST)
+#
+# From Paul Eggert (2023-01-23), from a 2001-01-08 heads-up from Rives McDow:
+# Public law 106-564 (2000-12-23) introduced "Chamorro standard time"
 # for time in Guam and the Northern Marianas.  See the file "australasia".
+# Also see 15 U.S.C. §263 <https://www.law.cornell.edu/uscode/text/15/263>.
 #
 # From Paul Eggert (2015-04-17):
 # HST and HDT are standardized abbreviations for Hawaii-Aleutian
 # standard and daylight times.  See section 9.47 (p 234) of the
 # U.S. Government Printing Office Style Manual (2008)
-# http://www.gpo.gov/fdsys/pkg/GPO-STYLEMANUAL-2008/pdf/GPO-STYLEMANUAL-2008.pdf
+# https://www.gpo.gov/fdsys/pkg/GPO-STYLEMANUAL-2008/pdf/GPO-STYLEMANUAL-2008.pdf
 
 # From Arthur David Olson, 2005-08-09
 # The following was signed into law on 2005-08-08.
@@ -10541,21 +12795,30 @@ Zone	PST8PDT		 -8:00	US	P%sT
 # Roberts, city administrator in Phenix City. as saying "We are in the Central
 # time zone, but we do go by the Eastern time zone because so many people work
 # in Columbus."
+#
+# From Paul Eggert (2017-02-22):
+# Four cities are involved.  The two not mentioned above are Smiths Station
+# and Valley.  Barbara Brooks, Valley's assistant treasurer, heard it started
+# because West Point Pepperell textile mills were in Alabama while the
+# corporate office was in Georgia, and residents voted to keep Eastern
+# time even after the mills closed.  See: Kazek K. Did you know which
+# Alabama towns are in a different time zone?  al.com 2017-02-06.
+# http://www.al.com/living/index.ssf/2017/02/do_you_know_which_alabama_town.html
 
 # From Paul Eggert (2014-09-06):
 # Monthly Notices of the Royal Astronomical Society 44, 4 (1884-02-08), 208
 # says that New York City Hall time was 3 minutes 58.4 seconds fast of
-# Eastern time (i.e., -4:56:01.6) just before the 1883 switch.  Round to the
-# nearest second.
+# Eastern time (i.e., -4:56:01.6) just before the 1883 switch.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER
 Rule	NYC	1920	only	-	Mar	lastSun	2:00	1:00	D
 Rule	NYC	1920	only	-	Oct	lastSun	2:00	0	S
 Rule	NYC	1921	1966	-	Apr	lastSun	2:00	1:00	D
 Rule	NYC	1921	1954	-	Sep	lastSun	2:00	0	S
 Rule	NYC	1955	1966	-	Oct	lastSun	2:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/New_York	-4:56:02 -	LMT	1883 Nov 18 12:03:58
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	-4:56:01.6
+Zone America/New_York	-4:56:02 -	LMT	1883 Nov 18 17:00u
 			-5:00	US	E%sT	1920
 			-5:00	NYC	E%sT	1942
 			-5:00	US	E%sT	1946
@@ -10573,8 +12836,20 @@ Zone America/New_York	-4:56:02 -	LMT	1883 Nov 18 12:03:58
 # Nebraska, eastern North Dakota, Oklahoma, eastern South Dakota,
 # western Tennessee, most of Texas, Wisconsin
 
+# From Paul Eggert (2018-01-07):
+# In 1869 the Chicago Astronomical Society contracted with the city to keep
+# time.  Though delayed by the Great Fire, by 1880 a wire ran from the
+# Dearborn Observatory (on the University of Chicago campus) to City Hall,
+# which then sent signals to police and fire stations.  However, railroads got
+# their time signals from the Allegheny Observatory, the Madison Observatory,
+# the Ann Arbor Observatory, etc., so their clocks did not agree with each
+# other or with the city's official time.  The confusion took some years to
+# clear up.  See:
+# Moser M. How Chicago gave America its time zones. Chicago. 2018-01-04.
+# http://www.chicagomag.com/city-life/January-2018/How-Chicago-Gave-America-Its-Time-Zones/
+
 # From Larry M. Smith (2006-04-26) re Wisconsin:
-# http://www.legis.state.wi.us/statutes/Stat0175.pdf ...
+# https://docs.legis.wisconsin.gov/statutes/statutes/175.pdf
 # is currently enforced at the 01:00 time of change.  Because the local
 # "bar time" in the state corresponds to 02:00, a number of citations
 # are issued for the "sale of class 'B' alcohol after prohibited
@@ -10583,7 +12858,7 @@ Zone America/New_York	-4:56:02 -	LMT	1883 Nov 18 12:03:58
 # From Douglas R. Bomberg (2007-03-12):
 # Wisconsin has enacted (nearly eleventh-hour) legislation to get WI
 # Statue 175 closer in synch with the US Congress' intent....
-# http://www.legis.state.wi.us/2007/data/acts/07Act3.pdf
+# https://docs.legis.wisconsin.gov/2007/related/acts/3
 
 # From an email administrator of the City of Fort Pierre, SD (2015-12-21):
 # Fort Pierre is technically located in the Mountain time zone as is
@@ -10595,15 +12870,40 @@ Zone America/New_York	-4:56:02 -	LMT	1883 Nov 18 12:03:58
 # From Paul Eggert (2015-12-25):
 # Assume this practice predates 1970, so Fort Pierre can use America/Chicago.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER
+# From Paul Eggert (2015-04-06):
+# In 1950s Nashville a public clock had dueling faces, one for conservatives
+# and the other for liberals; the two sides didn't agree about the time of day.
+# I haven't found a photo of this clock, nor have I tracked down the TIME
+# magazine report cited below, but here's the story as told by the late
+# American journalist John Seigenthaler, who was there:
+#
+# "The two [newspaper] owners held strongly contrasting political and
+# ideological views.  Evans was a New South liberal, Stahlman an Old South
+# conservative, and their two papers frequently clashed editorially, often on
+# the same day....  In the 1950s as the state legislature was grappling with
+# the question of whether to approve daylight saving time for the entire state,
+# TIME magazine reported:
+#
+# "'The Nashville Banner and The Nashville Tennessean rarely agree on anything
+# but the time of day - and last week they couldn't agree on that.'
+#
+# "It was all too true. The clock on the front of the building had two faces -
+# The Tennessean side of the building facing west, the other, east.  When it
+# was high noon Banner time, it was 11 a.m. Tennessean time."
+#
+# Seigenthaler J. For 100 years, Tennessean had it covered.
+# The Tennessean 2007-05-11, republished 2015-04-06.
+# https://www.tennessean.com/story/insider/extras/2015/04/06/archives-seigenthaler-for-100-years-the-tennessean-had-it-covered/25348545/
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER
 Rule	Chicago	1920	only	-	Jun	13	2:00	1:00	D
 Rule	Chicago	1920	1921	-	Oct	lastSun	2:00	0	S
 Rule	Chicago	1921	only	-	Mar	lastSun	2:00	1:00	D
 Rule	Chicago	1922	1966	-	Apr	lastSun	2:00	1:00	D
 Rule	Chicago	1922	1954	-	Sep	lastSun	2:00	0	S
 Rule	Chicago	1955	1966	-	Oct	lastSun	2:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Chicago	-5:50:36 -	LMT	1883 Nov 18 12:09:24
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone America/Chicago	-5:50:36 -	LMT	1883 Nov 18 18:00u
 			-6:00	US	C%sT	1920
 			-6:00	Chicago	C%sT	1936 Mar  1  2:00
 			-5:00	-	EST	1936 Nov 15  2:00
@@ -10612,7 +12912,7 @@ Zone America/Chicago	-5:50:36 -	LMT	1883 Nov 18 12:09:24
 			-6:00	Chicago	C%sT	1967
 			-6:00	US	C%sT
 # Oliver County, ND switched from mountain to central time on 1992-10-25.
-Zone America/North_Dakota/Center -6:45:12 - LMT	1883 Nov 18 12:14:48
+Zone America/North_Dakota/Center -6:45:12 - LMT	1883 Nov 18 19:00u
 			-7:00	US	M%sT	1992 Oct 25  2:00
 			-6:00	US	C%sT
 # Morton County, ND, switched from mountain to central time on
@@ -10622,7 +12922,7 @@ Zone America/North_Dakota/Center -6:45:12 - LMT	1883 Nov 18 12:14:48
 # Jones, Mellette, and Todd Counties in South Dakota;
 # but in practice these other counties were already observing central time.
 # See <http://www.epa.gov/fedrgstr/EPA-IMPACT/2003/October/Day-28/i27056.htm>.
-Zone America/North_Dakota/New_Salem -6:45:39 - LMT	1883 Nov 18 12:14:21
+Zone America/North_Dakota/New_Salem -6:45:39 - LMT 1883 Nov 18 19:00u
 			-7:00	US	M%sT	2003 Oct 26  2:00
 			-6:00	US	C%sT
 
@@ -10630,17 +12930,16 @@ Zone America/North_Dakota/New_Salem -6:45:39 - LMT	1883 Nov 18 12:14:21
 # ...it appears that Mercer County, North Dakota, changed from the
 # mountain time zone to the central time zone at the last transition from
 # daylight-saving to standard time (on Nov. 7, 2010):
-# http://www.gpo.gov/fdsys/pkg/FR-2010-09-29/html/2010-24376.htm
+# https://www.gpo.gov/fdsys/pkg/FR-2010-09-29/html/2010-24376.htm
 # http://www.bismarcktribune.com/news/local/article_1eb1b588-c758-11df-b472-001cc4c03286.html
 
 # From Andy Lipscomb (2011-01-24):
 # ...according to the Census Bureau, the largest city is Beulah (although
 # it's commonly referred to as Beulah-Hazen, with Hazen being the next
 # largest city in Mercer County).  Google Maps places Beulah's city hall
-# at 47 degrees 15' 51" N, 101 degrees 46' 40" W, which yields an offset
-# of 6h47'07".
+# at 47° 15' 51" N, 101° 46' 40" W, which yields an offset of 6h47'07".
 
-Zone America/North_Dakota/Beulah -6:47:07 - LMT	1883 Nov 18 12:12:53
+Zone America/North_Dakota/Beulah -6:47:07 - LMT	1883 Nov 18 19:00u
 			-7:00	US	M%sT	2010 Nov  7  2:00
 			-6:00	US	C%sT
 
@@ -10652,14 +12951,27 @@ Zone America/North_Dakota/Beulah -6:47:07 - LMT	1883 Nov 18 12:12:53
 # western South Dakota, far western Texas (El Paso County, Hudspeth County,
 # and Pine Springs and Nickel Creek in Culberson County), Utah, Wyoming
 #
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER
+# From Paul Eggert (2018-10-25):
+# On 1921-03-04 federal law placed all of Texas into the central time zone.
+# However, El Paso ignored the law for decades and continued to observe
+# mountain time, on the grounds that that's what they had always done
+# and they weren't about to let the federal government tell them what to do.
+# Eventually the federal government gave in and changed the law on
+# 1970-04-10 to match what El Paso was actually doing.  Although
+# that's slightly after our 1970 cutoff, there is no need to create a
+# separate zone for El Paso since they were ignoring the law anyway.  See:
+# Long T. El Pasoans were time rebels, fought to stay in Mountain zone.
+# El Paso Times. 2018-10-24 06:40 -06.
+# https://www.elpasotimes.com/story/news/local/el-paso/2018/10/24/el-pasoans-were-time-rebels-fought-stay-mountain-zone/1744509002/
+#
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER
 Rule	Denver	1920	1921	-	Mar	lastSun	2:00	1:00	D
 Rule	Denver	1920	only	-	Oct	lastSun	2:00	0	S
 Rule	Denver	1921	only	-	May	22	2:00	0	S
 Rule	Denver	1965	1966	-	Apr	lastSun	2:00	1:00	D
 Rule	Denver	1965	1966	-	Oct	lastSun	2:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Denver	-6:59:56 -	LMT	1883 Nov 18 12:00:04
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone America/Denver	-6:59:56 -	LMT	1883 Nov 18 19:00u
 			-7:00	US	M%sT	1920
 			-7:00	Denver	M%sT	1942
 			-7:00	US	M%sT	1946
@@ -10671,7 +12983,7 @@ Zone America/Denver	-6:59:56 -	LMT	1883 Nov 18 12:00:04
 # California, northern Idaho (Benewah, Bonner, Boundary, Clearwater,
 # Kootenai, Latah, Lewis, Nez Perce, and Shoshone counties, Idaho county
 # north of the Salmon River, and the towns of Burgdorf and Warren),
-# Nevada (except West Wendover), Oregon (except the northern 3/4 of
+# Nevada (except West Wendover), Oregon (except the northern ¾ of
 # Malheur county), and Washington
 
 # From Paul Eggert (2016-08-20):
@@ -10681,7 +12993,7 @@ Zone America/Denver	-6:59:56 -	LMT	1883 Nov 18 12:00:04
 # legal time, and is not part of the data here.)  See:
 # Ross SA. An energy crisis from the past: Northern California in 1948.
 # Working Paper No. 8, Institute of Governmental Studies, UC Berkeley,
-# 1973-11.  http://escholarship.org/uc/item/8x22k30c
+# 1973-11.  https://escholarship.org/uc/item/8x22k30c
 #
 # In another measure to save electricity, DST was instituted from 1948-03-14
 # at 02:01 to 1949-01-16 at 02:00, with the governor having the option to move
@@ -10702,41 +13014,52 @@ Zone America/Denver	-6:59:56 -	LMT	1883 Nov 18 12:00:04
 # which established DST from April's last Sunday at 01:00 until September's
 # last Sunday at 02:00. This was amended by 1962's Proposition 6, which changed
 # the fall-back date to October's last Sunday. See:
-# http://repository.uchastings.edu/cgi/viewcontent.cgi?article=1501&context=ca_ballot_props
-# http://repository.uchastings.edu/cgi/viewcontent.cgi?article=1636&context=ca_ballot_props
+# https://repository.uchastings.edu/cgi/viewcontent.cgi?article=1501&context=ca_ballot_props
+# https://repository.uchastings.edu/cgi/viewcontent.cgi?article=1636&context=ca_ballot_props
 #
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER
 Rule	CA	1948	only	-	Mar	14	2:01	1:00	D
 Rule	CA	1949	only	-	Jan	 1	2:00	0	S
 Rule	CA	1950	1966	-	Apr	lastSun	1:00	1:00	D
 Rule	CA	1950	1961	-	Sep	lastSun	2:00	0	S
 Rule	CA	1962	1966	-	Oct	lastSun	2:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Los_Angeles -7:52:58 -	LMT	1883 Nov 18 12:07:02
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone America/Los_Angeles -7:52:58 -	LMT	1883 Nov 18 20:00u
 			-8:00	US	P%sT	1946
 			-8:00	CA	P%sT	1967
 			-8:00	US	P%sT
 
 # Alaska
-# AK%sT is the modern abbreviation for -9:00 per USNO.
+# AK%sT is the modern abbreviation for -09 per USNO.
 #
-# From Paul Eggert (2001-05-30):
+# From Paul Eggert (2017-06-15):
 # Howse writes that Alaska switched from the Julian to the Gregorian calendar,
 # and from east-of-GMT to west-of-GMT days, when the US bought it from Russia.
-# This was on 1867-10-18, a Friday; the previous day was 1867-10-06 Julian,
-# also a Friday.  Include only the time zone part of this transition,
-# ignoring the switch from Julian to Gregorian, since we can't represent
-# the Julian calendar.
+# On Friday, 1867-10-18 (Gregorian), at precisely 15:30 local time, the
+# Russian forts and fleet at Sitka fired salutes to mark the ceremony of
+# formal transfer.  See the Sacramento Daily Union (1867-11-14), p 3, col 2.
+# https://cdnc.ucr.edu/cgi-bin/cdnc?a=d&d=SDU18671114.2.12.1
+# Sitka workers did not change their calendars until Sunday, 1867-10-20,
+# and so celebrated two Sundays that week.  See: Ahllund T (tr Hallamaa P).
+# From the memoirs of a Finnish workman. Alaska History. 2006 Fall;21(2):1-25.
+# http://alaskahistoricalsociety.org/wp-content/uploads/2016/12/Ahllund-2006-Memoirs-of-a-Finnish-Workman.pdf
+# Include only the time zone part of this transition, ignoring the switch
+# from Julian to Gregorian, since we can't represent the Julian calendar.
 #
-# As far as we know, none of the exact locations mentioned below were
+# As far as we know, of the locations mentioned below only Sitka was
 # permanently inhabited in 1867 by anyone using either calendar.
-# (Yakutat was colonized by the Russians in 1799, but the settlement
-# was destroyed in 1805 by a Yakutat-kon war party.)  However, there
-# were nearby inhabitants in some cases and for our purposes perhaps
-# it's best to simply use the official transition.
+# (Yakutat was colonized by the Russians in 1799, but the settlement was
+# destroyed in 1805 by a Yakutat-kon war party.)  Many of Alaska's inhabitants
+# were unaware of the US acquisition of Alaska, much less of any calendar or
+# time change.  However, the Russian-influenced part of Alaska did observe
+# Russian time, and it is more accurate to model this than to ignore it.
+# The database format requires an exact transition time; use the Russian
+# salute as a somewhat-arbitrary time for the formal transfer of control for
+# all of Alaska.  Sitka's UTC offset is -9:01:13; adjust its 15:30 to the
+# local times of other Alaskan locations so that they change simultaneously.
 
 # From Paul Eggert (2014-07-18):
-# One opinion of the early-1980s turmoil in Alaska over time zones and
+# One opinion of the early 1980s turmoil in Alaska over time zones and
 # daylight saving time appeared as graffiti on a Juneau airport wall:
 # "Welcome to Juneau.  Please turn your watch back to the 19th century."
 # See: Turner W. Alaska's four time zones now two. NY Times 1983-11-01.
@@ -10786,10 +13109,34 @@ Zone America/Los_Angeles -7:52:58 -	LMT	1883 Nov 18 12:07:02
 # It seems Metlakatla did go off PST on Sunday, November 1, changing
 # their time to AKST and are going to follow Alaska's DST, switching
 # between AKST and AKDT from now on....
-# http://www.krbd.org/2015/10/30/annette-island-times-they-are-a-changing/
+# https://www.krbd.org/2015/10/30/annette-island-times-they-are-a-changing/
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Juneau	 15:02:19 -	LMT	1867 Oct 18
+# From Ryan Stanley (2018-11-06):
+# The Metlakatla community in Alaska has decided not to change its
+# clock back an hour starting on November 4th, 2018 (day before yesterday).
+# They will be gmtoff=-28800 year-round.
+# https://www.facebook.com/141055983004923/photos/pb.141055983004923.-2207520000.1541465673./569081370202380/
+
+# From Paul Eggert (2018-12-16):
+# In a 2018-12-11 special election, Metlakatla voted to go back to
+# Alaska time (including daylight saving time) starting next year.
+# https://www.krbd.org/2018/12/12/metlakatla-to-follow-alaska-standard-time-allow-liquor-sales/
+#
+# From Ryan Stanley (2019-01-11):
+# The community will be changing back on the 20th of this month...
+# From Tim Parenti (2019-01-11):
+# Per an announcement on the Metlakatla community's official Facebook page, the
+# "fall back" will be on Sunday 2019-01-20 at 02:00:
+# https://www.facebook.com/141055983004923/photos/607150969728753/
+# So they won't be waiting for Alaska to join them on 2019-03-10, but will
+# rather change their clocks twice in seven weeks.
+
+# From Paul Eggert (2023-01-23):
+# America/Adak is for the Aleutian Islands that are part of Alaska
+# and are west of 169.5° W.
+
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone America/Juneau	 15:02:19 -	LMT	1867 Oct 19 15:33:32
 			 -8:57:41 -	LMT	1900 Aug 20 12:00
 			 -8:00	-	PST	1942
 			 -8:00	US	P%sT	1946
@@ -10799,7 +13146,7 @@ Zone America/Juneau	 15:02:19 -	LMT	1867 Oct 18
 			 -8:00	US	P%sT	1983 Oct 30  2:00
 			 -9:00	US	Y%sT	1983 Nov 30
 			 -9:00	US	AK%sT
-Zone America/Sitka	 14:58:47 -	LMT	1867 Oct 18
+Zone America/Sitka	 14:58:47 -	LMT	1867 Oct 19 15:30
 			 -9:01:13 -	LMT	1900 Aug 20 12:00
 			 -8:00	-	PST	1942
 			 -8:00	US	P%sT	1946
@@ -10807,32 +13154,32 @@ Zone America/Sitka	 14:58:47 -	LMT	1867 Oct 18
 			 -8:00	US	P%sT	1983 Oct 30  2:00
 			 -9:00	US	Y%sT	1983 Nov 30
 			 -9:00	US	AK%sT
-Zone America/Metlakatla	 15:13:42 -	LMT	1867 Oct 18
+Zone America/Metlakatla	 15:13:42 -	LMT	1867 Oct 19 15:44:55
 			 -8:46:18 -	LMT	1900 Aug 20 12:00
 			 -8:00	-	PST	1942
 			 -8:00	US	P%sT	1946
 			 -8:00	-	PST	1969
 			 -8:00	US	P%sT	1983 Oct 30  2:00
 			 -8:00	-	PST	2015 Nov  1  2:00
+			 -9:00	US	AK%sT	2018 Nov  4  2:00
+			 -8:00	-	PST	2019 Jan 20  2:00
 			 -9:00	US	AK%sT
-Zone America/Yakutat	 14:41:05 -	LMT	1867 Oct 18
+Zone America/Yakutat	 14:41:05 -	LMT	1867 Oct 19 15:12:18
 			 -9:18:55 -	LMT	1900 Aug 20 12:00
 			 -9:00	-	YST	1942
 			 -9:00	US	Y%sT	1946
 			 -9:00	-	YST	1969
 			 -9:00	US	Y%sT	1983 Nov 30
 			 -9:00	US	AK%sT
-Zone America/Anchorage	 14:00:24 -	LMT	1867 Oct 18
+Zone America/Anchorage	 14:00:24 -	LMT	1867 Oct 19 14:31:37
 			 -9:59:36 -	LMT	1900 Aug 20 12:00
-			-10:00	-	CAT	1942
-			-10:00	US	CAT/CAWT 1945 Aug 14 23:00u
-			-10:00	US	CAT/CAPT 1946 # Peace
-			-10:00	-	CAT	1967 Apr
+			-10:00	-	AST	1942
+			-10:00	US	A%sT	1967 Apr
 			-10:00	-	AHST	1969
 			-10:00	US	AH%sT	1983 Oct 30  2:00
 			 -9:00	US	Y%sT	1983 Nov 30
 			 -9:00	US	AK%sT
-Zone America/Nome	 12:58:21 -	LMT	1867 Oct 18
+Zone America/Nome	 12:58:22 -	LMT	1867 Oct 19 13:29:35
 			-11:01:38 -	LMT	1900 Aug 20 12:00
 			-11:00	-	NST	1942
 			-11:00	US	N%sT	1946
@@ -10841,7 +13188,7 @@ Zone America/Nome	 12:58:21 -	LMT	1867 Oct 18
 			-11:00	US	B%sT	1983 Oct 30  2:00
 			 -9:00	US	Y%sT	1983 Nov 30
 			 -9:00	US	AK%sT
-Zone America/Adak	 12:13:21 -	LMT	1867 Oct 18
+Zone America/Adak	 12:13:22 -	LMT	1867 Oct 19 12:44:35
 			-11:46:38 -	LMT	1900 Aug 20 12:00
 			-11:00	-	NST	1942
 			-11:00	US	N%sT	1946
@@ -10850,7 +13197,11 @@ Zone America/Adak	 12:13:21 -	LMT	1867 Oct 18
 			-11:00	US	B%sT	1983 Oct 30  2:00
 			-10:00	US	AH%sT	1983 Nov 30
 			-10:00	US	H%sT
-# The following switches don't quite make our 1970 cutoff.
+# The following switches don't make our 1970 cutoff.
+#
+# Kiska observed Tokyo date and time during Japanese occupation from
+# 1942-06-06 to 1943-07-29, and similarly for Attu from 1942-06-07 to
+# 1943-05-29 (all dates American).  Both islands are now uninhabited.
 #
 # Shanks writes that part of southwest Alaska (e.g. Aniak)
 # switched from -11:00 to -10:00 on 1968-09-22 at 02:00,
@@ -10877,7 +13228,7 @@ Zone America/Adak	 12:13:21 -	LMT	1867 Oct 18
 # "Hawaiian Time" by Robert C. Schmitt and Doak C. Cox appears on pages 207-225
 # of volume 26 of The Hawaiian Journal of History (1992). As of 2010-12-09,
 # the article is available at
-# http://evols.library.manoa.hawaii.edu/bitstream/10524/239/2/JL26215.pdf
+# https://evols.library.manoa.hawaii.edu/bitstream/10524/239/2/JL26215.pdf
 # and indicates that standard time was adopted effective noon, January
 # 13, 1896 (page 218), that in "1933, the Legislature decreed daylight
 # saving for the period between the last Sunday of each April and the
@@ -10908,15 +13259,12 @@ Zone America/Adak	 12:13:21 -	LMT	1867 Oct 18
 # Note that 1933-05-21 was a Sunday.
 # We're left to guess the time of day when Act 163 was approved; guess noon.
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Honolulu	-10:31:26 -	LMT	1896 Jan 13 12:00
 			-10:30	-	HST	1933 Apr 30  2:00
 			-10:30	1:00	HDT	1933 May 21 12:00
-			-10:30	-	HST	1942 Feb  9  2:00
-			-10:30	1:00	HDT	1945 Sep 30  2:00
-			-10:30	-	HST	1947 Jun  8  2:00
+			-10:30	US	H%sT	1947 Jun  8  2:00
 			-10:00	-	HST
-Link Pacific/Honolulu Pacific/Johnston
 
 # Now we turn to US areas that have diverged from the consensus since 1970.
 
@@ -10941,14 +13289,15 @@ Link Pacific/Honolulu Pacific/Johnston
 # Shanks says the 1944 experiment came to an end on 1944-03-17.
 # Go with the Arizona State Library instead.
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Phoenix	-7:28:18 -	LMT	1883 Nov 18 11:31:42
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone America/Phoenix	-7:28:18 -	LMT	1883 Nov 18 19:00u
 			-7:00	US	M%sT	1944 Jan  1  0:01
 			-7:00	-	MST	1944 Apr  1  0:01
 			-7:00	US	M%sT	1944 Oct  1  0:01
 			-7:00	-	MST	1967
 			-7:00	US	M%sT	1968 Mar 21
 			-7:00	-	MST
+
 # From Arthur David Olson (1988-02-13):
 # A writer from the Inter Tribal Council of Arizona, Inc.,
 # notes in private correspondence dated 1987-12-28 that "Presently, only the
@@ -10967,8 +13316,8 @@ Zone America/Phoenix	-7:28:18 -	LMT	1883 Nov 18 11:31:42
 # quarter of Idaho county) and eastern Oregon (most of Malheur County)
 # switched four weeks late in 1974.
 #
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Boise	-7:44:49 -	LMT	1883 Nov 18 12:15:11
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone America/Boise	-7:44:49 -	LMT	1883 Nov 18 20:00u
 			-8:00	US	P%sT	1923 May 13  2:00
 			-7:00	US	M%sT	1974
 			-7:00	-	MST	1974 Feb  3  2:00
@@ -10977,7 +13326,23 @@ Zone America/Boise	-7:44:49 -	LMT	1883 Nov 18 12:15:11
 # Indiana
 #
 # For a map of Indiana's time zone regions, see:
-# http://en.wikipedia.org/wiki/Time_in_Indiana
+# https://en.wikipedia.org/wiki/Time_in_Indiana
+#
+# From Paul Eggert (2018-11-30):
+# A brief but entertaining history of time in Indiana describes a 1949 debate
+# in the Indiana House where city legislators (who favored "fast time")
+# tussled with farm legislators (who didn't) over a bill to outlaw DST:
+#  "Lacking enough votes, the city faction tries to filibuster until time runs
+#   out on the session at midnight, but rural champion Rep. Herbert Copeland,
+#   R-Madison, leans over the gallery railing and forces the official clock
+#   back to 9 p.m., breaking it in the process.  The clock sticks on 9 as the
+#   debate rages on into the night.  The filibuster finally dies out and the
+#   bill passes, while outside the chamber, clocks read 3:30 a.m.  In the end,
+#   it doesn't matter which side won.  The law has no enforcement powers and
+#   is simply ignored by fast-time communities."
+# How Indiana went from 'God's time' to split zones and daylight-saving.
+# Indianapolis Star. 2018-11-27 14:58 -05.
+# https://www.indystar.com/story/news/politics/2018/11/27/indianapolis-indiana-time-zone-history-central-eastern-daylight-savings-time/2126300002/
 #
 # From Paul Eggert (2007-08-17):
 # Since 1970, most of Indiana has been like America/Indiana/Indianapolis,
@@ -11019,12 +13384,12 @@ Zone America/Boise	-7:44:49 -	LMT	1883 Nov 18 12:15:11
 # going to switch from Central to Eastern Time on March 11, 2007....
 # http://www.indystar.com/apps/pbcs.dll/article?AID=/20070207/LOCAL190108/702070524/0/LOCAL
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER
 Rule Indianapolis 1941	only	-	Jun	22	2:00	1:00	D
 Rule Indianapolis 1941	1954	-	Sep	lastSun	2:00	0	S
 Rule Indianapolis 1946	1954	-	Apr	lastSun	2:00	1:00	D
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Indiana/Indianapolis -5:44:38 - LMT	1883 Nov 18 12:15:22
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone America/Indiana/Indianapolis -5:44:38 - LMT 1883 Nov 18 18:00u
 			-6:00	US	C%sT	1920
 			-6:00 Indianapolis C%sT	1942
 			-6:00	US	C%sT	1946
@@ -11038,13 +13403,13 @@ Zone America/Indiana/Indianapolis -5:44:38 - LMT	1883 Nov 18 12:15:22
 #
 # Eastern Crawford County, Indiana, left its clocks alone in 1974,
 # as well as from 1976 through 2005.
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER
 Rule	Marengo	1951	only	-	Apr	lastSun	2:00	1:00	D
 Rule	Marengo	1951	only	-	Sep	lastSun	2:00	0	S
 Rule	Marengo	1954	1960	-	Apr	lastSun	2:00	1:00	D
 Rule	Marengo	1954	1960	-	Sep	lastSun	2:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Indiana/Marengo -5:45:23 -	LMT	1883 Nov 18 12:14:37
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone America/Indiana/Marengo -5:45:23 -	LMT	1883 Nov 18 18:00u
 			-6:00	US	C%sT	1951
 			-6:00	Marengo	C%sT	1961 Apr 30  2:00
 			-5:00	-	EST	1969
@@ -11057,7 +13422,7 @@ Zone America/Indiana/Marengo -5:45:23 -	LMT	1883 Nov 18 12:14:37
 # Daviess, Dubois, Knox, and Martin Counties, Indiana,
 # switched from eastern to central time in April 2006, then switched back
 # in November 2007.
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER
 Rule Vincennes	1946	only	-	Apr	lastSun	2:00	1:00	D
 Rule Vincennes	1946	only	-	Sep	lastSun	2:00	0	S
 Rule Vincennes	1953	1954	-	Apr	lastSun	2:00	1:00	D
@@ -11067,8 +13432,8 @@ Rule Vincennes	1956	1963	-	Apr	lastSun	2:00	1:00	D
 Rule Vincennes	1960	only	-	Oct	lastSun	2:00	0	S
 Rule Vincennes	1961	only	-	Sep	lastSun	2:00	0	S
 Rule Vincennes	1962	1963	-	Oct	lastSun	2:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Indiana/Vincennes -5:50:07 - LMT	1883 Nov 18 12:09:53
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone America/Indiana/Vincennes -5:50:07 - LMT	1883 Nov 18 18:00u
 			-6:00	US	C%sT	1946
 			-6:00 Vincennes	C%sT	1964 Apr 26  2:00
 			-5:00	-	EST	1969
@@ -11078,34 +13443,34 @@ Zone America/Indiana/Vincennes -5:50:07 - LMT	1883 Nov 18 12:09:53
 			-5:00	US	E%sT
 #
 # Perry County, Indiana, switched from eastern to central time in April 2006.
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER
-Rule Perry	1946	only	-	Apr	lastSun	2:00	1:00	D
-Rule Perry	1946	only	-	Sep	lastSun	2:00	0	S
-Rule Perry	1953	1954	-	Apr	lastSun	2:00	1:00	D
-Rule Perry	1953	1959	-	Sep	lastSun	2:00	0	S
+# From Alois Treindl (2019-07-09):
+# The Indianapolis News, Friday 27 October 1967 states that Perry County
+# returned to CST.  It went again to EST on 27 April 1969, as documented by the
+# Indianapolis star of Saturday 26 April.
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER
 Rule Perry	1955	only	-	May	 1	0:00	1:00	D
+Rule Perry	1955	1960	-	Sep	lastSun	2:00	0	S
 Rule Perry	1956	1963	-	Apr	lastSun	2:00	1:00	D
-Rule Perry	1960	only	-	Oct	lastSun	2:00	0	S
-Rule Perry	1961	only	-	Sep	lastSun	2:00	0	S
-Rule Perry	1962	1963	-	Oct	lastSun	2:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Indiana/Tell_City -5:47:03 - LMT	1883 Nov 18 12:12:57
+Rule Perry	1961	1963	-	Oct	lastSun	2:00	0	S
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone America/Indiana/Tell_City -5:47:03 - LMT	1883 Nov 18 18:00u
 			-6:00	US	C%sT	1946
 			-6:00 Perry	C%sT	1964 Apr 26  2:00
-			-5:00	-	EST	1969
+			-5:00	-	EST	1967 Oct 29  2:00
+			-6:00	US	C%sT	1969 Apr 27  2:00
 			-5:00	US	E%sT	1971
 			-5:00	-	EST	2006 Apr  2  2:00
 			-6:00	US	C%sT
 #
 # Pike County, Indiana moved from central to eastern time in 1977,
 # then switched back in 2006, then switched back again in 2007.
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER
 Rule	Pike	1955	only	-	May	 1	0:00	1:00	D
 Rule	Pike	1955	1960	-	Sep	lastSun	2:00	0	S
 Rule	Pike	1956	1964	-	Apr	lastSun	2:00	1:00	D
 Rule	Pike	1961	1964	-	Oct	lastSun	2:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Indiana/Petersburg -5:49:07 - LMT	1883 Nov 18 12:10:53
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone America/Indiana/Petersburg -5:49:07 - LMT	1883 Nov 18 18:00u
 			-6:00	US	C%sT	1955
 			-6:00	Pike	C%sT	1965 Apr 25  2:00
 			-5:00	-	EST	1966 Oct 30  2:00
@@ -11120,14 +13485,14 @@ Zone America/Indiana/Petersburg -5:49:07 - LMT	1883 Nov 18 12:10:53
 # An article on page A3 of the Sunday, 1991-10-27 Washington Post
 # notes that Starke County switched from Central time to Eastern time as of
 # 1991-10-27.
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER
 Rule	Starke	1947	1961	-	Apr	lastSun	2:00	1:00	D
 Rule	Starke	1947	1954	-	Sep	lastSun	2:00	0	S
 Rule	Starke	1955	1956	-	Oct	lastSun	2:00	0	S
 Rule	Starke	1957	1958	-	Sep	lastSun	2:00	0	S
 Rule	Starke	1959	1961	-	Oct	lastSun	2:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Indiana/Knox -5:46:30 -	LMT	1883 Nov 18 12:13:30
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone America/Indiana/Knox -5:46:30 -	LMT	1883 Nov 18 18:00u
 			-6:00	US	C%sT	1947
 			-6:00	Starke	C%sT	1962 Apr 29  2:00
 			-5:00	-	EST	1963 Oct 27  2:00
@@ -11137,13 +13502,13 @@ Zone America/Indiana/Knox -5:46:30 -	LMT	1883 Nov 18 12:13:30
 #
 # Pulaski County, Indiana, switched from eastern to central time in
 # April 2006 and then switched back in March 2007.
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER
 Rule	Pulaski	1946	1960	-	Apr	lastSun	2:00	1:00	D
 Rule	Pulaski	1946	1954	-	Sep	lastSun	2:00	0	S
 Rule	Pulaski	1955	1956	-	Oct	lastSun	2:00	0	S
 Rule	Pulaski	1957	1960	-	Sep	lastSun	2:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Indiana/Winamac -5:46:25 - LMT	1883 Nov 18 12:13:35
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone America/Indiana/Winamac -5:46:25 - LMT	1883 Nov 18 18:00u
 			-6:00	US	C%sT	1946
 			-6:00	Pulaski	C%sT	1961 Apr 30  2:00
 			-5:00	-	EST	1969
@@ -11153,26 +13518,44 @@ Zone America/Indiana/Winamac -5:46:25 - LMT	1883 Nov 18 12:13:35
 			-5:00	US	E%sT
 #
 # Switzerland County, Indiana, did not observe DST from 1973 through 2005.
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Indiana/Vevay -5:40:16 -	LMT	1883 Nov 18 12:19:44
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone America/Indiana/Vevay -5:40:16 -	LMT	1883 Nov 18 18:00u
 			-6:00	US	C%sT	1954 Apr 25  2:00
 			-5:00	-	EST	1969
 			-5:00	US	E%sT	1973
 			-5:00	-	EST	2006
 			-5:00	US	E%sT
 
+# From Paul Eggert (2018-03-20):
+# The Louisville & Nashville Railroad's 1883-11-18 change occurred at
+# 10:00 old local time; train were supposed to come to a standstill
+# for precisely 18 minutes.  See Bartky Fig. 1 (page 50).  It is not
+# clear how this matched civil time in Louisville, so for now continue
+# to assume Louisville switched at noon new local time, like New York.
+#
+# From Michael Deckers (2019-08-06):
+# From the contemporary source given by Alois Treindl,
+# the switch in Louisville on 1946-04-28 was on 00:01
+# From Paul Eggert (2019-08-26):
+# That source was the Louisville Courier-Journal, 1946-04-27, p 4.
+# Shanks gives 02:00 for all 20th-century transition times in Louisville.
+# Evidently this is wrong for spring 1946.  Although also likely wrong
+# for other dates, we have no data.
+#
 # Part of Kentucky left its clocks alone in 1974.
 # This also includes Clark, Floyd, and Harrison counties in Indiana.
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER
 Rule Louisville	1921	only	-	May	1	2:00	1:00	D
 Rule Louisville	1921	only	-	Sep	1	2:00	0	S
-Rule Louisville	1941	1961	-	Apr	lastSun	2:00	1:00	D
+Rule Louisville	1941	only	-	Apr	lastSun	2:00	1:00	D
 Rule Louisville	1941	only	-	Sep	lastSun	2:00	0	S
+Rule Louisville	1946	only	-	Apr	lastSun	0:01	1:00	D
 Rule Louisville	1946	only	-	Jun	2	2:00	0	S
+Rule Louisville	1950	1961	-	Apr	lastSun	2:00	1:00	D
 Rule Louisville	1950	1955	-	Sep	lastSun	2:00	0	S
-Rule Louisville	1956	1960	-	Oct	lastSun	2:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Kentucky/Louisville -5:43:02 -	LMT	1883 Nov 18 12:16:58
+Rule Louisville	1956	1961	-	Oct	lastSun	2:00	0	S
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone America/Kentucky/Louisville -5:43:02 - LMT	1883 Nov 18 18:00u
 			-6:00	US	C%sT	1921
 			-6:00 Louisville C%sT	1942
 			-6:00	US	C%sT	1946
@@ -11204,9 +13587,9 @@ Zone America/Kentucky/Louisville -5:43:02 -	LMT	1883 Nov 18 12:16:58
 # From Paul Eggert (2001-07-16):
 # The final rule was published in the
 # Federal Register 65, 160 (2000-08-17), pp 50154-50158.
-# http://frwebgate.access.gpo.gov/cgi-bin/getdoc.cgi?dbname=2000_register&docid=fr17au00-22
+# https://www.gpo.gov/fdsys/pkg/FR-2000-08-17/html/00-20854.htm
 #
-Zone America/Kentucky/Monticello -5:39:24 - LMT	1883 Nov 18 12:20:36
+Zone America/Kentucky/Monticello -5:39:24 - LMT	1883 Nov 18 18:00u
 			-6:00	US	C%sT	1946
 			-6:00	-	CST	1968
 			-6:00	US	C%sT	2000 Oct 29  2:00
@@ -11230,7 +13613,7 @@ Zone America/Kentucky/Monticello -5:39:24 - LMT	1883 Nov 18 12:20:36
 # West Wendover, NV officially switched from Pacific to mountain time on
 # 1999-10-31.  See the
 # Federal Register 64, 203 (1999-10-21), pp 56705-56707.
-# http://frwebgate.access.gpo.gov/cgi-bin/getdoc.cgi?dbname=1999_register&docid=fr21oc99-15
+# https://www.gpo.gov/fdsys/pkg/FR-1999-10-21/html/99-27240.htm
 # However, the Federal Register says that West Wendover already operated
 # on mountain time, and the rule merely made this official;
 # hence a separate tz entry is not needed.
@@ -11260,30 +13643,44 @@ Zone America/Kentucky/Monticello -5:39:24 - LMT	1883 Nov 18 12:20:36
 # one hour in 1914."  This change is not in Shanks.  We have no more
 # info, so omit this for now.
 #
+# From Paul Eggert (2019-07-06):
+# Due to a complicated set of legal maneuvers, in 1967 Michigan did
+# not start daylight saving time when the rest of the US did.
+# Instead, it began DST on Jun 14 at 00:01.  This was big news:
+# the Detroit Free Press reported it at the top of Page 1 on
+# 1967-06-14, in an article "State Adjusting to Switch to Fast Time"
+# by Gary Blonston, above an article about Thurgood Marshall's
+# confirmation to the US Supreme Court.  Although Shanks says Detroit
+# observed DST until 1967-10-29 00:01, that time of day seems to be
+# incorrect, as the Free Press later said DST ended in Michigan at the
+# same time as the rest of the US.  Also, although Shanks reports no DST in
+# Detroit in 1968, it did observe DST that year; in the November 1968
+# election Michigan voters narrowly repealed DST, effective 1969.
+#
 # Most of Michigan observed DST from 1973 on, but was a bit late in 1975.
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER
 Rule	Detroit	1948	only	-	Apr	lastSun	2:00	1:00	D
 Rule	Detroit	1948	only	-	Sep	lastSun	2:00	0	S
-Rule	Detroit	1967	only	-	Jun	14	2:00	1:00	D
-Rule	Detroit	1967	only	-	Oct	lastSun	2:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Detroit	-5:32:11 -	LMT	1905
 			-6:00	-	CST	1915 May 15  2:00
 			-5:00	-	EST	1942
 			-5:00	US	E%sT	1946
-			-5:00	Detroit	E%sT	1973
+			-5:00	Detroit	E%sT	1967 Jun 14  0:01
+			-5:00	US	E%sT	1969
+			-5:00	-	EST	1973
 			-5:00	US	E%sT	1975
 			-5:00	-	EST	1975 Apr 27  2:00
 			-5:00	US	E%sT
 #
 # Dickinson, Gogebic, Iron, and Menominee Counties, Michigan,
 # switched from EST to CST/CDT in 1973.
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER
 Rule Menominee	1946	only	-	Apr	lastSun	2:00	1:00	D
 Rule Menominee	1946	only	-	Sep	lastSun	2:00	0	S
 Rule Menominee	1966	only	-	Apr	lastSun	2:00	1:00	D
 Rule Menominee	1966	only	-	Oct	lastSun	2:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Menominee	-5:50:27 -	LMT	1885 Sep 18 12:00
 			-6:00	US	C%sT	1946
 			-6:00 Menominee	C%sT	1969 Apr 27  2:00
@@ -11304,21 +13701,27 @@ Zone America/Menominee	-5:50:27 -	LMT	1885 Sep 18 12:00
 ################################################################################
 
 
-# From Paul Eggert (2014-10-31):
+# From Paul Eggert (2017-02-10):
 #
 # Unless otherwise specified, the source for data through 1990 is:
 # Thomas G. Shanks and Rique Pottenger, The International Atlas (6th edition),
 # San Diego: ACS Publications, Inc. (2003).
 # Unfortunately this book contains many errors and cites no sources.
 #
-# Gwillim Law writes that a good source
-# for recent time zone data is the International Air Transport
+# Many years ago Gwillim Law wrote that a good source
+# for time zone data was the International Air Transport
 # Association's Standard Schedules Information Manual (IATA SSIM),
 # published semiannually.  Law sent in several helpful summaries
 # of the IATA's data after 1990.  Except where otherwise noted,
 # IATA SSIM is the source for entries after 1990.
 #
 # Other sources occasionally used include:
+#
+#	Milne J. Civil time. Geogr J. 1899 Feb;13(2):173-94
+#	<https://www.jstor.org/stable/1774359>.
+#
+#	Pearce C. The Great Daylight Saving Time Controversy.
+#	Australian Ebook Publisher. 2017. ISBN 978-1-925516-96-8.
 #
 #	Edward W. Whitman, World Time Differences,
 #	Whitman Publishing Co, 2 Niagara Av, Ealing, London (undated),
@@ -11328,8 +13731,9 @@ Zone America/Menominee	-5:50:27 -	LMT	1885 Sep 18 12:00
 #	<http://cs.ucla.edu/~eggert/The-Waste-of-Daylight-19th.pdf>
 #	[PDF] (1914-03)
 #
-#	Milne J. Civil time. Geogr J. 1899 Feb;13(2):173-94
-#	<http://www.jstor.org/stable/1774359>.
+# For the 1911/1912 establishment of standard time in French possessions, see:
+# Société Française de Physique, Recueil de constantes physiques (1913),
+# page 752, 18b.
 #
 # See the 'europe' file for Greenland.
 
@@ -11375,19 +13779,19 @@ Zone America/Menominee	-5:50:27 -	LMT	1885 Sep 18 12:00
 # The British Columbia government announced yesterday that it will
 # adjust daylight savings next year to align with changes in the
 # U.S. and the rest of Canada....
-# http://www2.news.gov.bc.ca/news_releases_2005-2009/2006AG0014-000330.htm
+# https://archive.news.gov.bc.ca/releases/news_releases_2005-2009/2006AG0014-000330.htm
 # ...
 # Nova Scotia
 # Daylight saving time will be extended by four weeks starting in 2007....
-# http://www.gov.ns.ca/just/regulations/rg2/2006/ma1206.pdf
+# https://www.novascotia.ca/just/regulations/rg2/2006/ma1206.pdf
 #
 # [For New Brunswick] the new legislation dictates that the time change is to
 # be done at 02:00 instead of 00:01.
-# http://www.gnb.ca/0062/acts/BBA-2006/Chap-19.pdf
+# https://www.gnb.ca/0062/acts/BBA-2006/Chap-19.pdf
 # ...
 # Manitoba has traditionally changed the clock every fall at 03:00.
 # As of 2006, the transition is to take place one hour earlier at 02:00.
-# http://web2.gov.mb.ca/laws/statutes/ccsm/o030e.php
+# https://web2.gov.mb.ca/laws/statutes/ccsm/o030e.php
 # ...
 # [Alberta, Ontario, Quebec] will follow US rules.
 # http://www.qp.gov.ab.ca/documents/spring/CH03_06.CFM
@@ -11401,7 +13805,7 @@ Zone America/Menominee	-5:50:27 -	LMT	1885 Sep 18 12:00
 # http://www.hoa.gov.nl.ca/hoa/bills/Bill0634.htm
 # ...
 # Yukon
-# http://www.gov.yk.ca/legislation/regs/oic2006_127.pdf
+# https://www.gov.yk.ca/legislation/regs/oic2006_127.pdf
 # ...
 # N.W.T. will follow US rules.  Whoever maintains the government web site
 # does not seem to believe in bookmarks.  To see the news release, click the
@@ -11417,13 +13821,13 @@ Zone America/Menominee	-5:50:27 -	LMT	1885 Sep 18 12:00
 # From Paul Eggert (2014-10-18):
 # H. David Matthews and Mary Vincent's map
 # "It's about TIME", _Canadian Geographic_ (September-October 1998)
-# http://www.canadiangeographic.ca/Magazine/SO98/alacarte.asp
+# https://web.archive.org/web/19990827055050/https://canadiangeographic.ca/SO98/geomap.htm
 # contains detailed boundaries for regions observing nonstandard
 # time and daylight saving time arrangements in Canada circa 1998.
 #
 # National Research Council Canada maintains info about time zones and DST.
-# http://www.nrc-cnrc.gc.ca/eng/services/time/time_zones.html
-# http://www.nrc-cnrc.gc.ca/eng/services/time/faq/index.html#Q5
+# https://www.nrc-cnrc.gc.ca/eng/services/time/time_zones.html
+# https://www.nrc-cnrc.gc.ca/eng/services/time/faq/index.html#Q5
 # Its unofficial information is often taken from Matthews and Vincent.
 
 # From Paul Eggert (2006-06-27):
@@ -11445,7 +13849,7 @@ Zone America/Menominee	-5:50:27 -	LMT	1885 Sep 18 12:00
 # Oct 31, to Oct 27, 1918 (and Sunday is a more likely transition day
 # than Thursday) in all Canadian rulesets.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Canada	1918	only	-	Apr	14	2:00	1:00	D
 Rule	Canada	1918	only	-	Oct	27	2:00	0	S
 Rule	Canada	1942	only	-	Feb	 9	2:00	1:00	W # War
@@ -11460,13 +13864,15 @@ Rule	Canada	2007	max	-	Nov	Sun>=1	2:00	0	S
 
 # Newfoundland and Labrador
 
-# From Paul Eggert (2000-10-02):
-# Matthews and Vincent (1998) write that Labrador should use NST/NDT,
-# but the only part of Labrador that follows the rules is the
-# southeast corner, including Port Hope Simpson and Mary's Harbour,
-# but excluding, say, Black Tickle.
+# From Paul Eggert (2017-10-14):
+# Legally Labrador should observe Newfoundland time; see:
+# McLeod J. Labrador time - legal or not? St. John's Telegram, 2017-10-07
+# http://www.thetelegram.com/news/local/labrador-time--legal-or-not-154860/
+# Matthews and Vincent (1998) write that the only part of Labrador
+# that follows the rules is the southeast corner, including Port Hope
+# Simpson and Mary's Harbour, but excluding, say, Black Tickle.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	StJohns	1917	only	-	Apr	 8	2:00	1:00	D
 Rule	StJohns	1917	only	-	Sep	17	2:00	0	S
 # Whitman gives 1919 Apr 5 and 1920 Apr 5; go with Shanks & Pottenger.
@@ -11514,8 +13920,8 @@ Rule	StJohns	1989	2006	-	Apr	Sun>=1	0:01	1:00	D
 Rule	StJohns	2007	2011	-	Mar	Sun>=8	0:01	1:00	D
 Rule	StJohns	2007	2010	-	Nov	Sun>=1	0:01	0	S
 #
-# St John's has an apostrophe, but Posix file names can't have apostrophes.
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# St John's has an apostrophe, but POSIX file names can't have apostrophes.
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/St_Johns	-3:30:52 -	LMT	1884
 			-3:30:52 StJohns N%sT	1918
 			-3:30:52 Canada	N%sT	1919
@@ -11528,7 +13934,7 @@ Zone America/St_Johns	-3:30:52 -	LMT	1884
 # most of east Labrador
 
 # The name 'Happy Valley-Goose Bay' is too long; use 'Goose Bay'.
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Goose_Bay	-4:01:40 -	LMT	1884 # Happy Valley-Goose Bay
 			-3:30:52 -	NST	1918
 			-3:30:52 Canada N%sT	1919
@@ -11541,7 +13947,8 @@ Zone America/Goose_Bay	-4:01:40 -	LMT	1884 # Happy Valley-Goose Bay
 			-4:00	Canada	A%sT
 
 
-# west Labrador, Nova Scotia, Prince Edward I
+# west Labrador, Nova Scotia, Prince Edward I,
+# Îles-de-la-Madeleine, Listuguj reserve
 
 # From Brian Inglis (2015-07-20):
 # From the historical weather station records available at:
@@ -11560,7 +13967,14 @@ Zone America/Goose_Bay	-4:01:40 -	LMT	1884 # Happy Valley-Goose Bay
 # in Canada to observe DST in 1971 but not 1970; for now we'll assume
 # this is a typo.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# From Jeffery Nichols (2020-01-09):
+# America/Halifax ... also applies to Îles-de-la-Madeleine and the Listuguj
+# reserve in Quebec. Officially, this came into effect on January 1, 2007
+# (Legal Time Act, CQLR c T-5.1), but the legislative debates surrounding that
+# bill say that it is "accommodating the customs and practices" of those
+# regions, which suggests that they have always been in-line with Halifax.
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Halifax	1916	only	-	Apr	 1	0:00	1:00	D
 Rule	Halifax	1916	only	-	Oct	 1	0:00	0	S
 Rule	Halifax	1920	only	-	May	 9	0:00	1:00	D
@@ -11602,7 +14016,7 @@ Rule	Halifax	1956	1959	-	Apr	lastSun	2:00	1:00	D
 Rule	Halifax	1956	1959	-	Sep	lastSun	2:00	0	S
 Rule	Halifax	1962	1973	-	Apr	lastSun	2:00	1:00	D
 Rule	Halifax	1962	1973	-	Oct	lastSun	2:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Halifax	-4:14:24 -	LMT	1902 Jun 15
 			-4:00	Halifax	A%sT	1918
 			-4:00	Canada	A%sT	1919
@@ -11626,7 +14040,7 @@ Zone America/Glace_Bay	-3:59:48 -	LMT	1902 Jun 15
 # clear that this was the case since at least 1993.
 # For now, assume it started in 1993.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Moncton	1933	1935	-	Jun	Sun>=8	1:00	1:00	D
 Rule	Moncton	1933	1935	-	Sep	Sun>=8	1:00	0	S
 Rule	Moncton	1936	1938	-	Jun	Sun>=1	1:00	1:00	D
@@ -11640,7 +14054,7 @@ Rule	Moncton	1946	1956	-	Sep	lastSun	2:00	0	S
 Rule	Moncton	1957	1972	-	Oct	lastSun	2:00	0	S
 Rule	Moncton	1993	2006	-	Apr	Sun>=1	0:01	1:00	D
 Rule	Moncton	1993	2006	-	Oct	lastSun	0:01	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Moncton	-4:19:08 -	LMT	1883 Dec  9
 			-5:00	-	EST	1902 Jun 15
 			-4:00	Canada	A%sT	1933
@@ -11653,36 +14067,12 @@ Zone America/Moncton	-4:19:08 -	LMT	1883 Dec  9
 
 # Quebec
 
-# From Paul Eggert (2015-03-24):
+# From Paul Eggert (2020-01-10):
 # See America/Toronto for most of Quebec, including Montreal.
-#
-# Matthews and Vincent (1998) also write that Quebec east of the -63
-# meridian is supposed to observe AST, but residents as far east as
-# Natashquan use EST/EDT, and residents east of Natashquan use AST.
-# The Quebec department of justice writes in
-# "The situation in Minganie and Basse-Côte-Nord"
-# http://www.justice.gouv.qc.ca/english/publications/generale/temps-minganie-a.htm
-# that the coastal strip from just east of Natashquan to Blanc-Sablon
-# observes Atlantic standard time all year round.
-# http://www.assnat.qc.ca/Media/Process.aspx?MediaId=ANQ.Vigie.Bll.DocumentGenerique_8845en
-# says this common practice was codified into law as of 2007.
-# For lack of better info, guess this practice began around 1970, contra to
-# Shanks & Pottenger who have this region observing AST/ADT.
-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Blanc-Sablon -3:48:28 -	LMT	1884
-			-4:00	Canada	A%sT	1970
-			-4:00	-	AST
+# See America/Halifax for the Îles de la Madeleine and the Listuguj reserve.
+# See America/Puerto_Rico for east of Natashquan.
 
 # Ontario
-
-# From Paul Eggert (2006-07-09):
-# Shanks & Pottenger write that since 1970 most of Ontario has been like
-# Toronto.
-# Thunder Bay skipped DST in 1973.
-# Many smaller locales did not observe peacetime DST until 1974;
-# Nipigon (EST) and Rainy River (CST) are the largest that we know of.
-# Far west Ontario is like Winnipeg; far east Quebec is like Halifax.
 
 # From Mark Brader (2003-07-26):
 # [According to the Toronto Star] Orillia, Ontario, adopted DST
@@ -11696,67 +14086,22 @@ Zone America/Blanc-Sablon -3:48:28 -	LMT	1884
 # earlier in June).
 #
 # Kenora, Ontario, was to abandon DST on 1914-06-01 (-05-21).
-
-# From Paul Eggert (1997-10-17):
-# Mark Brader writes that an article in the 1997-10-14 Toronto Star
-# says that Atikokan, Ontario currently does not observe DST,
-# but will vote on 11-10 whether to use EST/EDT.
-# He also writes that the Ontario Time Act (1990, Chapter T.9)
-# http://www.gov.on.ca/MBS/english/publications/statregs/conttext.html
-# says that Ontario east of 90W uses EST/EDT, and west of 90W uses CST/CDT.
-# Officially Atikokan is therefore on CST/CDT, and most likely this report
-# concerns a non-official time observed as a matter of local practice.
 #
-# From Paul Eggert (2000-10-02):
-# Matthews and Vincent (1998) write that Atikokan, Pickle Lake, and
-# New Osnaburgh observe CST all year, that Big Trout Lake observes
-# CST/CDT, and that Upsala and Shebandowan observe EST/EDT, all in
-# violation of the official Ontario rules.
-#
-# From Paul Eggert (2006-07-09):
-# Chris Walton (2006-07-06) mentioned an article by Stephanie MacLellan in the
-# 2005-07-21 Chronicle-Journal, which said:
-#
-#	The clocks in Atikokan stay set on standard time year-round.
-#	This means they spend about half the time on central time and
-#	the other half on eastern time.
-#
-#	For the most part, the system works, Mayor Dennis Brown said.
-#
-#	"The majority of businesses in Atikokan deal more with Eastern
-#	Canada, but there are some that deal with Western Canada," he
-#	said.  "I don't see any changes happening here."
-#
-# Walton also writes "Supposedly Pickle Lake and Mishkeegogamang
-# [New Osnaburgh] follow the same practice."
-
-# From Garry McKinnon (2006-07-14) via Chris Walton:
-# I chatted with a member of my board who has an outstanding memory
-# and a long history in Atikokan (and in the telecom industry) and he
-# can say for certain that Atikokan has been practicing the current
-# time keeping since 1952, at least.
-
-# From Paul Eggert (2006-07-17):
-# Shanks & Pottenger say that Atikokan has agreed with Rainy River
-# ever since standard time was introduced, but the information from
-# McKinnon sounds more authoritative.  For now, assume that Atikokan
-# switched to EST immediately after WWII era daylight saving time
-# ended.  This matches the old (less-populous) America/Coral_Harbour
-# entry since our cutoff date of 1970, so we can move
-# America/Coral_Harbour to the 'backward' file.
+# From Paul Eggert (2017-07-08):
+# For more on Orillia, see: Daubs K. Bold attempt at daylight saving
+# time became a comic failure in Orillia. Toronto Star 2017-07-08.
+# https://www.thestar.com/news/insight/2017/07/08/bold-attempt-at-daylight-saving-time-became-a-comic-failure-in-orillia.html
+# From Paul Eggert (2025-03-20):
+# Also see the 1912-06-17 front page of The Evening Sunbeam,
+# reproduced in: Richardson M. "Daylight saving was a confusing
+# time in Orillia" in the 2025-03-15 Orillia Matters. Richardson writes,
+# "The first Sunday after the switch was made, [DST proponent and
+# Orillia mayor William Sword] Frost walked into church an hour late.
+# This became a symbol of the downfall of daylight saving in Orillia."
+# The mayor became known as "Daylight Bill".
+# https://www.orilliamatters.com/local-news/column-daylight-saving-was-a-confusing-time-in-orillia-10377529
 
 # From Mark Brader (2010-03-06):
-#
-# Currently the database has:
-#
-# # Ontario
-#
-# # From Paul Eggert (2006-07-09):
-# # Shanks & Pottenger write that since 1970 most of Ontario has been like
-# # Toronto.
-# # Thunder Bay skipped DST in 1973.
-# # Many smaller locales did not observe peacetime DST until 1974;
-# # Nipigon (EST) and Rainy River (CST) are the largest that we know of.
 #
 # In the (Toronto) Globe and Mail for Saturday, 1955-09-24, in the bottom
 # right corner of page 1, it says that Toronto will return to standard
@@ -11765,15 +14110,22 @@ Zone America/Blanc-Sablon -3:48:28 -	LMT	1884
 #     The one-hour setback will go into effect throughout most of Ontario,
 #     except in areas like Windsor which remains on standard time all year.
 #
-# Windsor is, of course, a lot larger than Nipigon.
-#
-# I only came across this incidentally.  I don't know if Windsor began
-# observing DST when Detroit did, or in 1974, or on some other date.
+# ... I don't know if Windsor began observing DST when Detroit did,
+# or in 1974, or on some other date.
 #
 # By the way, the article continues by noting that:
 #
 #     Some cities in the United States have pushed the deadline back
 #     three weeks and will change over from daylight saving in October.
+
+# From Chris Walton (2024-01-09):
+# The [Toronto] changes in 1947, 1948, and 1949 took place at 2:00 a.m. local
+# time instead of midnight....  Toronto Daily Star - ...
+# April 2, 1947 - Page 39 ... April 7, 1948 - Page 13 ...
+# April 2, 1949 - Page 1 ... April 7, 1949 - Page 24 ...
+# November 25, 1949 - Page 52 ... April 21, 1950 - Page 14 ...
+# September 19, 1950 - Page 46 ... September 20, 1950 - Page 3 ...
+# November 24, 1950 - Page 21
 
 # From Arthur David Olson (2010-07-17):
 #
@@ -11820,7 +14172,7 @@ Zone America/Blanc-Sablon -3:48:28 -	LMT	1884
 #   With some exceptions, the use of daylight saving may be said to be limited
 # to those cities and towns lying between Quebec city and Windsor, Ont.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Toronto	1919	only	-	Mar	30	23:30	1:00	D
 Rule	Toronto	1919	only	-	Oct	26	0:00	0	S
 Rule	Toronto	1920	only	-	May	 2	2:00	1:00	D
@@ -11832,26 +14184,13 @@ Rule	Toronto	1922	1923	-	May	Sun>=8	2:00	1:00	D
 # was meant.
 Rule	Toronto	1922	1926	-	Sep	Sun>=15	2:00	0	S
 Rule	Toronto	1924	1927	-	May	Sun>=1	2:00	1:00	D
-# The 1927-to-1939 rules can be expressed more simply as
-# Rule	Toronto	1927	1937	-	Sep	Sun>=25	2:00	0	S
-# Rule	Toronto	1928	1937	-	Apr	Sun>=25	2:00	1:00	D
-# Rule	Toronto	1938	1940	-	Apr	lastSun	2:00	1:00	D
-# Rule	Toronto	1938	1939	-	Sep	lastSun	2:00	0	S
-# The rules below avoid use of Sun>=25
-# (which pre-2004 versions of zic cannot handle).
-Rule	Toronto	1927	1932	-	Sep	lastSun	2:00	0	S
-Rule	Toronto	1928	1931	-	Apr	lastSun	2:00	1:00	D
-Rule	Toronto	1932	only	-	May	1	2:00	1:00	D
-Rule	Toronto	1933	1940	-	Apr	lastSun	2:00	1:00	D
-Rule	Toronto	1933	only	-	Oct	1	2:00	0	S
-Rule	Toronto	1934	1939	-	Sep	lastSun	2:00	0	S
-Rule	Toronto	1945	1946	-	Sep	lastSun	2:00	0	S
-Rule	Toronto	1946	only	-	Apr	lastSun	2:00	1:00	D
-Rule	Toronto	1947	1949	-	Apr	lastSun	0:00	1:00	D
-Rule	Toronto	1947	1948	-	Sep	lastSun	0:00	0	S
-Rule	Toronto	1949	only	-	Nov	lastSun	0:00	0	S
-Rule	Toronto	1950	1973	-	Apr	lastSun	2:00	1:00	D
-Rule	Toronto	1950	only	-	Nov	lastSun	2:00	0	S
+Rule	Toronto	1927	1937	-	Sep	Sun>=25	2:00	0	S
+Rule	Toronto	1928	1937	-	Apr	Sun>=25	2:00	1:00	D
+Rule	Toronto	1938	1940	-	Apr	lastSun	2:00	1:00	D
+Rule	Toronto	1938	1939	-	Sep	lastSun	2:00	0	S
+Rule	Toronto	1945	1948	-	Sep	lastSun	2:00	0	S
+Rule	Toronto	1946	1973	-	Apr	lastSun	2:00	1:00	D
+Rule	Toronto	1949	1950	-	Nov	lastSun	2:00	0	S
 Rule	Toronto	1951	1956	-	Sep	lastSun	2:00	0	S
 # Shanks & Pottenger say Toronto ended DST a week early in 1971,
 # namely on 1971-10-24, but Mark Brader wrote (2003-05-31) that this
@@ -11859,51 +14198,16 @@ Rule	Toronto	1951	1956	-	Sep	lastSun	2:00	0	S
 # Toronto Star, which said that DST was ending 1971-10-31 as usual.
 Rule	Toronto	1957	1973	-	Oct	lastSun	2:00	0	S
 
-# From Paul Eggert (2003-07-27):
-# Willett (1914-03) writes (p. 17) "In the Cities of Fort William, and
-# Port Arthur, Ontario, the principle of the Bill has been in
-# operation for the past three years, and in the City of Moose Jaw,
-# Saskatchewan, for one year."
+# The Bahamas match Toronto since 1970.
 
-# From David Bryan via Tory Tronrud, Director/Curator,
-# Thunder Bay Museum (2003-11-12):
-# There is some suggestion, however, that, by-law or not, daylight
-# savings time was being practiced in Fort William and Port Arthur
-# before 1909.... [I]n 1910, the line between the Eastern and Central
-# Time Zones was permanently moved about two hundred miles west to
-# include the Thunder Bay area....  When Canada adopted daylight
-# savings time in 1916, Fort William and Port Arthur, having done so
-# already, did not change their clocks....  During the Second World
-# War,... [t]he cities agreed to implement DST during the summer
-# months for the remainder of the war years.
-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Toronto	-5:17:32 -	LMT	1895
 			-5:00	Canada	E%sT	1919
 			-5:00	Toronto	E%sT	1942 Feb  9  2:00s
 			-5:00	Canada	E%sT	1946
 			-5:00	Toronto	E%sT	1974
 			-5:00	Canada	E%sT
-Zone America/Thunder_Bay -5:57:00 -	LMT	1895
-			-6:00	-	CST	1910
-			-5:00	-	EST	1942
-			-5:00	Canada	E%sT	1970
-			-5:00	Toronto	E%sT	1973
-			-5:00	-	EST	1974
-			-5:00	Canada	E%sT
-Zone America/Nipigon	-5:53:04 -	LMT	1895
-			-5:00	Canada	E%sT	1940 Sep 29
-			-5:00	1:00	EDT	1942 Feb  9  2:00s
-			-5:00	Canada	E%sT
-Zone America/Rainy_River -6:18:16 -	LMT	1895
-			-6:00	Canada	C%sT	1940 Sep 29
-			-6:00	1:00	CDT	1942 Feb  9  2:00s
-			-6:00	Canada	C%sT
-Zone America/Atikokan	-6:06:28 -	LMT	1895
-			-6:00	Canada	C%sT	1940 Sep 29
-			-6:00	1:00	CDT	1942 Feb  9  2:00s
-			-6:00	Canada	C%sT	1945 Sep 30  2:00
-			-5:00	-	EST
+# For Atikokan see America/Panama.
 
 
 # Manitoba
@@ -11927,7 +14231,7 @@ Zone America/Atikokan	-6:06:28 -	LMT	1895
 # starting 1966.  Since 02:00s is clearly correct for 1967 on, assume
 # it was also 02:00s in 1966.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Winn	1916	only	-	Apr	23	0:00	1:00	D
 Rule	Winn	1916	only	-	Sep	17	0:00	0	S
 Rule	Winn	1918	only	-	Apr	14	2:00	1:00	D
@@ -11952,7 +14256,7 @@ Rule	Winn	1963	only	-	Sep	22	2:00	0	S
 Rule	Winn	1966	1986	-	Apr	lastSun	2:00s	1:00	D
 Rule	Winn	1966	2005	-	Oct	lastSun	2:00s	0	S
 Rule	Winn	1987	2005	-	Apr	Sun>=1	2:00s	1:00	D
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Winnipeg	-6:28:36 -	LMT	1887 Jul 16
 			-6:00	Winn	C%sT	2006
 			-6:00	Canada	C%sT
@@ -11973,6 +14277,12 @@ Zone America/Winnipeg	-6:28:36 -	LMT	1887 Jul 16
 # From Paul Eggert (2003-07-27):
 # Willett (1914-03) notes that DST "has been in operation ... in the
 # City of Moose Jaw, Saskatchewan, for one year."
+
+# From Paul Eggert (2019-07-25):
+# Pearce's book says Regina observed DST in 1914-1917.  No dates and times,
+# unfortunately.  It also says that in 1914 Saskatoon observed DST
+# from 1 June to 6 July, and that DST was also tried out in Davidson,
+# Melfort, and Prince Albert.
 
 # From Paul Eggert (2006-03-22):
 # Shanks & Pottenger say that since 1970 this region has mostly been as Regina.
@@ -12012,7 +14322,7 @@ Zone America/Winnipeg	-6:28:36 -	LMT	1887 Jul 16
 # long and rather painful to read.
 # http://www.qp.gov.sk.ca/documents/English/Statutes/Statutes/T14.pdf
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Regina	1918	only	-	Apr	14	2:00	1:00	D
 Rule	Regina	1918	only	-	Oct	27	2:00	0	S
 Rule	Regina	1930	1934	-	May	Sun>=1	0:00	1:00	D
@@ -12036,7 +14346,7 @@ Rule	Swift	1957	only	-	Oct	lastSun	2:00	0	S
 Rule	Swift	1959	1961	-	Apr	lastSun	2:00	1:00	D
 Rule	Swift	1959	only	-	Oct	lastSun	2:00	0	S
 Rule	Swift	1960	1961	-	Sep	lastSun	2:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Regina	-6:58:36 -	LMT	1905 Sep
 			-7:00	Regina	M%sT	1960 Apr lastSun  2:00
 			-6:00	-	CST
@@ -12049,7 +14359,20 @@ Zone America/Swift_Current -7:11:20 -	LMT	1905 Sep
 
 # Alberta
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# From Alois Treindl (2019-07-19):
+# There was no DST in Alberta in 1967... Calgary Herald, 29 April 1967.
+# 1969, no DST, from Edmonton Journal 18 April 1969
+#
+# From Paul Eggert (2019-07-25):
+# Pearce's book says that Alberta's 1948 Daylight Saving Act required
+# Mountain Standard Time without DST, and that "anyone who broke that law
+# could be fined up to $25 and costs".  There seems to be no record of
+# anybody paying the fine.  The law was not changed until an August 1971
+# plebiscite reinstituted DST in 1972.  This story is also mentioned in:
+# Boyer JP. Forcing Choice: The Risky Reward of Referendums. Dundum. 2017.
+# ISBN 978-1459739123.
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Edm	1918	1919	-	Apr	Sun>=8	2:00	1:00	D
 Rule	Edm	1918	only	-	Oct	27	2:00	0	S
 Rule	Edm	1919	only	-	May	27	2:00	0	S
@@ -12061,13 +14384,9 @@ Rule	Edm	1945	only	-	Aug	14	23:00u	1:00	P # Peace
 Rule	Edm	1945	only	-	Sep	lastSun	2:00	0	S
 Rule	Edm	1947	only	-	Apr	lastSun	2:00	1:00	D
 Rule	Edm	1947	only	-	Sep	lastSun	2:00	0	S
-Rule	Edm	1967	only	-	Apr	lastSun	2:00	1:00	D
-Rule	Edm	1967	only	-	Oct	lastSun	2:00	0	S
-Rule	Edm	1969	only	-	Apr	lastSun	2:00	1:00	D
-Rule	Edm	1969	only	-	Oct	lastSun	2:00	0	S
 Rule	Edm	1972	1986	-	Apr	lastSun	2:00	1:00	D
 Rule	Edm	1972	2006	-	Oct	lastSun	2:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Edmonton	-7:33:52 -	LMT	1906 Sep
 			-7:00	Edm	M%sT	1987
 			-7:00	Canada	M%sT
@@ -12079,60 +14398,6 @@ Zone America/Edmonton	-7:33:52 -	LMT	1906 Sep
 # Shanks & Pottenger write that since 1970 most of this region has
 # been like Vancouver.
 # Dawson Creek uses MST.  Much of east BC is like Edmonton.
-# Matthews and Vincent (1998) write that Creston is like Dawson Creek.
-
-# It seems though that (re: Creston) is not entirely correct:
-
-# From Chris Walton (2011-12-01):
-# There are two areas within the Canadian province of British Columbia
-# that do not currently observe daylight saving:
-# a) The Creston Valley (includes the town of Creston and surrounding area)
-# b) The eastern half of the Peace River Regional District
-# (includes the cities of Dawson Creek and Fort St. John)
-
-# Earlier this year I stumbled across a detailed article about the time
-# keeping history of Creston; it was written by Tammy Hardwick who is the
-# manager of the Creston & District Museum. The article was written in May 2009.
-# http://www.ilovecreston.com/?p=articles&t=spec&ar=260
-# According to the article, Creston has not changed its clocks since June 1918.
-# i.e. Creston has been stuck on UTC-7 for 93 years.
-# Dawson Creek, on the other hand, changed its clocks as recently as April 1972.
-
-# Unfortunately the exact date for the time change in June 1918 remains
-# unknown and will be difficult to ascertain.  I e-mailed Tammy a few months
-# ago to ask if Sunday June 2 was a reasonable guess.  She said it was just
-# as plausible as any other date (in June).  She also said that after writing
-# the article she had discovered another time change in 1916; this is the
-# subject of another article which she wrote in October 2010.
-# http://www.creston.museum.bc.ca/index.php?module=comments&uop=view_comment&cm+id=56
-
-# Here is a summary of the three clock change events in Creston's history:
-# 1. 1884 or 1885: adoption of Mountain Standard Time (GMT-7)
-# Exact date unknown
-# 2. Oct 1916: switch to Pacific Standard Time (GMT-8)
-# Exact date in October unknown; Sunday October 1 is a reasonable guess.
-# 3. June 1918: switch to Pacific Daylight Time (GMT-7)
-# Exact date in June unknown; Sunday June 2 is a reasonable guess.
-# note 1:
-# On Oct 27/1918 when daylight saving ended in the rest of Canada,
-# Creston did not change its clocks.
-# note 2:
-# During WWII when the Federal Government legislated a mandatory clock change,
-# Creston did not oblige.
-# note 3:
-# There is no guarantee that Creston will remain on Mountain Standard Time
-# (UTC-7) forever.
-# The subject was debated at least once this year by the town Council.
-# http://www.bclocalnews.com/kootenay_rockies/crestonvalleyadvance/news/116760809.html
-
-# During a period WWII, summer time (Daylight saying) was mandatory in Canada.
-# In Creston, that was handled by shifting the area to PST (-8:00) then applying
-# summer time to cause the offset to be -7:00, the same as it had been before
-# the change.  It can be argued that the timezone abbreviation during this
-# period should be PDT rather than MST, but that doesn't seem important enough
-# (to anyone) to further complicate the rules.
-
-# The transition dates (and times) are guesses.
 
 # From Matt Johnson (2015-09-21):
 # Fort Nelson, BC, Canada will cancel DST this year.  So while previously they
@@ -12147,20 +14412,32 @@ Zone America/Edmonton	-7:33:52 -	LMT	1906 Sep
 # been on MST (-0700) like Dawson Creek since it advanced its clocks on
 # 2015-03-08.
 #
-# From Paul Eggert (2015-09-23):
+# From Paul Eggert (2019-07-25):
 # Shanks says Fort Nelson did not observe DST in 1946, unlike Vancouver.
+# Alois Treindl confirmed this on 07-22, citing the 1946-04-27 Vancouver Daily
+# Province.  He also cited the 1946-09-28 Victoria Daily Times, which said
+# that Vancouver, Victoria, etc. "change at midnight Saturday"; for now,
+# guess they meant 02:00 Sunday since 02:00 was common practice in Vancouver.
+#
+# Early Vancouver, Volume Four, by Major J.S. Matthews, V.D., 2011 edition
+# says that a 1922 plebiscite adopted DST, but a 1923 plebiscite rejected it.
+# http://former.vancouver.ca/ctyclerk/archives/digitized/EarlyVan/SearchEarlyVan/Vol4pdf/MatthewsEarlyVancouverVol4_DaylightSavings.pdf
+# A catalog entry for a newspaper clipping seems to indicate that Vancouver
+# observed DST in 1941 from 07-07 through 09-27; see
+# https://searcharchives.vancouver.ca/daylight-saving-1918-starts-again-july-7-1941-start-d-s-sept-27-end-of-d-s-1941
+# We have no further details, so omit them for now.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Vanc	1918	only	-	Apr	14	2:00	1:00	D
 Rule	Vanc	1918	only	-	Oct	27	2:00	0	S
 Rule	Vanc	1942	only	-	Feb	 9	2:00	1:00	W # War
 Rule	Vanc	1945	only	-	Aug	14	23:00u	1:00	P # Peace
 Rule	Vanc	1945	only	-	Sep	30	2:00	0	S
 Rule	Vanc	1946	1986	-	Apr	lastSun	2:00	1:00	D
-Rule	Vanc	1946	only	-	Oct	13	2:00	0	S
+Rule	Vanc	1946	only	-	Sep	29	2:00	0	S
 Rule	Vanc	1947	1961	-	Sep	lastSun	2:00	0	S
 Rule	Vanc	1962	2006	-	Oct	lastSun	2:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Vancouver	-8:12:28 -	LMT	1884
 			-8:00	Vanc	P%sT	1987
 			-8:00	Canada	P%sT
@@ -12174,12 +14451,40 @@ Zone America/Fort_Nelson	-8:10:47 -	LMT	1884
 			-8:00	Vanc	P%sT	1987
 			-8:00	Canada	P%sT	2015 Mar  8  2:00
 			-7:00	-	MST
-Zone America/Creston	-7:46:04 -	LMT	1884
-			-7:00	-	MST	1916 Oct 1
-			-8:00	-	PST	1918 Jun 2
-			-7:00	-	MST
+# For Creston see America/Phoenix.
 
 # Northwest Territories, Nunavut, Yukon
+
+# From Chris Walton (2022-11-06):
+# Whitehorse Star - Thursday April 22, 1965 - page 1
+# title: DST Starts Monday ...
+# https://www.newspapers.com/image/578587481/
+# The title of this first article is wrong and/or misleading.
+# Also, the start time shown in the  article is vague; it simply says "after
+# midnight" when it probably should have stated 2:00a.m....
+#
+# Whitehorse Star - Monday October 25, 1965 - page 15 ...
+# https://www.newspapers.com/image/578589147/
+# The 1965 Yukon Council minutes can be found here:
+# http://assets.yukonarchives.ca/PER_YG_06_1965_C20_S02_v1.pdf
+# ... I do not currently believe that NWT touched any of its clocks in 1965....
+#
+# Whitehorse Star - Thursday Feb 24,1966 - page 2
+# title: It's Time for YDT ...
+# https://www.newspapers.com/image/578575979/ ...
+# America/Whitehorse as a permanent change from UTC-9(YST) to
+# UTC-8(PST) at 00:00 on Sunday February 27, 1966....
+#
+# Whitehorse Star - Friday April 28,1972 - page 6
+# title: Daylight Saving Time for N.W.T....
+# https://www.newspapers.com/image/578701610/ ...
+# Nunavut and NWT zones ... DST starting in 1972.... Start and End ...
+# should be the same as the rest of Canada
+#
+#
+# From Paul Eggert (2022-11-06):
+# For now, assume Yukon's 1965-04-22 spring forward was 00:00 -> 02:00, as this
+# seems likely than 02:00 -> 04:00 and matches "after midnight".
 
 # From Paul Eggert (2006-03-22):
 # Dawson switched to PST in 1973.  Inuvik switched to MST in 1979.
@@ -12187,7 +14492,7 @@ Zone America/Creston	-7:46:04 -	LMT	1884
 #	* 1967. Paragraph 28(34)(g) of the Interpretation Act, S.C. 1967-68,
 #	c. 7 defines Yukon standard time as UTC-9....
 #	see Interpretation Act, R.S.C. 1985, c. I-21, s. 35(1).
-#	[http://canlii.ca/t/7vhg]
+#	[https://www.canlii.org/en/ca/laws/stat/rsc-1985-c-i-21/latest/rsc-1985-c-i-21.html]
 #	* C.O. 1973/214 switched Yukon to PST on 1973-10-28 00:00.
 #	* O.I.C. 1980/02 established DST.
 #	* O.I.C. 1987/056 changed DST to Apr firstSun 2:00 to Oct lastSun 2:00.
@@ -12231,7 +14536,7 @@ Zone America/Creston	-7:46:04 -	LMT	1884
 #     varying the manner of reckoning standard time.
 #
 # * Yukon Territory Commissioner's Order 1966-20 Interpretation Ordinance
-#   http://? - no online source found
+#   [no online source found]
 #
 # * Standard Time and Time Zones in Canada; Thomson, Malcolm M.; JRASC,
 #   Vol. 64, pp.129-162; June 1970; SAO/NASA Astrophysics Data System (ADS)
@@ -12252,7 +14557,7 @@ Zone America/Creston	-7:46:04 -	LMT	1884
 #     hours behind Greenwich Time.
 #
 # * Yukon Standard Time defined as Pacific Standard Time, YCO 1973/214
-#   http://www.canlii.org/en/yk/laws/regu/yco-1973-214/latest/yco-1973-214.html
+#   https://www.canlii.org/en/yk/laws/regu/yco-1973-214/latest/yco-1973-214.html
 #   C.O. 1973/214 INTERPRETATION ACT ...
 #
 #     1. Effective October 28, 1973 Commissioner's Order 1967/59 is hereby
@@ -12264,10 +14569,10 @@ Zone America/Creston	-7:46:04 -	LMT	1884
 #     to say eight hours behind Greenwich Time.
 #
 # * O.I.C. 1980/02 INTERPRETATION ACT
-#   http://? - no online source found
+#   https://mm.icann.org/pipermail/tz/attachments/20201125/d5adc93b/CAYTOIC1980-02DST1980-01-04-0001.pdf
 #
 # * Yukon Daylight Saving Time, YOIC 1987/56
-#   http://www.canlii.org/en/yk/laws/regu/yoic-1987-56/latest/yoic-1987-56.html
+#   https://www.canlii.org/en/yk/laws/regu/yoic-1987-56/latest/yoic-1987-56.html
 #   O.I.C. 1987/056 INTERPRETATION ACT ...
 #
 #   In every year between
@@ -12279,7 +14584,7 @@ Zone America/Creston	-7:46:04 -	LMT	1884
 #   Dated ... 9th day of March, A.D., 1987.
 #
 # * Yukon Daylight Saving Time 2006, YOIC 2006/127
-#   http://www.canlii.org/en/yk/laws/regu/yoic-2006-127/latest/yoic-2006-127.html
+#   https://www.canlii.org/en/yk/laws/regu/yoic-2006-127/latest/yoic-2006-127.html
 #   O.I.C. 2006/127 INTERPRETATION ACT ...
 #
 #     1. In Yukon each year the time for general purposes shall be 7 hours
@@ -12293,54 +14598,24 @@ Zone America/Creston	-7:46:04 -	LMT	1884
 #     3. This order comes into force January 1, 2007.
 #
 # * Interpretation Act, RSY 2002, c 125
-# http://www.canlii.org/en/yk/laws/stat/rsy-2002-c-125/latest/rsy-2002-c-125.html
+# https://www.canlii.org/en/yk/laws/stat/rsy-2002-c-125/latest/rsy-2002-c-125.html
+
+# From Chris Walton (2022-11-06):
+# The 5th edition of the Atlas of Canada contains a time zone map that
+# shows both legislated and observed time zone boundaries.
+# All communities on Baffin Island are shown to be observing Eastern time.
+# The date on the map is 1984.
+# https://ftp.maps.canada.ca/pub/nrcan_rncan/raster/atlas_5_ed/eng/other/referencemaps/mcr4056.pdf
 
 # From Rives McDow (1999-09-04):
 # Nunavut ... moved ... to incorporate the whole territory into one time zone.
 # Nunavut moves to single time zone Oct. 31
 # http://www.nunatsiaq.com/nunavut/nvt90903_13.html
-#
-# From Antoine Leca (1999-09-06):
-# We then need to create a new timezone for the Kitikmeot region of Nunavut
-# to differentiate it from the Yellowknife region.
 
 # From Paul Eggert (1999-09-20):
 # Basic Facts: The New Territory
 # http://www.nunavut.com/basicfacts/english/basicfacts_1territory.html
-# (1999) reports that Pangnirtung operates on eastern time,
-# and that Coral Harbour does not observe DST.  We don't know when
-# Pangnirtung switched to eastern time; we'll guess 1995.
-
-# From Rives McDow (1999-11-08):
-# On October 31, when the rest of Nunavut went to Central time,
-# Pangnirtung wobbled.  Here is the result of their wobble:
-#
-# The following businesses and organizations in Pangnirtung use Central Time:
-#
-#	First Air, Power Corp, Nunavut Construction, Health Center, RCMP,
-#	Eastern Arctic National Parks, A & D Specialist
-#
-# The following businesses and organizations in Pangnirtung use Eastern Time:
-#
-#	Hamlet office, All other businesses, Both schools, Airport operator
-#
-# This has made for an interesting situation there, which warranted the news.
-# No one there that I spoke with seems concerned, or has plans to
-# change the local methods of keeping time, as it evidently does not
-# really interfere with any activities or make things difficult locally.
-# They plan to celebrate New Year's turn-over twice, one hour apart,
-# so it appears that the situation will last at least that long.
-# The Nunavut Intergovernmental Affairs hopes that they will "come to
-# their senses", but the locals evidently don't see any problem with
-# the current state of affairs.
-
-# From Michaela Rodrigue, writing in the
-# Nunatsiaq News (1999-11-19):
-# http://www.nunatsiaq.com/archives/nunavut991130/nvt91119_17.html
-# Clyde River, Pangnirtung and Sanikiluaq now operate with two time zones,
-# central - or Nunavut time - for government offices, and eastern time
-# for municipal offices and schools....  Igloolik [was similar but then]
-# made the switch to central time on Saturday, Nov. 6.
+# (1999) reports that ... Coral Harbour does not observe DST.
 
 # From Paul Eggert (2000-10-02):
 # Matthews and Vincent (1998) say the following, but we lack histories
@@ -12354,7 +14629,7 @@ Zone America/Creston	-7:46:04 -	LMT	1884
 # Central Time and Southampton Island [in the Central zone] is not
 # required to use daylight savings.
 
-# From <http://www.nunatsiaq.com/archives/nunavut001130/nvt21110_02.html>
+# From <http://www.nunatsiaqonline.ca/archives/nunavut001130/nvt21110_02.html>
 # Nunavut now has two time zones (2000-11-10):
 # The Nunavut government would allow its employees in Kugluktuk and
 # Cambridge Bay to operate on central time year-round, putting them
@@ -12467,7 +14742,31 @@ Zone America/Creston	-7:46:04 -	LMT	1884
 # obtained in November 2008 should be ignored...
 # I apologize for reporting incorrect information in 2008.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# From Tim Parenti (2020-03-05):
+# The government of Yukon announced [yesterday] the cessation of seasonal time
+# changes.  "After clocks are pushed ahead one hour on March 8, the territory
+# will remain on [UTC-07].  ... [The government] found 93 per cent of
+# respondents wanted to end seasonal time changes and, of that group, 70 per
+# cent wanted 'permanent Pacific Daylight Saving Time.'"
+# https://www.cbc.ca/news/canada/north/yukon-end-daylight-saving-time-1.5486358
+#
+# Although the government press release prefers PDT, we prefer MST for
+# consistency with nearby Dawson Creek, Creston, and Fort Nelson.
+# https://yukon.ca/en/news/yukon-end-seasonal-time-change
+
+# From Andrew G. Smith (2020-09-24):
+# Yukon has completed its regulatory change to be on UTC -7 year-round....
+# http://www.gov.yk.ca/legislation/regs/oic2020_125.pdf
+# What we have done is re-defined Yukon Standard Time, as we are
+# authorized to do under section 33 of our Interpretation Act:
+# http://www.gov.yk.ca/legislation/acts/interpretation_c.pdf
+#
+# From Paul Eggert (2020-09-24):
+# tzdb uses the obsolete YST abbreviation for standard time in Yukon through
+# about 1970, and uses PST for standard time in Yukon since then.  Consistent
+# with that, use MST for -07, the new standard time in Yukon effective Nov. 1.
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	NT_YK	1918	only	-	Apr	14	2:00	1:00	D
 Rule	NT_YK	1918	only	-	Oct	27	2:00	0	S
 Rule	NT_YK	1919	only	-	May	25	2:00	1:00	D
@@ -12475,18 +14774,12 @@ Rule	NT_YK	1919	only	-	Nov	 1	0:00	0	S
 Rule	NT_YK	1942	only	-	Feb	 9	2:00	1:00	W # War
 Rule	NT_YK	1945	only	-	Aug	14	23:00u	1:00	P # Peace
 Rule	NT_YK	1945	only	-	Sep	30	2:00	0	S
-Rule	NT_YK	1965	only	-	Apr	lastSun	0:00	2:00	DD
-Rule	NT_YK	1965	only	-	Oct	lastSun	2:00	0	S
-Rule	NT_YK	1980	1986	-	Apr	lastSun	2:00	1:00	D
-Rule	NT_YK	1980	2006	-	Oct	lastSun	2:00	0	S
+Rule	NT_YK	1972	1986	-	Apr	lastSun	2:00	1:00	D
+Rule	NT_YK	1972	2006	-	Oct	lastSun	2:00	0	S
 Rule	NT_YK	1987	2006	-	Apr	Sun>=1	2:00	1:00	D
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-# aka Panniqtuuq
-Zone America/Pangnirtung 0	-	-00	1921 # trading post est.
-			-4:00	NT_YK	A%sT	1995 Apr Sun>=1  2:00
-			-5:00	Canada	E%sT	1999 Oct 31  2:00
-			-6:00	Canada	C%sT	2000 Oct 29  2:00
-			-5:00	Canada	E%sT
+Rule	Yukon	1965	only	-	Apr	lastSun	0:00	2:00	DD
+Rule	Yukon	1965	only	-	Oct	lastSun	2:00	0	S
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 # formerly Frobisher Bay
 Zone America/Iqaluit	0	-	-00	1942 Aug # Frobisher Bay est.
 			-5:00	NT_YK	E%sT	1999 Oct 31  2:00
@@ -12511,21 +14804,22 @@ Zone America/Cambridge_Bay 0	-	-00	1920 # trading post est.?
 			-5:00	-	EST	2000 Nov  5  0:00
 			-6:00	-	CST	2001 Apr  1  3:00
 			-7:00	Canada	M%sT
-Zone America/Yellowknife 0	-	-00	1935 # Yellowknife founded?
-			-7:00	NT_YK	M%sT	1980
-			-7:00	Canada	M%sT
 Zone America/Inuvik	0	-	-00	1953 # Inuvik founded
 			-8:00	NT_YK	P%sT	1979 Apr lastSun  2:00
 			-7:00	NT_YK	M%sT	1980
 			-7:00	Canada	M%sT
 Zone America/Whitehorse	-9:00:12 -	LMT	1900 Aug 20
-			-9:00	NT_YK	Y%sT	1967 May 28  0:00
-			-8:00	NT_YK	P%sT	1980
-			-8:00	Canada	P%sT
+			-9:00	NT_YK	Y%sT	1965
+			-9:00	Yukon	Y%sT	1966 Feb 27  0:00
+			-8:00	-	PST	1980
+			-8:00	Canada	P%sT	2020 Nov  1
+			-7:00	-	MST
 Zone America/Dawson	-9:17:40 -	LMT	1900 Aug 20
-			-9:00	NT_YK	Y%sT	1973 Oct 28  0:00
-			-8:00	NT_YK	P%sT	1980
-			-8:00	Canada	P%sT
+			-9:00	NT_YK	Y%sT	1965
+			-9:00	Yukon	Y%sT	1973 Oct 28  0:00
+			-8:00	-	PST	1980
+			-8:00	Canada	P%sT	2020 Nov  1
+			-7:00	-	MST
 
 
 ###############################################################################
@@ -12550,6 +14844,81 @@ Zone America/Dawson	-9:17:40 -	LMT	1900 Aug 20
 # tz database.  I think they can best be explained by supposing that
 # the researchers who prepared the Decrees page failed to find some of
 # the relevant documents.
+
+# From Heitor David Pinto (2024-08-04):
+# In 1931, the decree implementing DST specified that it would take
+# effect on 30 April....
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?cod_diario=192270&pagina=2&seccion=1
+#
+# In 1981, the decree changing Campeche, Yucatán and Quintana Roo to UTC-5
+# specified that it would enter into force on 26 December 1981 at 2:00....
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4705667&fecha=23/12/1981&cod_diario=202796
+#
+# In 1982, the decree returning Campeche and Yucatán to UTC-6 specified that
+# it would enter into force on 2 November 1982 at 2:00....
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?cod_diario=205689&pagina=3&seccion=0
+#
+# Quintana Roo changed to UTC-6 on 4 January 1983 at 0:00, and again
+# to UTC-5 on 26 October 1997 at 2:00....
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4787355&fecha=28/12/1982&cod_diario=206112
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?cod_diario=209559&pagina=15&seccion=0
+#
+# Durango, Coahuila, Nuevo León and Tamaulipas were set to UTC-7 on 1 January
+# 1922, and changed to UTC-6 on 10 June 1927.  Then Durango, Coahuila and
+# Nuevo León (but not Tamaulipas) returned to UTC-7 on 15 November 1930,
+# observed DST in 1931, and changed again to UTC-6 on 1 April 1932....
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4441846&fecha=29/12/1921&cod_diario=187468
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4541520&fecha=09/06/1927&cod_diario=193920
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4491963&fecha=15/11/1930&cod_diario=190835
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4418437&fecha=21/01/1932&cod_diario=185588
+#
+# ... the ... 10 June 1927 ... decree only said 10 June 1927, without
+# specifying a time, so I suppose that it should be considered at 0:00.
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4541520&fecha=09/06/1927&cod_diario=193920
+#
+# In 1942, the decree changing Baja California, Baja California Sur, Sonora,
+# Sinaloa and Nayarit to UTC-7 was published on 24 April, but it said that it
+# would apply from 1 April, so it's unclear when the change actually
+# occurred. The database currently shows 24 April 1942.
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?cod_diario=192203&pagina=2&seccion=1
+#
+# Baja California Sur, Sonora, Sinaloa and Nayarit never used UTC-8.  The ...
+# 14 January 1949 ... change [to UTC-8] only occurred in Baja California.
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4515613&fecha=13/01/1949&cod_diario=192309
+#
+# In 1945, the decree changing Baja California to UTC-8 specified that it
+# would take effect on the third day from its publication.
+# It was published on 12 November, so it would take effect on 15 November....
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4555049&fecha=12/11/1945&cod_diario=194763
+#
+# In 1948, the decree changing Baja California to UTC-7 specified that it
+# would take effect on "this date".  The decree was made on 13 March,
+# but published on 5 April, so it's unclear when the change actually occurred.
+# The database currently shows 5 April 1948.
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?cod_diario=188624&pagina=2&seccion=0
+#
+# In 1949, the decree changing Baja California to UTC-8 was published on 13
+# January, but it said that it would apply from 1 January, so it's unclear when
+# the change actually occurred.  The database currently shows 14 January 1949.
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4515613&fecha=13/01/1949&cod_diario=192309
+#
+# Baja California also observed UTC-7 from 1 May to 24 September 1950,
+# from 29 April to 30 September 1951 at 2:00,
+# and from 27 April to 28 September 1952 at 2:00....
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4600403&fecha=29/04/1950&cod_diario=197505
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4623553&fecha=23/09/1950&cod_diario=198805
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4469444&fecha=27/04/1951&cod_diario=189317
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4533868&fecha=10/03/1952&cod_diario=193465
+#
+# All changes in Baja California from 1948 to 1952 match those in California,
+# on the same dates or with a difference of one day.
+# So it may be easier to implement these changes as DST with rule CA
+# during this whole period.
+#
+# From Paul Eggert (2024-08-18):
+# For now, maintain the slightly-different history for Baja California,
+# as we have no information on whether 1948/1952 clocks in Tijuana followed
+# the decrees or followed San Diego.
 
 # From Alan Perry (1996-02-15):
 # A guy from our Mexico subsidiary finally found the Presidential Decree
@@ -12627,7 +14996,7 @@ Zone America/Dawson	-9:17:40 -	LMT	1900 Aug 20
 
 # From Paul Eggert (2001-03-03):
 #
-# http://www.latimes.com/news/nation/20010303/t000018766.html
+# https://www.latimes.com/archives/la-xpm-2001-mar-03-mn-32561-story.html
 # James F. Smith writes in today's LA Times
 # * Sonora will continue to observe standard time.
 # * Last week Mexico City's mayor Andrés Manuel López Obrador decreed that
@@ -12685,7 +15054,7 @@ Zone America/Dawson	-9:17:40 -	LMT	1900 Aug 20
 # http://gaceta.diputados.gob.mx/Gaceta/61/2009/dic/V2-101209.html
 #
 # Our page:
-# http://www.timeanddate.com/news/time/north-mexico-dst-change.html
+# https://www.timeanddate.com/news/time/north-mexico-dst-change.html
 
 # From Arthur David Olson (2010-01-20):
 # The page
@@ -12739,7 +15108,23 @@ Zone America/Dawson	-9:17:40 -	LMT	1900 Aug 20
 # 5- The islands, reefs and keys shall take their timezone from the
 #    longitude they are located at.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# From Paul Eggert (2022-10-28):
+# The new Mexican law was published today:
+# https://www.dof.gob.mx/nota_detalle.php?codigo=5670045&fecha=28/10/2022
+# This abolishes DST except where US DST rules are observed,
+# and in addition changes all of Chihuahua to -06 with no DST.
+
+# From Heitor David Pinto (2022-11-28):
+# Now the northern [municipios] want to have the same time zone as the
+# respective neighboring cities in the US, for example Juárez in UTC-7 with
+# DST, matching El Paso, and Ojinaga in UTC-6 with DST, matching Presidio....
+# the president authorized the publication of the decree for November 29,
+# so the time change would occur on November 30 at 0:00.
+# http://puentelibre.mx/noticia/ciudad_juarez_cambio_horario_noviembre_2022/
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Mexico	1931	only	-	Apr	30	0:00	1:00	D
+Rule	Mexico	1931	only	-	Oct	1	0:00	0	S
 Rule	Mexico	1939	only	-	Feb	5	0:00	1:00	D
 Rule	Mexico	1939	only	-	Jun	25	0:00	0	S
 Rule	Mexico	1940	only	-	Dec	9	0:00	1:00	D
@@ -12752,88 +15137,111 @@ Rule	Mexico	1996	2000	-	Apr	Sun>=1	2:00	1:00	D
 Rule	Mexico	1996	2000	-	Oct	lastSun	2:00	0	S
 Rule	Mexico	2001	only	-	May	Sun>=1	2:00	1:00	D
 Rule	Mexico	2001	only	-	Sep	lastSun	2:00	0	S
-Rule	Mexico	2002	max	-	Apr	Sun>=1	2:00	1:00	D
-Rule	Mexico	2002	max	-	Oct	lastSun	2:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+Rule	Mexico	2002	2022	-	Apr	Sun>=1	2:00	1:00	D
+Rule	Mexico	2002	2022	-	Oct	lastSun	2:00	0	S
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 # Quintana Roo; represented by Cancún
-Zone America/Cancun	-5:47:04 -	LMT	1922 Jan  1  0:12:56
-			-6:00	-	CST	1981 Dec 23
+Zone America/Cancun	-5:47:04 -	LMT	1922 Jan  1  6:00u
+			-6:00	-	CST	1981 Dec 26  2:00
+			-5:00	-	EST	1983 Jan  4  0:00
+			-6:00	Mexico	C%sT	1997 Oct 26  2:00
 			-5:00	Mexico	E%sT	1998 Aug  2  2:00
 			-6:00	Mexico	C%sT	2015 Feb  1  2:00
 			-5:00	-	EST
 # Campeche, Yucatán; represented by Mérida
-Zone America/Merida	-5:58:28 -	LMT	1922 Jan  1  0:01:32
-			-6:00	-	CST	1981 Dec 23
-			-5:00	-	EST	1982 Dec  2
+Zone America/Merida	-5:58:28 -	LMT	1922 Jan  1  6:00u
+			-6:00	-	CST	1981 Dec 26  2:00
+			-5:00	-	EST	1982 Nov  2  2:00
 			-6:00	Mexico	C%sT
 # Coahuila, Nuevo León, Tamaulipas (near US border)
-# This includes the following municipalities:
-#   in Coahuila: Ocampo, Acuña, Zaragoza, Jiménez, Piedras Negras, Nava,
-#     Guerrero, Hidalgo.
-#   in Nuevo León: Anáhuac, Los Aldama.
+# This includes the following municipios:
+#   in Coahuila: Acuña, Allende, Guerrero, Hidalgo, Jiménez, Morelos, Nava,
+#     Ocampo, Piedras Negras, Villa Unión, Zaragoza
+#   in Nuevo León: Anáhuac
 #   in Tamaulipas: Nuevo Laredo, Guerrero, Mier, Miguel Alemán, Camargo,
 #     Gustavo Díaz Ordaz, Reynosa, Río Bravo, Valle Hermoso, Matamoros.
-# See: Inicia mañana Horario de Verano en zona fronteriza, El Universal,
-# 2016-03-12
-# http://www.eluniversal.com.mx/articulo/estados/2016/03/12/inicia-manana-horario-de-verano-en-zona-fronteriza
-Zone America/Matamoros	-6:40:00 -	LMT	1921 Dec 31 23:20:00
+# https://www.dof.gob.mx/nota_detalle.php?codigo=5670045&fecha=28/10/2022
+Zone America/Matamoros	-6:30:00 -	LMT	1922 Jan  1  6:00u
 			-6:00	-	CST	1988
 			-6:00	US	C%sT	1989
 			-6:00	Mexico	C%sT	2010
 			-6:00	US	C%sT
 # Durango; Coahuila, Nuevo León, Tamaulipas (away from US border)
-Zone America/Monterrey	-6:41:16 -	LMT	1921 Dec 31 23:18:44
+Zone America/Monterrey	-6:41:16 -	LMT	1922 Jan  1  6:00u
+			-7:00	-	MST	1927 Jun 10
+			-6:00	-	CST	1930 Nov 15
+			-7:00	Mexico	M%sT	1932 Apr  1
 			-6:00	-	CST	1988
 			-6:00	US	C%sT	1989
 			-6:00	Mexico	C%sT
 # Central Mexico
-Zone America/Mexico_City -6:36:36 -	LMT	1922 Jan  1  0:23:24
-			-7:00	-	MST	1927 Jun 10 23:00
+Zone America/Mexico_City -6:36:36 -	LMT	1922 Jan  1  7:00u
+			-7:00	-	MST	1927 Jun 10
 			-6:00	-	CST	1930 Nov 15
-			-7:00	-	MST	1931 May  1 23:00
-			-6:00	-	CST	1931 Oct
-			-7:00	-	MST	1932 Apr  1
+			-7:00	Mexico	M%sT	1932 Apr  1
 			-6:00	Mexico	C%sT	2001 Sep 30  2:00
 			-6:00	-	CST	2002 Feb 20
 			-6:00	Mexico	C%sT
-# Chihuahua (near US border)
-# This includes the municipalities of Janos, Ascensión, Juárez, Guadalupe,
-# Práxedis G Guerrero, Coyame del Sotol, Ojinaga, and Manuel Benavides.
-# (See the 2016-03-12 El Universal source mentioned above.)
-Zone America/Ojinaga	-6:57:40 -	LMT	1922 Jan  1  0:02:20
-			-7:00	-	MST	1927 Jun 10 23:00
+# Chihuahua (near US border - western side)
+# This includes the municipios of Janos, Ascensión, Juárez, Guadalupe, and
+# Práxedis G Guerrero.
+# http://gaceta.diputados.gob.mx/PDF/65/2a022/nov/20221124-VII.pdf
+Zone America/Ciudad_Juarez -7:05:56 -	LMT	1922 Jan  1  7:00u
+			-7:00	-	MST	1927 Jun 10
 			-6:00	-	CST	1930 Nov 15
-			-7:00	-	MST	1931 May  1 23:00
-			-6:00	-	CST	1931 Oct
-			-7:00	-	MST	1932 Apr  1
+			-7:00	Mexico	M%sT	1932 Apr  1
 			-6:00	-	CST	1996
 			-6:00	Mexico	C%sT	1998
 			-6:00	-	CST	1998 Apr Sun>=1  3:00
 			-7:00	Mexico	M%sT	2010
+			-7:00	US	M%sT	2022 Oct 30  2:00
+			-6:00	-	CST	2022 Nov 30  0:00
 			-7:00	US	M%sT
-# Chihuahua (away from US border)
-Zone America/Chihuahua	-7:04:20 -	LMT	1921 Dec 31 23:55:40
-			-7:00	-	MST	1927 Jun 10 23:00
+# Chihuahua (near US border - eastern side)
+# This includes the municipios of Coyame del Sotol, Ojinaga, and Manuel
+# Benavides.
+# http://gaceta.diputados.gob.mx/PDF/65/2a022/nov/20221124-VII.pdf
+Zone America/Ojinaga	-6:57:40 -	LMT	1922 Jan  1  7:00u
+			-7:00	-	MST	1927 Jun 10
 			-6:00	-	CST	1930 Nov 15
-			-7:00	-	MST	1931 May  1 23:00
-			-6:00	-	CST	1931 Oct
-			-7:00	-	MST	1932 Apr  1
+			-7:00	Mexico	M%sT	1932 Apr  1
 			-6:00	-	CST	1996
 			-6:00	Mexico	C%sT	1998
 			-6:00	-	CST	1998 Apr Sun>=1  3:00
-			-7:00	Mexico	M%sT
-# Sonora
-Zone America/Hermosillo	-7:23:52 -	LMT	1921 Dec 31 23:36:08
-			-7:00	-	MST	1927 Jun 10 23:00
+			-7:00	Mexico	M%sT	2010
+			-7:00	US	M%sT	2022 Oct 30  2:00
+			-6:00	-	CST	2022 Nov 30  0:00
+			-6:00	US	C%sT
+# Chihuahua (away from US border)
+Zone America/Chihuahua	-7:04:20 -	LMT	1922 Jan  1  7:00u
+			-7:00	-	MST	1927 Jun 10
 			-6:00	-	CST	1930 Nov 15
-			-7:00	-	MST	1931 May  1 23:00
-			-6:00	-	CST	1931 Oct
-			-7:00	-	MST	1932 Apr  1
+			-7:00	Mexico	M%sT	1932 Apr  1
+			-6:00	-	CST	1996
+			-6:00	Mexico	C%sT	1998
+			-6:00	-	CST	1998 Apr Sun>=1  3:00
+			-7:00	Mexico	M%sT	2022 Oct 30  2:00
+			-6:00	-	CST
+# Sonora
+Zone America/Hermosillo	-7:23:52 -	LMT	1922 Jan  1  7:00u
+			-7:00	-	MST	1927 Jun 10
+			-6:00	-	CST	1930 Nov 15
+			-7:00	Mexico	M%sT	1932 Apr  1
 			-6:00	-	CST	1942 Apr 24
-			-7:00	-	MST	1949 Jan 14
-			-8:00	-	PST	1970
+			-7:00	-	MST	1996
 			-7:00	Mexico	M%sT	1999
 			-7:00	-	MST
+
+# Baja California Sur, Nayarit (except Bahía de Banderas), Sinaloa
+Zone America/Mazatlan	-7:05:40 -	LMT	1922 Jan  1  7:00u
+			-7:00	-	MST	1927 Jun 10
+			-6:00	-	CST	1930 Nov 15
+			-7:00	Mexico	M%sT	1932 Apr  1
+			-6:00	-	CST	1942 Apr 24
+			-7:00	-	MST	1970
+			-7:00	Mexico	M%sT
+
+# Bahía de Banderas
 
 # From Alexander Krivenyshev (2010-04-21):
 # According to news, Bahía de Banderas (Mexican state of Nayarit)
@@ -12862,43 +15270,33 @@ Zone America/Hermosillo	-7:23:52 -	LMT	1921 Dec 31 23:36:08
 # From Arthur David Olson (2010-05-01):
 # Use "Bahia_Banderas" to keep the name to fourteen characters.
 
-# Mazatlán
-Zone America/Mazatlan	-7:05:40 -	LMT	1921 Dec 31 23:54:20
-			-7:00	-	MST	1927 Jun 10 23:00
+Zone America/Bahia_Banderas -7:01:00 -	LMT	1922 Jan  1  7:00u
+			-7:00	-	MST	1927 Jun 10
 			-6:00	-	CST	1930 Nov 15
-			-7:00	-	MST	1931 May  1 23:00
-			-6:00	-	CST	1931 Oct
-			-7:00	-	MST	1932 Apr  1
+			-7:00	Mexico	M%sT	1932 Apr  1
 			-6:00	-	CST	1942 Apr 24
-			-7:00	-	MST	1949 Jan 14
-			-8:00	-	PST	1970
-			-7:00	Mexico	M%sT
-
-# Bahía de Banderas
-Zone America/Bahia_Banderas	-7:01:00 -	LMT	1921 Dec 31 23:59:00
-			-7:00	-	MST	1927 Jun 10 23:00
-			-6:00	-	CST	1930 Nov 15
-			-7:00	-	MST	1931 May  1 23:00
-			-6:00	-	CST	1931 Oct
-			-7:00	-	MST	1932 Apr  1
-			-6:00	-	CST	1942 Apr 24
-			-7:00	-	MST	1949 Jan 14
-			-8:00	-	PST	1970
+			-7:00	-	MST	1970
 			-7:00	Mexico	M%sT	2010 Apr  4  2:00
 			-6:00	Mexico	C%sT
 
 # Baja California
-Zone America/Tijuana	-7:48:04 -	LMT	1922 Jan  1  0:11:56
+Zone America/Tijuana	-7:48:04 -	LMT	1922 Jan  1  7:00u
 			-7:00	-	MST	1924
-			-8:00	-	PST	1927 Jun 10 23:00
+			-8:00	-	PST	1927 Jun 10
 			-7:00	-	MST	1930 Nov 15
 			-8:00	-	PST	1931 Apr  1
 			-8:00	1:00	PDT	1931 Sep 30
 			-8:00	-	PST	1942 Apr 24
 			-8:00	1:00	PWT	1945 Aug 14 23:00u
-			-8:00	1:00	PPT	1945 Nov 12 # Peace
+			-8:00	1:00	PPT	1945 Nov 15 # Peace
 			-8:00	-	PST	1948 Apr  5
 			-8:00	1:00	PDT	1949 Jan 14
+			-8:00	-	PST	1950 May  1
+			-8:00	1:00	PDT	1950 Sep 24
+			-8:00	-	PST	1951 Apr 29  2:00
+			-8:00	1:00	PDT	1951 Sep 30  2:00
+			-8:00	-	PST	1952 Apr 27  2:00
+			-8:00	1:00	PDT	1952 Sep 28  2:00
 			-8:00	-	PST	1954
 			-8:00	CA	P%sT	1961
 			-8:00	-	PST	1976
@@ -12925,88 +15323,233 @@ Zone America/Tijuana	-7:48:04 -	LMT	1922 Jan  1  0:11:56
 # http://dof.gob.mx/nota_detalle.php?codigo=5127480&fecha=06/01/2010
 # It has been moved to the 'backward' file.
 #
+# From Paul Eggert (2022-10-28):
+# Today's new law states that the entire state of Baja California
+# follows US DST rules, which agrees with simplifications noted above.
+#
 #
 # Revillagigedo Is
 # no information
 
 ###############################################################################
 
-# Anguilla
-# Antigua and Barbuda
-# See America/Port_of_Spain.
-
-# Bahamas
-#
-# For 1899 Milne gives -5:09:29.5; round that.
-#
-# From Sue Williams (2006-12-07):
-# The Bahamas announced about a month ago that they plan to change their DST
-# rules to sync with the U.S. starting in 2007....
-# http://www.jonesbahamas.com/?c=45&a=10412
-
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Bahamas	1964	1975	-	Oct	lastSun	2:00	0	S
-Rule	Bahamas	1964	1975	-	Apr	lastSun	2:00	1:00	D
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	America/Nassau	-5:09:30 -	LMT	1912 Mar 2
-			-5:00	Bahamas	E%sT	1976
-			-5:00	US	E%sT
-
 # Barbados
 
-# For 1899 Milne gives -3:58:29.2; round that.
+# For 1899 Milne gives -3:58:29.2.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# From P Chan (2020-12-09 and 2020-12-11):
+# Standard time of GMT-4 was adopted in 1911.
+# Definition of Time Act, 1911 (1911-7) [1911-08-28]
+# 1912, Laws of Barbados (5 v.), OCLC Number: 919801291, Vol. 4, Image No. 522
+# 1944, Laws of Barbados (5 v.), OCLC Number: 84548697, Vol. 4, Image No. 122
+# http://llmc.com/browse.aspx?type=2&coll=85&div=297
+#
+# DST was observed in 1942-44.
+# Defence (Daylight Saving) Regulations, 1942, 1942-04-13
+# Defence (Daylight Saving) (Repeal) Regulations, 1942, 1942-08-22
+# Defence (Daylight Saving) Regulations, 1943, 1943-04-16
+# Defence (Daylight Saving) (Repeal) Regulations, 1943, 1943-09-01
+# Defence (Daylight Saving) Regulations, 1944, 1944-03-21
+# [Defence (Daylight Saving) (Amendment) Regulations 1944, 1944-03-28]
+# Defence (Daylight Saving) (Repeal) Regulations, 1944, 1944-08-30
+#
+# 1914-, Subsidiary Legis., Annual Vols. OCLC Number: 226290591
+# 1942: Image Nos. 527-528, 555-556
+# 1943: Image Nos. 178-179, 198
+# 1944: Image Nos. 113-115, 129
+# http://llmc.com/titledescfull.aspx?type=2&coll=85&div=297&set=98437
+#
+# From Tim Parenti (2021-02-20):
+# The transitions below are derived from P Chan's sources, except that the 1977
+# through 1980 transitions are from Shanks & Pottenger since we have no better
+# data there.  Of particular note, the 1944 DST regulation only advanced the
+# time to "exactly three and a half hours later than Greenwich mean time", as
+# opposed to "three hours" in the 1942 and 1943 regulations.
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Barb	1942	only	-	Apr	19	5:00u	1:00	D
+Rule	Barb	1942	only	-	Aug	31	6:00u	0	S
+Rule	Barb	1943	only	-	May	 2	5:00u	1:00	D
+Rule	Barb	1943	only	-	Sep	 5	6:00u	0	S
+Rule	Barb	1944	only	-	Apr	10	5:00u	0:30	-
+Rule	Barb	1944	only	-	Sep	10	6:00u	0	S
 Rule	Barb	1977	only	-	Jun	12	2:00	1:00	D
 Rule	Barb	1977	1978	-	Oct	Sun>=1	2:00	0	S
 Rule	Barb	1978	1980	-	Apr	Sun>=15	2:00	1:00	D
 Rule	Barb	1979	only	-	Sep	30	2:00	0	S
 Rule	Barb	1980	only	-	Sep	25	2:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Barbados	-3:58:29 -	LMT	1924 # Bridgetown
-			-3:58:29 -	BMT	1932 # Bridgetown Mean Time
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	-3:58:29.2
+Zone America/Barbados	-3:58:29 -	LMT	1911 Aug 28 # Bridgetown
+			-4:00	Barb	A%sT	1944
+			-4:00	Barb	AST/-0330 1945
 			-4:00	Barb	A%sT
 
 # Belize
-# Whitman entirely disagrees with Shanks; go with Shanks & Pottenger.
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Belize	1918	1942	-	Oct	Sun>=2	0:00	0:30	HD
-Rule	Belize	1919	1943	-	Feb	Sun>=9	0:00	0	S
-Rule	Belize	1973	only	-	Dec	 5	0:00	1:00	D
-Rule	Belize	1974	only	-	Feb	 9	0:00	0	S
-Rule	Belize	1982	only	-	Dec	18	0:00	1:00	D
-Rule	Belize	1983	only	-	Feb	12	0:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	America/Belize	-5:52:48 -	LMT	1912 Apr
-			-6:00	Belize	C%sT
+
+# From P Chan (2020-11-03):
+# Below are some laws related to the time in British Honduras/Belize:
+#
+# Definition of Time Ordinance, 1927 (No.4 of 1927) [1927-04-01]
+# Ordinances of British Honduras Passed in the Year 1927, p 19-20
+# https://books.google.com/books?id=LqEpAQAAMAAJ&pg=RA3-PA19
+#
+# Definition of Time (Amendment) Ordinance, 1942 (No. 5 of 1942) [1942-06-27]
+# Ordinances of British Honduras Passed in the Year 1942, p 31-32
+# https://books.google.com/books?id=h6MpAQAAMAAJ&pg=RA6-PA95-IA44
+#
+# Definition of Time Ordinance, 1945 (No. 19 of 1945) [1945-12-15]
+# Ordinances of British Honduras Passed in the Year 1945, p 49-50
+# https://books.google.com/books?id=xaMpAQAAMAAJ&pg=RA2-PP1
+#
+# Definition of Time Ordinance, 1947 (No. 1 of 1947) [1947-03-11]
+# Ordinances of British Honduras Passed in the Year 1947, p 1-2
+# https://books.google.com/books?id=xaMpAQAAMAAJ&pg=RA3-PA1
+#
+# Time (Definition of) Ordinance  (Chapter 180)
+# The Laws of British Honduras in Force on the 15th Day of September, 1958 , Volume IV, p 2580
+# https://books.google.com/books?id=v5QpAQAAMAAJ&pg=PA2580
+#
+# Time (Definition of) (Amendment) Ordinance, 1968 (No. 13 of 1968) [1968-08-03]
+# https://books.google.com/books?id=xij7KEB_58wC&pg=RA1-PA428-IA9
+#
+# Definition of Time Act (Chapter 339)
+# Law of Belize, Revised Edition 2000
+# http://www.belizelaw.org/web/lawadmin/PDF%20files/cap339.pdf
+
+# From Paul Eggert (2020-11-03):
+# The transitions below are derived from P Chan's sources, except that the
+# 1973 through 1983 transitions are from Shanks & Pottenger since we have
+# no better data there.
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Belize	1918	1941	-	Oct	Sat>=1	24:00	0:30	-0530
+Rule	Belize	1919	1942	-	Feb	Sat>=8	24:00	0	CST
+Rule	Belize	1942	only	-	Jun	27	24:00	1:00	CWT
+Rule	Belize	1945	only	-	Aug	14	23:00u	1:00	CPT
+Rule	Belize	1945	only	-	Dec	15	24:00	0	CST
+Rule	Belize	1947	1967	-	Oct	Sat>=1	24:00	0:30	-0530
+Rule	Belize	1948	1968	-	Feb	Sat>=8	24:00	0	CST
+Rule	Belize	1973	only	-	Dec	 5	0:00	1:00	CDT
+Rule	Belize	1974	only	-	Feb	 9	0:00	0	CST
+Rule	Belize	1982	only	-	Dec	18	0:00	1:00	CDT
+Rule	Belize	1983	only	-	Feb	12	0:00	0	CST
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	America/Belize	-5:52:48 -	LMT	1912 Apr  1
+			-6:00	Belize	%s
 
 # Bermuda
 
+# From Paul Eggert (2022-07-27):
 # For 1899 Milne gives -4:19:18.3 as the meridian of the clock tower,
-# Bermuda dockyard, Ireland I; round that.
+# Bermuda dockyard, Ireland I.  This agrees with standard offset given in the
+# Daylight Saving Act, 1917 cited below.
+# It is not known when this time became standard for Bermuda; guess 1890.
+# The transition to -04 was specified by:
+# 1930: The Time Zone Act, 1929 (1929: No. 39) [1929-11-08]
+# https://books.google.com/books?id=7tdMAQAAIAAJ&pg=RA54-PP1
+
+# From P Chan (2020-11-20):
+# Most of the information can be found online from the Bermuda National
+# Library - Digital Collection which includes The Royal Gazette (RG) until 1957
+# https://bnl.contentdm.oclc.org/digital/
+# I will cite the ID.  For example, [10000] means
+# https://bnl.contentdm.oclc.org/digital/collection/BermudaNP02/id/10000
+#
+# 1917: Apr 5 midnight to Sep 30 midnight
+# Daylight Saving Act, 1917 (1917 No. 13) [1917-04-02]
+# Bermuda Acts and Resolves 1917, p 37-38
+# https://books.google.com/books?id=M-lCAQAAMAAJ&pg=PA36-IA2
+# RG, 1917-04-04, p 6 [42340] gives the spring forward date.
+#
+# 1918: Apr 13 midnight to Sep 15 midnight
+# Daylight Saving Act, 1918 (1918 No. 9) [1918-04-06]
+# Bermuda Acts and Resolves 1917, p 13
+# https://books.google.com/books?id=K-lCAQAAMAAJ&pg=RA1-PA7
+#
+# Note that local mean time was still used before 1930.
+#
+# During WWII, DST was introduced by Defence Regulations
+# 1942: Jan 11 02:00 to Oct 18 02:00 [113646], [115726]
+# 1943: Mar 21 02:00 to Oct 31 02:00 [116704], [118193]
+# 1944: Mar 12 02:00 to Nov 5 02:00 [119225], [121593]
+# 1945: Mar 11 02:00 to Nov 4 02:00 [122369], [124461]
+# RG, 1942-01-08, p 2, 1942-10-12, p 2 , 1943-03-06, p 2, 1943-09-03, p 1,
+# 1944-02-29, p 6, 1944-09-20, p 2, 1945-02-13, p 2, 1945-11-03, p 1
+#
+# In 1946, the House of Assembly rejected DST twice. [128686], [128076]
+# RG, 1946-03-16 p 1,1946-04-13 p 1
+#
+# 1947: third Sunday in May 02:00 to second Sunday in September 02:00
+# DST in 1947 was defined in the Daylight Saving Act, 1947 (1947: No. 12)
+# which expired at the end of the year.  [125784] ,[132405], [144454], [138226]
+# RG, 1947-02-27, p 1, 1947-05-15, p 1, 1947-09-13, p 1, 1947-12-30, p 1
+#
+# 1948-1952: fourth Sunday in May 02:00 to first Sunday in September 02:00
+# DST in 1948 was defined in the Daylight Saving Act, 1948 (1948 : No. 12)
+# which was set to expired at the end of the year but it was extended until
+# the end of 1952 and was not further extended.
+# [129802], [139403], [146008], [135240], [144330], [139049], [143309],
+# [148271], [149773], [153589], [153802], [155924]
+# RG, 1948-04-13, p 1, 1948-05-22, p 1, 1948-09-04, p 1, 1949-05-21, p1,
+# 1949-09-03, p 1, 1950-05-27 p 1, 1950-09-02, p 1, 1951-05-27, p 1,
+# 1951-09-01, p 1, 1952-05-23, p 1, 1952-09-26, p 1, 1952-12-21, p 8
+#
+# In 1953-1955, the House of Assembly rejected DST each year. [158996],
+# [162620], [166720] RG, 1953-05-02, p 1, 1954-04-01 p 1, 1955-03-12, p 1
+#
+# 1956: fourth Sunday in May 02:00 to last Sunday in October 02:00
+# Time Zone (Seasonal Variation) Act, 1956 (1956: No.44) [1956-05-25]
+# Bermuda Public Acts 1956, p 331-332
+# https://books.google.com/books?id=Xs1AlmD_cEwC&pg=PA63
+#
+# The extension of the Act was rejected by the House of Assembly. [176218]
+# RG, 1956-12-13, p 1
+#
+# From the Chronological Table of Public and Private Acts up to 1985, it seems
+# that there does not exist other Acts related to DST before 1973.
+# https://books.google.com/books?id=r9hMAQAAIAAJ&pg=RA23-PA1
+# Public Acts of the Legislature of the Islands of Bermuda, Together with
+# Statutory Instruments in Force Thereunder, Vol VII
 
 # From Dan Jones, reporting in The Royal Gazette (2006-06-26):
-
 # Next year, however, clocks in the US will go forward on the second Sunday
 # in March, until the first Sunday in November.  And, after the Time Zone
 # (Seasonal Variation) Bill 2006 was passed in the House of Assembly on
 # Friday, the same thing will happen in Bermuda.
 # http://www.theroyalgazette.com/apps/pbcs.dll/article?AID=/20060529/NEWS/105290135
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone Atlantic/Bermuda	-4:19:18 -	LMT	1930 Jan  1  2:00 # Hamilton
-			-4:00	-	AST	1974 Apr 28  2:00
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Bermuda	1917	only	-	Apr	 5	24:00	1:00	-
+Rule	Bermuda	1917	only	-	Sep	30	24:00	0	-
+Rule	Bermuda	1918	only	-	Apr	13	24:00	1:00	-
+Rule	Bermuda	1918	only	-	Sep	15	24:00	0	S
+Rule	Bermuda	1942	only	-	Jan	11	 2:00	1:00	D
+Rule	Bermuda	1942	only	-	Oct	18	 2:00	0	S
+Rule	Bermuda	1943	only	-	Mar	21	 2:00	1:00	D
+Rule	Bermuda	1943	only	-	Oct	31	 2:00	0	S
+Rule	Bermuda	1944	1945	-	Mar	Sun>=8	 2:00	1:00	D
+Rule	Bermuda	1944	1945	-	Nov	Sun>=1	 2:00	0	S
+Rule	Bermuda	1947	only	-	May	Sun>=15	 2:00	1:00	D
+Rule	Bermuda	1947	only	-	Sep	Sun>=8	 2:00	0	S
+Rule	Bermuda	1948	1952	-	May	Sun>=22	 2:00	1:00	D
+Rule	Bermuda	1948	1952	-	Sep	Sun>=1	 2:00	0	S
+Rule	Bermuda	1956	only	-	May	Sun>=22	 2:00	1:00	D
+Rule	Bermuda	1956	only	-	Oct	lastSun	 2:00	0	S
+
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	-4:19:18.3
+Zone Atlantic/Bermuda	-4:19:18 -	LMT	1890	# Hamilton
+			-4:19:18 Bermuda BMT/BST 1930 Jan 1  2:00
+			-4:00	Bermuda	A%sT	1974 Apr 28  2:00
 			-4:00	Canada	A%sT	1976
 			-4:00	US	A%sT
 
-# Cayman Is
-# See America/Panama.
-
 # Costa Rica
 
-# Milne gives -5:36:13.3 as San José mean time; round to nearest.
+# Milne gives -5:36:13.3 as San José mean time.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	CR	1979	1980	-	Feb	lastSun	0:00	1:00	D
 Rule	CR	1979	1980	-	Jun	Sun>=1	0:00	0	S
 Rule	CR	1991	1992	-	Jan	Sat>=15	0:00	1:00	D
@@ -13015,7 +15558,8 @@ Rule	CR	1991	1992	-	Jan	Sat>=15	0:00	1:00	D
 Rule	CR	1991	only	-	Jul	 1	0:00	0	S
 Rule	CR	1992	only	-	Mar	15	0:00	0	S
 # There are too many San Josés elsewhere, so we'll use 'Costa Rica'.
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	-5:36:13.3
 Zone America/Costa_Rica	-5:36:13 -	LMT	1890        # San José
 			-5:36:13 -	SJMT	1921 Jan 15 # San José Mean Time
 			-6:00	CR	C%sT
@@ -13079,7 +15623,7 @@ Zone America/Costa_Rica	-5:36:13 -	LMT	1890        # San José
 #
 # He supplied these references:
 #
-# http://www.prensalatina.com.mx/article.asp?ID=%7B4CC32C1B-A9F7-42FB-8A07-8631AFC923AF%7D&language=ES
+# http://www.prensalatina.com.mx/article.asp?ID={4CC32C1B-A9F7-42FB-8A07-8631AFC923AF}&language=ES
 # http://actualidad.terra.es/sociedad/articulo/cuba_llama_ahorrar_energia_cambio_1957044.htm
 #
 # From Alex Krivenyshev (2007-10-25):
@@ -13104,7 +15648,7 @@ Zone America/Costa_Rica	-5:36:13 -	LMT	1890        # San José
 # http://www.nnc.cubaweb.cu/marzo-2008/cien-1-11-3-08.htm
 #
 # Some more background information is posted here:
-# http://www.timeanddate.com/news/time/cuba-starts-dst-march-16.html
+# https://www.timeanddate.com/news/time/cuba-starts-dst-march-16.html
 #
 # The article also says that Cuba has been observing DST since 1963,
 # while Shanks (and tzdata) has 1965 as the first date (except in the
@@ -13151,7 +15695,7 @@ Zone America/Costa_Rica	-5:36:13 -	LMT	1890        # San José
 # http://granma.co.cu/2011/03/08/nacional/artic01.html
 #
 # Our info:
-# http://www.timeanddate.com/news/time/cuba-starts-dst-2011.html
+# https://www.timeanddate.com/news/time/cuba-starts-dst-2011.html
 #
 # From Steffen Thorsen (2011-10-30)
 # Cuba will end DST two weeks later this year. Instead of going back
@@ -13161,7 +15705,7 @@ Zone America/Costa_Rica	-5:36:13 -	LMT	1890        # San José
 # http://www.radioangulo.cu/noticias/cuba/17105-cuba-restablecera-el-horario-del-meridiano-de-greenwich.html
 #
 # Our page:
-# http://www.timeanddate.com/news/time/cuba-time-changes-2011.html
+# https://www.timeanddate.com/news/time/cuba-time-changes-2011.html
 #
 # From Steffen Thorsen (2012-03-01)
 # According to Radio Reloj, Cuba will start DST on Midnight between March
@@ -13171,7 +15715,7 @@ Zone America/Costa_Rica	-5:36:13 -	LMT	1890        # San José
 # http://www.radioreloj.cu/index.php/noticias-radio-reloj/71-miscelaneas/7529-cuba-aplicara-el-horario-de-verano-desde-el-1-de-abril
 #
 # Our info on it:
-# http://www.timeanddate.com/news/time/cuba-starts-dst-2012.html
+# https://www.timeanddate.com/news/time/cuba-starts-dst-2012.html
 
 # From Steffen Thorsen (2012-11-03):
 # Radio Reloj and many other sources report that Cuba is changing back
@@ -13180,7 +15724,7 @@ Zone America/Costa_Rica	-5:36:13 -	LMT	1890        # San José
 # From Paul Eggert (2012-11-03):
 # For now, assume the future rule is first Sunday in November.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Cuba	1928	only	-	Jun	10	0:00	1:00	D
 Rule	Cuba	1928	only	-	Oct	10	0:00	0	S
 Rule	Cuba	1940	1942	-	Jun	Sun>=1	0:00	1:00	D
@@ -13221,13 +15765,10 @@ Rule	Cuba	2012	only	-	Apr	1	0:00s	1:00	D
 Rule	Cuba	2012	max	-	Nov	Sun>=1	0:00s	0	S
 Rule	Cuba	2013	max	-	Mar	Sun>=8	0:00s	1:00	D
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	America/Havana	-5:29:28 -	LMT	1890
 			-5:29:36 -	HMT	1925 Jul 19 12:00 # Havana MT
 			-5:00	Cuba	C%sT
-
-# Dominica
-# See America/Port_of_Spain.
 
 # Dominican Republic
 
@@ -13249,37 +15790,31 @@ Zone	America/Havana	-5:29:28 -	LMT	1890
 # decided to revert.
 
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	DR	1966	only	-	Oct	30	0:00	1:00	D
-Rule	DR	1967	only	-	Feb	28	0:00	0	S
-Rule	DR	1969	1973	-	Oct	lastSun	0:00	0:30	HD
-Rule	DR	1970	only	-	Feb	21	0:00	0	S
-Rule	DR	1971	only	-	Jan	20	0:00	0	S
-Rule	DR	1972	1974	-	Jan	21	0:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	DR	1966	only	-	Oct	30	0:00	1:00	EDT
+Rule	DR	1967	only	-	Feb	28	0:00	0	EST
+Rule	DR	1969	1973	-	Oct	lastSun	0:00	0:30	-0430
+Rule	DR	1970	only	-	Feb	21	0:00	0	EST
+Rule	DR	1971	only	-	Jan	20	0:00	0	EST
+Rule	DR	1972	1974	-	Jan	21	0:00	0	EST
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Santo_Domingo -4:39:36 -	LMT	1890
 			-4:40	-	SDMT	1933 Apr  1 12:00 # S. Dom. MT
-			-5:00	DR	E%sT	1974 Oct 27
+			-5:00	DR	%s	1974 Oct 27
 			-4:00	-	AST	2000 Oct 29  2:00
 			-5:00	US	E%sT	2000 Dec  3  1:00
 			-4:00	-	AST
 
 # El Salvador
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Salv	1987	1988	-	May	Sun>=1	0:00	1:00	D
 Rule	Salv	1987	1988	-	Sep	lastSun	0:00	0	S
 # There are too many San Salvadors elsewhere, so use America/El_Salvador
 # instead of America/San_Salvador.
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/El_Salvador -5:56:48 -	LMT	1921 # San Salvador
 			-6:00	Salv	C%sT
-
-# Grenada
-# Guadeloupe
-# St Barthélemy
-# St Martin (French part)
-# See America/Port_of_Spain.
 
 # Guatemala
 #
@@ -13295,7 +15830,7 @@ Zone America/El_Salvador -5:56:48 -	LMT	1921 # San Salvador
 # (2006-04-19), says DST ends at 24:00.  See
 # http://www.sieca.org.gt/Sitio_publico/Energeticos/Doc/Medidas/Cambio_Horario_Nac_190406.pdf
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Guat	1973	only	-	Nov	25	0:00	1:00	D
 Rule	Guat	1974	only	-	Feb	24	0:00	0	S
 Rule	Guat	1983	only	-	May	21	0:00	1:00	D
@@ -13304,7 +15839,7 @@ Rule	Guat	1991	only	-	Mar	23	0:00	1:00	D
 Rule	Guat	1991	only	-	Sep	 7	0:00	0	S
 Rule	Guat	2006	only	-	Apr	30	0:00	1:00	D
 Rule	Guat	2006	only	-	Oct	 1	0:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Guatemala	-6:02:04 -	LMT	1918 Oct 5
 			-6:00	Guat	C%sT
 
@@ -13366,11 +15901,17 @@ Zone America/Guatemala	-6:02:04 -	LMT	1918 Oct 5
 # From Steffen Thorsen (2016-03-12):
 # Jean Antoine, editor of www.haiti-reference.com informed us that Haiti
 # are not going on DST this year.  Several other resources confirm this: ...
-# http://www.radiotelevisioncaraibes.com/presse/heure_d_t_pas_de_changement_d_heure_pr_vu_pour_cet_ann_e.html
-# http://www.vantbefinfo.com/changement-dheure-pas-pour-haiti/
+# https://www.radiotelevisioncaraibes.com/presse/heure_d_t_pas_de_changement_d_heure_pr_vu_pour_cet_ann_e.html
+# https://www.vantbefinfo.com/changement-dheure-pas-pour-haiti/
 # http://news.anmwe.com/haiti-lheure-nationale-ne-sera-ni-avancee-ni-reculee-cette-annee/
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# From Steffen Thorsen (2017-03-12):
+# We have received 4 mails from different people telling that Haiti
+# has started DST again today, and this source seems to confirm that,
+# I have not been able to find a more authoritative source:
+# https://www.haitilibre.com/en/news-20319-haiti-notices-time-change-in-haiti.html
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Haiti	1983	only	-	May	8	0:00	1:00	D
 Rule	Haiti	1984	1987	-	Apr	lastSun	0:00	1:00	D
 Rule	Haiti	1983	1987	-	Oct	lastSun	0:00	0	S
@@ -13382,7 +15923,9 @@ Rule	Haiti	2005	2006	-	Apr	Sun>=1	0:00	1:00	D
 Rule	Haiti	2005	2006	-	Oct	lastSun	0:00	0	S
 Rule	Haiti	2012	2015	-	Mar	Sun>=8	2:00	1:00	D
 Rule	Haiti	2012	2015	-	Nov	Sun>=1	2:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+Rule	Haiti	2017	max	-	Mar	Sun>=8	2:00	1:00	D
+Rule	Haiti	2017	max	-	Nov	Sun>=1	2:00	0	S
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Port-au-Prince -4:49:20 -	LMT	1890
 			-4:49	-	PPMT	1917 Jan 24 12:00 # P-a-P MT
 			-5:00	Haiti	E%sT
@@ -13416,12 +15959,12 @@ Zone America/Port-au-Prince -4:49:20 -	LMT	1890
 # http://www.laprensahn.com/pais_nota.php?id04962=7386
 # So it seems that Honduras will not enter DST this year....
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Hond	1987	1988	-	May	Sun>=1	0:00	1:00	D
 Rule	Hond	1987	1988	-	Sep	lastSun	0:00	0	S
 Rule	Hond	2006	only	-	May	Sun>=1	0:00	1:00	D
 Rule	Hond	2006	only	-	Aug	Mon>=1	0:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Tegucigalpa -5:48:52 -	LMT	1921 Apr
 			-6:00	Hond	C%sT
 #
@@ -13430,7 +15973,7 @@ Zone America/Tegucigalpa -5:48:52 -	LMT	1921 Apr
 # Jamaica
 # Shanks & Pottenger give -5:07:12, but Milne records -5:07:10.41 from an
 # unspecified official document, and says "This time is used throughout the
-# island".  Go with Milne.  Round to the nearest second as required by zic.
+# island".  Go with Milne.
 #
 # Shanks & Pottenger give April 28 for the 1974 spring-forward transition, but
 # Lance Neita writes that Prime Minister Michael Manley decreed it January 5.
@@ -13442,23 +15985,21 @@ Zone America/Tegucigalpa -5:48:52 -	LMT	1921 Apr
 # Neita L. The politician in all of us. Jamaica Observer 2014-09-20
 # http://www.jamaicaobserver.com/columns/The-politician-in-all-of-us_17573647
 #
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	America/Jamaica	-5:07:11 -	LMT	1890        # Kingston
-			-5:07:11 -	KMT	1912 Feb    # Kingston Mean Time
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	-5:07:10.41
+Zone	America/Jamaica	-5:07:10 -	LMT	1890        # Kingston
+			-5:07:10 -	KMT	1912 Feb    # Kingston Mean Time
 			-5:00	-	EST	1974
 			-5:00	US	E%sT	1984
 			-5:00	-	EST
 
 # Martinique
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Martinique	-4:04:20 -      LMT	1890        # Fort-de-France
-			-4:04:20 -	FFMT	1911 May    # Fort-de-France MT
+			-4:04:20 -	FFMT	1911 May  1 # Fort-de-France MT
 			-4:00	-	AST	1980 Apr  6
 			-4:00	1:00	ADT	1980 Sep 28
 			-4:00	-	AST
-
-# Montserrat
-# See America/Port_of_Spain.
 
 # Nicaragua
 #
@@ -13507,14 +16048,14 @@ Zone America/Martinique	-4:04:20 -      LMT	1890        # Fort-de-France
 # The natural sun time is restored in all the national territory, in that the
 # time is returned one hour at 01:00 am of October 1 of 2006.
 #
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Nic	1979	1980	-	Mar	Sun>=16	0:00	1:00	D
 Rule	Nic	1979	1980	-	Jun	Mon>=23	0:00	0	S
 Rule	Nic	2005	only	-	Apr	10	0:00	1:00	D
 Rule	Nic	2005	only	-	Oct	Sun>=1	0:00	0	S
 Rule	Nic	2006	only	-	Apr	30	2:00	1:00	D
 Rule	Nic	2006	only	-	Oct	Sun>=1	1:00	0	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	America/Managua	-5:45:08 -	LMT	1890
 			-5:45:12 -	MMT	1934 Jun 23 # Managua Mean Time?
 			-6:00	-	CST	1973 May
@@ -13525,40 +16066,52 @@ Zone	America/Managua	-5:45:08 -	LMT	1890
 			-5:00	-	EST	1997
 			-6:00	Nic	C%sT
 
+# Cayman Is
 # Panama
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+#
+# Atikokan and Coral Harbour, Canada, match Panama since 1970.
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	America/Panama	-5:18:08 -	LMT	1890
 			-5:19:36 -	CMT	1908 Apr 22 # Colón Mean Time
 			-5:00	-	EST
-Link America/Panama America/Cayman
 
+# Anguilla
+# Antigua & Barbuda
+# Aruba
+# Caribbean Netherlands
+# Curaçao
+# Dominica
+# Grenada
+# Guadeloupe
+# Montserrat
 # Puerto Rico
+# St Barthélemy
+# St Kitts-Nevis
+# Sint Maarten / St Martin
+# St Lucia
+# St Vincent & the Grenadines
+# Trinidad & Tobago
+# Virgin Is (UK & US)
+#
 # There are too many San Juans elsewhere, so we'll use 'Puerto_Rico'.
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Puerto_Rico -4:24:25 -	LMT	1899 Mar 28 12:00 # San Juan
 			-4:00	-	AST	1942 May  3
 			-4:00	US	A%sT	1946
 			-4:00	-	AST
 
-# St Kitts-Nevis
-# St Lucia
-# See America/Port_of_Spain.
-
 # St Pierre and Miquelon
 # There are too many St Pierres elsewhere, so we'll use 'Miquelon'.
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Miquelon	-3:44:40 -	LMT	1911 May 15 # St Pierre
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone America/Miquelon	-3:44:40 -	LMT	1911 Jun 15 # St Pierre
 			-4:00	-	AST	1980 May
-			-3:00	-	PMST	1987 # Pierre & Miquelon Time
-			-3:00	Canada	PM%sT
-
-# St Vincent and the Grenadines
-# See America/Port_of_Spain.
+			-3:00	-	%z	1987
+			-3:00	Canada	%z
 
 # Turks and Caicos
 #
 # From Chris Dunn in
-# http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=415007
+# https://bugs.debian.org/415007
 # (2007-03-15): In the Turks & Caicos Islands (America/Grand_Turk) the
 # daylight saving dates for time changes have been adjusted to match
 # the recent U.S. change of dates.
@@ -13570,7 +16123,7 @@ Zone America/Miquelon	-3:44:40 -	LMT	1911 May 15 # St Pierre
 # "Eastern Standard Times Begins 2007
 # Clocks are set back one hour at 2:00 a.m. local Daylight Saving Time"
 # indicating that the normal ET rules are followed.
-#
+
 # From Paul Eggert (2014-08-19):
 # The 2014-08-13 Cabinet meeting decided to stay on UT -04 year-round.  See:
 # http://tcweeklynews.com/daylight-savings-time-to-be-maintained-p5353-127.htm
@@ -13580,21 +16133,55 @@ Zone America/Miquelon	-3:44:40 -	LMT	1911 May 15 # St Pierre
 # "permanent daylight saving time" by one year....
 # http://tcweeklynews.com/time-change-to-go-ahead-this-november-p5437-127.htm
 #
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# From the Turks & Caicos Cabinet (2017-07-20), heads-up from Steffen Thorsen:
+# ... agreed to the reintroduction in TCI of Daylight Saving Time (DST)
+# during the summer months and Standard Time, also known as Local
+# Time, during the winter months with effect from April 2018 ...
+# https://www.gov.uk/government/news/turks-and-caicos-post-cabinet-meeting-statement--3
+# From Paul Eggert (2017-08-26):
+# The date of effect of the spring 2018 change appears to be March 11,
+# which makes more sense.  See: Hamilton D. Time change back
+# by March 2018 for TCI. Magnetic Media. 2017-08-25.
+# http://magneticmediatv.com/2017/08/time-change-back-by-march-2018-for-tci/
+#
+# From P Chan (2020-11-27):
+# Standard Time Declaration Order 2015 (L.N. 15/2015)
+# http://online.fliphtml5.com/fizd/czin/#p=2
+#
+# Standard Time Declaration Order 2017 (L.N. 31/2017)
+# http://online.fliphtml5.com/fizd/dmcu/#p=2
+#
+# From Tim Parenti (2020-12-05):
+# Although L.N. 31/2017 reads that it "shall come into operation at 2:00 a.m.
+# on 11th March 2018", a precise interpretation here poses some problems.  The
+# order states that "the standard time to be observed throughout the Turks and
+# Caicos Islands shall be the same time zone as the Eastern United States of
+# America" and further clarifies "[f]or the avoidance of doubt" that it
+# "applies to the Eastern Standard Time as well as any changes thereto for
+# Daylight Saving Time."  However, as clocks in Turks and Caicos approached
+# 02:00 -04, and thus the declared implementation time, it was still 01:00 EST
+# (-05), as DST in the Eastern US would not start until an hour later.
+#
+# Since it is unlikely that those on the islands switched their clocks twice in
+# the span of an hour, we assume instead that the adoption of EDT actually took
+# effect once clocks in the Eastern US had sprung forward, from 03:00 -04.
+# This discrepancy only affects the time zone abbreviation and DST flag for the
+# intervening hour, not wall clock times, as -04 was maintained throughout.
+
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Grand_Turk	-4:44:32 -	LMT	1890
-			-5:07:11 -	KMT	1912 Feb # Kingston Mean Time
+		#STDOFF	-5:07:10.41
+			-5:07:10 -	KMT	1912 Feb # Kingston Mean Time
 			-5:00	-	EST	1979
-			-5:00	US	E%sT	2015 Nov Sun>=1 2:00
-			-4:00	-	AST
-
-# British Virgin Is
-# Virgin Is
-# See America/Port_of_Spain.
-
+			-5:00	US	E%sT	2015 Mar  8  2:00
+			-4:00	-	AST	2018 Mar 11  3:00
+			-5:00	US	E%sT
 
 # Local Variables:
 # coding: utf-8
 # End:
+# tzdb data for South America and environs
+
 # This file is in the public domain, so clarified as of
 # 2009-05-17 by Arthur David Olson.
 
@@ -13603,15 +16190,15 @@ Zone America/Grand_Turk	-4:44:32 -	LMT	1890
 # tz@iana.org for general use in the future).  For more, please see
 # the file CONTRIBUTING in the tz distribution.
 
-# From Paul Eggert (2014-10-31):
+# From Paul Eggert (2016-12-05):
 #
 # Unless otherwise specified, the source for data through 1990 is:
 # Thomas G. Shanks and Rique Pottenger, The International Atlas (6th edition),
 # San Diego: ACS Publications, Inc. (2003).
 # Unfortunately this book contains many errors and cites no sources.
 #
-# Gwillim Law writes that a good source
-# for recent time zone data is the International Air Transport
+# Many years ago Gwillim Law wrote that a good source
+# for time zone data was the International Air Transport
 # Association's Standard Schedules Information Manual (IATA SSIM),
 # published semiannually.  Law sent in several helpful summaries
 # of the IATA's data after 1990.  Except where otherwise noted,
@@ -13619,34 +16206,12 @@ Zone America/Grand_Turk	-4:44:32 -	LMT	1890
 #
 # For data circa 1899, a common source is:
 # Milne J. Civil time. Geogr J. 1899 Feb;13(2):173-94.
-# http://www.jstor.org/stable/1774359
+# https://www.jstor.org/stable/1774359
 #
-# Earlier editions of these tables used the North American style (e.g. ARST and
-# ARDT for Argentine Standard and Daylight Time), but the following quote
-# suggests that it's better to use European style (e.g. ART and ARST).
-#	I suggest the use of _Summer time_ instead of the more cumbersome
-#	_daylight-saving time_.  _Summer time_ seems to be in general use
-#	in Europe and South America.
-#	-- E O Cutler, _New York Times_ (1937-02-14), quoted in
-#	H L Mencken, _The American Language: Supplement I_ (1960), p 466
-#
-# Earlier editions of these tables also used the North American style
-# for time zones in Brazil, but this was incorrect, as Brazilians say
-# "summer time".  Reinaldo Goulart, a São Paulo businessman active in
-# the railroad sector, writes (1999-07-06):
-#	The subject of time zones is currently a matter of discussion/debate in
-#	Brazil.  Let's say that "the Brasília time" is considered the
-#	"official time" because Brasília is the capital city.
-#	The other three time zones are called "Brasília time "minus one" or
-#	"plus one" or "plus two".  As far as I know there is no such
-#	name/designation as "Eastern Time" or "Central Time".
-# So I invented the following (English-language) abbreviations for now.
-# Corrections are welcome!
-#		std	dst
-#	-2:00	FNT	FNST	Fernando de Noronha
-#	-3:00	BRT	BRST	Brasília
-#	-4:00	AMT	AMST	Amazon
-#	-5:00	ACT	ACST	Acre
+# These tables use numeric abbreviations like -03 and -0330 for
+# integer hour and minute UT offsets.  Although earlier editions used
+# alphabetic time zone abbreviations, these abbreviations were
+# invented and did not reflect common practice.
 
 ###############################################################################
 
@@ -13665,29 +16230,29 @@ Zone America/Grand_Turk	-4:44:32 -	LMT	1890
 # I am sending modifications to the Argentine time zone table...
 # AR was chosen because they are the ISO letters that represent Argentina.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Arg	1930	only	-	Dec	 1	0:00	1:00	S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Arg	1930	only	-	Dec	 1	0:00	1:00	-
 Rule	Arg	1931	only	-	Apr	 1	0:00	0	-
-Rule	Arg	1931	only	-	Oct	15	0:00	1:00	S
+Rule	Arg	1931	only	-	Oct	15	0:00	1:00	-
 Rule	Arg	1932	1940	-	Mar	 1	0:00	0	-
-Rule	Arg	1932	1939	-	Nov	 1	0:00	1:00	S
-Rule	Arg	1940	only	-	Jul	 1	0:00	1:00	S
+Rule	Arg	1932	1939	-	Nov	 1	0:00	1:00	-
+Rule	Arg	1940	only	-	Jul	 1	0:00	1:00	-
 Rule	Arg	1941	only	-	Jun	15	0:00	0	-
-Rule	Arg	1941	only	-	Oct	15	0:00	1:00	S
+Rule	Arg	1941	only	-	Oct	15	0:00	1:00	-
 Rule	Arg	1943	only	-	Aug	 1	0:00	0	-
-Rule	Arg	1943	only	-	Oct	15	0:00	1:00	S
+Rule	Arg	1943	only	-	Oct	15	0:00	1:00	-
 Rule	Arg	1946	only	-	Mar	 1	0:00	0	-
-Rule	Arg	1946	only	-	Oct	 1	0:00	1:00	S
+Rule	Arg	1946	only	-	Oct	 1	0:00	1:00	-
 Rule	Arg	1963	only	-	Oct	 1	0:00	0	-
-Rule	Arg	1963	only	-	Dec	15	0:00	1:00	S
+Rule	Arg	1963	only	-	Dec	15	0:00	1:00	-
 Rule	Arg	1964	1966	-	Mar	 1	0:00	0	-
-Rule	Arg	1964	1966	-	Oct	15	0:00	1:00	S
+Rule	Arg	1964	1966	-	Oct	15	0:00	1:00	-
 Rule	Arg	1967	only	-	Apr	 2	0:00	0	-
-Rule	Arg	1967	1968	-	Oct	Sun>=1	0:00	1:00	S
+Rule	Arg	1967	1968	-	Oct	Sun>=1	0:00	1:00	-
 Rule	Arg	1968	1969	-	Apr	Sun>=1	0:00	0	-
-Rule	Arg	1974	only	-	Jan	23	0:00	1:00	S
+Rule	Arg	1974	only	-	Jan	23	0:00	1:00	-
 Rule	Arg	1974	only	-	May	 1	0:00	0	-
-Rule	Arg	1988	only	-	Dec	 1	0:00	1:00	S
+Rule	Arg	1988	only	-	Dec	 1	0:00	1:00	-
 #
 # From Hernan G. Otero (1995-06-26):
 # These corrections were contributed by InterSoft Argentina S.A.,
@@ -13695,7 +16260,7 @@ Rule	Arg	1988	only	-	Dec	 1	0:00	1:00	S
 # Talleres de Hidrografía Naval Argentina
 # (Argentine Naval Hydrography Institute)
 Rule	Arg	1989	1993	-	Mar	Sun>=1	0:00	0	-
-Rule	Arg	1989	1992	-	Oct	Sun>=15	0:00	1:00	S
+Rule	Arg	1989	1992	-	Oct	Sun>=15	0:00	1:00	-
 #
 # From Hernan G. Otero (1995-06-26):
 # From this moment on, the law that mandated the daylight saving
@@ -13706,7 +16271,7 @@ Rule	Arg	1989	1992	-	Oct	Sun>=15	0:00	1:00	S
 # On October 3, 1999, 0:00 local, Argentina implemented daylight savings time,
 # which did not result in the switch of a time zone, as they stayed 9 hours
 # from the International Date Line.
-Rule	Arg	1999	only	-	Oct	Sun>=1	0:00	1:00	S
+Rule	Arg	1999	only	-	Oct	Sun>=1	0:00	1:00	-
 # From Paul Eggert (2007-12-28):
 # DST was set to expire on March 5, not March 3, but since it was converted
 # to standard time on March 3 it's more convenient for us to pretend that
@@ -13809,9 +16374,9 @@ Rule	Arg	2000	only	-	Mar	3	0:00	0	-
 # la modificación del huso horario, ya que 2009 nos encuentra con
 # crecimiento en la producción y distribución energética."
 
-Rule	Arg	2007	only	-	Dec	30	0:00	1:00	S
+Rule	Arg	2007	only	-	Dec	30	0:00	1:00	-
 Rule	Arg	2008	2009	-	Mar	Sun>=15	0:00	0	-
-Rule	Arg	2008	only	-	Oct	Sun>=15	0:00	1:00	S
+Rule	Arg	2008	only	-	Oct	Sun>=15	0:00	1:00	-
 
 # From Mariano Absatz (2004-05-21):
 # Today it was officially published that the Province of Mendoza is changing
@@ -13821,12 +16386,14 @@ Rule	Arg	2008	only	-	Oct	Sun>=15	0:00	1:00	S
 # It's Law No. 7,210.  This change is due to a public power emergency, so for
 # now we'll assume it's for this year only.
 #
-# From Paul Eggert (2014-08-09):
+# From Paul Eggert (2018-01-31):
 # Hora de verano para la República Argentina
 # http://buenasiembra.com.ar/esoterismo/astrologia/hora-de-verano-de-la-republica-argentina-27.html
 # says that standard time in Argentina from 1894-10-31
-# to 1920-05-01 was -4:16:48.25.  Go with this more-precise value
-# over Shanks & Pottenger.
+# to 1920-05-01 was -4:16:48.25.  Go with this more precise value
+# over Shanks & Pottenger.  It is upward compatible with Milne, who
+# says Córdoba time was -4:16:48.2.
+
 #
 # From Mariano Absatz (2004-06-05):
 # These media articles from a major newspaper mostly cover the current state:
@@ -13884,8 +16451,8 @@ Rule	Arg	2008	only	-	Oct	Sun>=15	0:00	1:00	S
 #
 # Es inminente que en San Luis atrasen una hora los relojes
 # (It is imminent in San Luis clocks one hour delay)
-# http://www.lagaceta.com.ar/nota/253414/Economia/Es-inminente-que-en-San-Luis-atrasen-una-hora-los-relojes.html
-# http://www.worldtimezone.net/dst_news/dst_news_argentina02.html
+# https://www.lagaceta.com.ar/nota/253414/Economia/Es-inminente-que-en-San-Luis-atrasen-una-hora-los-relojes.html
+# http://www.worldtimezone.com/dst_news/dst_news_argentina02.html
 
 # From Jesper Nørgaard Welen (2008-01-18):
 # The page of the San Luis provincial government
@@ -13981,12 +16548,6 @@ Rule	Arg	2008	only	-	Oct	Sun>=15	0:00	1:00	S
 #
 # So I guess a new set of rules, besides "Arg", must be made and the last
 # America/Argentina/San_Luis entries should change to use these...
-#
-# I'm enclosing a patch that does what I say... regretfully, the San Luis
-# timezone must be called "WART/WARST" even when most of the time (like,
-# right now) WARST == ART... that is, since last Sunday, all the country
-# is using UTC-3, but in my patch, San Luis calls it "WARST" and the rest
-# of the country calls it "ART".
 # ...
 
 # From Alexander Krivenyshev (2010-04-09):
@@ -14006,30 +16567,28 @@ Rule	Arg	2008	only	-	Oct	Sun>=15	0:00	1:00	S
 # rules...San Luis is still using "Western ARgentina Time" and it got
 # stuck on Summer daylight savings time even though the summer is over.
 
-# From Paul Eggert (2013-09-05):
+# From Paul Eggert (2018-01-23):
 # Perhaps San Luis operates on the legal fiction that it is at -04
-# with perpetual summer time, but ordinary usage typically seems to
+# with perpetual daylight saving time, but ordinary usage typically seems to
 # just say it's at -03; see, for example,
-# http://es.wikipedia.org/wiki/Hora_oficial_argentina
+# https://es.wikipedia.org/wiki/Hora_oficial_argentina
 # We've documented similar situations as being plain changes to
 # standard time, so let's do that here too.  This does not change UTC
 # offsets, only tm_isdst and the time zone abbreviations.  One minor
 # plus is that this silences a zic complaint that there's no POSIX TZ
-# setting for time stamps past 2038.
+# setting for timestamps past 2038.
 
-# From Paul Eggert (2013-02-21):
-# Milne says Córdoba time was -4:16:48.2.  Round to the nearest second.
-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 #
 # Buenos Aires (BA), Capital Federal (CF),
 Zone America/Argentina/Buenos_Aires -3:53:48 - LMT	1894 Oct 31
+		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May    # Córdoba Mean Time
-			-4:00	-	ART	1930 Dec
-			-4:00	Arg	AR%sT	1969 Oct  5
-			-3:00	Arg	AR%sT	1999 Oct  3
-			-4:00	Arg	AR%sT	2000 Mar  3
-			-3:00	Arg	AR%sT
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	Arg	%z
 #
 # Córdoba (CB), Santa Fe (SF), Entre Ríos (ER), Corrientes (CN), Misiones (MN),
 # Chaco (CC), Formosa (FM), Santiago del Estero (SE)
@@ -14041,171 +16600,179 @@ Zone America/Argentina/Buenos_Aires -3:53:48 - LMT	1894 Oct 31
 # - Santiago del Estero switched to -4:00 on 1991-04-01,
 #   then to -3:00 on 1991-04-26.
 #
+		#STDOFF	       -4:16:48.25
 Zone America/Argentina/Cordoba -4:16:48 - LMT	1894 Oct 31
 			-4:16:48 -	CMT	1920 May
-			-4:00	-	ART	1930 Dec
-			-4:00	Arg	AR%sT	1969 Oct  5
-			-3:00	Arg	AR%sT	1991 Mar  3
-			-4:00	-	WART	1991 Oct 20
-			-3:00	Arg	AR%sT	1999 Oct  3
-			-4:00	Arg	AR%sT	2000 Mar  3
-			-3:00	Arg	AR%sT
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1991 Mar  3
+			-4:00	-	%z	1991 Oct 20
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	Arg	%z
 #
 # Salta (SA), La Pampa (LP), Neuquén (NQ), Rio Negro (RN)
 Zone America/Argentina/Salta -4:21:40 - LMT	1894 Oct 31
+		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
-			-4:00	-	ART	1930 Dec
-			-4:00	Arg	AR%sT	1969 Oct  5
-			-3:00	Arg	AR%sT	1991 Mar  3
-			-4:00	-	WART	1991 Oct 20
-			-3:00	Arg	AR%sT	1999 Oct  3
-			-4:00	Arg	AR%sT	2000 Mar  3
-			-3:00	Arg	AR%sT	2008 Oct 18
-			-3:00	-	ART
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1991 Mar  3
+			-4:00	-	%z	1991 Oct 20
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	Arg	%z	2008 Oct 18
+			-3:00	-	%z
 #
 # Tucumán (TM)
 Zone America/Argentina/Tucuman -4:20:52 - LMT	1894 Oct 31
+		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
-			-4:00	-	ART	1930 Dec
-			-4:00	Arg	AR%sT	1969 Oct  5
-			-3:00	Arg	AR%sT	1991 Mar  3
-			-4:00	-	WART	1991 Oct 20
-			-3:00	Arg	AR%sT	1999 Oct  3
-			-4:00	Arg	AR%sT	2000 Mar  3
-			-3:00	-	ART	2004 Jun  1
-			-4:00	-	WART	2004 Jun 13
-			-3:00	Arg	AR%sT
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1991 Mar  3
+			-4:00	-	%z	1991 Oct 20
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	-	%z	2004 Jun  1
+			-4:00	-	%z	2004 Jun 13
+			-3:00	Arg	%z
 #
 # La Rioja (LR)
 Zone America/Argentina/La_Rioja -4:27:24 - LMT	1894 Oct 31
+		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
-			-4:00	-	ART	1930 Dec
-			-4:00	Arg	AR%sT	1969 Oct  5
-			-3:00	Arg	AR%sT	1991 Mar  1
-			-4:00	-	WART	1991 May  7
-			-3:00	Arg	AR%sT	1999 Oct  3
-			-4:00	Arg	AR%sT	2000 Mar  3
-			-3:00	-	ART	2004 Jun  1
-			-4:00	-	WART	2004 Jun 20
-			-3:00	Arg	AR%sT	2008 Oct 18
-			-3:00	-	ART
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1991 Mar  1
+			-4:00	-	%z	1991 May  7
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	-	%z	2004 Jun  1
+			-4:00	-	%z	2004 Jun 20
+			-3:00	Arg	%z	2008 Oct 18
+			-3:00	-	%z
 #
 # San Juan (SJ)
 Zone America/Argentina/San_Juan -4:34:04 - LMT	1894 Oct 31
+		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
-			-4:00	-	ART	1930 Dec
-			-4:00	Arg	AR%sT	1969 Oct  5
-			-3:00	Arg	AR%sT	1991 Mar  1
-			-4:00	-	WART	1991 May  7
-			-3:00	Arg	AR%sT	1999 Oct  3
-			-4:00	Arg	AR%sT	2000 Mar  3
-			-3:00	-	ART	2004 May 31
-			-4:00	-	WART	2004 Jul 25
-			-3:00	Arg	AR%sT	2008 Oct 18
-			-3:00	-	ART
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1991 Mar  1
+			-4:00	-	%z	1991 May  7
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	-	%z	2004 May 31
+			-4:00	-	%z	2004 Jul 25
+			-3:00	Arg	%z	2008 Oct 18
+			-3:00	-	%z
 #
 # Jujuy (JY)
 Zone America/Argentina/Jujuy -4:21:12 -	LMT	1894 Oct 31
+		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
-			-4:00	-	ART	1930 Dec
-			-4:00	Arg	AR%sT	1969 Oct  5
-			-3:00	Arg	AR%sT	1990 Mar  4
-			-4:00	-	WART	1990 Oct 28
-			-4:00	1:00	WARST	1991 Mar 17
-			-4:00	-	WART	1991 Oct  6
-			-3:00	1:00	ARST	1992
-			-3:00	Arg	AR%sT	1999 Oct  3
-			-4:00	Arg	AR%sT	2000 Mar  3
-			-3:00	Arg	AR%sT	2008 Oct 18
-			-3:00	-	ART
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1990 Mar  4
+			-4:00	-	%z	1990 Oct 28
+			-4:00	1:00	%z	1991 Mar 17
+			-4:00	-	%z	1991 Oct  6
+			-3:00	1:00	%z	1992
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	Arg	%z	2008 Oct 18
+			-3:00	-	%z
 #
 # Catamarca (CT), Chubut (CH)
 Zone America/Argentina/Catamarca -4:23:08 - LMT	1894 Oct 31
+		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
-			-4:00	-	ART	1930 Dec
-			-4:00	Arg	AR%sT	1969 Oct  5
-			-3:00	Arg	AR%sT	1991 Mar  3
-			-4:00	-	WART	1991 Oct 20
-			-3:00	Arg	AR%sT	1999 Oct  3
-			-4:00	Arg	AR%sT	2000 Mar  3
-			-3:00	-	ART	2004 Jun  1
-			-4:00	-	WART	2004 Jun 20
-			-3:00	Arg	AR%sT	2008 Oct 18
-			-3:00	-	ART
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1991 Mar  3
+			-4:00	-	%z	1991 Oct 20
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	-	%z	2004 Jun  1
+			-4:00	-	%z	2004 Jun 20
+			-3:00	Arg	%z	2008 Oct 18
+			-3:00	-	%z
 #
 # Mendoza (MZ)
 Zone America/Argentina/Mendoza -4:35:16 - LMT	1894 Oct 31
+		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
-			-4:00	-	ART	1930 Dec
-			-4:00	Arg	AR%sT	1969 Oct  5
-			-3:00	Arg	AR%sT	1990 Mar  4
-			-4:00	-	WART	1990 Oct 15
-			-4:00	1:00	WARST	1991 Mar  1
-			-4:00	-	WART	1991 Oct 15
-			-4:00	1:00	WARST	1992 Mar  1
-			-4:00	-	WART	1992 Oct 18
-			-3:00	Arg	AR%sT	1999 Oct  3
-			-4:00	Arg	AR%sT	2000 Mar  3
-			-3:00	-	ART	2004 May 23
-			-4:00	-	WART	2004 Sep 26
-			-3:00	Arg	AR%sT	2008 Oct 18
-			-3:00	-	ART
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1990 Mar  4
+			-4:00	-	%z	1990 Oct 15
+			-4:00	1:00	%z	1991 Mar  1
+			-4:00	-	%z	1991 Oct 15
+			-4:00	1:00	%z	1992 Mar  1
+			-4:00	-	%z	1992 Oct 18
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	-	%z	2004 May 23
+			-4:00	-	%z	2004 Sep 26
+			-3:00	Arg	%z	2008 Oct 18
+			-3:00	-	%z
 #
 # San Luis (SL)
 
 Rule	SanLuis	2008	2009	-	Mar	Sun>=8	0:00	0	-
-Rule	SanLuis	2007	2008	-	Oct	Sun>=8	0:00	1:00	S
+Rule	SanLuis	2007	2008	-	Oct	Sun>=8	0:00	1:00	-
 
 Zone America/Argentina/San_Luis -4:25:24 - LMT	1894 Oct 31
+		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
-			-4:00	-	ART	1930 Dec
-			-4:00	Arg	AR%sT	1969 Oct  5
-			-3:00	Arg	AR%sT	1990
-			-3:00	1:00	ARST	1990 Mar 14
-			-4:00	-	WART	1990 Oct 15
-			-4:00	1:00	WARST	1991 Mar  1
-			-4:00	-	WART	1991 Jun  1
-			-3:00	-	ART	1999 Oct  3
-			-4:00	1:00	WARST	2000 Mar  3
-			-3:00	-	ART	2004 May 31
-			-4:00	-	WART	2004 Jul 25
-			-3:00	Arg	AR%sT	2008 Jan 21
-			-4:00	SanLuis	WAR%sT	2009 Oct 11
-			-3:00	-	ART
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1990
+			-3:00	1:00	%z	1990 Mar 14
+			-4:00	-	%z	1990 Oct 15
+			-4:00	1:00	%z	1991 Mar  1
+			-4:00	-	%z	1991 Jun  1
+			-3:00	-	%z	1999 Oct  3
+			-4:00	1:00	%z	2000 Mar  3
+			-3:00	-	%z	2004 May 31
+			-4:00	-	%z	2004 Jul 25
+			-3:00	Arg	%z	2008 Jan 21
+			-4:00	SanLuis	%z	2009 Oct 11
+			-3:00	-	%z
 #
 # Santa Cruz (SC)
 Zone America/Argentina/Rio_Gallegos -4:36:52 - LMT	1894 Oct 31
-			-4:16:48 -	CMT	1920 May    # Córdoba Mean Time
-			-4:00	-	ART	1930 Dec
-			-4:00	Arg	AR%sT	1969 Oct  5
-			-3:00	Arg	AR%sT	1999 Oct  3
-			-4:00	Arg	AR%sT	2000 Mar  3
-			-3:00	-	ART	2004 Jun  1
-			-4:00	-	WART	2004 Jun 20
-			-3:00	Arg	AR%sT	2008 Oct 18
-			-3:00	-	ART
+		#STDOFF	-4:16:48.25
+			-4:16:48 -	CMT	1920 May
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	-	%z	2004 Jun  1
+			-4:00	-	%z	2004 Jun 20
+			-3:00	Arg	%z	2008 Oct 18
+			-3:00	-	%z
 #
 # Tierra del Fuego, Antártida e Islas del Atlántico Sur (TF)
 Zone America/Argentina/Ushuaia -4:33:12 - LMT	1894 Oct 31
-			-4:16:48 -	CMT	1920 May    # Córdoba Mean Time
-			-4:00	-	ART	1930 Dec
-			-4:00	Arg	AR%sT	1969 Oct  5
-			-3:00	Arg	AR%sT	1999 Oct  3
-			-4:00	Arg	AR%sT	2000 Mar  3
-			-3:00	-	ART	2004 May 30
-			-4:00	-	WART	2004 Jun 20
-			-3:00	Arg	AR%sT	2008 Oct 18
-			-3:00	-	ART
-
-# Aruba
-Link America/Curacao America/Aruba
+		#STDOFF	-4:16:48.25
+			-4:16:48 -	CMT	1920 May
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	-	%z	2004 May 30
+			-4:00	-	%z	2004 Jun 20
+			-3:00	Arg	%z	2008 Oct 18
+			-3:00	-	%z
 
 # Bolivia
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	America/La_Paz	-4:32:36 -	LMT	1890
 			-4:32:36 -	CMT	1931 Oct 15 # Calamarca MT
-			-4:32:36 1:00	BOST	1932 Mar 21 # Bolivia ST
-			-4:00	-	BOT	# Bolivia Time
+			-4:32:36 1:00	BST	1932 Mar 21 # Bolivia ST
+			-4:00	-	%z
 
 # Brazil
 
@@ -14269,7 +16836,7 @@ Zone	America/La_Paz	-4:32:36 -	LMT	1890
 
 # From Rodrigo Severo (2004-10-04):
 # It's just the biannual change made necessary by the much hyped, supposedly
-# modern Brazilian eletronic voting machines which, apparently, can't deal
+# modern Brazilian ... voting machines which, apparently, can't deal
 # with a time change between the first and the second rounds of the elections.
 
 # From Steffen Thorsen (2007-09-20):
@@ -14341,7 +16908,7 @@ Zone	America/La_Paz	-4:32:36 -	LMT	1890
 # (Portuguese)
 #
 # We have a written a short article about it as well:
-# http://www.timeanddate.com/news/time/brazil-dst-2008-2009.html
+# https://www.timeanddate.com/news/time/brazil-dst-2008-2009.html
 #
 # From Alexander Krivenyshev (2011-10-04):
 # State Bahia will return to Daylight savings time this year after 8 years off.
@@ -14350,7 +16917,7 @@ Zone	America/La_Paz	-4:32:36 -	LMT	1890
 
 # In Portuguese:
 # http://g1.globo.com/bahia/noticia/2011/10/governador-jaques-wagner-confirma-horario-de-verao-na-bahia.html
-# http://noticias.terra.com.br/brasil/noticias/0,,OI5390887-EI8139,00-Bahia+volta+a+ter+horario+de+verao+apos+oito+anos.html
+# https://noticias.terra.com.br/brasil/noticias/0,,OI5390887-EI8139,00-Bahia+volta+a+ter+horario+de+verao+apos+oito+anos.html
 
 # From Guilherme Bernardes Rodrigues (2011-10-07):
 # There is news in the media, however there is still no decree about it.
@@ -14376,16 +16943,16 @@ Zone	America/La_Paz	-4:32:36 -	LMT	1890
 
 # From Rodrigo Severo (2012-10-16):
 # Tocantins state will have DST.
-# http://noticias.terra.com.br/brasil/noticias/0,,OI6232536-EI306.html
+# https://noticias.terra.com.br/brasil/noticias/0,,OI6232536-EI306.html
 
 # From Steffen Thorsen (2013-09-20):
 # Tocantins in Brazil is very likely not to observe DST from October....
 # http://conexaoto.com.br/2013/09/18/ministerio-confirma-que-tocantins-esta-fora-do-horario-de-verao-em-2013-mas-falta-publicacao-de-decreto
 # We will keep this article updated when this is confirmed:
-# http://www.timeanddate.com/news/time/brazil-starts-dst-2013.html
+# https://www.timeanddate.com/news/time/brazil-starts-dst-2013.html
 
 # From Steffen Thorsen (2013-10-17):
-# http://www.timeanddate.com/news/time/acre-amazonas-change-time-zone.html
+# https://www.timeanddate.com/news/time/acre-amazonas-change-time-zone.html
 # Senator Jorge Viana announced that Acre will change time zone on November 10.
 # He did not specify the time of the change, nor if western parts of Amazonas
 # will change as well.
@@ -14393,17 +16960,17 @@ Zone	America/La_Paz	-4:32:36 -	LMT	1890
 # From Paul Eggert (2013-10-17):
 # For now, assume western Amazonas will change as well.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 # Decree 20,466 <http://pcdsh01.on.br/HV20466.htm> (1931-10-01)
 # Decree 21,896 <http://pcdsh01.on.br/HV21896.htm> (1932-01-10)
-Rule	Brazil	1931	only	-	Oct	 3	11:00	1:00	S
+Rule	Brazil	1931	only	-	Oct	 3	11:00	1:00	-
 Rule	Brazil	1932	1933	-	Apr	 1	 0:00	0	-
-Rule	Brazil	1932	only	-	Oct	 3	 0:00	1:00	S
+Rule	Brazil	1932	only	-	Oct	 3	 0:00	1:00	-
 # Decree 23,195 <http://pcdsh01.on.br/HV23195.htm> (1933-10-10)
 # revoked DST.
 # Decree 27,496 <http://pcdsh01.on.br/HV27496.htm> (1949-11-24)
 # Decree 27,998 <http://pcdsh01.on.br/HV27998.htm> (1950-04-13)
-Rule	Brazil	1949	1952	-	Dec	 1	 0:00	1:00	S
+Rule	Brazil	1949	1952	-	Dec	 1	 0:00	1:00	-
 Rule	Brazil	1950	only	-	Apr	16	 1:00	0	-
 Rule	Brazil	1951	1952	-	Apr	 1	 0:00	0	-
 # Decree 32,308 <http://pcdsh01.on.br/HV32308.htm> (1953-02-24)
@@ -14415,51 +16982,51 @@ Rule	Brazil	1953	only	-	Mar	 1	 0:00	0	-
 # in SP, RJ, GB, MG, ES, due to the prolongation of the drought.
 # Decree 53,071 <http://pcdsh01.on.br/HV53071.htm> (1963-12-03)
 # extended the above decree to all of the national territory on 12-09.
-Rule	Brazil	1963	only	-	Dec	 9	 0:00	1:00	S
+Rule	Brazil	1963	only	-	Dec	 9	 0:00	1:00	-
 # Decree 53,604 <http://pcdsh01.on.br/HV53604.htm> (1964-02-25)
 # extended summer time by one day to 1964-03-01 00:00 (start of school).
 Rule	Brazil	1964	only	-	Mar	 1	 0:00	0	-
 # Decree 55,639 <http://pcdsh01.on.br/HV55639.htm> (1965-01-27)
-Rule	Brazil	1965	only	-	Jan	31	 0:00	1:00	S
+Rule	Brazil	1965	only	-	Jan	31	 0:00	1:00	-
 Rule	Brazil	1965	only	-	Mar	31	 0:00	0	-
 # Decree 57,303 <http://pcdsh01.on.br/HV57303.htm> (1965-11-22)
-Rule	Brazil	1965	only	-	Dec	 1	 0:00	1:00	S
+Rule	Brazil	1965	only	-	Dec	 1	 0:00	1:00	-
 # Decree 57,843 <http://pcdsh01.on.br/HV57843.htm> (1966-02-18)
 Rule	Brazil	1966	1968	-	Mar	 1	 0:00	0	-
-Rule	Brazil	1966	1967	-	Nov	 1	 0:00	1:00	S
+Rule	Brazil	1966	1967	-	Nov	 1	 0:00	1:00	-
 # Decree 63,429 <http://pcdsh01.on.br/HV63429.htm> (1968-10-15)
 # revoked DST.
 # Decree 91,698 <http://pcdsh01.on.br/HV91698.htm> (1985-09-27)
-Rule	Brazil	1985	only	-	Nov	 2	 0:00	1:00	S
+Rule	Brazil	1985	only	-	Nov	 2	 0:00	1:00	-
 # Decree 92,310 (1986-01-21)
 # Decree 92,463 (1986-03-13)
 Rule	Brazil	1986	only	-	Mar	15	 0:00	0	-
 # Decree 93,316 (1986-10-01)
-Rule	Brazil	1986	only	-	Oct	25	 0:00	1:00	S
+Rule	Brazil	1986	only	-	Oct	25	 0:00	1:00	-
 Rule	Brazil	1987	only	-	Feb	14	 0:00	0	-
 # Decree 94,922 <http://pcdsh01.on.br/HV94922.htm> (1987-09-22)
-Rule	Brazil	1987	only	-	Oct	25	 0:00	1:00	S
+Rule	Brazil	1987	only	-	Oct	25	 0:00	1:00	-
 Rule	Brazil	1988	only	-	Feb	 7	 0:00	0	-
 # Decree 96,676 <http://pcdsh01.on.br/HV96676.htm> (1988-09-12)
 # except for the states of AC, AM, PA, RR, RO, and AP (then a territory)
-Rule	Brazil	1988	only	-	Oct	16	 0:00	1:00	S
+Rule	Brazil	1988	only	-	Oct	16	 0:00	1:00	-
 Rule	Brazil	1989	only	-	Jan	29	 0:00	0	-
 # Decree 98,077 <http://pcdsh01.on.br/HV98077.htm> (1989-08-21)
 # with the same exceptions
-Rule	Brazil	1989	only	-	Oct	15	 0:00	1:00	S
+Rule	Brazil	1989	only	-	Oct	15	 0:00	1:00	-
 Rule	Brazil	1990	only	-	Feb	11	 0:00	0	-
 # Decree 99,530 <http://pcdsh01.on.br/HV99530.htm> (1990-09-17)
 # adopted by RS, SC, PR, SP, RJ, ES, MG, GO, MS, DF.
 # Decree 99,629 (1990-10-19) adds BA, MT.
-Rule	Brazil	1990	only	-	Oct	21	 0:00	1:00	S
+Rule	Brazil	1990	only	-	Oct	21	 0:00	1:00	-
 Rule	Brazil	1991	only	-	Feb	17	 0:00	0	-
 # Unnumbered decree <http://pcdsh01.on.br/HV1991.htm> (1991-09-25)
 # adopted by RS, SC, PR, SP, RJ, ES, MG, BA, GO, MT, MS, DF.
-Rule	Brazil	1991	only	-	Oct	20	 0:00	1:00	S
+Rule	Brazil	1991	only	-	Oct	20	 0:00	1:00	-
 Rule	Brazil	1992	only	-	Feb	 9	 0:00	0	-
 # Unnumbered decree <http://pcdsh01.on.br/HV1992.htm> (1992-10-16)
 # adopted by same states.
-Rule	Brazil	1992	only	-	Oct	25	 0:00	1:00	S
+Rule	Brazil	1992	only	-	Oct	25	 0:00	1:00	-
 Rule	Brazil	1993	only	-	Jan	31	 0:00	0	-
 # Decree 942 <http://pcdsh01.on.br/HV942.htm> (1993-09-28)
 # adopted by same states, plus AM.
@@ -14469,12 +17036,12 @@ Rule	Brazil	1993	only	-	Jan	31	 0:00	0	-
 # adopted by same states, plus MT and TO.
 # Decree 1,674 <http://pcdsh01.on.br/HV1674.htm> (1995-10-13)
 # adds AL, SE.
-Rule	Brazil	1993	1995	-	Oct	Sun>=11	 0:00	1:00	S
+Rule	Brazil	1993	1995	-	Oct	Sun>=11	 0:00	1:00	-
 Rule	Brazil	1994	1995	-	Feb	Sun>=15	 0:00	0	-
 Rule	Brazil	1996	only	-	Feb	11	 0:00	0	-
 # Decree 2,000 <http://pcdsh01.on.br/HV2000.htm> (1996-09-04)
 # adopted by same states, minus AL, SE.
-Rule	Brazil	1996	only	-	Oct	 6	 0:00	1:00	S
+Rule	Brazil	1996	only	-	Oct	 6	 0:00	1:00	-
 Rule	Brazil	1997	only	-	Feb	16	 0:00	0	-
 # From Daniel C. Sobral (1998-02-12):
 # In 1997, the DS began on October 6. The stated reason was that
@@ -14484,19 +17051,19 @@ Rule	Brazil	1997	only	-	Feb	16	 0:00	0	-
 # to help dealing with the shortages of electric power.
 #
 # Decree 2,317 (1997-09-04), adopted by same states.
-Rule	Brazil	1997	only	-	Oct	 6	 0:00	1:00	S
+Rule	Brazil	1997	only	-	Oct	 6	 0:00	1:00	-
 # Decree 2,495 <http://pcdsh01.on.br/figuras/HV2495.JPG>
 # (1998-02-10)
 Rule	Brazil	1998	only	-	Mar	 1	 0:00	0	-
 # Decree 2,780 <http://pcdsh01.on.br/figuras/Hv98.jpg> (1998-09-11)
 # adopted by the same states as before.
-Rule	Brazil	1998	only	-	Oct	11	 0:00	1:00	S
+Rule	Brazil	1998	only	-	Oct	11	 0:00	1:00	-
 Rule	Brazil	1999	only	-	Feb	21	 0:00	0	-
 # Decree 3,150 <http://pcdsh01.on.br/figuras/HV3150.gif>
 # (1999-08-23) adopted by same states.
 # Decree 3,188 <http://pcdsh01.on.br/DecHV99.gif> (1999-09-30)
 # adds SE, AL, PB, PE, RN, CE, PI, MA and RR.
-Rule	Brazil	1999	only	-	Oct	 3	 0:00	1:00	S
+Rule	Brazil	1999	only	-	Oct	 3	 0:00	1:00	-
 Rule	Brazil	2000	only	-	Feb	27	 0:00	0	-
 # Decree 3,592 <http://pcdsh01.on.br/DEC3592.htm> (2000-09-06)
 # adopted by the same states as before.
@@ -14506,63 +17073,82 @@ Rule	Brazil	2000	only	-	Feb	27	 0:00	0	-
 # repeals DST in SE, AL, PB, RN, CE, PI and MA, effective 2000-10-22 00:00.
 # Decree 3,916 <http://pcdsh01.on.br/figuras/HV3916.gif>
 # (2001-09-13) reestablishes DST in AL, CE, MA, PB, PE, PI, RN, SE.
-Rule	Brazil	2000	2001	-	Oct	Sun>=8	 0:00	1:00	S
+Rule	Brazil	2000	2001	-	Oct	Sun>=8	 0:00	1:00	-
 Rule	Brazil	2001	2006	-	Feb	Sun>=15	 0:00	0	-
 # Decree 4,399 (2002-10-01) repeals DST in AL, CE, MA, PB, PE, PI, RN, SE.
 # 4,399 <http://www.presidencia.gov.br/CCIVIL/decreto/2002/D4399.htm>
-Rule	Brazil	2002	only	-	Nov	 3	 0:00	1:00	S
+Rule	Brazil	2002	only	-	Nov	 3	 0:00	1:00	-
 # Decree 4,844 (2003-09-24; corrected 2003-09-26) repeals DST in BA, MT, TO.
 # 4,844 <http://www.presidencia.gov.br/CCIVIL/decreto/2003/D4844.htm>
-Rule	Brazil	2003	only	-	Oct	19	 0:00	1:00	S
+Rule	Brazil	2003	only	-	Oct	19	 0:00	1:00	-
 # Decree 5,223 (2004-10-01) reestablishes DST in MT.
 # 5,223 <http://www.planalto.gov.br/ccivil_03/_Ato2004-2006/2004/Decreto/D5223.htm>
-Rule	Brazil	2004	only	-	Nov	 2	 0:00	1:00	S
+Rule	Brazil	2004	only	-	Nov	 2	 0:00	1:00	-
 # Decree 5,539 <http://pcdsh01.on.br/DecHV5539.gif> (2005-09-19),
 # adopted by the same states as before.
-Rule	Brazil	2005	only	-	Oct	16	 0:00	1:00	S
+Rule	Brazil	2005	only	-	Oct	16	 0:00	1:00	-
 # Decree 5,920 <http://pcdsh01.on.br/DecHV5920.gif> (2006-10-03),
 # adopted by the same states as before.
-Rule	Brazil	2006	only	-	Nov	 5	 0:00	1:00	S
+Rule	Brazil	2006	only	-	Nov	 5	 0:00	1:00	-
 Rule	Brazil	2007	only	-	Feb	25	 0:00	0	-
 # Decree 6,212 <http://pcdsh01.on.br/DecHV6212.gif> (2007-09-26),
 # adopted by the same states as before.
-Rule	Brazil	2007	only	-	Oct	Sun>=8	 0:00	1:00	S
+Rule	Brazil	2007	only	-	Oct	Sun>=8	 0:00	1:00	-
 # From Frederico A. C. Neves (2008-09-10):
 # According to this decree
 # http://www.planalto.gov.br/ccivil_03/_Ato2007-2010/2008/Decreto/D6558.htm
 # [t]he DST period in Brazil now on will be from the 3rd Oct Sunday to the
 # 3rd Feb Sunday. There is an exception on the return date when this is
 # the Carnival Sunday then the return date will be the next Sunday...
-Rule	Brazil	2008	max	-	Oct	Sun>=15	0:00	1:00	S
+Rule	Brazil	2008	2017	-	Oct	Sun>=15	0:00	1:00	-
 Rule	Brazil	2008	2011	-	Feb	Sun>=15	0:00	0	-
+# Decree 7,584 <http://pcdsh01.on.br/HVdecreto7584_20111013.jpg> (2011-10-13)
+# added Bahia.
 Rule	Brazil	2012	only	-	Feb	Sun>=22	0:00	0	-
+# Decree 7,826 <http://pcdsh01.on.br/HVdecreto7826_20121015.jpg> (2012-10-15)
+# removed Bahia and added Tocantins.
+# Decree 8,112 <http://pcdsh01.on.br/HVdecreto8112_20130930.JPG> (2013-09-30)
+# removed Tocantins.
 Rule	Brazil	2013	2014	-	Feb	Sun>=15	0:00	0	-
 Rule	Brazil	2015	only	-	Feb	Sun>=22	0:00	0	-
-Rule	Brazil	2016	2022	-	Feb	Sun>=15	0:00	0	-
-Rule	Brazil	2023	only	-	Feb	Sun>=22	0:00	0	-
-Rule	Brazil	2024	2025	-	Feb	Sun>=15	0:00	0	-
-Rule	Brazil	2026	only	-	Feb	Sun>=22	0:00	0	-
-Rule	Brazil	2027	2033	-	Feb	Sun>=15	0:00	0	-
-Rule	Brazil	2034	only	-	Feb	Sun>=22	0:00	0	-
-Rule	Brazil	2035	2036	-	Feb	Sun>=15	0:00	0	-
-Rule	Brazil	2037	only	-	Feb	Sun>=22	0:00	0	-
-# From Arthur David Olson (2008-09-29):
-# The next is wrong in some years but is better than nothing.
-Rule	Brazil	2038	max	-	Feb	Sun>=15	0:00	0	-
-
-# The latest ruleset listed above says that the following states observe DST:
+Rule	Brazil	2016	2019	-	Feb	Sun>=15	0:00	0	-
+# From Steffen Thorsen (2017-12-18):
+# According to many media sources, next year's DST start in Brazil will move to
+# the first Sunday of November
+# ... https://www.timeanddate.com/news/time/brazil-delays-dst-2018.html
+# From Steffen Thorsen (2017-12-20):
+# http://www.planalto.gov.br/ccivil_03/_ato2015-2018/2017/decreto/D9242.htm
+# From Fábio Gomes (2018-10-04):
+# The Brazilian president just announced a new change on this year DST.
+# It was scheduled to start on November 4th and it was changed to November 18th.
+# From Rodrigo Brüning Wessler (2018-10-15):
+# The Brazilian government just announced that the change in DST was
+# canceled....  Maybe the president Michel Temer also woke up one hour
+# earlier today. :)
+Rule	Brazil	2018	only	-	Nov	Sun>=1	0:00	1:00	-
+# The last ruleset listed above says that the following states observed DST:
 # DF, ES, GO, MG, MS, MT, PR, RJ, RS, SC, SP.
+#
+# From Steffen Thorsen (2019-04-05):
+# According to multiple sources the Brazilian president wants to get rid of DST.
+# https://gmconline.com.br/noticias/politica/bolsonaro-horario-de-verao-deve-acabar-este-ano
+# https://g1.globo.com/economia/noticia/2019/04/05/governo-anuncia-fim-do-horario-de-verao.ghtml
+# From Marcus Diniz (2019-04-25):
+# Brazil no longer has DST changes - decree signed today
+# https://g1.globo.com/politica/noticia/2019/04/25/bolsonaro-assina-decreto-que-acaba-com-o-horario-de-verao.ghtml
+# From Daniel Soares de Oliveira (2019-04-26):
+# http://www.planalto.gov.br/ccivil_03/_Ato2019-2022/2019/Decreto/D9772.htm
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 #
 # Fernando de Noronha (administratively part of PE)
 Zone America/Noronha	-2:09:40 -	LMT	1914
-			-2:00	Brazil	FN%sT	1990 Sep 17
-			-2:00	-	FNT	1999 Sep 30
-			-2:00	Brazil	FN%sT	2000 Oct 15
-			-2:00	-	FNT	2001 Sep 13
-			-2:00	Brazil	FN%sT	2002 Oct  1
-			-2:00	-	FNT
+			-2:00	Brazil	%z	1990 Sep 17
+			-2:00	-	%z	1999 Sep 30
+			-2:00	Brazil	%z	2000 Oct 15
+			-2:00	-	%z	2001 Sep 13
+			-2:00	Brazil	%z	2002 Oct  1
+			-2:00	-	%z
 # Other Atlantic islands have no permanent settlement.
 # These include Trindade and Martim Vaz (administratively part of ES),
 # Rocas Atoll (RN), and the St Peter and St Paul Archipelago (PE).
@@ -14575,125 +17161,125 @@ Zone America/Noronha	-2:09:40 -	LMT	1914
 # In the north a very small part from the river Javary (now Jari I guess,
 # the border with Amapá) to the Amazon, then to the Xingu.
 Zone America/Belem	-3:13:56 -	LMT	1914
-			-3:00	Brazil	BR%sT	1988 Sep 12
-			-3:00	-	BRT
+			-3:00	Brazil	%z	1988 Sep 12
+			-3:00	-	%z
 #
 # west Pará (PA)
 # West Pará includes Altamira, Óbidos, Prainha, Oriximiná, and Santarém.
 Zone America/Santarem	-3:38:48 -	LMT	1914
-			-4:00	Brazil	AM%sT	1988 Sep 12
-			-4:00	-	AMT	2008 Jun 24  0:00
-			-3:00	-	BRT
+			-4:00	Brazil	%z	1988 Sep 12
+			-4:00	-	%z	2008 Jun 24  0:00
+			-3:00	-	%z
 #
 # Maranhão (MA), Piauí (PI), Ceará (CE), Rio Grande do Norte (RN),
 # Paraíba (PB)
 Zone America/Fortaleza	-2:34:00 -	LMT	1914
-			-3:00	Brazil	BR%sT	1990 Sep 17
-			-3:00	-	BRT	1999 Sep 30
-			-3:00	Brazil	BR%sT	2000 Oct 22
-			-3:00	-	BRT	2001 Sep 13
-			-3:00	Brazil	BR%sT	2002 Oct  1
-			-3:00	-	BRT
+			-3:00	Brazil	%z	1990 Sep 17
+			-3:00	-	%z	1999 Sep 30
+			-3:00	Brazil	%z	2000 Oct 22
+			-3:00	-	%z	2001 Sep 13
+			-3:00	Brazil	%z	2002 Oct  1
+			-3:00	-	%z
 #
 # Pernambuco (PE) (except Atlantic islands)
 Zone America/Recife	-2:19:36 -	LMT	1914
-			-3:00	Brazil	BR%sT	1990 Sep 17
-			-3:00	-	BRT	1999 Sep 30
-			-3:00	Brazil	BR%sT	2000 Oct 15
-			-3:00	-	BRT	2001 Sep 13
-			-3:00	Brazil	BR%sT	2002 Oct  1
-			-3:00	-	BRT
+			-3:00	Brazil	%z	1990 Sep 17
+			-3:00	-	%z	1999 Sep 30
+			-3:00	Brazil	%z	2000 Oct 15
+			-3:00	-	%z	2001 Sep 13
+			-3:00	Brazil	%z	2002 Oct  1
+			-3:00	-	%z
 #
 # Tocantins (TO)
 Zone America/Araguaina	-3:12:48 -	LMT	1914
-			-3:00	Brazil	BR%sT	1990 Sep 17
-			-3:00	-	BRT	1995 Sep 14
-			-3:00	Brazil	BR%sT	2003 Sep 24
-			-3:00	-	BRT	2012 Oct 21
-			-3:00	Brazil	BR%sT	2013 Sep
-			-3:00	-	BRT
+			-3:00	Brazil	%z	1990 Sep 17
+			-3:00	-	%z	1995 Sep 14
+			-3:00	Brazil	%z	2003 Sep 24
+			-3:00	-	%z	2012 Oct 21
+			-3:00	Brazil	%z	2013 Sep
+			-3:00	-	%z
 #
 # Alagoas (AL), Sergipe (SE)
 Zone America/Maceio	-2:22:52 -	LMT	1914
-			-3:00	Brazil	BR%sT	1990 Sep 17
-			-3:00	-	BRT	1995 Oct 13
-			-3:00	Brazil	BR%sT	1996 Sep  4
-			-3:00	-	BRT	1999 Sep 30
-			-3:00	Brazil	BR%sT	2000 Oct 22
-			-3:00	-	BRT	2001 Sep 13
-			-3:00	Brazil	BR%sT	2002 Oct  1
-			-3:00	-	BRT
+			-3:00	Brazil	%z	1990 Sep 17
+			-3:00	-	%z	1995 Oct 13
+			-3:00	Brazil	%z	1996 Sep  4
+			-3:00	-	%z	1999 Sep 30
+			-3:00	Brazil	%z	2000 Oct 22
+			-3:00	-	%z	2001 Sep 13
+			-3:00	Brazil	%z	2002 Oct  1
+			-3:00	-	%z
 #
 # Bahia (BA)
 # There are too many Salvadors elsewhere, so use America/Bahia instead
 # of America/Salvador.
 Zone America/Bahia	-2:34:04 -	LMT	1914
-			-3:00	Brazil	BR%sT	2003 Sep 24
-			-3:00	-	BRT	2011 Oct 16
-			-3:00	Brazil	BR%sT	2012 Oct 21
-			-3:00	-	BRT
+			-3:00	Brazil	%z	2003 Sep 24
+			-3:00	-	%z	2011 Oct 16
+			-3:00	Brazil	%z	2012 Oct 21
+			-3:00	-	%z
 #
 # Goiás (GO), Distrito Federal (DF), Minas Gerais (MG),
 # Espírito Santo (ES), Rio de Janeiro (RJ), São Paulo (SP), Paraná (PR),
 # Santa Catarina (SC), Rio Grande do Sul (RS)
 Zone America/Sao_Paulo	-3:06:28 -	LMT	1914
-			-3:00	Brazil	BR%sT	1963 Oct 23  0:00
-			-3:00	1:00	BRST	1964
-			-3:00	Brazil	BR%sT
+			-3:00	Brazil	%z	1963 Oct 23  0:00
+			-3:00	1:00	%z	1964
+			-3:00	Brazil	%z
 #
 # Mato Grosso do Sul (MS)
 Zone America/Campo_Grande -3:38:28 -	LMT	1914
-			-4:00	Brazil	AM%sT
+			-4:00	Brazil	%z
 #
 # Mato Grosso (MT)
 Zone America/Cuiaba	-3:44:20 -	LMT	1914
-			-4:00	Brazil	AM%sT	2003 Sep 24
-			-4:00	-	AMT	2004 Oct  1
-			-4:00	Brazil	AM%sT
+			-4:00	Brazil	%z	2003 Sep 24
+			-4:00	-	%z	2004 Oct  1
+			-4:00	Brazil	%z
 #
 # Rondônia (RO)
 Zone America/Porto_Velho -4:15:36 -	LMT	1914
-			-4:00	Brazil	AM%sT	1988 Sep 12
-			-4:00	-	AMT
+			-4:00	Brazil	%z	1988 Sep 12
+			-4:00	-	%z
 #
 # Roraima (RR)
 Zone America/Boa_Vista	-4:02:40 -	LMT	1914
-			-4:00	Brazil	AM%sT	1988 Sep 12
-			-4:00	-	AMT	1999 Sep 30
-			-4:00	Brazil	AM%sT	2000 Oct 15
-			-4:00	-	AMT
+			-4:00	Brazil	%z	1988 Sep 12
+			-4:00	-	%z	1999 Sep 30
+			-4:00	Brazil	%z	2000 Oct 15
+			-4:00	-	%z
 #
 # east Amazonas (AM): Boca do Acre, Jutaí, Manaus, Floriano Peixoto
 # The great circle line from Tabatinga to Porto Acre divides
 # east from west Amazonas.
 Zone America/Manaus	-4:00:04 -	LMT	1914
-			-4:00	Brazil	AM%sT	1988 Sep 12
-			-4:00	-	AMT	1993 Sep 28
-			-4:00	Brazil	AM%sT	1994 Sep 22
-			-4:00	-	AMT
+			-4:00	Brazil	%z	1988 Sep 12
+			-4:00	-	%z	1993 Sep 28
+			-4:00	Brazil	%z	1994 Sep 22
+			-4:00	-	%z
 #
 # west Amazonas (AM): Atalaia do Norte, Boca do Maoco, Benjamin Constant,
 #	Eirunepé, Envira, Ipixuna
 Zone America/Eirunepe	-4:39:28 -	LMT	1914
-			-5:00	Brazil	AC%sT	1988 Sep 12
-			-5:00	-	ACT	1993 Sep 28
-			-5:00	Brazil	AC%sT	1994 Sep 22
-			-5:00	-	ACT	2008 Jun 24  0:00
-			-4:00	-	AMT	2013 Nov 10
-			-5:00	-	ACT
+			-5:00	Brazil	%z	1988 Sep 12
+			-5:00	-	%z	1993 Sep 28
+			-5:00	Brazil	%z	1994 Sep 22
+			-5:00	-	%z	2008 Jun 24  0:00
+			-4:00	-	%z	2013 Nov 10
+			-5:00	-	%z
 #
 # Acre (AC)
 Zone America/Rio_Branco	-4:31:12 -	LMT	1914
-			-5:00	Brazil	AC%sT	1988 Sep 12
-			-5:00	-	ACT	2008 Jun 24  0:00
-			-4:00	-	AMT	2013 Nov 10
-			-5:00	-	ACT
+			-5:00	Brazil	%z	1988 Sep 12
+			-5:00	-	%z	2008 Jun 24  0:00
+			-4:00	-	%z	2013 Nov 10
+			-5:00	-	%z
 
 # Chile
 
-# From Paul Eggert (2015-04-03):
+# From Paul Eggert (2022-03-15):
 # Shanks & Pottenger says America/Santiago introduced standard time in
-# 1890 and rounds its UTC offset to 70W40; guess that in practice this
+# 1890 and rounds its UT offset to 70W40; guess that in practice this
 # was the same offset as in 1916-1919.  It also says Pacific/Easter
 # standardized on 109W22 in 1890; assume this didn't change the clocks.
 #
@@ -14701,20 +17287,20 @@ Zone America/Rio_Branco	-4:31:12 -	LMT	1914
 # the following source, cited by Oscar van Vlijmen (2006-10-08):
 # [1] Chile Law
 # http://www.webexhibits.org/daylightsaving/chile.html
-# This contains a copy of a this official table:
+# This contains a copy of this official table:
 # Cambios en la hora oficial de Chile desde 1900 (retrieved 2008-03-30)
-# http://web.archive.org/web/20080330200901/http://www.horaoficial.cl/cambio.htm
+# https://web.archive.org/web/20080330200901/http://www.horaoficial.cl/cambio.htm
 # [1] needs several corrections, though.
 #
 # The first set of corrections is from:
 # [2] History of the Official Time of Chile
 # http://www.horaoficial.cl/ing/horaof_ing.html (retrieved 2012-03-06).  See:
-# http://web.archive.org/web/20120306042032/http://www.horaoficial.cl/ing/horaof_ing.html
+# https://web.archive.org/web/20120306042032/http://www.horaoficial.cl/ing/horaof_ing.html
 # This is an English translation of:
 # Historia de la hora oficial de Chile (retrieved 2012-10-24).  See:
-# http://web.archive.org/web/20121024234627/http://www.horaoficial.cl/horaof.htm
+# https://web.archive.org/web/20121024234627/http://www.horaoficial.cl/horaof.htm
 # A fancier Spanish version (requiring mouse-clicking) is at:
-# http://www.horaoficial.cl/historia_hora.html
+# http://www.horaoficial.cl/historia_hora.php
 # Conflicts between [1] and [2] were resolved as follows:
 #
 #  - [1] says the 1910 transition was Jan 1, [2] says Jan 10 and cites
@@ -14723,7 +17309,8 @@ Zone America/Rio_Branco	-4:31:12 -	LMT	1914
 #  - [1] says SMT was -4:42:45, [2] says Chile's official time from
 #    1916 to 1919 was -4:42:46.3, the meridian of Chile's National
 #    Astronomical Observatory (OAN), then located in what is now
-#    Quinta Normal in Santiago.  Go with [2], rounding it to -4:42:46.
+#    Quinta Normal in Santiago.  Go with [1], as this matches the meridian
+#    referred to by the relevant Chilean laws to this day.
 #
 #  - [1] says the 1918 transition was Sep 1, [2] says Sep 10 and cites
 #    Boletín No. 22, Aviso No. 129/1918 (1918-08-23).  Go with [2].
@@ -14744,6 +17331,39 @@ Zone America/Rio_Branco	-4:31:12 -	LMT	1914
 # Pacific/Easter is always two hours behind America/Santiago;
 # this is known to work for DST transitions starting in 2008 and
 # may well be true for earlier transitions.
+
+# From Tim Parenti (2022-07-06):
+# For a brief period of roughly six weeks in 1946, DST was only observed on an
+# emergency basis in specific regions of central Chile; namely, "the national
+# territory between the provinces of Coquimbo and Concepción, inclusive".
+# This was enacted by Decree 3,891, dated 1946-07-13, and took effect
+# 1946-07-14 24:00, advancing these central regions to -03.
+# https://www.diariooficial.interior.gob.cl/versiones-anteriores/do-h/19460715/#page/1
+# The decree contemplated "[t]hat this advancement of the Official Time, even
+# though it has been proposed for the cities of Santiago and Valparaíso only,
+# must be agreed with that of other cities, due to the connection of various
+# activities that require it, such as, for example, the operation of rail
+# services".  It was originally set to expire after 30 days but was extended
+# through 1946-08-31 by Decree 4,506, dated 1946-08-13.
+# https://www.diariooficial.interior.gob.cl/versiones-anteriores/do-h/19460814/#page/1
+#
+# Law Number 8,522, promulgated 1946-08-27, reunified Chilean clocks at their
+# new "Summer Time" of -04, reckoned as that of "the meridian of the
+# Astronomical Observatory of Lo Espejo, advanced by 42 minutes and 45
+# seconds".  Although this law specified the new Summer Time to start on 1
+# September each year, a special "transitional article" started it a few days
+# early, as soon as the law took effect.  As the law was to take force "from
+# the date of its publication in the 'Diario Oficial', which happened the
+# following day, presume the change took place in Santiago and its environs
+# from 24:00 -03 to 23:00 -04 on Wednesday 1946-08-28.  Although this was a
+# no-op for wall clocks in the north and south of the country, put their formal
+# start to DST an hour later when they reached 24:00 -04.
+# https://www.diariooficial.interior.gob.cl/versiones-anteriores/do-h/19460828/#page/1
+# After a brief "Winter Time" stint at -05 beginning 1947-04-01, Law Number
+# 8,777, promulgated 1947-05-17, established year-round -04 "from 23:00 on the
+# second day after it is published in the 'Diario Oficial'."  It was published
+# on Monday 1947-05-19 and so took effect from Wednesday 1947-05-21 23:00.
+# https://www.diariooficial.interior.gob.cl/versiones-anteriores/do-h/19470519/#page/1
 
 # From Eduardo Krell (1995-10-19):
 # The law says to switch to DST at midnight [24:00] on the second SATURDAY
@@ -14808,53 +17428,138 @@ Zone America/Rio_Branco	-4:31:12 -	LMT	1914
 # dates to 2014.
 # DST End: last Saturday of April 2014 (Sun 27 Apr 2014 03:00 UTC)
 # DST Start: first Saturday of September 2014 (Sun 07 Sep 2014 04:00 UTC)
-# http://www.diariooficial.interior.gob.cl//media/2014/02/19/do-20140219.pdf
+# From Tim Parenti (2025-03-22):
+# Decreto 307 of 2014 of the Ministry of the Interior and Public Security,
+# promulgated 2014-01-30 and published 2014-02-19:
+# https://www.diariooficial.interior.gob.cl/media/2014/02/19/do-20140219.pdf#page=1
+# https://www.bcn.cl/leychile/navegar?idNorma=1059557
 
 # From Eduardo Romero Urra (2015-03-03):
 # Today has been published officially that Chile will use the DST time
 # permanently until March 25 of 2017
-# http://www.diariooficial.interior.gob.cl/media/2015/03/03/1-large.jpg
-#
-# From Paul Eggert (2015-03-03):
-# For now, assume that the extension will persist indefinitely.
+# From Tim Parenti (2025-03-22):
+# Decreto 106 of 2015 of the Ministry of the Interior and Public Security,
+# promulgated 2015-01-27 and published 2015-03-03:
+# https://www.diariooficial.interior.gob.cl/media/2015/03/03/do-20150303.pdf#page=1
+# https://www.bcn.cl/leychile/navegar?idNorma=1075157
 
 # From Juan Correa (2016-03-18):
-# The decree regarding DST has been published in today's Official Gazette:
-# http://www.diariooficial.interior.gob.cl/versiones-anteriores/do/20160318/
-# http://www.leychile.cl/Navegar?idNorma=1088502
+# The decree regarding DST has been published in today's Official Gazette...
 # It does consider the second Saturday of May and August as the dates
 # for the transition; and it lists DST dates until 2019, but I think
 # this scheme will stick.
-#
 # From Paul Eggert (2016-03-18):
-# For now, assume the pattern holds for the indefinite future.
 # The decree says transitions occur at 24:00; in practice this appears
 # to mean 24:00 mainland time, not 24:00 local time, so that Easter
 # Island is always two hours behind the mainland.
+# From Tim Parenti (2025-03-22):
+# Decreto 253 of 2016 of the Ministry of the Interior and Public Security,
+# promulgated 2016-03-16 and published 2016-03-18.
+# https://www.diariooficial.interior.gob.cl/media/2016/03/18/do-20160318.pdf#page=1
+# https://www.bcn.cl/leychile/navegar?idNorma=1088502
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Chile	1927	1931	-	Sep	 1	0:00	1:00	S
+# From Juan Correa (2016-12-04):
+# Magallanes region ... will keep DST (UTC -3) all year round....
+# http://www.soychile.cl/Santiago/Sociedad/2016/12/04/433428/Bachelet-firmo-el-decreto-para-establecer-un-horario-unico-para-la-Region-de-Magallanes.aspx
+# From Tim Parenti (2025-03-22), via Deborah Goldsmith (2017-01-19):
+# Decreto 1820 of 2016 of the Ministry of the Interior and Public Security,
+# promulgated 2016-12-02 and published 2017-01-17:
+# https://www.diariooficial.interior.gob.cl/publicaciones/2017/01/17/41660/01/1169626.pdf
+# https://www.bcn.cl/leychile/Navegar?idNorma=1099217
+# Model this as a change to standard offset effective 2016-12-04.
+
+# From Juan Correa (2018-08-13):
+# As of moments ago, the Ministry of Energy in Chile has announced the new
+# schema for DST. ...  Announcement in video (in Spanish):
+# https://twitter.com/MinEnergia/status/1029000399129374720
+# From Yonathan Dossow (2018-08-13):
+# The video says "first Saturday of September", we all know it means Sunday at
+# midnight.
+# From Tim Parenti (2018-08-13):
+# Translating the captions on the video at 0:44-0:55, "We want to announce as
+# Government that from 2019, Winter Time will be increased to 5 months, between
+# the first Saturday of April and the first Saturday of September."
+# At 2:08-2:20, "The Magallanes region will maintain its current time, as
+# decided by the citizens during 2017, but our Government will promote a
+# regional dialogue table to gather their opinion on this matter."
+# https://twitter.com/MinEnergia/status/1029009354001973248
+# "We will keep the new time policy unchanged for at least the next 4 years."
+# So we extend the new rules on Saturdays at 24:00 mainland time indefinitely.
+# From Tim Parenti (2025-03-22), via Juan Correa (2019-02-04):
+# Decreto 1286 of 2018 of the Ministry of the Interior and Public Security,
+# promulgated 2018-09-21 and published 2018-11-23:
+# https://www.diariooficial.interior.gob.cl/publicaciones/2018/11/23/42212/01/1498738.pdf
+# https://www.bcn.cl/leychile/Navegar?idNorma=1125760
+
+# From Juan Correa (2022-04-02):
+# I found there was a decree published last Thursday that will keep
+# Magallanes region to UTC -3 "indefinitely".
+# From Tim Parenti (2025-03-22):
+# Decreto 143 of 2022 of the Ministry of the Interior and Public Security,
+# promulgated 2022-03-29 and published 2022-03-31:
+# https://www.diariooficial.interior.gob.cl/publicaciones/2022/03/31/43217-B/01/2108910.pdf
+# https://www.bcn.cl/leychile/Navegar?idNorma=1174342
+
+# From Juan Correa (2022-08-09):
+# the Internal Affairs Ministry (Ministerio del Interior) informed DST
+# for America/Santiago will start on midnight of September 11th;
+# and will end on April 1st, 2023. Magallanes region (America/Punta_Arenas)
+# will keep UTC -3 "indefinitely"...  This is because on September 4th
+# we will have a voting whether to approve a new Constitution.
+#
+# From Tim Parenti (2025-03-22), via Eduardo Romero Urra (2022-08-17):
+# Decreto 224 of 2022 of the Ministry of the Interior and Public Security,
+# promulgated 2022-07-14 and published 2022-08-13:
+# https://www.diariooficial.interior.gob.cl/publicaciones/2022/08/13/43327/01/2172567.pdf
+# https://www.bcn.cl/leychile/navegar?idNorma=1179983
+#
+# From Paul Eggert (2022-08-17):
+# Although the presidential decree stops at fall 2026, assume that
+# similar DST rules will continue thereafter.
+
+# From Paul Eggert (2025-01-15):
+# Diario Regional Aysén's Sebastián Martel reports that 94% of Aysén
+# citizens polled in November favored changing the rules from
+# -04/-03-with-DST to -03 all year...
+# https://www.diarioregionalaysen.cl/noticia/actualidad/2024/12/presentan-decision-que-gano-la-votacion-sobre-el-cambio-del-huso-horario-en-aysen
+#
+# From Yonathan Dossow (2025-03-20):
+# [T]oday we have more confirmation of the change.  [Aysén] region will keep
+# UTC-3 all year...
+# https://www.cnnchile.com/pais/region-de-aysen-mantendra-horario-de-verano-todo-el-ano_20250320/
+# https://www.latercera.com/nacional/noticia/tras-consulta-ciudadana-region-de-aysen-mantendra-el-horario-de-verano-durante-todo-el-ano/
+# https://x.com/min_interior/status/1902692504270672098
+#
+# From Tim Parenti (2025-03-22), via Eduardo Romero Urra (2025-03-20):
+# Decreto 93 of 2025 of the Ministry of the Interior and Public Security,
+# promulgated 2025-03-11 and published 2025-03-20:
+# https://www.diariooficial.interior.gob.cl/publicaciones/2025/03/20/44104/01/2624263.pdf
+# https://www.bcn.cl/leychile/Navegar?idNorma=1211955
+# Model this as a change to standard offset effective 2025-03-20.
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Chile	1927	1931	-	Sep	 1	0:00	1:00	-
 Rule	Chile	1928	1932	-	Apr	 1	0:00	0	-
-Rule	Chile	1968	only	-	Nov	 3	4:00u	1:00	S
+Rule	Chile	1968	only	-	Nov	 3	4:00u	1:00	-
 Rule	Chile	1969	only	-	Mar	30	3:00u	0	-
-Rule	Chile	1969	only	-	Nov	23	4:00u	1:00	S
+Rule	Chile	1969	only	-	Nov	23	4:00u	1:00	-
 Rule	Chile	1970	only	-	Mar	29	3:00u	0	-
 Rule	Chile	1971	only	-	Mar	14	3:00u	0	-
-Rule	Chile	1970	1972	-	Oct	Sun>=9	4:00u	1:00	S
+Rule	Chile	1970	1972	-	Oct	Sun>=9	4:00u	1:00	-
 Rule	Chile	1972	1986	-	Mar	Sun>=9	3:00u	0	-
-Rule	Chile	1973	only	-	Sep	30	4:00u	1:00	S
-Rule	Chile	1974	1987	-	Oct	Sun>=9	4:00u	1:00	S
+Rule	Chile	1973	only	-	Sep	30	4:00u	1:00	-
+Rule	Chile	1974	1987	-	Oct	Sun>=9	4:00u	1:00	-
 Rule	Chile	1987	only	-	Apr	12	3:00u	0	-
 Rule	Chile	1988	1990	-	Mar	Sun>=9	3:00u	0	-
-Rule	Chile	1988	1989	-	Oct	Sun>=9	4:00u	1:00	S
-Rule	Chile	1990	only	-	Sep	16	4:00u	1:00	S
+Rule	Chile	1988	1989	-	Oct	Sun>=9	4:00u	1:00	-
+Rule	Chile	1990	only	-	Sep	16	4:00u	1:00	-
 Rule	Chile	1991	1996	-	Mar	Sun>=9	3:00u	0	-
-Rule	Chile	1991	1997	-	Oct	Sun>=9	4:00u	1:00	S
+Rule	Chile	1991	1997	-	Oct	Sun>=9	4:00u	1:00	-
 Rule	Chile	1997	only	-	Mar	30	3:00u	0	-
 Rule	Chile	1998	only	-	Mar	Sun>=9	3:00u	0	-
-Rule	Chile	1998	only	-	Sep	27	4:00u	1:00	S
+Rule	Chile	1998	only	-	Sep	27	4:00u	1:00	-
 Rule	Chile	1999	only	-	Apr	 4	3:00u	0	-
-Rule	Chile	1999	2010	-	Oct	Sun>=9	4:00u	1:00	S
+Rule	Chile	1999	2010	-	Oct	Sun>=9	4:00u	1:00	-
 Rule	Chile	2000	2007	-	Mar	Sun>=9	3:00u	0	-
 # N.B.: the end of March 29 in Chile is March 30 in Universal time,
 # which is used below in specifying the transition.
@@ -14862,32 +17567,64 @@ Rule	Chile	2008	only	-	Mar	30	3:00u	0	-
 Rule	Chile	2009	only	-	Mar	Sun>=9	3:00u	0	-
 Rule	Chile	2010	only	-	Apr	Sun>=1	3:00u	0	-
 Rule	Chile	2011	only	-	May	Sun>=2	3:00u	0	-
-Rule	Chile	2011	only	-	Aug	Sun>=16	4:00u	1:00	S
+Rule	Chile	2011	only	-	Aug	Sun>=16	4:00u	1:00	-
 Rule	Chile	2012	2014	-	Apr	Sun>=23	3:00u	0	-
-Rule	Chile	2012	2014	-	Sep	Sun>=2	4:00u	1:00	S
-Rule	Chile	2016	max	-	May	Sun>=9	3:00u	0	-
-Rule	Chile	2016	max	-	Aug	Sun>=9	4:00u	1:00	S
+Rule	Chile	2012	2014	-	Sep	Sun>=2	4:00u	1:00	-
+Rule	Chile	2016	2018	-	May	Sun>=9	3:00u	0	-
+Rule	Chile	2016	2018	-	Aug	Sun>=9	4:00u	1:00	-
+Rule	Chile	2019	max	-	Apr	Sun>=2	3:00u	0	-
+Rule	Chile	2019	2021	-	Sep	Sun>=2	4:00u	1:00	-
+Rule	Chile	2022	only	-	Sep	Sun>=9	4:00u	1:00	-
+Rule	Chile	2023	max	-	Sep	Sun>=2	4:00u	1:00	-
 # IATA SSIM anomalies: (1992-02) says 1992-03-14;
 # (1996-09) says 1998-03-08.  Ignore these.
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Santiago	-4:42:46 -	LMT	1890
-			-4:42:46 -	SMT	1910 Jan 10 # Santiago Mean Time
-			-5:00	-	CLT	1916 Jul  1 # Chile Time
-			-4:42:46 -	SMT	1918 Sep 10
-			-4:00	-	CLT	1919 Jul  1
-			-4:42:46 -	SMT	1927 Sep  1
-			-5:00	Chile	CL%sT	1932 Sep  1
-			-4:00	-	CLT	1942 Jun  1
-			-5:00	-	CLT	1942 Aug  1
-			-4:00	-	CLT	1946 Jul 15
-			-4:00	1:00	CLST	1946 Sep  1 # central Chile
-			-4:00	-	CLT	1947 Apr  1
-			-5:00	-	CLT	1947 May 21 23:00
-			-4:00	Chile	CL%sT
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone America/Santiago	-4:42:45 -	LMT	1890
+			-4:42:45 -	SMT	1910 Jan 10 # Santiago Mean Time
+			-5:00	-	%z	1916 Jul  1
+			-4:42:45 -	SMT	1918 Sep 10
+			-4:00	-	%z	1919 Jul  1
+			-4:42:45 -	SMT	1927 Sep  1
+			-5:00	Chile	%z	1932 Sep  1
+			-4:00	-	%z	1942 Jun  1
+			-5:00	-	%z	1942 Aug  1
+			-4:00	-	%z	1946 Jul 14 24:00
+			-4:00	1:00	%z	1946 Aug 28 24:00 # central CL
+			-5:00	1:00	%z	1947 Mar 31 24:00
+			-5:00	-	%z	1947 May 21 23:00
+			-4:00	Chile	%z
+Zone America/Coyhaique	-4:48:16 -	LMT	1890
+			-4:42:45 -	SMT	1910 Jan 10
+			-5:00	-	%z	1916 Jul  1
+			-4:42:45 -	SMT	1918 Sep 10
+			-4:00	-	%z	1919 Jul  1
+			-4:42:45 -	SMT	1927 Sep  1
+			-5:00	Chile	%z	1932 Sep  1
+			-4:00	-	%z	1942 Jun  1
+			-5:00	-	%z	1942 Aug  1
+			-4:00	-	%z	1946 Aug 28 24:00
+			-5:00	1:00	%z	1947 Mar 31 24:00
+			-5:00	-	%z	1947 May 21 23:00
+			-4:00	Chile	%z	2025 Mar 20
+			-3:00	-	%z
+Zone America/Punta_Arenas -4:43:40 -	LMT	1890
+			-4:42:45 -	SMT	1910 Jan 10
+			-5:00	-	%z	1916 Jul  1
+			-4:42:45 -	SMT	1918 Sep 10
+			-4:00	-	%z	1919 Jul  1
+			-4:42:45 -	SMT	1927 Sep  1
+			-5:00	Chile	%z	1932 Sep  1
+			-4:00	-	%z	1942 Jun  1
+			-5:00	-	%z	1942 Aug  1
+			-4:00	-	%z	1946 Aug 28 24:00
+			-5:00	1:00	%z	1947 Mar 31 24:00
+			-5:00	-	%z	1947 May 21 23:00
+			-4:00	Chile	%z	2016 Dec  4
+			-3:00	-	%z
 Zone Pacific/Easter	-7:17:28 -	LMT	1890
 			-7:17:28 -	EMT	1932 Sep    # Easter Mean Time
-			-7:00	Chile	EAS%sT	1982 Mar 14 3:00u # Easter Time
-			-6:00	Chile	EAS%sT
+			-7:00	Chile	%z	1982 Mar 14 3:00u # Easter Time
+			-6:00	Chile	%z
 #
 # Salas y Gómez Island is uninhabited.
 # Other Chilean locations, including Juan Fernández Is, Desventuradas Is,
@@ -14905,75 +17642,65 @@ Zone Pacific/Easter	-7:17:28 -	LMT	1890
 # Palmer has followed Chile.  Prior to that, before the Falklands War,
 # Palmer used to be supplied from Argentina.
 #
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Antarctica/Palmer	0	-	-00	1965
-			-4:00	Arg	AR%sT	1969 Oct  5
-			-3:00	Arg	AR%sT	1982 May
-			-4:00	Chile	CL%sT
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1982 May
+			-4:00	Chile	%z	2016 Dec  4
+			-3:00	-	%z
 
 # Colombia
 
-# Milne gives 4:56:16.4 for Bogotá time in 1899; round to nearest.  He writes,
+# Milne gives 4:56:16.4 for Bogotá time in 1899.  He writes,
 # "A variation of fifteen minutes in the public clocks of Bogota is not rare."
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	CO	1992	only	-	May	 3	0:00	1:00	S
-Rule	CO	1993	only	-	Apr	 4	0:00	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# From Alois Treindl (2022-11-10):
+# End of time change in Colombia 1993 ... should be 6 February 24h ...
+# DECRETO 267 DE 1993
+# https://www.suin-juriscol.gov.co/viewDocument.asp?ruta=Decretos/1061335
+
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	CO	1992	only	-	May	 3	 0:00	1:00	-
+Rule	CO	1993	only	-	Feb	 6	24:00	0	-
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	-4:56:16.4
 Zone	America/Bogota	-4:56:16 -	LMT	1884 Mar 13
 			-4:56:16 -	BMT	1914 Nov 23 # Bogotá Mean Time
-			-5:00	CO	CO%sT	# Colombia Time
+			-5:00	CO	%z
 # Malpelo, Providencia, San Andres
 # no information; probably like America/Bogota
 
-# Curaçao
-
-# Milne gives 4:35:46.9 for Curaçao mean time; round to nearest.
-#
-# From Paul Eggert (2006-03-22):
-# Shanks & Pottenger say that The Bottom and Philipsburg have been at
-# -4:00 since standard time was introduced on 1912-03-02; and that
-# Kralendijk and Rincon used Kralendijk Mean Time (-4:33:08) from
-# 1912-02-02 to 1965-01-01.  The former is dubious, since S&P also say
-# Saba Island has been like Curaçao.
-# This all predates our 1970 cutoff, though.
-#
-# By July 2007 Curaçao and St Maarten are planned to become
-# associated states within the Netherlands, much like Aruba;
-# Bonaire, Saba and St Eustatius would become directly part of the
-# Netherlands as Kingdom Islands.  This won't affect their time zones
-# though, as far as we know.
-#
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	America/Curacao	-4:35:47 -	LMT	1912 Feb 12 # Willemstad
-			-4:30	-	ANT	1965 # Netherlands Antilles Time
-			-4:00	-	AST
-
-# From Arthur David Olson (2011-06-15):
-# use links for places with new iso3166 codes.
-# The name "Lower Prince's Quarter" is both longer than fourteen characters
-# and contains an apostrophe; use "Lower_Princes" below.
-
-Link	America/Curacao	America/Lower_Princes	# Sint Maarten
-Link	America/Curacao	America/Kralendijk	# Caribbean Netherlands
 
 # Ecuador
 #
 # Milne says the Central and South American Telegraph Company used -5:24:15.
 #
-# From Paul Eggert (2007-03-04):
-# Apparently Ecuador had a failed experiment with DST in 1992.
-# <http://midena.gov.ec/content/view/1261/208/> (2007-02-27) and
-# <http://www.hoy.com.ec/NoticiaNue.asp?row_id=249856> (2006-11-06) both
-# talk about "hora Sixto".  Leave this alone for now, as we have no data.
+# From Alois Treindl (2016-12-15):
+# https://www.elcomercio.com/actualidad/hora-sixto-1993.html
+# ... Whether the law applied also to Galápagos, I do not know.
+# From Paul Eggert (2016-12-15):
+# https://www.elcomercio.com/afull/modificacion-husohorario-ecuador-presidentes-decreto.html
+# This says President Sixto Durán Ballén signed decree No. 285, which
+# established DST from 1992-11-28 to 1993-02-05; it does not give transition
+# times.  The people called it "hora de Sixto" ("Sixto hour").  The change did
+# not go over well; a popular song "Qué hora es" by Jaime Guevara had lyrics
+# that included "Amanecía en mitad de la noche, los guaguas iban a clase sin
+# sol" ("It was dawning in the middle of the night, the buses went to class
+# without sun").  Although Ballén's campaign slogan was "Ni un paso atrás"
+# (Not one step back), the clocks went back in 1993 and the experiment was not
+# repeated.  For now, assume transitions were at 00:00 local time country-wide.
 #
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Ecuador	1992	only	-	Nov	28	0:00	1:00	-
+Rule	Ecuador	1993	only	-	Feb	 5	0:00	0	-
+#
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Guayaquil	-5:19:20 -	LMT	1890
 			-5:14:00 -	QMT	1931 # Quito Mean Time
-			-5:00	-	ECT	# Ecuador Time
+			-5:00	Ecuador	%z
 Zone Pacific/Galapagos	-5:58:24 -	LMT	1931 # Puerto Baquerizo Moreno
-			-5:00	-	ECT	1986
-			-6:00	-	GALT	# Galápagos Time
+			-5:00	-	%z	1986
+			-6:00	Ecuador	%z
 
 # Falklands
 
@@ -15054,44 +17781,75 @@ Zone Pacific/Galapagos	-5:58:24 -	LMT	1931 # Puerto Baquerizo Moreno
 #   the maintainers of the database to inform them we're adopting
 #   the same policy this year and suggest recommendations for future years.
 #
-# For now we will assume permanent summer time for the Falklands
+# For now we will assume permanent -03 for the Falklands
 # until advised differently (to apply for 2012 and beyond, after the 2011
 # experiment was apparently successful.)
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Falk	1937	1938	-	Sep	lastSun	0:00	1:00	S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Falk	1937	1938	-	Sep	lastSun	0:00	1:00	-
 Rule	Falk	1938	1942	-	Mar	Sun>=19	0:00	0	-
-Rule	Falk	1939	only	-	Oct	1	0:00	1:00	S
-Rule	Falk	1940	1942	-	Sep	lastSun	0:00	1:00	S
+Rule	Falk	1939	only	-	Oct	1	0:00	1:00	-
+Rule	Falk	1940	1942	-	Sep	lastSun	0:00	1:00	-
 Rule	Falk	1943	only	-	Jan	1	0:00	0	-
-Rule	Falk	1983	only	-	Sep	lastSun	0:00	1:00	S
+Rule	Falk	1983	only	-	Sep	lastSun	0:00	1:00	-
 Rule	Falk	1984	1985	-	Apr	lastSun	0:00	0	-
-Rule	Falk	1984	only	-	Sep	16	0:00	1:00	S
-Rule	Falk	1985	2000	-	Sep	Sun>=9	0:00	1:00	S
+Rule	Falk	1984	only	-	Sep	16	0:00	1:00	-
+Rule	Falk	1985	2000	-	Sep	Sun>=9	0:00	1:00	-
 Rule	Falk	1986	2000	-	Apr	Sun>=16	0:00	0	-
 Rule	Falk	2001	2010	-	Apr	Sun>=15	2:00	0	-
-Rule	Falk	2001	2010	-	Sep	Sun>=1	2:00	1:00	S
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+Rule	Falk	2001	2010	-	Sep	Sun>=1	2:00	1:00	-
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Atlantic/Stanley	-3:51:24 -	LMT	1890
 			-3:51:24 -	SMT	1912 Mar 12 # Stanley Mean Time
-			-4:00	Falk	FK%sT	1983 May    # Falkland Is Time
-			-3:00	Falk	FK%sT	1985 Sep 15
-			-4:00	Falk	FK%sT	2010 Sep  5  2:00
-			-3:00	-	FKST
+			-4:00	Falk	%z	1983 May
+			-3:00	Falk	%z	1985 Sep 15
+			-4:00	Falk	%z	2010 Sep  5  2:00
+			-3:00	-	%z
 
 # French Guiana
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Cayenne	-3:29:20 -	LMT	1911 Jul
-			-4:00	-	GFT	1967 Oct # French Guiana Time
-			-3:00	-	GFT
+# For the 1911/1912 establishment of standard time in French possessions, see:
+# Société Française de Physique, Recueil de constantes physiques (1913),
+# page 752, 18b.
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone America/Cayenne	-3:29:20 -	LMT	1911 Jul  1
+			-4:00	-	%z	1967 Oct
+			-3:00	-	%z
 
 # Guyana
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	America/Guyana	-3:52:40 -	LMT	1915 Mar    # Georgetown
-			-3:45	-	GBGT	1966 May 26 # Br Guiana Time
-			-3:45	-	GYT	1975 Jul 31 # Guyana Time
-			-3:00	-	GYT	1991
-# IATA SSIM (1996-06) says -4:00.  Assume a 1991 switch.
-			-4:00	-	GYT
+
+# From P Chan (2020-11-27):
+# https://books.google.com/books?id=5-5CAQAAMAAJ&pg=SA1-PA547
+# The Official Gazette of British Guiana. (New Series.) Vol. XL. July to
+# December, 1915, p 1547, lists as several notes:
+# "Local Mean Time 3 hours 52 mins. 39 secs. slow of Greenwich Mean Time
+# (Georgetown.) From 1st August, 1911, British Guiana Standard Mean Time 4
+# hours slow of Greenwich Mean Time, by notice in Official Gazette on 1st July,
+# 1911.  From 1st March, 1915, British Guiana Standard Mean Time 3 hours 45
+# mins. 0 secs. slow of Greenwich Mean Time, by notice in Official Gazette on
+# 23rd January, 1915."
+#
+# https://parliament.gov.gy/documents/acts/10923-act_no._27_of_1975_-_interpretation_and_general_clauses_(amendment)_act_1975.pdf
+# Interpretation and general clauses (Amendment) Act 1975 (Act No. 27 of 1975)
+# [dated 1975-07-31]
+# "This Act...shall come into operation on 1st August, 1975."
+# "...where any expression of time occurs...the time referred to shall signify
+# the standard time of Guyana which shall be three hours behind Greenwich Mean
+# Time."
+#
+# Circular No. 10/1992 dated 1992-03-20
+# https://dps.gov.gy/wp-content/uploads/2018/12/1992-03-20-Circular-010.pdf
+# "...cabinet has decided that with effect from Sunday 29th March, 1992, Guyana
+# Standard Time would be re-established at 01:00 hours by adjusting the hands
+# of the clock back to 24:00 hours."
+# Legislated in the Interpretation and general clauses (Amendment) Act 1992
+# (Act No. 6 of 1992) [passed 1992-03-27, published 1992-04-18]
+# https://parliament.gov.gy/documents/acts/5885-6_of_1992_interpretation_and_general_clauses_(amendment)_act_1992.pdf
+
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone	America/Guyana	-3:52:39 -	LMT	1911 Aug  1 # Georgetown
+			-4:00	-	%z	1915 Mar  1
+			-3:45	-	%z	1975 Aug  1
+			-3:00	-	%z	1992 Mar 29  1:00
+			-4:00	-	%z
 
 # Paraguay
 #
@@ -15104,17 +17862,17 @@ Zone	America/Guyana	-3:52:40 -	LMT	1915 Mar    # Georgetown
 # No time of the day is established for the adjustment, so people normally
 # adjust their clocks at 0 hour of the given dates.
 #
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Para	1975	1988	-	Oct	 1	0:00	1:00	S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Para	1975	1988	-	Oct	 1	0:00	1:00	-
 Rule	Para	1975	1978	-	Mar	 1	0:00	0	-
 Rule	Para	1979	1991	-	Apr	 1	0:00	0	-
-Rule	Para	1989	only	-	Oct	22	0:00	1:00	S
-Rule	Para	1990	only	-	Oct	 1	0:00	1:00	S
-Rule	Para	1991	only	-	Oct	 6	0:00	1:00	S
+Rule	Para	1989	only	-	Oct	22	0:00	1:00	-
+Rule	Para	1990	only	-	Oct	 1	0:00	1:00	-
+Rule	Para	1991	only	-	Oct	 6	0:00	1:00	-
 Rule	Para	1992	only	-	Mar	 1	0:00	0	-
-Rule	Para	1992	only	-	Oct	 5	0:00	1:00	S
+Rule	Para	1992	only	-	Oct	 5	0:00	1:00	-
 Rule	Para	1993	only	-	Mar	31	0:00	0	-
-Rule	Para	1993	1995	-	Oct	 1	0:00	1:00	S
+Rule	Para	1993	1995	-	Oct	 1	0:00	1:00	-
 Rule	Para	1994	1995	-	Feb	lastSun	0:00	0	-
 Rule	Para	1996	only	-	Mar	 1	0:00	0	-
 # IATA SSIM (2000-02) says 1999-10-10; ignore this for now.
@@ -15132,7 +17890,7 @@ Rule	Para	1996	only	-	Mar	 1	0:00	0	-
 # year, the time will change on the first Sunday of October; likewise, the
 # clock will be set back on the first Sunday of March.
 #
-Rule	Para	1996	2001	-	Oct	Sun>=1	0:00	1:00	S
+Rule	Para	1996	2001	-	Oct	Sun>=1	0:00	1:00	-
 # IATA SSIM (1997-09) says Mar 1; go with Shanks & Pottenger.
 Rule	Para	1997	only	-	Feb	lastSun	0:00	0	-
 # Shanks & Pottenger say 1999-02-28; IATA SSIM (1999-02) says 1999-02-27, but
@@ -15143,7 +17901,7 @@ Rule	Para	1998	2001	-	Mar	Sun>=1	0:00	0	-
 # dst method to be from the first Sunday in September to the first Sunday in
 # April.
 Rule	Para	2002	2004	-	Apr	Sun>=1	0:00	0	-
-Rule	Para	2002	2003	-	Sep	Sun>=1	0:00	1:00	S
+Rule	Para	2002	2003	-	Sep	Sun>=1	0:00	1:00	-
 #
 # From Jesper Nørgaard Welen (2005-01-02):
 # There are several sources that claim that Paraguay made
@@ -15152,7 +17910,7 @@ Rule	Para	2002	2003	-	Sep	Sun>=1	0:00	1:00	S
 # Decree 1,867 (2004-03-05)
 # From Carlos Raúl Perasso via Jesper Nørgaard Welen (2006-10-13)
 # http://www.presidencia.gov.py/decretos/D1867.pdf
-Rule	Para	2004	2009	-	Oct	Sun>=15	0:00	1:00	S
+Rule	Para	2004	2009	-	Oct	Sun>=15	0:00	1:00	-
 Rule	Para	2005	2009	-	Mar	Sun>=8	0:00	0	-
 # From Carlos Raúl Perasso (2010-02-18):
 # By decree number 3958 issued yesterday
@@ -15165,7 +17923,7 @@ Rule	Para	2005	2009	-	Mar	Sun>=8	0:00	0	-
 # and that on the first Sunday of the month of October, it is to be set
 # forward 60 minutes, in all the territory of the Paraguayan Republic.
 # ...
-Rule	Para	2010	max	-	Oct	Sun>=1	0:00	1:00	S
+Rule	Para	2010	2024	-	Oct	Sun>=1	0:00	1:00	-
 Rule	Para	2010	2012	-	Apr	Sun>=8	0:00	0	-
 #
 # From Steffen Thorsen (2013-03-07):
@@ -15178,14 +17936,41 @@ Rule	Para	2010	2012	-	Apr	Sun>=8	0:00	0	-
 # From Carlos Raúl Perasso (2014-02-28):
 # Decree 1264 can be found at:
 # http://www.presidencia.gov.py/archivos/documentos/DECRETO1264_ey9r8zai.pdf
-Rule	Para	2013	max	-	Mar	Sun>=22	0:00	0	-
+#
+# From Paul Eggert (2023-07-26):
+# Transition dates are now set by Law No. 7115, not by presidential decree.
+# https://www.abc.com.py/politica/2023/07/12/promulgacion-el-cambio-de-hora-sera-por-ley/
+# From Carlos Raúl Perasso (2023-07-27):
+# http://silpy.congreso.gov.py/descarga/ley-144138
+Rule	Para	2013	2024	-	Mar	Sun>=22	0:00	0	-
+#
+# From Heitor David Pinto (2024-09-24):
+# Today the Congress of Paraguay passed a bill to observe UTC-3 permanently....
+# The text of the bill says that it would enter into force on the first
+# Sunday in October 2024, the same date currently scheduled to start DST....
+# https://silpy.congreso.gov.py/web/expediente/132531
+# (2024-10-14):
+# The president approved the law on 11 October 2024,
+# and it was officially published on 14 October 2024.
+# https://www.gacetaoficial.gov.py/index/detalle_publicacion/89723
+# The text of the law says that it enters into force on the first
+# Sunday in October 2024 (6 October 2024).  But the constitution
+# prohibits retroactive effect, and the civil code says that laws
+# enter into force on the day after their publication or on the day
+# that they specify, and it also says that they don't have retroactive
+# effect.  So I think that the time change on 6 October 2024 should
+# still be considered as DST according to the previous law, and
+# permanently UTC-3 from 15 October 2024 according to the new law....
+# https://www.constituteproject.org/constitution/Paraguay_2011
+# https://www.oas.org/dil/esp/codigo_civil_paraguay.pdf
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Asuncion	-3:50:40 -	LMT	1890
 			-3:50:40 -	AMT	1931 Oct 10 # Asunción Mean Time
-			-4:00	-	PYT	1972 Oct    # Paraguay Time
-			-3:00	-	PYT	1974 Apr
-			-4:00	Para	PY%sT
+			-4:00	-	%z	1972 Oct
+			-3:00	-	%z	1974 Apr
+			-4:00	Para	%z	2024 Oct 15
+			-3:00	-	%z
 
 # Peru
 #
@@ -15197,129 +17982,237 @@ Zone America/Asuncion	-3:50:40 -	LMT	1890
 # From Paul Eggert (2006-03-22):
 # Shanks & Pottenger don't have this transition.  Assume 1986 was like 1987.
 
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-Rule	Peru	1938	only	-	Jan	 1	0:00	1:00	S
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Peru	1938	only	-	Jan	 1	0:00	1:00	-
 Rule	Peru	1938	only	-	Apr	 1	0:00	0	-
-Rule	Peru	1938	1939	-	Sep	lastSun	0:00	1:00	S
+Rule	Peru	1938	1939	-	Sep	lastSun	0:00	1:00	-
 Rule	Peru	1939	1940	-	Mar	Sun>=24	0:00	0	-
-Rule	Peru	1986	1987	-	Jan	 1	0:00	1:00	S
+Rule	Peru	1986	1987	-	Jan	 1	0:00	1:00	-
 Rule	Peru	1986	1987	-	Apr	 1	0:00	0	-
-Rule	Peru	1990	only	-	Jan	 1	0:00	1:00	S
+Rule	Peru	1990	only	-	Jan	 1	0:00	1:00	-
 Rule	Peru	1990	only	-	Apr	 1	0:00	0	-
 # IATA is ambiguous for 1993/1995; go with Shanks & Pottenger.
-Rule	Peru	1994	only	-	Jan	 1	0:00	1:00	S
+Rule	Peru	1994	only	-	Jan	 1	0:00	1:00	-
 Rule	Peru	1994	only	-	Apr	 1	0:00	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	America/Lima	-5:08:12 -	LMT	1890
 			-5:08:36 -	LMT	1908 Jul 28 # Lima Mean Time?
-			-5:00	Peru	PE%sT	# Peru Time
+			-5:00	Peru	%z
 
 # South Georgia
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Atlantic/South_Georgia -2:26:08 -	LMT	1890 # Grytviken
-			-2:00	-	GST	# South Georgia Time
+			-2:00	-	%z
 
 # South Sandwich Is
 # uninhabited; scientific personnel have wintered
 
 # Suriname
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Paramaribo	-3:40:40 -	LMT	1911
 			-3:40:52 -	PMT	1935     # Paramaribo Mean Time
 			-3:40:36 -	PMT	1945 Oct    # The capital moved?
-			-3:30	-	NEGT	1975 Nov 20 # Dutch Guiana Time
-			-3:30	-	SRT	1984 Oct    # Suriname Time
-			-3:00	-	SRT
-
-# Trinidad and Tobago
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Port_of_Spain -4:06:04 -	LMT	1912 Mar 2
-			-4:00	-	AST
-
-# These all agree with Trinidad and Tobago since 1970.
-Link America/Port_of_Spain America/Anguilla
-Link America/Port_of_Spain America/Antigua
-Link America/Port_of_Spain America/Dominica
-Link America/Port_of_Spain America/Grenada
-Link America/Port_of_Spain America/Guadeloupe
-Link America/Port_of_Spain America/Marigot	# St Martin (French part)
-Link America/Port_of_Spain America/Montserrat
-Link America/Port_of_Spain America/St_Barthelemy # St Barthélemy
-Link America/Port_of_Spain America/St_Kitts	# St Kitts & Nevis
-Link America/Port_of_Spain America/St_Lucia
-Link America/Port_of_Spain America/St_Thomas	# Virgin Islands (US)
-Link America/Port_of_Spain America/St_Vincent
-Link America/Port_of_Spain America/Tortola	# Virgin Islands (UK)
+			-3:30	-	%z	1984 Oct
+			-3:00	-	%z
 
 # Uruguay
 # From Paul Eggert (1993-11-18):
 # Uruguay wins the prize for the strangest peacetime manipulation of the rules.
-# From Shanks & Pottenger:
-# Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-# Whitman gives 1923 Oct 1; go with Shanks & Pottenger.
-Rule	Uruguay	1923	only	-	Oct	 2	 0:00	0:30	HS
+#
+# From Tim Parenti (2018-02-20), per Jeremie Bonjour (2018-01-31) and Michael
+# Deckers (2018-02-20):
+# ... At least they kept good records...
+#
+# http://www.armada.mil.uy/ContenidosPDFs/sohma/web/almanaque/almanaque_2018.pdf#page=36
+# Page 36 of Almanaque 2018, published by the Oceanography, Hydrography, and
+# Meteorology Service of the Uruguayan Navy, seems to give many transitions
+# with greater clarity than we've had before.  It directly references many laws
+# and decrees which are, in turn, referenced below.  They can be viewed in the
+# public archives of the Diario Oficial (in Spanish) at
+# http://www.impo.com.uy/diariooficial/
+#
+# Ley No. 3920 of 1908-06-10 placed the determination of legal time under the
+# auspices of the National Institute for the Prediction of Time.  It is unclear
+# exactly what offset was used during this period, though Ley No. 7200 of
+# 1920-04-23 used the Observatory of the National Meteorological Institute in
+# Montevideo (34° 54' 33" S, 56° 12' 45" W) as its reference meridian,
+# retarding legal time by 15 minutes 9 seconds from 1920-04-30 24:00,
+# resulting in UT-04.  Assume the corresponding LMT of UT-03:44:51 (given on
+# page 725 of the Proceedings of the Second Pan-American Scientific Congress,
+# 1915-1916) was in use, and merely became official from 1908-06-10.
+# https://www.impo.com.uy/diariooficial/1908/06/18/12
+# https://www.impo.com.uy/diariooficial/1920/04/27/9
+#
+# Ley No. 7594 of 1923-06-28 specified legal time as Observatory time advanced
+# by 44 minutes 51 seconds (UT-03) "from 30 September to 31 March", and by 14
+# minutes 51 seconds (UT-03:30) "the rest of the year"; a message from the
+# National Council of Administration the same day, published directly below the
+# law in the Diario Oficial, specified the first transition to be 1923-09-30
+# 24:00.  This effectively established standard time at UT-03:30 with 30
+# minutes DST.  Assume transitions at 24:00 on the specified days until Ley No.
+# 7919 of 1926-03-05 ended this arrangement, repealing all "laws and other
+# provisions which oppose" it, resulting in year-round UT-03:30; a Resolución
+# of 1926-03-11 puts the final transition at 1926-03-31 24:00, the same as it
+# would have been under the previous law.
+# https://www.impo.com.uy/diariooficial/1923/07/02/2
+# https://www.impo.com.uy/diariooficial/1926/03/10/2
+# https://www.impo.com.uy/diariooficial/1926/03/18/2
+#
+# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Uruguay	1923	1925	-	Oct	 1	 0:00	0:30	-
 Rule	Uruguay	1924	1926	-	Apr	 1	 0:00	0	-
-Rule	Uruguay	1924	1925	-	Oct	 1	 0:00	0:30	HS
-Rule	Uruguay	1933	1935	-	Oct	lastSun	 0:00	0:30	HS
-# Shanks & Pottenger give 1935 Apr 1 0:00 & 1936 Mar 30 0:00; go with Whitman.
-Rule	Uruguay	1934	1936	-	Mar	Sat>=25	23:30s	0	-
-Rule	Uruguay	1936	only	-	Nov	 1	 0:00	0:30	HS
-Rule	Uruguay	1937	1941	-	Mar	lastSun	 0:00	0	-
-# Whitman gives 1937 Oct 3; go with Shanks & Pottenger.
-Rule	Uruguay	1937	1940	-	Oct	lastSun	 0:00	0:30	HS
-# Whitman gives 1941 Oct 24 - 1942 Mar 27, 1942 Dec 14 - 1943 Apr 13,
-# and 1943 Apr 13 "to present time"; go with Shanks & Pottenger.
-Rule	Uruguay	1941	only	-	Aug	 1	 0:00	0:30	HS
-Rule	Uruguay	1942	only	-	Jan	 1	 0:00	0	-
-Rule	Uruguay	1942	only	-	Dec	14	 0:00	1:00	S
+# From Tim Parenti (2018-02-15):
+# http://www.impo.com.uy/diariooficial/1933/10/27/6
+#
+# It appears Ley No. 9122 of 1933 was never published as such in the Diario
+# Oficial, but instead appeared as Document 26 in the Diario on Friday
+# 1933-10-27 as a decree made Monday 1933-10-23 and filed under the Ministry of
+# National Defense.  It reinstituted a DST of 30 minutes (to UT-03) "from the
+# last Sunday of October...until the last Saturday of March."  In accordance
+# with this provision, the first transition was explicitly specified in Article
+# 2 of the decree as Saturday 1933-10-28 at 24:00; that is, Sunday 1933-10-29
+# at 00:00.  Assume transitions at 00:00 Sunday throughout.
+#
+# Departing from the matter-of-fact nature of previous timekeeping laws, the
+# 1933 decree "consider[s] the advantages of...the advance of legal time":
+#
+#   "Whereas: The measure adopted by almost all nations at the time of the last
+#    World War still persists in North America and Europe, precisely because of
+#    the economic, hygienic, and social advantages derived from such an
+#    emergency measure...
+#
+#    Whereas: The advance of the legal time during the summer seasons, by
+#    displacing social activity near sunrise, favors the citizen populations
+#    and especially the society that creates and works..."
+#
+# It further specified that "necessary measures" be taken to ensure that
+# "public spectacles finish, in general, before [01:00]."
+Rule	Uruguay	1933	1938	-	Oct	lastSun	 0:00	0:30	-
+Rule	Uruguay	1934	1941	-	Mar	lastSat	24:00	0	-
+# From Tim Parenti (2018-02-15):
+# Most of the Rules below, and their contemporaneous Zone lines, have been
+# updated simply to match the Almanaque 2018.  Although the document does not
+# list exact transition times, midnight transitions were already present in our
+# data here for all transitions through 2004-09, and this is both consistent
+# with prior transitions and verified in several decrees marked below between
+# 1939-09 and 2004-09, wherein the relevant text was typically of the form:
+#
+#   "From 0 hours on [date], the legal time of the entire Republic will be...
+#
+#    In accordance with [the preceding], on [previous date] at 24 hours, all
+#    clocks throughout the Republic will be [advanced/retarded] by..."
+#
+# It is possible that there is greater specificity to be found for the Rules
+# below, but it is buried in no fewer than 40 different decrees individually
+# referenced by the Almanaque for the period from 1939-09 to 2014-09.
+# Four-fifths of these were promulgated less than two weeks before taking
+# effect; more than half within a week and none more than 5 weeks.  Only the
+# handful with comments below have been checked with any thoroughness.
+Rule	Uruguay	1939	only	-	Oct	 1	 0:00	0:30	-
+Rule	Uruguay	1940	only	-	Oct	27	 0:00	0:30	-
+# From Tim Parenti (2018-02-15):
+# Decreto 1145 of the Ministry of National Defense, dated 1941-07-26, specified
+# UT-03 from Friday 1941-08-01 00:00, citing an "urgent...need to save fuel".
+# http://www.impo.com.uy/diariooficial/1941/08/04/1
+Rule	Uruguay	1941	only	-	Aug	 1	 0:00	0:30	-
+# From Tim Parenti (2018-02-15):
+# Decreto 1866 of the Ministry of National Defense, dated 1942-12-09, specified
+# further advancement (to UT-02:30) from Sunday 1942-12-13 24:00.  Since clocks
+# never went back to UT-03:30 thereafter, this is modeled as advancing standard
+# time by 30 minutes to UT-03, while retaining 30 minutes of DST.
+# http://www.impo.com.uy/diariooficial/1942/12/16/3
+Rule	Uruguay	1942	only	-	Dec	14	 0:00	0:30	-
 Rule	Uruguay	1943	only	-	Mar	14	 0:00	0	-
-Rule	Uruguay	1959	only	-	May	24	 0:00	1:00	S
+Rule	Uruguay	1959	only	-	May	24	 0:00	0:30	-
 Rule	Uruguay	1959	only	-	Nov	15	 0:00	0	-
-Rule	Uruguay	1960	only	-	Jan	17	 0:00	1:00	S
+Rule	Uruguay	1960	only	-	Jan	17	 0:00	1:00	-
 Rule	Uruguay	1960	only	-	Mar	 6	 0:00	0	-
-Rule	Uruguay	1965	1967	-	Apr	Sun>=1	 0:00	1:00	S
+Rule	Uruguay	1965	only	-	Apr	 4	 0:00	1:00	-
 Rule	Uruguay	1965	only	-	Sep	26	 0:00	0	-
-Rule	Uruguay	1966	1967	-	Oct	31	 0:00	0	-
-Rule	Uruguay	1968	1970	-	May	27	 0:00	0:30	HS
-Rule	Uruguay	1968	1970	-	Dec	 2	 0:00	0	-
-Rule	Uruguay	1972	only	-	Apr	24	 0:00	1:00	S
-Rule	Uruguay	1972	only	-	Aug	15	 0:00	0	-
-Rule	Uruguay	1974	only	-	Mar	10	 0:00	0:30	HS
-Rule	Uruguay	1974	only	-	Dec	22	 0:00	1:00	S
-Rule	Uruguay	1976	only	-	Oct	 1	 0:00	0	-
-Rule	Uruguay	1977	only	-	Dec	 4	 0:00	1:00	S
-Rule	Uruguay	1978	only	-	Apr	 1	 0:00	0	-
-Rule	Uruguay	1979	only	-	Oct	 1	 0:00	1:00	S
-Rule	Uruguay	1980	only	-	May	 1	 0:00	0	-
-Rule	Uruguay	1987	only	-	Dec	14	 0:00	1:00	S
-Rule	Uruguay	1988	only	-	Mar	14	 0:00	0	-
-Rule	Uruguay	1988	only	-	Dec	11	 0:00	1:00	S
-Rule	Uruguay	1989	only	-	Mar	12	 0:00	0	-
-Rule	Uruguay	1989	only	-	Oct	29	 0:00	1:00	S
-# Shanks & Pottenger say no DST was observed in 1990/1 and 1991/2,
-# and that 1992/3's DST was from 10-25 to 03-01.  Go with IATA.
-Rule	Uruguay	1990	1992	-	Mar	Sun>=1	 0:00	0	-
-Rule	Uruguay	1990	1991	-	Oct	Sun>=21	 0:00	1:00	S
-Rule	Uruguay	1992	only	-	Oct	18	 0:00	1:00	S
+# From Tim Parenti (2018-02-15):
+# Decreto 321/968 of 1968-05-25, citing emergency drought measures decreed the
+# day before, brought clocks forward 30 minutes from Monday 1968-05-27 00:00.
+# http://www.impo.com.uy/diariooficial/1968/05/30/5
+Rule	Uruguay	1968	only	-	May	27	 0:00	0:30	-
+Rule	Uruguay	1968	only	-	Dec	 1	 0:00	0	-
+# From Tim Parenti (2018-02-15):
+# Decreto 188/970 of 1970-04-23 instituted restrictions on electricity
+# consumption "as a consequence of the current rainfall regime in the country".
+# Articles 13 and 14 advanced clocks by an hour from Saturday 1970-04-25 00:00.
+# http://www.impo.com.uy/diariooficial/1970/04/29/4
+Rule	Uruguay	1970	only	-	Apr	25	 0:00	1:00	-
+Rule	Uruguay	1970	only	-	Jun	14	 0:00	0	-
+Rule	Uruguay	1972	only	-	Apr	23	 0:00	1:00	-
+Rule	Uruguay	1972	only	-	Jul	16	 0:00	0	-
+# From Tim Parenti (2018-02-15):
+# Decreto 29/974 of 1974-01-11, citing "the international rise in the price of
+# oil", advanced clocks by 90 minutes (to UT-01:30).  Decreto 163/974 of
+# 1974-03-04 returned 60 of those minutes (to UT-02:30), and the remaining 30
+# minutes followed in Decreto 679/974 of 1974-08-29.
+# http://www.impo.com.uy/diariooficial/1974/01/22/11
+# http://www.impo.com.uy/diariooficial/1974/03/14/3
+# http://www.impo.com.uy/diariooficial/1974/09/04/6
+Rule	Uruguay	1974	only	-	Jan	13	 0:00	1:30	-
+Rule	Uruguay	1974	only	-	Mar	10	 0:00	0:30	-
+Rule	Uruguay	1974	only	-	Sep	 1	 0:00	0	-
+Rule	Uruguay	1974	only	-	Dec	22	 0:00	1:00	-
+Rule	Uruguay	1975	only	-	Mar	30	 0:00	0	-
+Rule	Uruguay	1976	only	-	Dec	19	 0:00	1:00	-
+Rule	Uruguay	1977	only	-	Mar	 6	 0:00	0	-
+Rule	Uruguay	1977	only	-	Dec	 4	 0:00	1:00	-
+Rule	Uruguay	1978	1979	-	Mar	Sun>=1	 0:00	0	-
+Rule	Uruguay	1978	only	-	Dec	17	 0:00	1:00	-
+Rule	Uruguay	1979	only	-	Apr	29	 0:00	1:00	-
+Rule	Uruguay	1980	only	-	Mar	16	 0:00	0	-
+# From Tim Parenti (2018-02-15):
+# Decreto 725/987 of 1987-12-04 cited "better use of national tourist
+# attractions" to advance clocks one hour from Monday 1987-12-14 00:00.
+# http://www.impo.com.uy/diariooficial/1988/01/25/1
+Rule	Uruguay	1987	only	-	Dec	14	 0:00	1:00	-
+Rule	Uruguay	1988	only	-	Feb	28	 0:00	0	-
+Rule	Uruguay	1988	only	-	Dec	11	 0:00	1:00	-
+Rule	Uruguay	1989	only	-	Mar	 5	 0:00	0	-
+Rule	Uruguay	1989	only	-	Oct	29	 0:00	1:00	-
+Rule	Uruguay	1990	only	-	Feb	25	 0:00	0	-
+# From Tim Parenti (2018-02-15), per Paul Eggert (1999-11-04):
+# IATA agrees as below for 1990-10 through 1993-02.  Per Almanaque 2018, the
+# 1992/1993 season appears to be the first in over half a century where DST
+# both began and ended pursuant to the same decree.
+Rule	Uruguay	1990	1991	-	Oct	Sun>=21	 0:00	1:00	-
+Rule	Uruguay	1991	1992	-	Mar	Sun>=1	 0:00	0	-
+Rule	Uruguay	1992	only	-	Oct	18	 0:00	1:00	-
 Rule	Uruguay	1993	only	-	Feb	28	 0:00	0	-
 # From Eduardo Cota (2004-09-20):
 # The Uruguayan government has decreed a change in the local time....
-# http://www.presidencia.gub.uy/decretos/2004091502.htm
-Rule	Uruguay	2004	only	-	Sep	19	 0:00	1:00	S
+# From Tim Parenti (2018-02-15):
+# Decreto 328/004 of 2004-09-15.
+# http://www.impo.com.uy/diariooficial/2004/09/23/documentos.pdf#page=1
+Rule	Uruguay	2004	only	-	Sep	19	 0:00	1:00	-
 # From Steffen Thorsen (2005-03-11):
 # Uruguay's DST was scheduled to end on Sunday, 2005-03-13, but in order to
 # save energy ... it was postponed two weeks....
-# http://www.presidencia.gub.uy/_Web/noticias/2005/03/2005031005.htm
+# From Tim Parenti (2018-02-15):
+# This 2005 postponement is not in Almanaque 2018.  Go with the contemporaneous
+# reporting, which is confirmed by Decreto 107/005 of 2005-03-10 amending
+# Decreto 328/004:
+# http://www.impo.com.uy/diariooficial/2005/03/15/documentos.pdf#page=1
+# The original decree specified a transition of 2005-03-12 24:00, but the new
+# one specified 2005-03-27 02:00.
 Rule	Uruguay	2005	only	-	Mar	27	 2:00	0	-
 # From Eduardo Cota (2005-09-27):
-# http://www.presidencia.gub.uy/_Web/decretos/2005/09/CM%20119_09%2009%202005_00001.PDF
-# This means that from 2005-10-09 at 02:00 local time, until 2006-03-12 at
-# 02:00 local time, official time in Uruguay will be at GMT -2.
-Rule	Uruguay	2005	only	-	Oct	 9	 2:00	1:00	S
-Rule	Uruguay	2006	only	-	Mar	12	 2:00	0	-
-# From Jesper Nørgaard Welen (2006-09-06):
-# http://www.presidencia.gub.uy/_web/decretos/2006/09/CM%20210_08%2006%202006_00001.PDF
-#
+# ...from 2005-10-09 at 02:00 local time, until 2006-03-12 at 02:00 local time,
+# official time in Uruguay will be at GMT -2.
+# From Tim Parenti (2018-02-15):
+# Decreto 318/005 of 2005-09-19.
+# http://www.impo.com.uy/diariooficial/2005/09/23/documentos.pdf#page=1
+Rule	Uruguay	2005	only	-	Oct	 9	 2:00	1:00	-
+Rule	Uruguay	2006	2015	-	Mar	Sun>=8	 2:00	0	-
+# From Tim Parenti (2018-02-15), per Jesper Nørgaard Welen (2006-09-06):
+# Decreto 311/006 of 2006-09-04 established regular DST from the first Sunday
+# of October at 02:00 through the second Sunday of March at 02:00.  Almanaque
+# 2018 appears to have a few typoed dates through this period; ignore them.
+# http://www.impo.com.uy/diariooficial/2006/09/08/documentos.pdf#page=1
+Rule	Uruguay	2006	2014	-	Oct	Sun>=1	 2:00	1:00	-
 # From Steffen Thorsen (2015-06-30):
 # ... it looks like they will not be using DST the coming summer:
 # http://www.elobservador.com.uy/gobierno-resolvio-que-no-habra-cambio-horario-verano-n656787
@@ -15329,14 +18222,21 @@ Rule	Uruguay	2006	only	-	Mar	12	 2:00	0	-
 # instead of out to dinner.
 # From Pablo Camargo (2015-07-13):
 # http://archivo.presidencia.gub.uy/sci/decretos/2015/06/cons_min_201.pdf
-# [dated 2015-06-29; repeals Decree 311/006 dated 2006-09-04]
-Rule	Uruguay	2006	2014	-	Oct	Sun>=1	 2:00	1:00	S
-Rule	Uruguay	2007	2015	-	Mar	Sun>=8	 2:00	0	-
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone America/Montevideo	-3:44:44 -	LMT	1898 Jun 28
-			-3:44:44 -	MMT	1920 May  1 # Montevideo MT
-			-3:30	Uruguay	UY%sT	1942 Dec 14 # Uruguay Time
-			-3:00	Uruguay	UY%sT
+# From Tim Parenti (2018-02-15):
+# Decreto 178/015 of 2015-06-29; repeals Decreto 311/006.
+
+# This Zone can be simplified once we assume zic %z.
+Zone America/Montevideo	-3:44:51 -	LMT	1908 Jun 10
+			-3:44:51 -	MMT	1920 May  1 # Montevideo MT
+			-4:00	-	%z	1923 Oct  1
+			-3:30	Uruguay	%z	1942 Dec 14
+			-3:00	Uruguay	%z	1960
+			-3:00	Uruguay	%z	1968
+			-3:00	Uruguay	%z	1970
+			-3:00	Uruguay	%z	1974
+			-3:00	Uruguay	%z	1974 Mar 10
+			-3:00	Uruguay	%z	1974 Dec 22
+			-3:00	Uruguay	%z
 
 # Venezuela
 #
@@ -15361,67 +18261,53 @@ Zone America/Montevideo	-3:44:44 -	LMT	1898 Jun 28
 # hours of presidential broadcasts, hours of lines,' quipped comedian
 # Jean Mary Curró ...". See: Cawthorne A, Kai D. Venezuela scraps
 # half-hour time difference set by Chavez. Reuters 2016-04-15 14:50 -0400
-# http://www.reuters.com/article/us-venezuela-timezone-idUSKCN0XC2BE
+# https://www.reuters.com/article/us-venezuela-timezone-idUSKCN0XC2BE
 #
 # From Matt Johnson (2016-04-20):
 # ... published in the official Gazette [2016-04-18], here:
 # http://historico.tsj.gob.ve/gaceta_ext/abril/1842016/E-1842016-4551.pdf
 
-# Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	America/Caracas	-4:27:44 -	LMT	1890
 			-4:27:40 -	CMT	1912 Feb 12 # Caracas Mean Time?
-			-4:30	-	VET	1965 Jan  1  0:00 # Venezuela T.
-			-4:00	-	VET	2007 Dec  9  3:00
-			-4:30	-	VET	2016 May  1  2:30
-			-4:00	-	VET
+			-4:30	-	%z	1965 Jan  1  0:00
+			-4:00	-	%z	2007 Dec  9  3:00
+			-4:30	-	%z	2016 May  1  2:30
+			-4:00	-	%z
+# Links and zones for backward compatibility
+
 # This file is in the public domain, so clarified as of
 # 2009-05-17 by Arthur David Olson.
 
-# This file provides links between current names for time zones
-# and their old names.  Many names changed in late 1993.
+# This file provides links from old or merged timezone names to current ones.
+# It also provides a few zone entries for old naming conventions.
+# Many names changed in 1993 and in 1995, and many merged names moved here
+# in the period from 2013 through 2022.  Several of these names are
+# also present in the file 'backzone', which has data important only
+# for pre-1970 timestamps and so is out of scope for tzdb proper.
 
-# Link	TARGET			LINK-NAME
-Link	Africa/Nairobi		Africa/Asmera
-Link	Africa/Abidjan		Africa/Timbuktu
-Link	America/Argentina/Catamarca	America/Argentina/ComodRivadavia
-Link	America/Adak		America/Atka
-Link	America/Argentina/Buenos_Aires	America/Buenos_Aires
-Link	America/Argentina/Catamarca	America/Catamarca
-Link	America/Atikokan	America/Coral_Harbour
-Link	America/Argentina/Cordoba	America/Cordoba
-Link	America/Tijuana		America/Ensenada
-Link	America/Indiana/Indianapolis	America/Fort_Wayne
-Link	America/Indiana/Indianapolis	America/Indianapolis
-Link	America/Argentina/Jujuy	America/Jujuy
-Link	America/Indiana/Knox	America/Knox_IN
-Link	America/Kentucky/Louisville	America/Louisville
-Link	America/Argentina/Mendoza	America/Mendoza
-Link	America/Toronto		America/Montreal
-Link	America/Rio_Branco	America/Porto_Acre
-Link	America/Argentina/Cordoba	America/Rosario
-Link	America/Tijuana		America/Santa_Isabel
-Link	America/Denver		America/Shiprock
-Link	America/Port_of_Spain	America/Virgin
-Link	Pacific/Auckland	Antarctica/South_Pole
-Link	Asia/Ashgabat		Asia/Ashkhabad
-Link	Asia/Kolkata		Asia/Calcutta
-Link	Asia/Shanghai		Asia/Chongqing
-Link	Asia/Shanghai		Asia/Chungking
-Link	Asia/Dhaka		Asia/Dacca
-Link	Asia/Shanghai		Asia/Harbin
-Link	Asia/Urumqi		Asia/Kashgar
-Link	Asia/Kathmandu		Asia/Katmandu
-Link	Asia/Macau		Asia/Macao
-Link	Asia/Yangon		Asia/Rangoon
-Link	Asia/Ho_Chi_Minh	Asia/Saigon
-Link	Asia/Jerusalem		Asia/Tel_Aviv
-Link	Asia/Thimphu		Asia/Thimbu
-Link	Asia/Makassar		Asia/Ujung_Pandang
-Link	Asia/Ulaanbaatar	Asia/Ulan_Bator
-Link	Atlantic/Faroe		Atlantic/Faeroe
-Link	Europe/Oslo		Atlantic/Jan_Mayen
-Link	Australia/Sydney	Australia/ACT
-Link	Australia/Sydney	Australia/Canberra
+# Although this file is optional and tzdb will work if you omit it by
+# building with 'make BACKWARD=', in practice downstream users
+# typically use this file for backward compatibility.
+
+# This file is divided into sections, one for each major reason for a
+# backward compatibility link.  Each section is sorted by link name.
+
+# A "#= TARGET1" comment labels each link inserted only because some
+# .zi parsers (including tzcode through 2022e) mishandle links to links.
+# The comment says what the target would be if these parsers were fixed
+# so that data could contain links to links.  For example, the line
+# "Link Australia/Sydney Australia/ACT #= Australia/Canberra" would be
+# "Link Australia/Canberra Australia/ACT" were it not that data lines
+# refrain from linking to links like Australia/Canberra, which means
+# the Australia/ACT line links instead to Australia/Sydney,
+# Australia/Canberra's target.
+
+
+# Pre-1993 naming conventions
+
+# Link	TARGET			LINK-NAME	#= TARGET1
+Link	Australia/Sydney	Australia/ACT	#= Australia/Canberra
 Link	Australia/Lord_Howe	Australia/LHI
 Link	Australia/Sydney	Australia/NSW
 Link	Australia/Darwin	Australia/North
@@ -15431,13 +18317,17 @@ Link	Australia/Hobart	Australia/Tasmania
 Link	Australia/Melbourne	Australia/Victoria
 Link	Australia/Perth		Australia/West
 Link	Australia/Broken_Hill	Australia/Yancowinna
-Link	America/Rio_Branco	Brazil/Acre
+Link	America/Rio_Branco	Brazil/Acre	#= America/Porto_Acre
 Link	America/Noronha		Brazil/DeNoronha
 Link	America/Sao_Paulo	Brazil/East
 Link	America/Manaus		Brazil/West
+Link	Europe/Brussels		CET
+Link	America/Chicago		CST6CDT
 Link	America/Halifax		Canada/Atlantic
 Link	America/Winnipeg	Canada/Central
-Link	America/Regina		Canada/East-Saskatchewan
+# This line is commented out, as the name exceeded the 14-character limit
+# and was an unused misnomer.
+#Link	America/Regina		Canada/East-Saskatchewan
 Link	America/Toronto		Canada/Eastern
 Link	America/Edmonton	Canada/Mountain
 Link	America/St_Johns	Canada/Newfoundland
@@ -15447,42 +18337,64 @@ Link	America/Whitehorse	Canada/Yukon
 Link	America/Santiago	Chile/Continental
 Link	Pacific/Easter		Chile/EasterIsland
 Link	America/Havana		Cuba
+Link	Europe/Athens		EET
+Link	America/Panama		EST
+Link	America/New_York	EST5EDT
 Link	Africa/Cairo		Egypt
 Link	Europe/Dublin		Eire
-Link	Europe/London		Europe/Belfast
-Link	Europe/Chisinau		Europe/Tiraspol
+# Vanguard section, for most .zi parsers.
+#Link	GMT			Etc/GMT
+#Link	GMT			Etc/GMT+0
+#Link	GMT			Etc/GMT-0
+#Link	GMT			Etc/GMT0
+#Link	GMT			Etc/Greenwich
+# Rearguard section, for TZUpdater 2.3.2 and earlier.
+Link	Etc/GMT			Etc/GMT+0
+Link	Etc/GMT			Etc/GMT-0
+Link	Etc/GMT			Etc/GMT0
+Link	Etc/GMT			Etc/Greenwich
+# End of rearguard section.
+Link	Etc/UTC			Etc/UCT
+Link	Etc/UTC			Etc/Universal
+Link	Etc/UTC			Etc/Zulu
 Link	Europe/London		GB
 Link	Europe/London		GB-Eire
+# Vanguard section, for most .zi parsers.
+#Link	GMT			GMT+0
+#Link	GMT			GMT-0
+#Link	GMT			GMT0
+#Link	GMT			Greenwich
+# Rearguard section, for TZUpdater 2.3.2 and earlier.
 Link	Etc/GMT			GMT+0
 Link	Etc/GMT			GMT-0
 Link	Etc/GMT			GMT0
 Link	Etc/GMT			Greenwich
+# End of rearguard section.
 Link	Asia/Hong_Kong		Hongkong
-Link	Atlantic/Reykjavik	Iceland
+Link	Africa/Abidjan		Iceland	#= Atlantic/Reykjavik
 Link	Asia/Tehran		Iran
 Link	Asia/Jerusalem		Israel
 Link	America/Jamaica		Jamaica
 Link	Asia/Tokyo		Japan
 Link	Pacific/Kwajalein	Kwajalein
 Link	Africa/Tripoli		Libya
+Link	Europe/Brussels		MET
+Link	America/Phoenix		MST
+Link	America/Denver		MST7MDT
 Link	America/Tijuana		Mexico/BajaNorte
 Link	America/Mazatlan	Mexico/BajaSur
 Link	America/Mexico_City	Mexico/General
 Link	Pacific/Auckland	NZ
 Link	Pacific/Chatham		NZ-CHAT
-Link	America/Denver		Navajo
+Link	America/Denver		Navajo	#= America/Shiprock
 Link	Asia/Shanghai		PRC
-Link	Pacific/Pohnpei		Pacific/Ponape
-Link	Pacific/Pago_Pago	Pacific/Samoa
-Link	Pacific/Chuuk		Pacific/Truk
-Link	Pacific/Chuuk		Pacific/Yap
 Link	Europe/Warsaw		Poland
 Link	Europe/Lisbon		Portugal
 Link	Asia/Taipei		ROC
 Link	Asia/Seoul		ROK
 Link	Asia/Singapore		Singapore
 Link	Europe/Istanbul		Turkey
-Link	Etc/UCT			UCT
+Link	Etc/UTC			UCT
 Link	America/Anchorage	US/Alaska
 Link	America/Adak		US/Aleutian
 Link	America/Phoenix		US/Arizona
@@ -15499,3 +18411,197 @@ Link	Etc/UTC			UTC
 Link	Etc/UTC			Universal
 Link	Europe/Moscow		W-SU
 Link	Etc/UTC			Zulu
+
+
+# Two-part names that were renamed mostly to three-part names in 1995
+
+# Link	TARGET				LINK-NAME	#= TARGET1
+Link	America/Argentina/Buenos_Aires	America/Buenos_Aires
+Link	America/Argentina/Catamarca	America/Catamarca
+Link	America/Argentina/Cordoba	America/Cordoba
+Link	America/Indiana/Indianapolis	America/Indianapolis
+Link	America/Argentina/Jujuy		America/Jujuy
+Link	America/Indiana/Knox		America/Knox_IN
+Link	America/Kentucky/Louisville	America/Louisville
+Link	America/Argentina/Mendoza	America/Mendoza
+Link	America/Puerto_Rico		America/Virgin	#= America/St_Thomas
+Link	Pacific/Pago_Pago		Pacific/Samoa
+
+
+# Pre-2013 practice, which typically had a Zone per zone.tab line
+
+# Link	TARGET			LINK-NAME
+Link	Africa/Abidjan		Africa/Accra
+Link	Africa/Nairobi		Africa/Addis_Ababa
+Link	Africa/Nairobi		Africa/Asmara
+Link	Africa/Abidjan		Africa/Bamako
+Link	Africa/Lagos		Africa/Bangui
+Link	Africa/Abidjan		Africa/Banjul
+Link	Africa/Maputo		Africa/Blantyre
+Link	Africa/Lagos		Africa/Brazzaville
+Link	Africa/Maputo		Africa/Bujumbura
+Link	Africa/Abidjan		Africa/Conakry
+Link	Africa/Abidjan		Africa/Dakar
+Link	Africa/Nairobi		Africa/Dar_es_Salaam
+Link	Africa/Nairobi		Africa/Djibouti
+Link	Africa/Lagos		Africa/Douala
+Link	Africa/Abidjan		Africa/Freetown
+Link	Africa/Maputo		Africa/Gaborone
+Link	Africa/Maputo		Africa/Harare
+Link	Africa/Nairobi		Africa/Kampala
+Link	Africa/Maputo		Africa/Kigali
+Link	Africa/Lagos		Africa/Kinshasa
+Link	Africa/Lagos		Africa/Libreville
+Link	Africa/Abidjan		Africa/Lome
+Link	Africa/Lagos		Africa/Luanda
+Link	Africa/Maputo		Africa/Lubumbashi
+Link	Africa/Maputo		Africa/Lusaka
+Link	Africa/Lagos		Africa/Malabo
+Link	Africa/Johannesburg	Africa/Maseru
+Link	Africa/Johannesburg	Africa/Mbabane
+Link	Africa/Nairobi		Africa/Mogadishu
+Link	Africa/Lagos		Africa/Niamey
+Link	Africa/Abidjan		Africa/Nouakchott
+Link	Africa/Abidjan		Africa/Ouagadougou
+Link	Africa/Lagos		Africa/Porto-Novo
+Link	America/Puerto_Rico	America/Anguilla
+Link	America/Puerto_Rico	America/Antigua
+Link	America/Puerto_Rico	America/Aruba
+Link	America/Panama		America/Atikokan
+Link	America/Puerto_Rico	America/Blanc-Sablon
+Link	America/Panama		America/Cayman
+Link	America/Phoenix		America/Creston
+Link	America/Puerto_Rico	America/Curacao
+Link	America/Puerto_Rico	America/Dominica
+Link	America/Puerto_Rico	America/Grenada
+Link	America/Puerto_Rico	America/Guadeloupe
+Link	America/Puerto_Rico	America/Kralendijk
+Link	America/Puerto_Rico	America/Lower_Princes
+Link	America/Puerto_Rico	America/Marigot
+Link	America/Puerto_Rico	America/Montserrat
+Link	America/Toronto		America/Nassau
+Link	America/Puerto_Rico	America/Port_of_Spain
+Link	America/Puerto_Rico	America/St_Barthelemy
+Link	America/Puerto_Rico	America/St_Kitts
+Link	America/Puerto_Rico	America/St_Lucia
+Link	America/Puerto_Rico	America/St_Thomas
+Link	America/Puerto_Rico	America/St_Vincent
+Link	America/Puerto_Rico	America/Tortola
+Link	Pacific/Port_Moresby	Antarctica/DumontDUrville
+Link	Pacific/Auckland	Antarctica/McMurdo
+Link	Asia/Riyadh		Antarctica/Syowa
+Link	Europe/Berlin		Arctic/Longyearbyen
+Link	Asia/Riyadh		Asia/Aden
+Link	Asia/Qatar		Asia/Bahrain
+Link	Asia/Kuching		Asia/Brunei
+Link	Asia/Singapore		Asia/Kuala_Lumpur
+Link	Asia/Riyadh		Asia/Kuwait
+Link	Asia/Dubai		Asia/Muscat
+Link	Asia/Bangkok		Asia/Phnom_Penh
+Link	Asia/Bangkok		Asia/Vientiane
+Link	Africa/Abidjan		Atlantic/Reykjavik
+Link	Africa/Abidjan		Atlantic/St_Helena
+Link	Europe/Brussels		Europe/Amsterdam
+Link	Europe/Prague		Europe/Bratislava
+Link	Europe/Zurich		Europe/Busingen
+Link	Europe/Berlin		Europe/Copenhagen
+Link	Europe/London		Europe/Guernsey
+Link	Europe/London		Europe/Isle_of_Man
+Link	Europe/London		Europe/Jersey
+Link	Europe/Belgrade		Europe/Ljubljana
+Link	Europe/Brussels		Europe/Luxembourg
+Link	Europe/Helsinki		Europe/Mariehamn
+Link	Europe/Paris		Europe/Monaco
+Link	Europe/Berlin		Europe/Oslo
+Link	Europe/Belgrade		Europe/Podgorica
+Link	Europe/Rome		Europe/San_Marino
+Link	Europe/Belgrade		Europe/Sarajevo
+Link	Europe/Belgrade		Europe/Skopje
+Link	Europe/Berlin		Europe/Stockholm
+Link	Europe/Zurich		Europe/Vaduz
+Link	Europe/Rome		Europe/Vatican
+Link	Europe/Belgrade		Europe/Zagreb
+Link	Africa/Nairobi		Indian/Antananarivo
+Link	Asia/Bangkok		Indian/Christmas
+Link	Asia/Yangon		Indian/Cocos
+Link	Africa/Nairobi		Indian/Comoro
+Link	Indian/Maldives		Indian/Kerguelen
+Link	Asia/Dubai		Indian/Mahe
+Link	Africa/Nairobi		Indian/Mayotte
+Link	Asia/Dubai		Indian/Reunion
+Link	Pacific/Port_Moresby	Pacific/Chuuk
+Link	Pacific/Tarawa		Pacific/Funafuti
+Link	Pacific/Tarawa		Pacific/Majuro
+Link	Pacific/Pago_Pago	Pacific/Midway
+Link	Pacific/Guadalcanal	Pacific/Pohnpei
+Link	Pacific/Guam		Pacific/Saipan
+Link	Pacific/Tarawa		Pacific/Wake
+Link	Pacific/Tarawa		Pacific/Wallis
+
+
+# Non-zone.tab locations with timestamps since 1970 that duplicate
+# those of an existing location
+
+# Link	TARGET			LINK-NAME
+Link	Africa/Abidjan		Africa/Timbuktu
+Link	America/Argentina/Catamarca	America/Argentina/ComodRivadavia
+Link	America/Adak		America/Atka
+Link	America/Panama		America/Coral_Harbour
+Link	America/Tijuana		America/Ensenada
+Link	America/Indiana/Indianapolis	America/Fort_Wayne
+Link	America/Toronto		America/Montreal
+Link	America/Toronto		America/Nipigon
+Link	America/Iqaluit		America/Pangnirtung
+Link	America/Rio_Branco	America/Porto_Acre
+Link	America/Winnipeg	America/Rainy_River
+Link	America/Argentina/Cordoba	America/Rosario
+Link	America/Tijuana		America/Santa_Isabel
+Link	America/Denver		America/Shiprock
+Link	America/Toronto		America/Thunder_Bay
+Link	America/Edmonton	America/Yellowknife
+Link	Pacific/Auckland	Antarctica/South_Pole
+Link	Asia/Ulaanbaatar	Asia/Choibalsan
+Link	Asia/Shanghai		Asia/Chongqing
+Link	Asia/Shanghai		Asia/Harbin
+Link	Asia/Urumqi		Asia/Kashgar
+Link	Asia/Jerusalem		Asia/Tel_Aviv
+Link	Europe/Berlin		Atlantic/Jan_Mayen
+Link	Australia/Sydney	Australia/Canberra
+Link	Australia/Hobart	Australia/Currie
+Link	Europe/London		Europe/Belfast
+Link	Europe/Chisinau		Europe/Tiraspol
+Link	Europe/Kyiv		Europe/Uzhgorod
+Link	Europe/Kyiv		Europe/Zaporozhye
+Link	Pacific/Kanton		Pacific/Enderbury
+Link	Pacific/Honolulu	Pacific/Johnston
+Link	Pacific/Port_Moresby	Pacific/Yap
+Link	Europe/Lisbon		WET
+
+
+# Alternate names for the same location
+
+# Link	TARGET			LINK-NAME	#= TARGET1
+Link	Africa/Nairobi		Africa/Asmera	#= Africa/Asmara
+Link	America/Nuuk		America/Godthab
+Link	Asia/Ashgabat		Asia/Ashkhabad
+Link	Asia/Kolkata		Asia/Calcutta
+Link	Asia/Shanghai		Asia/Chungking	#= Asia/Chongqing
+Link	Asia/Dhaka		Asia/Dacca
+# Istanbul is in both continents.
+Link	Europe/Istanbul		Asia/Istanbul
+Link	Asia/Kathmandu		Asia/Katmandu
+Link	Asia/Macau		Asia/Macao
+Link	Asia/Yangon		Asia/Rangoon
+Link	Asia/Ho_Chi_Minh	Asia/Saigon
+Link	Asia/Thimphu		Asia/Thimbu
+Link	Asia/Makassar		Asia/Ujung_Pandang
+Link	Asia/Ulaanbaatar	Asia/Ulan_Bator
+Link	Atlantic/Faroe		Atlantic/Faeroe
+Link	Europe/Kyiv		Europe/Kiev
+# Classically, Cyprus is in Asia; e.g. see Herodotus, Histories, I.72.
+# However, for various reasons many users expect to find it under Europe.
+Link	Asia/Nicosia		Europe/Nicosia
+Link	Pacific/Honolulu	HST
+Link	America/Los_Angeles	PST8PDT
+Link	Pacific/Guadalcanal	Pacific/Ponape	#= Pacific/Pohnpei
+Link	Pacific/Port_Moresby	Pacific/Truk	#= Pacific/Chuuk

--- a/tools/timezones.py
+++ b/tools/timezones.py
@@ -88,7 +88,8 @@ dstzone_list = ("-",
                 "Moldova",
                 "Iran",
                 "Chile",
-                "Tonga")
+                "Tonga",
+                "Eire")
 dstzone_dict = {name: index for index, name in enumerate(dstzone_list)}
 
 # Make sure some of these values don't move around, because the firmware code in


### PR DESCRIPTION
Fixes FIRM-566

Updated the timezone database (`timezones_olson.txt`) by running 
update_timezones.py.

(Compilation failed until I also added `Eire` to the `dstzone` list).

Tested that the watch showed the wrong time for Mexico City before this 
change (off by one hour), then the correct time after flashing this 
change.

Signed-off-by: Steve Penna <steve@penna.org.uk>