### PR TITLE
fw/comm/ble/ancs: Auto-recover from lost ANCS subscriptions [FIRM-881]

### DIFF
--- a/src/fw/comm/ble/kernel_le_client/ancs/ancs.c
+++ b/src/fw/comm/ble/kernel_le_client/ancs/ancs.c
@@ -295,7 +295,7 @@ static void prv_reset_due_to_bt_error(void) {
 // Is Alive Logic
 
 #define ANCS_INVALID_PARAM 0xA2
-#define ANCS_IS_ALIVE_NEXT_CHECK_TIME_MINUTES 60 // 1 hour (60 minutes)
+#define ANCS_IS_ALIVE_NEXT_CHECK_TIME_MINUTES 15 // Check every 15 minutes for faster recovery
 #define ANCS_IS_ALIVE_RESPONSE_WAIT_TIME_SECONDS 5 // 5 seconds
 
 
@@ -335,6 +335,34 @@ static void prv_ancs_is_alive_start_tracking(void) {
   prv_ancs_is_alive_schedule_next_check();
 }
 
+static void prv_resubscribe_to_ancs(void) {
+  if (!s_ancs_client) {
+    return;
+  }
+
+  // Check if we have valid characteristic handles to re-subscribe to
+  if (s_ancs_client->characteristics[ANCSCharacteristicNotification] == BLE_CHARACTERISTIC_INVALID) {
+    PBL_LOG(LOG_LEVEL_WARNING, "Cannot resubscribe to ANCS: no valid characteristic handles");
+    return;
+  }
+
+  PBL_LOG(LOG_LEVEL_INFO, "Re-subscribing to ANCS characteristics");
+
+  // Re-subscribe to Data, then to Notification characteristics
+  // (same order as in ancs_handle_service_discovered)
+  for (int c = ANCSCharacteristicData; c >= ANCSCharacteristicNotification; --c) {
+    BLECharacteristic charx = s_ancs_client->characteristics[c];
+    if (charx != BLE_CHARACTERISTIC_INVALID) {
+      const BTErrno e = gatt_client_subscriptions_subscribe(charx,
+                                                            BLESubscriptionNotifications,
+                                                            GAPLEClientKernel);
+      if (e != BTErrnoOK) {
+        PBL_LOG(LOG_LEVEL_ERROR, "Failed to resubscribe to ANCS charx %d: %d", c, e);
+      }
+    }
+  }
+}
+
 static void prv_is_ancs_alive_response_timeout_launcher_task_cb(void *data) {
   if (!s_ancs_client) {
     return;
@@ -344,6 +372,11 @@ static void prv_is_ancs_alive_response_timeout_launcher_task_cb(void *data) {
 
   // Stop the wait for response timer
   prv_ancs_is_alive_stop_timer();
+
+  // Try to recover by re-subscribing to ANCS characteristics
+  // This handles the case where iOS has dropped the GATT subscription
+  // without the watch knowing about it (common during PPoGATT resets)
+  prv_resubscribe_to_ancs();
 }
 
 static void prv_is_ancs_alive_response_timeout(void *data) {


### PR DESCRIPTION
User reported that iOS notifications stop working daily and require forgetting and re-pairing the device to fix. Analysis of device logs shows that ANCS notifications stop after PPoGATT resets, even though the BLE connection remains active.

The root cause is that iOS can silently drop GATT subscriptions during BLE instability (PPoGATT timeouts, connection parameter update failures) without sending a service change indication. The watch doesn't know the subscription was lost, so it never re-subscribes.

I (hopefully) fixed this by:
- Reducing the ANCS alive check interval from 60 to 15 minutes for faster detection of dead ANCS
- Adding automatic re-subscription to ANCS characteristics when the alive check fails, which restores notifications without requiring the user to re-pair
