### PR TITLE
Misc LSM6DSO accelerometer fixes

### DIFF
--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -128,6 +128,7 @@ static RegularTimerInfo s_interrupt_watchdog_timer = {
 #define LSM6DSO_INTERRUPT_GAP_LOG_THRESHOLD_MS 3000
 #define LSM6DSO_INTERRUPT_WATCHDOG_MS 10000 //run watchdog every 10 seconds
 #define LSM6DSO_INTERRUPT_WATCHDOG_TIMEOUT_MS 5000  // but count as failure if no interrupt in 5 seconds
+#define LSM6DSO_INTERRUPT_WATCHDOG_MS_NO_SAMPLES 600000 //if no samples are requested, every 10 minutes is fine
 
 // LSM6DSO configuration entrypoints
 
@@ -896,8 +897,8 @@ static void prv_lsm6dso_interrupt_watchdog_callback(void *data) {
   
   PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Interrupt age: %lu ms, last interrupt: %lu ms, now: %lu ms",
           (unsigned long)interrupt_age_ms, (unsigned long)s_last_interrupt_ms, (unsigned long)now_ms);
-  
-  if (interrupt_age_ms >= LSM6DSO_INTERRUPT_WATCHDOG_TIMEOUT_MS) {
+
+  if ((interrupt_age_ms >= LSM6DSO_INTERRUPT_WATCHDOG_TIMEOUT_MS && s_lsm6dso_state.num_samples > 0) || (interrupt_age_ms >= LSM6DSO_INTERRUPT_WATCHDOG_MS_NO_SAMPLES && s_lsm6dso_state.num_samples == 0)) {
     PBL_LOG(LOG_LEVEL_WARNING,
             "LSM6DSO: Interrupt watchdog triggered - no interrupts for %lu ms, count=%lu; forcing reinit",
             (unsigned long)interrupt_age_ms, (unsigned long)s_interrupt_count);

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -866,6 +866,9 @@ static bool prv_is_vibing(void) {
 static bool prv_lsm6dso_force_reinit(void) {
   PBL_LOG(LOG_LEVEL_WARNING, "LSM6DSO: Performing forced sensor reinitialization");
 
+  // Stop the watchdog timer before clearing state to prevent double-registration
+  regular_timer_remove_callback(&s_interrupt_watchdog_timer);
+
   // Prevent spurious edges while the device is reconfigured
   exti_disable(BOARD_CONFIG_ACCEL.accel_ints[0]);
 


### PR DESCRIPTION
Two small fixes for the LSM6DSO driver's watchdog logic:

### Fix watchdog condition check during sample handling
The watchdog was force re-initing every 10 seconds, even when samples are not actively being requested!

### Fix watchdog timer double-registration during forced reinit
The watchdog timer wasn't being removed before `prv_lsm6dso_force_reinit()` reset state and called `prv_lsm6dso_chase_target_state()`. Since `chase_target_state()` adds the timer when transitioning `s_lsm6dso_running` from false→true, this created duplicate timers or confused the timer system.
This explains field reports where the sensor took 15-30 seconds of shaking to recover, and log messages showing "no interrupts for 12922 ms" when the watchdog should fire every 10 seconds. The timer just... wasn't firing on schedule. Now it will actually run every 10 seconds like it's supposed to.