### PR TITLE
fw/drivers/sf32lb52/lptim: periodically calibrate

### DIFF
--- a/src/fw/drivers/lptim_systick.h
+++ b/src/fw/drivers/lptim_systick.h
@@ -8,6 +8,8 @@
 
 void lptim_systick_init(void);
 
+void lptim_calibrate_init(void);
+
 bool lptim_systick_is_initialized(void);
 
 void lptim_systick_enable(void);

--- a/src/fw/main.c
+++ b/src/fw/main.c
@@ -328,6 +328,10 @@ static void init_drivers(void) {
   rtc_init_timers();
   rtc_alarm_init();
 
+#ifdef MICRO_FAMILY_SF32LB52
+  lptim_calibrate_init();
+#endif
+
   power_tracking_init();
 }
 


### PR DESCRIPTION
RC10K is wildly inaccurate, and the LPTIM driver assumed its frequency was 9000 Hz. This patch measures RC10K (LPTIM clock) frequency at startup and adds a new call to configure a periodic timer to measure its frequency so we can tweak the LPTIM compare register accordingly.

We should have a single point where to do the RC vs HXT48 measurements/calibrations, as the RTC driver also does that, but we can refactor this a bit later.

Fixes #488 