### PR TITLE
music_app: unsubscribe tick timer on app exit [FIRM-1213]

### DIFF
--- a/src/fw/apps/system_apps/music_app.c
+++ b/src/fw/apps/system_apps/music_app.c
@@ -981,12 +981,11 @@ static void prv_handle_init(void) {
 }
 
 static void prv_handle_deinit(void) {
+  tick_timer_service_unsubscribe();
   music_request_reduced_latency(false);
 
   MusicAppData *data = app_state_get_user_data();
   i18n_free_all(data);
-
-  // we'll be cleaned up properly by the system
 }
 
 static void prv_main(void) {


### PR DESCRIPTION
Firmware update failed because music was playing in the background. When the system tried to close the music app, a timer callback kept running after the app's data was freed, which caused a crash. Coredump shows prv_update_track_progress being called with 0xa5a5a5a5 (freed memory pattern) at music_app.c:771. Added missing cleanup to stop the timer when the app exits.