### PR TITLE
bugfix for touch is invalid in mfg when touch the pannel befor enter to test touch item

### DIFF
--- a/src/fw/apps/prf_apps/mfg_touch_app.c
+++ b/src/fw/apps/prf_apps/mfg_touch_app.c
@@ -106,6 +106,7 @@ static void prv_handle_init(void) {
     .type = PEBBLE_TOUCH_EVENT,
     .handler = prv_handle_touch_event,
   };
+  touch_reset();
   event_service_client_subscribe(&data->event_info);
 }
 


### PR DESCRIPTION
The touch event would be pending if no client to consume it, so reset it before the mfg_touch_app subscribe the event.