### PR TITLE
compositor: force full screen updates on Getafix

### DIFF
--- a/src/fw/services/common/compositor/compositor_display.c
+++ b/src/fw/services/common/compositor/compositor_display.c
@@ -139,6 +139,10 @@ void compositor_display_update(void (*handle_update_complete_cb)(void)) {
   if (!framebuffer_is_dirty(fb)) {
     return;
   }
+#if PLATFORM_GETAFIX
+  // Force full screen updates - partial ROI causes animation issues on getafix display
+  fb->dirty_rect = (GRect){ GPointZero, fb->size };
+#endif
 #if PLATFORM_OBELIX
   // Capture dirty region bounds for corner restoration later
   s_dirty_y0 = fb->dirty_rect.origin.y;
@@ -153,4 +157,3 @@ void compositor_display_update(void (*handle_update_complete_cb)(void)) {
 bool compositor_display_update_in_progress(void) {
   return display_update_in_progress();
 }
-


### PR DESCRIPTION
The Getafix JDI display doesn't handle partial ROI updates correctly, causing some animations to freeze and only show the final frame. This is because the display driver does in-place pixel format conversion (222↔332) and H-mirroring only for dirty rows, but partial ROI updates on the getafix display don't work reliably.

Force the dirty rect to cover the entire framebuffer before display updates on Getafix. This ensures all rows go through the LUT conversion and mirroring, and the full screen is sent to the display.