### PR TITLE
Revert "third_party/memfault: wire up Pebble DEVICE analytics to memfault"

### DIFF
--- a/src/fw/services/normal/analytics/analytics_heartbeat.c
+++ b/src/fw/services/normal/analytics/analytics_heartbeat.c
@@ -136,18 +136,9 @@ static int64_t prv_location_get_value(uint8_t *location, AnalyticsMetricElementT
 //////////
 // Set
 
-void memfault_metric_set_device_from_pebble_analytics(AnalyticsMetric metric, int64_t val);
-
 void analytics_heartbeat_set(AnalyticsHeartbeat *heartbeat, AnalyticsMetric metric, int64_t val) {
   uint8_t *location = prv_heartbeat_get_location(heartbeat, metric);
   prv_location_set_value(location, val, analytics_metric_element_type(metric));
-
-#if MEMFAULT
-  if (heartbeat->kind == ANALYTICS_HEARTBEAT_KIND_DEVICE) {
-    memfault_metric_set_device_from_pebble_analytics(metric, val);
-  }
-#endif
-
 }
 
 void analytics_heartbeat_set_array(AnalyticsHeartbeat *heartbeat, AnalyticsMetric metric, uint32_t index, int64_t val) {

--- a/third_party/memfault/port/include/memfault_metrics_heartbeat_config.def
+++ b/third_party/memfault/port/include/memfault_metrics_heartbeat_config.def
@@ -27,30 +27,3 @@ MEMFAULT_METRICS_KEY_DEFINE(accel_lsm6dso_double_tap_events, kMemfaultMetricType
 // just gone out to lunch and the user didn't ask for that at all
 // (FIRM-425).
 MEMFAULT_METRICS_KEY_DEFINE(firm_425_back_button_long_presses_cancelled, kMemfaultMetricType_Unsigned)
-
-///// Import old legacy PebbleOS metrics into Memfault. /////
-
-// exports: #define ANALYTICS_METRIC_TABLE(MARKER, DEVICE, APP, UINT8, UINT16, UINT32, INT8, INT16, INT32)
-#include "services/common/analytics/analytics_metric_table.h"
-
-#define ENTRY1(name) // no memfault metric for name without type
-#define ENTRY2(name, element_type) MEMFAULT_METRICS_KEY_DEFINE(name, element_type)
-#define ENTRY3(name, element_type, num_elements) // no memfault metric for array
-
-#define GET_MACRO(_1, _2, _3, NAME, ...) NAME
-#define ENTRY(...) GET_MACRO(__VA_ARGS__, ENTRY3, ENTRY2, ENTRY1)(__VA_ARGS__)
-
-// We don't support Memfault metrics for per-app launch yet -- that would be
-// a 'session' analytic, whenever we're ready for that.
-#define NOOP(...)
-
-ANALYTICS_METRIC_TABLE(ENTRY /* marker */, ENTRY /* system */, NOOP /* app */,
-  kMemfaultMetricType_Unsigned, kMemfaultMetricType_Unsigned, kMemfaultMetricType_Unsigned,
-  kMemfaultMetricType_Signed, kMemfaultMetricType_Signed, kMemfaultMetricType_Signed)
-
-#undef ENTRY
-#undef GET_MACRO
-#undef ENTRY1
-#undef ENTRY2
-#undef ENTRY3
-#undef NOOP

--- a/third_party/memfault/port/src/memfault_platform_metrics.c
+++ b/third_party/memfault/port/src/memfault_platform_metrics.c
@@ -5,38 +5,6 @@
 #include "drivers/imu/lsm6dso/lsm6dso.h"
 #include "services/common/battery/battery_state.h"
 #include "util/heap.h"
-#include "services/common/analytics/analytics_metric_table.h"
-#include "services/common/analytics/analytics_external.h"
-
-void memfault_metric_set_device_from_pebble_analytics(AnalyticsMetric metric, int64_t val) {
-
-#define ENTRY1(name) // no memfault metric for name without type
-#define ENTRY2(name, element_type) case name: element_type(name, val); break;
-#define ENTRY3(name, element_type, num_elements) // no memfault metric for array
-
-#define GET_MACRO(_1, _2, _3, NAME, ...) NAME
-#define ENTRY(...) GET_MACRO(__VA_ARGS__, ENTRY3, ENTRY2, ENTRY1)(__VA_ARGS__)
-
-// We don't support Memfault metrics for per-app launch yet -- that would be
-// a 'session' analytic, whenever we're ready for that.
-#define NOOP(...)
-
-  switch (metric) {
-    ANALYTICS_METRIC_TABLE(ENTRY /* marker */, ENTRY /* system */, NOOP /* app */,
-      MEMFAULT_METRIC_SET_UNSIGNED, MEMFAULT_METRIC_SET_UNSIGNED, MEMFAULT_METRIC_SET_UNSIGNED,
-      MEMFAULT_METRIC_SET_SIGNED, MEMFAULT_METRIC_SET_SIGNED, MEMFAULT_METRIC_SET_SIGNED);
-    default:
-      break; /* it is a metric type we don't export to Memfault -- oh, well */
-  }
-
-#undef ENTRY
-#undef GET_MACRO
-#undef ENTRY1
-#undef ENTRY2
-#undef ENTRY3
-#undef NOOP
-
-}
 
 int memfault_platform_get_stateofcharge(sMfltPlatformBatterySoc *soc) {
   BatteryChargeState chargestate = battery_get_charge_state();
@@ -89,8 +57,4 @@ void memfault_metrics_heartbeat_collect_data(void) {
 
   extern uint32_t metric_firm_425_back_button_long_presses_cancelled;
   MEMFAULT_METRIC_SET_UNSIGNED(firm_425_back_button_long_presses_cancelled, metric_firm_425_back_button_long_presses_cancelled);
-
-#if !RECOVERY_FW
-  analytics_external_update();
-#endif
 }


### PR DESCRIPTION
This reverts the analytics integration from commit b028e387.

The integration added all 185 Pebble analytics metrics to Memfault heartbeat data, which caused metrics to stop appearing in Memfault. The large payload (185 metrics vs the original ~15) likely exceeds size limits or schema expectations in the mobile app or Memfault backend.

Reverting to the original small set of metrics:
- Battery voltage
- Heap/memory usage
- Accelerometer diagnostics (LSM6DSO)
- Back button long press counter

We can revert this for now so that memfault works and see what is actually going wrong later