### PR TITLE
fw/apps/health: Scale UI for larger displays

### DIFF
--- a/src/fw/apps/system_apps/health/health_activity_summary_card.c
+++ b/src/fw/apps/system_apps/health/health_activity_summary_card.c
@@ -24,12 +24,24 @@
 #include "applib/pbl_std/pbl_std.h"
 #include "applib/ui/kino/kino_reel.h"
 #include "applib/ui/text_layer.h"
+#include "board/display.h"
 #include "kernel/pbl_malloc.h"
 #include "resource/resource_ids.auto.h"
 #include "services/common/i18n/i18n.h"
 #include "system/logging.h"
 #include "util/size.h"
 #include "util/string.h"
+
+// Compile-time display offset calculations
+#define HEALTH_X_OFFSET ((DISP_COLS - LEGACY_2X_DISP_COLS) / 2)
+#define HEALTH_Y_OFFSET ((DISP_ROWS - LEGACY_2X_DISP_ROWS) / 2)
+
+// Use larger font for taller displays
+#if DISP_ROWS > LEGACY_2X_DISP_ROWS
+#define HEALTH_STEPS_FONT FONT_KEY_LECO_32_BOLD_NUMBERS
+#else
+#define HEALTH_STEPS_FONT FONT_KEY_LECO_26_BOLD_NUMBERS_AM_PM
+#endif
 
 typedef struct HealthActivitySummaryCardData {
   HealthData *health_data;
@@ -92,7 +104,7 @@ static void prv_render_progress_bar(GContext *ctx, Layer *base_layer) {
 static void prv_render_icon(GContext *ctx, Layer *base_layer) {
   HealthActivitySummaryCardData *data = layer_get_data(base_layer);
 
-  const int y = PBL_IF_RECT_ELSE(PBL_IF_BW_ELSE(43, 38), 43);
+  const int y = PBL_IF_RECT_ELSE(PBL_IF_BW_ELSE(43, 38), 43) + HEALTH_Y_OFFSET;
   const int x_center_offset = PBL_IF_BW_ELSE(19, 18);
   kino_reel_draw(data->icon, ctx, GPoint(base_layer->bounds.size.w / 2 - x_center_offset, y));
 }
@@ -103,17 +115,17 @@ static void prv_render_current_steps(GContext *ctx, Layer *base_layer) {
   char buffer[8];
   GFont font;
   if (data->current_steps) {
-    font = fonts_get_system_font(FONT_KEY_LECO_26_BOLD_NUMBERS_AM_PM);
+    font = fonts_get_system_font(HEALTH_STEPS_FONT);
     snprintf(buffer, sizeof(buffer), "%"PRIu32"", data->current_steps);
   } else {
     font = fonts_get_system_font(FONT_KEY_GOTHIC_28_BOLD);
     snprintf(buffer, sizeof(buffer), EM_DASH);
   }
 
-  const int y = PBL_IF_RECT_ELSE(PBL_IF_BW_ELSE(85, 83), 88);
+  const int y = PBL_IF_RECT_ELSE(PBL_IF_BW_ELSE(85, 83), 88) + HEALTH_Y_OFFSET;
   graphics_context_set_text_color(ctx, CURRENT_TEXT_COLOR);
   graphics_draw_text(ctx, buffer, font,
-                     GRect(0, y, base_layer->bounds.size.w, 35),
+                     GRect(0, y, base_layer->bounds.size.w, 40),
                      GTextOverflowModeFill, GTextAlignmentCenter, NULL);
 }
 

--- a/src/fw/apps/system_apps/health/health_activity_summary_card_segments.h
+++ b/src/fw/apps/system_apps/health/health_activity_summary_card_segments.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "health_progress.h"
+#include "board/display.h"
 
 //! 5 main segments + 2 real corners + 2 endcaps implemented as corners (for bw)
 //! Each of the 5 non-corener segments get 20% of the total
@@ -24,6 +25,11 @@
 
 // Found through trial and error
 #define DEFAULT_MARK_WIDTH 50
+
+// Dynamically center based on display size vs legacy 144x168 base
+// Round displays need additional adjustment for the bezel
+#define X_ADJ (((DISP_COLS - LEGACY_2X_DISP_COLS) / 2) + PBL_IF_ROUND_ELSE(18, 0))
+#define Y_ADJ (((DISP_ROWS - LEGACY_2X_DISP_ROWS) / 2) + PBL_IF_ROUND_ELSE(6, 0))
 
 #if PBL_BW
 // The shape of the hexagon is slightly different on BW than on Color
@@ -85,11 +91,6 @@ static HealthProgressSegment s_activity_summary_progress_segments[] = {
   },
 };
 #else // Color
-// The shape is the same, but the offsets are different
-// Slightly adjust the points on Round
-#define X_ADJ (PBL_IF_ROUND_ELSE(18, 0))
-#define Y_ADJ (PBL_IF_ROUND_ELSE(6, 0))
-
 static HealthProgressSegment s_activity_summary_progress_segments[] = {
   {
     // This is an endcap for BW (is a no-op on color)

--- a/src/fw/apps/system_apps/health/health_detail_card.c
+++ b/src/fw/apps/system_apps/health/health_detail_card.c
@@ -17,6 +17,7 @@
 #include "health_detail_card.h"
 
 #include "applib/pbl_std/pbl_std.h"
+#include "board/display.h"
 #include "kernel/pbl_malloc.h"
 #include "resource/resource_ids.auto.h"
 #include "services/common/i18n/i18n.h"
@@ -25,11 +26,16 @@
 
 #include "system/logging.h"
 
+// Compile-time display offset calculations
+#define HEALTH_Y_OFFSET ((DISP_ROWS - LEGACY_2X_DISP_ROWS) / 2)
+#define HEALTH_PADDING_OFFSET (HEALTH_Y_OFFSET / 10)
+#define HEALTH_HEIGHT_OFFSET (HEALTH_Y_OFFSET / 5)
+
 #define CORNER_RADIUS (3)
 
 static void prv_draw_headings(HealthDetailCard *detail_card, GContext *ctx, const Layer *layer) {
-  const int16_t rect_padding = PBL_IF_RECT_ELSE(5, 22);
-  const int16_t rect_height = 35;
+  const int16_t rect_padding = PBL_IF_RECT_ELSE(5 + HEALTH_PADDING_OFFSET, 22);
+  const int16_t rect_height = 35 + HEALTH_HEIGHT_OFFSET;
 
   for (int i = 0; i < detail_card->num_headings; i++) {
     HealthDetailHeading *heading = &detail_card->headings[i];
@@ -110,8 +116,8 @@ static void prv_draw_headings(HealthDetailCard *detail_card, GContext *ctx, cons
 }
 
 static void prv_draw_subtitles(HealthDetailCard *detail_card, GContext *ctx, const Layer *layer) {
-  const int16_t rect_padding = PBL_IF_RECT_ELSE(5, 0);
-  const int16_t rect_height = PBL_IF_RECT_ELSE(23, 36);
+  const int16_t rect_padding = PBL_IF_RECT_ELSE(5 + HEALTH_PADDING_OFFSET, 0);
+  const int16_t rect_height = PBL_IF_RECT_ELSE(23 + HEALTH_HEIGHT_OFFSET, 36);
 
   for (int i = 0; i < detail_card->num_subtitles; i++) {
     HealthDetailSubtitle *subtitle = &detail_card->subtitles[i];
@@ -224,8 +230,8 @@ static void prv_draw_zones(HealthDetailCard *detail_card, GContext *ctx) {
     return;
   }
 
-  const int16_t rect_padding = 5;
-  const int16_t rect_height = 33;
+  const int16_t rect_padding = 5 + HEALTH_PADDING_OFFSET;
+  const int16_t rect_height = 33 + HEALTH_HEIGHT_OFFSET;
 
   GRect zone_rect = grect_inset(detail_card->window.layer.bounds, GEdgeInsets(rect_padding));
   zone_rect.origin.y += detail_card->y_origin;

--- a/src/fw/apps/system_apps/health/health_graph_card.c
+++ b/src/fw/apps/system_apps/health/health_graph_card.c
@@ -18,6 +18,7 @@
 
 #include "applib/graphics/graphics.h"
 #include "applib/graphics/text.h"
+#include "board/display.h"
 #include "drivers/rtc.h"
 #include "kernel/pbl_malloc.h"
 #include "services/common/clock.h"
@@ -27,14 +28,30 @@
 #include "util/string.h"
 #include "util/time/time.h"
 
-//! Marks where the graph begins
-#define GRAPH_OFFSET_Y PBL_IF_RECT_ELSE(38, 48)
+// Compile-time display offset calculations
+#define DISPLAY_Y_OFFSET ((DISP_ROWS - LEGACY_2X_DISP_ROWS) / 2)
 
-//! Marks where the graph ends and where the labels begin
-#define LABEL_OFFSET_Y PBL_IF_RECT_ELSE(118, 113)
+//! Marks where the graph begins - base values for 168px height
+#define GRAPH_OFFSET_Y_BASE PBL_IF_RECT_ELSE(38, 48)
+
+//! Marks where the graph ends and where the labels begin - base values for 168px height
+#define LABEL_OFFSET_Y_BASE PBL_IF_RECT_ELSE(118, 113)
 #define LABEL_HEIGHT 27
+#define GRAPH_OFFSET_Y (GRAPH_OFFSET_Y_BASE + DISPLAY_Y_OFFSET)
+#define LABEL_OFFSET_Y (LABEL_OFFSET_Y_BASE + DISPLAY_Y_OFFSET)
 
 #define GRAPH_HEIGHT (LABEL_OFFSET_Y - GRAPH_OFFSET_Y)
+
+// Compile-time bar width calculation
+#define HEALTH_BAR_WIDTH (23 + (DISP_COLS - LEGACY_2X_DISP_COLS) / 19)
+#define HEALTH_BAR_INSET 3
+#define HEALTH_TOTAL_BAR_WIDTHS PBL_IF_RECT_ELSE((HEALTH_BAR_WIDTH * 7 + 3) - (HEALTH_BAR_INSET * 6), 141)
+
+// Compile-time avg line width calculations
+#define HEALTH_WEEKDAY_WIDTH_BASE PBL_IF_RECT_ELSE(103, 119)
+#define HEALTH_WEEKEND_WIDTH_BASE PBL_IF_RECT_ELSE(38, 58)
+#define HEALTH_WEEKDAY_WIDTH (HEALTH_WEEKDAY_WIDTH_BASE + (DISP_COLS - LEGACY_2X_DISP_COLS) * HEALTH_WEEKDAY_WIDTH_BASE / LEGACY_2X_DISP_COLS)
+#define HEALTH_WEEKEND_WIDTH (HEALTH_WEEKEND_WIDTH_BASE + (DISP_COLS - LEGACY_2X_DISP_COLS) * HEALTH_WEEKEND_WIDTH_BASE / LEGACY_2X_DISP_COLS)
 
 #define AVG_LINE_HEIGHT 4
 #define AVG_LINE_LEGEND_WIDTH 10
@@ -101,7 +118,7 @@ static int32_t prv_convert_to_graph_height(HealthGraphCard *graph_card, int32_t 
 }
 
 static void prv_setup_day_bar_box(int weekday, GRect *box, int16_t bar_height) {
-  const int w = 23; // normal bar width;
+  const int w = HEALTH_BAR_WIDTH;
 #if PBL_RECT
   // The center bars are slightly wider than the other bars
   // Note that Thursday is the center bar, not Wednesday since drawing begins with Monday
@@ -165,7 +182,7 @@ static GColor prv_get_bar_color(HealthGraphCard *graph_card, bool is_active, boo
 static void prv_draw_day_bars(HealthGraphCard *graph_card, GContext *ctx) {
   // With values from prv_setup_day_bar_box and prv_draw_day_bar,
   // total_bar_width is sum(bar_widths) - (bar_inset * (DAYS_PER_WEEK - 1))
-  const int total_bar_widths = PBL_IF_RECT_ELSE(144, 141);
+  const int total_bar_widths = HEALTH_TOTAL_BAR_WIDTHS;
   const int legend_line_height = fonts_get_font_height(graph_card->legend_font);
   const GRect *bounds = &graph_card->layer.bounds;
   GRect box = { .origin.x = (bounds->size.w - total_bar_widths) / 2, .origin.y = LABEL_OFFSET_Y };
@@ -223,11 +240,9 @@ static void prv_draw_avg_line(HealthGraphCard *graph_card, GContext *ctx, int32_
 
 static void prv_draw_avg_lines(HealthGraphCard *graph_card, GContext *ctx) {
   const GRect *bounds = &graph_card->layer.bounds;
-  const int weekday_width = PBL_IF_RECT_ELSE(103, 119);
-  prv_draw_avg_line(graph_card, ctx, graph_card->stats.weekday.avg, 0, weekday_width);
-  const int weekend_width = PBL_IF_RECT_ELSE(38, 58);
-  prv_draw_avg_line(graph_card, ctx, graph_card->stats.weekend.avg, bounds->size.w - weekend_width,
-                    weekend_width);
+  prv_draw_avg_line(graph_card, ctx, graph_card->stats.weekday.avg, 0, HEALTH_WEEKDAY_WIDTH);
+  prv_draw_avg_line(graph_card, ctx, graph_card->stats.weekend.avg, bounds->size.w - HEALTH_WEEKEND_WIDTH,
+                    HEALTH_WEEKEND_WIDTH);
 }
 
 static int32_t prv_get_info_data_point(HealthGraphCard *graph_card) {

--- a/src/fw/apps/system_apps/health/health_hr_summary_card_segments.h
+++ b/src/fw/apps/system_apps/health/health_hr_summary_card_segments.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "board/display.h"
 #include "health_progress.h"
 
 //! 4 main segments + 4 real corners
@@ -23,9 +24,10 @@
 #define AMOUNT_PER_SEGMENT (HEALTH_PROGRESS_BAR_MAX_VALUE * 25 / 100)
 
 // The shape is the same, but the offsets are different
-// Slightly adjust the points on Round
-#define X_SHIFT (PBL_IF_ROUND_ELSE(18, 0))
-#define Y_SHIFT (PBL_IF_ROUND_ELSE(6, 0))
+// Dynamically center based on display size vs legacy 144x168 base
+// Round displays need additional adjustment for the bezel
+#define X_SHIFT (((DISP_COLS - LEGACY_2X_DISP_COLS) / 2) + PBL_IF_ROUND_ELSE(18, 0))
+#define Y_SHIFT (((DISP_ROWS - LEGACY_2X_DISP_ROWS) / 2) + PBL_IF_ROUND_ELSE(6, 0))
 
 static HealthProgressSegment s_hr_summary_progress_segments[] = {
   {

--- a/src/fw/apps/system_apps/health/health_sleep_summary_card.c
+++ b/src/fw/apps/system_apps/health/health_sleep_summary_card.c
@@ -24,12 +24,17 @@
 #include "applib/pbl_std/pbl_std.h"
 #include "applib/ui/kino/kino_layer.h"
 #include "applib/ui/text_layer.h"
+#include "board/display.h"
 #include "kernel/pbl_malloc.h"
 #include "resource/resource_ids.auto.h"
 #include "services/common/i18n/i18n.h"
 #include "system/logging.h"
 #include "util/size.h"
 #include "util/string.h"
+
+// Compile-time display offset calculations
+#define HEALTH_X_OFFSET ((DISP_COLS - LEGACY_2X_DISP_COLS) / 2)
+#define HEALTH_Y_OFFSET ((DISP_ROWS - LEGACY_2X_DISP_ROWS) / 2)
 
 typedef struct HealthSleepSummaryCardData {
   HealthData *health_data;
@@ -164,7 +169,7 @@ static void prv_render_progress_bar(GContext *ctx, Layer *base_layer) {
 static void prv_render_icon(GContext *ctx, Layer *base_layer) {
   HealthSleepSummaryCardData *data = layer_get_data(base_layer);
 
-  const int y = PBL_IF_RECT_ELSE(PBL_IF_BW_ELSE(37, 32), 39);
+  const int y = PBL_IF_RECT_ELSE(PBL_IF_BW_ELSE(37, 32), 39) + HEALTH_Y_OFFSET;
   const int x_center_offset = 17;
   kino_reel_draw(data->icon, ctx, GPoint(base_layer->bounds.size.w / 2 - x_center_offset, y));
 }
@@ -172,8 +177,8 @@ static void prv_render_icon(GContext *ctx, Layer *base_layer) {
 static void prv_render_current_sleep_text(GContext *ctx, Layer *base_layer) {
   HealthSleepSummaryCardData *data = layer_get_data(base_layer);
 
-  const int y = PBL_IF_RECT_ELSE(PBL_IF_BW_ELSE(85, 83), 88);
-  const GRect rect = GRect(0, y, base_layer->bounds.size.w, 35);
+  const int y = PBL_IF_RECT_ELSE(PBL_IF_BW_ELSE(85, 83), 88) + HEALTH_Y_OFFSET;
+  const GRect rect = GRect(0, y, base_layer->bounds.size.w, 40);
 
   const int current_sleep = health_data_current_sleep_get(data->health_data);
   if (current_sleep) {
@@ -215,7 +220,7 @@ static void prv_render_typical_sleep_text(GContext *ctx, Layer *base_layer) {
 static void prv_render_no_sleep_data_text(GContext *ctx, Layer *base_layer) {
   HealthSleepSummaryCardData *data = layer_get_data(base_layer);
 
-  const int y = PBL_IF_RECT_ELSE(91, 100);
+  const int y = PBL_IF_RECT_ELSE(91, 100) + HEALTH_Y_OFFSET;
   const GRect rect = GRect(0, y, base_layer->bounds.size.w, 60);
 
   const char *text = i18n_get("No sleep data,\nwear your watch\nto sleep", base_layer);
@@ -269,8 +274,13 @@ Layer *health_sleep_summary_card_create(HealthData *health_data) {
       .segments = s_sleep_summary_progress_segments,
     },
     .health_data = health_data,
+#if DISP_ROWS > LEGACY_2X_DISP_ROWS
+    .number_font = fonts_get_system_font(FONT_KEY_LECO_32_BOLD_NUMBERS),
+    .unit_font = fonts_get_system_font(FONT_KEY_LECO_26_BOLD_NUMBERS_AM_PM),
+#else
     .number_font = fonts_get_system_font(FONT_KEY_LECO_26_BOLD_NUMBERS_AM_PM),
     .unit_font = fonts_get_system_font(FONT_KEY_LECO_20_BOLD_NUMBERS),
+#endif
     .typical_font = fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD),
     .em_dash_font = fonts_get_system_font(FONT_KEY_GOTHIC_28_BOLD),
   };

--- a/src/fw/apps/system_apps/health/health_sleep_summary_card_segments.h
+++ b/src/fw/apps/system_apps/health/health_sleep_summary_card_segments.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "board/display.h"
 #include "health_progress.h"
 
 //! 5 main segments + 4 real corners
@@ -26,8 +27,10 @@
 // Found through trial and error
 #define DEFAULT_MARK_WIDTH 40
 
-#define X_SHIFT (PBL_IF_ROUND_ELSE(23, PBL_IF_BW_ELSE(1, 0)))
-#define Y_SHIFT (PBL_IF_ROUND_ELSE(8, PBL_IF_BW_ELSE(3, 0)))
+// Dynamically center based on display size vs legacy 144x168 base
+// Round displays need additional adjustment for the bezel
+#define X_SHIFT (((DISP_COLS - LEGACY_2X_DISP_COLS) / 2) + PBL_IF_ROUND_ELSE(23, PBL_IF_BW_ELSE(1, 0)))
+#define Y_SHIFT (((DISP_ROWS - LEGACY_2X_DISP_ROWS) / 2) + PBL_IF_ROUND_ELSE(8, PBL_IF_BW_ELSE(3, 0)))
 
 // Used to shrink the thinkness of the bars
 #define X_SHRINK (PBL_IF_BW_ELSE(2, 0))

--- a/src/fw/apps/system_apps/health/health_ui.c
+++ b/src/fw/apps/system_apps/health/health_ui.c
@@ -17,8 +17,14 @@
 #include "health_ui.h"
 
 #include "applib/pbl_std/pbl_std.h"
+#include "board/display.h"
 #include "services/common/i18n/i18n.h"
 #include "util/string.h"
+
+// Compile-time display offset calculations
+#define HEALTH_X_OFFSET ((DISP_COLS - LEGACY_2X_DISP_COLS) / 2)
+#define HEALTH_Y_OFFSET ((DISP_ROWS - LEGACY_2X_DISP_ROWS) / 2)
+#define HEALTH_INSET (18 + HEALTH_X_OFFSET / 5)
 
 void health_ui_draw_text_in_box(GContext *ctx, const char *text, const GRect drawing_bounds,
                                 const int16_t y_offset, const GFont small_font, GColor box_color,
@@ -65,10 +71,10 @@ void health_ui_render_typical_text_box(GContext *ctx, Layer *layer, const char *
   char typical_text[32];
   snprintf(typical_text, sizeof(typical_text), i18n_get("TYPICAL %s", layer), weekday);
 
-  const int y = PBL_IF_RECT_ELSE(PBL_IF_BW_ELSE(122, 120), 125);
+  const int y = PBL_IF_RECT_ELSE(PBL_IF_BW_ELSE(122, 120), 125) + HEALTH_Y_OFFSET;
   GRect rect = GRect(0, y, layer->bounds.size.w, PBL_IF_RECT_ELSE(35, 36));
 #if PBL_RECT
-  rect = grect_inset(rect, GEdgeInsets(0, 18));
+  rect = grect_inset(rect, GEdgeInsets(0, HEALTH_INSET));
 #endif
 
   const GColor bg_color = PBL_IF_COLOR_ELSE(GColorYellow, GColorBlack);


### PR DESCRIPTION
Add compile-time dynamic scaling for the health app to support larger displays like Obelix (200x228). All UI element positions, progress bar segments, and font selections now scale automatically based on DISP_COLS and DISP_ROWS relative to the legacy 144x168 base dimensions.