### PR TITLE
fw/drivers/sf32lb52/audio: fix audio playback failure after first use

### DIFF
--- a/src/fw/drivers/sf32lb52/audio/audec.c
+++ b/src/fw/drivers/sf32lb52/audio/audec.c
@@ -343,6 +343,7 @@ void audec_start(AudioDevice* audio_device, AudioTransCB cb) {
     prv_allocate_buffers(state);
 
     prv_bf0_audio_pll_config(audio_device, &codec_dac_clk_config[haudcodec->Init.samplerate_index]);
+    HAL_AUDCODEC_Config_TChanel(haudcodec, 0, &haudcodec->Init.dac_cfg);
     HAL_NVIC_SetPriority(audio_device->audec_dma_irq, audio_device->irq_priority, 0);
     HAL_AUDCODEC_Transmit_DMA(haudcodec, haudcodec->buf[HAL_AUDCODEC_DAC_CH0], haudcodec->bufSize, HAL_AUDCODEC_DAC_CH0);
     HAL_NVIC_EnableIRQ(audio_device->audec_dma_irq);


### PR DESCRIPTION
Audio playback in manufacturing tests (and other apps) would fail on subsequent attempts - first playback worked fine, but after that only silence followed by a click when the speaker powered off.

The issue was that audec_stop() clears all channel configurations via HAL_AUDCODEC_Clear_All_Channel(), but audec_start() never restored the transmit channel configuration. Since audec_init() is only called once during board initialization, the channel config was only set up once. After the first stop, it was gone.

Fix by adding HAL_AUDCODEC_Config_TChanel() call in audec_start() to reconfigure the transmit channel before starting DMA, ensuring the channel is properly configured on every playback session.