### PR TITLE
fw: Add dynamic backlight feature with ALS-based intensity control

### DIFF
--- a/platform/platform_capabilities.py
+++ b/platform/platform_capabilities.py
@@ -59,6 +59,7 @@ master_capability_set = {
     'HAS_FLASH_OTP',
     'HAS_VIBE_AW86225',
     'HAS_PBLBOOT',
+    'HAS_DYNAMIC_BACKLIGHT',
 }
 
 board_capability_dicts = [
@@ -365,6 +366,7 @@ board_capability_dicts = [
             'HAS_ALS_W1160',
             'HAS_MAGNETOMETER',
             'HAS_PBLBOOT',
+            'HAS_DYNAMIC_BACKLIGHT',
         },
     },
 ]

--- a/src/fw/apps/system_apps/settings/settings_display.c
+++ b/src/fw/apps/system_apps/settings/settings_display.c
@@ -166,6 +166,9 @@ enum SettingsDisplayItem {
   SettingsDisplayBacklightMode,
   SettingsDisplayMotionSensor,
   SettingsDisplayAmbientSensor,
+#if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
+  SettingsDisplayDynamicIntensity,
+#endif
   SettingsDisplayBacklightIntensity,
   SettingsDisplayBacklightTimeout,
 #if PLATFORM_SPALDING
@@ -208,6 +211,11 @@ static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
     case SettingsDisplayAmbientSensor:
       light_toggle_ambient_sensor_enabled();
       break;
+#if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
+    case SettingsDisplayDynamicIntensity:
+      backlight_set_dynamic_intensity_enabled(!backlight_is_dynamic_intensity_enabled());
+      break;
+#endif
     case SettingsDisplayBacklightIntensity:
       prv_intensity_menu_push(data);
       break;
@@ -266,8 +274,26 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
         subtitle = i18n_noop("Off");
       }
       break;
+#if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
+    case SettingsDisplayDynamicIntensity:
+      title = i18n_noop("Dynamic Backlight");
+      if (backlight_is_dynamic_intensity_enabled()) {
+        subtitle = i18n_noop("On");
+      } else {
+        subtitle = i18n_noop("Off");
+      }
+      break;
+#endif
     case SettingsDisplayBacklightIntensity:
+#if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
+      if (backlight_is_dynamic_intensity_enabled()) {
+        title = i18n_noop("Max Intensity");
+      } else {
+        title = i18n_noop("Intensity");
+      }
+#else
       title = i18n_noop("Intensity");
+#endif
       subtitle = s_intensity_labels[prv_intensity_get_selection_index()];
       break;
     case SettingsDisplayBacklightTimeout:

--- a/src/fw/board/board_sf32lb52.h
+++ b/src/fw/board/board_sf32lb52.h
@@ -131,6 +131,11 @@ typedef struct {
   //ambient light config
   uint32_t ambient_light_dark_threshold;
   uint32_t ambient_k_delta_threshold;
+#if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
+  //dynamic backlight thresholds
+  uint32_t dynamic_backlight_min_threshold;
+  uint32_t dynamic_backlight_max_threshold;
+#endif
 } BoardConfig;
 
 typedef struct {

--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -546,6 +546,8 @@ const BoardConfig BOARD_CONFIG = {
   .backlight_on_percent = 25,
   .ambient_light_dark_threshold = 150,
   .ambient_k_delta_threshold = 25,
+  .dynamic_backlight_min_threshold = 20,
+  .dynamic_backlight_max_threshold = 120,
 };
 
 const BoardConfigButton BOARD_CONFIG_BUTTON = {

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -78,6 +78,11 @@ static bool s_backlight_motion_enabled = true;
 #define PREF_KEY_MOTION_SENSITIVITY "motionSensitivity"
 static uint8_t s_motion_sensitivity = 100; // Default to maximum sensitivity (100%)
 
+#if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
+#define PREF_KEY_BACKLIGHT_DYNAMIC_INTENSITY "lightDynamicIntensity"
+static bool s_backlight_dynamic_intensity_enabled = false;
+#endif
+
 #define PREF_KEY_BACKLIGHT_AMBIENT_THRESHOLD "lightAmbientThreshold"
 static uint32_t s_backlight_ambient_threshold = 0; // default set from board config in shell_prefs_init()
 
@@ -277,6 +282,13 @@ static bool prv_set_s_backlight_motion_enabled(bool *enabled) {
   s_backlight_motion_enabled = *enabled;
   return true;
 }
+
+#if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
+static bool prv_set_s_backlight_dynamic_intensity_enabled(bool *enabled) {
+  s_backlight_dynamic_intensity_enabled = *enabled;
+  return true;
+}
+#endif
 
 static bool prv_set_s_motion_sensitivity(uint8_t *sensitivity) {
   // Clamp sensitivity to 0-100 range
@@ -879,6 +891,16 @@ bool backlight_is_motion_enabled(void) {
 void backlight_set_motion_enabled(bool enable) {
   prv_pref_set(PREF_KEY_BACKLIGHT_MOTION, &enable, sizeof(enable));
 }
+
+#if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
+bool backlight_is_dynamic_intensity_enabled(void) {
+  return s_backlight_dynamic_intensity_enabled;
+}
+
+void backlight_set_dynamic_intensity_enabled(bool enable) {
+  prv_pref_set(PREF_KEY_BACKLIGHT_DYNAMIC_INTENSITY, &enable, sizeof(enable));
+}
+#endif
 
 uint8_t shell_prefs_get_motion_sensitivity(void) {
   return s_motion_sensitivity;

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -9,6 +9,9 @@
   PREFS_MACRO(PREF_KEY_BACKLIGHT_INTENSITY, s_backlight_intensity)
   PREFS_MACRO(PREF_KEY_BACKLIGHT_MOTION, s_backlight_motion_enabled)
   PREFS_MACRO(PREF_KEY_MOTION_SENSITIVITY, s_motion_sensitivity)
+#if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
+  PREFS_MACRO(PREF_KEY_BACKLIGHT_DYNAMIC_INTENSITY, s_backlight_dynamic_intensity_enabled)
+#endif
   PREFS_MACRO(PREF_KEY_BACKLIGHT_AMBIENT_THRESHOLD, s_backlight_ambient_threshold)
   PREFS_MACRO(PREF_KEY_STATIONARY, s_stationary_mode_enabled)
   PREFS_MACRO(PREF_KEY_DEFAULT_WORKER, s_default_worker)

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -89,6 +89,12 @@ void backlight_set_intensity_percent(uint8_t intensity_percent);
 bool backlight_is_motion_enabled(void);
 void backlight_set_motion_enabled(bool enable);
 
+#if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
+// Dynamic backlight intensity based on ambient light sensor
+bool backlight_is_dynamic_intensity_enabled(void);
+void backlight_set_dynamic_intensity_enabled(bool enable);
+#endif
+
 // Motion sensitivity for accelerometer shake detection (0-100, lower = less sensitive)
 // Only available on platforms with LSM6DSO (Asterix, Obelix)
 uint8_t shell_prefs_get_motion_sensitivity(void);


### PR DESCRIPTION
Implements user-toggleable dynamic backlight that automatically adjusts backlight intensity based on ambient light sensor readings. When enabled, backlight intensity scales linearly between 5% (Low) and the user's configured max intensity based on ambient light condition.

Note: Threshold values (20/120) are initial estimates and will likely need to be adjusted based on real-world testing and user feedback