### PR TITLE
fw/stop: enable sf32lb52 deep sleep mode

### DIFF
--- a/src/fw/drivers/sf32lb52/lptim_systick.c
+++ b/src/fw/drivers/sf32lb52/lptim_systick.c
@@ -148,4 +148,6 @@ void AON_IRQHandler(void)
 {
   NVIC_DisableIRQ(AON_IRQn);
   HAL_HPAON_CLEAR_POWER_MODE();
+
+  HAL_HPAON_CLEAR_WSR(0);
 }

--- a/src/fw/freertos_application.c
+++ b/src/fw/freertos_application.c
@@ -33,6 +33,10 @@
 #include "system/logging.h"
 #include "util/math.h"
 
+#if defined(MICRO_FAMILY_SF32LB52)
+#include <ipc_queue.h>
+#endif
+
 #define STM32F2_COMPATIBLE
 #define STM32F4_COMPATIBLE
 #define STM32F7_COMPATIBLE
@@ -80,9 +84,9 @@ static const RtcTicks EARLY_WAKEUP_TICKS = 2;
 static const RtcTicks MIN_STOP_TICKS = 5;
 #elif defined(MICRO_FAMILY_SF32LB52)
 //! Stop mode until this number of ticks before the next scheduled task
-static const RtcTicks EARLY_WAKEUP_TICKS = 2;
+static const RtcTicks EARLY_WAKEUP_TICKS = 10; // relative large to avid tasks.c:1960 assert
 //! Stop mode until this number of ticks before the next scheduled task
-static const RtcTicks MIN_STOP_TICKS = 0xFFFFFFFF; // disable stop mode for now
+static const RtcTicks MIN_STOP_TICKS = 15;
 #else
 #error "Unknown micro family"
 #endif
@@ -99,7 +103,9 @@ extern void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime ) {
     return;
   }
 #else
