### PR TITLE
fw/apps/settings_display: actually fix backlight option

### DIFF
--- a/src/fw/apps/system_apps/settings/settings_display.c
+++ b/src/fw/apps/system_apps/settings/settings_display.c
@@ -265,7 +265,7 @@ enum SettingsDisplayItem {
 
 // number of items under SettingsDisplayBacklightMode which are hidden when backlight is disabled
 static const int NUM_BACKLIGHT_SUB_ITEMS = CLIP(SettingsDisplayBacklightTimeout -
-                                           SettingsDisplayBacklightMode, 0, NumSettingsDisplayItems);
+                                           SettingsDisplayBacklightMode - 1, 0, NumSettingsDisplayItems);
 
 static bool prv_should_show_backlight_sub_items() {
   return backlight_is_enabled();


### PR DESCRIPTION
Actually fixes "Backlight" toggle hiding itself in display settings from #329 
With all the git actions I missed the -1 that actually fixes the problem and just added the clip

### Problem

When toggling the "Backlight" option off in the display settings screen it would disappear, preventing the user from turning the backlight back on
### Solution

Changed the number of backlight sub items count to only take into account the sub items and not the main backlight setting too

