### PR TITLE
fix: SDK was missing the --emit-relocs linker flag

### DIFF
--- a/sdk/waftools/pebble_sdk_common.py
+++ b/sdk/waftools/pebble_sdk_common.py
@@ -264,11 +264,15 @@ def setup_pebble_cprogram(task_gen):
                 append_to_attr(task_gen, 'stlibpath', platform_binary_path.abspath())
                 append_to_attr(task_gen, 'stlib', lib['name'])
 
-    append_to_attr(task_gen, 'linkflags',
-                   ['-Wl,--build-id=sha1',
-                    '-Wl,-Map,pebble-{}.map,--emit-relocs'.format(getattr(task_gen,
-                                                                          'bin_type',
-                                                                          'app'))])
+    link_flags = ['-Wl,--build-id=sha1',
+                  '-Wl,-Map,pebble-{}.map,--emit-relocs'.format(getattr(task_gen,
+                                                                        'bin_type',
+                                                                        'app'))]
+    append_to_attr(task_gen, 'linkflags', link_flags)
+    # Waf 2.x requires setting LINKFLAGS in the environment, not just the task generator
+    if not hasattr(task_gen.env, 'LINKFLAGS'):
+        task_gen.env.LINKFLAGS = []
+    task_gen.env.LINKFLAGS.extend(link_flags)
     if not hasattr(task_gen, 'ldscript'):
         task_gen.ldscript = (
                 build_node.find_or_declare('pebble_app.ld.auto').path_from(task_gen.path))


### PR DESCRIPTION
The --emit-relocs linker flag is required to include a special ELF section indicating where are the addresses that need relocation.

This elf section is converted at build time (inject_metadata.py) into a binary table that is appended at the end of the app binary.

The process loader (`process_loader_storage.c`) reads this table to apply the relocation offset to the app when it is loaded in memory.

With waf2, this linker flag (and a few less important ones) were ignored during the build. This caused inject_metadata.py to inject 0 relocation entries and caused some crashes. I saw this happened when a function pointer was passed to applib but there were probably other bugs caused by this.