### PR TITLE
fw/shell: add obelix quicklaunch apps 

### DIFF
--- a/src/fw/shell/normal/system_app_registry_list.json
+++ b/src/fw/shell/normal/system_app_registry_list.json
@@ -499,7 +499,9 @@
         "snowy",
         "spalding",
         "silk",
-        "robert"
+        "robert",
+        "asterix",
+        "obelix"
       ]
     },
     {
@@ -580,7 +582,8 @@
         "spalding",
         "silk",
         "robert",
-        "asterix"
+        "asterix",
+        "obelix"
       ]
     },
     {
@@ -592,7 +595,8 @@
         "spalding",
         "silk",
         "robert",
-        "asterix"
+        "asterix",
+        "obelix"
       ]
     },
     {
@@ -604,7 +608,8 @@
         "spalding",
         "silk",
         "robert",
-        "asterix"
+        "asterix",
+        "obelix"
       ]
     },
     {
@@ -616,7 +621,8 @@
         "spalding",
         "silk",
         "robert",
-        "asterix"
+        "asterix",
+        "obelix"
       ]
     },
     {


### PR DESCRIPTION

similar to https://github.com/coredevices/pebbleos/pull/37

Fixes MOB-1700

Signed-off-by: Eric Migicovsky <eric@repebble.com>