### PR TITLE
platform: disable glyph bitmap caching on snowy_emery

### DIFF
--- a/platform/platform_capabilities.py
+++ b/platform/platform_capabilities.py
@@ -134,7 +134,6 @@ board_capability_dicts = [
             'HAS_APPLE_MFI',
             'HAS_APP_GLANCES',
             'HAS_DEFECTIVE_FW_CRC',
-            'HAS_GLYPH_BITMAP_CACHING',
             'HAS_HARDWARE_PANIC_SCREEN',
             'HAS_HEALTH_TRACKING',
             'HAS_ROCKY_JS',


### PR DESCRIPTION
The increase of MAX_FONT_GLYPH_SIZE from 320 to 512 for emery caused the snowy_emery emulator to fail to boot due to increased FontCache memory requirements. Disable glyph bitmap caching on snowy_emery to reduce memory usage.