### PR TITLE
fw: remove unused HRM parameters

### DIFF
--- a/src/fw/kernel/events.c
+++ b/src/fw/kernel/events.c
@@ -300,12 +300,6 @@ void **event_get_buffer(PebbleEvent *event) {
       }
       break;
 
-    case PEBBLE_HRM_EVENT:
-      if (event->hrm.event_type == HRMEvent_Diagnostics) {
-        return (void **)(&event->hrm.debug);
-      }
-      break;
-
     case PEBBLE_APP_GLANCE_EVENT:
       return (void **)&event->app_glance.app_uuid;
 

--- a/src/fw/kernel/events.h
+++ b/src/fw/kernel/events.h
@@ -622,19 +622,6 @@ typedef struct HRMHRVData { // 3 bytes
   HRMQuality quality:8;
 } HRMHRVData;
 
-typedef struct HRMLEDData { // 4 bytes
-  uint16_t current_ua;
-  uint16_t tia; //!< Transimpendance Amplifier value.
-                //!< This is used with thresholds (provided by AMS) to verify the part is
-                //!< functioning within specification.
-
-} HRMLEDData;
-
-typedef struct HRMDiagnosticsData {
-  HRMPPGData ppg_data;
-  HRMAccelData accel_data;
-} HRMDiagnosticsData;
-
 typedef struct HRMSubscriptionExpiringData { // 4 bytes
   HRMSessionRef session_ref;
 } HRMSubscriptionExpiringData;
