### PR TITLE
fw/debug: Add Boot slot to logs

### DIFF
--- a/src/fw/debug/debug.c
+++ b/src/fw/debug/debug.c
@@ -190,6 +190,10 @@ void debug_init(McuRebootReason mcu_reboot_reason) {
   version_copy_current_build_id_hex_string(build_id_string, 64);
   DEBUG_LOG(LOG_LEVEL_INFO, "BUILD ID: %s", build_id_string);
 
+#if CAPABILITY_HAS_PBLBOOT
+  DEBUG_LOG(LOG_LEVEL_INFO, "Boot slot: %d", TINTIN_METADATA.is_slot_0 ? 0 : 1);
+#endif
+
   #if MEMFAULT
   // This must be called before debug_reboot_reason_print which resets the reason
   memfault_platform_boot();


### PR DESCRIPTION
once we get more obelixes out its gonna be painful to debug if we dont know what slot the user booted from!