### PR TITLE
treewide: add support for "silk_flint" platform

### DIFF
--- a/platform/platform_capabilities.py
+++ b/platform/platform_capabilities.py
@@ -209,6 +209,30 @@ board_capability_dicts = [
         },
     },
     {
+        'boards': ['silk_flint'],
+        'capabilities':
+        {
+            'HAS_APP_GLANCES',
+            'HAS_CORE_NAVIGATION4',
+            'HAS_HEALTH_TRACKING',
+            'HAS_ROCKY_JS',
+            'HAS_LAUNCHER4',
+            # 'HAS_MAPPABLE_FLASH' -- TODO: PBL-33860 verify memory-mappable flash works on silk before activating
+            'HAS_MICROPHONE',
+            # 'USE_PARALLEL_FLASH' -- FIXME hack to get the "modern" flash layout. Fix when we add support for new flash
+            'HAS_SDK_SHELL4',
+            'HAS_SPRF_V3',
+            'HAS_TEMPERATURE',
+            'HAS_TIMELINE_PEEK',
+            'HAS_VIBE_SCORES',
+            'HAS_WEATHER',
+            'HAS_PUTBYTES_PREACKING',
+            'HAS_MAGNETOMETER',
+            'HAS_PMIC',
+            'HAS_FLASH_OTP',
+        },
+    },
+    {
         'boards': ['robert_bb', 'robert_bb2', 'robert_evt'],
         'capabilities':
         {

--- a/src/fw/apps/system_apps/settings/settings_certifications.h
+++ b/src/fw/apps/system_apps/settings/settings_certifications.h
@@ -167,7 +167,7 @@ static const CertificationIds * prv_get_certification_ids(void) {
   return &s_certification_ids_snowy;
 #elif defined(BOARD_SPALDING) || defined(BOARD_SPALDING_EVT)
   return &s_certification_ids_spalding;
-#elif PLATFORM_SILK
+#elif PLATFORM_SILK && !defined(BOARD_SILK_FLINT)
   if (mfg_info_is_hrm_present()) {
     return &s_certification_ids_silk_hr;
   } else {

--- a/src/fw/board/board_definitions.h
+++ b/src/fw/board/board_definitions.h
@@ -51,6 +51,8 @@
 #include "boards/board_silk.h"
 #elif BOARD_SILK
 #include "boards/board_silk.h"
+#elif BOARD_SILK_FLINT
+#include "boards/board_silk.h"
 #elif BOARD_CUTTS_BB
 #include "boards/board_robert.h" // prototypes for Cutts
 #elif BOARD_ROBERT_BB

--- a/src/fw/board/boards/board_silk.c
+++ b/src/fw/board/boards/board_silk.c
@@ -279,6 +279,15 @@ I2CSlavePort * const I2C_AS7000 = &I2C_SLAVE_AS7000;
 IRQ_MAP(I2C3_EV, i2c_hal_event_irq_handler, &I2C_PMIC_HRM_BUS);
 IRQ_MAP(I2C3_ER, i2c_hal_error_irq_handler, &I2C_PMIC_HRM_BUS);
 
+#if BOARD_SILK_FLINT
+//We need this to get mag working on fake flint
+static const I2CSlavePort I2C_SLAVE_MAG3110 = {
+  .bus = &I2C_PMIC_HRM_BUS,
+  .address = 0x1C
+};
+I2CSlavePort * const I2C_MAG3110 = &I2C_SLAVE_MAG3110;
+#endif
+
 
 // VOLTAGE MONITOR DEVICES
 static const VoltageMonitorDevice VOLTAGE_MONITOR_ALS_DEVICE = {

--- a/src/fw/board/boards/board_silk.h
+++ b/src/fw/board/boards/board_silk.h
@@ -221,6 +221,22 @@ static const TimerIrqConfig BOARD_BT_WATCHDOG_TIMER = {
   .irq_channel = TIM6_IRQn,
 };
 
+#if BOARD_SILK_FLINT
+//We need this to get mag working on fake flint
+static const BoardConfigMag BOARD_CONFIG_MAG = {
+  .mag_config = {
+    .axes_offsets[AXIS_X] = 1,
+    .axes_offsets[AXIS_Y] = 0,
+    .axes_offsets[AXIS_Z] = 2,
+    .axes_inverts[AXIS_X] = false,
+    .axes_inverts[AXIS_Y] = true,
+    .axes_inverts[AXIS_Z] = false,
+  },
+};
+
+extern I2CSlavePort * const I2C_MAG3110;
+#endif
+
 extern DMARequest * const COMPOSITOR_DMA;
 extern DMARequest * const SHARP_SPI_TX_DMA;
 

--- a/src/fw/board/display.h
+++ b/src/fw/board/display.h
@@ -71,6 +71,8 @@ typedef struct {
 #include "displays/display_silk.h"
 #elif BOARD_SILK
 #include "displays/display_silk.h"
+#elif BOARD_SILK_FLINT
+#include "displays/display_silk.h"
 #elif BOARD_CALVIN_BB
 #include "displays/display_silk.h"
 #elif BOARD_ASTERIX

--- a/src/fw/board/wscript_build
+++ b/src/fw/board/wscript_build
@@ -65,7 +65,7 @@ elif board in ('spalding_evt','spalding', 'spalding_bb2'):
             'drivers',
         ],
     )
-elif board in ('silk_evt', 'silk_bb', 'silk_bb2', 'silk',):
+elif board in ('silk_evt', 'silk_bb', 'silk_bb2', 'silk', 'silk_flint'):
     bld.objects(
         name='board',
         source=[

--- a/src/fw/drivers/wscript_build
+++ b/src/fw/drivers/wscript_build
@@ -1149,7 +1149,7 @@ if bld.is_tintin() and not bld.env.QEMU:
         ],
     )
 
-if bld.is_tintin() or bld.is_snowy_compatible() or bld.is_cutts() or bld.is_robert():
+if bld.is_tintin() or bld.is_snowy_compatible() or bld.is_cutts() or bld.is_robert() or bld.env.BOARD == 'silk_flint':
     bld.objects(
         name='driver_mag3110',
         source=[

--- a/wscript
+++ b/wscript
@@ -44,6 +44,7 @@ RUNNERS = {
     'silk_bb': ['openocd'],
     'silk': ['openocd'],
     'silk_bb2': ['openocd'],
+    'silk_flint': ['openocd'],
     'cutts_bb': ['openocd'],
     'robert_bb': ['openocd'],
     'robert_bb2': ['openocd'],
@@ -106,6 +107,7 @@ def options(opt):
                              'silk_bb',
                              'silk',
                              'silk_bb2',
+                             'silk_flint', # "silk", but it has the flint apis for the emulator
                              'cutts_bb',
                              'robert_bb',
                              'robert_bb2',
@@ -500,13 +502,13 @@ def configure(conf):
     elif conf.is_snowy_compatible():
         conf.env.PLATFORM_NAME = 'basalt'
         conf.env.MIN_SDK_VERSION = 2
-    elif conf.is_silk():
+    elif conf.is_silk() and conf.options.board != 'silk_flint':
         conf.env.PLATFORM_NAME = 'diorite'
         conf.env.MIN_SDK_VERSION = 2
     elif conf.is_cutts() or conf.is_robert() or conf.is_obelix():
         conf.env.PLATFORM_NAME = 'emery'
         conf.env.MIN_SDK_VERSION = 3
-    elif conf.is_asterix():
+    elif conf.is_asterix() or conf.options.board == 'silk_flint':
         conf.env.PLATFORM_NAME = 'flint'
         conf.env.MIN_SDK_VERSION = 2
     else:


### PR DESCRIPTION
because there is no "nrf52" version of QEMU, we hack together a "Silk and It's Completely Different but Also Still Silk" that has all the APIs we create for flint