### PR TITLE
third_party/memfault: disable memfault on PRF

### DIFF
--- a/third_party/memfault/wscript
+++ b/third_party/memfault/wscript
@@ -22,6 +22,12 @@ def build(bld):
     if not bld.env.memfault:
         return
 
+    if bld.variant == "prf":
+        bld.env.DEFINES = [d for d in bld.env.DEFINES if not d.startswith('MEMFAULT')]
+        bld.env.append_value('DEFINES', 'MEMFAULT=0')
+        bld.env.memfault = 0
+        return
+
     memfault_includes = [
         "memfault-firmware-sdk/",
         "memfault-firmware-sdk/components/include",


### PR DESCRIPTION
PRF build has analytics stubbed out, so enabling memfault would cause a boot-time deadlock due to missing memfault components being initialized (e.g. lock). This went off the radar because Obelix had PRF disabled due to flash space overflow, but all PRFs were broken, including Asterix!