### PR TITLE
tools: add script to analyze coredumps

### DIFF
--- a/tools/analyze_coredump.py
+++ b/tools/analyze_coredump.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+# Copyright 2025 Core Devices LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Coredump analyzer for ARM embedded systems using arm-none-eabi-gdb.
+Loads a coredump file and extracts relevant debugging information to a text file.
+"""
+
+import subprocess
+import sys
+import os
+import argparse
+import tempfile
+from datetime import datetime
+
+
+class CoredumpAnalyzer:
+    def __init__(self, elf_file, coredump_file, output_file=None):
+        self.elf_file = elf_file
+        self.coredump_file = coredump_file
+        self.output_file = (
+            output_file
+            or f"coredump_analysis_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt"
+        )
+        self.gdb_executable = "arm-none-eabi-gdb"
+
+    def create_gdb_script(self):
+        """Create a GDB script with commands to extract relevant information."""
+        commands = [
+            # Load the files
+            f"file {self.elf_file}",
+            f"core-file {self.coredump_file}",
+            "",
+            # Basic info
+            "echo \\n=== BASIC INFORMATION ===\\n",
+            "info target",
+            "",
+            # Thread information
+            "echo \\n=== THREAD INFORMATION ===\\n",
+            "info threads",
+            "thread apply all bt",
+            "",
+            # Current thread detailed backtrace
+            "echo \\n=== CURRENT THREAD DETAILED BACKTRACE ===\\n",
+            "bt full",
+            "",
+            # Register state
+            "echo \\n=== REGISTER STATE ===\\n",
+            "info registers",
+            "info all-registers",
+            "",
+            # Memory mappings
+            "echo \\n=== MEMORY MAPPINGS ===\\n",
+            "info proc mappings",
+            "maintenance info sections",
+            "",
+            # Stack examination
+            "echo \\n=== STACK EXAMINATION ===\\n",
+            "x/32xw $sp",
+            "",
+            # Local variables in current frame
+            "echo \\n=== LOCAL VARIABLES (CURRENT FRAME) ===\\n",
+            "info locals",
+            "",
+            # Arguments in current frame
+            "echo \\n=== FUNCTION ARGUMENTS (CURRENT FRAME) ===\\n",
+            "info args",
+            "",
+            # Source information
+            "echo \\n=== SOURCE INFORMATION ===\\n",
+            "info source",
+            "info line",
+            "",
+            # Disassembly around current PC
+            "echo \\n=== DISASSEMBLY AROUND PC ===\\n",
+            "x/20i $pc-40",
+            "",
+            # Frame information for all threads
+            "echo \\n=== DETAILED FRAME INFO FOR ALL THREADS ===\\n",
+            "thread apply all frame",
+            "thread apply all info frame",
+            "",
+            # Exit
+            "quit",
+        ]
+
+        return "\n".join(commands)
+
+    def analyze(self):
+        """Run GDB with the script and capture output."""
+        print(f"Analyzing coredump: {self.coredump_file}")
+        print(f"Using ELF file: {self.elf_file}")
+        print(f"Output will be saved to: {self.output_file}")
+
+        # Create GDB script
+        gdb_script = self.create_gdb_script()
+
+        # Write script to temporary file
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".gdb", delete=False
+        ) as script_file:
+            script_file.write(gdb_script)
+            script_path = script_file.name
+
+        # Run GDB with the script
+        try:
+            result = subprocess.run(
+                [self.gdb_executable, "--batch", "--quiet", "-x", script_path],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            # Clean up temporary file
+            os.unlink(script_path)
+
+            # Prepare output
+            output_lines = []
+            output_lines.append("=" * 80)
+            output_lines.append(f"COREDUMP ANALYSIS REPORT")
+            output_lines.append(
+                f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+            )
+            output_lines.append(f"ELF File: {self.elf_file}")
+            output_lines.append(f"Coredump File: {self.coredump_file}")
+            output_lines.append("=" * 80)
+            output_lines.append("")
+
+            # Add GDB output
+            if result.stdout:
+                output_lines.append(result.stdout)
+
+            # Add any errors
+            if result.stderr:
+                output_lines.append("\n=== GDB ERRORS/WARNINGS ===")
+                output_lines.append(result.stderr)
+
+            # Write to file
+            with open(self.output_file, "w") as f:
+                f.write("\n".join(output_lines))
+
+            print("\nAnalysis complete!")
+
+            return result.returncode == 0
+
+        except FileNotFoundError:
+            print(
+                f"Error: {self.gdb_executable} not found. Please ensure arm-none-eabi-gdb is installed and in PATH."
+            )
+            return False
+        except Exception as e:
+            print(f"Error during analysis: {e}")
+            return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Analyze ARM coredump files using arm-none-eabi-gdb",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s firmware.elf core.dump
+  %(prog)s firmware.elf core.dump -o crash_analysis.txt
+  %(prog)s --elf app.elf --core coredump.bin
+  %(prog)s --elf app.elf --core coredump.bin --output report.txt
+        """,
+    )
+
+    parser.add_argument("elf", nargs="?", help="ELF file with debug symbols")
+    parser.add_argument("coredump", nargs="?", help="Coredump file")
+    parser.add_argument(
+        "-e",
+        "--elf",
+        dest="elf_file",
+        help="ELF file with debug symbols (alternative syntax)",
+    )
+    parser.add_argument(
+        "-c", "--core", dest="core_file", help="Coredump file (alternative syntax)"
+    )
+    parser.add_argument(
+        "-o", "--output", help="Output file name (default: timestamped file)"
+    )
+
+    args = parser.parse_args()
+
+    # Determine which arguments to use
+    elf_file = args.elf_file or args.elf
+    coredump_file = args.core_file or args.coredump
+
+    if not elf_file or not coredump_file:
+        parser.print_help()
+        sys.exit(1)
+
+    # Validate input files exist
+    if not os.path.exists(elf_file):
+        print(f"Error: ELF file '{elf_file}' not found")
+        sys.exit(1)
+
+    if not os.path.exists(coredump_file):
+        print(f"Error: Coredump file '{coredump_file}' not found")
+        sys.exit(1)
+
+    # Run analysis
+    analyzer = CoredumpAnalyzer(elf_file, coredump_file, args.output)
+    success = analyzer.analyze()
+
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Example:

