### PR TITLE
fw/shell: Add watchface usage time tracking

### DIFF
--- a/src/fw/process_management/app_manager.c
+++ b/src/fw/process_management/app_manager.c
@@ -42,7 +42,13 @@
 #include "services/normal/app_outbox_service.h"
 #include "shell/normal/app_idle_timeout.h"
 #include "shell/normal/watchface.h"
+#if !RECOVERY_FW
+#include "shell/normal/watchface_metrics.h"
+#endif
 #include "shell/shell.h"
+#if MEMFAULT
+#include "memfault/components.h"
+#endif
 #include "shell/system_app_state_machine.h"
 #include "syscall/syscall.h"
 #include "syscall/syscall_internal.h"
@@ -900,6 +906,16 @@ static void prv_handle_app_start_analytics(const PebbleProcessMd *app_md,
     analytics_inc(ANALYTICS_DEVICE_METRIC_APP_USER_LAUNCH_COUNT, AnalyticsClient_System);
     analytics_inc(ANALYTICS_APP_METRIC_USER_LAUNCH_COUNT, AnalyticsClient_App);
   }
+
+  // Track per-watchface usage metrics
+#if !RECOVERY_FW
+  if (app_md->process_type == ProcessTypeWatchface) {
+    watchface_metrics_start(&app_md->uuid);
+#if MEMFAULT
+    MEMFAULT_METRIC_ADD(watchface_launch_count, 1);
+#endif
+  }
+#endif
 }
 
 

--- a/src/fw/process_management/process_manager.c
+++ b/src/fw/process_management/process_manager.c
@@ -33,6 +33,9 @@
 #include "services/normal/persist.h"
 #include "services/normal/voice/voice.h"
 #include "shell/normal/watchface.h"
+#if !RECOVERY_FW
+#include "shell/normal/watchface_metrics.h"
+#endif
 
 #include "syscall/syscall.h"
 #include "system/logging.h"
@@ -359,6 +362,12 @@ static void prv_handle_app_stop_analytics(const ProcessContext *const context,
   }
   if (task == PebbleTask_App) {
     analytics_stopwatch_stop(ANALYTICS_APP_METRIC_FRONT_MOST_TIME);
+#if !RECOVERY_FW
+    // Stop per-watchface time tracking if this was a watchface
+    if (context->app_md->process_type == ProcessTypeWatchface) {
+      watchface_metrics_stop();
+    }
+#endif
   }
   analytics_external_collect_app_cpu_stats();
   analytics_external_collect_app_flash_read_stats();

--- a/src/fw/shell/normal/shell_event_loop.c
+++ b/src/fw/shell/normal/shell_event_loop.c
@@ -35,6 +35,7 @@
 #include "shell/normal/display_calibration_prompt.h"
 #include "shell/normal/quick_launch.h"
 #include "shell/normal/watchface.h"
+#include "shell/normal/watchface_metrics.h"
 #include "shell/prefs.h"
 #include "system/logging.h"
 
