### PR TITLE
tools/log_hashing/miniterm: ignore decode errors

### DIFF
--- a/tools/log_hashing/miniterm_co.py
+++ b/tools/log_hashing/miniterm_co.py
@@ -27,7 +27,7 @@ def dehash_read(self, size, plain_read):
     #  - If not, continue as usual
     #  - If it does, dehash the buffered line and use clever tricks to swap it into the terminal
     #    view in-place (obviously, don't be using this method for raw serial IO or file output)
-    raw_read_data = plain_read(self, size).decode()
+    raw_read_data = plain_read(self, size).decode(errors="ignore")
     read_data = []
     for read_char in raw_read_data:
         if read_char == "\n":


### PR DESCRIPTION
So we can run firmware without pulse protocol and other parts with it (e.g. bootloader, where it's always used).