### PR TITLE
fw/drivers: recover AW2016 backlight from I2C clock stretching

### DIFF
--- a/src/fw/drivers/led_controller.h
+++ b/src/fw/drivers/led_controller.h
@@ -27,3 +27,7 @@ void led_controller_backlight_set_brightness(uint8_t brightness);
 void led_controller_rgb_set_color(uint32_t rgb_color);
 
 uint32_t led_controller_rgb_get_color(void);
+
+//! Recover AW2016 from I2C bus reset caused by clock stretching.
+//! Call this after NPM1300 operations that may cause long clock stretches.
+void led_controller_recover_from_i2c_reset(void);

--- a/src/fw/drivers/led_controller/aw9364e.c
+++ b/src/fw/drivers/led_controller/aw9364e.c
@@ -51,6 +51,10 @@ void led_controller_backlight_set_brightness(uint8_t brightness) {
 
 void led_controller_rgb_set_color(uint32_t rgb_color) {}
 
+void led_controller_recover_from_i2c_reset(void) {
+  // AW9364E uses GPIO, not I2C - no recovery needed
+}
+
 uint32_t led_controller_rgb_get_color(void) {
   return 0UL;
 }

--- a/src/fw/drivers/led_controller/is31fl3196.c
+++ b/src/fw/drivers/led_controller/is31fl3196.c
@@ -164,6 +164,10 @@ uint32_t led_controller_rgb_get_color(void) {
   return s_rgb_current_color;
 }
 
+void led_controller_recover_from_i2c_reset(void) {
+  // IS31FL3196 is on a separate I2C bus - no recovery needed
+}
+
 void command_rgb_set_color(const char* color) {
   uint32_t color_val = strtol(color, NULL, 16);
 

--- a/src/fw/drivers/led_controller/pwm.c
+++ b/src/fw/drivers/led_controller/pwm.c
@@ -68,6 +68,10 @@ void led_controller_rgb_set_color(uint32_t rgb_color) {
 
 uint32_t led_controller_rgb_get_color(void) { return s_rgb_current_color; }
 
+void led_controller_recover_from_i2c_reset(void) {
+  // PWM-based LED controller doesn't use I2C - no recovery needed
+}
+
 void command_rgb_set_color(const char* color) {
   uint32_t color_val = strtol(color, NULL, 16);
 

--- a/src/fw/drivers/pmic/npm1300.c
+++ b/src/fw/drivers/pmic/npm1300.c
@@ -7,6 +7,7 @@
 #include "drivers/battery.h"
 
 #include "board/board.h"
+#include "drivers/led_controller.h"
 #include "console/prompt.h"
 #include "drivers/battery.h"
 #include "drivers/exti.h"
@@ -448,7 +449,10 @@ uint16_t pmic_get_vsys(void) {
   }
   uint16_t vsys_raw = (vsys_msb << 2) | (lsbs >> 6);
   uint32_t vsys = vsys_raw * 6375 / 1023;
-  
+#if PLATFORM_OBELIX
+  // Recover AW2016 backlight if reset by I2C clock stretching
+  led_controller_recover_from_i2c_reset();
+#endif
   return vsys;
 }
 
@@ -484,7 +488,11 @@ int battery_get_millivolts(void) {
   }
   uint16_t vbat_raw = (vbat_msb << 2) | (lsbs & 3);
   uint32_t vbat = vbat_raw * 5000 / 1023;
-  
+#if PLATFORM_OBELIX
+  // Recover AW2016 backlight if reset by I2C clock stretching
+  led_controller_recover_from_i2c_reset();
+#endif
+
   return vbat;
 }
 
@@ -621,6 +629,11 @@ int battery_get_constants(BatteryConstants *constants) {
   float inv_temp_k = (1.f / 298.15f) - (log_result / (float)NPM1300_CONFIG.thermistor_beta);
 
   constants->t_mc = (int32_t)(1000.0f * ((1.f / inv_temp_k) - 273.15f));
+
+#if PLATFORM_OBELIX
+  // Recover AW2016 backlight if reset by I2C clock stretching
+  led_controller_recover_from_i2c_reset();
+#endif
 
   return 0;
 }


### PR DESCRIPTION
NPM1300 ADC operations can cause I2C clock stretching >130ms, which resets the AW2016 LED controller on Obelix (shared I2C bus). Add recovery function that detects AW2016 reset and restores brightness state after NPM1300 ADC reads.