### PR TITLE
fw/applib/voice: delay dictation start until BLE fast mode

### DIFF
--- a/src/fw/applib/voice/voice_window.c
+++ b/src/fw/applib/voice/voice_window.c
@@ -82,6 +82,9 @@ static const uint32_t UNFOLD_DURATION = 500;
 
 #define VOICE_LOG(fmt, args...)   PBL_LOG_D(LOG_DOMAIN_VOICE, LOG_LEVEL_DEBUG, fmt, ## args)
 
+// Track current voice window for granted handler callback
+static VoiceUiData *s_current_voice_window = NULL;
+
 static void prv_start_dictation(VoiceUiData *data);
 static void prv_stop_dictation(VoiceUiData *data);
 static void prv_cancel_dictation(VoiceUiData *data);
@@ -1324,11 +1327,51 @@ static void prv_mic_window_disappear(Window *window) {
   }
 }
 
+// Called when BLE responsiveness reaches ResponseTimeMin (fast mode)
+static void prv_responsiveness_granted_handler(void) {
+  VoiceUiData *data = s_current_voice_window;
+  if (!data) {
+    return;
+  }
+
+  VOICE_LOG("ResponseTimeMin granted, starting dictation");
+  data->responsiveness_granted = true;
+
+  // If window is visible and waiting to start, start dictation now
+  if ((data->state == StateStart) || (data->state == StateWaitForReady)) {
+    prv_start_dictation(data);
+  }
+}
+
 static void prv_mic_window_appear(Window *window) {
   VoiceUiData *data = window_get_user_data(window);
+  s_current_voice_window = data;
+
   if ((data->state == StateStart) || (data->state == StateFinished)) {
     sys_light_enable_respect_settings(true);
+
+#if !defined(TARGET_QEMU)
+    // Request low latency mode and wait for it to be granted before starting dictation
+    CommSession *comm_session = comm_session_get_system_session();
+    if (comm_session) {
+      VOICE_LOG("Requesting ResponseTimeMin with granted handler");
+      comm_session_set_responsiveness_ext(comm_session, BtConsumerPpVoiceEndpoint, ResponseTimeMin,
+                                          MIN_LATENCY_MODE_TIMEOUT_VOICE_SECS,
+                                          prv_responsiveness_granted_handler);
+    }
+
+    // If already granted (or QEMU), start immediately
+    if (data->responsiveness_granted) {
+      prv_start_dictation(data);
+    } else {
+      // Show pulsing dot while waiting for fast mode
+      VOICE_LOG("Waiting for ResponseTimeMin to be granted");
+      prv_set_mic_window_state(data, StateWaitForReady);
+    }
+#else
+    // On QEMU, just start immediately
     prv_start_dictation(data);
+#endif
   }
 }
 
@@ -1365,12 +1408,16 @@ VoiceWindow *voice_window_create(char *buffer, size_t buffer_size,
     .message = buffer,
     .buffer_size = buffer_size,
     .session_type = session_type,
+    .responsiveness_granted = false,
   };
 
   return data;
 }
 
 void voice_window_destroy(VoiceWindow *voice_window) {
+  if (s_current_voice_window == voice_window) {
+    s_current_voice_window = NULL;
+  }
   voice_window_pop(voice_window);
   applib_free(voice_window->message);
   applib_free(voice_window);

--- a/src/fw/applib/voice/voice_window_private.h
+++ b/src/fw/applib/voice/voice_window_private.h
@@ -86,6 +86,7 @@ typedef struct VoiceUiData {
 
   VoiceSessionId session_id;
   VoiceEndpointSessionType session_type;
+  bool responsiveness_granted;  // Track if ResponseTimeMin has been granted
 } VoiceUiData;
 
 void voice_window_lose_focus(VoiceWindow *voice_window);

--- a/src/fw/services/normal/voice/voice.c
+++ b/src/fw/services/normal/voice/voice.c
@@ -410,15 +410,6 @@ VoiceSessionId voice_start_dictation(VoiceEndpointSessionType session_type) {
     VOICE_LOG("Starting system-initiated voice dictation session");
   }
 
-#if !defined(TARGET_QEMU)
-  // Set up communication session responsiveness for voice session
-  CommSession *comm_session = comm_session_get_system_session();
-  if (comm_session) {
-    comm_session_set_responsiveness(comm_session, BtConsumerPpVoiceEndpoint, ResponseTimeMin,
-                                    MIN_LATENCY_MODE_TIMEOUT_VOICE_SECS);
-  }
-#endif
-
   // Get Speex transfer info
   AudioTransferInfoSpeex transfer_info;
   voice_speex_get_transfer_info(&transfer_info);

--- a/src/fw/services/normal/voice_endpoint.c
+++ b/src/fw/services/normal/voice_endpoint.c
@@ -184,8 +184,6 @@ void voice_endpoint_setup_session(VoiceEndpointSessionType session_type,
     AudioEndpointSessionId session_id, AudioTransferInfoSpeex *info, Uuid *app_uuid) {
 
   CommSession *comm_session = comm_session_get_system_session();
-  comm_session_set_responsiveness(comm_session, BtConsumerPpVoiceEndpoint, ResponseTimeMin,
-                                  MIN_LATENCY_MODE_TIMEOUT_VOICE_SECS);
 
   // We're only sending one attribute now: the speex audio transfer info packet
   size_t size = sizeof(SessionSetupMsg) + sizeof(GenericAttribute) +


### PR DESCRIPTION
After commit 5d0999c, voice dictation experienced lag at startup because ResponseTimeMax was changed from 150-180ms to 600-630ms intervals for power savings. Voice would request ResponseTimeMin (15ms) only after the user pressed the record button, requiring BLE parameter negotiation at the slow 600ms rate.

Solution:
- Request ResponseTimeMin when voice window appears
- Use granted handler callback to delay actual dictation start
- User sees pulsing dot (good feedback) during BLE negotiation
- Once fast mode granted, dictation starts with no lag