@@ -642,8 +629,6 @@ typedef struct HRMSubscriptionExpiringData { // 4 bytes
 typedef enum HRMEventType {
   HRMEvent_BPM = 0,
   HRMEvent_HRV,
-  HRMEvent_LEDCurrent,
-  HRMEvent_Diagnostics,
   HRMEvent_SubscriptionExpiring
 } HRMEventType;
 
@@ -652,8 +637,6 @@ typedef struct PACKED PebbleHRMEvent { // 5 bytes
   union {
     HRMBPMData bpm;
     HRMHRVData hrv;
-    HRMLEDData led;
-    HRMDiagnosticsData *debug;
     HRMSubscriptionExpiringData expiring;
   };
 } PebbleHRMEvent;

--- a/src/fw/services/common/hrm/hrm_manager.h
+++ b/src/fw/services/common/hrm/hrm_manager.h
@@ -26,20 +26,12 @@ typedef enum {
 typedef enum {
   HRMFeatureShift_BPM = 0,
   HRMFeatureShift_HRV = 1,
-  HRMFeatureShift_LEDCurrent = 2,
-  HRMFeatureShift_Diagnostics = 3,
-
   HRMFeatureShiftMax
 } HRMFeatureShift;
 
 typedef enum {
   HRMFeature_BPM = (1 << HRMFeatureShift_BPM), //!< Collect heartrate BPM.
   HRMFeature_HRV = (1 << HRMFeatureShift_HRV), //!< Collect heartrate variability.
-  HRMFeature_LEDCurrent = (1 << HRMFeatureShift_LEDCurrent), //!< Collect the LED current
-                                                             //!< consumption (uA). This should not
-                                                             //!< be made public by the HRM service,
-                                                             //!< and should only be used internally
-  HRMFeature_Diagnostics = (1 << 3), //!< Collect PPG & Accel data
   HRMFeatureMax
 } HRMFeature;
 
@@ -136,28 +128,13 @@ void hrm_manager_enable(bool on);
 //------------------------------------------------------------------------------
 // The driver needs to provide new data to the service and needs to pull accel data.
 
-#define MAX_PPG_SAMPLES 20
-
-typedef struct {
-  int num_samples;
-  uint8_t indexes[MAX_PPG_SAMPLES];
-  uint16_t ppg[MAX_PPG_SAMPLES];
-  uint16_t tia[MAX_PPG_SAMPLES];
-} HRMPPGData;
-
 //! HRMData will contain all HRM information that is currently available from the device.
 typedef struct {
-  uint16_t led_current_ua;
-
   uint8_t hrm_bpm;
   HRMQuality hrm_quality;
 
   uint16_t hrv_ppi_ms;
   HRMQuality hrv_quality;
-  uint8_t hrm_status;
-
-  HRMAccelData accel_data;
-  HRMPPGData ppg_data;
 } HRMData;
 
 //! Callback used by HRM Driver to indicate that new data is available.

--- a/tests/fw/services/test_hrm_manager.c
+++ b/tests/fw/services/test_hrm_manager.c
@@ -382,10 +382,6 @@ void test_hrm_manager__different_feature_callbacks(void) {
   AppInstallId  app_id = 1;
   const uint16_t expire_s = SECONDS_PER_MINUTE;
   HRMSessionRef bpm_session = sys_hrm_manager_app_subscribe(app_id, 1, expire_s, HRMFeature_BPM);
-  HRMSessionRef led_session = sys_hrm_manager_app_subscribe(app_id + 1, 1, expire_s,
-                                                            HRMFeature_LEDCurrent);
-  HRMSessionRef all_session = sys_hrm_manager_app_subscribe(app_id + 2, 1, expire_s,
-                                                            HRMFeature_BPM|HRMFeature_LEDCurrent);
   HRMSessionRef no_session = sys_hrm_manager_app_subscribe(app_id + 3, 1, expire_s,
                                                             0 /* no features */);
 
@@ -409,7 +405,7 @@ void test_hrm_manager__multiple_feature_callbacks(void) {
   for (int i = 0; i < num_refs; ++i, app_id++) {
     session_refs[i] = TO_SESSION_REF(i+1);
     const uint16_t expire_s = SECONDS_PER_MINUTE;
-    sys_hrm_manager_app_subscribe(app_id, 1, expire_s, HRMFeature_BPM|HRMFeature_LEDCurrent);
+    sys_hrm_manager_app_subscribe(app_id, 1, expire_s, HRMFeature_BPM);
   }
 
   prv_fake_send_new_data();
@@ -498,13 +494,13 @@ void test_hrm_manager__set_features(void) {
   // Starts off with BPM enabled
   cl_assert_equal_i(state->features, HRMFeature_BPM);
 
-  // Change to only LED Current
-  sys_hrm_manager_set_features(session_ref, HRMFeature_LEDCurrent);
-  cl_assert_equal_i(state->features, HRMFeature_LEDCurrent);
+  // Change to none
+  sys_hrm_manager_set_features(session_ref, 0);
+  cl_assert_equal_i(state->features, 0);
 
-  // Change to LEDCurrent + BPM
-  sys_hrm_manager_set_features(session_ref, HRMFeature_LEDCurrent | HRMFeature_BPM);
-  cl_assert_equal_i(state->features, HRMFeature_LEDCurrent | HRMFeature_BPM);
+  // Change to BPM
+  sys_hrm_manager_set_features(session_ref, HRMFeature_BPM);
+  cl_assert_equal_i(state->features, HRMFeature_BPM);
 }
 
 void test_hrm_manager__set_update_internal(void) {
@@ -527,7 +523,7 @@ void test_hrm_manager__set_update_internal(void) {
   cl_assert(state->expire_utc == rtc_get_time() + expire_b_s);
 }
 
-#define NUM_TEST_EVENTS 2
+#define NUM_TEST_EVENTS 1
 void test_hrm_manager__circular_buffer_event_copy(void) {
   // Make sure there will be unaligned data
   const uint16_t buf_size = sizeof(PebbleHRMEvent) * 2 + sizeof(PebbleHRMEvent) / 2;
@@ -538,7 +534,6 @@ void test_hrm_manager__circular_buffer_event_copy(void) {
 
   PebbleHRMEvent event[NUM_TEST_EVENTS] = {
     { .event_type = HRMEvent_BPM, .bpm = { .bpm = 65, .quality = 5 } },
-    { .event_type = HRMEvent_LEDCurrent, .led = { .current_ua = 243 } },
   };
   { // These events will insert properly aligned in the buffer
     for (int i = 0; i < NUM_TEST_EVENTS; ++i) {


### PR DESCRIPTION
LED current/Diagnostics were only used during manufacturing of old devices, something that will not happen again. New devices do not expose things as LED current, diagnostics, etc. Let's keep things clean.