### PR TITLE
fw/shell: Add ambient light threshold settings [FIRM-554]

### DIFF
--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -8,6 +8,7 @@
   PREFS_MACRO(PREF_KEY_BACKLIGHT_TIMEOUT_MS, s_backlight_timeout_ms)
   PREFS_MACRO(PREF_KEY_BACKLIGHT_INTENSITY, s_backlight_intensity)
   PREFS_MACRO(PREF_KEY_BACKLIGHT_MOTION, s_backlight_motion_enabled)
+  PREFS_MACRO(PREF_KEY_BACKLIGHT_AMBIENT_THRESHOLD, s_backlight_ambient_threshold)
   PREFS_MACRO(PREF_KEY_STATIONARY, s_stationary_mode_enabled)
   PREFS_MACRO(PREF_KEY_DEFAULT_WORKER, s_default_worker)
   PREFS_MACRO(PREF_KEY_TEXT_STYLE, s_text_style)

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -89,6 +89,10 @@ void backlight_set_intensity_percent(uint8_t intensity_percent);
 bool backlight_is_motion_enabled(void);
 void backlight_set_motion_enabled(bool enable);
 
+// The backlight ambient light threshold setting
+uint32_t backlight_get_ambient_threshold(void);
+void backlight_set_ambient_threshold(uint32_t threshold);
+
 // Stationary mode will put the watch in a low power state. Disabling will
 // prevent the watch from turning off any features.
 bool shell_prefs_get_stationary_enabled(void);


### PR DESCRIPTION
This pull request adds a user-facing setting to adjust the ambient light sensor (ALS) threshold for the backlight, allowing users to control the light level at which the backlight turns on. The implementation includes UI integration in the display settings, persistent storage of the threshold, and updates to the ambient light driver. 