### PR TITLE
services/voice_endpoint: Fix voice crash from invalid session setup result code

### DIFF
--- a/src/fw/services/normal/voice_endpoint.c
+++ b/src/fw/services/normal/voice_endpoint.c
@@ -147,8 +147,17 @@ void voice_endpoint_protocol_msg_callback(CommSession *session, const uint8_t* d
     case MsgIdSessionSetup: {
       if (size >= sizeof(SessionSetupResultMsg)) {
         SessionSetupResultMsg *msg = (SessionSetupResultMsg *) data;
+        
+        // Validate result enum value to prevent crashes from invalid values
+        VoiceEndpointResult result = msg->result;
+        if (result > VoiceEndpointResultFailInvalidMessage) {
+          PBL_LOG(LOG_LEVEL_ERROR, "Invalid VoiceEndpointResult value: %d, treating as invalid message", 
+                  (int)result);
+          result = VoiceEndpointResultFailInvalidMessage;
+        }
+        
         bool app_initiated = (msg->flags.app_initiated == 1);
-        voice_handle_session_setup_result(msg->result, msg->session_type, app_initiated);
+        voice_handle_session_setup_result(result, msg->session_type, app_initiated);
       } else {
         PBL_LOG(LOG_LEVEL_WARNING, "Invalid size for session setup result message");
       }


### PR DESCRIPTION
A user experienced a watch crash when attempting voice replies to text messages.

The coredump revealed that the watch was sent a session setup result message with an invalid `VoiceEndpointResult` value of 0x11 (17). The VoiceEndpointResult enum only defines values 0x00-0x06, but the protocol handler in voice_endpoint.c was passing the raw message value to voice_handle_session_setup_result() without validation.

This invalid enum value caused undefined behavior that allowed code execution to reach an unexpected state, eventually triggering an assertion failure.