### PR TITLE
fw/applib/accel_service: fix use-after-free in cleanup [FIRM-1090]

### DIFF
--- a/src/fw/applib/accel_service.c
+++ b/src/fw/applib/accel_service.c
@@ -54,6 +54,7 @@ void accel_service_cleanup_task_session(PebbleTask task) {
   AccelServiceState *state = accel_service_private_get_session(task);
   if (state->manager_state) {
     sys_accel_manager_data_unsubscribe(state->manager_state);
+    state->manager_state = NULL;
   }
 }
 


### PR DESCRIPTION
Clear manager_state to NULL after unsubscribing in accel_service_cleanup_task_session to prevent use-after-free.

Previously, if the AccelManagerState was already freed (e.g., by the app calling accel_data_service_unsubscribe), the cleanup function could attempt to unsubscribe again using a stale pointer, causing an assertion failure in shared_circular_buffer_remove_client when the list_node was not found in the buffer's client list.

This matches the cleanup pattern used in accel_session_data_unsubscribe.