-  if (!lptim_systick_is_initialized() || !sleep_mode_is_allowed()) {
+  if (!lptim_systick_is_initialized() || !sleep_mode_is_allowed() ||
+      !ipc_queue_check_idle()) {
+    // To avoid LCPU enter incorrect state, make sure ipc queue is empty before enter stop mode.
     return;
   }
 #endif

--- a/src/fw/kernel/util/stop.c
+++ b/src/fw/kernel/util/stop.c
@@ -121,19 +121,20 @@ void enter_stop_mode(void) {
   HAL_RCC_HCPU_DisableDLL1();
   HAL_RCC_HCPU_DisableDLL2();
 
-  // HAL_HPAON_DISABLE_PAD();
-  // HAL_HPAON_DISABLE_VHP();
-
   HAL_HPAON_CLEAR_HP_ACTIVE();
   HAL_HPAON_SET_POWER_MODE(AON_PMR_DEEP_SLEEP);
 
-  // Go stop now.
-  __DSB(); // Drain any pending memory writes before entering sleep.
-  do_wfi(); // Wait for Interrupt (enter sleep mode). Work around F2/F4 errata.
-  __ISB(); // Let the pipeline catch up (force the WFI to activate before moving on).
-
-  // HAL_HPAON_ENABLE_PAD();
-  // HAL_HPAON_ENABLE_VHP();
+  __WFI();
+  __NOP();
+  __NOP();
+  __NOP();
+  __NOP();
+  __NOP();
+  __NOP();
+  __NOP();
+  __NOP();
+  __NOP();
+  __NOP();
 
   HAL_HPAON_SET_HP_ACTIVE();
   HAL_HPAON_CLEAR_POWER_MODE();


### PR DESCRIPTION
Still not wroking yet, add this to track the ~#260~ #261 

2025/09/17:
After add `HAL_HPAON_CLEAR_WSR(0);` to `AON_IRQHandler`, The #260 issue have been fixed.

New issue meet,  The `AON->WSR` status  LPAON_WAKEUP_SRC_HP2LP_REQ is set. It's happened after below log.
```
I ? 08:00:29.839 freertos_application.c:216> xExpectedIdleTime: 982, elapsed: 979
I ? 08:00:30.839 freertos_application.c:216> xExpectedIdleTime: 979, elapsed: 978
I ? 08:00:30.867 freertos_application.c:216> xExpectedIdleTime: 978, elapsed: 969
I ? 08:00:32.839 freertos_application.c:216> xExpectedIdleTime: 969, elapsed: 968
I ? 08:00:32.843 freertos_application.c:216> xExpectedIdleTime: 28, elapsed: 19
D T 08:00:32.871 gap_le_advert.c:200> Job is performing next advertising term (1/2)
D T 08:00:32.871 gap_le_advert.c:311> Disable last Ad job
D T 08:00:32.875 gap_le_advert.c:335> Enable Ad job RCN
I ? 08:00:32.878 freertos_application.c:216> xExpectedIdleTime: 985, elapsed: 2
``` 

After add a ISSR status check before tickless idle, like below.
```
  if (!lptim_systick_is_initialized() || !sleep_mode_is_allowed() || 
      (hwp_hpsys_aon->ISSR & HPSYS_AON_ISSR_LP2HP_REQ_Msk)) {
    return;
  }
```
Then the HCPU can go ahead, but the BLE looks enter wrong state. Below is the log.
```
I ? 08:00:23.843 freertos_application.c:216> xExpectedIdleTime: 20, elapsed: 19
I ? 08:00:24.843 freertos_application.c:216> xExpectedIdleTime: 996, elapsed: 995
I ? 08:00:25.843 freertos_application.c:216> xExpectedIdleTime: 995, elapsed: 993
I ? 08:00:26.843 freertos_application.c:216> xExpectedIdleTime: 993, elapsed: 992
I ? 08:00:27.843 freertos_application.c:216> xExpectedIdleTime: 992, elapsed: 991
I ? 08:00:28.835 freertos_application.c:216> xExpectedIdleTime: 991, elapsed: 982
I ? 08:00:29.839 freertos_application.c:216> xExpectedIdleTime: 982, elapsed: 979
I ? 08:00:30.839 freertos_application.c:216> xExpectedIdleTime: 979, elapsed: 978
I ? 08:00:30.867 freertos_application.c:216> xExpectedIdleTime: 978, elapsed: 969
I ? 08:00:32.839 freertos_application.c:216> xExpectedIdleTime: 969, elapsed: 968
I ? 08:00:32.843 freertos_application.c:216> xExpectedIdleTime: 28, elapsed: 19
D T 08:00:32.871 gap_le_advert.c:200> Job is performing next advertising term (1/2)
D T 08:00:32.871 gap_le_advert.c:311> Disable last Ad job
D T 08:00:32.875 gap_le_advert.c:335> Enable Ad job RCN
I ? 08:00:32.878 freertos_application.c:216> xExpectedIdleTime: 985, elapsed: 2
E T 08:00:36.101 advert.c:399> Failed to start advertising (0x0013)
D T 08:00:36.101 dls_endpoint.c:127> session 232 timeout
D T 08:00:36.101 gap_le_advert.c:335> Enable Ad job RCN
E T 08:00:38.351 advert.c:399> Failed to start advertising (0x0013)
D T 08:00:38.351 gap_le_advert.c:335> Enable Ad job RCN
E T 08:00:38.355 advert.c:399> Failed to start advertising (0x0016)
D T 08:00:38.355 gap_le_advert.c:335> Enable Ad job RCN
E T 08:00:38.355 advert.c:399> Failed to start advertising (0x0016)
D T 08:00:38.355 gap_le_advert.c:335> Enable Ad job RCN
E T 08:00:38.355 advert.c:399> Failed to start advertising (0x0016)
W B 08:00:38.359 init.c:57> NimBLE reset (reason: 19)
D T 08:00:39.468 gap_le_advert.c:335> Enable Ad job RCN
E T 08:00:39.472 advert.c:393> Failed to infer own address type (21)
D T 08:00:40.597 gap_le_advert.c:335> Enable Ad job RCN
E T 08:00:40.597 advert.c:393> Failed to infer own address type (21)
W B 08:00:40.609 init.c:57> NimBLE reset (reason: 19)
D T 08:00:41.722 gap_le_advert.c:335> Enable Ad job RCN
E T 08:00:41.722 advert.c:393> Failed to infer own address type (21)
D T 08:00:42.847 gap_le_advert.c:335> Enable Ad job RCN
E T 08:00:42.847 advert.c:393> Failed to infer own address type (21)
W B 08:00:42.863 init.c:57> NimBLE reset (reason: 19)
D T 08:00:43.972 gap_le_advert.c:335> Enable Ad job RCN
E T 08:00:43.972 advert.c:393> Failed to infer own address type (21)
D T 08:00:45.097 gap_le_advert.c:335> Enable Ad job RCN
E T 08:00:45.097 advert.c:393> Failed to infer own address type (21)
W B 08:00:45.113 init.c:57> NimBLE reset (reason: 19)
D T 08:00:46.222 gap_le_advert.c:335> Enable Ad job RCN
```
The power consumption after deepsleep worked, with #261 issue, is nearly 3mA.
<img width="2206" height="1119" alt="Screenshot from 2025-09-17 23-40-35" src="https://github.com/user-attachments/assets/6df9a263-0447-4a65-b02c-10173c83c2bc" />

=========

After add ipc_queue_check_idle before enter stop mode, the BLE works fine now.

So, only the #261 remain in now.
 