```
================================================================================
COREDUMP ANALYSIS REPORT
Generated: 2025-09-23 15:39:11
ELF File: /home/gmarull/Downloads/firmware_asterix_v4.9.9-core52.elf
Coredump File: cd.elf
================================================================================

[New process 536926316]
[New process 536927656]
[New process 536930640]
[New process 536926192]
[New process 536937048]
[New process 536936160]
[New process 536926920]
[New process 536930764]
[New process 536937288]
[New process 1]
Core was generated by `ISR'.
Program terminated with signal SIGABRT, Aborted.
#0  0x00036770 in vPortSuppressTicksAndSleep (xExpectedIdleTime=<optimized out>) at ../src/fw/freertos_application.c:239
[Current thread is 1 (process 536926316)]

=== BASIC INFORMATION ===
Symbols from "/home/gmarull/Downloads/firmware_asterix_v4.9.9-core52.elf".
Local core dump file:
	`/home/gmarull/ws/pebble/pebbleos/cd.elf', file type elf32-littlearm.
	0x20000000 - 0x20040000 is load1
	0xe000e100 - 0xe000e120 is load2
	0xe000e200 - 0xe000e220 is load3
	0xe000e300 - 0xe000e320 is load4
	While running this, GDB does not access memory from...
Local exec file:
	`/home/gmarull/Downloads/firmware_asterix_v4.9.9-core52.elf', file type elf32-littlearm.
	Entry point: 0x8110
	0x00008000 - 0x00008100 is .isr_vector
	0x20000000 - 0x20000100 is .retained
	0x00008100 - 0x00008108 is .ARM.exidx
	0x00008110 - 0x000f4e20 is .text
	0x20028000 - 0x2003fa81 is .app_ram
	0x20000100 - 0x20000d38 is .kernel_data
	0x20000d38 - 0x20001800 is .kernel_ro_bss
	0x20001800 - 0x2000c570 is .kernel_bss
	0x2000c570 - 0x2000c5b0 is .noinit.mflt_reboot_info
	0x2000c5b0 - 0x2000c9c0 is .stack
	0x2000c9c0 - 0x2000d1c0 is .kernel_main_stack
	0x2000d1c0 - 0x2000d7c0 is .kernel_bg_stack
	0x2000d7c0 - 0x20025000 is .kernel_heap
	0x000f5a58 - 0x000f5a7c is .note.gnu.build-id
	0x000f5a7c - 0x000f5aab is .fw_version

=== THREAD INFORMATION ===
  Id   Target Id         Frame 
* 1    process 536926316 0x00036770 in vPortSuppressTicksAndSleep (xExpectedIdleTime=<optimized out>) at ../src/fw/freertos_application.c:239
  2    process 536927656 xLightMutexLock (xMutex=xMutex@entry=0x2000e4c4, xTicksToWait=<optimized out>, xTicksToWait@entry=103079214) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/light_mutex.c:289
  3    process 536930640 xLightMutexLock (xMutex=xMutex@entry=0x2000e4c4, xTicksToWait=<optimized out>, xTicksToWait@entry=103079214) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/light_mutex.c:289
  4    process 536926192 xLightMutexLock (xMutex=xMutex@entry=0x2000e924, xTicksToWait=<optimized out>, xTicksToWait@entry=4294967294) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/light_mutex.c:289
  5    process 536937048 0x0007dcaa in xQueueGenericReceive (xQueue=0x2000f8e4, pvBuffer=0x20025534, xTicksToWait=<optimized out>, xJustPeeking=0) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:1533
  6    process 536936160 0x0007dcaa in xQueueGenericReceive (xQueue=0x20021264, pvBuffer=0x200287cc, xTicksToWait=<optimized out>, xJustPeeking=0) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:1533
  7    process 536926920 0x0007dcaa in xQueueGenericReceive (xQueue=0x2000d9d8, pvBuffer=pvBuffer@entry=0x2000d78c, xTicksToWait=<optimized out>, xTicksToWait@entry=4294967295, xJustPeeking=xJustPeeking@entry=0) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:1533
  8    process 536930764 0x0007dcaa in xQueueGenericReceive (xQueue=0x2000e6c4, pvBuffer=pvBuffer@entry=0x20021730, xTicksToWait=<optimized out>, xJustPeeking=0) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:1533
  9    process 536937288 0x0007dcaa in xQueueGenericReceive (xQueue=0x200102d4, pvBuffer=pvBuffer@entry=0x0, xTicksToWait=<optimized out>, xTicksToWait@entry=4294967295, xJustPeeking=xJustPeeking@entry=0) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:1533
  10   process 1         NMI_Handler () at ../src/fw/kernel/core_dump.c:537

Thread 10 (process 1):
#0  NMI_Handler () at ../src/fw/kernel/core_dump.c:537
#1  <signal handler called>
#2  core_dump_reset (is_forced=is_forced@entry=false) at ../src/fw/kernel/core_dump.c:526
#3  0x0001eb16 in system_reset () at ../src/fw/kernel/reset.c:60
#4  0x00023ca0 in reset_due_to_software_failure () at ../src/fw/system/die.c:51
#5  0x0003a60a in QDEC_IRQHandler () at ../src/fw/drivers/task_watchdog.c:251
#6  <signal handler called>
#7  0x65776f6c in ?? ()
#8  0x6c612074 in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

