### PR TITLE
fw/bluetooth: fix NimbleHost stack overflow during firmware updates

### DIFF
--- a/src/bluetooth-fw/nimble/init.c
+++ b/src/bluetooth-fw/nimble/init.c
@@ -70,7 +70,7 @@ void bt_driver_init(void) {
   TaskParameters_t host_task_params = {
       .pvTaskCode = prv_host_task_main,
       .pcName = "NimbleHost",
-      .usStackDepth = 4000 / sizeof(StackType_t),  // TODO: probably reduce this
+      .usStackDepth = 5000 / sizeof(StackType_t),
       .uxPriority = (configMAX_PRIORITIES - 2) | portPRIVILEGE_BIT,
       .puxStackBuffer = NULL,
   };

--- a/src/fw/services/common/put_bytes/put_bytes_storage_raw.c
+++ b/src/fw/services/common/put_bytes/put_bytes_storage_raw.c
@@ -3,11 +3,13 @@
 
 #include "put_bytes_storage_raw.h"
 
+#include "bluetooth/responsiveness.h"
 #include "drivers/flash.h"
 #include "drivers/task_watchdog.h"
 #include "flash_region/flash_region.h"
 #include "kernel/pbl_malloc.h"
 #include "resource/resource_storage_flash.h"
+#include "services/common/comm_session/session.h"
 #include "system/firmware_storage.h"
 #include "util/math.h"
 
@@ -120,6 +122,13 @@ bool pb_storage_raw_init(PutBytesStorage *storage, PutBytesObjectType object_typ
 
   storage->current_offset = layout->start_offset;
 
+  // Reduce BLE activity for the duration of raw flash operations to help prevent stack overflow
+  // in NimbleHost task. Flash operations block and concurrent BLE mbuf handling can cause deep
+  // call stacks. Using ResponseTimeMiddle reduces the frequency of BLE events while still
+  // maintaining reasonable transfer speeds.
+  comm_session_set_responsiveness(comm_session_get_system_session(),
+                                  BtConsumerPpPutBytes, ResponseTimeMiddle, 0);
+
   // This erase operation will take awhile, so disable the task watchdog for the current task
   // while we're doing this.
   bool previous_system_task_watchdog_state = task_watchdog_mask_get(PebbleTask_KernelBackground);
@@ -170,5 +179,8 @@ uint32_t pb_storage_raw_calculate_crc(PutBytesStorage *storage, PutBytesCrcType 
 }
 
 void pb_storage_raw_deinit(PutBytesStorage *storage, bool is_success) {
-  // Nothing to do
+  // Restore normal BLE responsiveness that was reduced in pb_storage_raw_init
+  comm_session_set_responsiveness(comm_session_get_system_session(),
+                                  BtConsumerPpPutBytes, ResponseTimeMin,
+                                  MIN_LATENCY_MODE_TIMEOUT_PUT_BYTES_SECS);
 }


### PR DESCRIPTION
During firmware updates, the watch was crashing with a stack overflow in the NimbleHost BLE task. The crash occurred in `os_mbuf_pullup` → `memmove` while processing BLE packets concurrently with flash operations.

I introduced a two-pronged approach for defense:

1. **Increase NimbleHost stack size** from 4000 → 5000 bytes (+25% headroom)

2. **Reduce BLE activity during raw flash operations** by setting `ResponseTimeMiddle` for the entire firmware update session (init → deinit). This increases the BLE connection interval, reducing the frequency of BLE events and thus the load on the NimbleHost task stack.