### PR TITLE
fw/blob_db: fix crash from concurrent settings file access [FIRM-1284]

### DIFF
--- a/src/fw/services/normal/notifications/alerts_preferences.c
+++ b/src/fw/services/normal/notifications/alerts_preferences.c
@@ -501,6 +501,14 @@ void alerts_preferences_dnd_set_smart_enabled(bool enable) {
   SET_PREF(PREF_KEY_DND_SMART_ENABLED, s_do_not_disturb_smart_dnd_enabled);
 }
 
+void alerts_preferences_lock(void) {
+  mutex_lock(s_mutex);
+}
+
+void alerts_preferences_unlock(void) {
+  mutex_unlock(s_mutex);
+}
+
 void alerts_preferences_handle_blob_db_event(PebbleBlobDBEvent *event) {
   if (event->type != BlobDBEventTypeInsert) {
     return;

--- a/src/fw/services/normal/notifications/alerts_preferences_private.h
+++ b/src/fw/services/normal/notifications/alerts_preferences_private.h
@@ -76,6 +76,12 @@ bool alerts_preferences_dnd_is_smart_enabled(void);
 
 void alerts_preferences_dnd_set_smart_enabled(bool enable);
 
+//! Lock the alerts preferences mutex. Must be paired with alerts_preferences_unlock().
+void alerts_preferences_lock(void);
+
+//! Unlock the alerts preferences mutex. Must be paired with alerts_preferences_lock().
+void alerts_preferences_unlock(void);
+
 //! Process a BlobDB event for notification preferences. For BlobDBEventTypeInsert
 //! events, this method will update the internal global copy of that preference based on the
 //! new value that was placed into the backing store.

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -909,6 +909,15 @@ bool prefs_private_read_backing(const uint8_t *key, size_t key_len, void *value,
 }
 
 
+void prefs_private_lock(void) {
+  mutex_lock(s_mutex);
+}
+
+void prefs_private_unlock(void) {
+  mutex_unlock(s_mutex);
+}
+
+
 // ------------------------------------------------------------------------------------
 // Called from KernelMain when we get a blob DB event. We take this opportunity to update the state
 // of the given pref

--- a/src/fw/shell/prefs_private.h
+++ b/src/fw/shell/prefs_private.h
@@ -37,6 +37,12 @@ int prefs_private_get_backing_len(const uint8_t *key, size_t key_len);
 //! @return true on success, false if failure
 bool prefs_private_read_backing(const uint8_t *key, size_t key_len, void *value, int value_len);
 
+//! Lock the prefs mutex. Must be paired with prefs_private_unlock().
+void prefs_private_lock(void);
+
+//! Unlock the prefs mutex. Must be paired with prefs_private_lock().
+void prefs_private_unlock(void);
+
 //! Process a blobDB event issued for the prefs DB (BlobDBIdPrefs). For BlobDBEventTypeInsert
 //! events, this  method will update the internal global copy of that preference based on the
 //! new value that was placed into the backing store.

--- a/src/fw/shell/sdk/prefs.c
+++ b/src/fw/shell/sdk/prefs.c
@@ -100,6 +100,14 @@ void shell_prefs_set_automatic_timezone_id(int16_t timezone_id) {
 }
 
 
+void prefs_private_lock(void) {
+  mutex_lock(s_mutex);
+}
+
+void prefs_private_unlock(void) {
+  mutex_unlock(s_mutex);
+}
+
 // Exported function used by blob_db API to set the backing store for a specific key.
 // Not used by the SDK shell
 bool prefs_private_write_backing(const uint8_t *key, size_t key_len, const void *value,


### PR DESCRIPTION
BlobDB sync on KernelBG could preempt the App task while a settings file was still open, causing PFS to return E_BUSY and hitting PBL_CROAK("Settings file is already open!").

Expose lock/unlock APIs from prefs.c and alerts_preferences.c, then acquire the appropriate mutex in settings_blob_db.c before every file open. Functions accessing both files lock/unlock each section independently to avoid deadlocks. Insert functions unlock before calling event handlers since those re-acquire the same mutex.