### PR TITLE
comm/ble: Fix deadlock between NimbleHost and KernelMain threads [FIRM-646]

### DIFF
--- a/src/fw/comm/ble/gap_le_connect_params.c
+++ b/src/fw/comm/ble/gap_le_connect_params.c
@@ -225,8 +225,8 @@ void gap_le_connect_params_request(GAPLEConnection *connection,
   prv_request_params_update(connection, desired_state);
 }
 
-void gap_le_connect_params_setup_connection(GAPLEConnection *connection) {
-  connection->param_update_info.watchdog_timer = new_timer_create();
+void gap_le_connect_params_setup_connection(GAPLEConnection *connection, TimerID timer) {
+  connection->param_update_info.watchdog_timer = timer;
 }
 
 void gap_le_connect_params_cleanup_by_connection(GAPLEConnection *connection) {

--- a/src/fw/comm/ble/gap_le_connection.c
+++ b/src/fw/comm/ble/gap_le_connection.c
@@ -47,7 +47,7 @@ extern void gatt_client_discovery_cleanup_by_connection(GAPLEConnection *connect
 extern void gatt_client_cleanup_discovery_jobs(GAPLEConnection *connection);
 
 // Defined in gap_le_connect_params.c
-extern void gap_le_connect_params_setup_connection(GAPLEConnection *connection);
+extern void gap_le_connect_params_setup_connection(GAPLEConnection *connection, TimerID timer);
 extern void gap_le_connect_params_cleanup_by_connection(GAPLEConnection *connection);
 
 // -------------------------------------------------------------------------------------------------
@@ -130,7 +130,8 @@ void gap_le_connection_set_irk(GAPLEConnection *connection, const SMIdentityReso
 
 GAPLEConnection *gap_le_connection_add(const BTDeviceInternal *device,
                                        const SMIdentityResolvingKey *irk,
-                                       bool local_is_master) {
+                                       bool local_is_master,
+                                       TimerID param_watchdog_timer) {
   bt_lock_assert_held(true /* is_held */);
   PBL_ASSERTN(!gap_le_connection_is_connected(device));
 
@@ -150,7 +151,7 @@ GAPLEConnection *gap_le_connection_add(const BTDeviceInternal *device,
   s_connections = (GAPLEConnection *) list_prepend(&s_connections->node,
                                                    &connection->node);
 
-  gap_le_connect_params_setup_connection(connection);
+  gap_le_connect_params_setup_connection(connection, param_watchdog_timer);
 
   return connection;
 }

--- a/src/fw/comm/ble/gap_le_connection.h
+++ b/src/fw/comm/ble/gap_le_connection.h
@@ -157,7 +157,8 @@ typedef struct GAPLEConnection {
 
 GAPLEConnection *gap_le_connection_add(const BTDeviceInternal *device,
                                        const SMIdentityResolvingKey *irk,
-                                       bool local_is_master);
+                                       bool local_is_master,
+                                       TimerID param_watchdog_timer);
 
 //! Checks to see if the LE connection is in our list of currently tracked
 //! connections


### PR DESCRIPTION
Fix a lock ordering violation that causes deadlock between the NimbleHost and KernelMain threads. The deadlock occurs when:

1. KernelMain holds bt_lock and tries to acquire TaskTimerManager mutex (by calling new_timer_create()) 
2. NimbleHost holds TaskTimerManager mutex and tries to acquire bt_lock (when calling back into firmware code)