### PR TITLE
Bugfix: PDM gain setting

### DIFF
--- a/src/fw/drivers/mic/sf32lb52/pdm.c
+++ b/src/fw/drivers/mic/sf32lb52/pdm.c
@@ -28,8 +28,8 @@
 #include "FreeRTOS.h"
 
 #define PDM_AUDIO_RECORD_PIPE_SIZE         (288)
-#define PDM_AUDIO_RECORD_GAIN_DEFAULT      (127)
-#define PDM_AUDIO_RECORD_GAIN_MAX          (127)
+#define PDM_AUDIO_RECORD_GAIN_DEFAULT      (120)
+#define PDM_AUDIO_RECORD_GAIN_MAX          (120)
 
 // PDM Configuration
 #define PDM_BUFFER_SIZE_SAMPLES            (320)


### PR DESCRIPTION
pdm mic HAL gain ctrl maxmum is 120, otherwise it would revert.