### PR TITLE
FIRM-615: create on-device debugging options to generate a core dump

### DIFF
--- a/src/fw/applib/ui/dialogs/actionable_dialog.c
+++ b/src/fw/applib/ui/dialogs/actionable_dialog.c
@@ -250,3 +250,11 @@ void actionable_dialog_set_click_config_provider(ActionableDialog *actionable_di
                                                  ClickConfigProvider click_config_provider) {
   actionable_dialog->config_provider = click_config_provider;
 }
+
+void actionable_dialog_set_user_data(ActionableDialog *actionable_dialog, void *user_data) {
+  actionable_dialog->user_data = user_data;
+}
+
+void *actionable_dialog_get_user_data(ActionableDialog *actionable_dialog) {
+  return actionable_dialog->user_data;
+}

--- a/src/fw/applib/ui/dialogs/actionable_dialog.h
+++ b/src/fw/applib/ui/dialogs/actionable_dialog.h
@@ -73,3 +73,10 @@ void app_actionable_dialog_push(ActionableDialog *actionable_dialog);
 //! Pops the given \ref ActionableDialog from the window stack it was pushed to.
 //! @param actionable_dialog Pointer to a \ref ActionableDialog to pop
 void actionable_dialog_pop(ActionableDialog *actionable_dialog);
+
+//! Attaches user data to an \ref ActionableDialog, since the \ref
+//! ActionableDialog already uses the \ref Window 's user_data field.
+void actionable_dialog_set_user_data(ActionableDialog *actionable_dialog, void *context);
+
+//! Retrieve user data associated with an \ref ActionableDialog.
+void *actionable_dialog_get_user_data(ActionableDialog *actionable_dialog);

--- a/src/fw/applib/ui/dialogs/actionable_dialog_private.h
+++ b/src/fw/applib/ui/dialogs/actionable_dialog_private.h
@@ -54,4 +54,5 @@ typedef struct ActionableDialog {
   };
   ActionBarLayer *action_bar;
   ClickConfigProvider config_provider;
+  void *user_data;
 } ActionableDialog;

--- a/src/fw/debug/debug_reboot_reason.c
+++ b/src/fw/debug/debug_reboot_reason.c
@@ -194,10 +194,15 @@ void debug_reboot_reason_print(McuRebootReason mcu_reboot_reason) {
   }
 #endif
 
+  // Core dumps always get an alert display, since the user asked for it.
+  if (reason.code == RebootReasonCode_ForcedCoreDump) {
+    crashed_ui_show_forced_core_dump();
+  }
+
 #ifdef SHOW_PEBBLE_JUST_RESET_ALERT
   // Trigger an alert display so that the user knows the watch rebooted due to a crash. This event
   // will be caught and handled by the launcher.c event loop.
