### PR TITLE
settings/settings_notifications: 30 Seconds option notification timeout settings

### DIFF
--- a/resources/normal/base/lang/es_ES/tintin.po
+++ b/resources/normal/base/lang/es_ES/tintin.po
@@ -879,6 +879,11 @@ msgstr "Tamaño texto"
 msgid "15 Seconds"
 msgstr "15 Segundos"
 
+#. / 30 Second Notification Window Timeout
+#: ../src/fw/apps/system_apps/settings/settings_notifications.c:208
+msgid "30 Seconds"
+msgstr "30 Segundos"
+
 #. / 1 Minute Notification Window Timeout
 #: ../src/fw/apps/system_apps/settings/settings_notifications.c:188
 msgid "1 Minute"

--- a/resources/normal/base/lang/it_IT/tintin.po
+++ b/resources/normal/base/lang/it_IT/tintin.po
@@ -873,6 +873,11 @@ msgstr "Dim. tes."
 msgid "15 Seconds"
 msgstr "15 Secondi"
 
+#. / 30 Second Notification Window Timeout
+#: ../src/fw/apps/system_apps/settings/settings_notifications.c:208
+msgid "30 Seconds"
+msgstr "30 Secondi"
+
 #. / 1 Minute Notification Window Timeout
 #: ../src/fw/apps/system_apps/settings/settings_notifications.c:188
 msgid "1 Minute"

--- a/resources/normal/base/lang/tintin.pot
+++ b/resources/normal/base/lang/tintin.pot
@@ -822,6 +822,11 @@ msgstr ""
 msgid "15 Seconds"
 msgstr ""
 
+#. / 30 Second Notification Window Timeout
+#: ../src/fw/apps/system_apps/settings/settings_notifications.c:208
+msgid "30 Seconds"
+msgstr ""
+
 #. / 1 Minute Notification Window Timeout
 #: ../src/fw/apps/system_apps/settings/settings_notifications.c:204
 msgid "1 Minute"

--- a/src/fw/apps/system_apps/settings/settings_notifications.c
+++ b/src/fw/apps/system_apps/settings/settings_notifications.c
@@ -194,6 +194,7 @@ static void prv_text_size_menu_push(SettingsNotificationsData *data) {
 // NOTE: Keep the following two arrays in sync and with the same size.
 static const uint32_t s_window_timeouts_ms[] = {
   15 * MS_PER_SECOND,
+  30 * MS_PER_SECOND,
   1  * MS_PER_MINUTE,
   NOTIF_WINDOW_TIMEOUT_DEFAULT,
   10 * MS_PER_MINUTE,
@@ -203,6 +204,8 @@ static const uint32_t s_window_timeouts_ms[] = {
 static const char *s_window_timeouts_labels[] = {
   /// 15 Second Notification Window Timeout
   i18n_noop("15 Seconds"),
+  /// 30 Second Notification Window Timeout
+  i18n_noop("30 Seconds"),
   /// 1 Minute Notification Window Timeout
   i18n_noop("1 Minute"),
   /// 3 Minute Notification Window Timeout
@@ -216,7 +219,7 @@ static const char *s_window_timeouts_labels[] = {
 _Static_assert(ARRAY_LENGTH(s_window_timeouts_ms) == ARRAY_LENGTH(s_window_timeouts_labels), "");
 
 static int prv_window_timeout_get_selection_index(void) {
-  const int DEFAULT_IDX = 2;
+  const int DEFAULT_IDX = 3;
   // Double check no one has fudged with the order and the fallback/default
   PBL_ASSERTN(s_window_timeouts_ms[DEFAULT_IDX] == NOTIF_WINDOW_TIMEOUT_DEFAULT);
 


### PR DESCRIPTION
Add a new "30 Seconds" option to the notification timeout settings menu,
filling the gap between the existing "15 Seconds" and "1 Minute" options.

This provides users with an intermediate timeout duration that was previously
missing, offering more flexibility for reading notifications without
waiting a full minute.

Signed-off-by: Federico Bechini <federico.bechini@gmail.com>

<img width="100" height="200" alt="CleanShot 2025-11-29 at 18 35 43@2x" src="https://github.com/user-attachments/assets/3c825ec6-9e6e-4371-86ad-a2a58c9e1c44" />
