### PR TITLE
wscript: use sftool to flash resources on SF32LB52

### DIFF
--- a/wscript
+++ b/wscript
@@ -1591,8 +1591,18 @@ def image_resources(ctx):
         waflib.Logs.pprint('RED', 'Error: --tty not specified')
         return
 
-    tool_name = _get_pulse_flash_tool(ctx)
     pbpack_path = ctx.get_pbpack_node().abspath()
+
+    # Use sftool for Sifli-based boards
+    if ctx.env.MICRO_FAMILY == 'SF32LB52':
+        waflib.Logs.pprint('CYAN', 'Writing pbpack "%s" to tty %s using sftool' % (pbpack_path, tty))
+        from waftools import sftool
+        # FIXME(SF32LB52): Make this configurable!
+        # FLASH_REGION_SYSTEM_RESOURCES_BANK_0_BEGIN is 0x12620000
+        sftool.write_flash(ctx, f'{pbpack_path}@0x12620000')
+        return
+
+    tool_name = _get_pulse_flash_tool(ctx)
     waflib.Logs.pprint('CYAN', 'Writing pbpack "%s" to tty %s' % (pbpack_path, tty))
 
     ret = os.system("python ./tools/%s.py -t %s -p resources %s" % (tool_name, tty, pbpack_path))


### PR DESCRIPTION
It's easier and faster to flash resources using sftool. It also allows flashing resources on release builds, where pulse is not available. As of today, resources address is hardcoded in C files, not available in waf. We'll hopefully have something like Kconfig one day.