### PR TITLE
fw/drivers/hrm/gh3x2x: fix event queue overflow from runaway timer [FIRM-1047]

### DIFF
--- a/src/fw/drivers/hrm/gh3x2x/gh3x2x.c
+++ b/src/fw/drivers/hrm/gh3x2x/gh3x2x.c
@@ -178,6 +178,7 @@ static void gh3x2x_timer_stop_handle(void* arg) {
   if (HRM && HRM->state->timer) {
     app_timer_cancel(HRM->state->timer);
     HRM->state->timer = NULL;
+    HRM->state->timer_period_ms = 0;
   }
 }
 


### PR DESCRIPTION
Restore clearing of timer_period_ms when stopping the HRM timer. This line was accidentally removed in 9a92a7e0 ("fw/drivers/hrm: Support Goodix tuning app data collection via ble").

Without clearing the period, gh3x2x_timer_start_handle() could restart the timer unexpectedly after it was stopped, since it only checks if (timer_period_ms == 0) to early-exit. Each timer tick adds a callback to the system task queue via system_task_add_callback(), so a runaway timer quickly fills the 30-entry queue. When an HRM interrupt then tries to add a callback from ISR context, it fails and triggers a system reset with "event queue full".

Fixes crashes during app transitions when the HRM is active.