### PR TITLE
fw/services/normal/activity: fix race condition in prv_reset_state [FIRM-672]

### DIFF
--- a/src/fw/services/normal/activity/kraepelin/kraepelin_algorithm.c
+++ b/src/fw/services/normal/activity/kraepelin/kraepelin_algorithm.c
@@ -391,8 +391,14 @@ static void prv_reset_step_activity_state(KAlgStepActivityState *state) {
 
 // ----------------------------------------------------------------------------------------
 static void prv_reset_state(KAlgState *state) {
-  prv_reset_step_activity_state(&state->walk_state);
-  prv_reset_step_activity_state(&state->run_state);
+  // Only reset step activity states if they're not currently in progress to avoid
+  // race conditions with the minute handler
+  if (state->walk_state.start_time == KALG_START_TIME_NONE) {
+    prv_reset_step_activity_state(&state->walk_state);
+  }
+  if (state->run_state.start_time == KALG_START_TIME_NONE) {
+    prv_reset_step_activity_state(&state->run_state);
+  }
   state->sleep_state = (KAlgSleepActivityState){};
   state->deep_sleep_state = (KAlgDeepSleepActivityState){};
   state->not_worn_state = (KAlgNotWornState){};


### PR DESCRIPTION
Fixes a use-after-free race condition that causes a HardFault when plugging in the charger while activity tracking is running.