### PR TITLE
fw/battery: fix LPM not exiting when charger is connected [FIRM-869]

### DIFF
--- a/src/fw/services/common/battery/battery_monitor.c
+++ b/src/fw/services/common/battery/battery_monitor.c
@@ -87,7 +87,7 @@ static void prv_exit_critical(void) {
   // transition actions, only entry/exit actions.
   // We check that the state is PowerStateGood because the state machine does not transition through
   // all states in between the new and old states in a transition.
-  if (s_power_state == PowerStateGood) {
+  if (s_power_state == PowerStateGood || s_power_state == PowerStatePluggedIn) {
     prv_resume_normal_operation();
   }
 }
@@ -95,7 +95,7 @@ static void prv_exit_critical(void) {
 static void prv_exit_lpm(void) {
   // Checking the state here is a bit of a hack because the state machine does not have proper
   // transition actions, only entry/exit actions
-  if (s_power_state == PowerStateGood) {
+  if (s_power_state == PowerStateGood || s_power_state == PowerStatePluggedIn) {
     prv_resume_normal_operation();
   }
 }


### PR DESCRIPTION
When the watch enters low power mode due to low battery and is then placed on
the charger, it doesn't exit low power mode despite reestablishing Bluetooth
connectivity.

The battery monitor uses a state machine with these states:
- PowerStateGood
- PowerStateLowPower  
- PowerStateCritical
- PowerStatePluggedIn
- PowerStateStandby

When charging starts, the state transitions directly to PowerStatePluggedIn.
The exit handlers for PowerStateLowPower and PowerStateCritical check:

    if (s_power_state == PowerStateGood) {
        prv_resume_normal_operation();
    }

Since the new state is PowerStatePluggedIn (not PowerStateGood), the condition
is false and prv_resume_normal_operation() is never called.