### PR TITLE
ci: disable log hashing for QEMU builds

### DIFF
--- a/.github/workflows/build-qemu.yml
+++ b/.github/workflows/build-qemu.yml
@@ -57,7 +57,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Configure
-        run: ./waf configure --board ${{ matrix.board }} --qemu
+        run: ./waf configure --board ${{ matrix.board }} --qemu --nohash
 
       - name: Build
         run: ./waf build qemu_image_micro qemu_image_spi


### PR DESCRIPTION
Add --nohash to the waf configure step so that logs are human-readable, which is more useful for emulation and debugging.