### PR TITLE
fw/process_management: disable watchface metrics in SDK shell

### DIFF
--- a/src/fw/process_management/app_manager.c
+++ b/src/fw/process_management/app_manager.c
@@ -908,7 +908,7 @@ static void prv_handle_app_start_analytics(const PebbleProcessMd *app_md,
   }
 
   // Track per-watchface usage metrics
-#if !RECOVERY_FW
+#if !RECOVERY_FW && !SHELL_SDK
   if (app_md->process_type == ProcessTypeWatchface) {
     watchface_metrics_start(&app_md->uuid);
 #if MEMFAULT

--- a/src/fw/process_management/process_manager.c
+++ b/src/fw/process_management/process_manager.c
@@ -362,7 +362,7 @@ static void prv_handle_app_stop_analytics(const ProcessContext *const context,
   }
   if (task == PebbleTask_App) {
     analytics_stopwatch_stop(ANALYTICS_APP_METRIC_FRONT_MOST_TIME);
-#if !RECOVERY_FW
+#if !RECOVERY_FW && !SHELL_SDK
     // Stop per-watchface time tracking if this was a watchface
     if (context->app_md->process_type == ProcessTypeWatchface) {
       watchface_metrics_stop();


### PR DESCRIPTION
Disable watchface metrics tracking when running in SDK shell mode to avoid dependency issues during development builds.