### PR TITLE
fw/board: adjust backlight intensity scale for obelix

### DIFF
--- a/src/fw/apps/system_apps/settings/settings_display.c
+++ b/src/fw/apps/system_apps/settings/settings_display.c
@@ -37,8 +37,11 @@ typedef struct SettingsDisplayData {
 
 // Intensity Settings
 /////////////////////////////
-
+#if PLATFORM_OBELIX
+static const uint32_t s_intensity_values[] = { 15, 45, 70, 100 };
+#else
 static const uint32_t s_intensity_values[] = { 5, 25, 45, 70 };
+#endif
 
 static const char *s_intensity_labels[] = {
     i18n_noop("Low"),

--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -567,7 +567,7 @@ const BoardConfigPower BOARD_CONFIG_POWER = {
 };
 
 const BoardConfig BOARD_CONFIG = {
-  .backlight_on_percent = 45,
+  .backlight_on_percent = 70,
   .ambient_light_dark_threshold = 150,
   .ambient_k_delta_threshold = 25,
   .dynamic_backlight_min_threshold = 15,

--- a/src/fw/services/common/light.c
+++ b/src/fw/services/common/light.c
@@ -108,8 +108,8 @@ static uint16_t prv_backlight_get_intensity(void) {
     uint32_t light_level = s_cached_ambient_light_level;
     uint16_t user_max_intensity = backlight_get_intensity();
     
-    // Low intensity is always 10%
-    const uint16_t low_intensity = (BACKLIGHT_BRIGHTNESS_MAX * (uint32_t)10) / 100;
+    // Low intensity is always 15%
+    const uint16_t low_intensity = (BACKLIGHT_BRIGHTNESS_MAX * (uint32_t)15) / 100;
     
     // Get thresholds from preferences (allows runtime adjustment in debug menu)
     const uint32_t min_light_threshold = backlight_get_dynamic_min_threshold();


### PR DESCRIPTION
Backlight current is now capped at 15mA instead of 30mA, so update intensity percentages to compensate:
- Low: 15%, Medium: 45%, High: 70%, Blinding: 100%
- Default backlight changed to 70% (High)
- Dynamic backlight minimum adjusted to 15%