### PR TITLE
fw/comm/ble/ppogatt: add retry logic for meta characteristic read

### DIFF
--- a/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt_internal.h
+++ b/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt_internal.h
@@ -31,6 +31,11 @@
 //! Maximum amount of time PPoGATT will wait before sending an Ack for received data
 #define PPOGATT_MAX_DATA_ACK_LATENCY_MS (200)
 
+//! Number of maximum retries for reading the meta characteristic
+#define PPOGATT_META_READ_RETRY_COUNT_MAX (3)
+//! Delay in milliseconds before retrying a failed meta characteristic read
+#define PPOGATT_META_READ_RETRY_DELAY_MS (500)
+
 typedef enum {
   PPoGATTPacketTypeData = 0x0,
   PPoGATTPacketTypeAck = 0x1,


### PR DESCRIPTION
When the PPoGATT meta characteristic read fails (e.g., due to the iOS app not being ready immediately after GATT service discovery), the firmware now retries up to 3 times with a 500ms delay between attempts instead of immediately giving up.

This mitigates timing issues where ANCS/AMS work fine but PPoGATT session fails to open because the mobile app returns an error on the initial meta read.