### PR TITLE
sdk: add per-function updateRevision for minimum firmware detection [SDK-60]

### DIFF
--- a/sdk/tools/determine_min_sdk_version.py
+++ b/sdk/tools/determine_min_sdk_version.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2024 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from subprocess import Popen, PIPE
+
+# Shim internals that should not be matched against the API revision map
+SHIM_INTERNALS = {'jump_to_pbl_function', 'pbl_table_addr'}
+
+# Revision 89 is the last historical mapping, frozen at minor 0x56.
+# From revision 90 onward, minor byte = revision number.
+HISTORICAL_CUTOFF_REVISION = 89
+HISTORICAL_CUTOFF_MINOR = 0x56
+SDK_MAJOR = 0x5
+
+
+def revision_to_minor(revision):
+    """Convert an API revision number to an SDK minor byte.
+    Revisions <= 89 map to 0x56 (the historical cutoff).
+    Revisions >= 90 map directly to the revision number."""
+    if revision <= HISTORICAL_CUTOFF_REVISION:
+        return HISTORICAL_CUTOFF_MINOR
+    return revision
+
+
+def determine_min_sdk_version(elf_path, revision_map_path):
+    """Determine the minimum SDK version an app needs based on which
+    API functions it actually uses.
+
+    Args:
+        elf_path: Path to the linked ELF binary
+        revision_map_path: Path to api_update_revisions.json
+
+    Returns:
+        Tuple of (major, minor) SDK version bytes
+    """
+    with open(revision_map_path, 'r') as f:
+        revision_map = json.load(f)
+
+    # Get all defined symbols from the ELF
+    nm_process = Popen(['arm-none-eabi-nm', '--defined-only', elf_path], stdout=PIPE)
+    nm_output = nm_process.communicate()[0].decode('utf8')
+
+    if not nm_output:
+        # Fallback: no symbols found, use historical cutoff
+        return (SDK_MAJOR, HISTORICAL_CUTOFF_MINOR)
+
+    # Parse nm output to extract symbol names
+    defined_symbols = set()
+    for line in nm_output.splitlines():
+        parts = line.split()
+        if len(parts) == 3:
+            defined_symbols.add(parts[2])
+
+    # Find max revision among SDK functions used by the app
+    max_revision = 0
+    for symbol in defined_symbols:
+        if symbol in SHIM_INTERNALS:
+            continue
+        if symbol in revision_map:
+            max_revision = max(max_revision, revision_map[symbol])
+
+    if max_revision == 0:
+        # No SDK functions matched, use historical cutoff
+        return (SDK_MAJOR, HISTORICAL_CUTOFF_MINOR)
+
+    return (SDK_MAJOR, revision_to_minor(max_revision))

--- a/sdk/tools/inject_metadata.py
+++ b/sdk/tools/inject_metadata.py
@@ -75,7 +75,7 @@ class InvalidBinaryError(Exception):
 
 
 def inject_metadata(target_binary, target_elf, resources_file, timestamp, allow_js=False,
-                    has_worker=False):
+                    has_worker=False, sdk_version_override=None):
 
     if target_binary[-4:] != '.bin':
         raise Exception("Invalid filename <%s>! The filename should end in .bin" % target_binary)
@@ -286,6 +286,10 @@ def inject_metadata(target_binary, target_elf, resources_file, timestamp, allow_
         write_value_at_offset(NUM_RELOC_ENTRIES_ADDR, '<L', len(reloc_entries))
 
         write_value_at_offset(VIRTUAL_SIZE_ADDR, "<H", app_virtual_size)
+
+        if sdk_version_override:
+            f.seek(SDK_VERSION_ADDR)
+            f.write(pack('BB', sdk_version_override[0], sdk_version_override[1]))
 
         # Write the reloc_entries past the end of the binary. This expands the size of the binary,
         # but this new stuff won't actually be loaded into ram.

--- a/src/fw/process_management/pebble_process_info.h
+++ b/src/fw/process_management/pebble_process_info.h
@@ -149,6 +149,8 @@ typedef enum {
 // sdk.major:0x5 .minor:0x54 -- Add PlatformType enum and defines (rev 87)
 // sdk.major:0x5 .minor:0x55 -- Preferred Content Size (rev 88)
 // sdk.major:0x5 .minor:0x56 -- Add PlatformType enum and defines (rev 89)
+// sdk.major:0x5 .minor:0x56 -- revision 89 (last historical mapping)
+// From revision 90 onward, minor = revision number (90 = 0x5A, 91 = 0x5B, ...)
 
 #define PROCESS_INFO_CURRENT_SDK_VERSION_MAJOR 0x5
 #define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x56

--- a/tools/generate_native_sdk/exported_symbols.json
+++ b/tools/generate_native_sdk/exported_symbols.json
@@ -5,6 +5,7 @@
               "https://pebbletechnology.atlassian.net/wiki/display/DEV/SDK+API+Design+Guidelines"
             ],
   "revision" : "89",
+  "updateRevision" : "89",
   "version" : "2.0",
   "files": [
     "fw/drivers/ambient_light.h",

--- a/tools/generate_native_sdk/generate_json_api_description.py
+++ b/tools/generate_native_sdk/generate_json_api_description.py
@@ -25,6 +25,8 @@ def gen_json_api_description(functions):
             "removed": f.removed,
             "addedRevision": f.added_revision,
         }
+        if f.update_revision is not None:
+            json_f["updateRevision"] = f.update_revision
         json_functions.append(json_f)
 
     output['functions'] = json_functions

--- a/waftools/pebble_sdk_gcc.py
+++ b/waftools/pebble_sdk_gcc.py
@@ -68,7 +68,7 @@ def configure(conf):
 
 # -----------------------------------------------------------------------------------
 def gen_inject_metadata_rule(bld, src_bin_file, dst_bin_file, elf_file, resource_file, timestamp,
-                             has_pkjs, has_worker):
+                             has_pkjs, has_worker, revision_map_path=None):
     """
     Copy from src_bin_file to dst_bin_file and inject the correct meta-data into the
     header of dst_bin_file
@@ -99,8 +99,14 @@ def gen_inject_metadata_rule(bld, src_bin_file, dst_bin_file, elf_file, resource
             raise BuildError("Failed to copy %s to %s!" % (bin_path, tgt_path))
 
         # Now actually inject the metadata into the new copy of the binary.
+        sdk_version_override = None
+        if revision_map_path:
+            from determine_min_sdk_version import determine_min_sdk_version
+            sdk_version_override = determine_min_sdk_version(elf_path, revision_map_path)
+
         inject_metadata.inject_metadata(tgt_path, elf_path, res_path, timestamp,
-                                        allow_js=has_pkjs, has_worker=has_worker)
+                                        allow_js=has_pkjs, has_worker=has_worker,
+                                        sdk_version_override=sdk_version_override)
 
     sources = [src_bin_file, elf_file]
     if resource_file is not None:


### PR DESCRIPTION
Decouple symbol table ordering (addedRevision) from firmware compatibility by adding an updateRevision field to exported_symbols.json. After linking, the build system analyzes the app ELF to find which SDK functions are used, computes the max updateRevision among them, and patches the binary's SDK version field. This allows apps compiled with a newer SDK to target older firmware when they only use older APIs.

Revisions <= 89 map to minor 0x56 (historical cutoff); revisions >= 90 map directly to the minor byte (90 = 0x5A, 91 = 0x5B, etc.).

Basically a version of #577 that should not break existing behavior