Thread 9 (process 536937288):
#0  0x0007dcaa in xQueueGenericReceive (xQueue=0x200102d4, pvBuffer=pvBuffer@entry=0x0, xTicksToWait=<optimized out>, xTicksToWait@entry=4294967295, xJustPeeking=xJustPeeking@entry=0) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:1533
#1  0x0001b7b0 in prv_pulse_task_main (unused=<optimized out>) at ../src/fw/console/pulse2.c:291
#2  0x00000000 in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

Thread 8 (process 536930764):
#0  0x0007dcaa in xQueueGenericReceive (xQueue=0x2000e6c4, pvBuffer=pvBuffer@entry=0x20021730, xTicksToWait=<optimized out>, xJustPeeking=0) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:1533
#1  0x0004189a in npl_pebble_eventq_get (evq=evq@entry=0x20002a7c <g_ble_ll_data+20>, tmo=tmo@entry=4294967295) at ../third_party/nimble/port/src/npl_os_pebble.c:44
#2  0x00041e8a in ble_npl_eventq_get (evq=0x20002a7c <g_ble_ll_data+20>, tmo=4294967295) at ../third_party/nimble/port/include/nimble/nimble_npl_os.h:104
#3  ble_ll_task (arg=<optimized out>) at ../third_party/nimble/mynewt-nimble/nimble/controller/src/ble_ll.c:1390
#4  0x00000000 in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

Thread 7 (process 536926920):
#0  0x0007dcaa in xQueueGenericReceive (xQueue=0x2000d9d8, pvBuffer=pvBuffer@entry=0x2000d78c, xTicksToWait=<optimized out>, xTicksToWait@entry=4294967295, xJustPeeking=xJustPeeking@entry=0) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:1533
#1  0x000c43fc in xQueueSelectFromSet (xQueueSet=<optimized out>, xTicksToWait=xTicksToWait@entry=4294967295) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:2540
#2  0x0006400c in system_task_main (paramater=<optimized out>) at ../src/fw/services/common/system_task.c:69
#3  0x00000000 in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

Thread 6 (process 536936160):
#0  0x0007dcaa in xQueueGenericReceive (xQueue=0x20021264, pvBuffer=0x200287cc, xTicksToWait=<optimized out>, xJustPeeking=0) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:1533
#1  0x0004aeb0 in app_event_loop_common () at ../src/fw/applib/app.c:257
#2  0x000aa56c in app_event_loop () at ../src/fw/applib/app.c:282
#3  0x00018830 in prv_app_task_main (entry_point=0x285e1 <prv_main>) at ../src/fw/process_management/app_manager.c:158
#4  0x00000000 in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

Thread 5 (process 536937048):
#0  0x0007dcaa in xQueueGenericReceive (xQueue=0x2000f8e4, pvBuffer=0x20025534, xTicksToWait=<optimized out>, xJustPeeking=0) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:1533
#1  0x0009887a in __sys_psleep (millis=<optimized out>) at ../src/fw/syscall/syscall.c:98
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

Thread 4 (process 536926192):
#0  xLightMutexLock (xMutex=xMutex@entry=0x2000e924, xTicksToWait=<optimized out>, xTicksToWait@entry=4294967294) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/light_mutex.c:289
#1  0x0007d7b2 in xLightMutexLockRecursive (xMutex=0x2000e924, xTicksToWait=4294967294) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/light_mutex.c:445
#2  0x0007bbae in mutex_lock_recursive_with_timeout (handle=0x2000e944, timeout_ms=<optimized out>) at ../src/libos/mutex_freertos.c:170
#3  0x00041a66 in npl_pebble_mutex_pend (mu=mu@entry=0x200028f8 <ble_hs_mutex>, timeout=timeout@entry=4294967295) at ../third_party/nimble/port/src/npl_os_pebble.c:158
#4  0x0003eb9e in ble_npl_mutex_pend (mu=0x200028f8 <ble_hs_mutex>, timeout=4294967295) at ../third_party/nimble/port/include/nimble/nimble_npl_os.h:138
#5  0x000a5a0e in ble_hs_lock () at ../third_party/nimble/mynewt-nimble/nimble/host/src/ble_hs.c:203
#6  0x000a3b64 in ble_gap_conn_find_by_addr (addr=addr@entry=0x2000d034, out_desc=out_desc@entry=0x2000d03c) at ../third_party/nimble/mynewt-nimble/nimble/host/src/ble_gap.c:513
#7  0x0003bdf2 in pebble_device_to_nimble_conn_handle (device=0x20010040, handle=handle@entry=0x2000d086) at ../src/bluetooth-fw/nimble/nimble_type_conversions.c:44
#8  0x0003b5e6 in bt_driver_gatt_write (connection=<optimized out>, value=value@entry=0x2000d0f4 "\001", value_length=value_length@entry=2, att_handle=att_handle@entry=73, context=0x20010864) at ../src/bluetooth-fw/nimble/gatt_client_operations.c:83
#9  0x0009f9b6 in prv_write (obj_ref=obj_ref@entry=2684427208, value=value@entry=0x2000d0f4 "\001", value_length=value_length@entry=2, client=client@entry=GAPLEClientKernel, handle_getter=0x9f58b <gatt_client_descriptor_get_handle_and_connection>, subtype=subtype@entry=PebbleBLEGATTClientEventTypeCharacteristicSubscribe) at ../src/fw/comm/ble/gatt_client_operations.c:252
#10 0x00033bba in gatt_client_op_write_descriptor_cccd (cccd=cccd@entry=2684427208, value=value@entry=0x2000d0f4) at ../src/fw/comm/ble/gatt_client_operations.c:337
#11 0x00033cfc in prv_subscribe (characteristic_ref=characteristic_ref@entry=2684427143, subscription_type=<optimized out>, subscription_type@entry=BLESubscriptionNotifications, client=client@entry=GAPLEClientKernel, is_cleaning_up=is_cleaning_up@entry=false) at ../src/fw/comm/ble/gatt_client_subscriptions.c:660
#12 0x0009fa9e in gatt_client_subscriptions_subscribe (characteristic_ref=2684427143, subscription_type=subscription_type@entry=BLESubscriptionNotifications, client=client@entry=GAPLEClientKernel) at ../src/fw/comm/ble/gatt_client_subscriptions.c:717
#13 0x00036226 in prv_handle_meta_read (client=0x20010980, value=0x20010a2c "", value_length=19, error=BLEGATTErrorSuccess) at ../src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c:758
#14 ppogatt_handle_read_or_notification (characteristic=<optimized out>, value=0x20010a2c "", value_length=19, error=<optimized out>) at ../src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c:933
#15 0x0003595c in prv_consume_read_response (event=0x20002484 <e>, client=<optimized out>) at ../src/fw/comm/ble/kernel_le_client/kernel_le_client.c:365
#16 prv_handle_gatt_event (event=0x20002484 <e>) at ../src/fw/comm/ble/kernel_le_client/kernel_le_client.c:453
#17 kernel_le_client_handle_event (e=0x20002484 <e>) at ../src/fw/comm/ble/kernel_le_client/kernel_le_client.c:527
#18 0x0001dbb6 in prv_handle_event (e=0x20002484 <e>) at ../src/fw/kernel/event_loop.c:456
#19 0x0001dbfe in launcher_main_loop () at ../src/fw/kernel/event_loop.c:540
#20 0x00000000 in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

