### PR TITLE
feat: add new vibe triggers for hourly and disconnection notice

### DIFF
--- a/include/pbl/services/vibes/vibe_client.h
+++ b/include/pbl/services/vibes/vibe_client.h
@@ -9,7 +9,9 @@ typedef enum VibeClient {
   VibeClient_Notifications = 0,
   VibeClient_PhoneCalls,
   VibeClient_Alarms,
-  VibeClient_AlarmsLPM
+  VibeClient_AlarmsLPM,
+  VibeClient_Hourly,
+  VibeClient_OnDisconnect,
 } VibeClient;
 
 // Returns the appropriate vibe score for the client.

--- a/include/pbl/services/vibes/vibe_score_info.h
+++ b/include/pbl/services/vibes/vibe_score_info.h
@@ -20,10 +20,14 @@ typedef enum VibeScoreId {
 #define DEFAULT_VIBE_SCORE_NOTIFS (VibeScoreId_StandardShortPulseHigh)
 #define DEFAULT_VIBE_SCORE_INCOMING_CALLS (VibeScoreId_Pulse)
 #define DEFAULT_VIBE_SCORE_ALARMS (VibeScoreId_Reveille)
+#define DEFAULT_VIBE_SCORE_HOURLY (VibeScoreId_Disabled)
+#define DEFAULT_VIBE_SCORE_ON_DISCONNECT (VibeScoreId_Disabled)
 #else
 #define DEFAULT_VIBE_SCORE_NOTIFS (VibeScoreId_NudgeNudge)
 #define DEFAULT_VIBE_SCORE_INCOMING_CALLS (VibeScoreId_Pulse)
 #define DEFAULT_VIBE_SCORE_ALARMS (VibeScoreId_Reveille)
+#define DEFAULT_VIBE_SCORE_HOURLY (VibeScoreId_Disabled)
+#define DEFAULT_VIBE_SCORE_ON_DISCONNECT (VibeScoreId_Disabled)
 #endif
 
 // Returns the ResourceId for the VibeScore represented by this id.

--- a/src/fw/apps/system/settings/vibe_patterns.c
+++ b/src/fw/apps/system/settings/vibe_patterns.c
@@ -29,6 +29,8 @@ typedef enum VibeSettingsRow {
 #endif
   VibeSettingsRow_PhoneCalls,
   VibeSettingsRow_Alarms,
+  VibeSettingsRow_Hourly,
+  VibeSettingsRow_OnDisconnect,
   VibeSettingsRow_System,
   VibeSettingsRow_Count,
 } VibeSettingsRow;
@@ -77,6 +79,16 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
       client = VibeClient_Alarms;
       break;
     }
