### PR TITLE
fw/popups/notifications: Read correct vibe pattern 

### DIFF
--- a/src/fw/popups/notifications/notification_window.c
+++ b/src/fw/popups/notifications/notification_window.c
@@ -1366,15 +1366,20 @@ static void prv_handle_notification_added_common(Uuid *id, NotificationType type
 
   alerts_incoming_alert_analytics();
   if (alerts_should_vibrate_for_type(prv_alert_type_for_notification_type(type))) {
-  LayoutLayer *current = swap_layer_get_current_layout(&data->swap_layer);
-  TimelineItem *item = (TimelineItem *)layout_get_context(current);
-	Uint32List *vibeDurations = attribute_get_uint32_list(&item->attr_list, AttributeIdVibrationPattern);
-	if (vibeDurations && vibeDurations->num_values > 0) {
-	  VibePattern patt;
-	  patt.durations = vibeDurations->values;
-	  patt.num_segments = vibeDurations->num_values;
-	  vibes_enqueue_custom_pattern(patt);
-	} else {
+    TimelineItem *item = prv_get_current_notification(data);
+    // Check if the current notification is the one that just arrived - if not then reload to make sure
+    // it is, before reading the attributes.
+    if (!uuid_equal(&item->header.id, id)) {
+      prv_reload_swap_layer(data);
+      item = prv_get_current_notification(data);
+    }
+    Uint32List *vibeDurations = attribute_get_uint32_list(&item->attr_list, AttributeIdVibrationPattern);
+    if (vibeDurations && vibeDurations->num_values > 0) {
+      VibePattern patt;
+      patt.durations = vibeDurations->values;
+      patt.num_segments = vibeDurations->num_values;
+      vibes_enqueue_custom_pattern(patt);
+    } else {
 #if CAPABILITY_HAS_VIBE_SCORES
       VibeScore *score = vibe_client_get_score(VibeClient_Notifications);
       if (score) {


### PR DESCRIPTION
Previously, if a notification was already visible when a new one comes in, it would use the wrong vibe pattern (from the previous notification). In this scenario, force a reload before reading attributes from the notification.

This means that the correct vibe pattern is used.