Thread 3 (process 536930640):
#0  xLightMutexLock (xMutex=xMutex@entry=0x2000e4c4, xTicksToWait=<optimized out>, xTicksToWait@entry=103079214) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/light_mutex.c:289
#1  0x0007d7b2 in xLightMutexLockRecursive (xMutex=0x2000e4c4, xTicksToWait=103079214) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/light_mutex.c:445
#2  0x0007bb76 in mutex_lock_recursive_with_timeout_and_lr (handle=0x2000e4e4, timeout_ms=timeout_ms@entry=4294967295, myLR=244381) at ../src/libos/mutex_freertos.c:154
#3  0x00036514 in bt_lock () at ../src/fw/comm/bt_lock.c:48
#4  0x0003ba9c in prv_nimble_store_write_cccd (value_cccd=0x20022600) at ../src/bluetooth-fw/nimble/nimble_store.c:342
#5  prv_nimble_store_write (obj_type=3, val=0x20022600) at ../src/bluetooth-fw/nimble/nimble_store.c:412
#6  0x000413b8 in ble_store_write (obj_type=<optimized out>, val=<optimized out>) at ../third_party/nimble/mynewt-nimble/nimble/host/src/ble_store.c:55
#7  ble_store_write (obj_type=3, val=0x20022600) at ../third_party/nimble/mynewt-nimble/nimble/host/src/ble_store.c:45
#8  0x000a572e in ble_gatts_clt_cfg_access (conn_handle=<optimized out>, attr_handle=<optimized out>, op=<optimized out>, offset=<optimized out>, om=0x200064dc <ble_l2cap_chan_mem+16>, arg=0x0) at ../third_party/nimble/mynewt-nimble/nimble/host/src/ble_gatts.c:784
#9  0x000a30cc in ble_att_svr_write (conn_handle=conn_handle@entry=1, entry=0x200211d4, om=om@entry=0x200064dc <ble_l2cap_chan_mem+16>, out_att_err=out_att_err@entry=0x2002266f "", offset=0) at ../third_party/nimble/mynewt-nimble/nimble/host/src/ble_att_svr.c:541
#10 0x000a3720 in ble_att_svr_write_handle (offset=0, conn_handle=1, attr_handle=<optimized out>, om=0x200064dc <ble_l2cap_chan_mem+16>, out_att_err=0x2002266f "") at ../third_party/nimble/mynewt-nimble/nimble/host/src/ble_att_svr.c:572
#11 ble_att_svr_rx_write (conn_handle=<optimized out>, cid=<optimized out>, rxom=0x200064dc <ble_l2cap_chan_mem+16>) at ../third_party/nimble/mynewt-nimble/nimble/host/src/ble_att_svr.c:2137
#12 0x0003c78e in ble_att_rx_extended (conn_handle=1, cid=4, om=0x200064dc <ble_l2cap_chan_mem+16>) at ../third_party/nimble/mynewt-nimble/nimble/host/src/ble_att.c:555
#13 ble_att_rx (chan=0x200064cc <ble_l2cap_chan_mem>) at ../third_party/nimble/mynewt-nimble/nimble/host/src/ble_att.c:576
#14 0x000a5ffc in ble_hs_hci_evt_acl_process (om=0x0) at ../third_party/nimble/mynewt-nimble/nimble/host/src/ble_hs_hci_evt.c:1151
#15 0x0003ebc0 in ble_hs_process_rx_data_queue () at ../third_party/nimble/mynewt-nimble/nimble/host/src/ble_hs.c:227
#16 0x00041630 in ble_npl_event_run (ev=<optimized out>) at ../third_party/nimble/port/include/nimble/nimble_npl_os.h:115
#17 nimble_port_run () at ../third_party/nimble/mynewt-nimble/porting/nimble/src/nimble_port.c:75
#18 0x00000000 in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

