### PR TITLE
third_party/memfault: fix MEMFAULT define not being set globally

### DIFF
--- a/third_party/memfault/wscript
+++ b/third_party/memfault/wscript
@@ -12,18 +12,22 @@ def configure(conf):
         conf.env.memfault = int(conf.options.release and (conf.is_asterix() or conf.is_obelix()))
     else:
         conf.env.memfault = int(conf.env.memfault)
+    # FIXME(OBELIX): see GH-309 - disable memfault for Obelix PRF builds
+    if conf.is_obelix() and conf.variant == "prf":
+        conf.env.memfault = 0
+
+    # Set MEMFAULT define for all builds (will be 0 for Obelix PRF)
+    MEMFAULT = conf.env.memfault
+    conf.env.append_value("DEFINES", [f"MEMFAULT={MEMFAULT}"])
 
 
 def build(bld):
-    if not bld.env.memfault:
+    # FIXME(OBELIX): see GH-309 - disable memfault library build for Obelix PRF
+    if bld.is_obelix() and bld.variant == "prf":
         return
 
-    # FIXME(OBELIX): see GH-309
-    if bld.is_obelix() and bld.variant == "prf":
-        bld.env.memfault = 0
+    if not bld.env.memfault:
         return
-    
-    bld.env.append_value("DEFINES", [f"MEMFAULT={bld.env.memfault}"])
 
     memfault_includes = [
         "memfault-firmware-sdk/",


### PR DESCRIPTION
The MEMFAULT preprocessor define was moved to the build function in b7a08564, which meant it was only set in the local memfault build context and not propagated to firmware sources. This caused all `#if MEMFAULT` checks in src/fw/ to evaluate as undefined/false, breaking memfault metrics collection for release builds.

Move the define back to configure() so it's set globally for all build targets, while keeping the Obelix PRF library build disabled.