### PR TITLE
fw/freertos: Increase stop mode wakeup margins for SF32LB52 [FIRM-897]

### DIFF
--- a/src/fw/freertos_application.c
+++ b/src/fw/freertos_application.c
@@ -71,9 +71,9 @@ static const RtcTicks EARLY_WAKEUP_TICKS = 2;
 static const RtcTicks MIN_STOP_TICKS = 5;
 #elif defined(MICRO_FAMILY_SF32LB52)
 //! Stop mode until this number of ticks before the next scheduled task
-static const RtcTicks EARLY_WAKEUP_TICKS = 4;
+static const RtcTicks EARLY_WAKEUP_TICKS = 8;
 //! Stop mode until this number of ticks before the next scheduled task
-static const RtcTicks MIN_STOP_TICKS = 8;
+static const RtcTicks MIN_STOP_TICKS = 16;
 #else
 #error "Unknown micro family"
 #endif


### PR DESCRIPTION
The SF32LB52 has significant latency when exiting stop mode due to clock restoration (waiting for HXT48 ready, re-enabling DLL1/DLL2).

Increase EARLY_WAKEUP_TICKS from 4 to 8 and MIN_STOP_TICKS from 8 to 16 to account for this wakeup latency.

(Fixes an issue where the first vibration would be longer than the ones after during a notification)