### PR TITLE
notifications: Add timed mute options (1 hour, Today)

### DIFF
--- a/src/fw/services/normal/notifications/ancs/ancs_filtering.c
+++ b/src/fw/services/normal/notifications/ancs/ancs_filtering.c
@@ -72,6 +72,17 @@ void ancs_filtering_record_app(iOSNotifPrefs **notif_prefs,
     list_dirty = true;
   }
 
+  // Add the mute expiration attribute if we don't have one already
+  // Default to no expiration (0 means not muted by time)
+  if (!attribute_find(&new_attr_list, AttributeIdMuteExpiration)) {
+    uint32_t expiration_value = 0;
+    if (app_notif_prefs) {
+      expiration_value = attribute_get_uint32(&app_notif_prefs->attr_list, AttributeIdMuteExpiration, 0);
+    }
+    attribute_list_add_uint32(&new_attr_list, AttributeIdMuteExpiration, expiration_value);
+    list_dirty = true;
+  }
+
   // Add / update the "last seen" timestamp
   Attribute *last_updated = NULL;
   if (app_notif_prefs) {
@@ -121,12 +132,22 @@ uint8_t ancs_filtering_get_mute_type(const iOSNotifPrefs *app_notif_prefs) {
   return MuteBitfield_None;
 }
 
+uint32_t ancs_filtering_get_mute_expiration(const iOSNotifPrefs *app_notif_prefs) {
+  if (app_notif_prefs) {
+    return attribute_get_uint32(&app_notif_prefs->attr_list,
+                                 AttributeIdMuteExpiration, 0);
+  }
+
+  return 0;
+}
+
 bool ancs_filtering_is_muted(const iOSNotifPrefs *app_notif_prefs) {
   uint8_t mute_type = ancs_filtering_get_mute_type(app_notif_prefs);
+  uint32_t expiration_ts = ancs_filtering_get_mute_expiration(app_notif_prefs);
 
   struct tm now_tm;
   time_t now = rtc_get_time();
   localtime_r(&now, &now_tm);
 
-  return mute_type & (1 << now_tm.tm_wday);
+  return (mute_type & (1 << now_tm.tm_wday)) || (expiration_ts > (uint32_t)now);
 }

--- a/src/fw/services/normal/timeline/attribute.c
+++ b/src/fw/services/normal/timeline/attribute.c
@@ -80,6 +80,7 @@ static AttributeType prv_attribute_type(AttributeId id) {
     case AttributeIdLaunchCode:
     case AttributeIdAncsId:
     case AttributeIdTimestamp:
+    case AttributeIdMuteExpiration:
       return AttributeTypeUint32;
     case AttributeIdCannedResponses:
     case AttributeIdHeadings:

--- a/src/fw/services/normal/timeline/attribute.h
+++ b/src/fw/services/normal/timeline/attribute.h
@@ -113,6 +113,8 @@ typedef enum {
   AttributeIdIcon = 48,
   //! (Uint32List) Custom vibration pattern for a notification, used with vibes_enqueue_custom_pattern
   AttributeIdVibrationPattern = 49,
+  //! (uint32_t) Timestamp when the mute should expire.
+  AttributeIdMuteExpiration = 50,
   NumAttributeIds,
 } AttributeId;
 

--- a/tests/fw/services/blob_db/test_ios_notif_pref_db.c
+++ b/tests/fw/services/blob_db/test_ios_notif_pref_db.c
@@ -126,9 +126,11 @@ void test_ios_notif_pref_db__store_prefs(void) {
 
   // Update the current entry with a new attribute
   attribute_list_add_uint32(&attr_list, AttributeIdLastUpdated, 123456);
+  attribute_list_add_uint32(&attr_list, AttributeIdMuteExpiration, 1767322800);
   ios_notif_pref_db_store_prefs((uint8_t *)key, key_len, &attr_list, &action_group);
 
   // Make sure we can get all the data back
+  ios_notif_pref_db_free_prefs(notif_prefs);
   notif_prefs = ios_notif_pref_db_get_prefs((uint8_t *)key, key_len);
   cl_assert(notif_prefs);
   title = attribute_find(&notif_prefs->attr_list, AttributeIdShortTitle);
@@ -143,6 +145,9 @@ void test_ios_notif_pref_db__store_prefs(void) {
   Attribute *updated = attribute_find(&notif_prefs->attr_list, AttributeIdLastUpdated);
   cl_assert(updated);
   cl_assert_equal_i(updated->uint32, 123456);
+  Attribute *expiration = attribute_find(&notif_prefs->attr_list, AttributeIdMuteExpiration);
+  cl_assert(expiration);
+  cl_assert_equal_i(expiration->uint32, 1767322800);
 
   attribute_list_destroy_list(&attr_list);
   ios_notif_pref_db_free_prefs(notif_prefs);


### PR DESCRIPTION
Implement temporary mute functionality for notifications. 
This allows users to mute a specific app for 1 hour or until the end of the day directly from the notification action menu.

I have the mobile app changes but I don't want to push them, if its decided that this will not be merge.

Without the mobile app changes the new mute options will not take effect.

<img width="200" height="468" alt="image" src="https://github.com/user-attachments/assets/75188a80-9a05-431f-ac49-b5df65ae3786" />