### PR TITLE
fw/board: obelix use gpio1 wakeup source

### DIFF
--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -690,10 +690,4 @@ void board_init(void) {
   i2c_init(I2C3_BUS);
 
   mic_init(MIC);
-
-  /* Enable user buttons as AON wakeup source */
-  HAL_HPAON_EnableWakeupSrc(HPAON_WAKEUP_SRC_PIN10, AON_PIN_MODE_POS_EDGE);
-  HAL_HPAON_EnableWakeupSrc(HPAON_WAKEUP_SRC_PIN11, AON_PIN_MODE_NEG_EDGE);
-  HAL_HPAON_EnableWakeupSrc(HPAON_WAKEUP_SRC_PIN12, AON_PIN_MODE_NEG_EDGE);
-  HAL_HPAON_EnableWakeupSrc(HPAON_WAKEUP_SRC_PIN13, AON_PIN_MODE_NEG_EDGE);
 }

--- a/src/fw/drivers/sf32lb52/lptim_systick.c
+++ b/src/fw/drivers/sf32lb52/lptim_systick.c
@@ -46,6 +46,7 @@ void lptim_systick_init(void)
   HAL_HPAON_EnableWakeupSrc(HPAON_WAKEUP_SRC_LPTIM1, AON_PIN_MODE_HIGH);    // LPPTIM1 OC wakeup
   HAL_HPAON_EnableWakeupSrc(HPAON_WAKEUP_SRC_LP2HP_IRQ, AON_PIN_MODE_HIGH); // LP2HP mailbox interrupt
   HAL_HPAON_EnableWakeupSrc(HPAON_WAKEUP_SRC_LP2HP_REQ, AON_PIN_MODE_HIGH); // LP2HP manual wakeup
+  HAL_HPAON_EnableWakeupSrc(HPAON_WAKEUP_SRC_GPIO1, AON_PIN_MODE_HIGH);
 
   s_lptim_systick_initialized = true;
 }


### PR DESCRIPTION
Use gpio1 as wakeup source, have the same function with wakeup pin. And prepare for uart rx wakeup.