### PR TITLE
fw/services/blob_db: fix settings sync triggering at boot without connection

### DIFF
--- a/src/fw/services/normal/blob_db/settings_blob_db.c
+++ b/src/fw/services/normal/blob_db/settings_blob_db.c
@@ -7,6 +7,7 @@
 
 #include "kernel/pbl_malloc.h"
 #include "services/common/bluetooth/bluetooth_persistent_storage.h"
+#include "services/common/comm_session/session.h"
 #include "services/normal/notifications/alerts_preferences_private.h"
 #include "services/normal/settings/settings_file.h"
 #include "shell/prefs_private.h"
@@ -176,6 +177,12 @@ static bool prv_is_syncable(const uint8_t *key, int key_len) {
 //! This is coalesced - only one instance runs at a time.
 static void prv_deferred_sync_callback(void *data) {
   s_sync_callback_pending = false;
+
+  // Only sync if we have an active connection to the phone
+  if (!comm_session_get_system_session()) {
+    PBL_LOG(LOG_LEVEL_DEBUG, "No connection to phone, skipping settings sync");
+    return;
+  }
 
   // Only sync if the phone supports settings sync
   if (!settings_blob_db_phone_supports_sync()) {


### PR DESCRIPTION
The prv_deferred_sync_callback() was checking if the phone supports settings sync via cached capabilities, but not checking if the phone is currently connected. This caused sync attempts at boot when cached capabilities from a previous session indicated support, even though no phone was connected.

The sync attempt would try to open the 'shellpref' settings file while other initialization code already had it open, causing E_BUSY and triggering the "Settings file is already open!" assertion.

Fix by adding comm_session_get_system_session() check before attempting sync, matching the pattern used in sync.c:77-80. This ensures settings sync only runs when actively connected to a phone.