### PR TITLE
fw/services/common/light: fix dynamic backlight integer underflow [FIRM-1212]

### DIFF
--- a/src/fw/services/common/light.c
+++ b/src/fw/services/common/light.c
@@ -115,6 +115,12 @@ static uint16_t prv_backlight_get_intensity(void) {
     const uint32_t min_light_threshold = backlight_get_dynamic_min_threshold();
     const uint32_t max_light_threshold = backlight_get_dynamic_max_threshold();
     
+    // If user max intensity is below low intensity, clamp to low intensity
+    // to prevent underflow in the calculation below
+    if (user_max_intensity < low_intensity) {
+      user_max_intensity = low_intensity;
+    }
+
     // If below minimum threshold, return low intensity
     if (light_level < min_light_threshold) {
       return low_intensity;


### PR DESCRIPTION
When user max intensity is set below 10% (the hardcoded low_intensity threshold), the dynamic backlight calculation would cause an integer underflow. The subtraction (user_max_intensity - low_intensity) wraps around in unsigned arithmetic, producing a very large value that results in brightness exceeding BACKLIGHT_BRIGHTNESS_MAX (appearing as >100%).

Fix by clamping user_max_intensity to low_intensity minimum before performing the calculation.

Fixes backlight showing 187% when max intensity set to LOW (5%) on Obelix PVT 4.9.110.