### PR TITLE
fw/services/common/accel_manager: fix divide-by-zero crash in prv_setup_subsampling [FIRM-656]

### DIFF
--- a/src/fw/services/common/accel_manager.c
+++ b/src/fw/services/common/accel_manager.c
@@ -211,6 +211,17 @@ static void prv_setup_subsampling(uint32_t sampling_interval) {
   while (state) {
     uint32_t interval_gcd = gcd(sampling_interval,
                                 state->sampling_interval_us);
+
+    // Protect against divide-by-zero if gcd returns 0 (when either input is 0)
+    // This can happen if the accelerometer driver is not initialized properly
+    if (interval_gcd == 0) {
+      PBL_LOG(LOG_LEVEL_ERROR,
+              "Invalid sampling interval (sampling_interval=%" PRIu32 ", state->sampling_interval_us=%" PRIu32 "), skipping session %p",
+              sampling_interval, state->sampling_interval_us, state);
+      state = (AccelManagerState *)state->list_node.next;
+      continue;
+    }
+
     uint32_t numerator = sampling_interval / interval_gcd;
     uint32_t denominator = state->sampling_interval_us / interval_gcd;
 


### PR DESCRIPTION
Fixes a divide-by-zero hardfault in `accel_manager.c:215` that occurs when the LSM6DSO accelerometer driver fails to initialize.

When the accelerometer driver is not initialized:
1. `accel_set_sampling_interval()` returns 0 (driver state remains zeroed)
2. `prv_setup_subsampling()` is called with `sampling_interval = 0`
3. `gcd(0, state->sampling_interval_us)` returns 0
4. Division by zero occurs: `denominator = state->sampling_interval_us / 0`