### PR TITLE
fw/apps/settings: Add new Health menu with Distance Unit setting toggler

### DIFF
--- a/src/fw/apps/system_apps/settings/settings_health.c
+++ b/src/fw/apps/system_apps/settings/settings_health.c
@@ -1,0 +1,111 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "settings_health.h"
+#include "settings_menu.h"
+#include "settings_option_menu.h"
+#include "settings_window.h"
+
+#include "kernel/pbl_malloc.h"
+#include "services/common/i18n/i18n.h"
+#include "shell/prefs.h"
+#include "system/passert.h"
+
+#include <string.h>
+
+typedef struct SettingsHealthData {
+    SettingsCallbacks callbacks;
+} SettingsHealthData;
+
+static const char *s_units_distance_labels[] = {
+    i18n_noop("Kilometers"),
+    i18n_noop("Miles"),
+};
+
+enum SettingsHealthItem {
+    SettingsHealthUnitDistance,
+    NumSettingsHealthItems
+};
+
+static void prv_deinit_cb(SettingsCallbacks *context) {
+    SettingsHealthData *data = (SettingsHealthData*)context;
+
+    i18n_free_all(data);
+    app_free(data);
+}
+
+static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
+                            const Layer *cell_layer, uint16_t row, bool selected) {
+    SettingsHealthData *data = (SettingsHealthData*) context;
+
+    const char *title = NULL;
+    const char *subtitle = NULL;
+
+    switch (row) {
+        case SettingsHealthUnitDistance:
+            title = i18n_noop("Distance Unit");
+            UnitsDistance unit = shell_prefs_get_units_distance();
+            if (unit >= UnitsDistanceCount) {
+                subtitle = i18n_noop("Unknown");
+            } else {
+                subtitle = s_units_distance_labels[unit];
+            }
+            break;
+        default:
+            WTF;
+    }
+    menu_cell_basic_draw(ctx, cell_layer, title, subtitle, NULL);
+}
+
+static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
+    SettingsHealthData *data = (SettingsHealthData*)context;
+    switch (row) {
+        case SettingsHealthUnitDistance:
+            UnitsDistance unit = shell_prefs_get_units_distance();
+            unit = (unit + 1) % UnitsDistanceCount;
+            shell_prefs_set_units_distance(unit);
+            break;
+        default:
+            WTF;
+    }
+    settings_menu_reload_data(SettingsMenuItemHealth);
+    settings_menu_mark_dirty(SettingsMenuItemHealth);
+}
+
+static uint16_t prv_num_rows_cb(SettingsCallbacks *context) {
+    uint16_t rows = NumSettingsHealthItems;
+
+    return rows;
+}
+
+static void prv_appear_cb(SettingsCallbacks *context) {
+    SettingsHealthData *data = (SettingsHealthData*)context;
+}
+
+static void prv_hide_cb(SettingsCallbacks *context) {
+    SettingsHealthData *data = (SettingsHealthData*)context;
+}
+
+static Window *prv_init(void) {
+    SettingsHealthData *data = app_malloc_check(sizeof(*data));
+    *data = (SettingsHealthData){};
+
+    data->callbacks = (SettingsCallbacks) {
+        .deinit = prv_deinit_cb,
+        .draw_row = prv_draw_row_cb,
+        .select_click = prv_select_click_cb,
+        .num_rows = prv_num_rows_cb,
+        .appear = prv_appear_cb,
+        .hide = prv_hide_cb,
+    };
+
+    return settings_window_create(SettingsMenuItemHealth, &data->callbacks);
+}
+
+const SettingsModuleMetadata *settings_health_get_info(void) {
+    static const SettingsModuleMetadata s_module_info = {
+        .name = i18n_noop("Health"),
+        .init = prv_init,
+    };
+
+    return &s_module_info;
+}

--- a/src/fw/apps/system_apps/settings/settings_health.h
+++ b/src/fw/apps/system_apps/settings/settings_health.h
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include "settings_menu.h"
+
+const SettingsModuleMetadata *settings_health_get_info(void);

--- a/src/fw/apps/system_apps/settings/settings_menu.c
+++ b/src/fw/apps/system_apps/settings/settings_menu.c
@@ -13,6 +13,9 @@
 #include "settings_time.h"
 #include "settings_timeline.h"
 #include "settings_themes.h"
+#if CAPABILITY_HAS_HEALTH_TRACKING
+#include "settings_health.h"
+#endif
 
 #if CAPABILITY_HAS_VIBE_SCORES
 #include "settings_vibe_patterns.h"
@@ -32,6 +35,9 @@ static const SettingsModuleGetMetadata s_submodule_registry[] = {
   [SettingsMenuItemQuietTime]     = settings_quiet_time_get_info,
 #if CAPABILITY_HAS_TIMELINE_PEEK
   [SettingsMenuItemTimeline]      = settings_timeline_get_info,
+#endif
+#if CAPABILITY_HAS_HEALTH_TRACKING
+  [SettingsMenuItemHealth]    = settings_health_get_info,
 #endif
 #if !TINTIN_FORCE_FIT
   [SettingsMenuItemActivity]      = settings_activity_tracker_get_info,

--- a/src/fw/apps/system_apps/settings/settings_menu.h
+++ b/src/fw/apps/system_apps/settings/settings_menu.h
@@ -24,6 +24,9 @@ typedef enum {
   SettingsMenuItemQuickLaunch,
   SettingsMenuItemDateTime,
   SettingsMenuItemDisplay,
+#if CAPABILITY_HAS_HEALTH_TRACKING
+  SettingsMenuItemHealth,
+#endif
 #if PBL_COLOR
   SettingsMenuItemThemes,
 #endif


### PR DESCRIPTION
As there is currently no way to change this setting for the moment, this PR adds a Distance Unit setting toggler linked to the already existing Units Distance preference, inside a new Health menu.

We can now easily toggle between Kilometers and Miles.