### PR TITLE
services/bluetooth: Defer bonding callbacks to KernelMain to avoid deadlock [FIRM-723]

### DIFF
--- a/src/fw/services/common/bluetooth/bonding.c
+++ b/src/fw/services/common/bluetooth/bonding.c
@@ -20,11 +20,45 @@
 
 #include "services/common/bluetooth/bluetooth_persistent_storage.h"
 #include "services/common/bluetooth/local_addr.h"
+#include "kernel/event_loop.h"
+#include "kernel/pbl_malloc.h"
 #include "system/logging.h"
 
 #include <bluetooth/bonding_sync.h>
 #include <bluetooth/bluetooth_types.h>
 #include <bluetooth/sm_types.h>
+
+typedef struct {
+  BTBondingID bonding_id;
+  BTDeviceAddress addr;
+  bool is_gateway;
+} CreateBondingContext;
+
+static void prv_finalize_create_bonding(BTBondingID bonding_id,
+                                        const BTDeviceAddress *addr,
+                                        bool is_gateway) {
+  bt_lock();
+  GAPLEConnection *connection = gap_le_connection_by_addr(addr);
+  if (connection) {
+    connection->bonding_id = bonding_id;
+    connection->is_gateway = is_gateway;
+
+    if (!connection->is_gateway) {
+      PBL_LOG(LOG_LEVEL_DEBUG, "New bonding is not gateway?");
+    }
+
+    gap_le_device_name_request(&connection->device);
+  } else {
+    PBL_LOG(LOG_LEVEL_ERROR, "Couldn't find connection for bonding!");
+  }
+  bt_unlock();
+}
+
+static void prv_finalize_create_bonding_cb(void *data) {
+  CreateBondingContext *context = data;
+  prv_finalize_create_bonding(context->bonding_id, &context->addr, context->is_gateway);
+  kernel_free(context);
+}
 
 void bt_driver_cb_handle_create_bonding(const BleBonding *bonding,
                                         const BTDeviceAddress *addr) {
@@ -44,24 +78,21 @@ void bt_driver_cb_handle_create_bonding(const BleBonding *bonding,
                                                                    bonding->is_gateway, NULL,
                                                                    should_pin_address,
                                                                    flags);
-  bt_lock();
-  {
-    GAPLEConnection *connection = gap_le_connection_by_addr(addr);
-    if (connection) {
-      // Associate the connection with the bonding:
-      connection->bonding_id = bonding_id;
-      connection->is_gateway = bonding->is_gateway;
-
-      if (!connection->is_gateway) {
-        PBL_LOG(LOG_LEVEL_DEBUG, "New bonding is not gateway?");
-      }
-
-      // Request device name. iOS returns an "anonymized" device name before encryption, like
-      // "iPhone" and only returns the real name i.e. "Martijn's iPhone" after encryption is set up.
-      gap_le_device_name_request(&connection->device);
-    } else {
-      PBL_LOG(LOG_LEVEL_ERROR, "Couldn't find connection for bonding!");
-    }
+  if (bonding_id == BT_BONDING_ID_INVALID) {
+    return;
   }
-  bt_unlock();
+
+  if (launcher_task_is_current_task()) {
+    prv_finalize_create_bonding(bonding_id, addr, bonding->is_gateway);
+    return;
+  }
+
+  CreateBondingContext *context = kernel_malloc_check(sizeof(*context));
+
+  *context = (CreateBondingContext) {
+    .bonding_id = bonding_id,
+    .addr = *addr,
+    .is_gateway = bonding->is_gateway,
+  };
+  launcher_task_add_callback(prv_finalize_create_bonding_cb, context);
 }

--- a/src/fw/services/normal/bluetooth/bluetooth_persistent_storage.c
+++ b/src/fw/services/normal/bluetooth/bluetooth_persistent_storage.c
@@ -25,6 +25,7 @@
 #include "comm/ble/kernel_le_client/kernel_le_client.h"
 #include "comm/bt_lock.h"
 #include "console/prompt.h"
+#include "kernel/event_loop.h"
 #include "kernel/pbl_malloc.h"
 #include "os/mutex.h"
 #include "services/common/analytics/analytics.h"
@@ -583,8 +584,13 @@ static unsigned int prv_get_num_pairings_by_type(BtPersistBondingType type) {
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 //! BLE Pairing Info
 void gap_le_connection_handle_bonding_change(BTBondingID bonding, BtPersistBondingOp op);
-static void prv_call_ble_bonding_change_handlers(BTBondingID bonding,
-                                                 BtPersistBondingOp op) {
+typedef struct {
+  BTBondingID bonding;
+  BtPersistBondingOp op;
+} BleBondingChangeContext;
+
+static void prv_call_ble_bonding_change_handlers_impl(BTBondingID bonding,
+                                                      BtPersistBondingOp op) {
   prv_update_active_gateway_if_needed(bonding, op);
 
   if (!bt_ctl_is_bluetooth_running()) {
@@ -595,6 +601,28 @@ static void prv_call_ble_bonding_change_handlers(BTBondingID bonding,
   gap_le_connect_handle_bonding_change(bonding, op);
   kernel_le_client_handle_bonding_change(bonding, op);
   prv_call_common_bonding_change_handlers(bonding, op);
+}
+
+static void prv_call_ble_bonding_change_handlers_cb(void *data) {
+  BleBondingChangeContext *context = data;
+  prv_call_ble_bonding_change_handlers_impl(context->bonding, context->op);
+  kernel_free(context);
+}
+
+static void prv_call_ble_bonding_change_handlers(BTBondingID bonding,
+                                                 BtPersistBondingOp op) {
+  if (launcher_task_is_current_task()) {
+    prv_call_ble_bonding_change_handlers_impl(bonding, op);
+    return;
+  }
+
+  BleBondingChangeContext *context = kernel_malloc_check(sizeof(*context));
+
+  *context = (BleBondingChangeContext) {
+    .bonding = bonding,
+    .op = op,
+  };
+  launcher_task_add_callback(prv_call_ble_bonding_change_handlers_cb, context);
 }
 
 typedef struct {


### PR DESCRIPTION
- schedule BLE bonding change notifications on the launcher task when invoked from NimBLE
- queue bonding creation finalization to KernelMain so bt_lock is taken outside the host stack