### PR TITLE
fw/apps/system_apps/settings: make display scaling labels consistent

### DIFF
--- a/src/fw/apps/system_apps/settings/settings_display.c
+++ b/src/fw/apps/system_apps/settings/settings_display.c
@@ -166,7 +166,7 @@ static void prv_timeout_menu_push(SettingsDisplayData *data) {
 /////////////////////////////
 #if PLATFORM_OBELIX
 static const char *s_legacy_app_mode_labels[] = {
-    i18n_noop("Bezel"),
+    i18n_noop("Centered"),
     i18n_noop("Scaled")
 };
 


### PR DESCRIPTION
Currently, the preview label for the "Legacy Apps" display setting on Obelix will show Centered/Scaled, while expanding the menu shows Bezel/Scaled. This PR makes labeling consistent across both.