### PR TITLE
Implementation HAL_GetTick() for SifliSDK

### DIFF
--- a/third_party/hal_sifli/hal_glue.c
+++ b/third_party/hal_sifli/hal_glue.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 Core Devices LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <stdint.h>
+
+extern int rtc_get_ticks(void);
+
+uint32_t HAL_GetTick(void) {
+  return (uint32_t)rtc_get_ticks();
+}

--- a/third_party/hal_sifli/wscript
+++ b/third_party/hal_sifli/wscript
@@ -4,13 +4,15 @@ def configure(conf):
         conf.env.append_unique('DEFINES', 'SOC_BF0_HCPU')
         conf.env.append_unique('DEFINES', 'HAL_TICK_PER_SECOND=1024')
         conf.env.append_unique('DEFINES', 'HAL_NMI_HANLDER_OVERRIDED')
+        conf.env.append_unique('LINKFLAGS', '-Wl,--undefined=HAL_GetTick')
 
     if conf.env.MICRO_FAMILY == 'SF32LB52':
         conf.env.append_unique('DEFINES', 'SF32LB52X')
 
 
 def build(bld):
-    micro_sources = bld.path.ant_glob('SiFli-SDK/drivers/hal/*.c', excl=['**/bf0_hal_audcodec.c'])
+    micro_sources = ['hal_glue.c']
+    micro_sources += bld.path.ant_glob('SiFli-SDK/drivers/hal/*.c', excl=['**/bf0_hal_audcodec.c'])
 
     micro_sources += [
         'SiFli-SDK/middleware/ipc_queue/common/circular_buf.c',


### PR DESCRIPTION
Add strong implementation HAL_GetTick() for SifliSDK, as the I2C HAL driver would always busy wait if communicate with a non-exist device.  