### PR TITLE
fw/drivers/sf32lb52: increase EXTI handler limit to 16

### DIFF
--- a/src/fw/drivers/sf32lb52/exti.c
+++ b/src/fw/drivers/sf32lb52/exti.c
@@ -11,7 +11,7 @@
 #include "mcu/interrupts.h"
 #include "system/passert.h"
 
-#define EXTI_MAX_GPIO1_PIN_NUM 8
+#define EXTI_MAX_GPIO1_PIN_NUM 16
 #define EXTI_MAX_GPIO2_PIN_NUM 1
 
 typedef struct {


### PR DESCRIPTION
The EXTI handler array was limited to 8 slots, which became fully occupied after the HRM board configuration was added in 8768fd90. With PMIC, touch, accelerometer, HRM, and 4 buttons all registering handlers, the array was exactly full. This caused the down button (registered last) to silently fail on obelix.

Increase the limit to 16 to provide headroom for current and future EXTI uses.