+    case VibeSettingsRow_Hourly: {
+      title = i18n_noop("Hourly Notice");
+      client = VibeClient_Hourly;
+      break;
+    }
+    case VibeSettingsRow_OnDisconnect: {
+      title = i18n_noop("On Disconnect");
+      client = VibeClient_OnDisconnect;
+      break;
+    }
     case VibeSettingsRow_System: {
       /// Refers to the class of all non-score vibes, e.g. 3rd party app vibes
       title = i18n_noop("System");
@@ -123,6 +135,14 @@ static void prv_selection_changed_cb(SettingsCallbacks *context, uint16_t new_ro
       score = vibe_client_get_score(VibeClient_Alarms);
       break;
     }
+    case VibeSettingsRow_Hourly: {
+      score = vibe_client_get_score(VibeClient_Hourly);
+      break;
+    }
+    case VibeSettingsRow_OnDisconnect: {
+      score = vibe_client_get_score(VibeClient_OnDisconnect);
+      break;
+    }
     case VibeSettingsRow_System: {
       // Vibe a short pulse so the user can feel the current system default vibe intensity
       vibes_short_pulse();
@@ -164,6 +184,14 @@ static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
     }
     case VibeSettingsRow_Alarms: {
       client = VibeClient_Alarms;
+      break;
+    }
+    case VibeSettingsRow_Hourly: {
+      client = VibeClient_Hourly;
+      break;
+    }
+    case VibeSettingsRow_OnDisconnect: {
+      client = VibeClient_OnDisconnect;
       break;
     }
     case VibeSettingsRow_System: {

--- a/src/fw/services/clock/service.c
+++ b/src/fw/services/clock/service.c
@@ -24,6 +24,14 @@
 #include "util/string.h"
 #include "pbl/services/analytics/analytics.h"
 
+#ifndef RECOVERY_FW
+#include "pbl/services/notifications/do_not_disturb.h"
+#include "pbl/services/notifications/alerts.h"
+#include "pbl/services/notifications/alerts_preferences_private.h"
+#include "pbl/services/vibes/vibe_client.h"
+#include "pbl/services/vibes/vibe_score.h"
+#endif
+
 #include <stdio.h>
 
 // NOTE: There are RECOVERY_FW ifdefs in this file because PRF does not have
@@ -403,6 +411,21 @@ void clock_protocol_msg_callback(CommSession *session, const uint8_t* data, unsi
 static void prv_watch_dst(void* user) {
   const bool was_dst = (bool)user;
   const bool is_dst = time_get_isdst(rtc_get_time());
+  
+#ifndef RECOVERY_FW
+  if (alerts_should_vibrate_for_type(AlertOther)) {
+    if (time_utc_to_local(rtc_get_time()) % 3600 == 0) {
+      uint32_t vibe_id = vibe_score_info_get_resource_id(
+          alerts_preferences_get_vibe_score_for_client(VibeClient_Hourly)); 
+      VibeScore *score = vibe_score_create_with_resource_system(0, vibe_id);
+      if (score) {
+        vibe_score_do_vibe(score);
+        vibe_score_destroy(score);
+      }
+    }
+  }
+#endif
+
   if (is_dst != was_dst) {
     PebbleEvent e = {
       .type = PEBBLE_SET_TIME_EVENT,

--- a/src/fw/services/debounced_connection_service/service.c
+++ b/src/fw/services/debounced_connection_service/service.c
@@ -7,6 +7,16 @@
 #include "pbl/services/regular_timer.h"
 #include "syscall/syscall_internal.h"
 
+#ifndef RECOVERY_FW
+#include "pbl/services/notifications/do_not_disturb.h"
+#include "pbl/services/notifications/alerts.h"
+#include "pbl/services/notifications/alerts_preferences_private.h"
+#include "pbl/services/vibes/vibe_client.h"
+#include "pbl/services/vibes/vibe_score.h"
+#endif
+
+#include "system/logging.h"
+
 //! This module is responsible for propagating debounced connection events.
 //! Connection events are passed through right away to subscribers but
 //! disconnection events are only passed through if a re-connection did not
@@ -40,6 +50,17 @@ static void prv_handle_disconnection_debounced(void *data) {
   DebounceConnection conn_id = (DebounceConnection)data;
   s_debounced_state_is_connected[conn_id] = false;
   prv_put_debounced_connection_event(conn_id);
+#ifndef RECOVERY_FW
+  if (alerts_should_vibrate_for_type(AlertOther)) {
+    uint32_t vibe_id = vibe_score_info_get_resource_id(
+        alerts_preferences_get_vibe_score_for_client(VibeClient_OnDisconnect));
+    VibeScore *score = vibe_score_create_with_resource_system(0, vibe_id);
+    if (score) {
+      vibe_score_do_vibe(score);
+      vibe_score_destroy(score);
+    }
+  }
+#endif
   regular_timer_remove_callback(&s_debounce_timers[conn_id]);
 }
 

--- a/src/fw/services/notifications/alerts_preferences.c
+++ b/src/fw/services/notifications/alerts_preferences.c
@@ -58,6 +58,12 @@ static VibeScoreId s_vibe_score_incoming_calls = DEFAULT_VIBE_SCORE_INCOMING_CAL
 #define PREF_KEY_VIBE_SCORE_ALARMS ("vibeScoreAlarms")
 static VibeScoreId s_vibe_score_alarms = DEFAULT_VIBE_SCORE_ALARMS;
 
+#define PREF_KEY_VIBE_SCORE_HOURLY ("vibeScoreHourly")
+static VibeScoreId s_vibe_score_hourly = DEFAULT_VIBE_SCORE_HOURLY;
+
+#define PREF_KEY_VIBE_SCORE_ON_DISCONNECT ("vibeScoreOnDisconnect")
+static VibeScoreId s_vibe_score_on_disconnect = DEFAULT_VIBE_SCORE_ON_DISCONNECT;
+
 #define PREF_KEY_DND_MANUALLY_ENABLED "dndManuallyEnabled"
 static bool s_do_not_disturb_manually_enabled = false;
 
@@ -187,7 +193,9 @@ static void prv_migrate_legacy_first_use_settings(SettingsFile *file) {
 static void prv_save_changed_vibe_scores_to_file(SettingsFile *file,
                                                  VibeScoreId orig_notifications,
                                                  VibeScoreId orig_incoming_calls,
-                                                 VibeScoreId orig_alarms) {
+                                                 VibeScoreId orig_alarms,
+                                                 VibeScoreId orig_hourly,
+                                                 VibeScoreId orig_on_disconnect) {
 #define SET_PREF_IF_CHANGED(key, value, orig) \
   do { \
     if ((value) != (orig)) { \
@@ -200,6 +208,9 @@ static void prv_save_changed_vibe_scores_to_file(SettingsFile *file,
   SET_PREF_IF_CHANGED(PREF_KEY_VIBE_SCORE_INCOMING_CALLS, s_vibe_score_incoming_calls,
                       orig_incoming_calls);
   SET_PREF_IF_CHANGED(PREF_KEY_VIBE_SCORE_ALARMS, s_vibe_score_alarms, orig_alarms);
+  SET_PREF_IF_CHANGED(PREF_KEY_VIBE_SCORE_HOURLY, s_vibe_score_hourly, orig_hourly);
+  SET_PREF_IF_CHANGED(PREF_KEY_VIBE_SCORE_ON_DISCONNECT, s_vibe_score_on_disconnect, 
+                      orig_on_disconnect);
 #undef SET_PREF_IF_CHANGED
 }
 
@@ -215,6 +226,10 @@ static void prv_ensure_valid_vibe_scores(void) {
                                                               DEFAULT_VIBE_SCORE_INCOMING_CALLS);
   s_vibe_score_alarms = prv_return_default_if_invalid(s_vibe_score_alarms,
                                                       DEFAULT_VIBE_SCORE_ALARMS);
+  s_vibe_score_hourly = prv_return_default_if_invalid(s_vibe_score_hourly,
+                                                      DEFAULT_VIBE_SCORE_HOURLY);
+  s_vibe_score_on_disconnect = prv_return_default_if_invalid(s_vibe_score_on_disconnect,
+                                                            DEFAULT_VIBE_SCORE_ON_DISCONNECT);
 }
 
 static void prv_set_vibe_scores_based_on_legacy_intensity(VibeIntensity intensity) {
@@ -291,6 +306,8 @@ void alerts_preferences_init(void) {
   RESTORE_PREF(PREF_KEY_VIBE_SCORE_NOTIFICATIONS, s_vibe_score_notifications);
   RESTORE_PREF(PREF_KEY_VIBE_SCORE_INCOMING_CALLS, s_vibe_score_incoming_calls);
   RESTORE_PREF(PREF_KEY_VIBE_SCORE_ALARMS, s_vibe_score_alarms);
+  RESTORE_PREF(PREF_KEY_VIBE_SCORE_HOURLY, s_vibe_score_hourly);
+  RESTORE_PREF(PREF_KEY_VIBE_SCORE_ON_DISCONNECT, s_vibe_score_on_disconnect);
   RESTORE_PREF(PREF_KEY_DND_MANUALLY_ENABLED, s_do_not_disturb_manually_enabled);
   RESTORE_PREF(PREF_KEY_DND_SMART_ENABLED, s_do_not_disturb_smart_dnd_enabled);
   RESTORE_PREF(PREF_KEY_DND_INTERRUPTIONS_MASK, s_dnd_interruptions_mask);
@@ -320,13 +337,17 @@ void alerts_preferences_init(void) {
   const VibeScoreId orig_vibe_score_notifications = s_vibe_score_notifications;
   const VibeScoreId orig_vibe_score_incoming_calls = s_vibe_score_incoming_calls;
   const VibeScoreId orig_vibe_score_alarms = s_vibe_score_alarms;
+  const VibeScoreId orig_vibe_score_hourly = s_vibe_score_hourly;
+  const VibeScoreId orig_vibe_score_on_disconnect = s_vibe_score_on_disconnect;
 
   prv_migrate_legacy_first_use_settings(&file);
   prv_migrate_vibe_intensity_to_vibe_scores(&file);
   prv_ensure_valid_vibe_scores();
   prv_save_changed_vibe_scores_to_file(&file, orig_vibe_score_notifications,
                                        orig_vibe_score_incoming_calls,
-                                       orig_vibe_score_alarms);
+                                       orig_vibe_score_alarms,
+                                       orig_vibe_score_hourly,
+                                       orig_vibe_score_on_disconnect);
 
   settings_file_close(&file);
 }
@@ -435,6 +456,10 @@ VibeScoreId alerts_preferences_get_vibe_score_for_client(VibeClient client) {
       return s_vibe_score_incoming_calls;
     case VibeClient_Alarms:
       return s_vibe_score_alarms;
+    case VibeClient_Hourly:
+      return s_vibe_score_hourly;
+    case VibeClient_OnDisconnect:
+      return s_vibe_score_on_disconnect;
     default:
       WTF;
   }
@@ -456,6 +481,16 @@ void alerts_preferences_set_vibe_score_for_client(VibeClient client, VibeScoreId
     case VibeClient_Alarms: {
       s_vibe_score_alarms = id;
       key = PREF_KEY_VIBE_SCORE_ALARMS;
+      break;
+    }
+    case VibeClient_Hourly: {
+      s_vibe_score_hourly = id;
+      key = PREF_KEY_VIBE_SCORE_HOURLY;
+      break;
+    }
+    case VibeClient_OnDisconnect: {
+      s_vibe_score_on_disconnect = id;
+      key = PREF_KEY_VIBE_SCORE_ON_DISCONNECT;
       break;
     }
     default: {

--- a/src/fw/services/vibes/vibe_score_info.c
+++ b/src/fw/services/vibes/vibe_score_info.c
@@ -13,7 +13,9 @@ typedef enum AlertType {
   AlertType_Calls = 1 << 1,
   AlertType_Alarms = 1 << 2,
   AlertType_AlarmsLPM = 1 << 3,
-  AlertType_All = AlertType_Notifications | AlertType_Calls | AlertType_Alarms,
+  AlertType_Hourly = 1 << 4,
+  AlertType_OnDisconnect = 1 << 5,
+  AlertType_All = AlertType_Notifications | AlertType_Calls | AlertType_Alarms | AlertType_Hourly | AlertType_OnDisconnect,
 } AlertType;
 
 typedef struct {
@@ -77,6 +79,14 @@ VibeScoreId vibe_score_info_cycle_next(VibeClient client, VibeScoreId curr_id) {
     }
     case VibeClient_Alarms: {
       alert_type = AlertType_Alarms;
+      break;
+    }
+    case VibeClient_Hourly: {
+      alert_type = AlertType_Hourly;
+      break;
+    }
+    case VibeClient_OnDisconnect: {
+      alert_type = AlertType_OnDisconnect;
       break;
     }
     default: {

--- a/src/fw/services/vibes/vibes.def
+++ b/src/fw/services/vibes/vibes.def
@@ -1,10 +1,10 @@
 // IDs must be monotonically increasing, i.e. they must never be reused
 // ID 0 is reserved for "Invalid". Do not use!
 
-VIBE_DEF(1, Disabled, i18n_ctx_noop("NotifVibe", "Disabled"), (AlertType_Notifications | AlertType_Calls), RESOURCE_ID_INVALID)
-VIBE_DEF(2, StandardShortPulseLow, i18n_noop("Standard - Low"), AlertType_Notifications, RESOURCE_ID_VIBE_SCORE_STANDARD_SHORT_LOW)
+VIBE_DEF(1, Disabled, i18n_ctx_noop("NotifVibe", "Disabled"), (AlertType_Notifications | AlertType_Calls | AlertType_Hourly| AlertType_OnDisconnect), RESOURCE_ID_INVALID)
+VIBE_DEF(2, StandardShortPulseLow, i18n_noop("Standard - Low"), (AlertType_Notifications | AlertType_Hourly | AlertType_OnDisconnect), RESOURCE_ID_VIBE_SCORE_STANDARD_SHORT_LOW)
 VIBE_DEF(3, StandardLongPulseLow, i18n_noop("Standard - Low"), (AlertType_Calls | AlertType_Alarms), RESOURCE_ID_VIBE_SCORE_STANDARD_LONG_LOW)
-VIBE_DEF(4, StandardShortPulseHigh, i18n_noop("Standard - High"), AlertType_Notifications, RESOURCE_ID_VIBE_SCORE_STANDARD_SHORT_HIGH)
+VIBE_DEF(4, StandardShortPulseHigh, i18n_noop("Standard - High"), (AlertType_Notifications | AlertType_Hourly | AlertType_OnDisconnect), RESOURCE_ID_VIBE_SCORE_STANDARD_SHORT_HIGH)
 VIBE_DEF(5, StandardLongPulseHigh, i18n_noop("Standard - High"), (AlertType_Calls | AlertType_Alarms), RESOURCE_ID_VIBE_SCORE_STANDARD_LONG_HIGH)
 VIBE_DEF(8, Pulse, i18n_noop("Pulse"), AlertType_All, RESOURCE_ID_VIBE_SCORE_PULSE)
 VIBE_DEF(9, NudgeNudge, i18n_noop("Nudge Nudge"), AlertType_All, RESOURCE_ID_VIBE_SCORE_NUDGE_NUDGE)

--- a/tests/fw/apps/system_apps/timeline/test_timeline_app_includes.h
+++ b/tests/fw/apps/system_apps/timeline/test_timeline_app_includes.h
@@ -23,6 +23,7 @@
 
 #include "stubs_action_menu.h"
 #include "stubs_activity.h"
+#include "stubs_alerts.h"
 #include "stubs_alerts_preferences.h"
 #include "stubs_analytics.h"
 #include "stubs_ancs.h"
@@ -75,6 +76,8 @@
 #include "stubs_timeline_layout_animations.h"
 #include "stubs_timeline_peek.h"
 #include "stubs_timezone_database.h"
+#include "stubs_vibe_score.h"
+#include "stubs_vibe_score_info.h"
 #include "stubs_vibes.h"
 #include "stubs_wakeup.h"
 #include "stubs_watchface.h"

--- a/tests/fw/services/test_clock.c
+++ b/tests/fw/services/test_clock.c
@@ -23,7 +23,11 @@
 
 // Stubs
 ////////////////////////////////////
+#include "stubs_alerts.h"
+#include "stubs_alerts_preferences.h"
 #include "stubs_analytics.h"
+#include "stubs_vibe_score.h"
+#include "stubs_vibe_score_info.h"
 #include "stubs_hexdump.h"
 #include "stubs_language_ui.h"
 #include "stubs_logging.h"

--- a/tests/fw/services/test_debounced_connection_service.c
+++ b/tests/fw/services/test_debounced_connection_service.c
@@ -12,11 +12,15 @@
 #include "fake_system_task.h"
 #include "fake_pbl_malloc.h"
 #include "fake_session.h"
+#include "stubs_alerts.h"
+#include "stubs_alerts_preferences.h"
 #include "stubs_bt_lock.h"
 #include "stubs_logging.h"
 #include "stubs_mutex.h"
 #include "stubs_hexdump.h"
 #include "stubs_passert.h"
+#include "stubs_vibe_score.h"
+#include "stubs_vibe_score_info.h"
 
 // Fakes
 ///////////////////////////////////////////////////////////

--- a/tests/stubs/stubs_vibe_score.h
+++ b/tests/stubs/stubs_vibe_score.h
@@ -5,6 +5,10 @@
 
 #include "pbl/services/vibes/vibe_score.h"
 
+VibeScore *vibe_score_create_with_resource_system(ResAppNum app_num, uint32_t resource_id) {
+  return NULL;
+}
+
 void vibe_score_do_vibe(VibeScore *score) {}
 
 void vibe_score_destroy(VibeScore *score) {}

--- a/tests/stubs/stubs_vibe_score_info.h
+++ b/tests/stubs/stubs_vibe_score_info.h
@@ -12,3 +12,7 @@ bool vibe_score_info_is_valid(VibeScoreId id) {
 const char *vibe_score_info_get_name(VibeScoreId id) {
   return "test";
 }
+
+uint32_t vibe_score_info_get_resource_id(VibeScoreId id) {
+  return 0;
+}


### PR DESCRIPTION
This PR adds two new vibration triggers to all watches, one for the top of the hour and the other for a disconnect notice (both of which are already features in a number of community-made watchfaces, but never a system-wide feature). 

That being said, I am seeking feedback, specifically in regards to triggering the vibe score(s) in `clock.c` and `debounced_connection_service.c`. PebbleOS currently expects a system app (ResAppNum = 0) to be in focus when creating the vibe score, however, this will not work when the user is running a third-party app or watchface. At the moment, there is a workaround for this, but I am not sure if this is the cleanest or will be an accepted solution. Any pointers would be much appreciated :)

Resolves issue #690.