### PR TITLE
Revert "fw/stop: enable sf32lb52 deepsleep mode"

### DIFF
--- a/src/fw/drivers/sf32lb52/lptim_systick.c
+++ b/src/fw/drivers/sf32lb52/lptim_systick.c
@@ -148,6 +148,4 @@ void AON_IRQHandler(void)
 {
   NVIC_DisableIRQ(AON_IRQn);
   HAL_HPAON_CLEAR_POWER_MODE();
-
-  HAL_HPAON_CLEAR_WSR(0);
 }

--- a/src/fw/freertos_application.c
+++ b/src/fw/freertos_application.c
@@ -33,10 +33,6 @@
 #include "system/logging.h"
 #include "util/math.h"
 
-#if defined(MICRO_FAMILY_SF32LB52)
-#include <ipc_queue.h>
-#endif
-
 #define STM32F2_COMPATIBLE
 #define STM32F4_COMPATIBLE
 #define STM32F7_COMPATIBLE
@@ -84,9 +80,9 @@ static const RtcTicks EARLY_WAKEUP_TICKS = 2;
 static const RtcTicks MIN_STOP_TICKS = 5;
 #elif defined(MICRO_FAMILY_SF32LB52)
 //! Stop mode until this number of ticks before the next scheduled task
-static const RtcTicks EARLY_WAKEUP_TICKS = 10; // relative large to avid tasks.c:1960 assert
+static const RtcTicks EARLY_WAKEUP_TICKS = 2;
 //! Stop mode until this number of ticks before the next scheduled task
-static const RtcTicks MIN_STOP_TICKS = 15;
+static const RtcTicks MIN_STOP_TICKS = 0xFFFFFFFF; // disable stop mode for now
 #else
 #error "Unknown micro family"
 #endif
@@ -103,9 +99,7 @@ extern void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime ) {
     return;
   }
 #else
-  if (!lptim_systick_is_initialized() || !sleep_mode_is_allowed() ||
-      !ipc_queue_check_idle()) {
-    // To avoid LCPU enter incorrect state, make sure ipc queue is empty before enter stop mode.
+  if (!lptim_systick_is_initialized() || !sleep_mode_is_allowed()) {
     return;
   }
 #endif

--- a/src/fw/kernel/util/stop.c
+++ b/src/fw/kernel/util/stop.c
@@ -125,20 +125,19 @@ void enter_stop_mode(void) {
   HAL_RCC_HCPU_DisableDLL1();
   HAL_RCC_HCPU_DisableDLL2();
 
+  // HAL_HPAON_DISABLE_PAD();
+  // HAL_HPAON_DISABLE_VHP();
+
   HAL_HPAON_CLEAR_HP_ACTIVE();
   HAL_HPAON_SET_POWER_MODE(AON_PMR_DEEP_SLEEP);
 
-  __WFI();
-  __NOP();
-  __NOP();
-  __NOP();
-  __NOP();
-  __NOP();
-  __NOP();
-  __NOP();
-  __NOP();
-  __NOP();
-  __NOP();
+  // Go stop now.
+  __DSB(); // Drain any pending memory writes before entering sleep.
+  do_wfi(); // Wait for Interrupt (enter sleep mode). Work around F2/F4 errata.
+  __ISB(); // Let the pipeline catch up (force the WFI to activate before moving on).
+
+  // HAL_HPAON_ENABLE_PAD();
+  // HAL_HPAON_ENABLE_VHP();
 
   HAL_HPAON_SET_HP_ACTIVE();
   HAL_HPAON_CLEAR_POWER_MODE();


### PR DESCRIPTION
This reverts commit 236a87acf984ecdc5976a9d083f02faf2c4a2e6d.

It turns out using stop mode with deepsleep makes BLE unusable. See #288 