### PR TITLE
fw/imu/lsm6dso: update interrupt watchdog timeout to 10 seconds and adjust failure threshold

### DIFF
--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -126,7 +126,8 @@ static RegularTimerInfo s_interrupt_watchdog_timer = {
 // Error recovery thresholds and watchdog timeouts
 #define LSM6DSO_MAX_CONSECUTIVE_FAILURES 3
 #define LSM6DSO_INTERRUPT_GAP_LOG_THRESHOLD_MS 3000
-#define LSM6DSO_INTERRUPT_WATCHDOG_TIMEOUT_MS 9950  // slightly below 10 seconds
+#define LSM6DSO_INTERRUPT_WATCHDOG_MS 10000 //run watchdog every 10 seconds
+#define LSM6DSO_INTERRUPT_WATCHDOG_TIMEOUT_MS 5000  // but count as failure if no interrupt in 5 seconds
 
 // LSM6DSO configuration entrypoints
 
@@ -401,7 +402,7 @@ static void prv_lsm6dso_chase_target_state(void) {
     update_interrupts = true;
     // Start the interrupt watchdog when sensor starts running
     regular_timer_add_multisecond_callback(&s_interrupt_watchdog_timer, 
-                            (LSM6DSO_INTERRUPT_WATCHDOG_TIMEOUT_MS + 50) / 1000);
+                                  LSM6DSO_INTERRUPT_WATCHDOG_MS / 1000);
   }
 
   // Update number of samples


### PR DESCRIPTION
This pull request adjusts the interrupt watchdog logic for the LSM6DSO IMU driver to improve reliability and clarify timing behavior. The main changes involve separating the watchdog's check interval from its timeout threshold, ensuring the watchdog runs every 10 seconds but only triggers a failure if no interrupt is seen within the last 5 seconds.