-  if (show_reset_alert) {
+  if (show_reset_alert && reason.code != RebootReasonCode_ForcedCoreDump) {
     crashed_ui_show_pebble_reset();
   }
 #endif

--- a/src/fw/popups/crashed_ui.c
+++ b/src/fw/popups/crashed_ui.c
@@ -164,10 +164,14 @@ void crashed_ui_show_worker_crash(const AppInstallId install_id) {
 }
 
 // ---------------------------------------------------------------------------
-#if (defined(SHOW_BAD_BT_STATE_ALERT) || defined(SHOW_PEBBLE_JUST_RESET_ALERT))
+#define CORE_DUMP_COMPLETE \
+  i18n_noop("A bug report has been captured. " \
+            "Please finish uploading the bug report using the Pebble phone app.")
+
 #define YOUR_PEBBLE_RESET \
   i18n_noop("Your Pebble just reset. " \
             "Please report this using the 'Support' link in the Pebble phone app.")
+
 #define PHONE_BT_CONTROLLER_WEDGED \
   i18n_noop("Bluetooth on your phone is in a high power state. " \
             "Please report this using 'Support' and reboot your phone.")
@@ -183,6 +187,12 @@ static void prv_push_reset_dialog(void *context) {
 
   light_enable_interaction();
 }
+
+void crashed_ui_show_forced_core_dump(void) {
+  launcher_task_add_callback(prv_push_reset_dialog, CORE_DUMP_COMPLETE);
+}
+
+#if (defined(SHOW_BAD_BT_STATE_ALERT) || defined(SHOW_PEBBLE_JUST_RESET_ALERT))
 
 //! Restrict only to the two defines above
 //! Show the "Your pebble has just reset"

--- a/src/fw/popups/crashed_ui.h
+++ b/src/fw/popups/crashed_ui.h
@@ -18,6 +18,9 @@
 
 #include "process_management/app_install_types.h"
 
+//! Show the "Bug report captured" modal
+void crashed_ui_show_forced_core_dump(void);
+
 //! Show the "Your Pebble just reset" modal
 void crashed_ui_show_pebble_reset(void);
 

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -178,6 +178,9 @@ static uint16_t s_timeline_peek_before_time_m =
     (TIMELINE_PEEK_DEFAULT_SHOW_BEFORE_TIME_S / SECONDS_PER_MINUTE);
 #endif
 
+#define PREF_KEY_COREDUMP_ON_REQUEST "coredumpOnRequest"
+static bool s_coredump_on_request_enabled = false;
+
 // ============================================================================================
 // Handlers for each pref that validate the new setting and store the new value in our globals.
 // This handler will be called when the setting is changed from inside the firmware using one of
@@ -432,6 +435,11 @@ static bool prv_set_s_timeline_peek_before_time_m(uint16_t *before_time_m) {
   return true;
 }
 #endif
+
+static bool prv_set_s_coredump_on_request_enabled(bool *enabled) {
+  s_coredump_on_request_enabled = *enabled;
+  return true;
+}
 
 // ------------------------------------------------------------------------------------
 // Table of all prefs
@@ -1176,3 +1184,11 @@ uint16_t timeline_peek_prefs_get_before_time(void) {
   return TIMELINE_PEEK_DEFAULT_SHOW_BEFORE_TIME_S;
 }
 #endif
+
+bool shell_prefs_can_coredump_on_request(void) {
+  return s_coredump_on_request_enabled;
+}
+
+void shell_prefs_set_coredump_on_request(bool enabled) {
+  prv_pref_set(PREF_KEY_COREDUMP_ON_REQUEST, &enabled, sizeof(enabled));
+}

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -38,3 +38,4 @@
   PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_ENABLED, s_timeline_peek_enabled)
   PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_BEFORE_TIME_M, s_timeline_peek_before_time_m)
 #endif
+  PREFS_MACRO(PREF_KEY_COREDUMP_ON_REQUEST, s_coredump_on_request_enabled)

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -115,3 +115,6 @@ void timeline_peek_prefs_set_enabled(bool enabled);
 bool timeline_peek_prefs_get_enabled(void);
 void timeline_peek_prefs_set_before_time(uint16_t before_time_m);
 uint16_t timeline_peek_prefs_get_before_time(void);
+
+bool shell_prefs_can_coredump_on_request(void);
+void shell_prefs_set_coredump_on_request(bool enabled);

--- a/src/fw/shell/prf/stubs.c
+++ b/src/fw/shell/prf/stubs.c
@@ -192,6 +192,11 @@ int16_t shell_prefs_get_automatic_timezone_id(void) {
   return -1;
 }
 
+bool shell_prefs_can_coredump_on_request() {
+  // it would be good to have a core dump escape hatch in PRF
+  return true;
+}
+
 AlertMask alerts_get_mask(void) {
   return AlertMaskAllOff;
 }

--- a/src/fw/shell/prf/stubs.c
+++ b/src/fw/shell/prf/stubs.c
@@ -45,6 +45,9 @@ const char *app_custom_get_title(AppInstallId app_id) {
 void crashed_ui_show_worker_crash(AppInstallId install_id) {
 }
 
+void crashed_ui_show_forced_core_dump(void) {
+}
+
 void crashed_ui_show_pebble_reset(void) {
 }
 


### PR DESCRIPTION
As per FIRM-615, we surface two options to create a core dump: an immediate core dump option (previously hidden behind Settings -> System -> Information -> long-press Firmware), and a "core dump any time" option that can be enabled to trigger a core dump by rapidly clicking the back button 10 times in a row (intended for use with debugging FIRM-425).

We also create a 'debugging' menu in system settings (gated behind a confirmation dialog) to control these, and, while we're at it, if the user voluntarily creates a core dump, then we pop up a special dialog on reboot to explain why there was an unceremonious reboot, and to tell the user to go and upload the crash dump through CoreApp.