### PR TITLE
fw/drivers/pmic: add configuration for npm1300 vbus current limite

### DIFF
--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -410,6 +410,8 @@ const Npm1300Config NPM1300_CONFIG = {
   .dischg_limit_ma = 200,
   .term_current_pct = 10,
   .thermistor_beta = 3380,
+  .vbus_current_lim0 = 500,
+  .vbus_current_startup = 500,
 };
 
 const BoardConfigPower BOARD_CONFIG_POWER = {

--- a/src/fw/drivers/pmic/npm1300.h
+++ b/src/fw/drivers/pmic/npm1300.h
@@ -26,4 +26,8 @@ typedef struct {
   uint8_t term_current_pct;
   //! Thermistor beta value
   uint16_t thermistor_beta;
+  //! Vbus current limite0
+  uint16_t vbus_current_lim0;
+  //! Vbus current limite startup
+  uint16_t vbus_current_startup;
 } Npm1300Config;


### PR DESCRIPTION
Fix #230 ; The vbus current limitation default is 100mA, when the backlight and vibe work at same time, the current exceed the default limitation, now we config the limitation to 500mA for obelix.