### PR TITLE
fw/drivers/sf32lb52: add boot animation [FIRM-1154]

### DIFF
--- a/platform/platform_capabilities.py
+++ b/platform/platform_capabilities.py
@@ -53,6 +53,7 @@ master_capability_set = {
     'HAS_SPEAKER',
     'HAS_ACCEL_SENSITIVITY',
     'HAS_APP_SCALING',
+    'HAS_FPGA_DISPLAY',
 }
 
 board_capability_dicts = [
@@ -98,6 +99,7 @@ board_capability_dicts = [
             'HAS_VIBE_SCORES',
             'USE_PARALLEL_FLASH',
             'HAS_WEATHER',
+            'HAS_FPGA_DISPLAY',
         },
     },
     {
@@ -124,6 +126,7 @@ board_capability_dicts = [
             'HAS_VIBE_SCORES',
             'USE_PARALLEL_FLASH',
             'HAS_WEATHER',
+            'HAS_FPGA_DISPLAY',
         },
     },
     {
@@ -152,6 +155,7 @@ board_capability_dicts = [
             'USE_PARALLEL_FLASH',
             'HAS_WEATHER',
             'HAS_PUTBYTES_PREACKING',
+            'HAS_FPGA_DISPLAY',
             'HAS_APP_SCALING'
         }
     },
@@ -177,6 +181,7 @@ board_capability_dicts = [
             'HAS_VIBE_SCORES',
             'USE_PARALLEL_FLASH',
             'HAS_WEATHER',
+            'HAS_FPGA_DISPLAY',
         },
     },
     {
@@ -201,6 +206,7 @@ board_capability_dicts = [
             'HAS_VIBE_SCORES',
             'USE_PARALLEL_FLASH',
             'HAS_WEATHER',
+            'HAS_FPGA_DISPLAY',
         },
     },
     {
@@ -228,6 +234,7 @@ board_capability_dicts = [
             'USE_PARALLEL_FLASH',
             'HAS_WEATHER',
             'HAS_PUTBYTES_PREACKING',
+            'HAS_FPGA_DISPLAY',
             'HAS_APP_SCALING'
         },
     },
@@ -300,6 +307,7 @@ board_capability_dicts = [
             'HAS_VIBE_SCORES',
             'HAS_WEATHER',
             'HAS_PUTBYTES_PREACKING',
+            'HAS_FPGA_DISPLAY',
             'HAS_APP_SCALING'
         }
     },
@@ -326,6 +334,7 @@ board_capability_dicts = [
             'HAS_WEATHER',
             'HAS_PUTBYTES_PREACKING',
             'HAS_TOUCHSCREEN',
+            'HAS_FPGA_DISPLAY',
             'HAS_APP_SCALING'
         }
     },

