### PR TITLE
services/ancs: add info logs for ANCS notification events [FIRM-744]

### DIFF
--- a/src/fw/services/normal/notifications/ancs/ancs_notifications.c
+++ b/src/fw/services/normal/notifications/ancs/ancs_notifications.c
@@ -376,8 +376,10 @@ void ancs_notifications_handle_message(uint32_t uid,
       notification_storage_unlock();
       goto cleanup;
     }
+    PBL_LOG(LOG_LEVEL_INFO, "Updating ANCS notification: %"PRIu32, uid);
     prv_handle_ancs_update(notification, &existing_header);
   } else {
+    PBL_LOG(LOG_LEVEL_INFO, "New ANCS notification: %"PRIu32, uid);
     prv_handle_new_ancs_notif(notification);
   }
 


### PR DESCRIPTION
Note that I didn't test this due to not having an iOS device, but come on, do you really have to test this