### PR TITLE
Add basic Zig language support to SDK

### DIFF
--- a/waftools/pebble_sdk_zig.py
+++ b/waftools/pebble_sdk_zig.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from waflib import TaskGen, Task, Context
+
+
+@TaskGen.extension('.zig')
+def zig_hook(self, node):
+    "Binds the zig file extensions to create Zig task instances"
+    return self.create_compiled_task('zig', node)
+
+
+class zig(Task.Task):
+    "Compiles Zig files into object files"
+    run_str = '${ZIG} build-obj ${ZIGFLAGS} ${CPPPATH_ST:INCPATHS} ${DEFINES_ST:DEFINES} ${SRC} -femit-bin=${TGT[0].abspath()}'
+
+
+def configure(conf):
+    conf.find_program('zig', var='ZIG', mandatory=True)
+
+    # Lookup cross-compiler include paths
+    cc_include_paths = [path.strip() for path in conf.cmd_and_log([conf.env.CC[0], '-E', '-Wp,-v', '-xc', '/dev/null'], output=Context.STDERR, quiet=Context.BOTH).split('\n') if path.startswith(' /')]
+
+    optimize_flag = 'ReleaseSmall'
+
+    pebble_zigflags = ['-target', 'thumb-freestanding-eabi',
+                       '-mcpu', 'cortex_m3',
+                       '-fPIC',
+                       '-fno-unwind-tables',
+                       '-O', optimize_flag]
+
+    pebble_zigflags += ['-I' + path for path in cc_include_paths]
+
+    # Disable time.h and define time_t (see pebble_sdk_gcc.py)
+    if (conf.env.SDK_VERSION_MAJOR == 5) and (conf.env.SDK_VERSION_MINOR > 19):
+        pebble_zigflags.append('-D_TIME_H_')
+        pebble_zigflags.append('-Dtime_t=long')
+
+    conf.env.prepend_value('ZIGFLAGS', pebble_zigflags)


### PR DESCRIPTION
This PR adds optional, non-intrusive support for building Pebble apps and watchfaces in Zig. It does so by introducing a waf task to compile .zig files into object files, which are linked alongside other object files with GCC into the final ELF binary.

Zig can import C headers directly, so all Pebble APIs are availabe to Zig programs, as well much of the Zig language and the Zig standard library.

To use Zig, users can extend `wscript` to load `pebble_sdk_zig` for each target in `configure()`:

```diff
def configure(ctx):
    ...
    ctx.load('pebble_sdk')
+
+   for platform in ctx.env.TARGET_PLATFORMS:
+       ctx.env = ctx.all_envs[platform]
+       ctx.load('pebble_sdk_zig')
```

and glob for `*.zig` sources in `build()`:

```diff
def build(ctx):
    ...
-   ctx.pbl_build(source=ctx.path.ant_glob('src/c/**/*.c'), target=app_elf, bin_type='app')
+   ctx.pbl_build(source=ctx.path.ant_glob('src/zig/**/*.zig'), target=app_elf, bin_type='app')
```

Example Zig app:

```zig
const pebble = @cImport(@cInclude("pebble.h"));

var s_window: ?*pebble.Window = null;
var s_text_layer: ?*pebble.TextLayer = null;

fn window_load(window: ?*pebble.Window) callconv(.c) void {
    const window_layer = pebble.window_get_root_layer(window);
    const bounds = pebble.layer_get_bounds(window_layer);

    s_text_layer = pebble.text_layer_create(.{ .origin = .{ .x = 0, .y = 100 }, .size = .{ .w = bounds.size.w, .h = 20 } });
    pebble.text_layer_set_text(s_text_layer, "Hello World");
    pebble.text_layer_set_text_alignment(s_text_layer, pebble.GTextAlignmentCenter);

    pebble.layer_add_child(window_layer, pebble.text_layer_get_layer(s_text_layer));
}

fn window_unload(_: ?*pebble.Window) callconv(.c) void {
    pebble.text_layer_destroy(s_text_layer);
}

fn init() void {
    s_window = pebble.window_create();

    pebble.window_set_window_handlers(s_window, .{
        .load = window_load,
        .unload = window_unload,
    });

    pebble.window_stack_push(s_window, true);
}

fn deinit() void {
    pebble.window_destroy(s_window);
}

export fn main() void {
    init();
    pebble.app_event_loop();
    deinit();
}
```

