### PR TITLE
fw/popups: drop annoying/useless reset/BT popups

### DIFF
--- a/src/fw/debug/debug_reboot_reason.c
+++ b/src/fw/debug/debug_reboot_reason.c
@@ -186,13 +186,5 @@ void debug_reboot_reason_print(McuRebootReason mcu_reboot_reason) {
     crashed_ui_show_forced_core_dump();
   }
 
-#ifdef SHOW_PEBBLE_JUST_RESET_ALERT
-  // Trigger an alert display so that the user knows the watch rebooted due to a crash. This event
-  // will be caught and handled by the launcher.c event loop.
-  if (show_reset_alert && reason.code != RebootReasonCode_ForcedCoreDump) {
-    crashed_ui_show_pebble_reset();
-  }
-#endif
-
   reboot_reason_clear();
 }

--- a/src/fw/popups/crashed_ui.c
+++ b/src/fw/popups/crashed_ui.c
@@ -155,14 +155,6 @@ void crashed_ui_show_worker_crash(const AppInstallId install_id) {
   i18n_noop("A bug report has been captured. " \
             "Please finish uploading the bug report using the Pebble phone app.")
 
-#define YOUR_PEBBLE_RESET \
-  i18n_noop("Your Pebble just reset. " \
-            "Please report this using the 'Support' link in the Pebble phone app.")
-
-#define PHONE_BT_CONTROLLER_WEDGED \
-  i18n_noop("Bluetooth on your phone is in a high power state. " \
-            "Please report this using 'Support' and reboot your phone.")
-
 //! Display a dialog for watch reset or bluetooth being stuck.
 static void prv_push_reset_dialog(void *context) {
   const char *crash_reason = context;
@@ -178,19 +170,3 @@ static void prv_push_reset_dialog(void *context) {
 void crashed_ui_show_forced_core_dump(void) {
   launcher_task_add_callback(prv_push_reset_dialog, CORE_DUMP_COMPLETE);
 }
-
-#if (defined(SHOW_BAD_BT_STATE_ALERT) || defined(SHOW_PEBBLE_JUST_RESET_ALERT))
-
-//! Restrict only to the two defines above
-//! Show the "Your pebble has just reset"
-void crashed_ui_show_pebble_reset(void) {
-  launcher_task_add_callback(prv_push_reset_dialog, YOUR_PEBBLE_RESET);
-}
-
-//! Restrict only to the two defines above
-//! Show the "Your Bluetooth is ..."
-void crashed_ui_show_bluetooth_stuck(void) {
-  launcher_task_add_callback(prv_push_reset_dialog, PHONE_BT_CONTROLLER_WEDGED);
-}
-
-#endif

--- a/src/fw/popups/crashed_ui.h
+++ b/src/fw/popups/crashed_ui.h
@@ -8,10 +8,4 @@
 //! Show the "Bug report captured" modal
 void crashed_ui_show_forced_core_dump(void);
 
-//! Show the "Your Pebble just reset" modal
-void crashed_ui_show_pebble_reset(void);
-
-//! Show the "Bluetooth stuck in ..." modal
-void crashed_ui_show_bluetooth_stuck(void);
-
 void crashed_ui_show_worker_crash(const AppInstallId install_id);

--- a/src/fw/shell/prf/stubs.c
+++ b/src/fw/shell/prf/stubs.c
@@ -35,12 +35,6 @@ void crashed_ui_show_worker_crash(AppInstallId install_id) {
 void crashed_ui_show_forced_core_dump(void) {
 }
 
-void crashed_ui_show_pebble_reset(void) {
-}
-
-void crashed_ui_show_bluetooth_stuck(void) {
-}
-
 void app_idle_timeout_stop(void) {
 }
 

--- a/waftools/pebble_arm_gcc.py
+++ b/waftools/pebble_arm_gcc.py
@@ -254,8 +254,6 @@ Or re-configure with the --relax_toolchain_restrictions option. """
     if conf.options.release and conf.options.beta:
       raise RuntimeError("--beta and --release are mutually exclusive and cannot be used together")
     if not conf.options.release:
-      conf.env.append_value('DEFINES', [ 'SHOW_PEBBLE_JUST_RESET_ALERT' ])
-      conf.env.append_value('DEFINES', [ 'SHOW_BAD_BT_STATE_ALERT' ])
       if not conf.is_bigboard():
         conf.env.append_value('DEFINES', [ 'SHOW_ACTIVITY_DEMO' ])
 


### PR DESCRIPTION
These popups are pretty useless, also because we always test release mode firmwares... And the BT one is actually not used.