### PR TITLE
sdk: allow BDF fonts to be added as resources

### DIFF
--- a/tools/resources/resource_map/resource_generator_font.py
+++ b/tools/resources/resource_map/resource_generator_font.py
@@ -45,7 +45,7 @@ class FontResourceGenerator(ResourceGenerator):
     def generate_object(cls, task, definition):
         font_path = task.inputs[0].abspath()
         font_ext = os.path.splitext(font_path)[-1]
-        if font_ext in (".ttf", ".otf"):
+        if font_ext in (".ttf", ".otf", ".bdf"):
             font_data = cls.build_font_data(font_path, definition)
         elif font_ext == ".pbf":
             font_data = open(font_path, "rb").read()


### PR DESCRIPTION
This makes it easier to add custom bitmap fonts to watchapps. The font conversion in the SDK uses freetype, which already supports BDF bitmap fonts -- it is in fact already possible to use a BDF font by renaming it to *.ttf.

Tested with Terminus 16px and the sample app:
<img width="260" height="312" alt="image" src="https://github.com/user-attachments/assets/dcf0a2c2-c189-4b7c-98a2-5300a6a987d9" />
