### PR TITLE
fw/main: invalidate slot0/1 on PRF

### DIFF
--- a/src/fw/main.c
+++ b/src/fw/main.c
@@ -66,6 +66,7 @@
 #include "kernel/kernel_applib_state.h"
 #include "kernel/util/delay.h"
 #include "util/mbuf.h"
+#include "system/firmware_storage.h"
 #include "system/version.h"
 
 #include "kernel/event_loop.h"
@@ -456,6 +457,12 @@ static NOINLINE void prv_main_task_init(void) {
 
   // Do this early before things can screw ith it.
   check_prf_update();
+
+#if CAPABILITY_HAS_PBLBOOT && defined(RECOVERY_FW) && !defined(MANUFACTURING_FW)
+  // Invalidate slot0/1 when booting PRF, so we force main firmware re-install
+  firmware_storage_invalidate_firmware_slot(0);
+  firmware_storage_invalidate_firmware_slot(1);
+#endif
 
   // When there are new system resources waiting to be installed, this call
   // will actually install them:


### PR DESCRIPTION
Invalidate slot0/1 when booting PRF, so we force main firmware re-install.

Fixes FIRM-1008