### PR TITLE
feat: add display orientation setting for asterix devices

### DIFF
--- a/src/fw/apps/system_apps/settings/settings_display.c
+++ b/src/fw/apps/system_apps/settings/settings_display.c
@@ -92,6 +92,43 @@ static void prv_intensity_menu_push(SettingsDisplayData *data) {
       true /* icons_enabled */, s_intensity_labels, data);
 }
 
+#if PLATFORM_ASTERIX
+// Orientation Settings
+/////////////////////////////
+static const char *s_display_orientation_labels[] = {
+  i18n_noop("Default"),
+  i18n_noop("Flipped"),
+};
+
+static int prv_display_orientation_get_selection_index() { 
+  return display_is_flipped() ? 1 : 0; 
+}
+
+static void prv_display_orientation_menu_select(OptionMenu *option_menu, int selection, void *context) {
+  if (prv_display_orientation_get_selection_index() == selection) {
+    // No change
+    app_window_stack_remove(&option_menu->window, true /* animated */);
+    return;
+  }
+
+  display_set_flipped(!display_is_flipped());
+  app_window_stack_remove(&option_menu->window, true /* animated */);
+}
+
+static void prv_display_orientation_menu_push(SettingsDisplayData *data) {
+  const int index = prv_display_orientation_get_selection_index();
+  const OptionMenuCallbacks callbacks = {
+    .select = prv_display_orientation_menu_select,
+  };
+
+  const char *title = i18n_noop("Orientation");
+  settings_option_menu_push(
+    title, OptionMenuContentType_SingleLine, index, &callbacks,
+    ARRAY_LENGTH(s_display_orientation_labels), true, s_display_orientation_labels, 
+    data);
+}
+#endif
+
 // Timeout Settings
 /////////////////////////////
 
