### PR TITLE
settings/settings_quiet_time: Add "Notifications" toggle option to Quiet Time settings

### DIFF
--- a/src/fw/apps/system_apps/settings/settings_quiet_time.c
+++ b/src/fw/apps/system_apps/settings/settings_quiet_time.c
@@ -54,6 +54,7 @@ enum QuietTimeItem {
   QuietTimeItemWeekdayScheduled,
   QuietTimeItemWeekendScheduled,
   QuietTimeItemInterruptions,
+  QuietTimeItemNotifications,
   QuietTimeItem_Count,
 };
 
@@ -90,6 +91,36 @@ static const char *prv_get_dnd_mask_subtitle(void *i18n_key) {
       break;
   }
   return title;
+}
+
+static const DndNotificationMode s_dnd_notification_mode_cycle[] = {
+  DndNotificationModeShow,
+  DndNotificationModeHide,
+};
+
+static DndNotificationMode prv_cycle_dnd_notification_mode(void) {
+  DndNotificationMode mode = alerts_preferences_dnd_get_show_notifications();
+  int index = 0;
+  for (size_t i = 0; i < ARRAY_LENGTH(s_dnd_notification_mode_cycle); i++) {
+    if (s_dnd_notification_mode_cycle[i] == mode) {
+      index = i;
+      break;
+    }
+  }
+  mode = s_dnd_notification_mode_cycle[(index + 1) % ARRAY_LENGTH(s_dnd_notification_mode_cycle)];
+  alerts_preferences_dnd_set_show_notifications(mode);
+  return mode;
+}
+
+static const char *prv_get_dnd_notifications_enable(void *i18n_key) {
+  switch (alerts_preferences_dnd_get_show_notifications()) {
+    case DndNotificationModeShow:
+      return i18n_get("Show", i18n_key);
+    case DndNotificationModeHide:
+      return i18n_get("Hide", i18n_key);
+    default:
+      return "???";
+  }
 }
 
 ///////////////////////////////
@@ -274,6 +305,10 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
       title = i18n_get("Interruptions", data);
       strncpy(subtitle, prv_get_dnd_mask_subtitle(data), buffer_length);
       break;
+    case QuietTimeItemNotifications:
+      title = i18n_get("Notifications", data);
+      strncpy(subtitle, prv_get_dnd_notifications_enable(data), buffer_length);
+      break;
     default:
         WTF;
   }
@@ -299,6 +334,9 @@ static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
       break;
     case QuietTimeItemInterruptions:
       prv_cycle_dnd_mask();
+      break;
+    case QuietTimeItemNotifications:
+      prv_cycle_dnd_notification_mode();
       break;
     default:
         WTF;

--- a/src/fw/popups/notifications/notification_window.c
+++ b/src/fw/popups/notifications/notification_window.c
@@ -1340,6 +1340,12 @@ static void prv_handle_notification_added_common(Uuid *id, NotificationType type
     return;
   }
 
+  if (do_not_disturb_is_active() && 
+      alerts_preferences_dnd_get_show_notifications() == DndNotificationModeHide) {
+    alerts_incoming_alert_analytics();
+    return;
+  }
+
   NotificationWindowData *data = &s_notification_window_data;
 
   // will fail and return early if already init'ed.

--- a/src/fw/services/normal/notifications/alerts_preferences.c
+++ b/src/fw/services/normal/notifications/alerts_preferences.c
@@ -44,6 +44,9 @@ static AlertMask s_mask = AlertMaskAllOn;
 #define PREF_KEY_DND_INTERRUPTIONS_MASK "dndInterruptionsMask"
 static AlertMask s_dnd_interruptions_mask = AlertMaskAllOff;
 
+#define PREF_KEY_DND_SHOW_NOTIFICATIONS "dndShowNotifications"
+static DndNotificationMode s_dnd_show_notifications = DndNotificationModeShow;
+
 #define PREF_KEY_VIBE "vibe"
 static bool s_vibe_on_notification = true;
 
