### PR TITLE
wscript: fix openocd configuration generation

### DIFF
--- a/wscript
+++ b/wscript
@@ -539,7 +539,7 @@ def configure(conf):
 
     conf.recurse('bin/boot')
 
-    if conf.options.runner == 'openocd':
+    if conf.env.RUNNER == 'openocd':
         waftools.openocd.write_cfg(conf)
 
     # Save a baseline environment that we'll use for unit tests


### PR DESCRIPTION
It was not generated now. Nobody noticed because 'openocd.cfg' stays at the root of the repo and is almost never touched...