### PR TITLE
Replace legacy voice disabled help message

### DIFF
--- a/resources/normal/base/lang/de_DE/tintin.po
+++ b/resources/normal/base/lang/de_DE/tintin.po
@@ -2964,16 +2964,6 @@ msgstr "Diktieren nicht verfügbar."
 msgid "Error occurred. Try again."
 msgstr "Fehler aufgetreten. Versuche es erneut."
 
-#: ../src/fw/applib/voice/voice_window.c:351
-msgid ""
-"Turn on usage logs to use voice.\n"
-"\n"
-"On your phone, go to Settings in the Pebble Time app."
-msgstr ""
-"Aktiviere Nutzungsstatistiken, um Sprache zu verwenden.\n"
-"\n"
-"Öffne \"Einstellungen\" in der Pebble-Time-App auf deinem Handy."
-
 #: ../src/fw/applib/voice/voice_window.c:402
 msgid "Missed that. Try again."
 msgstr "Nicht verstanden. Nochmal bitte."

--- a/resources/normal/base/lang/es_ES/tintin.po
+++ b/resources/normal/base/lang/es_ES/tintin.po
@@ -3003,16 +3003,6 @@ msgstr "Dictado no disponible."
 msgid "Error occurred. Try again."
 msgstr "Algo va mal. Prueba otra vez."
 
-#: ../src/fw/applib/voice/voice_window.c:351
-msgid ""
-"Turn on usage logs to use voice.\n"
-"\n"
-"On your phone, go to Settings in the Pebble Time app."
-msgstr ""
-"Activa el envió de diagnósticos para utilizar la voz.\n"
-"\n"
-"En tu móvil, abre Ajustes en la app Pebble Time."
-
 #: ../src/fw/applib/voice/voice_window.c:402
 msgid "Missed that. Try again."
 msgstr "¿Perdón? Prueba otra vez."

--- a/resources/normal/base/lang/fr_FR/tintin.po
+++ b/resources/normal/base/lang/fr_FR/tintin.po
@@ -3007,15 +3007,6 @@ msgstr "Dictation vocale indisponible"
 msgid "Error occurred. Try again."
 msgstr "Erreur. Veuillez réessayer."
 
-#: ../src/fw/applib/voice/voice_window.c:351
-msgid ""
-"Turn on usage logs to use voice.\n"
-"\n"
-"On your phone, go to Settings in the Pebble Time app."
-msgstr ""
-"Veuillez autoriser la collecte de données dans l'application Pebble Time "
-"pour utiliser les fonctions vocales."
-
 #: ../src/fw/applib/voice/voice_window.c:402
 msgid "Missed that. Try again."
 msgstr "Je n'ai pas bien compris."

--- a/resources/normal/base/lang/it_IT/tintin.po
+++ b/resources/normal/base/lang/it_IT/tintin.po
@@ -2979,16 +2979,6 @@ msgstr "Dettatura non disponibile."
 msgid "Error occurred. Try again."
 msgstr "Errore. RItenta."
 
-#: ../src/fw/applib/voice/voice_window.c:351
-msgid ""
-"Turn on usage logs to use voice.\n"
-"\n"
-"On your phone, go to Settings in the Pebble Time app."
-msgstr ""
-"Attiva registri di util. per la voce.\n"
-"\n"
-"Sul tel., vai su Impostaz. nell'app Pebble Time."
-
 #: ../src/fw/applib/voice/voice_window.c:402
 msgid "Missed that. Try again."
 msgstr "Non riuscito. Riprova."

--- a/resources/normal/base/lang/pt_PT/tintin.po
+++ b/resources/normal/base/lang/pt_PT/tintin.po
@@ -3004,16 +3004,6 @@ msgstr "Ditado não disponível."
 msgid "Error occurred. Try again."
 msgstr "Ocorreu um erro. Tente de novo."
 
-#: ../src/fw/applib/voice/voice_window.c:351
-msgid ""
-"Turn on usage logs to use voice.\n"
-"\n"
-"On your phone, go to Settings in the Pebble Time app."
-msgstr ""
-"Ativar diagnósticos de uso para usar voz.\n"
-"\n"
-"Aceda a Definições na app Pebble Time."
-
 #: ../src/fw/applib/voice/voice_window.c:402
 msgid "Missed that. Try again."
 msgstr "Falhou. Tente de novo."

--- a/src/fw/applib/voice/voice_window.c
+++ b/src/fw/applib/voice/voice_window.c
@@ -364,8 +364,7 @@ static void prv_handle_ready_event(VoiceUiData *data, PebbleVoiceServiceEvent *e
       // tell the watch whether or not voice reply is enabled
       data->error_count = MAX_ERROR_COUNT;   // exit UI after the dialog is shown
       if (data->show_error_dialog) {
-        prv_push_long_error_dialog(data, NULL, i18n_noop("Turn on usage logs to use voice.\n\n"
-                                           "On your phone, go to Settings in the Pebble Time app."),
+        prv_push_long_error_dialog(data, NULL, i18n_noop("Enable voice in the settings page of the Pebble app."),
                                    RESOURCE_ID_GENERIC_WARNING_TINY);
         data->error_exit_status = DictationSessionStatusFailureDisabled;
       } else {


### PR DESCRIPTION
Just replaces the 'voice disabled' error help with something more relevant to the new app.