### PR TITLE
fw/services/bluetooth: fix deadlock in evaluate_pairing_refcount [FIRM-1233]

### DIFF
--- a/src/fw/services/common/bluetooth/pairability.c
+++ b/src/fw/services/common/bluetooth/pairability.c
@@ -22,6 +22,7 @@ static void prv_pairability_timer_cb(void *unused);
 
 static int s_allow_bt_pairing_refcount = 0;
 static int s_allow_ble_pairing_refcount = 0;
+static bool s_last_ble_discoverable_state = false;
 
 static RegularTimerInfo s_pairability_timer_info = {
   .cb = prv_pairability_timer_cb,
@@ -40,13 +41,14 @@ static void evaluate_pairing_refcount(void *data) {
   bool is_ble_pairable_and_discoverable = (s_allow_ble_pairing_refcount > 0);
 
   bt_driver_le_pairability_set_enabled(is_ble_pairable_and_discoverable);
-  if (gap_le_slave_is_discoverable() != is_ble_pairable_and_discoverable) {
+  if (s_last_ble_discoverable_state != is_ble_pairable_and_discoverable) {
     if (is_ble_pairable_and_discoverable) {
       bt_local_addr_pause_cycling();
     } else {
       bt_local_addr_resume_cycling();
     }
     gap_le_slave_set_discoverable(is_ble_pairable_and_discoverable);
+    s_last_ble_discoverable_state = is_ble_pairable_and_discoverable;
   }
 
   if (bt_driver_supports_bt_classic()) {


### PR DESCRIPTION
The evaluate_pairing_refcount callback was calling gap_le_slave_is_discoverable() which acquires bt_lock from the System Task context. This caused a deadlock when the Launcher Task already held bt_lock while waiting for ble_hs_mutex, resulting in a watchdog timeout.

Fix by caching the BLE discoverable state locally instead of querying it via gap_le_slave_is_discoverable(), eliminating the cross-task lock acquisition.

The cached state maintains the same optimization (avoiding redundant calls to gap_le_slave_set_discoverable) without the deadlock risk.