### PR TITLE
fw: replace platform checks with display height for UI layout [FIRM-1206]

### DIFF
--- a/src/fw/applib/preferred_content_size.h
+++ b/src/fw/applib/preferred_content_size.h
@@ -3,6 +3,10 @@
 
 #pragma once
 
+#if !PUBLIC_SDK
+#include "board/display.h"
+#endif
+
 //! PreferredContentSize represents the display scale of all the app's UI components. The enum
 //! contains all sizes that all platforms as a whole are capable of displaying, but each individual
 //! platform may not be able to display all sizes.
@@ -17,8 +21,8 @@ typedef enum PreferredContentSize {
 } PreferredContentSize;
 
 #if !PUBLIC_SDK
-//! TODO PBL-41920: This belongs in a platform specific location
-#if PLATFORM_ROBERT || PLATFORM_OBELIX || PLATFORM_GETAFIX
+//! Use display height to determine default content size: larger displays (>= 200px height) use Large
+#if PBL_DISPLAY_HEIGHT >= 200
 #define PreferredContentSizeDefault PreferredContentSizeLarge
 #else
 #define PreferredContentSizeDefault PreferredContentSizeMedium

--- a/src/fw/applib/ui/dialogs/simple_dialog.c
+++ b/src/fw/applib/ui/dialogs/simple_dialog.c
@@ -51,7 +51,7 @@ static int prv_get_rendered_text_height(const char *text, const GRect *text_box)
 
 static int prv_get_icon_top_margin(bool has_status_bar, int icon_height, int window_height) {
   const uint16_t status_layer_offset = has_status_bar ? 6 : 0;
-#if PLATFORM_ROBERT || PLATFORM_CALCULUS || PLATFORM_OBELIX || PLATFORM_GETAFIX
+#if PBL_DISPLAY_HEIGHT >= 200
   const uint16_t icon_top_default_margin_px = 42 + status_layer_offset;
 #else
   const uint16_t icon_top_default_margin_px = 18 + status_layer_offset;

--- a/src/fw/apps/core_apps/spinner_ui_window.c
+++ b/src/fw/apps/core_apps/spinner_ui_window.c
@@ -50,7 +50,8 @@ static void prv_draw_spinner_circles(Layer *layer, GContext* ctx) {
   SpinnerUIData *data = window_get_user_data(layer_get_window(layer));
 
   // This is the background image's circle.
-#if PLATFORM_ROBERT || PLATFORM_CALCULUS || PLATFORM_OBELIX
+  // Only applies to rectangular displays >= 200px height (ROBERT, CALCULUS, OBELIX)
+#if PBL_DISPLAY_HEIGHT >= 200 && PBL_RECT
   const unsigned int center_of_circle_y_val = 103;
 #else
   const unsigned int center_of_circle_y_val = PBL_IF_RECT_ELSE(72, layer->bounds.size.h / 2);

--- a/src/fw/apps/system_apps/launcher/default/launcher_app_glance_settings.c
+++ b/src/fw/apps/system_apps/launcher/default/launcher_app_glance_settings.c
@@ -206,7 +206,7 @@ static GTextNode *prv_create_subtitle_node(LauncherAppGlanceStructured *structur
                                            vertically_centered_battery_percent_text_node);
   }
 
-#if PLATFORM_ROBERT || PLATFORM_OBELIX || PLATFORM_GETAFIX
+#if PBL_DISPLAY_HEIGHT >= 200
   const int16_t subtitle_icon_offset_y = 5;
 #else
   const int16_t subtitle_icon_offset_y = 2;

--- a/src/fw/apps/system_apps/launcher/default/launcher_app_glance_structured.c
+++ b/src/fw/apps/system_apps/launcher/default/launcher_app_glance_structured.c
@@ -16,8 +16,10 @@
 #include "util/attributes.h"
 #include "util/string.h"
 #include "util/struct.h"
+#include "board/display.h"
 
-#if PLATFORM_ROBERT || PLATFORM_OBELIX || PLATFORM_GETAFIX
+// Use display height to determine icon margins: larger displays use more margin
+#if PBL_DISPLAY_HEIGHT >= 200
 #define LAUNCHER_APP_GLANCE_STRUCTURED_ICON_HORIZONTAL_MARGIN (9)
 #else
 #define LAUNCHER_APP_GLANCE_STRUCTURED_ICON_HORIZONTAL_MARGIN (5)
@@ -347,7 +349,7 @@ static GTextNode *prv_create_structured_glance_title_subtitle_node(
   // We require a valid title node
   PBL_ASSERTN(title_node);
   // Push the title node a little up or down to match the relevant design spec
-#if PLATFORM_ROBERT || PLATFORM_OBELIX || PLATFORM_GETAFIX
+#if PBL_DISPLAY_HEIGHT >= 200
   title_node->offset.y += 1;
 #else
   title_node->offset.y -= 1;
@@ -423,8 +425,7 @@ static void prv_draw_processed(KinoReel *reel, GContext *ctx, GPoint offset,
   }
 
   GRect glance_frame = (GRect) { .origin = offset, .size = structured_glance->glance.size };
-#if PLATFORM_GETAFIX
-  // Create arc effect following the circular display edge
+#if PBL_ROUND && PBL_DISPLAY_HEIGHT >= 200
   // For a circle: x = R - sqrt(R^2 - (y - R)^2), where R = display_size / 2
   const int16_t radius = PBL_DISPLAY_HEIGHT / 2;
 
@@ -442,7 +443,7 @@ static void prv_draw_processed(KinoReel *reel, GContext *ctx, GPoint offset,
   // Extra 2px shift for non-center rows to push content slightly more inward
   const int16_t base_inset = 10;
   const int16_t horizontal_inset = base_inset + circle_inset;
-#elif PLATFORM_ROBERT || PLATFORM_OBELIX
+#elif PBL_DISPLAY_HEIGHT >= 200 && PBL_RECT
   const int16_t horizontal_inset = 10;
 #else
   const int16_t horizontal_inset = PBL_IF_RECT_ELSE(6, 23);

--- a/src/fw/apps/system_apps/launcher/default/launcher_menu_layer.h
+++ b/src/fw/apps/system_apps/launcher/default/launcher_menu_layer.h
@@ -6,8 +6,10 @@
 #include "launcher_app_glance_service.h"
 
 #include "process_management/app_menu_data_source.h"
+#include "board/display.h"
 
-#if PLATFORM_ROBERT || PLATFORM_OBELIX || PLATFORM_GETAFIX
+// Use display height to determine launcher fonts: larger displays use larger fonts
+#if PBL_DISPLAY_HEIGHT >= 200
 #define LAUNCHER_MENU_LAYER_TITLE_FONT (FONT_KEY_GOTHIC_24_BOLD)
 #define LAUNCHER_MENU_LAYER_SUBTITLE_FONT (FONT_KEY_GOTHIC_18)
 #else

--- a/src/fw/apps/system_apps/launcher/default/launcher_menu_layer_private.h
+++ b/src/fw/apps/system_apps/launcher/default/launcher_menu_layer_private.h
@@ -4,14 +4,16 @@
 #pragma once
 
 #include "util/math.h"
+#include "board/display.h"
 
-#if PLATFORM_ROBERT || PLATFORM_OBELIX || PLATFORM_GETAFIX
+// Use display height to determine launcher cell height: larger displays use taller cells
+#if PBL_DISPLAY_HEIGHT >= 200
 #define LAUNCHER_MENU_LAYER_CELL_RECT_CELL_HEIGHT (53)
 #else
 #define LAUNCHER_MENU_LAYER_CELL_RECT_CELL_HEIGHT (42)
 #endif
 
-#if PLATFORM_GETAFIX
+#if PBL_ROUND && PBL_DISPLAY_HEIGHT >= 200
 #define LAUNCHER_MENU_LAYER_CELL_ROUND_FOCUSED_CELL_HEIGHT (55)
 #define LAUNCHER_MENU_LAYER_CELL_ROUND_UNFOCUSED_CELL_HEIGHT (45)
 #else
@@ -19,7 +21,7 @@
 #define LAUNCHER_MENU_LAYER_CELL_ROUND_UNFOCUSED_CELL_HEIGHT (38)
 #endif
 
-#if PLATFORM_GETAFIX
+#if PBL_ROUND && PBL_DISPLAY_HEIGHT >= 200
 //! Two "unfocused" cells above and below one centered "focused" cell (5 total for larger display)
 #define LAUNCHER_MENU_LAYER_NUM_UNFOCUSED_ROWS_PER_SIDE (2)
 #define LAUNCHER_MENU_LAYER_NUM_VISIBLE_ROWS (5)

--- a/src/fw/popups/bluetooth_pairing_ui.c
+++ b/src/fw/popups/bluetooth_pairing_ui.c
@@ -117,7 +117,7 @@ static void prv_update_text_layer_with_translation(TextLayer *text_layer,
 }
 
 static void prv_update_prf_info_text_layers_text(BTPairingUIData *data) {
-#if PLATFORM_ROBERT || PLATFORM_CALCULUS || PLATFORM_OBELIX || PLATFORM_GETAFIX
+#if PBL_DISPLAY_HEIGHT >= 200
   const char *font_key_default = FONT_KEY_GOTHIC_28_BOLD;
   const char *font_key_japanese = FONT_KEY_MINCHO_24_PAIR;
 #else
@@ -262,7 +262,7 @@ static void prv_adjust_background_frame_for_state(BTPairingUIData *data) {
   switch (data->ui_state) {
     case BTPairingUIStateAwaitingUserConfirmation:
       alignment = GAlignTopLeft;
-#if PLATFORM_ROBERT || PLATFORM_CALCULUS || PLATFORM_OBELIX || PLATFORM_GETAFIX
+#if PBL_DISPLAY_HEIGHT >= 200
       x_offset = 39;
       y_offset = 85;
 #else
@@ -273,7 +273,7 @@ static void prv_adjust_background_frame_for_state(BTPairingUIData *data) {
       break;
     case BTPairingUIStateAwaitingResult:
       alignment = GAlignLeft;
-#if PLATFORM_ROBERT || PLATFORM_CALCULUS || PLATFORM_OBELIX || PLATFORM_GETAFIX
+#if PBL_DISPLAY_HEIGHT >= 200
       x_offset = 76;
       y_offset = 30;
 #else
@@ -285,7 +285,7 @@ static void prv_adjust_background_frame_for_state(BTPairingUIData *data) {
     case BTPairingUIStateFailed:
     case BTPairingUIStateSuccess:
       alignment = GAlignTop;
-#if PLATFORM_ROBERT || PLATFORM_CALCULUS || PLATFORM_OBELIX || PLATFORM_GETAFIX
+#if PBL_DISPLAY_HEIGHT >= 200
       x_offset = 0;
       y_offset = 59;
 #else
@@ -373,7 +373,7 @@ static void prv_window_load(Window *window) {
   const int32_t width_of_action_bar_with_padding = ACTION_BAR_WIDTH + PBL_IF_RECT_ELSE(2, -4);
   const int32_t width = window->layer.bounds.size.w - width_of_action_bar_with_padding;
   const int32_t x_offset = PBL_IF_RECT_ELSE(0, 22);
-#if PLATFORM_ROBERT || PLATFORM_CALCULUS || PLATFORM_OBELIX || PLATFORM_GETAFIX
+#if PBL_DISPLAY_HEIGHT >= 200
   const int32_t info_text_y_offset = 36;
 #else
   const int32_t info_text_y_offset = PBL_IF_RECT_ELSE(10, 12);
@@ -383,13 +383,13 @@ static void prv_window_load(Window *window) {
   kino_layer_init(kino_layer, &window->layer.bounds);
   layer_add_child(&window->layer, &kino_layer->layer);
 
-#if PLATFORM_ROBERT || PLATFORM_CALCULUS || PLATFORM_OBELIX || PLATFORM_GETAFIX
+#if PBL_DISPLAY_HEIGHT >= 200
   GRect pair_text_area = GRect(0, -2, width, 44);
 #else
   GRect pair_text_area = GRect(0, -2, width, 30);
 #endif
 
-#if PLATFORM_ROBERT || PLATFORM_CALCULUS || PLATFORM_OBELIX || PLATFORM_GETAFIX
+#if PBL_DISPLAY_HEIGHT >= 200
   layer_set_frame(&data->info_text_mask_layer, &GRect(x_offset, info_text_y_offset, width, 30));
 #else
   layer_set_frame(&data->info_text_mask_layer, &GRect(x_offset, info_text_y_offset, width, 26));
@@ -401,7 +401,7 @@ static void prv_window_load(Window *window) {
   text_layer_init_with_parameters(info_text_layer,
                                   &pair_text_area,
                                   data->info_text_layer_buffer,
-#if PLATFORM_ROBERT || PLATFORM_CALCULUS || PLATFORM_OBELIX || PLATFORM_GETAFIX
+#if PBL_DISPLAY_HEIGHT >= 200
                                   fonts_get_system_font(FONT_KEY_GOTHIC_28_BOLD),
 #else
                                   fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD),
@@ -423,7 +423,7 @@ static void prv_window_load(Window *window) {
 
   prv_add_prf_layers(pair_text_area, data);
 
-#if PLATFORM_ROBERT || PLATFORM_CALCULUS || PLATFORM_OBELIX || PLATFORM_GETAFIX
+#if PBL_DISPLAY_HEIGHT >= 200
   const int16_t y_offset = 55;
 #else
   const int16_t y_offset = PBL_IF_RECT_ELSE(0, 2);


### PR DESCRIPTION
Replace hardcoded PLATFORM_ROBERT/OBELIX/GETAFIX checks with display height checks (PBL_DISPLAY_HEIGHT >= 200) for all UI layout constants. This fixes inconsistencies where snowy_emery (emulator) was using different layout values than obelix (hardware) despite having identical 200x228 displays.

This ensures consistent UI rendering across all platforms with the same display dimensions.