### PR TITLE
console: add `flash benchmark` command

### DIFF
--- a/src/fw/console/prompt_commands.h
+++ b/src/fw/console/prompt_commands.h
@@ -89,6 +89,7 @@ extern void command_flash_fill(const char*, const char*, const char*);
 extern void command_flash_test(const char* test_case_num_str, const char* iterations_str);
 extern void command_flash_test_locked_sectors(void);
 extern void command_flash_stress(const char *);
+extern void command_flash_benchmark(void);
 extern void command_flash_validate(void);
 extern void command_flash_apicheck(const char *len);
 extern void command_flash_unprotect(void);
@@ -661,6 +662,7 @@ static const Command s_prompt_commands[] = {
 
   // This command is dangerous to your flash.  Be careful.
   {"flash stress", command_flash_stress, 1 },
+  {"flash benchmark", command_flash_benchmark, 0 },
 #endif
 
   { "ping", command_ping_send, 0},


### PR DESCRIPTION
On Asterix, here's two different runs at `main`, both in airplane mode:

```
running flash read benchmark
benchmarking 4 bytes...
  -> 4 bytes: 16384 iters in 501 ticks = 29 us/iter
benchmarking 5 bytes...
  -> 5 bytes: 8192 iters in 421 ticks = 50 us/iter
benchmarking 16 bytes...
  -> 16 bytes: 8192 iters in 341 ticks = 40 us/iter
benchmarking 64 bytes...
  -> 64 bytes: 8192 iters in 427 ticks = 50 us/iter
benchmarking 256 bytes...
  -> 256 bytes: 4096 iters in 477 ticks = 113 us/iter
benchmarking 1024 bytes...
  -> 1024 bytes: 4096 iters in 1272 ticks = 303 us/iter
```

```
running flash read benchmark
benchmarking 4 bytes...
  -> 4 bytes: 16384 iters in 500 ticks = 29 us/iter
benchmarking 5 bytes...
  -> 5 bytes: 8192 iters in 421 ticks = 50 us/iter
benchmarking 16 bytes...
  -> 16 bytes: 8192 iters in 341 ticks = 40 us/iter
benchmarking 64 bytes...
  -> 64 bytes: 8192 iters in 429 ticks = 51 us/iter
benchmarking 256 bytes...
  -> 256 bytes: 4096 iters in 476 ticks = 113 us/iter
benchmarking 1024 bytes...
  -> 1024 bytes: 4096 iters in 1271 ticks = 303 us/iter
```

And on `asterix-stop-mode`:

```
running flash read benchmark
benchmarking 4 bytes...
  -> 4 bytes: 4096 iters in 691 ticks = 164 us/iter
benchmarking 5 bytes...
  -> 5 bytes: 4096 iters in 775 ticks = 184 us/iter
benchmarking 16 bytes...
  -> 16 bytes: 4096 iters in 739 ticks = 176 us/iter
benchmarking 64 bytes...
  -> 64 bytes: 4096 iters in 725 ticks = 172 us/iter
benchmarking 256 bytes...
  -> 256 bytes: 4096 iters in 900 ticks = 214 us/iter
benchmarking 1024 bytes...
  -> 1024 bytes: 4096 iters in 1706 ticks = 406 us/iter
```

So this really explains a lot.  I'll try to smooth out some of that newtimer stuff while I'm on the plane.