### PR TITLE
asterix: enable WEATHER and REMINDERS system apps

### DIFF
--- a/src/fw/shell/normal/system_app_registry_list.json
+++ b/src/fw/shell/normal/system_app_registry_list.json
@@ -323,7 +323,8 @@
         "snowy",
         "spalding",
         "silk",
-        "robert"
+        "robert",
+        "asterix"
       ]
     },
     {
@@ -558,7 +559,8 @@
         "snowy",
         "spalding",
         "silk",
-        "robert"
+        "robert",
+        "asterix"
       ]
     },
     {


### PR DESCRIPTION
I spent hours debugging why Gadgetbridge won't enable weather, it was just not built into the firmware.

I really think it should, along with reminders.