### PR TITLE
apps/music: Add new Music settings for Volume Controls and Progress Bar

### DIFF
--- a/src/fw/apps/system_apps/settings/settings_menu.c
+++ b/src/fw/apps/system_apps/settings/settings_menu.c
@@ -18,6 +18,7 @@
 #include "settings_bluetooth.h"
 #include "settings_display.h"
 #include "settings_menu.h"
+#include "settings_music.h"
 #include "settings_notifications.h"
 #include "settings_quick_launch.h"
 #include "settings_quiet_time.h"
@@ -47,13 +48,15 @@ static const SettingsModuleGetMetadata s_submodule_registry[] = {
   [SettingsMenuItemTimeline]      = settings_timeline_get_info,
 #endif
 #if !TINTIN_FORCE_FIT
-  [SettingsMenuItemActivity]      = settings_activity_tracker_get_info,
   [SettingsMenuItemQuickLaunch]   = settings_quick_launch_get_info,
+  [SettingsMenuItemMusic]         = settings_music_get_info,
   [SettingsMenuItemDateTime]      = settings_time_get_info,
+  [SettingsMenuItemActivity]      = settings_activity_tracker_get_info,
 #else
-  [SettingsMenuItemActivity]      = settings_system_get_info,
   [SettingsMenuItemQuickLaunch]   = settings_system_get_info,
+  [SettingsMenuItemMusic]         = settings_music_get_info,
   [SettingsMenuItemDateTime]      = settings_system_get_info,
+  [SettingsMenuItemActivity]      = settings_system_get_info,
 #endif
   [SettingsMenuItemDisplay]       = settings_display_get_info,
 #if PBL_COLOR

--- a/src/fw/apps/system_apps/settings/settings_menu.h
+++ b/src/fw/apps/system_apps/settings/settings_menu.h
@@ -35,6 +35,7 @@ typedef enum {
   SettingsMenuItemTimeline,
 #endif
   SettingsMenuItemQuickLaunch,
+  SettingsMenuItemMusic,
   SettingsMenuItemDateTime,
   SettingsMenuItemDisplay,
 #if PBL_COLOR

--- a/src/fw/apps/system_apps/settings/settings_music.c
+++ b/src/fw/apps/system_apps/settings/settings_music.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "settings_music.h"
+#include "settings_menu.h"
+#include "settings_option_menu.h"
+#include "settings_window.h"
+
+#include "applib/ui/app_window_stack.h"
+#include "applib/ui/option_menu_window.h"
+#include "applib/ui/ui.h"
+#include "kernel/pbl_malloc.h"
+#include "services/common/i18n/i18n.h"
+#include "shell/prefs.h"
+#include "system/passert.h"
+#include "util/size.h"
+
+#include <stdbool.h>
+
+typedef struct {
+  SettingsCallbacks callbacks;
+} SettingsMusicData;
+
+enum MusicItem {
+  MusicItemShowVolumeControls,
+  MusicItemShowProgressBar,
+  MusicItem_Count,
+};
+
+// Show Volume Controls
+//////////////////////////
+
+static bool prv_get_show_volume_controls(void) {
+  return shell_prefs_get_music_show_volume_controls();
+}
+
+static void prv_toggle_show_volume_controls(void) {
+  shell_prefs_set_music_show_volume_controls(!prv_get_show_volume_controls());
+}
+
+// Show Progress Bar
+//////////////////////////
+
+static bool prv_get_show_progress_bar(void) {
+  return shell_prefs_get_music_show_progress_bar();
+}
+
+static void prv_toggle_show_progress_bar(void) {
+  shell_prefs_set_music_show_progress_bar(!prv_get_show_progress_bar());
+}
+
+// Menu Layer Callbacks
+////////////////////////
+
+static uint16_t prv_num_rows_cb(SettingsCallbacks *context) {
+  return MusicItem_Count;
+}
+
+static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
+                            const Layer *cell_layer, uint16_t row, bool selected) {
+  SettingsMusicData *data = ((SettingsOptionMenuData *)context)->context;
+  const char *subtitle = NULL;
+  const char *title = NULL;
+
+  switch (row) {
+    case MusicItemShowVolumeControls:
+      title = i18n_noop("Volume Controls");
+      subtitle = prv_get_show_volume_controls() ? i18n_noop("Show") : i18n_noop("Hide");
+      break;
+    case MusicItemShowProgressBar:
+      title = i18n_noop("Progress Bar");
+      subtitle = prv_get_show_progress_bar() ? i18n_noop("Show") : i18n_noop("Hide");
+      break;
+    default:
+      WTF;
+  }
+
+  menu_cell_basic_draw(ctx, cell_layer, i18n_get(title, data), i18n_get(subtitle, data), NULL);
+}
+
+static void prv_deinit_cb(SettingsCallbacks *context) {
+  SettingsMusicData *data = (SettingsMusicData *)context;
+  i18n_free_all(data);
+  app_free(data);
+}
+
+static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
+  switch (row) {
+    case MusicItemShowVolumeControls:
+      prv_toggle_show_volume_controls();
+      break;
+    case MusicItemShowProgressBar:
+      prv_toggle_show_progress_bar();
+      break;
+    default:
+      WTF;
+  }
+  settings_menu_mark_dirty(SettingsMenuItemMusic);
+}
+
+static Window *prv_init(void) {
+  SettingsMusicData* data = app_malloc_check(sizeof(*data));
+  *data = (SettingsMusicData){};
+
+  data->callbacks = (SettingsCallbacks) {
+    .deinit = prv_deinit_cb,
+    .draw_row = prv_draw_row_cb,
+    .select_click = prv_select_click_cb,
+    .num_rows = prv_num_rows_cb,
+  };
+
+  return settings_window_create(SettingsMenuItemMusic, &data->callbacks);
+}
+
+const SettingsModuleMetadata *settings_music_get_info(void) {
+  static const SettingsModuleMetadata s_module_info = {
+    .name = i18n_noop("Music"),
+    .init = prv_init,
+  };
+
+  return &s_module_info;
+}