--- a/src/fw/drivers/display/display.h
+++ b/src/fw/drivers/display/display.h
@@ -17,8 +17,11 @@ typedef struct {
 typedef bool(*NextRowCallback)(DisplayRow* row);
 typedef void(*UpdateCompleteCallback)(void);
 
-//! Show the splash screen before the display has been fully initialized.
-void display_show_splash_screen(void);
+//! Update the display with a boot animation frame.
+//! This is a simple interface for the boot animation service to send frames
+//! to the display before the compositor is initialized.
+//! @param framebuffer Pointer to the framebuffer data (DISPLAY_FRAMEBUFFER_BYTES)
+void display_update_boot_frame(uint8_t *framebuffer);
 
 void display_init(void);
 

--- a/src/fw/drivers/display/ice40lp/ice40lp.c
+++ b/src/fw/drivers/display/ice40lp/ice40lp.c
@@ -570,13 +570,8 @@ void display_show_panic_screen(uint32_t error_code) {
   mutex_unlock(s_display_update_mutex);
 }
 
-void display_show_splash_screen(void) {
-  // Assumes that the FPGA is already in bootloader mode but the SPI peripheral
-  // and GPIOs are not yet configured; exactly the state that the system is
-  // expected to be in before display_init() is called.
-  display_start();
-  display_spi_configure_default();
-  boot_display_show_boot_splash();
+void display_update_boot_frame(uint8_t *framebuffer) {
+  // On ice40lp, there is only one splash screen, and we handle that in the boot splash service.
 }
 
 void display_set_offset(GPoint offset) {

--- a/src/fw/drivers/display/sharp_ls013b7dh01/sharp_ls013b7dh01.c
+++ b/src/fw/drivers/display/sharp_ls013b7dh01/sharp_ls013b7dh01.c
@@ -377,7 +377,7 @@ static void prv_setup_dma_transfer(uint8_t *framebuffer_addr, int framebuffer_si
                            prv_dma_handler, NULL);
 }
 
-void display_show_splash_screen(void) {
+void display_update_boot_frame(uint8_t *framebuffer) {
   // The bootloader has already drawn the splash screen for us; nothing to do!
 }
 

--- a/src/fw/drivers/display/sharp_ls013b7dh01/sharp_ls013b7dh01_nrf5.c
+++ b/src/fw/drivers/display/sharp_ls013b7dh01/sharp_ls013b7dh01_nrf5.c
@@ -236,7 +236,7 @@ uint32_t display_baud_rate_change(uint32_t new_frequency_hz) {
 
 void display_pulse_vcom(void) {}
 
-void display_show_splash_screen(void) {}
+void display_update_boot_frame(uint8_t *framebuffer) {}
 
 void display_set_offset(GPoint offset) {}
 

--- a/src/fw/drivers/stubs/display.c
+++ b/src/fw/drivers/stubs/display.c
@@ -27,7 +27,7 @@ void display_update(NextRowCallback nrcb, UpdateCompleteCallback uccb) {
 void display_pulse_vcom(void) {
 }
 
-void display_show_splash_screen(void) {
+void display_update_boot_frame(void) {
   // The bootloader has already drawn the splash screen for us; nothing to do!
 }
 

--- a/src/fw/main.c
+++ b/src/fw/main.c
@@ -54,6 +54,7 @@
 #include "kernel/panic.h"
 #include "kernel/pulse_logging.h"
 #include "services/services.h"
+#include "services/common/boot_splash.h"
 #include "services/common/clock.h"
 #include "services/common/compositor/compositor.h"
 #include "services/common/regular_timer.h"
@@ -420,7 +421,7 @@ static NOINLINE void prv_main_task_init(void) {
   board_early_init();
 #endif
 
-  display_show_splash_screen();
+  boot_splash_start();
 
   kernel_applib_init();
 
@@ -492,7 +493,9 @@ static NOINLINE void prv_main_task_init(void) {
   display_set_offset(mfg_offset);
   // Log display offsets for use in contact support logs
   PBL_LOG(LOG_LEVEL_INFO, "MFG Display Offsets (%"PRIi16",%"PRIi16").", mfg_offset.x, mfg_offset.y);
-
+  
+  // Stop boot splash before initializing compositor
+  boot_splash_stop();
   // Can't use the compositor framebuffer until the compositor is initialized
   compositor_init();
   kernel_ui_init();

--- a/src/fw/services/common/boot_splash.c
+++ b/src/fw/services/common/boot_splash.c
@@ -1,0 +1,211 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "boot_splash.h"
+
+#if CAPABILITY_HAS_PBLBOOT
+
+#include "board/display.h"
+#include "board/splash.h"
+#include "drivers/display/display.h"
+#include "kernel/pbl_malloc.h"
+#include "kernel/util/sleep.h"
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+#include <string.h>
+
+// Progress bar configuration
+#define PROGRESS_BAR_WIDTH      80
+#define PROGRESS_BAR_HEIGHT     4
+#define PROGRESS_INDICATOR_WIDTH 20
+#define PROGRESS_FRAME_DELAY_MS 100
+#define PROGRESS_TOTAL_FRAMES   20
+#define BOOT_SPLASH_TASK_STACK_SIZE 512
+#define BOOT_SPLASH_TASK_PRIORITY   (configMAX_PRIORITIES - 2)
+
+// Boot splash state
+static TaskHandle_t s_boot_splash_task;
+static volatile bool s_boot_splash_running;
+static uint8_t *s_boot_splash_fb;
+
+// Draw a filled rectangle
+static void prv_draw_filled_rect(uint8_t *fb, int16_t x0, int16_t y0,
+                                 int16_t width, int16_t height, uint8_t color) {
+  for (int16_t y = y0; y < y0 + height; y++) {
+    for (int16_t x = x0; x < x0 + width; x++) {
+      if (x >= 0 && x < PBL_DISPLAY_WIDTH && y >= 0 && y < PBL_DISPLAY_HEIGHT) {
+        fb[(uint32_t)y * PBL_DISPLAY_WIDTH + x] = color;
+      }
+    }
+  }
+}
+
+// Draw progress bar with animated indicator
+static void prv_draw_progress_bar(uint8_t *fb, int16_t center_x, int16_t center_y,
+                                  uint16_t frame) {
+  const uint8_t COLOR_TRACK = 0xB6;      // Light gray in RGB332
+  const uint8_t COLOR_INDICATOR = 0x00;  // Black
+
+  int16_t bar_x0 = center_x - PROGRESS_BAR_WIDTH / 2;
+  int16_t bar_y0 = center_y - PROGRESS_BAR_HEIGHT / 2;
+
+  // Draw track (background)
+  prv_draw_filled_rect(fb, bar_x0, bar_y0, PROGRESS_BAR_WIDTH, PROGRESS_BAR_HEIGHT, COLOR_TRACK);
+
+  // Calculate indicator position (ping-pong animation)
+  int32_t max_travel = PROGRESS_BAR_WIDTH - PROGRESS_INDICATOR_WIDTH;
+  int32_t half_frames = PROGRESS_TOTAL_FRAMES / 2;
+  int32_t cycle_frame = frame % PROGRESS_TOTAL_FRAMES;
+  int32_t indicator_offset;
+
+  if (cycle_frame < half_frames) {
+    // Moving right
+    indicator_offset = (cycle_frame * max_travel) / half_frames;
+  } else {
+    // Moving left
+    indicator_offset = max_travel - ((cycle_frame - half_frames) * max_travel) / half_frames;
+  }
+
+  // Draw indicator
+  prv_draw_filled_rect(fb, bar_x0 + indicator_offset, bar_y0,
+                       PROGRESS_INDICATOR_WIDTH, PROGRESS_BAR_HEIGHT, COLOR_INDICATOR);
+}
+
+// Boot splash task - runs until stopped
+static void prv_boot_splash_task(void *param) {
+  uint8_t *fb = s_boot_splash_fb;
+  uint16_t frame = 0;
+
+  // Get splash logo dimensions
+  const uint16_t logo_width = splash_width;
+  const uint16_t logo_height = splash_height;
+  const uint8_t *logo_data = splash_bits;
+
+  // Calculate logo position (centered)
+  uint16_t logo_x0 = (PBL_DISPLAY_WIDTH - logo_width) / 2;
+  uint16_t logo_y0 = (PBL_DISPLAY_HEIGHT - logo_height) / 2;
+
+  // Calculate progress bar center position (below centered logo)
+  int16_t progress_cx = PBL_DISPLAY_WIDTH / 2;
+  int16_t progress_cy = logo_y0 + logo_height + 20;
+
+  // Animation loop - runs until s_boot_splash_running is cleared
+  while (s_boot_splash_running) {
+    // Clear framebuffer to white
+    memset(fb, 0xFF, DISPLAY_FRAMEBUFFER_BYTES);
+
+    // Draw logo
+    for (uint16_t y = 0U; y < logo_height; y++) {
+      for (uint16_t x = 0U; x < logo_width; x++) {
+        if (logo_data[y * (logo_width / 8) + x / 8] & (0x1U << (x & 7))) {
+          fb[(y + logo_y0) * PBL_DISPLAY_WIDTH + (x + logo_x0)] = 0x00;
+        }
+      }
+    }
+
+    // Draw progress bar
+    prv_draw_progress_bar(fb, progress_cx, progress_cy, frame);
+
+    // Send frame to display
+    display_update_boot_frame(fb);
+
+    frame++;
+
+    // Wait for next frame using short delays to allow quick stop
+    for (uint8_t i = 0; i < (PROGRESS_FRAME_DELAY_MS / 10) && s_boot_splash_running; i++) {
+      vTaskDelay(pdMS_TO_TICKS(10));
+    }
+  }
+
+  // Cleanup
+  kernel_free(fb);
+  s_boot_splash_fb = NULL;
+  s_boot_splash_task = NULL;
+  vTaskDelete(NULL);
+}
+
+void boot_splash_start(void) {
+  // Initialize the display
+  display_init();
+
+  // Allocate framebuffer for boot splash
+  s_boot_splash_fb = kernel_malloc(DISPLAY_FRAMEBUFFER_BYTES);
+  if (!s_boot_splash_fb) {
+    return;
+  }
+
+  // Start the boot splash task
+  s_boot_splash_running = true;
+  xTaskCreate(prv_boot_splash_task,
+              "BootSplash",
+              BOOT_SPLASH_TASK_STACK_SIZE,
+              NULL,
+              BOOT_SPLASH_TASK_PRIORITY,
+              &s_boot_splash_task);
+}
+
+void boot_splash_stop(void) {
+  if (s_boot_splash_running && s_boot_splash_task != NULL) {
+    s_boot_splash_running = false;
+    // Wait for the splash task to finish (max ~10ms delay due to short sleep intervals)
+    while (s_boot_splash_task != NULL) {
+      psleep(10);
+    }
+
+    // Draw final frame with logo only (no progress bar)
+    uint8_t *fb = kernel_malloc(DISPLAY_FRAMEBUFFER_BYTES);
+    if (fb) {
+      memset(fb, 0xFF, DISPLAY_FRAMEBUFFER_BYTES);
+
+      // Get splash logo dimensions
+      const uint16_t logo_width = splash_width;
+      const uint16_t logo_height = splash_height;
+      const uint8_t *logo_data = splash_bits;
+
+      // Calculate logo position (centered, same as animation)
+      uint16_t logo_x0 = (PBL_DISPLAY_WIDTH - logo_width) / 2;
+      uint16_t logo_y0 = (PBL_DISPLAY_HEIGHT - logo_height) / 2;
+
+      // Draw logo
+      for (uint16_t y = 0U; y < logo_height; y++) {
+        for (uint16_t x = 0U; x < logo_width; x++) {
+          if (logo_data[y * (logo_width / 8) + x / 8] & (0x1U << (x & 7))) {
+            fb[(y + logo_y0) * PBL_DISPLAY_WIDTH + (x + logo_x0)] = 0x00;
+          }
+        }
+      }
+
+      display_update_boot_frame(fb);
+      kernel_free(fb);
+    }
+  }
+}
+
+#elif CAPABILITY_HAS_FPGA_DISPLAY
+#include "drivers/display/ice40lp/ice40lp_internal.h"
+#include "drivers/display/ice40lp/snowy_boot.h"
+
+// On platforms with FPGA display, we rely on the bootloader to show the splash screen.
+void boot_splash_start(void) {
+  display_start();
+  display_spi_configure_default();
+  boot_display_show_boot_splash();
+}
+
+void boot_splash_stop(void) {
+  // No-op; the display driver handles stopping the splash as needed
+}
+
+#else // Everything else
+
+void boot_splash_start(void) {
+  // No-op on platforms where the bootloader handles the splash
+}
+
+void boot_splash_stop(void) {
+  // No-op on platforms where the bootloader handles the splash
+}
+
+#endif

--- a/src/fw/services/common/boot_splash.h
+++ b/src/fw/services/common/boot_splash.h
@@ -1,0 +1,16 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+//! Start the boot splash screen.
+//! On platforms with software-rendered splash (PBLBOOT), this shows
+//! an animated splash with a spinning indicator. On other platforms, this
+//! calls the display driver's splash screen function
+void boot_splash_start(void);
+
+//! Stop the boot splash screen.
+//! This should be called when the compositor is ready to take over the display.
+//! On platforms with animated splash, this stops the animation task.
+//! On other platforms, this is a no-op.
+void boot_splash_stop(void);


### PR DESCRIPTION
Add an animated boot splash screen showing the Pebble logo with a rotating spinner below it. The animation runs in a background FreeRTOS task until the compositor is ready to display content.

- 8-dot spinner with one highlighted dot rotating clockwise
- Uses absolute timing (vTaskDelayUntil) for consistent frame rate
- High task priority ensures smooth animation during boot
- Automatically stops when display_update() is first called