### PR TITLE
wscript: fix --onlysdk build by adding nanopb dependency

### DIFF
--- a/wscript
+++ b/wscript
@@ -758,6 +758,7 @@ def build(bld):
     bld.load('file_name_c_define', tooldir='waftools')
 
     bld.recurse('platform')
+    bld.recurse('third_party/nanopb')
     bld.recurse('src/idl')
 
     if bld.cmd == 'install':


### PR DESCRIPTION
The SDK-only build was failing because src/idl/nanopb depends on third_party/nanopb for the pb.h header, but the nanopb directory was only recursed in the full firmware build path.

Add the nanopb recurse before src/idl to ensure the include paths are available for protobuf schema compilation.