@@ -276,6 +279,7 @@ void alerts_preferences_init(void) {
   RESTORE_PREF(PREF_KEY_DND_MANUALLY_ENABLED, s_do_not_disturb_manually_enabled);
   RESTORE_PREF(PREF_KEY_DND_SMART_ENABLED, s_do_not_disturb_smart_dnd_enabled);
   RESTORE_PREF(PREF_KEY_DND_INTERRUPTIONS_MASK, s_dnd_interruptions_mask);
+  RESTORE_PREF(PREF_KEY_DND_SHOW_NOTIFICATIONS, s_dnd_show_notifications);
   RESTORE_PREF(PREF_KEY_LEGACY_DND_SCHEDULE, s_legacy_dnd_schedule);
   RESTORE_PREF(PREF_KEY_LEGACY_DND_SCHEDULE_ENABLED, s_legacy_dnd_schedule_enabled);
   RESTORE_PREF(s_dnd_schedule_keys[WeekdaySchedule].schedule_pref_key,
@@ -425,6 +429,15 @@ void alerts_preferences_dnd_set_mask(AlertMask mask) {
 
 AlertMask alerts_preferences_dnd_get_mask(void) {
   return s_dnd_interruptions_mask;
+}
+
+void alerts_preferences_dnd_set_show_notifications(DndNotificationMode mode) {
+  s_dnd_show_notifications = mode;
+  SET_PREF(PREF_KEY_DND_SHOW_NOTIFICATIONS, s_dnd_show_notifications);
+}
+
+DndNotificationMode alerts_preferences_dnd_get_show_notifications(void) {
+  return s_dnd_show_notifications;
 }
 
 bool alerts_preferences_dnd_is_manually_enabled(void) {

--- a/src/fw/services/normal/notifications/alerts_preferences.h
+++ b/src/fw/services/normal/notifications/alerts_preferences.h
@@ -18,6 +18,8 @@
 
 #include <stdbool.h>
 
+#include "alerts_private.h"
+
 typedef enum FirstUseSource {
   FirstUseSourceManualDNDActionMenu = 0,
   FirstUseSourceManualDNDSettingsMenu,
@@ -31,6 +33,18 @@ typedef enum MuteBitfield {
   MuteBitfield_Weekdays = 0b00111110,
   MuteBitfield_Weekends = 0b01000001,
 } MuteBitfield;
+
+typedef enum {
+  DndNotificationModeHide = 0,
+  DndNotificationModeShow = 1,
+} DndNotificationMode;
+
+//! Set notification display mode when DND is active
+//! @param mode The display mode (Show or Hide)
+void alerts_preferences_dnd_set_show_notifications(DndNotificationMode mode);
+
+//! @return The notification display mode when DND is active
+DndNotificationMode alerts_preferences_dnd_get_show_notifications(void);
 
 //! Checks whether a given "first use" dialog has been shown and sets it as complete
 //! @param source The "first use" bit to check


### PR DESCRIPTION
Add a new "Notifications" option to the Quiet Time settings menu that allows users to control whether notifications are displayed during DND.

When "Notifications" is set to "Hide":
- All notifications are suppressed during Quiet Time.
- Analytics are still recorded for incoming notifications.
- The notification window is not displayed.

When "Notifications" is set to "Show" (default):
- Notifications behave normally during Quiet Time.
- Existing interruption mask settings still apply.

This provides users with finer control over their Quiet Time experience, allowing them to completely silence notifications while still allowing important interruptions (calls, alarms) based on the interruption mask.

For example: I don't want on QT mode to display notifications while I'm on the cinema, gym, dinner with friends, etc.

<img width="100" height="200" alt="CleanShot 2025-11-29 at 17 41 33@2x" src="https://github.com/user-attachments/assets/7fd1a9e9-f882-4e4b-aa0a-670b2d94df2e" />


Discord conversations: https://discord.com/channels/221364737269694464/1444175656500854925