@@ -52,6 +53,7 @@ void shell_event_loop_init(void) {
   app_outbox_service_init();
   app_message_sender_init();
   watchface_init();
+  watchface_metrics_init();
   timeline_peek_init();
 #if CAPABILITY_HAS_HEALTH_TRACKING
   // Start activity tracking if enabled

--- a/src/fw/shell/normal/watchface_metrics.c
+++ b/src/fw/shell/normal/watchface_metrics.c
@@ -1,0 +1,208 @@
+/* SPDX-FileCopyrightText: 2025 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "watchface_metrics.h"
+
+#include "drivers/rtc.h"
+#include "os/mutex.h"
+#include "services/common/regular_timer.h"
+#include "services/normal/settings/settings_file.h"
+#include "system/logging.h"
+#include "util/uuid.h"
+
+#include <string.h>
+
+#define WATCHFACE_METRICS_FILE "wfmetrics"
+#define WATCHFACE_METRICS_MAX_SIZE 256
+#define WATCHFACE_METRICS_SAVE_INTERVAL_MINS 5
+#define WATCHFACE_METRICS_KEY "current"
+
+// Stored data for the current watchface
+typedef struct {
+  Uuid uuid;
+  uint32_t total_time_secs;
+} WatchfaceMetricsData;
+
+// Runtime state (protected by s_mutex)
+static struct {
+  bool tracking;
+  Uuid current_uuid;
+  uint32_t start_ticks;
+  uint32_t current_total_secs;
+  uint32_t last_saved_secs;
+} s_state;
+
+static SettingsFile s_settings_file;
+static bool s_initialized = false;
+static RegularTimerInfo s_save_timer;
+static PebbleMutex *s_mutex;
+
+// -------------------------------------------------------------------------------------------
+static void prv_ensure_open(void) {
+  if (!s_initialized) {
+    status_t status = settings_file_open(&s_settings_file, WATCHFACE_METRICS_FILE,
+                                         WATCHFACE_METRICS_MAX_SIZE);
+    if (status != S_SUCCESS) {
+      PBL_LOG(LOG_LEVEL_ERROR, "Failed to open watchface metrics file: %d", (int)status);
+      return;
+    }
+    s_initialized = true;
+  }
+}
+
+// -------------------------------------------------------------------------------------------
+// Load the stored watchface data. Returns true if data exists and UUID matches.
+// Note: Caller must hold s_mutex
+static bool prv_load_data(const Uuid *uuid, uint32_t *out_time) {
+  prv_ensure_open();
+  if (!s_initialized) {
+    return false;
+  }
+
+  WatchfaceMetricsData data;
+  status_t status = settings_file_get(&s_settings_file,
+                                      WATCHFACE_METRICS_KEY, strlen(WATCHFACE_METRICS_KEY),
+                                      &data, sizeof(data));
+  if (status == S_SUCCESS && uuid_equal(&data.uuid, uuid)) {
+    *out_time = data.total_time_secs;
+    return true;
+  }
+  return false;
+}
+
+// -------------------------------------------------------------------------------------------
+// Note: Caller must hold s_mutex
+static void prv_save_data(const Uuid *uuid, uint32_t total_secs) {
+  prv_ensure_open();
+  if (!s_initialized) {
+    return;
+  }
+
+  WatchfaceMetricsData data = {
+    .uuid = *uuid,
+    .total_time_secs = total_secs,
+  };
+  status_t status = settings_file_set(&s_settings_file,
+                                      WATCHFACE_METRICS_KEY, strlen(WATCHFACE_METRICS_KEY),
+                                      &data, sizeof(data));
+  if (status != S_SUCCESS) {
+    PBL_LOG(LOG_LEVEL_ERROR, "Failed to save watchface metrics: %d", (int)status);
+  }
+}
+
+// -------------------------------------------------------------------------------------------
+static void prv_periodic_save_callback(void *data) {
+  mutex_lock(s_mutex);
+
+  if (!s_state.tracking) {
+    mutex_unlock(s_mutex);
+    return;
+  }
+
+  uint32_t now_ticks = rtc_get_ticks();
+  uint32_t elapsed_ticks = now_ticks - s_state.start_ticks;
+  uint32_t elapsed_secs = elapsed_ticks / RTC_TICKS_HZ;
+  uint32_t current_total = s_state.current_total_secs + elapsed_secs;
+
+  if (current_total != s_state.last_saved_secs) {
+    prv_save_data(&s_state.current_uuid, current_total);
+    s_state.last_saved_secs = current_total;
+    PBL_LOG(LOG_LEVEL_DEBUG, "Watchface metrics: periodic save, total: %lu secs",
+            (unsigned long)current_total);
+  }
+
+  mutex_unlock(s_mutex);
+}
+
+// -------------------------------------------------------------------------------------------
+void watchface_metrics_init(void) {
+  s_mutex = mutex_create();
+
+  s_state.tracking = false;
+  s_state.start_ticks = 0;
+  s_state.current_total_secs = 0;
+  s_state.last_saved_secs = 0;
+  memset(&s_state.current_uuid, 0, sizeof(Uuid));
+
+  s_save_timer = (RegularTimerInfo) {
+    .cb = prv_periodic_save_callback,
+  };
+  regular_timer_add_multiminute_callback(&s_save_timer, WATCHFACE_METRICS_SAVE_INTERVAL_MINS);
+}
+
+// -------------------------------------------------------------------------------------------
+void watchface_metrics_start(const Uuid *uuid) {
+  mutex_lock(s_mutex);
+
+  // Stop current tracking if any (inline to avoid recursive lock)
+  if (s_state.tracking) {
+    uint32_t now_ticks = rtc_get_ticks();
+    uint32_t elapsed_ticks = now_ticks - s_state.start_ticks;
+    uint32_t elapsed_secs = elapsed_ticks / RTC_TICKS_HZ;
+
+    s_state.current_total_secs += elapsed_secs;
+    prv_save_data(&s_state.current_uuid, s_state.current_total_secs);
+    s_state.tracking = false;
+  }
+
+  s_state.current_uuid = *uuid;
+  s_state.start_ticks = rtc_get_ticks();
+
+  // Load previous time only if it's the same watchface, otherwise reset to 0
+  uint32_t previous_time = 0;
+  if (prv_load_data(uuid, &previous_time)) {
+    s_state.current_total_secs = previous_time;
+    PBL_LOG(LOG_LEVEL_DEBUG, "Watchface metrics: resuming, previous total: %lu secs",
+            (unsigned long)previous_time);
+  } else {
+    s_state.current_total_secs = 0;
+    PBL_LOG(LOG_LEVEL_DEBUG, "Watchface metrics: new watchface, starting from 0");
+  }
+
+  s_state.last_saved_secs = s_state.current_total_secs;
+  s_state.tracking = true;
+
+  mutex_unlock(s_mutex);
+}
+
+// -------------------------------------------------------------------------------------------
+void watchface_metrics_stop(void) {
+  mutex_lock(s_mutex);
+
+  if (!s_state.tracking) {
+    mutex_unlock(s_mutex);
+    return;
+  }
+
+  uint32_t now_ticks = rtc_get_ticks();
+  uint32_t elapsed_ticks = now_ticks - s_state.start_ticks;
+  uint32_t elapsed_secs = elapsed_ticks / RTC_TICKS_HZ;
+
+  s_state.current_total_secs += elapsed_secs;
+  prv_save_data(&s_state.current_uuid, s_state.current_total_secs);
+  s_state.last_saved_secs = s_state.current_total_secs;
+
+  PBL_LOG(LOG_LEVEL_DEBUG, "Watchface metrics: stopped, session: %lu secs, total: %lu secs",
+          (unsigned long)elapsed_secs, (unsigned long)s_state.current_total_secs);
+
+  s_state.tracking = false;
+
+  mutex_unlock(s_mutex);
+}
+
+// -------------------------------------------------------------------------------------------
+uint32_t watchface_metrics_get_current_time(void) {
+  mutex_lock(s_mutex);
+
+  uint32_t result = 0;
+
+  if (s_state.tracking) {
+    uint32_t now_ticks = rtc_get_ticks();
+    uint32_t elapsed_ticks = now_ticks - s_state.start_ticks;
+    uint32_t elapsed_secs = elapsed_ticks / RTC_TICKS_HZ;
+    result = s_state.current_total_secs + elapsed_secs;
+  }
+
+  mutex_unlock(s_mutex);
+  return result;
+}

--- a/src/fw/shell/normal/watchface_metrics.h
+++ b/src/fw/shell/normal/watchface_metrics.h
@@ -1,0 +1,23 @@
+/* SPDX-FileCopyrightText: 2025 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include "util/uuid.h"
+#include <stdint.h>
+
+//! Initialize the watchface metrics module
+void watchface_metrics_init(void);
+
+//! Called when a watchface starts running. If a different watchface was
+//! previously tracked, the time resets to 0.
+//! @param uuid The UUID of the watchface
+void watchface_metrics_start(const Uuid *uuid);
+
+//! Called when a watchface stops running. Persists accumulated time.
+void watchface_metrics_stop(void);
+
+//! Get the total accumulated time for the current watchface.
+//! Time resets when switching to a different watchface.
+//! @return Total time in seconds
+uint32_t watchface_metrics_get_current_time(void);

--- a/third_party/memfault/port/include/memfault_metrics_heartbeat_config.def
+++ b/third_party/memfault/port/include/memfault_metrics_heartbeat_config.def
@@ -115,6 +115,10 @@ MEMFAULT_METRICS_KEY_DEFINE(ANALYTICS_DEVICE_METRIC_DISPLAY_UPDATES_PER_HOUR, kM
 MEMFAULT_METRICS_KEY_DEFINE(ANALYTICS_DEVICE_METRIC_FPGA_REPROGRAM_COUNT, kMemfaultMetricType_Unsigned)
 MEMFAULT_METRICS_STRING_KEY_DEFINE(active_watchface_name, 96)
 
+// Watchface usage metrics (per-watchface, tracked for current/default watchface)
+MEMFAULT_METRICS_KEY_DEFINE(watchface_total_time_secs, kMemfaultMetricType_Unsigned)
+MEMFAULT_METRICS_KEY_DEFINE(watchface_launch_count, kMemfaultMetricType_Unsigned)
+
 // Health/HRM
 MEMFAULT_METRICS_KEY_DEFINE(ANALYTICS_DEVICE_METRIC_HRM_ACCEL_DATA_MISSING, kMemfaultMetricType_Unsigned)
 MEMFAULT_METRICS_KEY_DEFINE(ANALYTICS_DEVICE_METRIC_HRM_ON_TIME, kMemfaultMetricType_Unsigned)

--- a/third_party/memfault/port/src/memfault_platform_metrics.c
+++ b/third_party/memfault/port/src/memfault_platform_metrics.c
@@ -9,6 +9,7 @@
 #include "services/common/analytics/analytics_external.h"
 #include "applib/app_message/app_message_internal.h"
 #include "shell/normal/watchface.h"
+#include "shell/normal/watchface_metrics.h"
 #include "process_management/app_install_manager.h"
 
 int memfault_platform_get_stateofcharge(sMfltPlatformBatterySoc *soc) {
@@ -294,7 +295,7 @@ void memfault_metrics_heartbeat_collect_data(void) {
   MEMFAULT_METRIC_SET_UNSIGNED(app_message_received_count, app_message_inbox_get_received_count());
   
 #if !RECOVERY_FW
-  // Active watchface name
+  // Active watchface name and usage time
   AppInstallId watchface_id = watchface_get_default_install_id();
   AppInstallEntry watchface_entry;
   if (app_install_get_entry_for_install_id(watchface_id, &watchface_entry)) {
@@ -302,6 +303,7 @@ void memfault_metrics_heartbeat_collect_data(void) {
   } else {
     MEMFAULT_METRIC_SET_STRING(active_watchface_name, "Unknown");
   }
+  MEMFAULT_METRIC_SET_UNSIGNED(watchface_total_time_secs, watchface_metrics_get_current_time());
 
   // Update Pebble analytics and forward curated metrics to Memfault
   analytics_external_update();


### PR DESCRIPTION
Add watchface_metrics module to track how long the current watchface has been active. Time accumulates across reboots for the same watchface but resets to 0 when switching to a different watchface.