### PR TITLE
sdk: compute minimum SDK version based on actual function usage

### DIFF
--- a/sdk/tools/compute_sdk_version.py
+++ b/sdk/tools/compute_sdk_version.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2025 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Computes the minimum required SDK version for an app based on which SDK
+functions it actually uses. This allows apps to only require SDK versions
+that contain the functions they need, rather than always requiring the
+newest SDK version they were compiled against.
+
+The key insight is that apps that don't use newly-added SDK functions
+should be able to run on older firmware that doesn't have those functions.
+"""
+
+import json
+import os
+import subprocess
+
+
+def get_used_symbols(elf_path):
+    """
+    Extract the list of defined symbols from an ELF file.
+    These are the SDK functions that were linked into the app.
+    """
+    try:
+        # Use nm to list all defined symbols in the text section
+        result = subprocess.run(
+            ['arm-none-eabi-nm', '--defined-only', elf_path],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+
+        symbols = set()
+        for line in result.stdout.splitlines():
+            parts = line.split()
+            if len(parts) >= 3:
+                # Format: address type name
+                symbol_type = parts[1]
+                symbol_name = parts[2]
+                # Only include text (T/t) symbols - these are functions
+                if symbol_type in ('T', 't'):
+                    symbols.add(symbol_name)
+
+        return symbols
+    except subprocess.CalledProcessError:
+        return set()
+    except FileNotFoundError:
+        # arm-none-eabi-nm not found
+        return set()
+
+
+def compute_sdk_version(elf_path, symbol_revisions_path, default_major, default_minor):
+    """
+    Compute the SDK version for an app.
+
+    The symbol_revisions.json file contains a mapping of function names to the
+    SDK minor version (not revision!) when they were added. We find the maximum
+    SDK minor version among all SDK functions the app uses.
+
+    Returns a dict with 'major' and 'minor' keys.
+    """
+    if not os.path.exists(symbol_revisions_path):
+        # Fall back to default if symbol_revisions.json doesn't exist
+        return {
+            'major': default_major,
+            'minor': default_minor
+        }
+
+    try:
+        # Load the symbol -> sdk_minor mapping
+        with open(symbol_revisions_path, 'r') as f:
+            symbol_data = json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return {
+            'major': default_major,
+            'minor': default_minor
+        }
+
+    symbol_sdk_minors = symbol_data.get('symbols', {})
+
+    # Get symbols used by the app
+    used_symbols = get_used_symbols(elf_path)
+
+    if not used_symbols or not symbol_sdk_minors:
+        return {
+            'major': default_major,
+            'minor': default_minor
+        }
+
+    # Find the maximum SDK minor version among used SDK functions
+    max_sdk_minor = 0
+    for symbol in used_symbols:
+        if symbol in symbol_sdk_minors:
+            sdk_minor = symbol_sdk_minors[symbol]
+            if sdk_minor > max_sdk_minor:
+                max_sdk_minor = sdk_minor
+
+    if max_sdk_minor > 0:
+        return {
+            'major': default_major,
+            'minor': max_sdk_minor
+        }
+    else:
+        return {
+            'major': default_major,
+            'minor': default_minor
+        }

--- a/sdk/tools/inject_metadata.py
+++ b/sdk/tools/inject_metadata.py
@@ -75,7 +75,7 @@ class InvalidBinaryError(Exception):
 
 
 def inject_metadata(target_binary, target_elf, resources_file, timestamp, allow_js=False,
-                    has_worker=False):
+                    has_worker=False, sdk_version=None):
 
     if target_binary[-4:] != '.bin':
         raise Exception("Invalid filename <%s>! The filename should end in .bin" % target_binary)
@@ -286,6 +286,12 @@ def inject_metadata(target_binary, target_elf, resources_file, timestamp, allow_
         write_value_at_offset(NUM_RELOC_ENTRIES_ADDR, '<L', len(reloc_entries))
 
         write_value_at_offset(VIRTUAL_SIZE_ADDR, "<H", app_virtual_size)
+
+        # Write SDK version if provided (Version struct: major byte, then minor byte)
+        if sdk_version is not None:
+            # Pack as little-endian u16: low byte = major, high byte = minor
+            sdk_version_u16 = sdk_version['major'] | (sdk_version['minor'] << 8)
+            write_value_at_offset(SDK_VERSION_ADDR, '<H', sdk_version_u16)
 
         # Write the reloc_entries past the end of the binary. This expands the size of the binary,
         # but this new stuff won't actually be loaded into ram.

--- a/sdk/waftools/process_bundle.py
+++ b/sdk/waftools/process_bundle.py
@@ -181,11 +181,18 @@ def make_pbl_bundle(task_gen):
         resources_pack = platform_build_node.make_node('app_resources.pbpack')
 
         bundle_sources.extend([app_bin_file, resources_pack])
+
+        # SDK version is computed and written to the binary by inject_metadata.
+        # Use the default SDK version for the manifest (the binary has the authoritative version).
+        sdk_version = {
+            'major': task_gen.bld.env.SDK_VERSION_MAJOR,
+            'minor': task_gen.bld.env.SDK_VERSION_MINOR
+        }
+
         bin_files.append({'watchapp': app_bin_file.abspath(),
                           'resources': resources_pack.abspath(),
                           'worker_bin': worker_bin_file.abspath() if worker_bin_file else None,
-                          'sdk_version': {'major': task_gen.bld.env.SDK_VERSION_MAJOR,
-                                          'minor': task_gen.bld.env.SDK_VERSION_MINOR},
+                          'sdk_version': sdk_version,
                           'subfolder': task_gen.bld.env.BUNDLE_BIN_DIR})
     task_gen.bld.env = cached_env
 

--- a/sdk/waftools/process_elf.py
+++ b/sdk/waftools/process_elf.py
@@ -1,8 +1,29 @@
 # SPDX-FileCopyrightText: 2024 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import objcopy
 import pebble_sdk_gcc
+
+
+def _find_symbol_revisions_path(env):
+    """
+    Find the path to symbol_revisions.json in the SDK.
+    Checks platform-specific path first, then common path.
+    """
+    # Try platform-specific SDK path
+    if env.PEBBLE_SDK_PLATFORM:
+        path = os.path.join(env.PEBBLE_SDK_PLATFORM, 'include', 'symbol_revisions.json')
+        if os.path.exists(path):
+            return path
+
+    # Try common SDK path
+    if env.PEBBLE_SDK_COMMON:
+        path = os.path.join(env.PEBBLE_SDK_COMMON, 'include', 'symbol_revisions.json')
+        if os.path.exists(path):
+            return path
+
+    return None
 
 
 # TODO: PBL-33841 Make this a feature
@@ -27,6 +48,9 @@ def generate_bin_file(task_gen, bin_type, elf_file, has_pkjs, has_worker):
     raw_bin_file = platform_build_node.make_node('pebble-{}.raw.bin'.format(bin_type))
     bin_file = platform_build_node.make_node('pebble-{}.bin'.format(bin_type))
 
+    # Find symbol_revisions.json for computing minimum SDK version
+    symbol_revisions_path = _find_symbol_revisions_path(task_gen.bld.env)
+
     task_gen.bld(rule=objcopy.objcopy_bin, source=elf_file, target=raw_bin_file)
     pebble_sdk_gcc.gen_inject_metadata_rule(task_gen.bld,
                                             src_bin_file=raw_bin_file,
@@ -35,5 +59,8 @@ def generate_bin_file(task_gen, bin_type, elf_file, has_pkjs, has_worker):
                                             resource_file=resources_file,
                                             timestamp=task_gen.bld.env.TIMESTAMP,
                                             has_pkjs=has_pkjs,
-                                            has_worker=has_worker)
+                                            has_worker=has_worker,
+                                            symbol_revisions_path=symbol_revisions_path,
+                                            sdk_version_major=task_gen.bld.env.SDK_VERSION_MAJOR,
+                                            sdk_version_minor=task_gen.bld.env.SDK_VERSION_MINOR)
     return bin_file

--- a/sdk/wscript
+++ b/sdk/wscript
@@ -226,7 +226,8 @@ def build(bld):
                                 platform_folder_node.make_node('include/pebble_sdk_version.h'),
                                 platform_folder_node.make_node('include/pebble_process_info.h'),
                                 platform_folder_node.make_node('include/pebble_worker.h'),
-                                platform_folder_node.make_node('include/pebble_worker_sdk_version.h')]
+                                platform_folder_node.make_node('include/pebble_worker_sdk_version.h'),
+                                platform_folder_node.make_node('include/symbol_revisions.json')]
     bld(rule="cd '{}' ; python '{}' --sdk-dir='{}' '{}' '{}' '{}' '{}' {}".
         format(tintin_home.abspath(),
                native_generator_script.abspath(),

--- a/tools/generate_native_sdk/exports.py
+++ b/tools/generate_native_sdk/exports.py
@@ -125,7 +125,7 @@ def parse_export_file(filename, internal_sdk_build):
         current_revision = INTERNAL_REVISION if internal_sdk_build else file_revision
         exports = parse_exports_list(shim_defs['exports'], current_revision)
 
-    return shim_defs['files'], exports
+    return shim_defs['files'], exports, file_revision
 
 
 def walk_tree(exports_tree, func, include_groups = False):

--- a/tools/generate_native_sdk/generate_symbol_revisions.py
+++ b/tools/generate_native_sdk/generate_symbol_revisions.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2025 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Generates a JSON file mapping SDK function names to their minimum required SDK minor version.
+This file is used at app build time to compute the minimum SDK version an app requires
+based on which SDK functions it actually uses.
+
+Key insight: The "addedRevision" in exported_symbols.json is NOT the same as
+SDK_VERSION_MINOR. We need to map function revisions to actual SDK minor versions.
+"""
+
+import json
+import os.path
+
+SYMBOL_REVISIONS_FILE = 'symbol_revisions.json'
+
+
+def gen_symbol_sdk_minors(functions, current_revision, current_sdk_minor):
+    """
+    Generates a dict mapping function names to their minimum required SDK minor version.
+    Only includes non-removed functions.
+
+    The mapping is:
+    - Functions added at current_revision -> current_sdk_minor
+    - Functions added at current_revision - N -> current_sdk_minor - N
+    - Functions added at revision 0 -> 0 (baseline)
+
+    This ensures apps only require the SDK version that has the functions they use.
+    """
+    symbols = {}
+    for f in functions:
+        if f.removed:
+            continue
+
+        # Calculate SDK minor version for this function
+        # The offset between revision and sdk_minor is: current_revision - current_sdk_minor
+        # So: sdk_minor = revision - (current_revision - current_sdk_minor)
+        # But we clamp to 0 as minimum
+        offset = current_revision - current_sdk_minor
+        sdk_minor = max(0, f.added_revision - offset)
+        symbols[f.name] = sdk_minor
+
+    return symbols
+
+
+def make_symbol_revisions_file(functions, sdk_include_dir, current_revision, current_sdk_minor):
+    """
+    Writes the symbol revisions JSON file to the SDK include directory.
+    This file maps SDK function names to their minimum required SDK minor version.
+
+    Args:
+        functions: List of FunctionExport objects from exported_symbols.json
+        sdk_include_dir: Path to SDK include directory
+        current_revision: Current revision from exported_symbols.json
+        current_sdk_minor: Current SDK_VERSION_MINOR from pebble_process_info.h
+    """
+    data = {
+        'version': 1,
+        'current_sdk_minor': current_sdk_minor,
+        'current_revision': current_revision,
+        'symbols': gen_symbol_sdk_minors(functions, current_revision, current_sdk_minor)
+    }
+
+    revisions_path = os.path.join(sdk_include_dir, SYMBOL_REVISIONS_FILE)
+    with open(revisions_path, 'w') as f:
+        json.dump(data, f, sort_keys=True, indent=2)


### PR DESCRIPTION
Right now, Apps will only work on the SDK version they are compiled for, even if they are not using newly added features! This change makes the app only require the SDK version that contains the functions they actually use, rather than always requiring the newest SDK version they were compiled with. This allows apps that don't use newly-added APIs to remain compatible with older firmware.

Implementation: 
- Generate symbol_revisions.json during SDK build, mapping each SDK function to the SDK minor version when it was added - At app build time, scan the ELF for used SDK symbols and compute the maximum SDK minor version required 
- Write the computed SDK version directly to the binary header in inject_metadata (not just the manifest)