### PR TITLE
Timeline: Add the full Timeline app in launcher

### DIFF
--- a/src/fw/apps/system_apps/timeline/timeline.h
+++ b/src/fw/apps/system_apps/timeline/timeline.h
@@ -39,6 +39,8 @@ typedef struct {
   bool launch_into_pin; //!< Launch to a pin specified by `pin_id`.
   bool stay_in_list_view; //!< Whether to stay in list view or launch into the detail view.
   Uuid pin_id;
+  bool force_full;
+  bool force_display_day_sep_on_start;
 } TimelineArgs;
 
 typedef struct {
@@ -65,6 +67,9 @@ typedef struct {
 
   bool launch_into_deep_pin; //!< Whether we launched directly into a pin that isn't the first
   bool in_pin_view; //!< Whether we're in pin view
+  bool full_app_view; //!< Whether we launched as full app mode
+  bool day_sep_displayed_on_start;
+  bool force_display_day_sep;
 } TimelineAppData;
 
 Animation *timeline_animate_back_from_card(void);
@@ -77,5 +82,10 @@ Animation *timeline_animate_back_from_card(void);
 #define TIMELINE_PAST_UUID_INIT {0xDA, 0xAE, 0x36, 0x86, 0xBF, 0xF6, 0x4B, 0xA5, \
                                  0x92, 0x1B, 0x26, 0x2F, 0x84, 0x7B, 0xB6, 0xE8}
 
+// uuid: 426ccd53-b380-4d83-8d06-9893de3477ce
+#define TIMELINE_FULL_UUID_INIT {0x42, 0x6c, 0xcd, 0x53, 0xb3, 0x80, 0x4d, 0x83, \
+                                 0x8d, 0x06, 0x98, 0x93, 0xde, 0x34, 0x77, 0xce}
+
 const PebbleProcessMd *timeline_get_app_info(void);
 const PebbleProcessMd *timeline_past_get_app_info(void);
+const PebbleProcessMd *timeline_full_get_app_info(void);

--- a/src/fw/shell/normal/system_app_registry_list.json
+++ b/src/fw/shell/normal/system_app_registry_list.json
@@ -656,6 +656,20 @@
       "id": -97,
       "enum": "SPORTS",
       "md_fn": "sports_app_get_info"
+    },
+    {
+      "id": -32,
+      "enum": "TIMELINE_FULL",
+      "md_fn": "timeline_full_get_app_info",
+      "target_platforms": [
+        "snowy",
+        "spalding",
+        "silk",
+        "robert",
+        "asterix",
+        "obelix",
+        "getafix"
+      ]
     }
   ],
   "resource_apps": [


### PR DESCRIPTION
This PR adds the full Timeline app in the launcher.

## Change
The application just starts as Timeline Future, but instead of going back to the watchface when pressing up, it switches to the Timeline Past app and instead of going back to the watchface when pressing back, it goes back to the launcher menu, as any other app would.
You can of course go back and forth between Past and Future.

A new "Timeline" is available in the quicklaunch menu, giving the ability to check both Past and Future from one press.

Behavior of Timeline Future and Timeline Past via the Quicklaunch remain unchanged, those changes are only applied if launching Timeline through the menu launcher or if launching "Timeline" through the Quicklaunch.

## Video

https://github.com/user-attachments/assets/768f0717-25a7-4845-a932-433213d6ddd9

## TODO
- [x] Proof of Concept
- [x] Add comments
- [x] Add Timeline launcher icon
- [x] Demo video
- [x] Solve known bug(s)

## Known bug(s)
- [x] If there is no future event for the current day, the day separator 'Today' won't be displayed when switching from Future to Past (illustrated in the video)
- [x] Same issue if no past event for the current day, the day separator 'Today' won't be displayed when switching from Past to Future
- [x] If Past or Future displays the No Event screen, it won't switch from Past to Future, or Future to Past

## Related issue(s)
Fix #456 