### PR TITLE
fw/drivers/mic/nrf5: respect boardconfig mic gain & increase on asterix

### DIFF
--- a/src/fw/board/board_nrf5.h
+++ b/src/fw/board/board_nrf5.h
@@ -18,6 +18,7 @@
 #include <nrfx_gpiote.h>
 #include <nrfx_timer.h>
 #include <nrfx_pwm.h>
+#include <nrfx_pdm.h>
 #pragma GCC diagnostic pop
 
 #define GPIO_Port_NULL (NULL)
@@ -157,7 +158,7 @@ typedef struct {
   AfConfig i2s_sd;
   NRF_SPIM_Type *spi;
   uint32_t spi_clock_ctrl;
-  uint16_t gain;
+  nrf_pdm_gain_t gain;
 
   //! Pin we use to control power to the microphone. Only used on certain boards.
   OutputConfig mic_gpio_power;

--- a/src/fw/board/boards/board_asterix.h
+++ b/src/fw/board/boards/board_asterix.h
@@ -27,6 +27,9 @@ static const BoardConfig BOARD_CONFIG = {
   },
 
   .has_mic = true,
+  .mic_config = {
+    .gain = 65,
+  }
 };
 
 static const BoardConfigButton BOARD_CONFIG_BUTTON = {

--- a/src/fw/drivers/mic/nrf5/pdm.c
+++ b/src/fw/drivers/mic/nrf5/pdm.c
@@ -187,6 +187,8 @@ void mic_init(const MicDevice *this) {
   state->pdm_config = (nrfx_pdm_config_t)NRFX_PDM_DEFAULT_CONFIG(this->clk_pin, this->data_pin);
   state->pdm_config.clock_freq = NRF_PDM_FREQ_1280K;
   state->pdm_config.ratio = NRF_PDM_RATIO_80X;
+  state->pdm_config.gain_l = BOARD_CONFIG.mic_config.gain;
+  state->pdm_config.gain_r = BOARD_CONFIG.mic_config.gain;
   
   // Create mutex for thread safety
   state->mutex = mutex_create_recursive();


### PR DESCRIPTION
NRF5 default gain is 40 (out of 80) which is equivalent to 0dB.
This PR makes it configurable and sets it to 65 on asterix to improve mic volume