### PR TITLE
fw/pfs: fix crash when removing file that's in use

### DIFF
--- a/src/fw/services/normal/blob_db/timeline_item_storage.c
+++ b/src/fw/services/normal/blob_db/timeline_item_storage.c
@@ -249,8 +249,18 @@ void timeline_item_storage_init(TimelineItemStorage *storage,
   };
   status_t rv = settings_file_open(&storage->file, storage->name, storage->max_size);
   if (FAILED(rv)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Unable to create settings file %s, rv = %"PRId32 "!",
-            filename, rv);
+    if (rv == E_INVALID_OPERATION) {
+      // File has invalid format (wrong magic or version), remove it and recreate
+      PBL_LOG(LOG_LEVEL_WARNING, "Timeline storage file %s is invalid, removing and recreating",
+              filename);
+      pfs_remove(filename);
+      // Try to open again to create a fresh file
+      rv = settings_file_open(&storage->file, storage->name, storage->max_size);
+    }
+    if (FAILED(rv)) {
+      PBL_LOG(LOG_LEVEL_ERROR, "Unable to create settings file %s, rv = %"PRId32 "!",
+              filename, rv);
+    }
   }
 }
 

--- a/src/fw/services/normal/filesystem/pfs.c
+++ b/src/fw/services/normal/filesystem/pfs.c
@@ -1491,8 +1491,10 @@ status_t pfs_remove(const char *name) {
   status_t rv = get_avail_fd(name, &fd, false);
   if (rv >= FDAlreadyLoaded) { // the file is in the cache
     if (rv == FDBusy) {
-      PBL_CROAK("Cannot delete %s, it is currently in use",
-                PFS_FD(fd).file.name);
+      PBL_LOG(LOG_LEVEL_WARNING, "Cannot delete %s, it is currently in use",
+              PFS_FD(fd).file.name);
+      rv = E_BUSY;
+      goto cleanup;
     }
     page = PFS_FD(fd).file.start_page;
     mark_fd_free(fd);

--- a/src/fw/services/normal/settings/settings_file.c
+++ b/src/fw/services/normal/settings/settings_file.c
@@ -75,16 +75,16 @@ static status_t prv_open(SettingsFile *file, const char *name, uint8_t flags, in
 
   if (memcmp(&file_hdr.magic, SETTINGS_FILE_MAGIC, sizeof(file_hdr.magic)) != 0) {
     PBL_LOG(LOG_LEVEL_ERROR, "Attempted to open %s, not a settings file.", name);
-    pfs_close_and_remove(fd);
+    pfs_close(fd);
     return E_INVALID_OPERATION;
   }
 
   if (file_hdr.version > SETTINGS_FILE_VERSION) {
     PBL_LOG(LOG_LEVEL_WARNING,
-            "Unrecognized version %d for file %s, removing...",
-            file_hdr.version, name);
-    pfs_close_and_remove(fd);
-    return prv_open(file, name, flags, max_used_space);
+            "Unrecognized version %d for file %s, expected %d",
+            file_hdr.version, name, SETTINGS_FILE_VERSION);
+    pfs_close(fd);
+    return E_INVALID_OPERATION;
   }
 
   status_t status = bootup_check(file);


### PR DESCRIPTION
Fix a race condition where pfs_remove() would crash with PBL_CROAK when attempting to delete a file that's currently open by another thread.

The issue occurred when the "app_comm" settings file was accessed concurrently without synchronization:
- Thread A: settings_file validation discovers invalid/corrupt file
- Thread B: app_session_capabilities queries the same file
- Thread A tries to remove the file and finds it's still open, crashes

Root cause: No mutex protecting concurrent access to app_comm file.

Changes:
- pfs_remove(): Return E_BUSY instead of croaking when file is in use
- settings_file: Don't try to remove files with invalid headers during open - just close and return error. File removal should only happen in controlled contexts (e.g., during init when holding a mutex)
- app_session_capabilities: Add mutex to synchronize all access to the app_comm file. Handle invalid files safely during init.

Fixes FIRM-638