### PR TITLE
system: add panic mode to system settings

### DIFF
--- a/src/fw/services/normal/stationary.c
+++ b/src/fw/services/normal/stationary.c
@@ -18,6 +18,7 @@
 #include "services/common/i18n/i18n.h"
 #include "services/common/regular_timer.h"
 #include "services/common/system_task.h"
+#include "services/normal/notifications/notification_storage.h"
 #include "services/runlevel.h"
 #include "shell/prefs.h"
 #include "system/logging.h"
@@ -103,6 +104,11 @@ void stationary_handle_battery_connection_change_event(void) {
             "Stationary mode battery state change event received");
   if (battery_is_usb_connected()) {
     analytics_event_stationary_state_change(rtc_get_time(), StationaryAnalyticsEnterCharging);
+    
+    // If panic mode is enabled, wipe notifications when charger is connected
+    if (shell_prefs_get_panic_mode_enabled()) {
+      notification_storage_reset_and_init();
+    }
   } else {
     analytics_event_stationary_state_change(rtc_get_time(), StationaryAnalyticsExitCharging);
   }
@@ -218,6 +224,11 @@ static void prv_enter_stationary_state(void) {
   services_set_runlevel(RunLevel_Stationary);
   accel_enable_high_sensitivity(true);
   s_current_state = StationaryStateStationary;
+  
+  // If panic mode is enabled, wipe notifications when entering stationary mode
+  if (shell_prefs_get_panic_mode_enabled()) {
+    notification_storage_reset_and_init();
+  }
 }
 
 static void prv_exit_stationary(void) {

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -97,6 +97,9 @@ static bool s_stationary_mode_enabled = false;
 static bool s_stationary_mode_enabled = true;
 #endif
 
+#define PREF_KEY_PANIC_MODE "panicMode"
+static bool s_panic_mode_enabled = false;
+
 #define PREF_KEY_DEFAULT_WORKER "workerId"
 static Uuid s_default_worker = UUID_INVALID_INIT;
 
@@ -374,6 +377,11 @@ static bool prv_set_s_display_orientation_left(bool *left) {
 
 static bool prv_set_s_stationary_mode_enabled(bool *enabled) {
   s_stationary_mode_enabled = *enabled;
+  return true;
+}
+
+static bool prv_set_s_panic_mode_enabled(bool *enabled) {
+  s_panic_mode_enabled = *enabled;
   return true;
 }
 
@@ -1058,6 +1066,14 @@ bool shell_prefs_get_stationary_enabled(void) {
 
 void shell_prefs_set_stationary_enabled(bool enabled) {
   prv_pref_set(PREF_KEY_STATIONARY, &enabled, sizeof(enabled));
+}
+
+bool shell_prefs_get_panic_mode_enabled(void) {
+  return s_panic_mode_enabled;
+}
+
+void shell_prefs_set_panic_mode_enabled(bool enabled) {
+  prv_pref_set(PREF_KEY_PANIC_MODE, &enabled, sizeof(enabled));
 }
 
 AppInstallId worker_preferences_get_default_worker(void) {

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -16,6 +16,7 @@
 #endif
   PREFS_MACRO(PREF_KEY_BACKLIGHT_AMBIENT_THRESHOLD, s_backlight_ambient_threshold)
   PREFS_MACRO(PREF_KEY_STATIONARY, s_stationary_mode_enabled)
+  PREFS_MACRO(PREF_KEY_PANIC_MODE, s_panic_mode_enabled)
   PREFS_MACRO(PREF_KEY_DEFAULT_WORKER, s_default_worker)
   PREFS_MACRO(PREF_KEY_TEXT_STYLE, s_text_style)
   PREFS_MACRO(PREF_KEY_LANG_ENGLISH, s_language_english)

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -102,6 +102,10 @@ void backlight_set_ambient_threshold(uint32_t threshold);
 bool shell_prefs_get_stationary_enabled(void);
 void shell_prefs_set_stationary_enabled(bool enabled);
 
+// Panic mode will wipe all notifications when entering airplane mode, stationary mode, or charging.
+bool shell_prefs_get_panic_mode_enabled(void);
+void shell_prefs_set_panic_mode_enabled(bool enabled);
+
 // The default worker setting is used by process_management.
 AppInstallId worker_preferences_get_default_worker(void);
 void worker_preferences_set_default_worker(AppInstallId id);


### PR DESCRIPTION
This feature adds a toggle to wipe notifications when the device enters airplane mode, stand-by mode, or starts charging