@@ -139,6 +176,9 @@ enum SettingsDisplayItem {
   SettingsDisplayAmbientSensor,
   SettingsDisplayBacklightIntensity,
   SettingsDisplayBacklightTimeout,
+#if PLATFORM_ASTERIX
+  SettingsDisplayOrientation,
+#endif
 #if PLATFORM_SPALDING
   SettingsDisplayAdjustAlignment,
 #endif
@@ -181,6 +221,11 @@ static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
     case SettingsDisplayBacklightTimeout:
       prv_timeout_menu_push(data);
       break;
+#if PLATFORM_ASTERIX
+    case SettingsDisplayOrientation:
+      prv_display_orientation_menu_push(data);
+      break;
+#endif
 #if PLATFORM_SPALDING
     case SettingsDisplayAdjustAlignment:
       settings_display_calibration_push(app_state_get_window_stack());
@@ -235,6 +280,12 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
       title = i18n_noop("Timeout");
       subtitle = s_timeout_labels[prv_timeout_get_selection_index()];
       break;
+#if PLATFORM_ASTERIX
+    case SettingsDisplayOrientation:
+      title = i18n_noop("Orientation");
+      subtitle = s_display_orientation_labels[prv_display_orientation_get_selection_index()];
+      break;
+#endif
 #if PLATFORM_SPALDING
     case SettingsDisplayAdjustAlignment:
       title = i18n_noop("Screen Alignment");

--- a/src/fw/board/boards/board_asterix.h
+++ b/src/fw/board/boards/board_asterix.h
@@ -44,6 +44,22 @@ static const BoardConfigButton BOARD_CONFIG_BUTTON = {
   .timer = NRFX_TIMER_INSTANCE(1),
 };
 
+static const BoardConfigButton BOARD_CONFIG_BUTTON_FLIPPED = {
+  .buttons = {
+    [BUTTON_ID_BACK] =
+        { "Back",   { NRFX_GPIOTE_INSTANCE(0), 2, NRF_GPIO_PIN_MAP(0, 28) }, NRF_GPIO_PIN_PULLUP },
+    [BUTTON_ID_UP] =
+        { "Up",     { NRFX_GPIOTE_INSTANCE(0), 5, NRF_GPIO_PIN_MAP(0, 31) }, NRF_GPIO_PIN_PULLUP },
+    [BUTTON_ID_SELECT] =
+        { "Select", { NRFX_GPIOTE_INSTANCE(0), 4, NRF_GPIO_PIN_MAP(0, 30) }, NRF_GPIO_PIN_PULLUP },
+    [BUTTON_ID_DOWN] =
+        { "Down",   { NRFX_GPIOTE_INSTANCE(0), 3, NRF_GPIO_PIN_MAP(0, 29) }, NRF_GPIO_PIN_PULLUP },
+  },
+  .active_high = false,
+  .timer = NRFX_TIMER_INSTANCE(1),
+};
+
+
 static const BoardConfigPower BOARD_CONFIG_POWER = {
   .pmic_int = { NRFX_GPIOTE_INSTANCE(0), 1, NRF_GPIO_PIN_MAP(1, 12) },
   .pmic_int_gpio = { NRF5_GPIO_RESOURCE_EXISTS, NRF_GPIO_PIN_MAP(1, 12) },

--- a/src/fw/drivers/nrf5/button.c
+++ b/src/fw/drivers/nrf5/button.c
@@ -7,9 +7,18 @@
 #include "kernel/events.h"
 #include "system/passert.h"
 
+#include "shell/prefs.h"
+
 bool button_is_pressed(ButtonId id) {
-  const ButtonConfig* button_config = &BOARD_CONFIG_BUTTON.buttons[id];
-  
+  const ButtonConfig* button_config = NULL;
+
+  // Check for orientation preference before setting button config
+  if (display_is_flipped()) {
+    button_config = &BOARD_CONFIG_BUTTON_FLIPPED.buttons[id];
+  } else {
+    button_config = &BOARD_CONFIG_BUTTON.buttons[id];
+  }
+
   uint32_t bit = nrf_gpio_pin_read(button_config->gpiote.gpio_pin);
   return (BOARD_CONFIG_BUTTON.active_high) ? bit : !bit;
 }
@@ -23,17 +32,15 @@ uint8_t button_get_state_bits(void) {
 }
 
 void button_init(void) {
-  if (BOARD_CONFIG_BUTTON.button_com.gpio_pin)
-    WTF; // NYI
+  if (BOARD_CONFIG_BUTTON.button_com.gpio_pin) WTF;  // NYI
 
   for (int i = 0; i < NUM_BUTTONS; ++i) {
-    nrf_gpio_cfg_input(BOARD_CONFIG_BUTTON.buttons[i].gpiote.gpio_pin, BOARD_CONFIG_BUTTON.buttons[i].pull);
+    nrf_gpio_cfg_input(BOARD_CONFIG_BUTTON.buttons[i].gpiote.gpio_pin,
+                       BOARD_CONFIG_BUTTON.buttons[i].pull);
   }
 }
 
-bool button_selftest(void) {
-  return button_get_state_bits() == 0;
-}
+bool button_selftest(void) { return button_get_state_bits() == 0; }
 
 void command_button_read(const char* button_id_str) {
   int button = atoi(button_id_str);

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -73,6 +73,11 @@ static uint16_t s_backlight_intensity; // default pulled from BOARD_CONFIGs in s
 #define PREF_KEY_BACKLIGHT_MOTION "lightMotion"
 static bool s_backlight_motion_enabled = true;
 
+#if PLATFORM_ASTERIX
+#define PREF_KEY_DISPLAY_FLIPPED "displayFlipped"
+static bool s_display_flipped = false;
+#endif
+
 #define PREF_KEY_STATIONARY "stationaryMode"
 #if RELEASE && !PLATFORM_SPALDING
 static bool s_stationary_mode_enabled = false;
@@ -252,6 +257,13 @@ static bool prv_set_s_backlight_motion_enabled(bool *enabled) {
   s_backlight_motion_enabled = *enabled;
   return true;
 }
+
+#if PLATFORM_ASTERIX
+static bool prv_set_s_display_flipped(bool *flipped) {
+  s_display_flipped = *flipped;
+  return true;
+}
+#endif
 
 static bool prv_set_s_stationary_mode_enabled(bool *enabled) {
   s_stationary_mode_enabled = *enabled;
@@ -775,6 +787,16 @@ bool backlight_is_motion_enabled(void) {
 void backlight_set_motion_enabled(bool enable) {
   prv_pref_set(PREF_KEY_BACKLIGHT_MOTION, &enable, sizeof(enable));
 }
+
+#if PLATFORM_ASTERIX
+bool display_is_flipped(void) { 
+  return s_display_flipped; 
+}
+
+void display_set_flipped(bool flipped) {
+  prv_pref_set(PREF_KEY_DISPLAY_FLIPPED, &flipped, sizeof(flipped));
+}
+#endif
 
 bool shell_prefs_get_stationary_enabled(void) {
   return s_stationary_mode_enabled;

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -38,3 +38,6 @@
   PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_ENABLED, s_timeline_peek_enabled)
   PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_BEFORE_TIME_M, s_timeline_peek_before_time_m)
 #endif
+#if PLATFORM_ASTERIX
+  PREFS_MACRO(PREF_KEY_DISPLAY_FLIPPED, s_display_flipped)
+ #endif

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -89,6 +89,13 @@ void backlight_set_intensity_percent(uint8_t intensity_percent);
 bool backlight_is_motion_enabled(void);
 void backlight_set_motion_enabled(bool enable);
 
+// The display flipped setting is used to rotate the display 180 degrees.
+// This is only available on asterix and is used by the display and button drivers.
+#if PLATFORM_ASTERIX
+bool display_is_flipped(void);
+void display_set_flipped(bool flipped);
+#endif
+
 // Stationary mode will put the watch in a low power state. Disabling will
 // prevent the watch from turning off any features.
 bool shell_prefs_get_stationary_enabled(void);


### PR DESCRIPTION
This (my first!) pull request introduces a new 'Orientation' display setting for asterix devices, allowing the user to more comfortably wear their watch on the right wrist. As opposed to reaching around with the left thumb to press Up/Down/Select, the navigation buttons can be pressed with the left index finger as shown:

https://github.com/user-attachments/assets/30c574ee-9aa2-47cc-96b8-4995c9d576cc