Thread 2 (process 536927656):
#0  xLightMutexLock (xMutex=xMutex@entry=0x2000e4c4, xTicksToWait=<optimized out>, xTicksToWait@entry=103079214) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/light_mutex.c:289
#1  0x0007d7b2 in xLightMutexLockRecursive (xMutex=0x2000e4c4, xTicksToWait=103079214) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/light_mutex.c:445
#2  0x0007bb76 in mutex_lock_recursive_with_timeout_and_lr (handle=0x2000e4e4, timeout_ms=timeout_ms@entry=4294967295, myLR=220323) at ../src/libos/mutex_freertos.c:154
#3  0x00036514 in bt_lock () at ../src/fw/comm/bt_lock.c:48
#4  0x00035ca2 in prv_timer_callback (unused=<optimized out>) at ../src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c:341
#5  0x00063880 in do_callbacks (list=list@entry=0x2000b098 <s_seconds_callbacks>) at ../src/fw/services/common/regular_timer.c:62
#6  0x000638f0 in timer_callback (data=<optimized out>) at ../src/fw/services/common/regular_timer.c:88
#7  0x0001f116 in task_timer_manager_execute_expired_timers (manager=manager@entry=0x2000b05c <s_task_timer_manager>) at ../src/fw/kernel/task_timer.c:336
#8  0x00062428 in new_timer_service_loop (data=<optimized out>) at ../src/fw/services/common/new_timer/new_timer.c:98
#9  0x00000000 in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

Thread 1 (process 536926316):
#0  0x00036770 in vPortSuppressTicksAndSleep (xExpectedIdleTime=<optimized out>) at ../src/fw/freertos_application.c:239
#1  0x0007e64a in prvIdleTask (pvParameters=<optimized out>) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/tasks.c:2771
#2  0x00000000 in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

=== CURRENT THREAD DETAILED BACKTRACE ===
#0  0x00036770 in vPortSuppressTicksAndSleep (xExpectedIdleTime=<optimized out>) at ../src/fw/freertos_application.c:239
No locals.
#1  0x0007e64a in prvIdleTask (pvParameters=<optimized out>) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/tasks.c:2771
        xExpectedIdleTime = <optimized out>
#2  0x00000000 in ?? ()
No symbol table info available.
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

=== REGISTER STATE ===
r0             0x3                 3
r1             0x0                 0
r2             0x4001e000          1073864704
r3             0x1                 1
r4             0xa5a5a5a5          2779096485
r5             0xa5a5a5a5          2779096485
r6             0xa5a5a5a5          2779096485
r7             0xa5a5a5a5          2779096485
r8             0xa5a5a5a5          2779096485
r9             0xa5a5a5a5          2779096485
r10            0xa5a5a5a5          2779096485
r11            0xa5a5a5a5          2779096485
r12            0xa5a5a5a5          2779096485
sp             0x20024fd8          0x20024fd8
lr             0x36761             223073
pc             0x36770             0x36770 <vPortSuppressTicksAndSleep+152>
cpsr           0x1000000           16777216
r0             0x3                 3
r1             0x0                 0
r2             0x4001e000          1073864704
r3             0x1                 1
r4             0xa5a5a5a5          2779096485
r5             0xa5a5a5a5          2779096485
r6             0xa5a5a5a5          2779096485
r7             0xa5a5a5a5          2779096485
r8             0xa5a5a5a5          2779096485
r9             0xa5a5a5a5          2779096485
r10            0xa5a5a5a5          2779096485
r11            0xa5a5a5a5          2779096485
r12            0xa5a5a5a5          2779096485
sp             0x20024fd8          0x20024fd8
lr             0x36761             223073
pc             0x36770             0x36770 <vPortSuppressTicksAndSleep+152>
f0             <unavailable>
f1             <unavailable>
f2             <unavailable>
f3             <unavailable>
f4             <unavailable>
f5             <unavailable>
f6             <unavailable>
f7             <unavailable>
fps            <unavailable>
cpsr           0x1000000           16777216

