### PR TITLE
fw/boards/obelix: fix LIS2DW addresses

### DIFF
--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -412,10 +412,10 @@ IRQ_MAP(I2C2, i2c_irq_handler, I2C2_BUS);
 #ifdef IMU_USE_LIS2DW12
 static const I2CSlavePort s_i2c_lsm2dw12 = {
     .bus = &s_i2c_bus_2,
-#if BOARD_OBELIX_DVT
-    .address = 0x19,
-#else
+#if BOARD_OBELIX_DVT || BOARD_OBELIX_BB2
     .address = 0x18,
+#else
+    .address = 0x19,
 #endif
 };
 


### PR DESCRIPTION
It was actually wrong! I guess it's the consequence of having so many boards on my table.