### PR TITLE
fw/drivers/sf32lb52/uart: disable stop mode if RX is enabled

### DIFF
--- a/src/fw/drivers/sf32lb52/uart.c
+++ b/src/fw/drivers/sf32lb52/uart.c
@@ -17,6 +17,7 @@
 #include "uart_definitions.h"
 
 #include "drivers/uart.h"
+#include "kernel/util/stop.h"
 #include "system/passert.h"
 
 #include "FreeRTOS.h"
@@ -37,12 +38,14 @@ static void prv_init(UARTDevice *dev, uint32_t mode) {
     case UART_MODE_TX_RX:
       HAL_PIN_Set(dev->tx.pad, dev->tx.func, dev->tx.flags, 1);
       HAL_PIN_Set(dev->rx.pad, dev->rx.func, dev->rx.flags, 1);
+      stop_mode_disable(InhibitorDbgSerial);
       break;
     case UART_MODE_TX:
       HAL_PIN_Set(dev->tx.pad, dev->tx.func, dev->tx.flags, 1);
       break;
     case UART_MODE_RX:
       HAL_PIN_Set(dev->rx.pad, dev->rx.func, dev->rx.flags, 1);
+      stop_mode_disable(InhibitorDbgSerial);
       break;
     default:
       WTF;


### PR DESCRIPTION
We cannot use stop mode (deepsleep) if UART RX is enabled, otherwise the system would not react to UART input when in deepsleep. While this increases power consumption significantly, it is not critical as on release builds (except on MFG firmware) the dbgserial is turned off.

Fixes #427