Build for `emery`:

```
$ pebble build
Setting top to                           : /home/demo/projects/software/watchface
Setting out to                           : /home/demo/projects/software/watchface/build
Checking for program 'webpack'           : /home/demo/.pebble-sdk/SDKs/current/node_modules/.bin/webpack
Found Pebble SDK for emery in:           : /home/demo/.pebble-sdk/SDKs/current/sdk-core/pebble/emery
Checking for program 'gcc, cc'           : arm-none-eabi-gcc
Checking for program 'ar'                : arm-none-eabi-ar
Checking if the -o link must be split from arguments : yes
Checking for program 'zig'                           : /usr/bin/zig
'configure' finished successfully (0.060s)
Waf: Entering directory `/home/demo/projects/software/watchface/build'
[1/3] Creating emery | message_key_json:  -> build/js/message_keys.json
[2/3] Creating emery | message_key_definitions:  -> build/src/message_keys.auto.c
[3/3] Creating emery | message_key_header:  -> build/include/message_keys.auto.h
[ 4/16] Creating emery | resource_ball:  -> build/emery/system_resources.resball
[ 5/16] Creating emery | /home/demo/projects/software/watchface/build/emery/appinfo.auto.c:  -> build/emery/appinfo.auto.c
[ 6/16] Compiling emery | subst: ../../../.pebble-sdk/SDKs/current/sdk-core/pebble/common/pebble_app.ld.template -> build/emery/pebble_app.ld.auto
[ 7/16] Compiling emery | c: build/src/message_keys.auto.c -> build/src/message_keys.auto.c.9.o
[ 8/16] Compiling emery | zig: src/zig/watchface.zig -> build/src/zig/watchface.zig.9.o
[ 9/16] Creating emery | /home/demo/projects/software/watchface/build/appinfo.json:  -> build/appinfo.json
[10/16] Compiling emery | generate_resource_id_definitions: build/emery/system_resources.resball -> build/emery/src/resource_ids.auto.c
[11/16] Compiling emery | generate_pbpack: build/emery/system_resources.resball -> build/emery/app_resources.pbpack
[12/16] Compiling emery | generate_resource_id_header: build/emery/system_resources.resball -> build/emery/src/resource_ids.auto.h
[13/16] Compiling emery | c: build/emery/src/resource_ids.auto.c -> build/emery/src/resource_ids.auto.c.9.o
[14/16] Compiling emery | c: build/emery/appinfo.auto.c -> build/emery/appinfo.auto.c.9.o
[15/16] Linking emery | cprogram: build/src/zig/watchface.zig.9.o build/emery/appinfo.auto.c.9.o build/emery/src/resource_ids.auto.c.9.o build/src/message_keys.auto.c.9.o -> build/emery/pebble-app.elf
[16/16] Processing emery | memory_usage_report: build/emery/pebble-app.elf build/emery/app_resources.pbpack
-------------------------------------------------------
EMERY APP MEMORY USAGE
Total size of resources:        4092 bytes / 256.0KB
Total footprint in RAM:         536 bytes / 128.0KB
Free RAM available (heap):      130536 bytes
-------------------------------------------------------
[17/19] Compiling emery | /home/demo/projects/software/watchface/build/emery/pebble-app.raw.bin: build/emery/pebble-app.elf -> build/emery/pebble-app.raw.bin
[18/19] Processing emery | inject-metadata: build/emery/pebble-app.raw.bin build/emery/pebble-app.elf build/emery/app_resources.pbpack -> build/emery/pebble-app.bin
[19/19] Creating emery | app_bundle:  -> build/watchface.pbw
Waf: Leaving directory `/home/demo/projects/software/watchface/build'
'build' finished successfully (0.148s)
$
```

Run:

```
$ pebble install --emulator emery
```

<img width="200" height="228" alt="screenshot" src="https://github.com/user-attachments/assets/e70b0406-843c-4aae-895d-3ee82d9b3f92" />

If this PR is accepted, I can also extend the `pebble-tool` new-project template with the modified `wscript` and an example Zig program.
