### PR TITLE
third_party/memfault: wire up legacy Pebble analytics to memfault

### DIFF
--- a/src/fw/services/normal/analytics/analytics.c
+++ b/src/fw/services/normal/analytics/analytics.c
@@ -34,6 +34,10 @@
 #include "services/common/analytics/analytics_logging.h"
 #include "services/common/analytics/analytics_external.h"
 
+#if MEMFAULT
+#include "memfault_metrics_entry.h"
+#endif
+
 // Stopwatches
 typedef struct {
   ListNode node;
@@ -47,6 +51,10 @@ static ListNode *s_stopwatch_list = NULL;
 static bool prv_is_stopwatch_for_metric(ListNode *found_node, void *data);
 
 void analytics_init(void) {
+#if MEMFAULT
+  // This must be called before any metrics fire
+  memfault_platform_boot_early();
+#endif
   analytics_metric_init();
   analytics_storage_init();
   analytics_logging_init();

--- a/src/fw/services/normal/analytics/analytics_heartbeat.c
+++ b/src/fw/services/normal/analytics/analytics_heartbeat.c
@@ -135,9 +135,21 @@ static int64_t prv_location_get_value(uint8_t *location, AnalyticsMetricElementT
 
 //////////
 // Set
+
+#if MEMFAULT
+#include "memfault_metrics_entry.h"
+#endif
+
 void analytics_heartbeat_set(AnalyticsHeartbeat *heartbeat, AnalyticsMetric metric, int64_t val) {
   uint8_t *location = prv_heartbeat_get_location(heartbeat, metric);
   prv_location_set_value(location, val, analytics_metric_element_type(metric));
+
+#if MEMFAULT
+  if (heartbeat->kind == ANALYTICS_HEARTBEAT_KIND_DEVICE) {
+    memfault_metric_set_device_from_pebble_analytics(metric, val);
+  }
+#endif
+
 }
 
 void analytics_heartbeat_set_array(AnalyticsHeartbeat *heartbeat, AnalyticsMetric metric, uint32_t index, int64_t val) {

--- a/third_party/memfault/port/include/memfault_metrics_heartbeat_config.def
+++ b/third_party/memfault/port/include/memfault_metrics_heartbeat_config.def
@@ -27,3 +27,30 @@ MEMFAULT_METRICS_KEY_DEFINE(accel_lsm6dso_double_tap_events, kMemfaultMetricType
 // just gone out to lunch and the user didn't ask for that at all
 // (FIRM-425).
 MEMFAULT_METRICS_KEY_DEFINE(firm_425_back_button_long_presses_cancelled, kMemfaultMetricType_Unsigned)
+
+///// Import old legacy PebbleOS metrics into Memfault. /////
+
+// exports: #define ANALYTICS_METRIC_TABLE(MARKER, DEVICE, APP, UINT8, UINT16, UINT32, INT8, INT16, INT32)
+#include "services/common/analytics/analytics_metric_table.h"
+
+#define ENTRY1(name) // no memfault metric for name without type
+#define ENTRY2(name, element_type) MEMFAULT_METRICS_KEY_DEFINE(name, element_type)
+#define ENTRY3(name, element_type, num_elements) // no memfault metric for array
+
+#define GET_MACRO(_1, _2, _3, NAME, ...) NAME
+#define ENTRY(...) GET_MACRO(__VA_ARGS__, ENTRY3, ENTRY2, ENTRY1)(__VA_ARGS__)
+
+// We don't support Memfault metrics for per-app launch yet -- that would be
+// a 'session' analytic, whenever we're ready for that.
+#define NOOP(...)
+
+ANALYTICS_METRIC_TABLE(ENTRY /* marker */, ENTRY /* system */, NOOP /* app */,
+  kMemfaultMetricType_Unsigned, kMemfaultMetricType_Unsigned, kMemfaultMetricType_Unsigned,
+  kMemfaultMetricType_Signed, kMemfaultMetricType_Signed, kMemfaultMetricType_Signed)
+
+#undef ENTRY
+#undef GET_MACRO
+#undef ENTRY1
+#undef ENTRY2
+#undef ENTRY3
+#undef NOOP

--- a/third_party/memfault/port/src/memfault_platform_metrics.c
+++ b/third_party/memfault/port/src/memfault_platform_metrics.c
@@ -5,6 +5,38 @@
 #include "drivers/imu/lsm6dso/lsm6dso.h"
 #include "services/common/battery/battery_state.h"
 #include "util/heap.h"
+#include "services/common/analytics/analytics_metric_table.h"
+#include "services/common/analytics/analytics_external.h"
+
+void memfault_metric_set_device_from_pebble_analytics(AnalyticsMetric metric, int64_t val) {
+
+#define ENTRY1(name) // no memfault metric for name without type
+#define ENTRY2(name, element_type) case name: element_type(name, val); break;
+#define ENTRY3(name, element_type, num_elements) // no memfault metric for array
+
+#define GET_MACRO(_1, _2, _3, NAME, ...) NAME
+#define ENTRY(...) GET_MACRO(__VA_ARGS__, ENTRY3, ENTRY2, ENTRY1)(__VA_ARGS__)
+
+// We don't support Memfault metrics for per-app launch yet -- that would be
+// a 'session' analytic, whenever we're ready for that.
+#define NOOP(...)
+
+  switch (metric) {
+    ANALYTICS_METRIC_TABLE(ENTRY /* marker */, ENTRY /* system */, NOOP /* app */,
+      MEMFAULT_METRIC_SET_UNSIGNED, MEMFAULT_METRIC_SET_UNSIGNED, MEMFAULT_METRIC_SET_UNSIGNED,
+      MEMFAULT_METRIC_SET_SIGNED, MEMFAULT_METRIC_SET_SIGNED, MEMFAULT_METRIC_SET_SIGNED);
+    default:
+      break; /* it is a metric type we don't export to Memfault -- oh, well */
+  }
+
+#undef ENTRY
+#undef GET_MACRO
+#undef ENTRY1
+#undef ENTRY2
+#undef ENTRY3
+#undef NOOP
+
+}
 
 int memfault_platform_get_stateofcharge(sMfltPlatformBatterySoc *soc) {
   BatteryChargeState chargestate = battery_get_charge_state();
@@ -17,8 +49,7 @@ int memfault_platform_get_stateofcharge(sMfltPlatformBatterySoc *soc) {
   return 0;
 }
 
-// Record some few sample metrics. FIXME: Memfault should instead capture the
-// analytics system metric data directly
+// Record some metrics.
 void memfault_metrics_heartbeat_collect_data(void) {
   // battery_state_get_voltage() actually returns the voltage in millivolts,
   // which is the unit for the battery_v metric as recorded on device.
@@ -58,4 +89,6 @@ void memfault_metrics_heartbeat_collect_data(void) {
 
   extern uint32_t metric_firm_425_back_button_long_presses_cancelled;
   MEMFAULT_METRIC_SET_UNSIGNED(firm_425_back_button_long_presses_cancelled, metric_firm_425_back_button_long_presses_cancelled);
+
+  analytics_external_update();
 }

--- a/third_party/memfault/port/src/memfault_platform_port.c
+++ b/third_party/memfault/port/src/memfault_platform_port.c
@@ -131,11 +131,16 @@ void memfault_unlock(void) {
   mutex_unlock_recursive(s_memfault_lock);
 }
 
-int memfault_platform_boot(void) {
+// We can't write to flash or read from flash yet (including for serial
+// numbers!), but we do at least want to be able to log metrics ASAP.
+void memfault_platform_boot_early(void) {
   s_memfault_lock = mutex_create_recursive();
 
   memfault_platform_reboot_tracking_boot();
+}
 
+int memfault_platform_boot(void) {
+  // Tracing requires being able to read flash, so don't do that in early boot!
   static uint8_t s_event_storage[1024];
   const sMemfaultEventStorageImpl *evt_storage =
     memfault_events_storage_boot(s_event_storage, sizeof(s_event_storage));

--- a/third_party/memfault/port/src/memfault_platform_port.c
+++ b/third_party/memfault/port/src/memfault_platform_port.c
@@ -49,9 +49,20 @@ void memfault_platform_get_device_info(sMemfaultDeviceInfo *info) {
 }
 
 void memfault_platform_log(eMemfaultPlatformLogLevel level, const char *fmt, ...) {
-#if 1
+  // Logging can be reentrant into memfault (i.e., logging can call into
+  // memfault because there is a flash write).  This could cause a deadlock
+  // if someone holds the flash lock and increments an analytic while
+  // memfault is otherwise logging (and holds the memfault lock and waits
+  // for the flash lock).  Memfault logs must all be logged at higher than
+  // FLASH_LOG_LEVEL.
+# if FLASH_LOG_LEVEL >= LOG_LEVEL_DEBUG
+#   warning memfault logging cannot be used if debug messages are logged to flash
+    return;
+# endif
+
   va_list args;
   va_start(args, fmt);
+
 
   if (level >= s_min_log_level) {
     // If needed, additional data could be emitted in the log line (timestamp,
@@ -61,13 +72,13 @@ void memfault_platform_log(eMemfaultPlatformLogLevel level, const char *fmt, ...
         pbl_log_vargs(LOG_LEVEL_DEBUG, __FILE__, __LINE__, fmt, args);
         break;
       case kMemfaultPlatformLogLevel_Info:
-        pbl_log_vargs(LOG_LEVEL_INFO, __FILE__, __LINE__, fmt, args);
+        pbl_log_vargs(LOG_LEVEL_DEBUG, __FILE__, __LINE__, fmt, args);
         break;
       case kMemfaultPlatformLogLevel_Warning:
-        pbl_log_vargs(LOG_LEVEL_WARNING, __FILE__, __LINE__, fmt, args);
+        pbl_log_vargs(LOG_LEVEL_DEBUG, __FILE__, __LINE__, fmt, args);
         break;
       case kMemfaultPlatformLogLevel_Error:
-        pbl_log_vargs(LOG_LEVEL_ERROR, __FILE__, __LINE__, fmt, args);
+        pbl_log_vargs(LOG_LEVEL_DEBUG, __FILE__, __LINE__, fmt, args);
         break;
       default:
         break;
@@ -75,16 +86,19 @@ void memfault_platform_log(eMemfaultPlatformLogLevel level, const char *fmt, ...
   }
 
   va_end(args);
-#endif
 }
 
 void memfault_platform_log_raw(const char *fmt, ...) {
+# if FLASH_LOG_LEVEL >= LOG_LEVEL_DEBUG
+    return;
+# endif
+
   char log_buf[MEMFAULT_DEBUG_LOG_BUFFER_SIZE_BYTES];
   va_list args;
   va_start(args, fmt);
 
   vsnprintf(log_buf, sizeof(log_buf), fmt, args);
-  printf("%s\n", log_buf);
+  PBL_LOG(LOG_LEVEL_DEBUG, "%s", log_buf);
 
   va_end(args);
 }


### PR DESCRIPTION
We mechanically transform Pebble's legacy analytics IDs (used with the `analytics_` API) into Memfault analytics IDs.  Since we are now incrementing Memfault analytics in many more places, we resolve a few deadlocks associated with being able to call Memfault from many more places in PebbleOS.