### PR TITLE
fw: Add Motion Sensitivity setting and LSM6DSO mapping

### DIFF
--- a/src/fw/services/common/accel_manager.h
+++ b/src/fw/services/common/accel_manager.h
@@ -90,5 +90,10 @@ bool gyro_manager_run_selftest(void);
 // event from any small movements
 void accel_enable_high_sensitivity(bool high_sensitivity);
 
+// Update the motion sensitivity based on user preference (0-100%)
+// Only available on Asterix/Obelix platforms
+// 100 = most sensitive, 0 = least sensitive
+void accel_manager_update_sensitivity(uint8_t sensitivity_percent);
+
 // lightweight call to determine if the watch is idle
 bool accel_is_idle(void);

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -8,6 +8,7 @@
   PREFS_MACRO(PREF_KEY_BACKLIGHT_TIMEOUT_MS, s_backlight_timeout_ms)
   PREFS_MACRO(PREF_KEY_BACKLIGHT_INTENSITY, s_backlight_intensity)
   PREFS_MACRO(PREF_KEY_BACKLIGHT_MOTION, s_backlight_motion_enabled)
+  PREFS_MACRO(PREF_KEY_MOTION_SENSITIVITY, s_motion_sensitivity)
   PREFS_MACRO(PREF_KEY_BACKLIGHT_AMBIENT_THRESHOLD, s_backlight_ambient_threshold)
   PREFS_MACRO(PREF_KEY_STATIONARY, s_stationary_mode_enabled)
   PREFS_MACRO(PREF_KEY_DEFAULT_WORKER, s_default_worker)

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -89,6 +89,11 @@ void backlight_set_intensity_percent(uint8_t intensity_percent);
 bool backlight_is_motion_enabled(void);
 void backlight_set_motion_enabled(bool enable);
 
+// Motion sensitivity for accelerometer shake detection (0-100, lower = less sensitive)
+// Only available on platforms with LSM6DSO (Asterix, Obelix)
+uint8_t shell_prefs_get_motion_sensitivity(void);
+void shell_prefs_set_motion_sensitivity(uint8_t sensitivity);
+
 // The backlight ambient light threshold setting
 uint32_t backlight_get_ambient_threshold(void);
 void backlight_set_ambient_threshold(uint32_t threshold);


### PR DESCRIPTION
Add an Asterix-only settings menu and preference (0-100%, default 100%) to control accelerometer shake sensitivity. Expose shell prefs and UI labels, and store the value in prefs_values. Introduce accel_manager_update_sensitivity and a driver API to set percent. Driver interpolates between board low/high wake thresholds (100% = most sensitive = low threshold), clamps values, logs changes, and reconfigures shake detection immediately.