### PR TITLE
configure sifli chipset power key reset time to 15s

### DIFF
--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -28,6 +28,7 @@
 
 
 #define HCPU_FREQ_MHZ 240
+#define PWRKEY_RESET_CNT (32000 * 15)
 
 static UARTDeviceState s_dbg_uart_state = {
   .huart = {
@@ -671,6 +672,9 @@ void board_early_init(void) {
 
   __HAL_SYSCFG_CLEAR_SECURITY();
   HAL_EFUSE_Init();
+
+  //set Sifli chipset pwrkey reset time to 15s, so it always use PMIC cold reboot for long press 
+  hwp_pmuc->PWRKEY_CNT = PWRKEY_RESET_CNT;
 }
 
 void board_init(void) {


### PR DESCRIPTION
So it always use PMIC cool reboot for long press the left button

Fixes FIRM-826