### PR TITLE
sdk/waftools: fix worker build failure in memory usage report

### DIFF
--- a/sdk/waftools/report_memory_usage.py
+++ b/sdk/waftools/report_memory_usage.py
@@ -86,8 +86,8 @@ def generate_memory_usage_report(task_gen):
         app_task.max_sizes = (app_max_ram, max_resources, max_resources_appstore)
         app_task.bin_type = 'app'
     if worker:
-        worker_task = task_gen.create_task('memory_usage_report',
-                                           task_gen.to_nodes(worker)[0])
+        worker_node = task_gen.path.find_or_declare(worker)
+        worker_task = task_gen.create_task('memory_usage_report', worker_node)
         worker_task.max_sizes = (worker_max_ram, None, None)
         worker_task.bin_type = 'worker'
     if lib:


### PR DESCRIPTION
Use find_or_declare() instead of to_nodes() when resolving the worker ELF path. The to_nodes() method fails for build targets that don't exist yet, causing "source not found" errors when building apps with workers.