### PR TITLE
lsm6dso: tighten watchdog, simplify recovery, and quiet down logs

### DIFF
--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -126,7 +126,7 @@ static RegularTimerInfo s_interrupt_watchdog_timer = {
 // Error recovery thresholds and watchdog timeouts
 #define LSM6DSO_MAX_CONSECUTIVE_FAILURES 3
 #define LSM6DSO_INTERRUPT_GAP_LOG_THRESHOLD_MS 3000
-#define LSM6DSO_INTERRUPT_WATCHDOG_TIMEOUT_MS 90000  // 90 seconds
+#define LSM6DSO_INTERRUPT_WATCHDOG_TIMEOUT_MS 30000  // 30 seconds
 
 // LSM6DSO configuration entrypoints
 

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -887,13 +887,13 @@ static bool prv_lsm6dso_force_reinit(void) {
 }
 
 static void prv_lsm6dso_interrupt_watchdog_callback(void *data) {
-  PBL_LOG(LOG_LEVEL_INFO, "LSM6DSO: Watchdog callback running");
+  PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Watchdog callback running");
   
   // Check if interrupts have stopped for too long
   const uint64_t now_ms = prv_get_timestamp_ms();
   const uint64_t interrupt_age_ms = prv_compute_age_ms(now_ms, s_last_interrupt_ms);
   
-  PBL_LOG(LOG_LEVEL_INFO, "LSM6DSO: Interrupt age: %lu ms, last interrupt: %lu ms, now: %lu ms",
+  PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Interrupt age: %lu ms, last interrupt: %lu ms, now: %lu ms",
           (unsigned long)interrupt_age_ms, (unsigned long)s_last_interrupt_ms, (unsigned long)now_ms);
   
   if (interrupt_age_ms >= LSM6DSO_INTERRUPT_WATCHDOG_TIMEOUT_MS) {


### PR DESCRIPTION
With core56 we finally achieved that the accel *really really* automatically recovers
The problem is though that there was a gap of a few minutes where the accel locks up and we dont recover!

So now, we force reinit every time, shorten the watchdog to 30 seconds and also quiet down logs since until now we would have every single watchdog run even if we dont try to recover anything!