### PR TITLE
fw/console/dbgserial: make EXTI optional

### DIFF
--- a/src/fw/board/board_sf32lb52.h
+++ b/src/fw/board/board_sf32lb52.h
@@ -124,8 +124,6 @@ typedef struct {
 typedef struct {
   uint8_t backlight_on_percent;
   uint8_t backlight_max_duty_cycle_percent;
-  ExtiConfig dbgserial_int;
-  InputConfig dbgserial_int_gpio;
   OutputConfig lcd_com;
   //ambient light config
   uint32_t ambient_light_dark_threshold;


### PR DESCRIPTION
This has been always applied, even though on some platforms (Sifli) this is never set... Effectively PA0 was being misconfigured. This just showed up badly after EXTI fixes.