### PR TITLE
feat: Add accent color settings to apps and settings menus

### DIFF
--- a/src/fw/applib/applib_malloc.json
+++ b/src/fw/applib/applib_malloc.json
@@ -274,9 +274,9 @@
         "_comment": ["Cache to speed up frequent health service API calls (only 3.9+)"]
     }, {
         "name": "OptionMenu",
-        "size_2x": 680,
+        "size_2x": 684,
         "size_3x_padding": 12,
-        "size_3x": 876,
+        "size_3x": 880,
         "dependencies": ["Window", "StatusBarLayer", "MenuLayer", "GBitmap", "GBitmap"],
         "_comment": "Not exported yet (only 3.x)"
     }, {

--- a/src/fw/applib/ui/option_menu_window.c
+++ b/src/fw/applib/ui/option_menu_window.c
@@ -159,6 +159,15 @@ static void prv_select_callback(MenuLayer *menu_layer, MenuIndex *cell_index, vo
   }
 }
 
+static void prv_selection_will_change_callback(MenuLayer *menu_layer, MenuIndex *new_index,
+                                                 MenuIndex old_index, void *context) {
+  OptionMenu *option_menu = context;
+  if (option_menu->callbacks.selection_will_change) {
+    option_menu->callbacks.selection_will_change(
+        option_menu, new_index->row, old_index.row, option_menu->context);
+  }
+}
+
 static void prv_window_load(Window *window) {
   OptionMenu *option_menu = window_get_user_data(window);
 
@@ -166,6 +175,7 @@ static void prv_window_load(Window *window) {
       .get_cell_height = prv_get_cell_height_callback,
       .get_num_rows = prv_get_num_rows_callback,
       .draw_row = prv_draw_row_callback,
+      .selection_will_change = prv_selection_will_change_callback,
       .select_click = prv_select_callback
   });
   menu_layer_set_click_config_onto_window(&option_menu->menu_layer, window);

--- a/src/fw/applib/ui/option_menu_window.h
+++ b/src/fw/applib/ui/option_menu_window.h
@@ -34,8 +34,18 @@ typedef void (*OptionMenuUnloadCallback)(OptionMenu *option_menu, void *context)
 typedef uint16_t (*OptionMenuGetCellHeightCallback)(OptionMenu *option_menu, uint16_t row,
                                                     bool selected, void *context);
 
