### PR TITLE
drivers/nrf5/qspi: poll instead of using a semaphore for very short reads

### DIFF
--- a/src/fw/drivers/nrf5/qspi.c
+++ b/src/fw/drivers/nrf5/qspi.c
@@ -25,6 +25,12 @@
 #include "FreeRTOS.h"
 #include "semphr.h"
 
+/* For short reads that don't take very long, there isn't enough time to
+ * do anything meaningful during a context switch; the requesting thread
+ * ought just spin-wait.
+ */
+#define READ_POLLING_THRESHOLD 512
+
 /* nRF5's QSPI controller is different enough from STM32's that we
  * reimplement qspi_flash.c, not stm32/qspi.c.  */
 
@@ -126,8 +132,12 @@ static void _flash_handler(nrfx_qspi_evt_t event, void *ctx) {
 
   PBL_ASSERTN(event == NRFX_QSPI_EVENT_DONE);
 
-  xSemaphoreGiveFromISR(dev->qspi->state->dma_semaphore, &woken);
-  portYIELD_FROM_ISR(woken);
+  if (dev->qspi->state->spin_waiting) {
+    dev->qspi->state->spin_waiting = false;
+  } else {
+    xSemaphoreGiveFromISR(dev->qspi->state->dma_semaphore, &woken);
+    portYIELD_FROM_ISR(woken);
+  }
 }
 
 static void prv_configure_qe(QSPIFlash *dev) {
@@ -332,8 +342,10 @@ void qspi_flash_read_blocking(QSPIFlash *dev, uint32_t addr, void *buffer, uint3
   buf_mid = length - buf_pre - buf_suf;
 
   if (buf_pre != 0U) {
+    dev->qspi->state->spin_waiting = true;
     err = nrfx_qspi_read(b_buf, 4U, addr);
-    prv_wait_for_completion(dev);
+    while (dev->qspi->state->spin_waiting)
+      ;
     PBL_ASSERTN(err == NRFX_SUCCESS);
 
     memcpy(buffer, b_buf, buf_pre);
@@ -342,8 +354,15 @@ void qspi_flash_read_blocking(QSPIFlash *dev, uint32_t addr, void *buffer, uint3
   }
 
   if (buf_mid != 0U) {
-    err = nrfx_qspi_read(buffer, buf_mid, addr);
-    prv_wait_for_completion(dev);
+    if (length < READ_POLLING_THRESHOLD) {
+      dev->qspi->state->spin_waiting = true;
+      err = nrfx_qspi_read(buffer, buf_mid, addr);
+      while (dev->qspi->state->spin_waiting)
+        ;
+    } else {
+      err = nrfx_qspi_read(buffer, buf_mid, addr);
+      prv_wait_for_completion(dev);
+    }
     PBL_ASSERTN(err == NRFX_SUCCESS);
 
     addr += buf_mid;
@@ -351,8 +370,10 @@ void qspi_flash_read_blocking(QSPIFlash *dev, uint32_t addr, void *buffer, uint3
   }
 
   if (buf_suf != 0U) {
+    dev->qspi->state->spin_waiting = true;
     err = nrfx_qspi_read(b_buf, 4U, addr);
-    prv_wait_for_completion(dev);
+    while (dev->qspi->state->spin_waiting)
+      ;
     PBL_ASSERTN(err == NRFX_SUCCESS);
 
     memcpy(buffer, b_buf, buf_suf);

--- a/src/fw/drivers/qspi_definitions.h
+++ b/src/fw/drivers/qspi_definitions.h
@@ -39,6 +39,9 @@ typedef struct QSPIPortState {
   SemaphoreHandle_t dma_semaphore;
   int use_count;
 #endif
+#if MICRO_FAMILY_NRF5
+  volatile bool spin_waiting;
+#endif
 } QSPIPortState;
 
 typedef const struct QSPIPort {


### PR DESCRIPTION
FreeRTOS semaphores and context switches can be pretty expensive, especially in comparison to very short flash reads.  So for reads of low byte counts, we do not actually try descheduling in the flash read mechanism -- instead, we spin-wait on a flag that is set in the ISR.  It would be nice to fully disable the ISR for these short reads, too, but that involves a little more surgery moving to nrf instead of nrfx.  So for now, this is a big improvement even still.

Performance improvements:

 * 4 bytes: 29us/read -> 20us/read (1.45x improvement)
 * 5 bytes: 50us/read -> 32us/read (1.56x improvement)
 * 16 bytes: 40us/read -> 24us/read (1.66x improvement)
 * 64 bytes: 51us/read -> 35us/read (1.45x improvement)
 * 256 bytes: 113us/read -> 83us/read (1.36x improvement)
 * 1024 bytes: 303us/read -> 303us/read (not affected by this change)