=== MEMORY MAPPINGS ===
Exec file: `/home/gmarull/Downloads/firmware_asterix_v4.9.9-core52.elf', file type elf32-littlearm.
 [0]      0x8000->0x8100 at 0x00001000: .isr_vector ALLOC LOAD READONLY DATA HAS_CONTENTS
 [1]      0x20000000->0x20000100 at 0x000f0000: .retained ALLOC LOAD DATA HAS_CONTENTS
 [2]      0x8100->0x8108 at 0x00001100: .ARM.exidx ALLOC LOAD READONLY DATA HAS_CONTENTS
 [3]      0x8110->0xf4e20 at 0x00001110: .text ALLOC LOAD READONLY CODE HAS_CONTENTS
 [4]      0x20028000->0x2003fa81 at 0x000f1000: .app_ram ALLOC
 [5]      0x20000100->0x20000d38 at 0x000ee100: .kernel_data ALLOC LOAD DATA HAS_CONTENTS
 [6]      0x20000d38->0x20001800 at 0x000efd38: .kernel_ro_bss ALLOC
 [7]      0x20001800->0x2000c570 at 0x000f0800: .kernel_bss ALLOC
 [8]      0x2000c570->0x2000c5b0 at 0x000f0570: .noinit.mflt_reboot_info ALLOC
 [9]      0x2000c5b0->0x2000c9c0 at 0x000f05b0: .stack ALLOC
 [10]     0x2000c9c0->0x2000d1c0 at 0x000f09c0: .kernel_main_stack ALLOC
 [11]     0x2000d1c0->0x2000d7c0 at 0x000f01c0: .kernel_bg_stack ALLOC
 [12]     0x2000d7c0->0x20025000 at 0x000f07c0: .kernel_heap ALLOC
 [13]     0xf5a58->0xf5a7c at 0x000efa58: .note.gnu.build-id ALLOC LOAD READONLY DATA HAS_CONTENTS
 [14]     0xf5a7c->0xf5aab at 0x000efa7c: .fw_version ALLOC LOAD READONLY DATA HAS_CONTENTS
 [15]     0xc0000000->0xc002655d at 0x000f0100: .log_strings READONLY HAS_CONTENTS
 [16]     0x0000->0x0045 at 0x0011665d: .comment READONLY HAS_CONTENTS
 [17]     0x0000->0x0030 at 0x001166a2: .ARM.attributes READONLY HAS_CONTENTS
 [18]     0x0000->0x1cea8 at 0x001166d8: .debug_aranges READONLY HAS_CONTENTS
 [19]     0x0000->0x88fe4d at 0x00133580: .debug_info READONLY HAS_CONTENTS
 [20]     0x0000->0xe14bf at 0x009c33cd: .debug_abbrev READONLY HAS_CONTENTS
 [21]     0x0000->0x3fb977 at 0x00aa488c: .debug_line READONLY HAS_CONTENTS
 [22]     0x0000->0x55fdc at 0x00ea0204: .debug_frame READONLY HAS_CONTENTS
 [23]     0x0000->0x1f0eb4 at 0x00ef61e0: .debug_str READONLY HAS_CONTENTS
 [24]     0x0000->0x25bac8 at 0x010e7094: .debug_loc READONLY HAS_CONTENTS
 [25]     0x0000->0x43d98 at 0x01342b5c: .debug_ranges READONLY HAS_CONTENTS
 [26]     0x0000->0x10f391 at 0x013868f4: .debug_macro READONLY HAS_CONTENTS
 [27]     0x0000->0x00ea at 0x01495c85: .debug_line_str READONLY HAS_CONTENTS
Core file: `/home/gmarull/ws/pebble/pebbleos/cd.elf', file type elf32-littlearm.
 [0]      0x0000->0x0ca4 at 0x0000004a: note0 HAS_CONTENTS
 [1]      0x0000->0x0048 at 0x0000011a: .reg/536926316 HAS_CONTENTS
 [2]      0x0000->0x0048 at 0x0000011a: .reg HAS_CONTENTS
 [3]      0x0000->0x0048 at 0x00000252: .reg/536927656 HAS_CONTENTS
 [4]      0x0000->0x0048 at 0x0000038a: .reg/536930640 HAS_CONTENTS
 [5]      0x0000->0x0048 at 0x000004c2: .reg/536926192 HAS_CONTENTS
 [6]      0x0000->0x0048 at 0x000005fa: .reg/536937048 HAS_CONTENTS
 [7]      0x0000->0x0048 at 0x00000732: .reg/536936160 HAS_CONTENTS
 [8]      0x0000->0x0048 at 0x0000086a: .reg/536926920 HAS_CONTENTS
 [9]      0x0000->0x0048 at 0x000009a2: .reg/536930764 HAS_CONTENTS
 [10]     0x0000->0x0048 at 0x00000ada: .reg/536937288 HAS_CONTENTS
 [11]     0x0000->0x0048 at 0x00000c12: .reg/1 HAS_CONTENTS
 [12]     0x20000000->0x20040000 at 0x00000cee: load1 ALLOC LOAD CODE HAS_CONTENTS
 [13]     0xe000e100->0xe000e120 at 0x00040cee: load2 ALLOC LOAD CODE HAS_CONTENTS
 [14]     0xe000e200->0xe000e220 at 0x00040d0e: load3 ALLOC LOAD CODE HAS_CONTENTS
 [15]     0xe000e300->0xe000e320 at 0x00040d2e: load4 ALLOC LOAD CODE HAS_CONTENTS

=== STACK EXAMINATION ===
0x20024fd8:	0x2000be54	0xa5a5a5a5	0x20000bac	0x0007e64b
0x20024fe8:	0xa5a5a5a5	0xa5a5a5a5	0xa5a5a5a5	0x00000000
0x20024ff8:	0xa5a5a5a5	0xa5a5a5a5	0xcd504ba7	0xd2df0970
0x20025008:	0xab38aae1	0x4657905b	0xeee6b31e	0xd54dcaf5
0x20025018:	0x56e77ec3	0x1daf0154	0xa5a5a5a5	0xa5a5a5a5
0x20025028:	0xa5a5a5a5	0xa5a5a5a5	0xa5a5a5a5	0xa5a5a5a5
0x20025038:	0xa5a5a5a5	0xa5a5a5a5	0xa5a5a5a5	0xa5a5a5a5
0x20025048:	0xa5a5a5a5	0xa5a5a5a5	0xa5a5a5a5	0xa5a5a5a5

=== LOCAL VARIABLES (CURRENT FRAME) ===
No locals.

=== FUNCTION ARGUMENTS (CURRENT FRAME) ===
xExpectedIdleTime = <optimized out>

=== SOURCE INFORMATION ===
Current source file is ../src/fw/freertos_application.c
Compilation directory is /__w/PebbleOS/PebbleOS/build
Source language is c.
Producer is GNU C11 14.2.1 20241119 -mthumb -mcpu=cortex-m4 -mfloat-abi=softfp -mfpu=fpv4-sp-d16 -march=armv7e-m+fp -g3 -gdwarf-4 -Os -std=c11 -fvar-tracking-assignments -ffreestanding -ffunction-sections -fbuiltin -fno-builtin-itoa.
Compiled with DWARF 4 debugging format.
Includes preprocessor macro info.
Line 239 of "../src/fw/freertos_application.c" is at address 0x367f8 <vApplicationStackOverflowHook> but contains no code.

