### PR TITLE
fw/services/wakeup: split clock change handling into two APIs [FIRM-1250]

### DIFF
--- a/src/fw/kernel/event_loop.c
+++ b/src/fw/kernel/event_loop.c
@@ -384,6 +384,7 @@ static NOINLINE void prv_extended_event_handler(PebbleEvent* e) {
           set_time_info->dst_changed ||
           ABS(set_time_info->utc_time_delta) > 15) {
         alarm_handle_clock_change();
+        wakeup_handle_significant_clock_change();
         cron_service_handle_clock_change(set_time_info);
       }
 

--- a/src/fw/services/normal/wakeup.h
+++ b/src/fw/services/normal/wakeup.h
@@ -56,5 +56,11 @@ WakeupId wakeup_get_next_scheduled(void);
 void wakeup_migrate_timezone(int utc_diff);
 
 //! @internal
-////! This function is used for updating wakeup events after a time change
+//! This function is called for significant time changes (>15s, timezone, DST).
+//! It rewrites the wakeup file to delete past events and show missed event popups.
+void wakeup_handle_significant_clock_change(void);
+
+//! @internal
+//! This function is called for all time changes (including small RTC calibrations).
+//! It reschedules the wakeup timer without deleting events or showing popups.
 void wakeup_handle_clock_change(void);


### PR DESCRIPTION
Previously, wakeup_handle_clock_change() was called on every time change (including small RTC calibrations every 5 minutes). This caused it to perform a full rewrite of the wakeup file, deleting past events and showing "missed event" popups even when the watch had been on.

This resulted in spurious "while your pebble was off wake up events occurred" popups appearing during normal operation after RTC calibrations.