--- a/src/fw/apps/system_apps/settings/settings_music.h
+++ b/src/fw/apps/system_apps/settings/settings_music.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "settings_menu.h"
+
+const SettingsModuleMetadata *settings_music_get_info(void);

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -232,10 +232,14 @@ static uint8_t s_legacy_app_render_mode = 0; // Default to bezel mode
 
 #define PREF_KEY_SETTINGS_MENU_HIGHLIGHT_COLOR "settingsMenuHighlightColor"
 #define PREF_KEY_APPS_MENU_HIGHLIGHT_COLOR "appsMenuHighlightColor"
+#define PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS "musicShowVolumeControls"
+#define PREF_KEY_MUSIC_SHOW_PROGRESS_BAR "musicShowProgressBar"
 
 
 static GColor s_settings_menu_highlight_color = GColorCobaltBlue;
 static GColor s_apps_menu_highlight_color = GColorVividCerulean;
+static bool s_music_show_volume_controls = true;
+static bool s_music_show_progress_bar = true;
 
 
 // ============================================================================================
@@ -613,6 +617,16 @@ static bool prv_set_s_apps_menu_highlight_color(GColor *color) {
 #else
   s_apps_menu_highlight_color = GColorBlack;
 #endif
+  return true;
+}
+
+static bool prv_set_s_music_show_volume_controls(bool *enabled) {
+  s_music_show_volume_controls = *enabled;
+  return true;
+}
+
+static bool prv_set_s_music_show_progress_bar(bool *enabled) {
+  s_music_show_progress_bar = *enabled;
   return true;
 }
   
@@ -1575,4 +1589,20 @@ GColor shell_prefs_get_apps_menu_highlight_color(void){
 
 void shell_prefs_set_apps_menu_highlight_color(GColor color) {
   prv_pref_set(PREF_KEY_APPS_MENU_HIGHLIGHT_COLOR, &color, sizeof(GColor));
+}
+
+bool shell_prefs_get_music_show_volume_controls(void) {
+  return s_music_show_volume_controls;
+}
+
+void shell_prefs_set_music_show_volume_controls(bool enabled) {
+  prv_pref_set(PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS, &enabled, sizeof(enabled));
+}
+
+bool shell_prefs_get_music_show_progress_bar(void) {
+  return s_music_show_progress_bar;
+}
+
+void shell_prefs_set_music_show_progress_bar(bool enabled) {
+  prv_pref_set(PREF_KEY_MUSIC_SHOW_PROGRESS_BAR, &enabled, sizeof(enabled));
 }

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -57,3 +57,5 @@
 
   PREFS_MACRO(PREF_KEY_SETTINGS_MENU_HIGHLIGHT_COLOR, s_settings_menu_highlight_color)
   PREFS_MACRO(PREF_KEY_APPS_MENU_HIGHLIGHT_COLOR, s_apps_menu_highlight_color)
+  PREFS_MACRO(PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS, s_music_show_volume_controls)
+  PREFS_MACRO(PREF_KEY_MUSIC_SHOW_PROGRESS_BAR, s_music_show_progress_bar)

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -162,3 +162,9 @@ void shell_prefs_set_settings_menu_highlight_color(GColor color);
 
 GColor shell_prefs_get_apps_menu_highlight_color(void);
 void shell_prefs_set_apps_menu_highlight_color(GColor color);
+
+bool shell_prefs_get_music_show_volume_controls(void);
+void shell_prefs_set_music_show_volume_controls(bool enabled);
+
+bool shell_prefs_get_music_show_progress_bar(void);
+void shell_prefs_set_music_show_progress_bar(bool enabled);


### PR DESCRIPTION
Add "Show Volume Controls" and "Show Progress Bar" options to the Music Settings menu.

When "Show Volume Controls" is hidden:
- UP/DOWN buttons perform next/previous track.
- The SELECT button long-press is disabled to prevent entering volume mode.

When "Show Progress Bar" is hidden:
- The progress bar and time labels are hidden.
- The app unsubscribes from the tick timer to save power.

I wanted to this since I'm iOS user and we don't have an alternative like MusicBoss.
I wanted to have a way to have the music player just with the play/pause next/previus buttons for fast click and not deal with the ellipsis button.

I tested on QEMU andmy pebble duo 2.

<img width="144" height="168" alt="img2" src="https://github.com/user-attachments/assets/d3644bab-c0b3-4663-8dfa-2fc8f891fc3b" />
<img width="144" height="168" alt="img3" src="https://github.com/user-attachments/assets/4eebf37c-1fff-4680-b0c8-4f4ec2710f3d" />
<img width="144" height="168" alt="img4" src="https://github.com/user-attachments/assets/ee79fece-73b7-49df-a75f-873cdbf3bb69" />
