### PR TITLE
Support custom vibration patterns in notifications

### DIFF
--- a/src/fw/services/normal/timeline/attribute.c
+++ b/src/fw/services/normal/timeline/attribute.c
@@ -88,6 +88,7 @@ static AttributeType prv_attribute_type(AttributeId id) {
     case AttributeIdMetricValues:
       return AttributeTypeStringList;
     case AttributeIdMetricIcons:
+    case AttributeIdVibrationPattern:
       return AttributeTypeUint32List;
     default:
       return AttributeTypeUnknown;

--- a/src/fw/services/normal/timeline/attribute.h
+++ b/src/fw/services/normal/timeline/attribute.h
@@ -99,7 +99,7 @@ typedef enum {
   AttributeIdMetricNames = 41,
   //! (StringList) Metric values for Generic pins to display numeric data
   AttributeIdMetricValues = 42,
-  //! (Uint32List) Metric icons, casted to TimelineResourceId (uin16_t) on use
+  //! (Uint32List) Metric icons, casted to TimelineResourceId (uint16_t) on use
   AttributeIdMetricIcons = 43,
   //! (uint8_t) Health activity that the item is from
   AttributeIdHealthActivityType = 44,
@@ -111,6 +111,8 @@ typedef enum {
   AttributeIdSubtitleTemplateString = 47,
   //! Generic icon.
   AttributeIdIcon = 48,
+  //! (Uint32List) Custom vibration pattern for a notification, used with vibes_enqueue_custom_pattern
+  AttributeIdVibrationPattern = 49,
   NumAttributeIds,
 } AttributeId;
 


### PR DESCRIPTION
Adds a new attribute to the TimelineItem for vibration patterns. It's just a uint32List that gets sent from the mobile app. It could probably be smaller, though a uint8 list seems a little small for millisecond intervals. I could see an argument for uint16 instead. It'd be an easy change, just more code :shrug: 