### PR TITLE
fw/board: obelix wakeup pin use edge trigger

### DIFF
--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -13,7 +13,6 @@
 #include "drivers/hrm/gh3x2x/gh3x2x.h"
 #include "drivers/watchdog.h"
 #include "system/passert.h"
-#include "kernel/util/stop.h"
 
 
 #define HCPU_FREQ_MHZ 240
@@ -697,7 +696,4 @@ void board_init(void) {
   HAL_HPAON_EnableWakeupSrc(HPAON_WAKEUP_SRC_PIN11, AON_PIN_MODE_NEG_EDGE);
   HAL_HPAON_EnableWakeupSrc(HPAON_WAKEUP_SRC_PIN12, AON_PIN_MODE_NEG_EDGE);
   HAL_HPAON_EnableWakeupSrc(HPAON_WAKEUP_SRC_PIN13, AON_PIN_MODE_NEG_EDGE);
-
-  // Temporarily disable stop mode (GH-452)
-  stop_mode_disable(InhibitorMain);
 }


### PR DESCRIPTION
Obelix wakeup pin change to edge trigger.

The miss trigger issue describe in sifli sdk as below is not reproduce, will talk with sifli for more detail.
````{note}
Due to delay in PIN edge detection, if woken up by other wakeup sources when there's a wakeup PIN level change, the PIN 
wakeup flag in WSR register may still be 0 when AON interrupt occurs, and becomes 1 after a while. Since the corresponding 
GPIO edge detection is not ready yet, the PIN wakeup status in WSR register won't be cleared and will keep not sleeping while 
missing one GPIO interrupt for edge detection. If not using `SysTick_Handler` implemented in drv_common.c in SDK as SysTick
 interrupt service routine, it's recommended to add the following code in custom SysTick interrupt service routine. When edge-
triggered wakeup PIN flag is found to be 1, manually trigger GPIO interrupt callback function once.

````