### PR TITLE
fw/services/light: implement 3-zone dynamic backlight algorithm

### DIFF
--- a/src/fw/apps/system_apps/settings/settings_system.c
+++ b/src/fw/apps/system_apps/settings/settings_system.c
@@ -68,7 +68,6 @@ enum {
 #endif
 #if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
   DebuggingItemDynamicBacklightMinThreshold,
-  DebuggingItemDynamicBacklightMaxThreshold,
 #endif
   DebuggingItem_Count,
 };
@@ -146,7 +145,6 @@ typedef struct SettingsSystemData {
 #if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
   // Dynamic backlight threshold data
   char dyn_bl_min_threshold_buffer[16];  // Buffer for formatted min threshold
-  char dyn_bl_max_threshold_buffer[16];  // Buffer for formatted max threshold
 #endif
 } SettingsSystemData;
 
@@ -500,36 +498,6 @@ static void prv_dyn_bl_min_threshold_menu_push(SettingsSystemData *data) {
   app_window_stack_push(&number_window->window, animated);
 }
 
-// Dynamic Backlight Max Threshold Settings
-/////////////////////////////
-static void prv_dyn_bl_max_threshold_selected(NumberWindow *number_window, void *context) {
-  uint32_t new_threshold = (uint32_t)number_window_get_value(number_window);
-  backlight_set_dynamic_max_threshold(new_threshold);
-  app_window_stack_remove(&number_window->window, true /* animated */);
-}
-
-static void prv_dyn_bl_max_threshold_menu_push(SettingsSystemData *data) {
-  NumberWindow *number_window = number_window_create(
-    "Max Light Threshold",
-    (NumberWindowCallbacks) {
-      .selected = prv_dyn_bl_max_threshold_selected,
-    },
-    data
-  );
-  
-  if (!number_window) {
-    return;
-  }
-  
-  // Set reasonable min/max values
-  number_window_set_min(number_window, 1);
-  number_window_set_max(number_window, AMBIENT_LIGHT_LEVEL_MAX);
-  number_window_set_step_size(number_window, 1);
-  number_window_set_value(number_window, (int32_t)backlight_get_dynamic_max_threshold());
-  
-  const bool animated = true;
-  app_window_stack_push(&number_window->window, animated);
-}
 #endif
 
 // Motion Sensitivity Settings (Asterix/Obelix only)
@@ -589,7 +557,6 @@ static const char* s_debugging_titles[DebuggingItem_Count] = {
 #endif
 #if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
   [DebuggingItemDynamicBacklightMinThreshold] = i18n_noop("Dyn BL Min Threshold"),
-  [DebuggingItemDynamicBacklightMaxThreshold] = i18n_noop("Dyn BL Max Threshold"),
 #endif
 };
 
@@ -628,12 +595,6 @@ static void prv_debugging_draw_row_callback(GContext* ctx, const Layer *cell_lay
     snprintf(data->dyn_bl_min_threshold_buffer, sizeof(data->dyn_bl_min_threshold_buffer),
              "%"PRIu32, min_threshold);
     subtitle_text = data->dyn_bl_min_threshold_buffer;
-  }
-  else if (cell_index->row == DebuggingItemDynamicBacklightMaxThreshold) {
-    uint32_t max_threshold = backlight_get_dynamic_max_threshold();
-    snprintf(data->dyn_bl_max_threshold_buffer, sizeof(data->dyn_bl_max_threshold_buffer),
-             "%"PRIu32, max_threshold);
-    subtitle_text = data->dyn_bl_max_threshold_buffer;
   }
 #endif
   menu_cell_basic_draw(ctx, cell_layer, title, subtitle_text, NULL);
@@ -675,9 +636,6 @@ static void prv_debugging_select_callback(MenuLayer *menu_layer,
 #if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
     case DebuggingItemDynamicBacklightMinThreshold:
       prv_dyn_bl_min_threshold_menu_push(data);
-      break;
-    case DebuggingItemDynamicBacklightMaxThreshold:
-      prv_dyn_bl_max_threshold_menu_push(data);
       break;
 #endif
     default:

--- a/src/fw/board/board_sf32lb52.h
+++ b/src/fw/board/board_sf32lb52.h
@@ -132,7 +132,6 @@ typedef struct {
 #if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
   //dynamic backlight thresholds
   uint32_t dynamic_backlight_min_threshold;
-  uint32_t dynamic_backlight_max_threshold;
 #endif
 } BoardConfig;
 
@@ -231,4 +230,3 @@ void board_early_init(void);
 void board_init(void);
 
 #include "board_definitions.h"
-

--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -561,8 +561,7 @@ const BoardConfig BOARD_CONFIG = {
   .backlight_on_percent = 45,
   .ambient_light_dark_threshold = 150,
   .ambient_k_delta_threshold = 25,
-  .dynamic_backlight_min_threshold = 15,
-  .dynamic_backlight_max_threshold = 50,
+  .dynamic_backlight_min_threshold = 5,
 };
 
 const BoardConfigButton BOARD_CONFIG_BUTTON = {

--- a/src/fw/services/normal/blob_db/settings_blob_db.c
+++ b/src/fw/services/normal/blob_db/settings_blob_db.c
@@ -64,7 +64,6 @@ static const char *s_syncable_settings[] = {
 #if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
   "lightDynamicIntensity",
   "dynBacklightMinThreshold",
-  "dynBacklightMaxThreshold",
 #endif
 
   // Language preferences

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -12,7 +12,6 @@
 #if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
   PREFS_MACRO(PREF_KEY_BACKLIGHT_DYNAMIC_INTENSITY, s_backlight_dynamic_intensity_enabled)
   PREFS_MACRO(PREF_KEY_DYNAMIC_BACKLIGHT_MIN_THRESHOLD, s_dynamic_backlight_min_threshold)
-  PREFS_MACRO(PREF_KEY_DYNAMIC_BACKLIGHT_MAX_THRESHOLD, s_dynamic_backlight_max_threshold)
 #endif
   PREFS_MACRO(PREF_KEY_BACKLIGHT_AMBIENT_THRESHOLD, s_backlight_ambient_threshold)
   PREFS_MACRO(PREF_KEY_STATIONARY, s_stationary_mode_enabled)

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -84,8 +84,6 @@ void backlight_set_dynamic_intensity_enabled(bool enable);
 // Dynamic backlight thresholds (for debug menu)
 uint32_t backlight_get_dynamic_min_threshold(void);
 void backlight_set_dynamic_min_threshold(uint32_t threshold);
-uint32_t backlight_get_dynamic_max_threshold(void);
-void backlight_set_dynamic_max_threshold(uint32_t threshold);
 #endif
 
 // Motion sensitivity for accelerometer shake detection (0-100, lower = less sensitive)


### PR DESCRIPTION
Refactors dynamic backlight from linear scaling to a simpler 3-zone approach:
- Zone 1 (utter darkness): 10% brightness when all ALS samples ≤ min threshold
- Zone 2 (dim/indoor): User max brightness
- Zone 3 (bright outdoor): Backlight disabled to save power

Uses multiple ALS samples before backlight activation for robust darkness detection and noise rejection. Removes dynBacklightMaxThreshold preference as it's no longer needed with the zone-based approach.