### PR TITLE
fw/console/dbserial: stub on release builds

### DIFF
--- a/src/fw/console/dbgserial.c
+++ b/src/fw/console/dbgserial.c
@@ -30,6 +30,7 @@
 #endif
 
 
+#ifndef RELEASE
 void dbgserial_init(void) {
   uart_init(DBG_UART);
   dbgserial_restore_baud_rate();
@@ -73,3 +74,28 @@ void dbgserial_putstr_fmt(char* buffer, unsigned int buffer_size, const char* fm
 
   dbgserial_putstr(buffer);
 }
+#else
+void dbgserial_init(void) {
+}
+
+void dbgserial_change_baud_rate(uint32_t new_baud) {
+}
+
+void dbgserial_restore_baud_rate(void) {
+}
+
+void dbgserial_putstr(const char* str) {
+}
+
+void dbgserial_putchar(uint8_t c) {
+}
+
+void dbgserial_putchar_lazy(uint8_t c) {
+}
+
+void dbgserial_flush(void) {
+}
+
+void dbgserial_putstr_fmt(char* buffer, unsigned int buffer_size, const char* fmt, ...) {
+}
+#endif

--- a/src/fw/console/dbgserial_input.c
+++ b/src/fw/console/dbgserial_input.c
@@ -30,6 +30,8 @@
 
 #include "drivers/gpio.h"
 
+#ifndef RELEASE
+
 #define STOP_MODE_TIMEOUT_MS (2000)
 
 static void dbgserial_interrupt_handler(bool *should_context_switch);
@@ -145,4 +147,20 @@ void dbgserial_enable_rx_dma_after_stop() {
   }
 }
 
+#endif
+
+#else
+void dbgserial_input_init(void) {}
+
+void dbgserial_enable_rx_exti(void) {}
+
+void dbgserial_register_character_callback(DbgSerialCharacterCallback callback) {}
+
+void dbgserial_set_rx_dma_enabled(bool enabled) {}
+
+#if MICRO_FAMILY_NRF5
+void dbgserial_disable_rx_dma_before_stop() {}
+
+void dbgserial_enable_rx_dma_after_stop() {}
+#endif
 #endif


### PR DESCRIPTION
While stuff like UART RX (the power hungry part) is disabled until there's no activity on RX pin, TX still happens. On release builds (meant for sealed watches) this means we're wasting cycles for nothing by transmitting stuff to a UART pin that is floating in the air. Now that firmware is open source, one can always build and flash a non-release build.