### PR TITLE
fw/services/kraepelin: fix Asterix sleep tracking by relaxing not-worn timeout

### DIFF
--- a/src/fw/services/normal/activity/kraepelin/kraepelin_algorithm.c
+++ b/src/fw/services/normal/activity/kraepelin/kraepelin_algorithm.c
@@ -310,7 +310,7 @@ typedef struct {
 static const KAlgNotWornParams KALG_NOT_WORN_PARAMS = {
   .max_non_worn_vmc = 2500,
   .min_worn_vmc = 15,  // Increased significantly for asterix - much higher baseline noise
-  .max_low_vmc_run_m = 30,  // Reduced to catch desk time within 30 minutes
+  .max_low_vmc_run_m = 120,  // Allow longer stillness during deep sleep while still catching desk time
 };
 #else
 static const KAlgNotWornParams KALG_NOT_WORN_PARAMS = {


### PR DESCRIPTION
The max_low_vmc_run_m parameter was set to 30 minutes for Asterix, causing legitimate deep sleep periods to be flagged as "not worn". This resulted in sleep sessions being truncated or rejected entirely, with users reporting 2-3 hours of sleep instead of 8.

Increase the timeout from 30 to 120 minutes. This still detects when the watch is sitting on a desk but allows for normal deep sleep cycles where users may remain still for 30-90 minutes at a time.