### PR TITLE
Revert "fw/apps: Include health in launcher if not quick launched"

### DIFF
--- a/src/fw/apps/system_apps/health/health.c
+++ b/src/fw/apps/system_apps/health/health.c
@@ -169,6 +169,9 @@ const PebbleProcessMd *health_app_get_info(void) {
     .common = {
       .main_func = &prv_main,
       .uuid = UUID_HEALTH_DATA_SOURCE,
+#if CAPABILITY_HAS_CORE_NAVIGATION4
+      .visibility = ProcessVisibilityHidden,
+#endif
     },
     .icon_resource_id = RESOURCE_ID_MENU_ICON_HEALTH,
     .name = i18n_noop("Health"),

--- a/src/fw/apps/system_apps/launcher/default/launcher_app.c
+++ b/src/fw/apps/system_apps/launcher/default/launcher_app.c
@@ -23,11 +23,9 @@
 #include "applib/ui/app_window_stack.h"
 #include "kernel/pbl_malloc.h"
 #include "shell/normal/app_idle_timeout.h"
-#include "shell/normal/quick_launch.h"
 #include "system/passert.h"
 #include "shell/prefs.h"
 #include "process_state/app_state/app_state.h"
-#include "services/normal/timeline/timeline.h"
 #include "util/attributes.h"
 
 typedef struct LauncherAppWindowData {
@@ -66,13 +64,6 @@ static void prv_will_focus(bool in_focus) {
 // AppMenuDataSource callbacks
 
 static bool prv_app_filter_callback(PBL_UNUSED AppMenuDataSource *source, AppInstallEntry *entry) {
-  // Skip Health app if it's set as the quick launch single-click up action
-  const Uuid health_uuid = UUID_HEALTH_DATA_SOURCE;
-  const AppInstallId health_install_id = app_install_get_id_for_uuid(&health_uuid);
-  const AppInstallId quick_launch_app_id = quick_launch_single_click_get_app(BUTTON_ID_UP);
-  if (entry->install_id == health_install_id && health_install_id == quick_launch_app_id) {
-      return false;
-  }
   // Skip watchfaces and hidden apps
   return (!app_install_entry_is_watchface(entry) && !app_install_entry_is_hidden((entry)));
 }


### PR DESCRIPTION
This reverts commit 64e68096367e86adf942a38818b0b22062970eb1.

The hiding mechanism caused launcher to get stuck if a third party app was set to the quick launch buttons