### PR TITLE
Add European neobanks to "known apps"

### DIFF
--- a/src/fw/services/normal/notifications/ancs/ancs_known_apps.h
+++ b/src/fw/services/normal/notifications/ancs/ancs_known_apps.h
@@ -52,6 +52,10 @@
     APP("com.apple.mobileslideshow", TIMELINE_RESOURCE_NOTIFICATION_IOS_PHOTOS, GColorBlueMoonARGB8),
     APP("com.linkedin.LinkedIn", TIMELINE_RESOURCE_NOTIFICATION_LINKEDIN, GColorCobaltBlueARGB8),
     APP("com.tinyspeck.chatlyio", TIMELINE_RESOURCE_NOTIFICATION_SLACK, GColorFollyARGB8),
+    APP("com.revolut.revolut", TIMELINE_RESOURCE_PAY_BILL, GColorDarkGrayARGB8),
+    APP("com.transferwise.Transferwise", TIMELINE_RESOURCE_PAY_BILL, GColorGreenARGB8),
+    APP("de.no26.Number26", TIMELINE_RESOURCE_PAY_BILL, GColorCadetBlueARGB8),
+    APP("com.bunq.ios", TIMELINE_RESOURCE_PAY_BILL, GColorVividCeruleanARGB8),
 #endif
 
 #undef APP


### PR DESCRIPTION
Added the ANCS definitions for the top-4-ish EU neobanks:

- [Revolut](https://apps.apple.com/be/app/revolut/id932493382) 
- [Wise](https://apps.apple.com/be/app/wise/id612261027)
- [N26](https://apps.apple.com/be/app/n26-love-your-bank/id956857223)
- [Bunq](https://apps.apple.com/be/app/bunq/id1021178150) - their logo is a rainbow, so I couldn't really pick a proper color

I assume that the ANCS "known apps" list is kept rather short to conserve space on the Pebble, so I decided to only add the largest and pan-European neo-banks, which should cover the majority of the EU neo-bank users.