### PR TITLE
fw/popups/notifications: add vibe timing setting

### DIFF
--- a/src/fw/apps/system_apps/settings/settings_notifications.c
+++ b/src/fw/apps/system_apps/settings/settings_notifications.c
@@ -47,6 +47,7 @@ enum NotificationsItem {
 #if PBL_BW
   NotificationsItemDesignStyle,
 #endif
+  NotificationsItemVibeDelay,
   NotificationsItem_Count,
 };
 
@@ -273,6 +274,38 @@ static void prv_design_style_menu_push(SettingsNotificationsData *data) {
 }
 #endif /* PBL_BW */
 
+// Vibe Delay
+////////////////////////
+
+static const char *s_vibe_delay_labels[] = {
+  /// Vibrate at the beginning of notification animation (immediate)
+  i18n_noop("Beginning"),
+  /// Vibrate at the end of notification animation (delayed)
+  i18n_noop("End"),
+};
+
+static int prv_vibe_delay_get_selection_index(void) {
+  return alerts_preferences_get_notification_vibe_delay() ? 1 : 0;
+}
+
+static void prv_vibe_delay_menu_select(OptionMenu *option_menu, int selection, void *context) {
+  alerts_preferences_set_notification_vibe_delay(selection == 1);
+  app_window_stack_remove(&option_menu->window, true /* animated */);
+}
+
+static void prv_vibe_delay_menu_push(SettingsNotificationsData *data) {
+  const int index = prv_vibe_delay_get_selection_index();
+  const OptionMenuCallbacks callbacks = {
+    .select = prv_vibe_delay_menu_select,
+  };
+  /// Status bar title for the Notification Vibe Timing settings screen
+  const char *title = i18n_noop("Vibe Timing");
+  settings_option_menu_push(
+      title, OptionMenuContentType_SingleLine, index, &callbacks,
+      ARRAY_LENGTH(s_vibe_delay_labels), true /* icons_enabled */, s_vibe_delay_labels,
+      data);
+}
+
 // Menu Layer Callbacks
 ////////////////////////
 
@@ -325,6 +358,12 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
       break;
     }
   #endif /* PBL_BW */
+    case NotificationsItemVibeDelay: {
+      /// String within Settings->Notifications that describes when vibration happens
+      title = i18n_noop("Vibe Timing");
+      subtitle = s_vibe_delay_labels[prv_vibe_delay_get_selection_index()];
+      break;
+    }
     default:
       WTF;
   }
@@ -364,6 +403,9 @@ static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
       prv_design_style_menu_push(data);
       break;
 #endif /* PBL_BW */
+    case NotificationsItemVibeDelay:
+      prv_vibe_delay_menu_push(data);
+      break;
     default:
       WTF;
   }

--- a/src/fw/popups/notifications/notification_window_private.h
+++ b/src/fw/popups/notifications/notification_window_private.h
@@ -48,4 +48,8 @@ typedef struct NotificationWindowData {
   Layer dnd_icon_layer;
   GBitmap dnd_icon;
   bool dnd_icon_visible;
+
+  // Delayed vibration support - vibe at end of animation instead of immediately
+  bool pending_vibe;
+  Uuid pending_vibe_id;
 } NotificationWindowData;

--- a/src/fw/services/normal/notifications/alerts_preferences.c
+++ b/src/fw/services/normal/notifications/alerts_preferences.c
@@ -66,6 +66,9 @@ static uint32_t s_notif_window_timeout_ms = NOTIF_WINDOW_TIMEOUT_DEFAULT;
 #define PREF_KEY_NOTIF_DESIGN_STYLE "notifDesignStyle"
 static bool s_notification_alternative_design = false;  // true = alternative (black banner), false = standard (default)
 
+#define PREF_KEY_NOTIF_VIBE_DELAY "notifVibeDelay"
+static bool s_notification_vibe_delay = false;  // true = vibe at end of animation, false = vibe immediately (default)
+
 ///////////////////////////////////
 //! Legacy preference keys
 ///////////////////////////////////
@@ -280,6 +283,7 @@ void alerts_preferences_init(void) {
   RESTORE_PREF(PREF_KEY_FIRST_USE_COMPLETE, s_first_use_complete);
   RESTORE_PREF(PREF_KEY_NOTIF_WINDOW_TIMEOUT, s_notif_window_timeout_ms);
   RESTORE_PREF(PREF_KEY_NOTIF_DESIGN_STYLE, s_notification_alternative_design);
+  RESTORE_PREF(PREF_KEY_NOTIF_VIBE_DELAY, s_notification_vibe_delay);
 #undef RESTORE_PREF
 
   prv_migrate_legacy_dnd_schedule(&file);
@@ -343,6 +347,15 @@ bool alerts_preferences_get_notification_alternative_design(void) {
 void alerts_preferences_set_notification_alternative_design(bool alternative) {
   s_notification_alternative_design = alternative;
   SET_PREF(PREF_KEY_NOTIF_DESIGN_STYLE, s_notification_alternative_design);
+}
+
+bool alerts_preferences_get_notification_vibe_delay(void) {
+  return s_notification_vibe_delay;
+}
+
+void alerts_preferences_set_notification_vibe_delay(bool delay) {
+  s_notification_vibe_delay = delay;
+  SET_PREF(PREF_KEY_NOTIF_VIBE_DELAY, s_notification_vibe_delay);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/fw/services/normal/notifications/alerts_preferences_private.h
+++ b/src/fw/services/normal/notifications/alerts_preferences_private.h
@@ -35,6 +35,10 @@ bool alerts_preferences_get_notification_alternative_design(void);
 
 void alerts_preferences_set_notification_alternative_design(bool alternative);
 
+bool alerts_preferences_get_notification_vibe_delay(void);
+
+void alerts_preferences_set_notification_vibe_delay(bool delay);
+
 bool alerts_preferences_get_vibrate(void);
 
 void alerts_preferences_set_vibrate(bool enable);


### PR DESCRIPTION
Add a "Vibe Timing" option in Settings -> Notifications that controls when the vibration occurs relative to the notification animation: 
- "Beginning" (default): vibrate immediately when notification arrives 
- "End": vibrate when the notification text becomes visible

This allows users who find the immediate vibration jarring to delay it until they can actually see what the notification is about.