### PR TITLE
fw/compositor: fix transition animation race with async display updates [FIRM-901]

### DIFF
--- a/src/fw/services/common/compositor/compositor.c
+++ b/src/fw/services/common/compositor/compositor.c
@@ -306,13 +306,16 @@ T_STATIC void prv_handle_display_update_complete(void) {
     s_deferred_render.animation.pending = false;
     prv_animation_update(s_animation_state.animation, s_deferred_render.animation.progress);
   }
-  if (s_deferred_render.app.pending) {
-    s_deferred_render.app.pending = false;
-    compositor_app_render_ready();
-  }
+  // Process transition_start before app so that the compositor state is set to
+  // AppTransitionPending before compositor_app_render_ready() is called. Otherwise, the app
+  // framebuffer may be rendered directly to the display before the transition animation starts.
   if (s_deferred_render.transition_start.pending) {
     s_deferred_render.transition_start.pending = false;
     compositor_transition(s_deferred_render.transition_start.compositor_animation);
+  }
+  if (s_deferred_render.app.pending) {
+    s_deferred_render.app.pending = false;
+    compositor_app_render_ready();
   }
 }
 


### PR DESCRIPTION
When display updates are asynchronous, a race condition in prv_handle_display_update_complete() could cause the destination app's framebuffer to be rendered directly to the display before the transition animation started.

Fix by processing transition_start before app in the deferred render handler, ensuring the compositor state is properly set before the app render ready callback runs.

This bug was exposed on Asterix after commit 6d095b2b changed the Sharp display driver from blocking to async operation. Previously, display_update_in_progress() always returned false by the time other code ran, so the deferred render paths were never triggered.