+typedef uint16_t (*OptionMenuSelectionChangedCallback)(OptionMenu *option_menu, uint16_t row,
+                                                    bool selected, void *context);
+
+typedef void (*OptionMenuSelectionWillChangeCallback)(OptionMenu *option_menu,
+                                                     uint16_t new_row,
+                                                     uint16_t old_row,
+                                                     void *context);
+
+                                                    
 typedef struct OptionMenuCallbacks {
   OptionMenuSelectCallback select;
+  OptionMenuSelectionWillChangeCallback selection_will_change;
   OptionMenuGetNumRowsCallback get_num_rows;
   OptionMenuDrawRowCallback draw_row;
   OptionMenuUnloadCallback unload;

--- a/src/fw/apps/system_apps/launcher/default/launcher_app.c
+++ b/src/fw/apps/system_apps/launcher/default/launcher_app.c
@@ -24,6 +24,7 @@
 #include "kernel/pbl_malloc.h"
 #include "shell/normal/app_idle_timeout.h"
 #include "system/passert.h"
+#include "shell/prefs.h"
 #include "process_state/app_state/app_state.h"
 #include "util/attributes.h"
 
@@ -130,7 +131,7 @@ static void prv_window_unload(Window *window) {
     .valid = true,
     .leave_time = rtc_get_ticks(),
     .draw_state.selection_vertical_range = launcher_selection_vertical_range,
-    .draw_state.selection_background_color = LAUNCHER_MENU_LAYER_SELECTION_BACKGROUND_COLOR,
+    .draw_state.selection_background_color = shell_prefs_get_apps_menu_highlight_color(),
   };
   launcher_menu_layer_get_selection_state(&data->launcher_menu_layer,
                                           &s_launcher_app_persisted_data.selection_state);

--- a/src/fw/apps/system_apps/launcher/default/launcher_menu_layer.c
+++ b/src/fw/apps/system_apps/launcher/default/launcher_menu_layer.c
@@ -26,6 +26,7 @@
 #include "resource/resource_ids.auto.h"
 #include "services/normal/timeline/timeline_resources.h"
 #include "system/passert.h"
+#include "shell/prefs.h"
 #include "util/attributes.h"
 #include "util/struct.h"
 
@@ -204,7 +205,7 @@ void launcher_menu_layer_init(LauncherMenuLayer *launcher_menu_layer,
   MenuLayer *menu_layer = &launcher_menu_layer->menu_layer;
   menu_layer_init(menu_layer, &menu_layer_frame);
   menu_layer_set_highlight_colors(menu_layer,
-                                  LAUNCHER_MENU_LAYER_SELECTION_BACKGROUND_COLOR,
+                                  shell_prefs_get_apps_menu_highlight_color(),
                                   PBL_IF_COLOR_ELSE(GColorBlack, GColorWhite));
   menu_layer_pad_bottom_enable(menu_layer, false);
   menu_layer_set_callbacks(menu_layer, launcher_menu_layer, &(MenuLayerCallbacks) {

--- a/src/fw/apps/system_apps/launcher/default/launcher_menu_layer.h
+++ b/src/fw/apps/system_apps/launcher/default/launcher_menu_layer.h
@@ -28,8 +28,6 @@
 #define LAUNCHER_MENU_LAYER_SUBTITLE_FONT (FONT_KEY_GOTHIC_14)
 #endif
 
-#define LAUNCHER_MENU_LAYER_SELECTION_BACKGROUND_COLOR (PBL_IF_COLOR_ELSE(GColorVividCerulean, \
-                                                                          GColorBlack))
 
 typedef struct LauncherMenuLayer {
   Layer container_layer;

--- a/src/fw/apps/system_apps/settings/settings.c
+++ b/src/fw/apps/system_apps/settings/settings.c
@@ -25,6 +25,7 @@
 #include "resource/resource_ids.auto.h"
 #include "services/common/i18n/i18n.h"
 #include "system/passert.h"
+#include "shell/prefs.h"
 
 #define SETTINGS_CATEGORY_MENU_CELL_UNFOCUSED_ROUND_VERTICAL_PADDING 14
 
@@ -46,6 +47,9 @@ static void prv_draw_row_callback(GContext *ctx, const Layer *cell_layer,
 
   const char *category_title = settings_menu_get_submodule_info(cell_index->row)->name;
   const char *title = i18n_get(category_title, data);
+  menu_layer_set_highlight_colors(&(data->menu_layer),
+                                shell_prefs_get_settings_menu_highlight_color(),
+                                GColorWhite);
   menu_cell_basic_draw(ctx, cell_layer, title, NULL, NULL);
 }
 
@@ -98,7 +102,7 @@ static void prv_window_load(Window *window) {
                                PBL_IF_COLOR_ELSE(GColorBlack, GColorWhite),
                                PBL_IF_COLOR_ELSE(GColorWhite, GColorBlack));
   menu_layer_set_highlight_colors(menu_layer,
-                                  PBL_IF_COLOR_ELSE(SETTINGS_MENU_HIGHLIGHT_COLOR, GColorBlack),
+                                  shell_prefs_get_settings_menu_highlight_color(),
                                   GColorWhite);
   menu_layer_set_click_config_onto_window(menu_layer, &data->window);
 

--- a/src/fw/apps/system_apps/settings/settings_activity_tracker.c
+++ b/src/fw/apps/system_apps/settings/settings_activity_tracker.c
@@ -252,7 +252,7 @@ static Window *prv_init(void) {
   // Not using option_menu_configure because prv_reload_menu_data already sets
   // icons_enabled and chosen row index
   option_menu_set_status_colors(&data->option_menu, GColorWhite, GColorBlack);
-  option_menu_set_highlight_colors(&data->option_menu, SETTINGS_MENU_HIGHLIGHT_COLOR, GColorWhite);
+  option_menu_set_highlight_colors(&data->option_menu, shell_prefs_get_settings_menu_highlight_color(), GColorWhite);
   option_menu_set_title(&data->option_menu, i18n_get("Background App", data));
   option_menu_set_content_type(&data->option_menu, OptionMenuContentType_SingleLine);
   option_menu_set_callbacks(&data->option_menu, &option_menu_callbacks, data);

--- a/src/fw/apps/system_apps/settings/settings_menu.c
+++ b/src/fw/apps/system_apps/settings/settings_menu.c
@@ -25,6 +25,7 @@
 #include "settings_system.h"
 #include "settings_time.h"
 #include "settings_timeline.h"
+#include "settings_themes.h"
 
 #if CAPABILITY_HAS_VIBE_SCORES
 #include "settings_vibe_patterns.h"
@@ -33,6 +34,7 @@
 #include "applib/ui/app_window_stack.h"
 #include "services/common/i18n/i18n.h"
 #include "system/passert.h"
+#include "shell/prefs.h"
 
 static const SettingsModuleGetMetadata s_submodule_registry[] = {
   [SettingsMenuItemBluetooth]     = settings_bluetooth_get_info,
@@ -55,6 +57,9 @@ static const SettingsModuleGetMetadata s_submodule_registry[] = {
 #endif
   [SettingsMenuItemDisplay]       = settings_display_get_info,
   [SettingsMenuItemSystem]        = settings_system_get_info,
+#if PBL_COLOR
+  [SettingsMenuItemThemes]        = settings_themes_get_info,
+#endif
 };
 
 const SettingsModuleMetadata *settings_menu_get_submodule_info(SettingsMenuItem category) {

--- a/src/fw/apps/system_apps/settings/settings_menu.h
+++ b/src/fw/apps/system_apps/settings/settings_menu.h
@@ -19,11 +19,10 @@
 #include "applib/graphics/gtypes.h"
 #include "applib/ui/layer.h"
 #include "applib/ui/window.h"
+#include "shell/prefs.h"
 
 #include <stdint.h>
 
-#define SETTINGS_MENU_HIGHLIGHT_COLOR PBL_IF_COLOR_ELSE(GColorCobaltBlue, GColorBlack)
-#define SETTINGS_MENU_TITLE_NORMAL_COLOR PBL_IF_COLOR_ELSE(GColorDarkGray, GColorBlack)
 
 typedef enum {
   SettingsMenuItemBluetooth = 0,
@@ -40,6 +39,9 @@ typedef enum {
   SettingsMenuItemDisplay,
   SettingsMenuItemActivity,
   SettingsMenuItemSystem,
+#if PBL_COLOR
+  SettingsMenuItemThemes,
+#endif
   SettingsMenuItem_Count,
   SettingsMenuItem_Invalid
 } SettingsMenuItem;

--- a/src/fw/apps/system_apps/settings/settings_option_menu.c
+++ b/src/fw/apps/system_apps/settings/settings_option_menu.c
@@ -55,7 +55,7 @@ OptionMenu *settings_option_menu_create(
     .content_type = content_type,
     .choice = choice,
     .status_colors = { GColorWhite, GColorBlack },
-    .highlight_colors = { SETTINGS_MENU_HIGHLIGHT_COLOR, GColorWhite },
+    .highlight_colors = { shell_prefs_get_settings_menu_highlight_color(), GColorWhite },
     .icons_enabled = icons_enabled,
   };
   option_menu_configure(option_menu, &config);

--- a/src/fw/apps/system_apps/settings/settings_quick_launch_app_menu.c
+++ b/src/fw/apps/system_apps/settings/settings_quick_launch_app_menu.c
@@ -34,6 +34,7 @@
 #include "process_management/app_install_manager.h"
 #include "process_management/app_menu_data_source.h"
 #include "resource/resource_ids.auto.h"
+#include "shell/prefs.h"
 
 typedef struct {
   AppMenuDataSource data_source;
@@ -126,7 +127,7 @@ void quick_launch_app_menu_window_push(ButtonId button) {
     .title = i18n_get(i18n_noop("Quick Launch"), data),
     .choice = (install_id == INSTALL_ID_INVALID) ? 0 : (app_index + NUM_CUSTOM_CELLS),
     .status_colors = { GColorWhite, GColorBlack, },
-    .highlight_colors = { SETTINGS_MENU_HIGHLIGHT_COLOR, GColorWhite },
+    .highlight_colors = { shell_prefs_get_settings_menu_highlight_color(), GColorWhite },
     .icons_enabled = true,
   };
   option_menu_configure(option_menu, &config);

--- a/src/fw/apps/system_apps/settings/settings_quiet_time.c
+++ b/src/fw/apps/system_apps/settings/settings_quiet_time.c
@@ -35,6 +35,7 @@
 #include "system/passert.h"
 #include "util/size.h"
 #include "util/string.h"
+#include "shell/prefs.h"
 
 #include <stdio.h>
 
@@ -177,7 +178,7 @@ static void prv_scheduled_dnd_menu_push(DoNotDisturbScheduleType type,
                                         SettingsQuietTimeData *data) {
   data->action_menu = (ActionMenuConfig) {
     .context = data,
-    .colors.background = SETTINGS_MENU_HIGHLIGHT_COLOR,
+    .colors.background = shell_prefs_get_settings_menu_highlight_color(),
     .did_close = prv_scheduled_dnd_menu_cleanup,
   };
 

--- a/src/fw/apps/system_apps/settings/settings_remote.c
+++ b/src/fw/apps/system_apps/settings/settings_remote.c
@@ -157,7 +157,7 @@ void settings_remote_menu_push(struct SettingsBluetoothData *bt_data, StoredRemo
 
   data->action_menu = (ActionMenuConfig) {
     .context = data,
-    .colors.background = SETTINGS_MENU_HIGHLIGHT_COLOR,
+    .colors.background = shell_prefs_get_settings_menu_highlight_color(),
     .did_close = prv_remote_menu_cleanup,
   };
 

--- a/src/fw/apps/system_apps/settings/settings_system.c
+++ b/src/fw/apps/system_apps/settings/settings_system.c
@@ -288,7 +288,7 @@ static void prv_information_window_load(Window *window) {
     .draw_row = prv_information_draw_row_callback,
     .select_click = prv_information_select_callback,
   });
-  menu_layer_set_highlight_colors(menu_layer, SETTINGS_MENU_HIGHLIGHT_COLOR, GColorWhite);
+  menu_layer_set_highlight_colors(menu_layer, shell_prefs_get_settings_menu_highlight_color(), GColorWhite);
   menu_layer_set_click_config_onto_window(menu_layer, &data->window);
 
   layer_add_child(&data->window.layer, menu_layer_get_layer(menu_layer));
@@ -445,7 +445,7 @@ static void prv_debugging_window_load(Window *window) {
     .draw_row = prv_debugging_draw_row_callback,
     .select_click = prv_debugging_select_callback,
   });
-  menu_layer_set_highlight_colors(menu_layer, SETTINGS_MENU_HIGHLIGHT_COLOR, GColorWhite);
+  menu_layer_set_highlight_colors(menu_layer, shell_prefs_get_settings_menu_highlight_color(), GColorWhite);
   menu_layer_set_click_config_onto_window(menu_layer, &data->window);
 
   layer_add_child(&data->window.layer, menu_layer_get_layer(menu_layer));
@@ -891,7 +891,7 @@ static void prv_certification_window_load(Window *window) {
     .draw_row = prv_certification_draw_row_callback,
     .select_click = prv_certification_select_callback,
   });
-  menu_layer_set_highlight_colors(menu_layer, SETTINGS_MENU_HIGHLIGHT_COLOR, GColorWhite);
+  menu_layer_set_highlight_colors(menu_layer, shell_prefs_get_settings_menu_highlight_color(), GColorWhite);
   menu_layer_set_click_config_onto_window(menu_layer, &data->window);
 
   layer_add_child(&data->window.layer, menu_layer_get_layer(menu_layer));

--- a/src/fw/apps/system_apps/settings/settings_themes.c
+++ b/src/fw/apps/system_apps/settings/settings_themes.c
@@ -1,0 +1,444 @@
+/*
+ * Copyright 2025 Elad Dvash
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "settings_themes.h"
+#include "settings_menu.h"
+#include "settings_option_menu.h"
+#include "settings_window.h"
+
+#include "applib/ui/dialogs/dialog.h"
+#include "applib/ui/dialogs/expandable_dialog.h"
+#include "applib/graphics/graphics.h"
+#include "applib/ui/menu_layer.h"
+#include "kernel/pbl_malloc.h"
+#include "services/common/i18n/i18n.h"
+#include "shell/prefs.h"
+#include "system/passert.h"
+#include "util/size.h"
+
+
+/* Per-window data for this settings module. */
+typedef struct SettingsThemesData {
+  SettingsCallbacks callbacks;
+} SettingsThemesData;
+
+
+/* Menu row indices for the Themes menu. */
+typedef enum ThemesMenuIndex {
+  ThemesMenuIndex_Apps,
+  ThemesMenuIndex_Settings,
+
+  ThemesMenuIndexCount
+} ThemesMenuIndex;
+
+/* Free i18n strings and allocated context when the menu is torn down. */
+static void prv_deinit_cb(SettingsCallbacks *context) {
+  i18n_free_all(context);
+  app_free(context);
+}
+
+static uint16_t prv_num_rows_cb(SettingsCallbacks *context) {
+  return ThemesMenuIndexCount;
+}
+
+static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
+                            const Layer *cell_layer, uint16_t row, bool selected) {
+  SettingsThemesData *data = (SettingsThemesData *)context;
+  const char *title = NULL;
+  const char *subtitle = NULL;
+
+  switch ((ThemesMenuIndex)row) {
+    case ThemesMenuIndex_Apps:
+      /* Title for the Apps accent color item. */
+      title = i18n_noop("Apps Accent");
+      break;
+    case ThemesMenuIndex_Settings:
+      /* Title for the Settings accent color item. */
+      title = i18n_noop("Settings Accent");
+      break;
+    case ThemesMenuIndexCount:
+      break;
+  }
+
+  PBL_ASSERTN(title);
+  menu_cell_basic_draw(ctx, cell_layer, i18n_get(title, data), i18n_get(subtitle, data), NULL);
+}
+
+static const char* color_names_short[ARRAY_LENGTH(s_color_definitions_short)];
+static bool color_names_short_initialized = false;
+static const char* color_names[ARRAY_LENGTH(s_color_definitions)];
+static bool color_names_initialized = false;
+
+static const char** prv_get_color_names(bool short_list) {
+  if (short_list) {
+    if (!color_names_short_initialized) {
+      for (size_t i = 0; i < ARRAY_LENGTH(s_color_definitions_short); i++) {
+        color_names_short[i] = (char*)s_color_definitions_short[i].name;
+      }
+      color_names_short_initialized = true;
+    }
+    return color_names_short;
+  }
+  if (!color_names_initialized) {
+    for (size_t i = 0; i < ARRAY_LENGTH(s_color_definitions); i++) {
+      color_names[i] = (char*)s_color_definitions[i].name;
+    }
+    color_names_initialized = true;
+  }
+  return color_names;
+}
+
+
+
+
+static int prv_color_to_index(GColor color, bool short_list, GColor default_color) {
+  if (color.argb == GColorClear.argb || color.argb == default_color.argb) {
+    return 0;
+  }
+  if (short_list) {
+    for (size_t i = 0; i < ARRAY_LENGTH(s_color_definitions_short); i++) {
+      if ((uint8_t)(color.argb) == (uint8_t)(s_color_definitions_short[i].value.argb)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+  for (size_t i = 0; i < ARRAY_LENGTH(s_color_definitions); i++) {
+    if ((uint8_t)(color.argb) == (uint8_t)(s_color_definitions[i].value.argb)) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+
+/////////////////////////////
+// Apps Accent Color Settings
+/////////////////////////////
+
+static void prv_apps_color_menu_select(OptionMenu *option_menu, int selection, void *context) {
+  if (selection == 0){
+    /* Default option selected -> restore default color. */
+    shell_prefs_set_apps_menu_highlight_color(DEFAULT_APPS_HIGHLIGHT_COLOR);
+    app_window_stack_remove(&option_menu->window, true /* animated */);
+    return;
+  }
+  shell_prefs_set_apps_menu_highlight_color(s_color_definitions[selection].value);
+  app_window_stack_remove(&option_menu->window, true /* animated */);
+}
+
+static void prv_option_apps_menu_selection_will_change(OptionMenu *option_menu,
+                                             uint16_t new_row,
+                                             uint16_t old_row,
+                                             void *context) {
+  if (new_row == old_row) {
+    return;
+  }
+  GColor color = s_color_definitions[new_row].value;
+  if (color.argb != GColorClear.argb) {
+    option_menu_set_highlight_colors(option_menu, color, GColorWhite);
+  }
+  else {
+    option_menu_set_highlight_colors(option_menu, DEFAULT_APPS_HIGHLIGHT_COLOR, GColorWhite);
+  }
+}
+
+static void prv_push_apps_color_menu(SettingsThemesData *data) {
+  const char *title = i18n_noop("Apps Menu Accent");
+  int selected = prv_color_to_index(shell_prefs_get_apps_menu_highlight_color(), false, DEFAULT_APPS_HIGHLIGHT_COLOR);
+  const char** color_names = prv_get_color_names(false);
+  const OptionMenuCallbacks callbacks = {
+    .select = prv_apps_color_menu_select,
+    .selection_will_change = prv_option_apps_menu_selection_will_change,
+  };
+  if (selected < 0) {
+    WTF;
+  }
+  OptionMenu * const option_menu = settings_option_menu_create(
+      title, OptionMenuContentType_SingleLine, selected, &callbacks,
+      ARRAY_LENGTH(s_color_definitions), true /* icons_enabled */, color_names, data);
+
+  if (option_menu) {
+    const bool animated = true;
+    if (selected == 0) {
+      option_menu_set_highlight_colors(option_menu, DEFAULT_APPS_HIGHLIGHT_COLOR, GColorWhite);
+    }
+    else {
+      option_menu_set_highlight_colors(option_menu, s_color_definitions[selected].value, GColorWhite);
+    }
+    app_window_stack_push(&option_menu->window, animated);
+  }
+}
+
+
+/////////////////////////////
+// Short Apps Accent Color Settings
+/////////////////////////////
+
+static void prv_apps_color_menu_select_short(OptionMenu *option_menu, int selection, void *context) {
+  if (selection == 0){
+    /* Default option selected -> restore default color. */
+    shell_prefs_set_apps_menu_highlight_color(DEFAULT_APPS_HIGHLIGHT_COLOR);
+    app_window_stack_remove(&option_menu->window, true /* animated */);
+    return;
+  }
+  else if (selection == ARRAY_LENGTH(s_color_definitions_short) - 1) {
+    /* "Show All..." -> open full color menu. */
+    prv_push_apps_color_menu((SettingsThemesData *)context);
+    return;
+  }
+  /* Map through to the full handler for regular short-list entries. */
+  prv_apps_color_menu_select(option_menu, selection, context);  
+}
+
+static void prv_option_apps_menu_selection_will_change_short(OptionMenu *option_menu,
+                                             uint16_t new_row,
+                                             uint16_t old_row,
+                                             void *context) {
+  if (new_row == old_row) {
+    return;
+  }
+  GColor color = s_color_definitions_short[new_row].value;
+  if (color.argb != GColorClear.argb) {
+    option_menu_set_highlight_colors(option_menu, color, GColorWhite);
+  }
+  else if (new_row == ARRAY_LENGTH(s_color_definitions_short) - 1) {
+    /* "Show All..." selected -> preview current saved color. */
+    option_menu_set_highlight_colors(option_menu, shell_prefs_get_apps_menu_highlight_color(), GColorWhite);
+  }
+  else {
+    option_menu_set_highlight_colors(option_menu, DEFAULT_APPS_HIGHLIGHT_COLOR, GColorWhite);
+  }
+}
+
+
+static void prv_push_apps_color_menu_short(SettingsThemesData *data) {
+  const char *title = i18n_noop("Apps Menu Accent");
+  int selected = prv_color_to_index(shell_prefs_get_apps_menu_highlight_color(), true, DEFAULT_APPS_HIGHLIGHT_COLOR);
+  const char** color_names = prv_get_color_names(true);
+  const OptionMenuCallbacks callbacks = {
+    .select = prv_apps_color_menu_select_short,
+    .selection_will_change = prv_option_apps_menu_selection_will_change_short,
+  };
+  if (selected < 0) {
+    selected = ARRAY_LENGTH(s_color_definitions_short) - 1;
+  }
+  OptionMenu * const option_menu = settings_option_menu_create(
+      title, OptionMenuContentType_SingleLine, selected, &callbacks,
+      ARRAY_LENGTH(s_color_definitions_short), true /* icons_enabled */, color_names, data);
+
+  if (option_menu) {
+    const bool animated = true;
+    if (selected == 0) {
+      option_menu_set_highlight_colors(option_menu, DEFAULT_APPS_HIGHLIGHT_COLOR, GColorWhite);
+    }
+    else if (selected == ARRAY_LENGTH(s_color_definitions_short) - 1) {
+      // "Show All..." option selected
+      option_menu_set_highlight_colors(option_menu, shell_prefs_get_apps_menu_highlight_color(), GColorWhite);
+    }
+    else {
+      option_menu_set_highlight_colors(option_menu, s_color_definitions_short[selected].value, GColorWhite);
+    }
+    app_window_stack_push(&option_menu->window, animated);
+  }
+}
+
+
+/////////////////////////////
+// Settings Accent Color Settings
+/////////////////////////////
+static void prv_settings_color_menu_select(OptionMenu *option_menu, int selection, void *context) {
+  if (selection == 0){
+    /* Default option selected -> restore default color. */
+    shell_prefs_set_settings_menu_highlight_color(DEFAULT_SETTINGS_HIGHLIGHT_COLOR);
+    app_window_stack_remove(&option_menu->window, true /* animated */);
+    return;
+  }
+  shell_prefs_set_settings_menu_highlight_color(s_color_definitions[selection].value);
+  app_window_stack_remove(&option_menu->window, true /* animated */);
+}
+
+static void prv_option_settings_menu_selection_will_change(OptionMenu *option_menu,
+                                             uint16_t new_row,
+                                             uint16_t old_row,
+                                             void *context) {
+  if (new_row == old_row) {
+    return;
+  }
+  GColor color = s_color_definitions[new_row].value;
+  if (color.argb != GColorClear.argb) {
+    option_menu_set_highlight_colors(option_menu, color, GColorWhite);
+  }
+  else {
+    option_menu_set_highlight_colors(option_menu, DEFAULT_SETTINGS_HIGHLIGHT_COLOR, GColorWhite);
+  }
+}
+
+static void prv_push_settings_color_menu(SettingsThemesData *data) {
+  const char *title = i18n_noop("Settings Accent");
+  int selected = prv_color_to_index(shell_prefs_get_settings_menu_highlight_color(), false, DEFAULT_SETTINGS_HIGHLIGHT_COLOR);
+  const char** color_names = prv_get_color_names(false);
+  const OptionMenuCallbacks callbacks = {
+    .select = prv_settings_color_menu_select,
+    .selection_will_change = prv_option_settings_menu_selection_will_change,
+  };
+  if (selected < 0) {
+    WTF;
+  }
+  OptionMenu * const option_menu = settings_option_menu_create(
+      title, OptionMenuContentType_SingleLine, selected, &callbacks,
+      ARRAY_LENGTH(s_color_definitions), true /* icons_enabled */, color_names, data);
+
+  if (option_menu) {
+    const bool animated = true;
+    if (selected == 0) {
+      option_menu_set_highlight_colors(option_menu, DEFAULT_SETTINGS_HIGHLIGHT_COLOR, GColorWhite);
+    }
+    else {
+      option_menu_set_highlight_colors(option_menu, s_color_definitions[selected].value, GColorWhite);
+    }
+    app_window_stack_push(&option_menu->window, animated);
+  }
+}
+
+
+/////////////////////////////
+// Short Settings Accent Color Settings
+/////////////////////////////
+static void prv_settings_color_menu_select_short(OptionMenu *option_menu, int selection, void *context) {
+  if (selection == 0){
+    /* Default option selected -> restore default color. */
+    shell_prefs_set_settings_menu_highlight_color(DEFAULT_SETTINGS_HIGHLIGHT_COLOR);
+    app_window_stack_remove(&option_menu->window, true /* animated */);
+    return;
+  }
+  else if (selection == ARRAY_LENGTH(s_color_definitions_short) - 1) {
+    prv_push_settings_color_menu((SettingsThemesData *)context);
+    return;
+  }
+  prv_settings_color_menu_select(option_menu, selection, context);
+}
+
+static void prv_option_settings_menu_selection_will_change_short(OptionMenu *option_menu,
+                                             uint16_t new_row,
+                                             uint16_t old_row,
+                                             void *context) {
+  if (new_row == old_row) {
+    return;
+  }
+  GColor color = s_color_definitions[new_row].value;
+  if (color.argb != GColorClear.argb) {
+    option_menu_set_highlight_colors(option_menu, color, GColorWhite);
+  }
+  else if (new_row == ARRAY_LENGTH(s_color_definitions_short) - 1) {
+    /* "Show All..." selected -> preview saved color. */
+    option_menu_set_highlight_colors(option_menu, shell_prefs_get_settings_menu_highlight_color(), GColorWhite);
+  }
+  else {
+    option_menu_set_highlight_colors(option_menu, DEFAULT_SETTINGS_HIGHLIGHT_COLOR, GColorWhite);
+  }
+}
+
+
+static void prv_push_settings_color_menu_short(SettingsThemesData *data) {
+  const char *title = i18n_noop("Settings Accent");
+  int selected = prv_color_to_index(shell_prefs_get_settings_menu_highlight_color(), true, DEFAULT_SETTINGS_HIGHLIGHT_COLOR);
+  const char** color_names = prv_get_color_names(true);
+  const OptionMenuCallbacks callbacks = {
+    .select = prv_settings_color_menu_select_short,
+    .selection_will_change = prv_option_settings_menu_selection_will_change_short,
+  };
+  if (selected < 0) {
+    selected = ARRAY_LENGTH(s_color_definitions_short) - 1;
+  }
+  OptionMenu * const option_menu = settings_option_menu_create(
+      title, OptionMenuContentType_SingleLine, selected, &callbacks,
+      ARRAY_LENGTH(s_color_definitions_short), true /* icons_enabled */, color_names, data);
+
+  if (option_menu) {
+    const bool animated = true;
+    if (selected == 0) {
+      option_menu_set_highlight_colors(option_menu, DEFAULT_SETTINGS_HIGHLIGHT_COLOR, GColorWhite);
+    }
+    else if (selected == ARRAY_LENGTH(s_color_definitions_short) - 1) {
+      // "Show All..." option selected
+      option_menu_set_highlight_colors(option_menu, shell_prefs_get_settings_menu_highlight_color(), GColorWhite);
+    }
+    else {
+      option_menu_set_highlight_colors(option_menu, s_color_definitions_short[selected].value, GColorWhite);
+    }
+    app_window_stack_push(&option_menu->window, animated);
+  }
+}
+
+
+
+static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
+#if PBL_COLOR
+  SettingsThemesData *data = (SettingsThemesData *)context;
+  switch ((ThemesMenuIndex)row) {
+    case ThemesMenuIndex_Apps:
+      prv_push_apps_color_menu_short(data);
+      goto done;
+    case ThemesMenuIndex_Settings:
+      prv_push_settings_color_menu_short(data);
+      goto done;
+    case ThemesMenuIndexCount:
+      break;
+  }
+  WTF;
+done:
+  settings_menu_reload_data(SettingsMenuItemThemes);
+#else
+  WTF;
+#endif
+}
+
+static Window *prv_create_settings_window(void) {
+#if PBL_COLOR
+  SettingsThemesData *data = app_malloc_check(sizeof(*data));
+
+  *data = (SettingsThemesData) {
+    .callbacks = {
+      .deinit = prv_deinit_cb,
+      .draw_row = prv_draw_row_cb,
+      .select_click = prv_select_click_cb,
+      .num_rows = prv_num_rows_cb,
+    }
+  };
+
+  return settings_window_create(SettingsMenuItemThemes, &data->callbacks);
+#else 
+  WTF;
+  return NULL;
+#endif
+}
+
+static Window *prv_init(void) {
+  return prv_create_settings_window();
+}
+
+
+const SettingsModuleMetadata *settings_themes_get_info(void) {
+  static const SettingsModuleMetadata s_module_info = {
+    /// Title of the Themes Settings submenu in Settings
+    .name = i18n_noop("Themes"),
+    .init = prv_init,
+  };
+
+  return &s_module_info;
+}

--- a/src/fw/apps/system_apps/settings/settings_themes.h
+++ b/src/fw/apps/system_apps/settings/settings_themes.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 Elad Dvash
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "settings_menu.h"
+#include "shell/system_theme.h"
+
+#ifndef DEFAULT_SETTINGS_HIGHLIGHT_COLOR
+#define DEFAULT_SETTINGS_HIGHLIGHT_COLOR GColorCobaltBlue
+#define DEFAULT_APPS_HIGHLIGHT_COLOR GColorVividCerulean
+#endif
+
+typedef struct ColorDefinition {
+  const char *name;
+  const GColor value;
+} ColorDefinition;
+
+static const ColorDefinition s_color_definitions[65] = {
+  // Pebble colors taken from gcolor_definitions.h
+  {"Default", GColorClear},
+  {"Black", GColorBlack},
+  {"Blue", GColorBlue},
+  {"Green", GColorGreen},
+  {"Cyan", GColorCyan},
+  {"Purple", GColorPurple},
+  {"Red", GColorRed},
+  {"Magenta", GColorMagenta},
+  {"Orange", GColorOrange},
+  {"Yellow", GColorYellow},
+  {"Gray", GColorDarkGray},
+
+  {"Oxford Blue", GColorOxfordBlue},
+  {"Duke Blue", GColorDukeBlue},
+  {"Dark Green", GColorDarkGreen},
+  {"Midnight Green", GColorMidnightGreen},
+  {"Cobalt Blue", GColorCobaltBlue},
+  {"Blue Moon", GColorBlueMoon},
+  {"Islamic Green", GColorIslamicGreen},
+  {"Jaeger Green", GColorJaegerGreen},
+  {"Tiffany Blue", GColorTiffanyBlue},
+  {"Vivid Cerulean", GColorVividCerulean},
+  {"Malachite", GColorMalachite},
+  {"Medium Spring Green", GColorMediumSpringGreen},
+  {"Bulgarian Rose", GColorBulgarianRose},
+  {"Imperial Purple", GColorImperialPurple},
+  {"Indigo", GColorIndigo},
+  {"Electric Ultramarine", GColorElectricUltramarine},
+  {"Army Green", GColorArmyGreen},
+  {"Liberty", GColorLiberty},
+  {"Very Light Blue", GColorVeryLightBlue},
+  {"Kelly Green", GColorKellyGreen},
+  {"May Green", GColorMayGreen},
+  {"Cadet Blue", GColorCadetBlue},
+  {"Picton Blue", GColorPictonBlue},
+  {"Bright Green", GColorBrightGreen},
+  {"Screamin Green", GColorScreaminGreen},
+  {"Medium Aquamarine", GColorMediumAquamarine},
+  {"Electric Blue", GColorElectricBlue},
+  {"Dark Candy Apple Red", GColorDarkCandyAppleRed},
+  {"Jazzberry Jam", GColorJazzberryJam},
+  {"Vivid Violet", GColorVividViolet},
+  {"Windsor Tan", GColorWindsorTan},
+  {"Rose Vale", GColorRoseVale},
+  {"Purpureus", GColorPurpureus},
+  {"Lavender Indigo", GColorLavenderIndigo},
+  {"Limerick", GColorLimerick},
+  {"Brass", GColorBrass},
+  {"Light Gray", GColorLightGray},
+  {"Baby Blue Eyes", GColorBabyBlueEyes},
+  {"Spring Bud", GColorSpringBud},
+  {"Inchworm", GColorInchworm},
+  {"Mint Green", GColorMintGreen},
+  {"Celeste", GColorCeleste},
+  {"Folly", GColorFolly},
+  {"Fashion Magenta", GColorFashionMagenta},
+  {"Sunset Orange", GColorSunsetOrange},
+  {"Brilliant Rose", GColorBrilliantRose},
+  {"Shocking Pink", GColorShockingPink},
+  {"Chrome Yellow", GColorChromeYellow},
+  {"Rajah", GColorRajah},
+  {"Melon", GColorMelon},
+  {"Rich Brilliant Lavender", GColorRichBrilliantLavender},
+  {"Icterine", GColorIcterine},
+  {"Pastel Yellow", GColorPastelYellow},
+  {"White", GColorWhite},
+};
+
+static const ColorDefinition s_color_definitions_short[12] = {
+  {"Default", GColorClear},
+  {"Black", GColorBlack},
+  {"Blue", GColorBlue},
+  {"Green", GColorGreen},
+  {"Cyan", GColorCyan},
+  {"Purple", GColorPurple},
+  {"Red", GColorRed},
+  {"Magenta", GColorMagenta},
+  {"Orange", GColorOrange},
+  {"Yellow", GColorYellow},
+  {"Gray", GColorDarkGray},
+  {"Show All...", GColorClear}, // Placeholder color for "Show All" option
+};
+
+const SettingsModuleMetadata *settings_themes_get_info(void);

--- a/src/fw/apps/system_apps/settings/settings_window.c
+++ b/src/fw/apps/system_apps/settings/settings_window.c
@@ -41,6 +41,7 @@
 #include "services/common/system_task.h"
 #include "system/bootbits.h"
 #include "system/passert.h"
+#include "shell/prefs.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -72,7 +73,7 @@ static SettingsCallbacks *prv_get_current_callbacks(SettingsData *data) {
 
 static void prv_set_sub_menu_colors(GContext *ctx, const Layer *cell_layer, bool highlight) {
   if (highlight) {
-    graphics_context_set_fill_color(ctx, SETTINGS_MENU_HIGHLIGHT_COLOR);
+    graphics_context_set_fill_color(ctx, shell_prefs_get_settings_menu_highlight_color());
     graphics_context_set_text_color(ctx, GColorWhite);
   } else {
     graphics_context_set_fill_color(ctx, GColorWhite);
@@ -192,7 +193,7 @@ static void prv_settings_window_load(Window *window) {
     .selection_will_change = prv_selection_will_change_callback,
   });
   menu_layer_set_normal_colors(menu_layer, GColorWhite, GColorBlack);
-  menu_layer_set_highlight_colors(menu_layer, SETTINGS_MENU_HIGHLIGHT_COLOR, GColorWhite);
+  menu_layer_set_highlight_colors(menu_layer, shell_prefs_get_settings_menu_highlight_color(), GColorWhite);
   menu_layer_set_click_config_onto_window(menu_layer, &data->window);
   layer_add_child(&data->window.layer, menu_layer_get_layer(menu_layer));
 

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -22,6 +22,7 @@
 
 #include "apps/system_apps/toggle/quiet_time.h"
 #include "board/board.h"
+#include "applib/graphics/gtypes.h"
 #include "drivers/ambient_light.h"
 #include "drivers/backlight.h"
 #include "mfg/mfg_info.h"
@@ -190,6 +191,14 @@ static bool s_coredump_on_request_enabled = false;
 #if PLATFORM_OBELIX
 static uint8_t s_legacy_app_render_mode = 0; // Default to bezel mode
 #endif
+
+#define PREF_KEY_SETTINGS_MENU_HIGHLIGHT_COLOR "settingsMenuHighlightColor"
+#define PREF_KEY_APPS_MENU_HIGHLIGHT_COLOR "appsMenuHighlightColor"
+
+
+static GColor s_settings_menu_highlight_color = GColorCobaltBlue;
+static GColor s_apps_menu_highlight_color = GColorVividCerulean;
+
 
 // ============================================================================================
 // Handlers for each pref that validate the new setting and store the new value in our globals.
@@ -477,6 +486,24 @@ static bool prv_set_s_legacy_app_render_mode(uint8_t *mode) {
 }
 #endif
 
+static bool prv_set_s_settings_menu_highlight_color(GColor *color) {
+#if PBL_COLOR
+  s_settings_menu_highlight_color = *color;
+#else
+  s_settings_menu_highlight_color = GColorBlack;
+#endif
+  return true;
+}
+
+static bool prv_set_s_apps_menu_highlight_color(GColor *color) {
+#if PBL_COLOR
+  s_apps_menu_highlight_color = *color;
+#else
+  s_apps_menu_highlight_color = GColorBlack;
+#endif
+  return true;
+}
+  
 // ------------------------------------------------------------------------------------
 // Table of all prefs
 typedef bool (*PrefSetHandler)(const void *value, size_t val_len);
@@ -1260,3 +1287,27 @@ void shell_prefs_set_legacy_app_render_mode(LegacyAppRenderMode mode) {
   prv_pref_set(PREF_KEY_LEGACY_APP_RENDER_MODE, &mode_value, sizeof(mode_value));
 }
 #endif
+
+GColor shell_prefs_get_settings_menu_highlight_color(void){
+  #if !PBL_COLOR
+    return GColorBlack;
+  #endif
+  return s_settings_menu_highlight_color;
+}
+
+void shell_prefs_set_settings_menu_highlight_color(GColor color) {
+  prv_pref_set(PREF_KEY_SETTINGS_MENU_HIGHLIGHT_COLOR, &color, sizeof(GColor));
+}
+
+
+
+GColor shell_prefs_get_apps_menu_highlight_color(void){
+  #if !PBL_COLOR
+    return GColorBlack;
+  #endif
+  return s_apps_menu_highlight_color;
+}
+
+void shell_prefs_set_apps_menu_highlight_color(GColor color) {
+  prv_pref_set(PREF_KEY_APPS_MENU_HIGHLIGHT_COLOR, &color, sizeof(GColor));
+}

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -43,3 +43,6 @@
 #if PLATFORM_OBELIX
   PREFS_MACRO(PREF_KEY_LEGACY_APP_RENDER_MODE, s_legacy_app_render_mode)
 #endif
+
+  PREFS_MACRO(PREF_KEY_SETTINGS_MENU_HIGHLIGHT_COLOR, s_settings_menu_highlight_color)
+  PREFS_MACRO(PREF_KEY_APPS_MENU_HIGHLIGHT_COLOR, s_apps_menu_highlight_color)

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -134,3 +134,9 @@ typedef enum LegacyAppRenderMode {
 LegacyAppRenderMode shell_prefs_get_legacy_app_render_mode(void);
 void shell_prefs_set_legacy_app_render_mode(LegacyAppRenderMode mode);
 #endif
+
+GColor shell_prefs_get_settings_menu_highlight_color(void);
+void shell_prefs_set_settings_menu_highlight_color(GColor color);
+
+GColor shell_prefs_get_apps_menu_highlight_color(void);
+void shell_prefs_set_apps_menu_highlight_color(GColor color);


### PR DESCRIPTION
Added an accent color settings module for both apps screen and the settings app

tested on silk (just doesn't show up and uses the defaults), snowy and spalding in QEMU 

for it to be expanded in the future for other apps will probably need a rewrite (unclear how dark/light/default modes will integrate into this too, might be able to squeeze it in this structure)

