### PR TITLE
Fix voice dictation frame drops by delaying recording start [FIRM-1254]

### DIFF
--- a/src/fw/applib/voice/voice_window_private.h
+++ b/src/fw/applib/voice/voice_window_private.h
@@ -86,7 +86,6 @@ typedef struct VoiceUiData {
 
   VoiceSessionId session_id;
   VoiceEndpointSessionType session_type;
-  bool responsiveness_granted;  // Track if ResponseTimeMin has been granted
 } VoiceUiData;
 
 void voice_window_lose_focus(VoiceWindow *voice_window);

--- a/src/fw/comm/ble/gap_le_connect_params.c
+++ b/src/fw/comm/ble/gap_le_connect_params.c
@@ -77,8 +77,8 @@
 static const GAPLEConnectRequestParams s_default_connection_params_table[NumResponseTimeState] = {
   [ResponseTimeMax] = {
     .slave_latency_events = 0,
-    .connection_interval_min_1_25ms = 480, // 600ms
-    .connection_interval_max_1_25ms = 504, // 630ms
+    .connection_interval_min_1_25ms = 240, // 300ms
+    .connection_interval_max_1_25ms = 252, // 315ms
     .supervision_timeout_10ms = 600, // 6s
   },
   [ResponseTimeMiddle] = {

--- a/src/fw/services/normal/voice/voice.c
+++ b/src/fw/services/normal/voice/voice.c
@@ -410,6 +410,15 @@ VoiceSessionId voice_start_dictation(VoiceEndpointSessionType session_type) {
     VOICE_LOG("Starting system-initiated voice dictation session");
   }
 
+#if !defined(TARGET_QEMU)
+  // Set up communication session responsiveness for voice session
+  CommSession *comm_session = comm_session_get_system_session();
+  if (comm_session) {
+    comm_session_set_responsiveness(comm_session, BtConsumerPpVoiceEndpoint, ResponseTimeMin,
+                                    MIN_LATENCY_MODE_TIMEOUT_VOICE_SECS);
+  }
+#endif
+
   // Get Speex transfer info
   AudioTransferInfoSpeex transfer_info;
   voice_speex_get_transfer_info(&transfer_info);

--- a/src/fw/services/normal/voice_endpoint.c
+++ b/src/fw/services/normal/voice_endpoint.c
@@ -184,6 +184,8 @@ void voice_endpoint_setup_session(VoiceEndpointSessionType session_type,
     AudioEndpointSessionId session_id, AudioTransferInfoSpeex *info, Uuid *app_uuid) {
 
   CommSession *comm_session = comm_session_get_system_session();
+  comm_session_set_responsiveness(comm_session, BtConsumerPpVoiceEndpoint, ResponseTimeMin,
+                                  MIN_LATENCY_MODE_TIMEOUT_VOICE_SECS);
 
   // We're only sending one attribute now: the speex audio transfer info packet
   size_t size = sizeof(SessionSetupMsg) + sizeof(GenericAttribute) +


### PR DESCRIPTION
After commit 5d0999c increased BLE baseline to 600ms, voice dictation started dropping 40-60 frames because BLE negotiation takes 2-6s but the PDM buffer only holds 320ms.

A previous fix (f2634eed) was reverted because it used callbacks that caused a bunch of errors.

This fix uses a simple 3.5s delay before showing the microphone icon and reduces the baseline from 600ms to 300ms, giving BLE time to negotiate without blocking or callbacks.