### PR TITLE
fw/services: reduce app eviction aggressiveness on Obelix [FIRM-1005]

### DIFF
--- a/src/fw/services/normal/app_cache.c
+++ b/src/fw/services/normal/app_cache.c
@@ -51,7 +51,7 @@
 
 //! Keep enough room for the maximum sized application based on platform, plus a little more room.
 //! Source: https://pebbletechnology.atlassian.net/wiki/display/DEV/PBW+3.0
-#if PLATFORM_TINTIN || PLATFORM_SILK || PLATFORM_ASTERIX || UNITTEST
+#if PLATFORM_TINTIN || PLATFORM_SILK || PLATFORM_ASTERIX || PLATFORM_OBELIX || UNITTEST
 #define APP_SPACE_BUFFER KiBYTES(300)
 #else
 #define APP_SPACE_BUFFER MiBYTES(4)


### PR DESCRIPTION
Add PLATFORM_OBELIX to the platforms using the smaller 300KB APP_SPACE_BUFFER instead of 4MB. This allows more apps to remain installed on the device before automatic eviction kicks in.

Previously, Obelix would evict apps when free filesystem space dropped below 4MB (~19% of the 21MB filesystem). Now eviction only occurs below 300KB (~1.4%).