=== DISASSEMBLY AROUND PC ===
   0x36748 <vPortSuppressTicksAndSleep+112>:	strd	r2, r1, [r4]
   0x3674c <vPortSuppressTicksAndSleep+116>:	ldrd	r2, r1, [r4, #8]
   0x36750 <vPortSuppressTicksAndSleep+120>:	adds	r2, r2, r3
   0x36752 <vPortSuppressTicksAndSleep+122>:	adc.w	r1, r1, #0
   0x36756 <vPortSuppressTicksAndSleep+126>:	strd	r2, r1, [r4, #8]
   0x3675a <vPortSuppressTicksAndSleep+130>:	movs	r0, #3
   0x3675c <vPortSuppressTicksAndSleep+132>:	bl	0x9684c <power_tracking_start>
   0x36760 <vPortSuppressTicksAndSleep+136>:	ldr	r2, [pc, #132]	@ (0x367e8 <vPortSuppressTicksAndSleep+272>)
   0x36762 <vPortSuppressTicksAndSleep+138>:	ldr.w	r3, [r2, #1344]	@ 0x540
   0x36766 <vPortSuppressTicksAndSleep+142>:	orr.w	r3, r3, #1
   0x3676a <vPortSuppressTicksAndSleep+146>:	str.w	r3, [r2, #1344]	@ 0x540
   0x3676e <vPortSuppressTicksAndSleep+150>:	cpsie	i
=> 0x36770 <vPortSuppressTicksAndSleep+152>:	pop	{r4, r5, r6, pc}
   0x36772 <vPortSuppressTicksAndSleep+154>:	bl	0x1fa58 <stop_mode_is_allowed>
   0x36776 <vPortSuppressTicksAndSleep+158>:	cmp	r0, #0
   0x36778 <vPortSuppressTicksAndSleep+160>:	beq.n	0x3670e <vPortSuppressTicksAndSleep+54>
   0x3677a <vPortSuppressTicksAndSleep+162>:	subs	r0, r5, #2
   0x3677c <vPortSuppressTicksAndSleep+164>:	mov.w	r3, #0
   0x36780 <vPortSuppressTicksAndSleep+168>:	movw	r2, #1025	@ 0x401
   0x36784 <vPortSuppressTicksAndSleep+172>:	adc.w	r1, r3, #4294967295	@ 0xffffffff

=== DETAILED FRAME INFO FOR ALL THREADS ===

Thread 10 (process 1):
#0  NMI_Handler () at ../src/fw/kernel/core_dump.c:537
warning: 537	../src/fw/kernel/core_dump.c: No such file or directory

Thread 9 (process 536937288):
#0  0x0007dcaa in xQueueGenericReceive (xQueue=0x200102d4, pvBuffer=pvBuffer@entry=0x0, xTicksToWait=<optimized out>, xTicksToWait@entry=4294967295, xJustPeeking=xJustPeeking@entry=0) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:1533
warning: 1533	../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c: No such file or directory

Thread 8 (process 536930764):
#0  0x0007dcaa in xQueueGenericReceive (xQueue=0x2000e6c4, pvBuffer=pvBuffer@entry=0x20021730, xTicksToWait=<optimized out>, xJustPeeking=0) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:1533
1533	in ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c

Thread 7 (process 536926920):
#0  0x0007dcaa in xQueueGenericReceive (xQueue=0x2000d9d8, pvBuffer=pvBuffer@entry=0x2000d78c, xTicksToWait=<optimized out>, xTicksToWait@entry=4294967295, xJustPeeking=xJustPeeking@entry=0) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:1533
1533	in ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c

Thread 6 (process 536936160):
#0  0x0007dcaa in xQueueGenericReceive (xQueue=0x20021264, pvBuffer=0x200287cc, xTicksToWait=<optimized out>, xJustPeeking=0) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:1533
1533	in ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c

Thread 5 (process 536937048):
#0  0x0007dcaa in xQueueGenericReceive (xQueue=0x2000f8e4, pvBuffer=0x20025534, xTicksToWait=<optimized out>, xJustPeeking=0) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:1533
1533	in ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c

Thread 4 (process 536926192):
#0  xLightMutexLock (xMutex=xMutex@entry=0x2000e924, xTicksToWait=<optimized out>, xTicksToWait@entry=4294967294) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/light_mutex.c:289
warning: 289	../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/light_mutex.c: No such file or directory

Thread 3 (process 536930640):
#0  xLightMutexLock (xMutex=xMutex@entry=0x2000e4c4, xTicksToWait=<optimized out>, xTicksToWait@entry=103079214) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/light_mutex.c:289
289	in ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/light_mutex.c

Thread 2 (process 536927656):
#0  xLightMutexLock (xMutex=xMutex@entry=0x2000e4c4, xTicksToWait=<optimized out>, xTicksToWait@entry=103079214) at ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/light_mutex.c:289
289	in ../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/light_mutex.c

Thread 1 (process 536926316):
#0  0x00036770 in vPortSuppressTicksAndSleep (xExpectedIdleTime=<optimized out>) at ../src/fw/freertos_application.c:239
warning: 239	../src/fw/freertos_application.c: No such file or directory

Thread 10 (process 1):
Stack level 0, frame at 0x2000c930:
 pc = 0x1cfc4 in NMI_Handler (../src/fw/kernel/core_dump.c:537); saved pc = 0xfffffff1
 called by frame at 0x2000c950
 source language c.
 Arglist at 0x2000c930, args: 
 Locals at 0x2000c930, Previous frame's sp is 0x2000c930

Thread 9 (process 536937288):
Stack level 0, frame at 0x2001fd38:
 pc = 0x7dcaa in xQueueGenericReceive (../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:1533); saved pc = 0x1b7b0
 called by frame at 0x2001fd70
 source language c.
 Arglist at 0x2001fd10, args: xQueue=0x200102d4, pvBuffer=pvBuffer@entry=0x0, xTicksToWait=<optimized out>, xTicksToWait@entry=4294967295, xJustPeeking=xJustPeeking@entry=0
 Locals at 0x2001fd10, Previous frame's sp is 0x2001fd38
 Saved registers:
  r4 at 0x2001fd20, r5 at 0x2001fd24, r6 at 0x2001fd28, r7 at 0x2001fd2c, r8 at 0x2001fd30, lr at 0x2001fd34

Thread 8 (process 536930764):
Stack level 0, frame at 0x20021730:
 pc = 0x7dcaa in xQueueGenericReceive (../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:1533); saved pc = 0x4189a
 called by frame at 0x20021740
 source language c.
 Arglist at 0x20021708, args: xQueue=0x2000e6c4, pvBuffer=pvBuffer@entry=0x20021730, xTicksToWait=<optimized out>, xJustPeeking=0
 Locals at 0x20021708, Previous frame's sp is 0x20021730
 Saved registers:
  r4 at 0x20021718, r5 at 0x2002171c, r6 at 0x20021720, r7 at 0x20021724, r8 at 0x20021728, lr at 0x2002172c

Thread 7 (process 536926920):
Stack level 0, frame at 0x2000d788:
 pc = 0x7dcaa in xQueueGenericReceive (../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:1533); saved pc = 0xc43fc
 called by frame at 0x2000d798
 source language c.
 Arglist at 0x2000d760, args: xQueue=0x2000d9d8, pvBuffer=pvBuffer@entry=0x2000d78c, xTicksToWait=<optimized out>, xTicksToWait@entry=4294967295, xJustPeeking=xJustPeeking@entry=0
 Locals at 0x2000d760, Previous frame's sp is 0x2000d788
 Saved registers:
  r4 at 0x2000d770, r5 at 0x2000d774, r6 at 0x2000d778, r7 at 0x2000d77c, r8 at 0x2000d780, lr at 0x2000d784

Thread 6 (process 536936160):
Stack level 0, frame at 0x200287c8:
 pc = 0x7dcaa in xQueueGenericReceive (../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:1533); saved pc = 0x4aeb0
 called by frame at 0x200287e8
 source language c.
 Arglist at 0x200287a0, args: xQueue=0x20021264, pvBuffer=0x200287cc, xTicksToWait=<optimized out>, xJustPeeking=0
 Locals at 0x200287a0, Previous frame's sp is 0x200287c8
 Saved registers:
  r4 at 0x200287b0, r5 at 0x200287b4, r6 at 0x200287b8, r7 at 0x200287bc, r8 at 0x200287c0, lr at 0x200287c4

Thread 5 (process 536937048):
Stack level 0, frame at 0x20025530:
 pc = 0x7dcaa in xQueueGenericReceive (../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/queue.c:1533); saved pc = 0x9887a
 called by frame at 0x20025530
 source language c.
 Arglist at 0x20025508, args: xQueue=0x2000f8e4, pvBuffer=0x20025534, xTicksToWait=<optimized out>, xJustPeeking=0
 Locals at 0x20025508, Previous frame's sp is 0x20025530
 Saved registers:
  r4 at 0x20025518, r5 at 0x2002551c, r6 at 0x20025520, r7 at 0x20025524, r8 at 0x20025528, lr at 0x2002552c

Thread 4 (process 536926192):
Stack level 0, frame at 0x2000cfe8:
 pc = 0x7d720 in xLightMutexLock (../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/light_mutex.c:289); saved pc = 0x7d7b2
 called by frame at 0x2000cff8
 source language c.
 Arglist at 0x2000cfc8, args: xMutex=xMutex@entry=0x2000e924, xTicksToWait=<optimized out>, xTicksToWait@entry=4294967294
 Locals at 0x2000cfc8, Previous frame's sp is 0x2000cfe8
 Saved registers:
  r4 at 0x2000cfd8, r5 at 0x2000cfdc, r6 at 0x2000cfe0, lr at 0x2000cfe4

Thread 3 (process 536930640):
Stack level 0, frame at 0x200224d0:
 pc = 0x7d720 in xLightMutexLock (../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/light_mutex.c:289); saved pc = 0x7d7b2
 called by frame at 0x200224e0
 source language c.
 Arglist at 0x200224b0, args: xMutex=xMutex@entry=0x2000e4c4, xTicksToWait=<optimized out>, xTicksToWait@entry=103079214
 Locals at 0x200224b0, Previous frame's sp is 0x200224d0
 Saved registers:
  r4 at 0x200224c0, r5 at 0x200224c4, r6 at 0x200224c8, lr at 0x200224cc

Thread 2 (process 536927656):
Stack level 0, frame at 0x200246f8:
 pc = 0x7d720 in xLightMutexLock (../third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/light_mutex.c:289); saved pc = 0x7d7b2
 called by frame at 0x20024708
 source language c.
 Arglist at 0x200246d8, args: xMutex=xMutex@entry=0x2000e4c4, xTicksToWait=<optimized out>, xTicksToWait@entry=103079214
 Locals at 0x200246d8, Previous frame's sp is 0x200246f8
 Saved registers:
  r4 at 0x200246e8, r5 at 0x200246ec, r6 at 0x200246f0, lr at 0x200246f4

Thread 1 (process 536926316):
Stack level 0, frame at 0x20024fe8:
 pc = 0x36770 in vPortSuppressTicksAndSleep (../src/fw/freertos_application.c:239); saved pc = 0x7e64a
 called by frame at 0x20024ff8
 source language c.
 Arglist at 0x20024fd8, args: xExpectedIdleTime=<optimized out>
 Locals at 0x20024fd8, Previous frame's sp is 0x20024fe8
 Saved registers:
  r4 at 0x20024fd8, r5 at 0x20024fdc, r6 at 0x20024fe0, lr at 0x20024fe4
```