### PR TITLE
sdk: fix Python 3 bytes/string in TLUT_SIGNATURE

### DIFF
--- a/sdk/waftools/process_timeline_resources.py
+++ b/sdk/waftools/process_timeline_resources.py
@@ -64,7 +64,7 @@ class timeline_reso(Task.Task):
         resource_id_mapping = self.env.RESOURCE_ID_MAPPING
 
         TIMELINE_RESOURCE_TABLE_ENTRY_FMT = '<III'
-        TLUT_SIGNATURE = 'TLUT'
+        TLUT_SIGNATURE = b'TLUT'
 
         timeline_resources = []
         published_media_from_libs = _collect_lib_published_media(self.generator)


### PR DESCRIPTION
Convert TLUT_SIGNATURE from string to bytes literal to fix Python 3 compatibility in timeline resource processing.