### PR TITLE
fw/system/logging: improve logging

### DIFF
--- a/src/bluetooth-fw/nimble/advert.c
+++ b/src/bluetooth-fw/nimble/advert.c
@@ -61,8 +61,7 @@ static void prv_handle_connection_event(struct ble_gap_event *event) {
 
   struct ble_gap_conn_desc desc;
   if (ble_gap_conn_find(event->connect.conn_handle, &desc) != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR,
-              "prv_handle_connection_event: Failed to find connection descriptor");
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_handle_connection_event: Failed to find connection descriptor");
     return;
   }
 
@@ -128,8 +127,7 @@ static void prv_handle_disconnection_event(struct ble_gap_event *event) {
 static void prv_handle_enc_change_event(struct ble_gap_event *event) {
   struct ble_gap_conn_desc desc;
   if (ble_gap_conn_find(event->enc_change.conn_handle, &desc) != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR,
-              "prv_handle_enc_change_event: Failed to find connection descriptor");
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_handle_enc_change_event: Failed to find connection descriptor");
     return;
   }
 
@@ -144,21 +142,18 @@ static void prv_handle_enc_change_event(struct ble_gap_event *event) {
 
 static void prv_handle_conn_params_updated_event(struct ble_gap_event *event) {
   if (event->conn_update.status != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR,
-              "Connection parameters update failed: 0x%04x",
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Connection parameters update failed: 0x%04x",
               (uint16_t)event->conn_update.status);
     return;
   }
 
   struct ble_gap_conn_desc desc;
   if (ble_gap_conn_find(event->conn_update.conn_handle, &desc) != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR,
-              "prv_handle_conn_params_updated_event: Failed to find connection descriptor");
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_handle_conn_params_updated_event: Failed to find connection descriptor");
     return;
   }
 
-  PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_INFO,
-            "Connection parameters updated: "
+  PBL_LOG_D_INFO(LOG_DOMAIN_BT, "Connection parameters updated: "
             "itvl=%u ms, latency=%u, spvn timeout=%u ms",
             desc.conn_itvl * BLE_HCI_CONN_ITVL / 1000, desc.conn_latency,
             desc.supervision_timeout * BLE_HCI_CONN_SPVN_TMO_UNITS);
@@ -175,8 +170,7 @@ static void prv_handle_conn_params_updated_event(struct ble_gap_event *event) {
 static void prv_handle_conn_update_req_event(struct ble_gap_event *event) {
   *event->conn_update_req.self_params = *event->conn_update_req.peer_params;
 
-  PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_INFO,
-            "Connection update request: "
+  PBL_LOG_D_INFO(LOG_DOMAIN_BT, "Connection update request: "
             "itvl=(%u, %u) ms, latency=%u, spvn timeout=%u ms",
             event->conn_update_req.self_params->itvl_min * BLE_HCI_CONN_ITVL / 1000,
             event->conn_update_req.self_params->itvl_max * BLE_HCI_CONN_ITVL / 1000,
@@ -218,8 +212,7 @@ static void prv_handle_pairing_complete_event(struct ble_gap_event *event) {
 static void prv_handle_identity_resolved_event(struct ble_gap_event *event) {
   struct ble_gap_conn_desc desc;
   if (ble_gap_conn_find(event->identity_resolved.conn_handle, &desc) != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR,
-              "prv_handle_identity_resolved_event: Failed to find connection descriptor");
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_handle_identity_resolved_event: Failed to find connection descriptor");
     return;
   }
 
@@ -232,8 +225,7 @@ static void prv_handle_identity_resolved_event(struct ble_gap_event *event) {
 static void prv_handle_mtu_change_event(struct ble_gap_event *event) {
   struct ble_gap_conn_desc desc;
   if (ble_gap_conn_find(event->mtu.conn_handle, &desc) != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR,
-              "prv_handle_mtu_change_event: Failed to find connection descriptor");
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_handle_mtu_change_event: Failed to find connection descriptor");
     return;
   }
 
@@ -245,8 +237,7 @@ static void prv_handle_mtu_change_event(struct ble_gap_event *event) {
 extern int pebble_pairing_service_get_connectivity_send_notification(uint16_t conn_handle,
                                                                      uint16_t attr_handle);
 static void prv_handle_subscription_event(struct ble_gap_event *event) {
-  PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG,
-            "prv_handle_subscription_event: connhandle: %d attr:%d notify:%d/%d indicate:%d/%d",
+  PBL_LOG_D_DBG(LOG_DOMAIN_BT, "prv_handle_subscription_event: connhandle: %d attr:%d notify:%d/%d indicate:%d/%d",
             event->subscribe.conn_handle, event->subscribe.attr_handle,
             event->subscribe.prev_notify, event->subscribe.cur_notify,
             event->subscribe.prev_indicate, event->subscribe.cur_indicate);
@@ -255,8 +246,7 @@ static void prv_handle_subscription_event(struct ble_gap_event *event) {
 static void prv_handle_notification_rx_event(struct ble_gap_event *event) {
   struct ble_gap_conn_desc desc;
   if (ble_gap_conn_find(event->notify_rx.conn_handle, &desc) != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR,
-              "prv_handle_notification_rx_event: Failed to find connection descriptor");
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_handle_notification_rx_event: Failed to find connection descriptor");
     return;
   }
 
@@ -275,8 +265,7 @@ static void prv_handle_notification_rx_event(struct ble_gap_event *event) {
 }
 
 static void prv_handle_notification_tx_event(struct ble_gap_event *event) {
-  PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG,
-            "notification tx event; status=%d attr_handle=%d indication=%d\n",
+  PBL_LOG_D_DBG(LOG_DOMAIN_BT, "notification tx event; status=%d attr_handle=%d indication=%d\n",
             event->notify_tx.status,
             event->notify_tx.attr_handle,
             event->notify_tx.indication);
@@ -300,63 +289,62 @@ static int prv_handle_repeat_pairing_event(struct ble_gap_event *event) {
 
   return BLE_GAP_REPEAT_PAIRING_RETRY;
 #else
-  PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_WARNING, "BLE_GAP_EVENT_REPEAT_PAIRING ignored");
+  PBL_LOG_D_WRN(LOG_DOMAIN_BT, "BLE_GAP_EVENT_REPEAT_PAIRING ignored");
   return BLE_GAP_REPEAT_PAIRING_IGNORE;
 #endif
 }
 
 static void prv_handle_phy_update_event(struct ble_gap_event *event) {
   if (event->phy_updated.status != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR,
-              "PHY update failed: 0x%04x",
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "PHY update failed: 0x%04x",
               (uint16_t)event->phy_updated.status);
     return;
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "PHY update complete; conn_handle=%d, tx_phy=%d, rx_phy=%d",
+  PBL_LOG_DBG("PHY update complete; conn_handle=%d, tx_phy=%d, rx_phy=%d",
           event->phy_updated.conn_handle, event->phy_updated.tx_phy, event->phy_updated.rx_phy);
 }
 
 static int prv_handle_gap_event(struct ble_gap_event *event, void *arg) {
   switch (event->type) {
     case BLE_GAP_EVENT_CONNECT:
-      PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG, "BLE_GAP_EVENT_CONNECT");
+      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_CONNECT");
       prv_handle_connection_event(event);
       break;
     case BLE_GAP_EVENT_DISCONNECT:
-      PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG, "BLE_GAP_EVENT_DISCONNECT");
+      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_DISCONNECT");
       prv_handle_disconnection_event(event);
       break;
     case BLE_GAP_EVENT_ENC_CHANGE:
-      PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG, "BLE_GAP_EVENT_ENC_CHANGE");
+      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_ENC_CHANGE");
       prv_handle_enc_change_event(event);
       break;
     case BLE_GAP_EVENT_CONN_UPDATE:
-      PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG, "BLE_GAP_EVENT_CONN_UPDATE");
+      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_CONN_UPDATE");
       prv_handle_conn_params_updated_event(event);
       break;
     case BLE_GAP_EVENT_CONN_UPDATE_REQ:
-      PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG, "BLE_GAP_EVENT_CONN_UPDATE_REQ");
+      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_CONN_UPDATE_REQ");
       prv_handle_conn_update_req_event(event);
       break;
     case BLE_GAP_EVENT_PASSKEY_ACTION:
-      PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG, "BLE_GAP_EVENT_PASSKEY_ACTION");
+      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_PASSKEY_ACTION");
       prv_handle_passkey_event(event);
       break;
     case BLE_GAP_EVENT_IDENTITY_RESOLVED:
-      PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG, "BLE_GAP_EVENT_IDENTITY_RESOLVED");
+      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_IDENTITY_RESOLVED");
       prv_handle_identity_resolved_event(event);
       break;
     case BLE_GAP_EVENT_PAIRING_COMPLETE:
-      PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG, "BLE_GAP_EVENT_PAIRING_COMPLETE");
+      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_PAIRING_COMPLETE");
       prv_handle_pairing_complete_event(event);
       break;
     case BLE_GAP_EVENT_MTU:
-      PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG, "BLE_GAP_EVENT_MTU");
+      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_MTU");
       prv_handle_mtu_change_event(event);
       break;
     case BLE_GAP_EVENT_SUBSCRIBE:
-      PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG, "BLE_GAP_EVENT_SUBSCRIBE");
+      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_SUBSCRIBE");
       prv_handle_subscription_event(event);
       break;
     case BLE_GAP_EVENT_NOTIFY_RX:
@@ -364,18 +352,18 @@ static int prv_handle_gap_event(struct ble_gap_event *event, void *arg) {
       prv_handle_notification_rx_event(event);
       break;
     case BLE_GAP_EVENT_NOTIFY_TX:
-      PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG, "BLE_GAP_EVENT_NOTIFY_TX");
+      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_NOTIFY_TX");
       prv_handle_notification_tx_event(event);
       break;
     case BLE_GAP_EVENT_REPEAT_PAIRING:
-      PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG, "BLE_GAP_EVENT_REPEAT_PAIRING");
+      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_REPEAT_PAIRING");
       return prv_handle_repeat_pairing_event(event);
     case BLE_GAP_EVENT_PHY_UPDATE_COMPLETE:
-      PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG, "BLE_GAP_EVENT_PHY_UPDATE_COMPLETE");
+      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_PHY_UPDATE_COMPLETE");
       prv_handle_phy_update_event(event);
       break;
     default:
-      PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_WARNING, "Unhandled GAP event: %d", event->type);
+      PBL_LOG_D_WRN(LOG_DOMAIN_BT, "Unhandled GAP event: %d", event->type);
       break;
   }
   return 0;
@@ -393,13 +381,13 @@ bool bt_driver_advert_advertising_enable(uint32_t min_interval_ms, uint32_t max_
 
   rc = ble_hs_id_infer_auto(0, &own_addr_type);
   if (rc != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR, "Failed to infer own address type (%d)", rc);
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Failed to infer own address type (%d)", rc);
     return false;
   }
 
   rc = ble_gap_adv_start(own_addr_type, NULL, BLE_HS_FOREVER, &advp, prv_handle_gap_event, NULL);
   if (rc != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR, "Failed to start advertising (0x%04x)", (uint16_t)rc);
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Failed to start advertising (0x%04x)", (uint16_t)rc);
     return false;
   }
 

--- a/src/bluetooth-fw/nimble/gap_le_connect.c
+++ b/src/bluetooth-fw/nimble/gap_le_connect.c
@@ -10,14 +10,13 @@ int bt_driver_gap_le_disconnect(const BTDeviceInternal *peer_address) {
   uint16_t conn_handle;
 
   if (!pebble_device_to_nimble_conn_handle(peer_address, &conn_handle)) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR,
-              "bt_driver_gap_le_disconnect: Failed to find connection handle");
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "bt_driver_gap_le_disconnect: Failed to find connection handle");
     return -1;
   }
 
   int rc = ble_gap_terminate(conn_handle, BLE_ERR_REM_USER_CONN_TERM);
   if (rc != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR, "ble_gap_terminate rc=0x%04x", (uint16_t)rc);
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "ble_gap_terminate rc=0x%04x", (uint16_t)rc);
   }
 
   return rc;

--- a/src/bluetooth-fw/nimble/gap_le_device_name.c
+++ b/src/bluetooth-fw/nimble/gap_le_device_name.c
@@ -17,7 +17,7 @@ static int prv_device_name_read_event_cb(uint16_t conn_handle, const struct ble_
                                          struct ble_gatt_attr *attr, void *arg) {
   if (error->status != 0) {
     if (error->status != BLE_HS_EDONE) {
-      PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR, "prv_device_name_read_event_cb error=%d",
+      PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_device_name_read_event_cb error=%d",
                 error->status);
     }
     return 0;
@@ -46,16 +46,14 @@ static int prv_device_name_read_event_cb(uint16_t conn_handle, const struct ble_
 static void prv_gap_le_device_name_request(GAPLEConnection *connection) {
   uint16_t conn_handle;
   if (!pebble_device_to_nimble_conn_handle(&connection->device, &conn_handle)) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR,
-              "prv_gap_le_device_name_request: Failed to find connection handle");
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_gap_le_device_name_request: Failed to find connection handle");
     return;
   }
 
   int rc = ble_gattc_read_by_uuid(conn_handle, 1, UINT16_MAX, (ble_uuid_t *)&device_name_chr_uuid,
                                   prv_device_name_read_event_cb, (void *)connection);
   if (rc != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR,
-              "prv_gap_le_device_name_request ble_gattc_read_by_uuid rc=0x%04x", (uint16_t)rc);
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_gap_le_device_name_request ble_gattc_read_by_uuid rc=0x%04x", (uint16_t)rc);
   }
 }
 
@@ -66,8 +64,7 @@ static void prv_request_device_name_cb(GAPLEConnection *connection, void *data) 
 void bt_driver_gap_le_device_name_request(const BTDeviceInternal *device) {
   GAPLEConnection *connection = gap_le_connection_by_device(device);
   if (connection == NULL) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR,
-              "bt_driver_gap_le_device_name_request gap_le_connection_by_device returned NULL");
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "bt_driver_gap_le_device_name_request gap_le_connection_by_device returned NULL");
     return;
   }
   prv_gap_le_device_name_request(connection);

--- a/src/bluetooth-fw/nimble/gatt_client_operations.c
+++ b/src/bluetooth-fw/nimble/gatt_client_operations.c
@@ -10,7 +10,7 @@
 static int prv_gatt_write_event_cb(uint16_t conn_handle, const struct ble_gatt_error *error,
                                    struct ble_gatt_attr *attr, void *arg) {
   if (error->status != 0U) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR, "GATT write failed (hdl: 0x%" PRIx16 "): 0x%" PRIx16,
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "GATT write failed (hdl: 0x%" PRIx16 "): 0x%" PRIx16,
               error->att_handle, error->status);
   }
 
@@ -27,7 +27,7 @@ static int prv_gatt_write_event_cb(uint16_t conn_handle, const struct ble_gatt_e
 static int prv_gatt_read_event_cb(uint16_t conn_handle, const struct ble_gatt_error *error,
                                   struct ble_gatt_attr *attr, void *arg) {
   if (error->status != 0U) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR, "GATT read failed (hdl: 0x%" PRIx16 "): 0x%" PRIx16,
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "GATT read failed (hdl: 0x%" PRIx16 "): 0x%" PRIx16,
               error->att_handle, error->status);
   }
 
@@ -47,7 +47,7 @@ static int prv_gatt_read_event_cb(uint16_t conn_handle, const struct ble_gatt_er
 
 BTErrno bt_driver_gatt_write_without_response(GAPLEConnection *connection, const uint8_t *value,
                                               size_t value_length, uint16_t att_handle) {
-  PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG_VERBOSE, "bt_driver_gatt_write_without_response: %d",
+  PBL_LOG_D_VERBOSE(LOG_DOMAIN_BT, "bt_driver_gatt_write_without_response: %d",
             att_handle);
   uint16_t conn_handle;
   if (!pebble_device_to_nimble_conn_handle(&connection->device, &conn_handle)) {
@@ -56,7 +56,7 @@ BTErrno bt_driver_gatt_write_without_response(GAPLEConnection *connection, const
 
   int rc = ble_gattc_write_no_rsp_flat(conn_handle, att_handle, value, value_length);
   if (rc != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR, "Failed to write without response: %d", rc);
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Failed to write without response: %d", rc);
     return BTErrnoInternalErrorBegin + rc;
   }
 
@@ -65,7 +65,7 @@ BTErrno bt_driver_gatt_write_without_response(GAPLEConnection *connection, const
 
 BTErrno bt_driver_gatt_write(GAPLEConnection *connection, const uint8_t *value, size_t value_length,
                              uint16_t att_handle, void *context) {
-  PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG_VERBOSE, "bt_driver_gatt_write: %d", att_handle);
+  PBL_LOG_D_VERBOSE(LOG_DOMAIN_BT, "bt_driver_gatt_write: %d", att_handle);
   uint16_t conn_handle;
   if (!pebble_device_to_nimble_conn_handle(&connection->device, &conn_handle)) {
     return BTErrnoInvalidState;
@@ -74,7 +74,7 @@ BTErrno bt_driver_gatt_write(GAPLEConnection *connection, const uint8_t *value, 
   int rc = ble_gattc_write_flat(conn_handle, att_handle, value, value_length,
                                 prv_gatt_write_event_cb, context);
   if (rc != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR, "Failed to write: %d", rc);
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Failed to write: %d", rc);
     return BTErrnoInternalErrorBegin + rc;
   }
 
@@ -82,7 +82,7 @@ BTErrno bt_driver_gatt_write(GAPLEConnection *connection, const uint8_t *value, 
 }
 
 BTErrno bt_driver_gatt_read(GAPLEConnection *connection, uint16_t att_handle, void *context) {
-  PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG_VERBOSE, "bt_driver_gatt_read: %d", att_handle);
+  PBL_LOG_D_VERBOSE(LOG_DOMAIN_BT, "bt_driver_gatt_read: %d", att_handle);
   uint16_t conn_handle;
   if (!pebble_device_to_nimble_conn_handle(&connection->device, &conn_handle)) {
     return BTErrnoInvalidState;
@@ -90,7 +90,7 @@ BTErrno bt_driver_gatt_read(GAPLEConnection *connection, uint16_t att_handle, vo
 
   int rc = ble_gattc_read(conn_handle, att_handle, prv_gatt_read_event_cb, context);
   if (rc != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR, "Failed to read: %d", rc);
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Failed to read: %d", rc);
     return BTErrnoInternalErrorBegin + rc;
   }
 

--- a/src/bluetooth-fw/nimble/init.c
+++ b/src/bluetooth-fw/nimble/init.c
@@ -38,16 +38,16 @@ static DisInfo s_dis_info;
 static struct ble_hs_stop_listener s_listener;
 
 static void prv_sync_cb(void) {
-  PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG, "NimBLE host synchronized");
+  PBL_LOG_D_DBG(LOG_DOMAIN_BT, "NimBLE host synchronized");
   xSemaphoreGive(s_host_started);
 }
 
 static void prv_reset_cb(int reason) {
-  PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_WARNING, "NimBLE reset (reason: %d)", reason);
+  PBL_LOG_D_WRN(LOG_DOMAIN_BT, "NimBLE reset (reason: %d)", reason);
 }
 
 static void prv_host_task_main(void *unused) {
-  PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG, "NimBLE host task started");
+  PBL_LOG_D_DBG(LOG_DOMAIN_BT, "NimBLE host task started");
 
   ble_hs_cfg.sync_cb = prv_sync_cb;
   ble_hs_cfg.reset_cb = prv_reset_cb;
@@ -118,13 +118,13 @@ bool bt_driver_start(BTDriverConfig *config) {
   ble_hs_sched_start();
   f_rc = xSemaphoreTake(s_host_started, milliseconds_to_ticks(s_bt_stack_start_stop_timeout_ms));
   if (f_rc != pdTRUE) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR, "Host synchronization timed out");
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Host synchronization timed out");
     return false;
   }
 
   rc = ble_hs_util_ensure_addr(0);
   if (rc != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR, "Failed to ensure address: 0x%04x", (uint16_t)rc);
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Failed to ensure address: 0x%04x", (uint16_t)rc);
     return false;
   }
 

--- a/src/bluetooth-fw/nimble/nimble_store.c
+++ b/src/bluetooth-fw/nimble/nimble_store.c
@@ -205,14 +205,14 @@ static void prv_notify_host_bonding_changed(const int obj_type,
   if (bonding.pairing_info.is_remote_encryption_info_valid) {
     bt_driver_cb_handle_create_bonding(&bonding, &addr);
   } else {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG, "Skipping notifying OS of our keys");
+    PBL_LOG_D_DBG(LOG_DOMAIN_BT, "Skipping notifying OS of our keys");
   }
 }
 
 static int prv_nimble_store_write_sec(const int obj_type,
                                       const struct ble_store_value_sec *value_sec) {
   if (value_sec->key_size != KEY_SIZE || value_sec->csrk_present) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR, "Unsupported security parameters");
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Unsupported security parameters");
     return BLE_HS_ENOTSUP;
   }
 
@@ -424,7 +424,7 @@ static int prv_nimble_store_gen_key(uint8_t key, struct ble_store_gen_key *gen_k
 
     ret = ble_hs_hci_rand(stored_keys, sizeof(stored_keys));
     if (ret != 0) {
-      PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR, "Could not generate root keys: %d", ret);
+      PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Could not generate root keys: %d", ret);
       return ret;
     }
 

--- a/src/bluetooth-fw/nimble/nimble_type_conversions.c
+++ b/src/bluetooth-fw/nimble/nimble_type_conversions.c
@@ -30,8 +30,7 @@ bool pebble_device_to_nimble_conn_handle(const BTDeviceInternal *device, uint16_
 
   int rc = ble_gap_conn_find_by_addr(&addr, &desc);
   if (rc != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR,
-      "failed to find connection handle for addr" BT_DEVICE_ADDRESS_FMT,
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "failed to find connection handle for addr" BT_DEVICE_ADDRESS_FMT,
       BT_DEVICE_ADDRESS_XPLODE(device->address));
   } else {
     *handle = desc.conn_handle;

--- a/src/bluetooth-fw/nimble/pairing_confirm.c
+++ b/src/bluetooth-fw/nimble/pairing_confirm.c
@@ -15,5 +15,5 @@ void bt_driver_pairing_confirm(const PairingUserConfirmationCtx *ctx, bool is_co
   };
   int rc = ble_sm_inject_io(conn_handle, &key);
 
-  PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG, "ble_sm_inject_io rc=0x%04x", (uint16_t)rc);
+  PBL_LOG_D_DBG(LOG_DOMAIN_BT, "ble_sm_inject_io rc=0x%04x", (uint16_t)rc);
 }

--- a/src/bluetooth-fw/nimble/pebble_pairing_service.c
+++ b/src/bluetooth-fw/nimble/pebble_pairing_service.c
@@ -20,9 +20,8 @@ static int pebble_pairing_service_get_connectivity_status(
   struct ble_gap_conn_desc desc;
   int rc = ble_gap_conn_find(conn_handle, &desc);
   if (rc != 0) {
-    PBL_LOG_D(
-        LOG_DOMAIN_BT, LOG_LEVEL_ERROR,
-        "Failed to find connection descriptor for %d when reading connection status, code: %d",
+    PBL_LOG_D_ERR(
+        LOG_DOMAIN_BT, "Failed to find connection descriptor for %d when reading connection status, code: %d",
         conn_handle, rc);
     return -1;
   }
@@ -41,16 +40,14 @@ int pebble_pairing_service_get_connectivity_send_notification(uint16_t conn_hand
   PebblePairingServiceConnectivityStatus status;
   int rc = pebble_pairing_service_get_connectivity_status(conn_handle, &status);
   if (rc != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR,
-              "pebble_pairing_service_get_connectivity_status failed: %d", rc);
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "pebble_pairing_service_get_connectivity_status failed: %d", rc);
     return rc;
   }
 
   struct os_mbuf *om = ble_hs_mbuf_from_flat(&status, sizeof(status));
   rc = ble_gatts_notify_custom(conn_handle, attr_handle, om);
   if (rc != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR,
-              "ble_gatts_notify_custom failed for attr %d: 0x%04x", attr_handle, (uint16_t)rc);
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "ble_gatts_notify_custom failed for attr %d: 0x%04x", attr_handle, (uint16_t)rc);
     return rc;
   }
 
@@ -64,7 +61,7 @@ static int prv_access_connection_status(uint16_t conn_handle, uint16_t attr_hand
   PebblePairingServiceConnectivityStatus status;
   int rc = pebble_pairing_service_get_connectivity_status(conn_handle, &status);
   if (rc != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR, "prv_access_connection_status failed: %d", rc);
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_access_connection_status failed: %d", rc);
     return 0;
   }
 
@@ -95,7 +92,7 @@ static int prv_access_trigger_pairing(uint16_t conn_handle, uint16_t attr_handle
       return rc;
     }
 
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_INFO, "Trigger pairing flags 0x%x", flags);
+    PBL_LOG_D_INFO(LOG_DOMAIN_BT, "Trigger pairing flags 0x%x", flags);
 
     if ((((flags & TRIGGER_PAIRING_NO_SEC_REQ) == 0U) && !desc.sec_state.encrypted) ||
         ((flags & TRIGGER_PAIRING_FORCE_SEC_REQ) != 0U)) {
@@ -153,16 +150,14 @@ void prv_notify_chr_updated(const GAPLEConnection *connection, const ble_uuid_t 
   uint16_t conn_handle;
 
   if (!pebble_device_to_nimble_conn_handle(&connection->device, &conn_handle)) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR,
-              "prv_notify_chr_updated: failed to find connection handle");
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_notify_chr_updated: failed to find connection handle");
     return;
   }
 
   uint16_t attr_handle;
   rc = ble_gatts_find_chr(pebble_pairing_svc[0].uuid, chr_uuid, NULL, &attr_handle);
   if (rc != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_ERROR,
-              "prv_notify_chr_updated: failed to find characteristic handle");
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_notify_chr_updated: failed to find characteristic handle");
     return;
   }
   pebble_pairing_service_get_connectivity_send_notification(conn_handle, attr_handle);

--- a/src/bluetooth-fw/nimble/responsiveness.c
+++ b/src/bluetooth-fw/nimble/responsiveness.c
@@ -17,21 +17,20 @@ bool bt_driver_le_connection_parameter_update(const BTDeviceInternal *addr,
 
   rc = ble_gap_conn_find_by_addr(&nimble_addr, &desc);
   if (rc != 0) {
-    PBL_LOG(LOG_LEVEL_ERROR, "ble_gap_conn_find_by_addr failed: %d", rc);
+    PBL_LOG_ERR("ble_gap_conn_find_by_addr failed: %d", rc);
     return false;
   }
 
   pebble_conn_update_to_nimble(req, &params);
 
-  PBL_LOG(LOG_LEVEL_DEBUG,
-          "Request connection parameters: "
+  PBL_LOG_DBG("Request connection parameters: "
           "interval=(%u, %u) ms, latency=%u, spvn timeout=%u ms",
           params.itvl_min * BLE_HCI_CONN_ITVL / 1000, params.itvl_max * BLE_HCI_CONN_ITVL / 1000,
           params.latency, params.supervision_timeout * BLE_HCI_CONN_SPVN_TMO_UNITS);
 
   rc = ble_gap_update_params(desc.conn_handle, &params);
   if (rc != 0) {
-    PBL_LOG(LOG_LEVEL_ERROR, "ble_gap_update_params failed: 0x%04x", (uint16_t)rc);
+    PBL_LOG_ERR("ble_gap_update_params failed: 0x%04x", (uint16_t)rc);
     return false;
   }
 

--- a/src/bluetooth-fw/nimble/wscript
+++ b/src/bluetooth-fw/nimble/wscript
@@ -12,7 +12,6 @@ def build(bld):
     bld.objects(
         source=driver_source,
         target='bt_driver',
-        defines=['FILE_LOG_COLOR=LOG_COLOR_BLUE'],
         use=[
           'nimble',
           'freertos',

--- a/src/bluetooth-fw/qemu/qemu_transport.c
+++ b/src/bluetooth-fw/qemu/qemu_transport.c
@@ -60,7 +60,7 @@ static void prv_send_next(Transport *transport) {
 // -----------------------------------------------------------------------------------------
 // bt_lock() is held by caller
 static void prv_reset(Transport *transport) {
-  PBL_LOG(LOG_LEVEL_INFO, "Unimplemented");
+  PBL_LOG_INFO("Unimplemented");
 }
 
 static void prv_granted_kernel_main_cb(void *ctx) {
@@ -71,7 +71,7 @@ static void prv_granted_kernel_main_cb(void *ctx) {
 static void prv_set_connection_responsiveness(
     Transport *transport, BtConsumer consumer, ResponseTimeState state, uint16_t max_period_secs,
     ResponsivenessGrantedHandler granted_handler) {
-  PBL_LOG(LOG_LEVEL_INFO, "Consumer %d: requesting change to %d for %" PRIu16 "seconds",
+  PBL_LOG_INFO("Consumer %d: requesting change to %d for %" PRIu16 "seconds",
           consumer, state, max_period_secs);
 
   // it's qemu, our request to bump the speed is always granted!
@@ -119,12 +119,12 @@ void qemu_transport_set_connected(bool is_connected) {
   bool send_event = true;
 
   if (is_connected && !s_transport.session) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Opening new QemuTransport CommSession");
+    PBL_LOG_DBG("Opening new QemuTransport CommSession");
     s_transport.session = comm_session_open((Transport *) &s_transport,
                                             &s_qemu_transport_implementation,
                                             TransportDestinationHybrid);
     if (!s_transport.session) {
-      PBL_LOG(LOG_LEVEL_ERROR, "CommSession couldn't be opened");
+      PBL_LOG_ERR("CommSession couldn't be opened");
       send_event = false;
     }
 
@@ -152,7 +152,7 @@ void qemu_transport_set_connected(bool is_connected) {
   }
 
   if (s_emulated_session_connected != is_connected) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Toggling emulated session connection state --> %s", is_connected ? "connecting" : "disconnecting");
+    PBL_LOG_DBG("Toggling emulated session connection state --> %s", is_connected ? "connecting" : "disconnecting");
 
     // Only send PEBBLE_COMM_SESSION_EVENT without opening or terminating a session
     // Apps will get notified in both case but the rest of the firmware will still
@@ -197,7 +197,7 @@ bool qemu_transport_is_connected(void) {
 void qemu_transport_handle_received_data(const uint8_t *data, uint32_t length) {
   bt_lock();
   if (!s_transport.session) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Received QEMU serial data, but session not connected!");
+    PBL_LOG_ERR("Received QEMU serial data, but session not connected!");
     goto unlock;
   }
   comm_session_receive_router_write(s_transport.session, data, length);

--- a/src/bluetooth-fw/qemu/wscript
+++ b/src/bluetooth-fw/qemu/wscript
@@ -9,7 +9,6 @@ def build(bld):
     sources = bld.path.ant_glob('**/*.c')
     bld.stlib(source=sources,
               target='bt_driver',
-              defines=['FILE_LOG_COLOR=LOG_COLOR_BLUE'],
               use=[
                 'fw_includes',
                 'freertos',

--- a/src/bluetooth-fw/stub/wscript
+++ b/src/bluetooth-fw/stub/wscript
@@ -9,7 +9,6 @@ def build(bld):
     sources = bld.path.ant_glob('**/*.c')
     bld.stlib(source=sources,
               target='bt_driver',
-              defines=['FILE_LOG_COLOR=LOG_COLOR_BLUE'],
               use=[
                 'fw_includes',
                 'freertos',

--- a/src/fw/applib/accel_service.c
+++ b/src/fw/applib/accel_service.c
@@ -145,7 +145,7 @@ static void prv_do_data_handle(void *context) {
 
   if (state->manager_state == NULL) {
     if (state->deferred_free) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Deferred free");
+      PBL_LOG_DBG("Deferred free");
       kernel_free(state);
     }
     // event queue is handled kernel-side, so an event may fire after we've unsubscribed

--- a/src/fw/applib/app.c
+++ b/src/fw/applib/app.c
@@ -72,7 +72,7 @@ static NOINLINE void event_loop_upkeep(void) {
   // Check to see if the most recent event caused us to pop our final window. If that's the case, we need to
   // kill ourselves.
   if (app_window_stack_count() == 0) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "No more windows, killing current app");
+    PBL_LOG_DBG("No more windows, killing current app");
 
     PebbleEvent event = { .type = PEBBLE_PROCESS_KILL_EVENT, .kill = { .gracefully = true, .task=PebbleTask_App } };
     sys_send_pebble_event_to_kernel(&event);

--- a/src/fw/applib/app_inbox.c
+++ b/src/fw/applib/app_inbox.c
@@ -24,7 +24,7 @@ AppInbox *app_inbox_create_and_register(size_t buffer_size, uint32_t min_num_mes
   buffer_size += (min_num_messages * sizeof(AppInboxMessageHeader));
   uint8_t *buffer = applib_zalloc(buffer_size);
   if (!buffer) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Not enough memory to allocate App Inbox of size %"PRIu32,
+    PBL_LOG_ERR("Not enough memory to allocate App Inbox of size %"PRIu32,
             (uint32_t)buffer_size);
     return NULL;
   }

--- a/src/fw/applib/app_message/app_message.c
+++ b/src/fw/applib/app_message/app_message.c
@@ -20,7 +20,7 @@ void app_message_init(void) {
 
 static bool prv_has_invalid_header_length(size_t length) {
   if (length < sizeof(AppMessageHeader)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Too short");
+    PBL_LOG_ERR("Too short");
     return true;
   }
   return false;
@@ -56,7 +56,7 @@ void app_message_app_protocol_msg_callback(CommSession *session,
       return;
 
     default:
-      PBL_LOG(LOG_LEVEL_ERROR, "Unknown Cmd 0x%x", message->command);
+      PBL_LOG_ERR("Unknown Cmd 0x%x", message->command);
       return;
   }
 }

--- a/src/fw/applib/app_message/app_message_inbox.c
+++ b/src/fw/applib/app_message/app_message_inbox.c
@@ -76,7 +76,7 @@ void app_message_inbox_receive(CommSession *session, AppMessagePush *push_messag
                                AppInboxConsumerInfo *consumer_info) {
   // Test if the data is long enough to contain a push message:
   if (length < sizeof(AppMessagePush)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Too short");
+    PBL_LOG_ERR("Too short");
     return;
   }
 

--- a/src/fw/applib/app_message/app_message_outbox.c
+++ b/src/fw/applib/app_message/app_message_outbox.c
@@ -155,7 +155,7 @@ AppMessageResult app_message_outbox_begin(DictionaryIterator **iterator) {
   AppMessagePhaseOut phase = outbox->phase;
   *iterator = NULL;
   if (prv_is_message_pending(phase)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Can't call app_message_outbox_begin() now, wait for sent_callback!");
+    PBL_LOG_ERR("Can't call app_message_outbox_begin() now, wait for sent_callback!");
 
     // See https://pebbletechnology.atlassian.net/browse/PBL-10146
     // Workaround for apps that sit in a while() loop waiting on app_message_outbox_begin().
@@ -164,12 +164,10 @@ AppMessageResult app_message_outbox_begin(DictionaryIterator **iterator) {
 
     return APP_MSG_BUSY;
   } else if (phase == OUT_WRITING) {
-    PBL_LOG(LOG_LEVEL_ERROR,
-            "Must call app_message_outbox_send() before calling app_message_outbox_begin() again!");
+    PBL_LOG_ERR("Must call app_message_outbox_send() before calling app_message_outbox_begin() again!");
     return APP_MSG_INVALID_STATE;
   } else if (phase == OUT_CLOSED) {
-    PBL_LOG(LOG_LEVEL_ERROR,
-            "Must call app_message_open() before calling app_message_outbox_begin()!");
+    PBL_LOG_ERR("Must call app_message_open() before calling app_message_outbox_begin()!");
     return APP_MSG_INVALID_STATE;
   }
 
@@ -200,7 +198,7 @@ void app_message_outbox_handle_app_outbox_message_sent(AppOutboxStatus status, v
   AppMessageSenderError e = (AppMessageSenderError)status;
   if (e != AppMessageSenderErrorSuccess) {
     if (e != AppMessageSenderErrorDisconnected) {
-      PBL_LOG(LOG_LEVEL_ERROR, "App message corrupted outbox? %"PRIu8, (uint8_t)e);
+      PBL_LOG_ERR("App message corrupted outbox? %"PRIu8, (uint8_t)e);
     }
 
     // Sleep a bit to prevent apps that hammer app_message_outbox_begin() when disconnected to
@@ -230,7 +228,7 @@ void app_message_outbox_handle_app_outbox_message_sent(AppOutboxStatus status, v
 AppMessageResult app_message_outbox_send(void) {
   AppMessageCtxOutbox *outbox = &app_state_get_app_message_ctx()->outbox;
   if (prv_is_message_pending(outbox->phase)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Can't call app_message_outbox_send() now, wait for sent_callback!");
+    PBL_LOG_ERR("Can't call app_message_outbox_send() now, wait for sent_callback!");
     return APP_MSG_BUSY;
   }
   if (outbox->phase != OUT_WRITING) {
@@ -271,12 +269,12 @@ void app_message_out_handle_ack_nack_received(const AppMessageHeader *header) {
   AppMessageCtxOutbox *outbox = &app_state_get_app_message_ctx()->outbox;
 
   if (!prv_is_awaiting_ack(outbox->phase)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Received (n)ack, but was not expecting one");
+    PBL_LOG_ERR("Received (n)ack, but was not expecting one");
     return;
   }
 
   if (outbox->transaction_id != header->transaction_id) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Tx ID mismatch: %"PRIu8" != %"PRIu8,
+    PBL_LOG_ERR("Tx ID mismatch: %"PRIu8" != %"PRIu8,
             outbox->transaction_id, header->transaction_id);
     return;
   }

--- a/src/fw/applib/app_message/app_message_receiver.c
+++ b/src/fw/applib/app_message/app_message_receiver.c
@@ -24,7 +24,7 @@ void app_message_receiver_dropped_handler(uint32_t num_dropped_messages) {
 bool app_message_receiver_open(size_t buffer_size) {
   AppInbox **app_message_inbox = app_state_get_app_message_inbox();
   if (*app_message_inbox) {
-    PBL_LOG(LOG_LEVEL_INFO, "App PP receiver already open, not opening again");
+    PBL_LOG_INFO("App PP receiver already open, not opening again");
     return true;
   }
 
@@ -48,7 +48,7 @@ bool app_message_receiver_open(size_t buffer_size) {
 void app_message_receiver_close(void) {
   AppInbox **inbox = app_state_get_app_message_inbox();
   if (!(*inbox)) {
-    PBL_LOG(LOG_LEVEL_INFO, "App PP receiver already closed");
+    PBL_LOG_INFO("App PP receiver already closed");
     return;
   }
 

--- a/src/fw/applib/bluetooth/ble_client.c
+++ b/src/fw/applib/bluetooth/ble_client.c
@@ -1,8 +1,6 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define FILE_LOG_COLOR LOG_COLOR_BLUE
-
 #include "ble_client.h"
 
 #include "ble_app_support.h"
@@ -174,7 +172,7 @@ static void prv_handle_characteristic_write(const PebbleBLEGATTClientEvent *e) {
 }
 
 static void prv_handle_characteristic_subscribe(const PebbleBLEGATTClientEvent *e) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "TODO: GATT Client Event, subtype=%u", e->subtype);
+  PBL_LOG_DBG("TODO: GATT Client Event, subtype=%u", e->subtype);
 }
 
 static void prv_handle_descriptor_read(const PebbleBLEGATTClientEvent *e) {

--- a/src/fw/applib/event_service_client.c
+++ b/src/fw/applib/event_service_client.c
@@ -49,7 +49,7 @@ void event_service_client_subscribe(EventServiceInfo *handler) {
   EventServiceInfo *state = prv_get_state();
   ListNode *list = &state->list_node;
   if (list_contains(list, &handler->list_node)) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Event service handler already subscribed");
+    PBL_LOG_DBG("Event service handler already subscribed");
     return;
   }
   // Add to handlers list
@@ -62,7 +62,7 @@ void event_service_client_unsubscribe(EventServiceInfo *handler) {
   EventServiceInfo *state = prv_get_state();
   ListNode *list = &state->list_node;
   if (!list_contains(list, &handler->list_node)) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Event service handler not subscribed");
+    PBL_LOG_DBG("Event service handler not subscribed");
     return;
   }
   sys_event_service_client_unsubscribe(state, handler);

--- a/src/fw/applib/fonts/fonts.c
+++ b/src/fw/applib/fonts/fonts.c
@@ -45,7 +45,7 @@ GFont fonts_get_system_font(const char *font_key) {
   }
 
   if (NULL == res) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Getting fallback font instead");
+    PBL_LOG_DBG("Getting fallback font instead");
     res = fonts_get_fallback_font();
     PBL_ASSERTN(res);
   }
@@ -56,7 +56,7 @@ GFont fonts_get_system_font(const char *font_key) {
 GFont fonts_load_custom_font(ResHandle handle) {
   GFont res = fonts_load_custom_font_system(sys_get_current_resource_num(), (uint32_t)handle);
   if (res == NULL) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Getting fallback font instead");
+    PBL_LOG_WRN("Getting fallback font instead");
     res = sys_font_get_system_font("RESOURCE_ID_GOTHIC_14");
   }
   return res;
@@ -64,13 +64,13 @@ GFont fonts_load_custom_font(ResHandle handle) {
 
 GFont fonts_load_custom_font_system(ResAppNum app_num, uint32_t resource_id) {
   if (resource_id == 0) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Tried to load a font from a NULL resource");
+    PBL_LOG_ERR("Tried to load a font from a NULL resource");
     return NULL;
   }
 
   FontInfo *font_info = applib_type_malloc(FontInfo);
   if (font_info == NULL) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Couldn't malloc space for new font");
+    PBL_LOG_ERR("Couldn't malloc space for new font");
     return NULL;
   }
 

--- a/src/fw/applib/graphics/1_bit/bitblt_private.c
+++ b/src/fw/applib/graphics/1_bit/bitblt_private.c
@@ -134,8 +134,7 @@ void bitblt_bitmap_into_bitmap_tiled_palette_to_1bit(GBitmap* dest_bitmap,
             *dest_block = (*dest_block & ~mask) | (look_up.palette_pattern[cindex] & mask);
             break;
           default:
-            PBL_LOG(LOG_LEVEL_DEBUG,
-                    "Only the assign, set and tint modes are allowed for palettized bitmaps");
+            PBL_LOG_DBG("Only the assign, set and tint modes are allowed for palettized bitmaps");
             return;
         }
         dest_x++;

--- a/src/fw/applib/graphics/8_bit/bitblt_private.c
+++ b/src/fw/applib/graphics/8_bit/bitblt_private.c
@@ -119,7 +119,7 @@ void bitblt_bitmap_into_bitmap_tiled_palette_to_8bit(GBitmap* dest_bitmap,
           break;
         }
         default:
-          PBL_LOG(LOG_LEVEL_DEBUG, "OP: %d NYI", (int)compositing_mode);
+          PBL_LOG_DBG("OP: %d NYI", (int)compositing_mode);
           return;
       }
     }
@@ -453,7 +453,7 @@ void bitblt_bitmap_into_bitmap_tiled(GBitmap* dest_bitmap, const GBitmap* src_bi
           break;
       }
     } else {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Only blitting to 8-bit supported.");
+      PBL_LOG_DBG("Only blitting to 8-bit supported.");
     }
   }
 }

--- a/src/fw/applib/graphics/gbitmap.c
+++ b/src/fw/applib/graphics/gbitmap.c
@@ -433,9 +433,9 @@ static bool prv_init_with_pbi_data(GBitmap *bitmap, uint8_t *data, size_t data_s
 
   if (data_size != required_total_size_bytes ||
       required_row_size_bytes > bitmap->row_size_bytes) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Bitmap metadata is inconsistent! data_size %u",
+    PBL_LOG_WRN("Bitmap metadata is inconsistent! data_size %u",
             (unsigned int) data_size);
-    PBL_LOG(LOG_LEVEL_WARNING, "format %u row_size_bytes %"PRIu16" width %"PRId16" height %"PRId16,
+    PBL_LOG_WRN("format %u row_size_bytes %"PRIu16" width %"PRId16" height %"PRId16,
             format, bitmap->row_size_bytes, bitmap->bounds.size.w, bitmap->bounds.size.h);
     return false;
   }

--- a/src/fw/applib/graphics/text_layout.c
+++ b/src/fw/applib/graphics/text_layout.c
@@ -1326,7 +1326,7 @@ static void prv_graphics_text_layout_update(GContext* ctx, const char* text, GFo
   const Utf8Bounds utf8_bounds = utf8_get_bounds(&success, text);
   if (!success) {
     layout->max_used_size = GSizeZero;
-    PBL_LOG(LOG_LEVEL_DEBUG, "Invalid UTF8");
+    PBL_LOG_DBG("Invalid UTF8");
     return;
   }
 
@@ -1418,7 +1418,7 @@ void graphics_draw_text(GContext* ctx, const char* text, GFont const font,
   bool success = false;
   const Utf8Bounds utf8_bounds = utf8_get_bounds(&success, text);
   if (!success) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Invalid UTF8");
+    PBL_LOG_DBG("Invalid UTF8");
     return;
   }
 

--- a/src/fw/applib/graphics/text_resources.c
+++ b/src/fw/applib/graphics/text_resources.c
@@ -94,8 +94,7 @@ static int prv_load_offset_table(Codepoint codepoint, FontCache *font_cache,
     FontHashTableEntry table_entry;
     Codepoint hash_entry_offset = s_font_md_size[version] + table_id * sizeof(FontHashTableEntry);
     // find which bucket the codepoint was put into TODO: cache hash table?
-    PBL_LOG_D(LOG_DOMAIN_TEXT, LOG_LEVEL_DEBUG,
-              "HTE read: table_id:%d, cp:%"PRIx32", offset:%"PRIx32,
+    PBL_LOG_D_DBG(LOG_DOMAIN_TEXT, "HTE read: table_id:%d, cp:%"PRIx32", offset:%"PRIx32,
               table_id, codepoint, hash_entry_offset);
 
     SYS_PROFILER_NODE_START(text_render_flash);
@@ -111,7 +110,7 @@ static int prv_load_offset_table(Codepoint codepoint, FontCache *font_cache,
     PBL_ASSERTN(num_bytes <= sizeof(font_cache->offsets_buffer_4_4));
   }
 
-  PBL_LOG_D(LOG_DOMAIN_TEXT, LOG_LEVEL_DEBUG, "HT read: offset: %zx, bytes: %zu", offset,
+  PBL_LOG_D_DBG(LOG_DOMAIN_TEXT, "HT read: offset: %zx, bytes: %zu", offset,
             num_bytes);
   SYS_PROFILER_NODE_START(text_render_flash);
   sys_resource_load_range(font_res->app_num, font_res->resource_id, offset,
@@ -320,8 +319,7 @@ static bool prv_load_glyph_bitmap(Codepoint codepoint, const FontResource *font_
 
   if (glyph_size_bytes) {
     uint8_t *target;
-    PBL_LOG_D(LOG_DOMAIN_TEXT, LOG_LEVEL_DEBUG,
-              "GD read: cp: %"PRIx32", res_bank: %"PRIu32", res_id: %"PRIu32", "
+    PBL_LOG_D_DBG(LOG_DOMAIN_TEXT, "GD read: cp: %"PRIx32", res_bank: %"PRIu32", res_id: %"PRIu32", "
               "offset: %"PRIx32", bytes: %zu",
               codepoint, font_res->app_num, font_res->resource_id, bitmap_addr, glyph_size_bytes);
     if (HAS_FEATURE(font_res->md.version, VERSION_FIELD_FEATURE_RLE4)) {
@@ -335,8 +333,7 @@ static bool prv_load_glyph_bitmap(Codepoint codepoint, const FontResource *font_
                                                       bitmap_addr, target, glyph_size_bytes);
     SYS_PROFILER_NODE_STOP(text_render_flash);
     if (glyph_size_bytes && !num_bytes_loaded) {
-      PBL_LOG(LOG_LEVEL_WARNING,
-              "Failed to load glyph bitmap from resources; cp: %"PRIx32", addr: %"PRIx32,
+      PBL_LOG_WRN("Failed to load glyph bitmap from resources; cp: %"PRIx32", addr: %"PRIx32,
               codepoint, bitmap_addr);
       return false;
     }
@@ -367,7 +364,7 @@ static const GlyphData *prv_get_glyph_metadata_from_spi(Codepoint codepoint,
     cached = (LineCacheData *)(font_cache->glyph_buffer);
   }
 #endif
-  PBL_LOG_D(LOG_DOMAIN_TEXT, LOG_LEVEL_DEBUG, "looking up cp: %"PRIx32", key:%"PRIx32,
+  PBL_LOG_D_DBG(LOG_DOMAIN_TEXT, "looking up cp: %"PRIx32", key:%"PRIx32,
             codepoint, cache_key);
 
   // If the glyph_buffer doesn't match this glyph, or we have bitmap caching, check the
@@ -408,7 +405,7 @@ static const GlyphData *prv_get_glyph_metadata_from_spi(Codepoint codepoint,
   GlyphData *g = &data->glyph_data;
 
   if (data->resource_offset == 0) {
-    PBL_LOG_D(LOG_DOMAIN_TEXT, LOG_LEVEL_DEBUG, "offset for cp: %"PRIx32" is NULL", codepoint);
+    PBL_LOG_D_DBG(LOG_DOMAIN_TEXT, "offset for cp: %"PRIx32" is NULL", codepoint);
     // Put the missing character into our cache so we don't waste time looking for it again
     keyed_circular_cache_push(&font_cache->line_cache, cache_key, data);
     return NULL;
@@ -417,7 +414,7 @@ static const GlyphData *prv_get_glyph_metadata_from_spi(Codepoint codepoint,
   size_t num_bytes_loaded;
   if (FONT_VERSION(font_res->md.version) == FONT_VERSION_1) {
     GlyphHeaderDataV1 header;
-    PBL_LOG_D(LOG_DOMAIN_TEXT, LOG_LEVEL_DEBUG, "LGMD READ: offset: %"PRIx32", bytes: %zu",
+    PBL_LOG_D_DBG(LOG_DOMAIN_TEXT, "LGMD READ: offset: %"PRIx32", bytes: %zu",
               data->resource_offset, sizeof(header));
     SYS_PROFILER_NODE_START(text_render_flash);
     num_bytes_loaded = sys_resource_load_range(font_res->app_num, font_res->resource_id,
@@ -429,8 +426,7 @@ static const GlyphData *prv_get_glyph_metadata_from_spi(Codepoint codepoint,
     memcpy(&g->header, &header, sizeof(GlyphHeaderData));
     g->header.horiz_advance = header.horiz_advance;
   } else {
-    PBL_LOG_D(LOG_DOMAIN_TEXT, LOG_LEVEL_DEBUG,
-              "GMD read: cp: %"PRIx32", offset: %"PRId32", bytes: %zu", codepoint,
+    PBL_LOG_D_DBG(LOG_DOMAIN_TEXT, "GMD read: cp: %"PRIx32", offset: %"PRId32", bytes: %zu", codepoint,
               data->resource_offset, sizeof(GlyphHeaderData));
     SYS_PROFILER_NODE_START(text_render_flash);
     num_bytes_loaded = sys_resource_load_range(font_res->app_num, font_res->resource_id,
@@ -440,8 +436,7 @@ static const GlyphData *prv_get_glyph_metadata_from_spi(Codepoint codepoint,
   }
 
   if (!num_bytes_loaded) {
-    PBL_LOG(LOG_LEVEL_WARNING,
-            "Failed to load glyph metadata from resources; cp: %"PRIx32", offset: %"PRIx32,
+    PBL_LOG_WRN("Failed to load glyph metadata from resources; cp: %"PRIx32", offset: %"PRIx32,
             codepoint, data->resource_offset);
     return NULL;
   }
@@ -493,7 +488,7 @@ static bool prv_load_font_res(ResAppNum app_num, uint32_t resource_id, FontResou
   if (resource_id != RESOURCE_ID_FONT_FALLBACK_INTERNAL &&
       !sys_resource_is_valid(app_num, resource_id)) {
     if (!is_extended) {
-      PBL_LOG(LOG_LEVEL_WARNING, "Invalid text resource id %"PRId32, resource_id);
+      PBL_LOG_WRN("Invalid text resource id %"PRId32, resource_id);
     }
     return false;
   }
@@ -502,7 +497,7 @@ static bool prv_load_font_res(ResAppNum app_num, uint32_t resource_id, FontResou
     return false;
   }
 
-  PBL_LOG_D(LOG_DOMAIN_TEXT, LOG_LEVEL_DEBUG, "FMD read: bytes:%d", (int)sizeof(FontMetaDataV3));
+  PBL_LOG_D_DBG(LOG_DOMAIN_TEXT, "FMD read: bytes:%d", (int)sizeof(FontMetaDataV3));
 
   FontMetaDataV3 header;
   SYS_PROFILER_NODE_START(text_render_flash);
@@ -510,7 +505,7 @@ static bool prv_load_font_res(ResAppNum app_num, uint32_t resource_id, FontResou
                                                 (uint8_t*)&header, sizeof(FontMetaDataV3));
   SYS_PROFILER_NODE_STOP(text_render_flash);
   if (bytes_read != sizeof(FontMetaDataV3)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Tried to load resource too small to have metadata for res %"PRId32,
+    PBL_LOG_ERR("Tried to load resource too small to have metadata for res %"PRId32,
         resource_id);
     return false;
   }
@@ -540,7 +535,7 @@ static bool prv_load_font_res(ResAppNum app_num, uint32_t resource_id, FontResou
       }
       break;
     default:
-      PBL_LOG(LOG_LEVEL_ERROR, "Unknown font resource version %"PRIu8, header.version);
+      PBL_LOG_ERR("Unknown font resource version %"PRIu8, header.version);
       return false;
   }
 
@@ -621,7 +616,7 @@ static const GlyphData *prv_get_glyph(FontCache *font_cache, Codepoint codepoint
       return data;
     }
   }
-  PBL_LOG(LOG_LEVEL_WARNING, "failed to load glyph or wildcard");
+  PBL_LOG_WRN("failed to load glyph or wildcard");
   return NULL;
 }
 

--- a/src/fw/applib/graphics/utf8.c
+++ b/src/fw/applib/graphics/utf8.c
@@ -74,12 +74,12 @@ void utf8_print_code_points(utf8_t *s) {
 
   for (; *s; ++s) {
     if (!utf8_decode(&state, &codepoint, *s)) {
-      PBL_LOG(LOG_LEVEL_ALWAYS, "U+%04"PRIX32, codepoint);
+      PBL_LOG_ALWAYS("U+%04"PRIX32, codepoint);
     }
   }
 
   if (state != VALID_UTF8) {
-    PBL_LOG(LOG_LEVEL_ALWAYS, "String is not well-formed");
+    PBL_LOG_ALWAYS("String is not well-formed");
   }
 }
 

--- a/src/fw/applib/health_service.c
+++ b/src/fw/applib/health_service.c
@@ -207,7 +207,7 @@ static bool prv_get_metric_daily_history(HealthServiceState *state, HealthMetric
   // Read in the metric history
   if (!sys_activity_get_metric(prv_get_activity_metric(metric),
                                ARRAY_LENGTH(daily->totals), daily->totals)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Error fetching metric data");
+    PBL_LOG_ERR("Error fetching metric data");
     return false;
   }
 
@@ -674,14 +674,14 @@ static HealthValue prv_compute_aggregate_using_minute_history(
   bool more_data = true;
   while (more_data && (time_start < time_end)) {
     uint32_t num_records = ARRAY_LENGTH(state->cache->minute_data);
-    PBL_LOG(LOG_LEVEL_DEBUG, "Fetching %"PRIu32" minute records for %d to %d...", num_records,
+    PBL_LOG_DBG("Fetching %"PRIu32" minute records for %d to %d...", num_records,
             (int)time_start, (int)time_end);
     bool success = sys_activity_get_minute_history(minute_data, &num_records, &time_start);
     if (!success) {
       APP_LOG(APP_LOG_LEVEL_WARNING, "Error fetching minute history");
       break;
     }
-    PBL_LOG(LOG_LEVEL_DEBUG, "   Got %"PRIu32" minute records for %d", num_records,
+    PBL_LOG_DBG("   Got %"PRIu32" minute records for %d", num_records,
             (int)time_start);
     if (num_records == 0) {
       // No more data available
@@ -1263,7 +1263,7 @@ bool health_service_set_heart_rate_sample_period(uint16_t interval_sec) {
   HRMSessionRef hrm_session = sys_hrm_manager_app_subscribe(app_id, interval_sec, 0 /*expire_sec*/,
                                                             HRMFeature_BPM);
   if (hrm_session == HRM_INVALID_SESSION_REF) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Error subscribing");
+    PBL_LOG_ERR("Error subscribing");
     return false;
   }
 

--- a/src/fw/applib/legacy2/ui/text_layer_legacy2.c
+++ b/src/fw/applib/legacy2/ui/text_layer_legacy2.c
@@ -178,7 +178,7 @@ void text_layer_legacy2_set_should_cache_layout(TextLayerLegacy2 *text_layer,
   text_layer->should_cache_layout = should_cache_layout;
 
   if (text_layer->should_cache_layout) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Init layout");
+    PBL_LOG_DBG("Init layout");
     graphics_text_layout_cache_init(&text_layer->layout_cache);
   } else {
     graphics_text_layout_cache_deinit(&text_layer->layout_cache);

--- a/src/fw/applib/plugin_service.c
+++ b/src/fw/applib/plugin_service.c
@@ -73,14 +73,14 @@ bool plugin_service_subscribe(Uuid *uuid, PluginServiceHandler handler) {
 
   ListNode *list = &state->subscribed_services;
   if (list_find(list, prv_service_filter, (void*)(uintptr_t)service_index)) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Plug service handler already subscribed");
+    PBL_LOG_DBG("Plug service handler already subscribed");
     return false;
   }
 
   // Add to handlers list
   PluginServiceEntry *entry = applib_type_zalloc(PluginServiceEntry);
   if (!entry) {
-    PBL_LOG(LOG_LEVEL_ERROR, "OOM in plugin_service_subscribe");
+    PBL_LOG_ERR("OOM in plugin_service_subscribe");
     return false;
   }
   entry->service_index = service_index;
@@ -106,7 +106,7 @@ bool plugin_service_unsubscribe(Uuid *uuid) {
   ListNode *list = &state->subscribed_services;
   found = list_find(list, prv_service_filter, (void*)(uintptr_t)service_index);
   if (!found) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Plug service handler already unsubscribed");
+    PBL_LOG_DBG("Plug service handler already unsubscribed");
     return true;
   }
 

--- a/src/fw/applib/rockyjs/rocky.c
+++ b/src/fw/applib/rockyjs/rocky.c
@@ -44,7 +44,7 @@ bool rocky_is_snapshot(const uint8_t *buffer, size_t buffer_size) {
   const uint8_t actual_version = buffer[offsetof(RockySnapshotHeader, version)];
   const uint8_t expected_version = ROCKY_EXPECTED_SNAPSHOT_HEADER.version;
   if (expected_version != actual_version) {
-    PBL_LOG(LOG_LEVEL_WARNING, "incompatible JS snapshot version %"PRIu8" (expected: %"PRIu8")",
+    PBL_LOG_WRN("incompatible JS snapshot version %"PRIu8" (expected: %"PRIu8")",
             actual_version, expected_version);
     return false;
   }
@@ -63,7 +63,7 @@ static bool prv_rocky_eval_buffer(const uint8_t *buffer, size_t buffer_size) {
     PBL_ASSERTN((uintptr_t)buffer % 8 == 0);
     rv = jerry_exec_snapshot(buffer, buffer_size, false);
   } else {
-    PBL_LOG(LOG_LEVEL_INFO, "Not a snapshot, interpreting buffer as JS source code");
+    PBL_LOG_INFO("Not a snapshot, interpreting buffer as JS source code");
     rv = jerry_eval((jerry_char_t *) buffer, buffer_size, false);
   }
 

--- a/src/fw/applib/ui/animation_private.h
+++ b/src/fw/applib/ui/animation_private.h
@@ -6,7 +6,7 @@
 #include "animation.h"
 
 #define ANIMATION_LOG_DEBUG(fmt, args...) \
-            PBL_LOG_D(LOG_DOMAIN_ANIMATION, LOG_LEVEL_DEBUG, fmt, ## args)
+            PBL_LOG_D_DBG(LOG_DOMAIN_ANIMATION, fmt, ## args)
 
 #define ANIMATION_MAX_CHILDREN  256
 #define ANIMATION_PLAY_COUNT_INFINITE_STORED ((uint16_t)~0)

--- a/src/fw/applib/ui/app_window_stack.c
+++ b/src/fw/applib/ui/app_window_stack.c
@@ -19,7 +19,7 @@
 #include "semphr.h"
 
 void app_window_stack_push(Window *window, bool animated) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Pushing window %p onto app window stack %p",
+  PBL_LOG_DBG("Pushing window %p onto app window stack %p",
       window, app_state_get_window_stack());
   window_stack_push(app_state_get_window_stack(), window, animated);
 }

--- a/src/fw/applib/ui/crumbs_layer.c
+++ b/src/fw/applib/ui/crumbs_layer.c
@@ -120,7 +120,7 @@ static void prv_crumbs_layer_update_proc_round(Layer *layer, GContext *ctx) {
 void crumbs_layer_set_level(CrumbsLayer *crumbs_layer, int level) {
   const int max_crumbs = prv_crumb_maximum_count();
   if (level > max_crumbs) {
-    PBL_LOG(LOG_LEVEL_WARNING, "exceeded max number of crumbs");
+    PBL_LOG_WRN("exceeded max number of crumbs");
     level = max_crumbs;
   }
   crumbs_layer->level = level;

--- a/src/fw/applib/ui/layer.c
+++ b/src/fw/applib/ui/layer.c
@@ -125,7 +125,7 @@ inline static Layer __attribute__((always_inline)) *prv_layer_tree_traverse_next
     if (*current_depth < stack_size-1) {
       return stack[++(*current_depth)] = top_of_stack->first_child;
     } else {
-      PBL_LOG(LOG_LEVEL_WARNING, "layer stack exceeded (%d). Will skip rendering.", stack_size);
+      PBL_LOG_WRN("layer stack exceeded (%d). Will skip rendering.", stack_size);
     }
   }
 
@@ -384,7 +384,7 @@ void layer_add_child(Layer *parent, Layer *child) {
     // Prevent setting the child to point to itself, causing infinite loop the next time this is
     // called
     if (sibling == child) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Layer has already been added to this parent!");
+      PBL_LOG_DBG("Layer has already been added to this parent!");
       return;
     }
 
@@ -471,7 +471,7 @@ bool layer_get_clips(const Layer *layer) {
 
 void* layer_get_data(const Layer *layer) {
   if (!layer->has_data) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Layer was not allocated with a data region.");
+    PBL_LOG_ERR("Layer was not allocated with a data region.");
     return NULL;
   }
   return ((DataLayer *)layer)->data;

--- a/src/fw/applib/ui/menu_layer.c
+++ b/src/fw/applib/ui/menu_layer.c
@@ -1156,7 +1156,7 @@ void menu_layer_set_selected_index(MenuLayer *menu_layer, MenuIndex index, MenuR
   }
   // check to make sure this callback has been set, return early if not
   if (menu_layer->callbacks.get_num_rows == NULL) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Please set menu layer callbacks before running menu_layer_set_selected_index.");
+    PBL_LOG_ERR("Please set menu layer callbacks before running menu_layer_set_selected_index.");
     return;
   }
 

--- a/src/fw/applib/ui/rotbmp_pair_layer.c
+++ b/src/fw/applib/ui/rotbmp_pair_layer.c
@@ -13,7 +13,7 @@ static void set_compositing(RotBmpPairLayer *pair) {
 void rotbmp_pair_layer_init(RotBmpPairLayer *pair, GBitmap *white, GBitmap *black) {
   if (white->bounds.size.w != black->bounds.size.w
       && white->bounds.size.h != black->bounds.size.h) {
-    PBL_LOG(LOG_LEVEL_ERROR, "rotbmp_pair inited with unmatching bitmaps");
+    PBL_LOG_ERR("rotbmp_pair inited with unmatching bitmaps");
     return;
   }
 

--- a/src/fw/applib/ui/text_layer.c
+++ b/src/fw/applib/ui/text_layer.c
@@ -182,7 +182,7 @@ void text_layer_set_should_cache_layout(TextLayer *text_layer, bool should_cache
   text_layer->should_cache_layout = should_cache_layout;
 
   if (text_layer->should_cache_layout) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Init layout");
+    PBL_LOG_DBG("Init layout");
     graphics_text_layout_cache_init(&text_layer->layout_cache);
   } else {
     graphics_text_layout_cache_deinit(&text_layer->layout_cache);

--- a/src/fw/applib/ui/vibes.c
+++ b/src/fw/applib/ui/vibes.c
@@ -37,7 +37,7 @@ void vibes_cancel(void) {
 
 void vibes_enqueue_custom_pattern(VibePattern pattern) {
   if (pattern.durations == NULL) {
-    PBL_LOG(LOG_LEVEL_ERROR, "tried to enqueue a null pattern");
+    PBL_LOG_ERR("tried to enqueue a null pattern");
     return;
   }
 

--- a/src/fw/applib/ui/window.c
+++ b/src/fw/applib/ui/window.c
@@ -169,7 +169,7 @@ GRect window_calc_frame(bool fullscreen) {
 // an alternate function for initializing the window that takes a frame dimension too.
 void window_init(Window *window, const char* debug_name) {
   if (window == NULL) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Tried to init a NULL window");
+    PBL_LOG_ERR("Tried to init a NULL window");
     return;
   }
   *window = (Window){};
@@ -339,7 +339,7 @@ void window_long_click_subscribe(ButtonId button_id, uint16_t delay_ms, ClickHan
 void window_raw_click_subscribe(ButtonId button_id, ClickHandler down_handler, ClickHandler up_handler, void *context) {
   prv_check_is_in_click_config_provider(window_manager_get_top_window(), "subscribe");
   if (button_id == BUTTON_ID_BACK) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Cannot register BUTTON_ID_BACK raw handler");
+    PBL_LOG_DBG("Cannot register BUTTON_ID_BACK raw handler");
     return;
   }
   ClickManager *mgr = prv_get_current_click_manager();

--- a/src/fw/applib/ui/window_stack.c
+++ b/src/fw/applib/ui/window_stack.c
@@ -223,7 +223,7 @@ static void prv_insert_with_function(WindowStack *window_stack_to, Window *windo
     prv_transition_to(window_from, window, transition_insert);
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "(+) %s=%p <%s>", is_app_window ? "window" : "modal window",
+  PBL_LOG_DBG("(+) %s=%p <%s>", is_app_window ? "window" : "modal window",
       window, window_get_debug_name(window));
 }
 
@@ -266,7 +266,7 @@ static Window *prv_remove_item(WindowStackItem *pop_item,
   // Store the window here, as we're potentially free'ing the item later on.
   Window *pop_item_window = pop_item->window;
   bool is_app_window = window_manager_is_app_window(pop_item_window);
-  PBL_LOG(LOG_LEVEL_DEBUG, "(-) %s=%p <%s>", is_app_window ? "window" : "modal window",
+  PBL_LOG_DBG("(-) %s=%p <%s>", is_app_window ? "window" : "modal window",
       pop_item_window, window_get_debug_name(pop_item_window));
 
   // Only animate if the window was previously at the top of the stack and there's a
@@ -339,7 +339,7 @@ Window *window_stack_pop(WindowStack *window_stack, bool animated) {
 Window *window_stack_pop_with_transition(WindowStack *window_stack,
                                          const WindowTransitionImplementation *transition) {
   if (window_stack->list_head == NULL) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Nothing to pop.");
+    PBL_LOG_DBG("Nothing to pop.");
     return NULL;
   }
 
@@ -455,7 +455,7 @@ bool window_transition_context_has_legacy_window_to(WindowStack *stack, Window *
 void window_transition_context_disappear(WindowTransitioningContext *context) {
   Window *window_from = context->window_from;
   if (!window_from || window_manager_is_window_visible(window_from)) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "No windows to unload from stack.");
+    PBL_LOG_DBG("No windows to unload from stack.");
     context->window_from = NULL;
     return;
   }

--- a/src/fw/applib/voice/dictation_session.c
+++ b/src/fw/applib/voice/dictation_session.c
@@ -19,7 +19,7 @@
 static void prv_handle_transcription_result(PebbleEvent *e, void *context) {
   PBL_ASSERTN(context);
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Exiting with status code: %"PRId8, e->dictation.result);
+  PBL_LOG_DBG("Exiting with status code: %"PRId8, e->dictation.result);
   DictationSession *session = context;
 
   session->callback(session, e->dictation.result, e->dictation.text, session->context);
@@ -66,7 +66,7 @@ DictationSession *dictation_session_create(uint32_t buffer_size,
   bool from_app = (pebble_task_get_current() == PebbleTask_App) &&
                    !app_install_id_from_system(sys_process_manager_get_current_process_id());
   if (from_app && !sys_system_pp_has_capability(CommSessionVoiceApiSupport)) {
-    PBL_LOG(LOG_LEVEL_INFO, "No phone connected or phone app does not support app-initiated "
+    PBL_LOG_INFO("No phone connected or phone app does not support app-initiated "
         "dictation sessions");
     return NULL;
   }

--- a/src/fw/applib/voice/voice_window.c
+++ b/src/fw/applib/voice/voice_window.c
@@ -80,7 +80,7 @@
 
 static const uint32_t UNFOLD_DURATION = 500;
 
-#define VOICE_LOG(fmt, args...)   PBL_LOG_D(LOG_DOMAIN_VOICE, LOG_LEVEL_DEBUG, fmt, ## args)
+#define VOICE_LOG(fmt, args...)   PBL_LOG_D_DBG(LOG_DOMAIN_VOICE, fmt, ## args)
 
 static void prv_start_dictation(VoiceUiData *data);
 static void prv_stop_dictation(VoiceUiData *data);
@@ -547,7 +547,7 @@ static void prv_start_dictation(VoiceUiData *data) {
   PBL_ASSERTN(data->session_id == VOICE_SESSION_ID_INVALID);
   data->session_id = sys_voice_start_dictation(data->session_type);
   if (data->session_id == VOICE_SESSION_ID_INVALID) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Dictation session failed to start");
+    PBL_LOG_ERR("Dictation session failed to start");
     prv_exit_and_send_result_event(data, DictationSessionStatusFailureInternalError);
     return;
   }

--- a/src/fw/apps/core_apps/progress_ui_app.c
+++ b/src/fw/apps/core_apps/progress_ui_app.c
@@ -222,7 +222,7 @@ static void prv_progress_ui_window_push(void) {
 
 static void prv_main(void) {
   if (!app_manager_get_task_context()->args) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Progress UI App must be launched with args");
+    PBL_LOG_WRN("Progress UI App must be launched with args");
     return;
   }
 

--- a/src/fw/apps/demo_apps/activity_test.c
+++ b/src/fw/apps/demo_apps/activity_test.c
@@ -685,7 +685,7 @@ static void prv_test_steps(void *context) {
   steps = health_service_sum_today(HealthMetricStepCount);
   steps -= before;
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "steps: %"PRId32, steps);
+  PBL_LOG_DBG("steps: %"PRId32, steps);
   if (steps >= 27 && steps <= 33) {
     passed = true;
   }
@@ -719,7 +719,7 @@ static void prv_test_30_min_walk(void *context) {
   int32_t steps;
   steps = health_service_sum_today(HealthMetricStepCount);
   steps -= before;
-  PBL_LOG(LOG_LEVEL_DEBUG, "steps: %"PRId32, steps);
+  PBL_LOG_DBG("steps: %"PRId32, steps);
   if (steps >= ((8 * k_steps_per_minute * k_num_minutes) / 10)) {
     passed = true;
   }
@@ -745,7 +745,7 @@ static void prv_test_sleep(void *context) {
   int32_t before_total, before_deep;
   activity_get_metric(ActivityMetricSleepTotalSeconds, 1, &before_total);
   activity_get_metric(ActivityMetricSleepRestfulSeconds, 1, &before_deep);
-  PBL_LOG(LOG_LEVEL_DEBUG, "start total: %d, start deep: %d", (int)before_total, (int)before_deep);
+  PBL_LOG_DBG("start total: %d, start deep: %d", (int)before_total, (int)before_deep);
 
   // Capture steps before sleep
   int32_t steps_before;
@@ -758,7 +758,7 @@ static void prv_test_sleep(void *context) {
 
   // Capture steps before sleep
   activity_get_metric(ActivityMetricSleepState, 1, &value);
-  PBL_LOG(LOG_LEVEL_DEBUG, "sleep state: %d", (int)value);
+  PBL_LOG_DBG("sleep state: %d", (int)value);
 
   // See how many steps we took during sleep. The light sleep simulator ends up providing about
   // 12 steps every 10 minutes, so without the "no steps during sleep" logic in the activity
@@ -766,9 +766,9 @@ static void prv_test_sleep(void *context) {
   // "no steps during sleep" logic in place, we should get close to 0 steps
   int32_t steps_after;
   activity_get_metric(ActivityMetricStepCount, 1, &steps_after);
-  PBL_LOG(LOG_LEVEL_DEBUG, "steps taken during sleep:: %d", (int)(steps_after - steps_before));
+  PBL_LOG_DBG("steps taken during sleep:: %d", (int)(steps_after - steps_before));
   if (steps_after - steps_before > 16) {
-    PBL_LOG(LOG_LEVEL_ERROR, "too many steps during sleep: test FAILED");
+    PBL_LOG_ERR("too many steps during sleep: test FAILED");
     passed = false;
   }
 
@@ -782,7 +782,7 @@ static void prv_test_sleep(void *context) {
   activity_get_metric(ActivityMetricSleepRestfulSeconds, 1, &deep_sleep);
   deep_sleep -= before_deep;
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "total: %d, deep: %d", (int)total_sleep / SECONDS_PER_MINUTE,
+  PBL_LOG_DBG("total: %d, deep: %d", (int)total_sleep / SECONDS_PER_MINUTE,
           (int)deep_sleep / SECONDS_PER_MINUTE);
   const int k_min_total_sleep_min = 240;
   const int k_max_total_sleep_min = 280;
@@ -799,16 +799,16 @@ static void prv_test_sleep(void *context) {
 
   // Check other sleep metrics
   activity_get_metric(ActivityMetricSleepEnterAtSeconds, 1, &value);
-  PBL_LOG(LOG_LEVEL_DEBUG, "entry minute: %d", (int)(value / SECONDS_PER_MINUTE));
+  PBL_LOG_DBG("entry minute: %d", (int)(value / SECONDS_PER_MINUTE));
 
   activity_get_metric(ActivityMetricSleepExitAtSeconds, 1, &value);
-  PBL_LOG(LOG_LEVEL_DEBUG, "exit minute: %d", (int)(value / SECONDS_PER_MINUTE));
+  PBL_LOG_DBG("exit minute: %d", (int)(value / SECONDS_PER_MINUTE));
 
   activity_get_metric(ActivityMetricSleepState, 1, &value);
-  PBL_LOG(LOG_LEVEL_DEBUG, "sleep state: %d", (int)value);
+  PBL_LOG_DBG("sleep state: %d", (int)value);
 
   activity_get_metric(ActivityMetricSleepStateSeconds, 1, &value);
-  PBL_LOG(LOG_LEVEL_DEBUG, "sleep state minutes: %d", (int)(value / SECONDS_PER_MINUTE));
+  PBL_LOG_DBG("sleep state minutes: %d", (int)(value / SECONDS_PER_MINUTE));
 
   prv_test_end(context, passed);
 }
@@ -828,7 +828,7 @@ static void prv_test_sleep_time_change(void *context) {
 
   // Get us into sleep mode
   time_t start_sleep_time = rtc_get_time();
-  PBL_LOG(LOG_LEVEL_DEBUG, "Start sleep: %d", (int)start_sleep_time);
+  PBL_LOG_DBG("Start sleep: %d", (int)start_sleep_time);
   prv_feed_light_sleep_min(80);
   prv_feed_steps_min(2);
   prv_feed_light_sleep_min(1);
@@ -849,7 +849,7 @@ static void prv_test_sleep_time_change(void *context) {
   // Make sure we registered sleep
   int32_t value;
   activity_get_metric(ActivityMetricSleepTotalSeconds, 1, &value);
-  PBL_LOG(LOG_LEVEL_DEBUG, "sleep total: %"PRIi32" ", value);
+  PBL_LOG_DBG("sleep total: %"PRIi32" ", value);
   if (value < (60 * SECONDS_PER_MINUTE) || value > (100 * SECONDS_PER_MINUTE)) {
     passed = false;
   }
@@ -870,14 +870,14 @@ static void prv_count_sleep_sessions(time_t after_time, int *num_sleep, int *num
     return;
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Looking for sessions...");
+  PBL_LOG_DBG("Looking for sessions...");
   for (uint32_t i = 0; i < session_entries; i++) {
     ActivitySession *session = &sessions[i];
-    PBL_LOG(LOG_LEVEL_DEBUG, "  Found session type: %d, start_min: %d, length_min: %"PRIu16" ",
+    PBL_LOG_DBG("  Found session type: %d, start_min: %d, length_min: %"PRIu16" ",
             (int)session->type, time_util_get_minute_of_day(session->start_utc),
             session->length_min);
     if (session->start_utc < after_time) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "  Ignoring because too old");
+      PBL_LOG_DBG("  Ignoring because too old");
       continue;
     }
     if ((session->type == ActivitySessionType_Sleep)
@@ -889,7 +889,7 @@ static void prv_count_sleep_sessions(time_t after_time, int *num_sleep, int *num
       (*num_nap)++;
     }
   }
-  PBL_LOG(LOG_LEVEL_DEBUG, "Done looking for sessions");
+  PBL_LOG_DBG("Done looking for sessions");
 }
 
 
@@ -900,7 +900,7 @@ static void prv_test_nap(void *context) {
   activity_prefs_sleep_insights_set_enabled(true);
 
   const time_t now_utc = rtc_get_time();
-  PBL_LOG(LOG_LEVEL_DEBUG, "test start time: %d", (int)now_utc);
+  PBL_LOG_DBG("test start time: %d", (int)now_utc);
 
   const time_t midnight_utc = time_util_get_midnight_of(now_utc);
   const time_t nap_time_start = midnight_utc + (ALG_PRIMARY_MORNING_MINUTE * SECONDS_PER_MINUTE);
@@ -914,7 +914,7 @@ static void prv_test_nap(void *context) {
   }
 
   time_t test_start_utc = rtc_get_time();
-  PBL_LOG(LOG_LEVEL_DEBUG, "test start time changed to: %d", (int)test_start_utc);
+  PBL_LOG_DBG("test start time changed to: %d", (int)test_start_utc);
 
   // Reset all stored data
   activity_test_reset(false /* reset_settings */, true /*tracking_on*/, NULL, NULL);
@@ -933,9 +933,9 @@ static void prv_test_nap(void *context) {
   int nap_count = 0;
   int sleep_count = 0;
   prv_count_sleep_sessions(test_start_utc, &sleep_count, &nap_count);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Found %d sleep sessions and %d nap sessions", sleep_count, nap_count);
+  PBL_LOG_DBG("Found %d sleep sessions and %d nap sessions", sleep_count, nap_count);
   if (nap_count > 0 || sleep_count == 0) {
-    PBL_LOG(LOG_LEVEL_ERROR, "FAILED: expected only sleep but got %d naps and %d sleep", nap_count,
+    PBL_LOG_ERR("FAILED: expected only sleep but got %d naps and %d sleep", nap_count,
             sleep_count);
     prv_test_end(context, false);
     return;
@@ -946,9 +946,9 @@ static void prv_test_nap(void *context) {
 
   // We should have only nap sessions now
   prv_count_sleep_sessions(test_start_utc, &sleep_count, &nap_count);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Found %d sleep sessions and %d nap sessions", sleep_count, nap_count);
+  PBL_LOG_DBG("Found %d sleep sessions and %d nap sessions", sleep_count, nap_count);
   if (nap_count == 0 || sleep_count > 0) {
-    PBL_LOG(LOG_LEVEL_ERROR, "FAILED: expected only naps but got %d nap and %d sleep", nap_count,
+    PBL_LOG_ERR("FAILED: expected only naps but got %d nap and %d sleep", nap_count,
             sleep_count);
     prv_test_end(context, false);
     return;
@@ -1229,7 +1229,7 @@ static TestEntry s_test_entries[] = {
 static void prv_test_begin(int index, void *context) {
   ActivityTestAppData *data = (ActivityTestAppData *)context;
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Running test: '%s'...", data->menu_items[index].title);
+  PBL_LOG_DBG("Running test: '%s'...", data->menu_items[index].title);
   data->menu_items[index].subtitle = "Running...";
   layer_mark_dirty(simple_menu_layer_get_layer(data->menu_layer));
 
@@ -1244,7 +1244,7 @@ static void prv_test_end(void *context, bool passed) {
   ActivityTestAppData *data = (ActivityTestAppData *)context;
 
   const char *result_str =  passed ? "PASS" : "FAIL";
-  PBL_LOG(LOG_LEVEL_DEBUG, "Test result: %s", result_str);
+  PBL_LOG_DBG("Test result: %s", result_str);
 
   data->menu_items[data->test_index].subtitle = result_str;
   layer_mark_dirty(simple_menu_layer_get_layer(data->menu_layer));

--- a/src/fw/apps/demo_apps/click_app.c
+++ b/src/fw/apps/demo_apps/click_app.c
@@ -43,9 +43,9 @@ static void raw_click_handler(ClickRecognizerRef recognizer, Window *window, con
   ClickAppData *data = window_get_user_data(window);
   sniprintf(data->text_buffer, TEXT_BUFFER_SIZE, up ? "Raw UP" : "Raw DOWN");
   if (up) {  // PBL_LOG requires a fixed const string, so can't use ternary
-    PBL_LOG(LOG_LEVEL_DEBUG, "Raw UP");
+    PBL_LOG_DBG("Raw UP");
   } else {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Raw DOWN");
+    PBL_LOG_DBG("Raw DOWN");
   }
   text_layer_set_text(&data->text, data->text_buffer);
   toggle_color(window);
@@ -64,7 +64,7 @@ static void select_multi_click_handler(ClickRecognizerRef recognizer, Window *wi
   ClickAppData *data = window_get_user_data(window);
   const uint16_t count = click_number_of_clicks_counted(recognizer);
   sniprintf(data->text_buffer, TEXT_BUFFER_SIZE, "Multi Click! (%u)\nMin: 2, Max: 10", count);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Multi Click! (%u)", click_number_of_clicks_counted(recognizer));
+  PBL_LOG_DBG("Multi Click! (%u)", click_number_of_clicks_counted(recognizer));
   text_layer_set_text(&data->text, data->text_buffer);
   toggle_color(window);
 }
@@ -73,7 +73,7 @@ static void select_single_click_handler(ClickRecognizerRef recognizer, Window *w
   ClickAppData *data = window_get_user_data(window);
   const uint16_t count = click_number_of_clicks_counted(recognizer);
   sniprintf(data->text_buffer, TEXT_BUFFER_SIZE, "Single Click! (%u)", count);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Single Click! (%u)", click_number_of_clicks_counted(recognizer));
+  PBL_LOG_DBG("Single Click! (%u)", click_number_of_clicks_counted(recognizer));
   text_layer_set_text(&data->text, data->text_buffer);
   toggle_color(window);
 
@@ -85,7 +85,7 @@ static void select_single_click_handler(ClickRecognizerRef recognizer, Window *w
 static void select_long_click_handler(ClickRecognizerRef recognizer, Window *window) {
   ClickAppData *data = window_get_user_data(window);
   sniprintf(data->text_buffer, TEXT_BUFFER_SIZE, "Long Click!");
-  PBL_LOG(LOG_LEVEL_DEBUG, "Long Click!");
+  PBL_LOG_DBG("Long Click!");
   text_layer_set_text(&data->text, data->text_buffer);
   toggle_color(window);
   (void)recognizer;
@@ -94,7 +94,7 @@ static void select_long_click_handler(ClickRecognizerRef recognizer, Window *win
 static void select_long_click_release_handler(ClickRecognizerRef recognizer, Window *window) {
   ClickAppData *data = window_get_user_data(window);
   sniprintf(data->text_buffer, TEXT_BUFFER_SIZE, "Long Click Released!");
-  PBL_LOG(LOG_LEVEL_DEBUG, "Long Click Released!");
+  PBL_LOG_DBG("Long Click Released!");
   text_layer_set_text(&data->text, data->text_buffer);
   toggle_color(window);
   (void)recognizer;

--- a/src/fw/apps/demo_apps/deadlock_app.c
+++ b/src/fw/apps/demo_apps/deadlock_app.c
@@ -19,9 +19,9 @@ static PebbleMutex *s_mutex;
 static PebbleMutex *s_mutex2;
 
 static void callback(void *data) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Locking mutex 2 (new timer)");
+  PBL_LOG_DBG("Locking mutex 2 (new timer)");
   mutex_lock(s_mutex2);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Locking mutex 1 (new timer)");
+  PBL_LOG_DBG("Locking mutex 1 (new timer)");
   mutex_lock(s_mutex);
 }
 
@@ -31,10 +31,10 @@ static void deadlock(void) {
   TimerID timer = new_timer_create();
   new_timer_start(timer, 10, callback, NULL, 0);
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Locking mutex 1");
+  PBL_LOG_DBG("Locking mutex 1");
   mutex_lock(s_mutex);
   psleep(20);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Locking mutex 2");
+  PBL_LOG_DBG("Locking mutex 2");
   mutex_lock(s_mutex2);
 }
 

--- a/src/fw/apps/demo_apps/flash_demo.c
+++ b/src/fw/apps/demo_apps/flash_demo.c
@@ -18,32 +18,32 @@ static Window *window;
 static void test_write_short(void) {
   uint16_t buffer;
   flash_read_bytes((uint8_t*) &buffer, BASE_ADDRESS, sizeof(buffer));
-  PBL_LOG(LOG_LEVEL_DEBUG, ">> Addr 0x%x is 0x%"PRIx16, BASE_ADDRESS, buffer);
+  PBL_LOG_DBG(">> Addr 0x%x is 0x%"PRIx16, BASE_ADDRESS, buffer);
 
   buffer = 0x0505;
   flash_write_bytes((uint8_t*) &buffer, BASE_ADDRESS, sizeof(buffer));
-  PBL_LOG(LOG_LEVEL_DEBUG, ">> Addr 0x%x Written to 0x%x", BASE_ADDRESS, buffer);
+  PBL_LOG_DBG(">> Addr 0x%x Written to 0x%x", BASE_ADDRESS, buffer);
 
   uint8_t read_buffer = 0x0;
   flash_read_bytes((uint8_t*) &read_buffer, BASE_ADDRESS, sizeof(read_buffer));
-  PBL_LOG(LOG_LEVEL_DEBUG, ">> Addr 0x%x is (8) 0x%"PRIx8, BASE_ADDRESS, read_buffer);
+  PBL_LOG_DBG(">> Addr 0x%x is (8) 0x%"PRIx8, BASE_ADDRESS, read_buffer);
 
   buffer = 0x0;
   flash_read_bytes((uint8_t*) &buffer, BASE_ADDRESS, sizeof(buffer));
-  PBL_LOG(LOG_LEVEL_DEBUG, ">> Addr 0x%x is (16) 0x%"PRIx16, BASE_ADDRESS, buffer);
+  PBL_LOG_DBG(">> Addr 0x%x is (16) 0x%"PRIx16, BASE_ADDRESS, buffer);
 }
 
 static void test_write_bytes(void) {
   for (int i = 1; i < 127; ++i) {
     uint8_t data = i;
     flash_write_bytes((uint8_t*) &data, BASE_ADDRESS + i, sizeof(data));
-    PBL_LOG(LOG_LEVEL_DEBUG, ">> Wrote Addr 0x%x is 0x%"PRIx8, i, data);
+    PBL_LOG_DBG(">> Wrote Addr 0x%x is 0x%"PRIx8, i, data);
   }
 
   for (int i = 0; i < 128; ++i) {
     uint8_t data = 0;
     flash_read_bytes((uint8_t*) &data, BASE_ADDRESS + i, sizeof(data));
-    PBL_LOG(LOG_LEVEL_DEBUG, ">> Read Addr 0x%x is (8) 0x%"PRIx8, i, data);
+    PBL_LOG_DBG(">> Read Addr 0x%x is (8) 0x%"PRIx8, i, data);
   }
 }
 
@@ -59,21 +59,21 @@ static void test_write_block(void) {
   for (int i = 0; i < 128; ++i) {
     uint8_t data = 0;
     flash_read_bytes((uint8_t*) &data, BASE_ADDRESS + i, sizeof(data));
-    PBL_LOG(LOG_LEVEL_DEBUG, ">> Read Addr 0x%x is (8) 0x%"PRIx8, i, data);
+    PBL_LOG_DBG(">> Read Addr 0x%x is (8) 0x%"PRIx8, i, data);
   }
 }
 
 static void do_flash_operation(void) {
-  PBL_LOG(LOG_LEVEL_DEBUG, ">> Flash operation time!");
-  PBL_LOG(LOG_LEVEL_DEBUG, ">> Flash operation time!");
-  PBL_LOG(LOG_LEVEL_DEBUG, ">> Flash operation time!");
-  PBL_LOG(LOG_LEVEL_DEBUG, ">> Flash operation time!");
-  PBL_LOG(LOG_LEVEL_DEBUG, ">> Flash operation time!");
-  PBL_LOG(LOG_LEVEL_DEBUG, ">> Flash operation time!");
+  PBL_LOG_DBG(">> Flash operation time!");
+  PBL_LOG_DBG(">> Flash operation time!");
+  PBL_LOG_DBG(">> Flash operation time!");
+  PBL_LOG_DBG(">> Flash operation time!");
+  PBL_LOG_DBG(">> Flash operation time!");
+  PBL_LOG_DBG(">> Flash operation time!");
 
-  PBL_LOG(LOG_LEVEL_DEBUG, ">> Erasing 0x%x", BASE_ADDRESS);
+  PBL_LOG_DBG(">> Erasing 0x%x", BASE_ADDRESS);
   flash_erase_sector_blocking(BASE_ADDRESS);
-  PBL_LOG(LOG_LEVEL_DEBUG, ">> Erasing 0x%x Done", BASE_ADDRESS);
+  PBL_LOG_DBG(">> Erasing 0x%x Done", BASE_ADDRESS);
 
   test_write_short();
 }

--- a/src/fw/apps/demo_apps/flash_diagnostic_app.c
+++ b/src/fw/apps/demo_apps/flash_diagnostic_app.c
@@ -70,13 +70,13 @@ typedef struct {
 
 
 static bool check_region_erased(struct Region region) {
-  PBL_LOG_SYNC(LOG_LEVEL_INFO, "Checking Erase ...");
+  PBL_LOG_SYNC_INFO("Checking Erase ...");
   bool success = true;
   for (uint32_t i = region.begin; i < region.end; i += sizeof(uint32_t)) {
     uint32_t read = 0;
     flash_read_bytes((uint8_t *)&read, i, sizeof(read));
     if (read != 0xffffffff) {
-      PBL_LOG_SYNC(LOG_LEVEL_INFO, ">>>> Address 0x%lx failed to erase: 0x%lx", i, read);
+      PBL_LOG_SYNC_INFO(">>>> Address 0x%lx failed to erase: 0x%lx", i, read);
       success = false;
     }
   }
@@ -92,7 +92,7 @@ static bool check_region_write(struct Region region, bool use_rand,
   bool success = true;
   uint32_t write_rand = (use_rand && perform_writes) ? rand() : 0;
 
-  PBL_LOG_SYNC(LOG_LEVEL_INFO, "%sChecking 0x%lx over 0x%lx 0x%lx",
+  PBL_LOG_SYNC_INFO("%sChecking 0x%lx over 0x%lx 0x%lx",
       (perform_writes) ? "Writing and " : "", write_rand, region.begin,
       region.end);
 
@@ -104,7 +104,7 @@ static bool check_region_write(struct Region region, bool use_rand,
     }
     flash_read_bytes((uint8_t *)&read, i, sizeof(read));
     if (read != write) {
-      PBL_LOG_SYNC(LOG_LEVEL_INFO, ">>>> Address 0x%lx failed to write: 0x%lx 0x%lx",
+      PBL_LOG_SYNC_INFO(">>>> Address 0x%lx failed to write: 0x%lx 0x%lx",
           i, read, write);
       success = false;
     }
@@ -121,7 +121,7 @@ static bool check_subsector_bitflip(struct Region region) {
   bool success = true;
 
   if (((region.end - region.begin) % (64 * 1024)) != 0) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Test only works on 64k aligned regions");
+    PBL_LOG_WRN("Test only works on 64k aligned regions");
     return (false);
   }
 
@@ -147,7 +147,7 @@ static bool check_subsector_bitflip(struct Region region) {
         subsec += subsector_size) {
       uint32_t erase = subsec + i;
       PBL_ASSERTN((erase % (4 * 1024)) == 0);
-      PBL_LOG_SYNC(LOG_LEVEL_INFO, "Subsector Erase of 0x%lx", erase);
+      PBL_LOG_SYNC_INFO("Subsector Erase of 0x%lx", erase);
       flash_erase_subsector_blocking(erase);
     }
 
@@ -160,20 +160,20 @@ static bool check_subsector_bitflip(struct Region region) {
 
   return (success);
 #else
-  PBL_LOG_SYNC(LOG_LEVEL_INFO, "Test not supported for parallel flash");
+  PBL_LOG_SYNC_INFO("Test not supported for parallel flash");
   return (false);
 #endif
 }
 
 static void menu_select_callback(int index, void *data) {
   struct Region region = s_flash_regions[index];
-  PBL_LOG(LOG_LEVEL_INFO, ">>>> Erase %s", region.name);
+  PBL_LOG_INFO(">>>> Erase %s", region.name);
   flash_region_erase_optimal_range(region.begin, region.begin, region.end, region.end);
-  PBL_LOG(LOG_LEVEL_INFO, ">>>> Checking '%s' is erased", region.name);
+  PBL_LOG_INFO(">>>> Checking '%s' is erased", region.name);
   check_region_erased(region);
-  PBL_LOG(LOG_LEVEL_INFO, ">>>> Checking '%s' can write", region.name);
+  PBL_LOG_INFO(">>>> Checking '%s' can write", region.name);
   check_region_write(region, false, true);
-  PBL_LOG(LOG_LEVEL_INFO, ">>>> Done!");
+  PBL_LOG_INFO(">>>> Done!");
 }
 
 FlashStressWindow stress_data;
@@ -189,9 +189,9 @@ static void update_text(int iter, int tot, bool failed) {
 static void app_timer_cb(void *data) {
   static const int num_stress_iters = 1000;
   struct Region region = s_flash_regions[2];
-  PBL_LOG(LOG_LEVEL_INFO, ">>>> %s %d", "Test Loop", stress_data.stress_iteration);
+  PBL_LOG_INFO(">>>> %s %d", "Test Loop", stress_data.stress_iteration);
 
-  PBL_LOG(LOG_LEVEL_INFO, "Erasing 0x%lx to 0x%lx", region.begin, region.end);
+  PBL_LOG_INFO("Erasing 0x%lx to 0x%lx", region.begin, region.end);
   flash_region_erase_optimal_range(region.begin, region.begin, region.end, region.end);
 
   bool failed = true;
@@ -200,7 +200,7 @@ static void app_timer_cb(void *data) {
   } else if (stress_data.stress_index == FILE_SUBSECTOR_STRESS) {
     failed = (!check_region_erased(region) || !check_subsector_bitflip(region));
   } else {
-    PBL_LOG(LOG_LEVEL_WARNING, "Unknown stress test %d!", stress_data.stress_index);
+    PBL_LOG_WRN("Unknown stress test %d!", stress_data.stress_index);
   }
 
   if (!abort_stress_test) {

--- a/src/fw/apps/demo_apps/flash_prof.c
+++ b/src/fw/apps/demo_apps/flash_prof.c
@@ -34,7 +34,7 @@ static void do_timed_read(NumberWindow *nw, void *data) {
   uint32_t num_bytes = nw->value;
   uint32_t predicted_time = num_bytes * 8 / 16000;
   uint32_t time = timed_read_bytes(num_bytes);
-  PBL_LOG(LOG_LEVEL_DEBUG, "time to read %lu bytes: predicted %lu, actual %lu", num_bytes, predicted_time, time);
+  PBL_LOG_DBG("time to read %lu bytes: predicted %lu, actual %lu", num_bytes, predicted_time, time);
   window_stack_remove(&number_window.window, false);
   app_window_stack_push(&number_window.window, true);
 }

--- a/src/fw/apps/demo_apps/flash_test.c
+++ b/src/fw/apps/demo_apps/flash_test.c
@@ -78,7 +78,7 @@ static void update_test_case_status(struct FlashTestData *data) {
       break;
     default:
       snprintf(data->status_text, STATUS_TEXT_SIZE, "Unknown Status");
-      PBL_LOG(LOG_LEVEL_DEBUG, "ERROR: Unknown Test Case Selected");
+      PBL_LOG_DBG("ERROR: Unknown Test Case Selected");
       break;
   }
 
@@ -196,7 +196,7 @@ static void run_test(void* context) {
     data->test_case_status = FLASH_TEST_STATUS_PASSED;
   }
   else {
-    PBL_LOG(LOG_LEVEL_DEBUG, ">>>>>FAILED TEST CASE<<<<<");
+    PBL_LOG_DBG(">>>>>FAILED TEST CASE<<<<<");
     data->test_case_status = FLASH_TEST_STATUS_FAILED;
   }
 

--- a/src/fw/apps/demo_apps/fps_test_app.c
+++ b/src/fw/apps/demo_apps/fps_test_app.c
@@ -81,11 +81,11 @@ static void prv_pop_all_windows_cb(void *cb_data) {
   AppData *data = app_state_get_user_data();
   int64_t time_rendered = prv_time_64() - data->time_started;
 
-  PBL_LOG(LOG_LEVEL_INFO, "## %d frames rendered", (int)data->rendered_frames);
+  PBL_LOG_INFO("## %d frames rendered", (int)data->rendered_frames);
   if (time_rendered) {
     int frame_period = time_rendered/(int64_t)data->rendered_frames;
     int fps = (int64_t)data->rendered_frames*1000/time_rendered;
-    PBL_LOG(LOG_LEVEL_INFO, "## at %d FPS (%d ms/frame)", fps, frame_period);
+    PBL_LOG_INFO("## at %d FPS (%d ms/frame)", fps, frame_period);
   }
 
   app_window_stack_pop_all(false);
@@ -186,8 +186,8 @@ static void prv_window_load(Window *window) {
   bitmap_layer_init(&data->topleft_layer, &GRect(0, 0, navbar_width, navbar_width));
   bitmap_layer_set_background_color_2bit(&data->topleft_layer, GColor2White);
   bitmap_layer_set_bitmap(&data->topleft_layer, &s_fps_topleft_bitmap);
-  // PBL_LOG(LOG_LEVEL_DEBUG, "heap_allocated: %d", s_fps_topleft_bitmap.is_heap_allocated);
-  // PBL_LOG(LOG_LEVEL_DEBUG, "bitmapformat: %d", s_fps_topleft_bitmap.format);
+  // PBL_LOG_DBG("heap_allocated: %d", s_fps_topleft_bitmap.is_heap_allocated);
+  // PBL_LOG_DBG("bitmapformat: %d", s_fps_topleft_bitmap.format);
 
   layer_add_child(&window->layer, &data->topleft_layer.layer);
 

--- a/src/fw/apps/demo_apps/gfx_tests/gfx_tests.c
+++ b/src/fw/apps/demo_apps/gfx_tests/gfx_tests.c
@@ -125,7 +125,7 @@ static void prv_results_window_load(Window *window) {
       "Units per frame @ 30fps:\n%"PRIu32".%"PRIu32,
       test->name, avg_us / 10, avg_us % 10, fps / 10, fps % 10, per_frame / 10, per_frame % 10,
       unit_per_frame / 10, unit_per_frame % 10);
-  PBL_LOG(LOG_LEVEL_DEBUG, "results: %s", app_data->results_str);
+  PBL_LOG_DBG("results: %s", app_data->results_str);
   text_layer_set_text(&app_data->results_text, app_data->results_str);
 }
 

--- a/src/fw/apps/demo_apps/grenade_launcher.c
+++ b/src/fw/apps/demo_apps/grenade_launcher.c
@@ -27,7 +27,7 @@
 // Helpers
 
 static void fw_update_reboot(void) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Rebooting to apply new firmware!");
+  PBL_LOG_DBG("Rebooting to apply new firmware!");
 
   boot_bit_set(BOOT_BIT_NEW_FW_AVAILABLE);
 
@@ -90,7 +90,7 @@ static void set_text(Window *window, char *message) {
   AppData *data = window_get_user_data(window);
   TextLayer *text = &data->text;
   text_layer_set_text(text, message);
-  PBL_LOG(LOG_LEVEL_DEBUG, "%s", message);
+  PBL_LOG_DBG("%s", message);
 }
 
 static void up_click_handler(ClickRecognizerRef recognizer, Window *window) {

--- a/src/fw/apps/demo_apps/idl_demo.c
+++ b/src/fw/apps/demo_apps/idl_demo.c
@@ -22,7 +22,7 @@ static void prv_init(void) {
   uint8_t *buffer = app_malloc(30);
   pb_ostream_t s = pb_ostream_from_buffer(buffer, 30);
   pb_encode(&s, SimpleMessage_fields, &msg);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Encoded message, size: %u bytes", s.bytes_written);
+  PBL_LOG_DBG("Encoded message, size: %u bytes", s.bytes_written);
   PBL_HEXDUMP(LOG_LEVEL_DEBUG, buffer, s.bytes_written);
   app_state_set_user_data(buffer);
 }
@@ -32,7 +32,7 @@ static void prv_deinit(void) {
   uint8_t *buffer = app_state_get_user_data();
   pb_istream_t s = pb_istream_from_buffer(buffer, 30);
   pb_decode(&s, SimpleMessage_fields, &msg);
-  PBL_LOG(LOG_LEVEL_DEBUG, "The lucky number is %"PRId32, msg.lucky_number);
+  PBL_LOG_DBG("The lucky number is %"PRId32, msg.lucky_number);
 }
 
 static void prv_app_main(void) {

--- a/src/fw/apps/demo_apps/kill_bt_app.c
+++ b/src/fw/apps/demo_apps/kill_bt_app.c
@@ -40,7 +40,7 @@ static void push_window(struct AppState *data) {
 // App boilerplate
 
 static void handle_second_tick(struct tm *tick_time, TimeUnits units_changed) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Try to kill the BT:%d", s_progress_count);
+  PBL_LOG_DBG("Try to kill the BT:%d", s_progress_count);
   s_progress_count += 1;
 
   bt_ctl_reset_bluetooth();

--- a/src/fw/apps/demo_apps/menu_layer_right_icon.c
+++ b/src/fw/apps/demo_apps/menu_layer_right_icon.c
@@ -77,7 +77,7 @@ static int16_t menu_get_cell_height_callback(struct MenuLayer *menu_layer, MenuI
 }
 
 static void prv_window_load(Window *window) {
-  PBL_LOG(LOG_LEVEL_INFO, "WINDOW LOADING");
+  PBL_LOG_INFO("WINDOW LOADING");
   AppData *data = window_get_user_data(window);
   gbitmap_init_with_resource(&data->checked_icon, RESOURCE_ID_CHECKBOX_ICON_CHECKED);
 
@@ -96,7 +96,7 @@ static void prv_window_load(Window *window) {
 }
 
 static void push_window(AppData *data) {
-  PBL_LOG(LOG_LEVEL_INFO, "PUSHING WINDOW");
+  PBL_LOG_INFO("PUSHING WINDOW");
   Window *window = &data->window;
   window_init(window, WINDOW_NAME("Demo Menu"));
   window_set_user_data(window, data);

--- a/src/fw/apps/demo_apps/number_field_app.c
+++ b/src/fw/apps/demo_apps/number_field_app.c
@@ -15,7 +15,7 @@ typedef struct {
 } AppData;
 
 static void selected(NumberWindow *nw, void *ctx) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "selected: %"PRId32, number_window_get_value(nw));
+  PBL_LOG_DBG("selected: %"PRId32, number_window_get_value(nw));
 
   const bool animated = true;
   app_window_stack_pop(animated);

--- a/src/fw/apps/demo_apps/option_menu_demo.c
+++ b/src/fw/apps/demo_apps/option_menu_demo.c
@@ -21,7 +21,7 @@ const char *s_strings[] = {
 };
 
 static void prv_menu_select(OptionMenu *option_menu, int selection, void *context) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Option Menu Demo: selected %d", selection);
+  PBL_LOG_DBG("Option Menu Demo: selected %d", selection);
 }
 
 static uint16_t prv_menu_get_num_rows(OptionMenu *option_menu, void *context) {

--- a/src/fw/apps/demo_apps/pebble_shapes.c
+++ b/src/fw/apps/demo_apps/pebble_shapes.c
@@ -138,29 +138,29 @@ typedef struct AppData {
 static void log_state(AppData *data) {
   switch (data->state_index) {
     case APP_STATE_FILL_NON_AA:
-      PBL_LOG(LOG_LEVEL_DEBUG, "State: Fill Non-Antialiased; SW: N/A (but currently: %d)",
+      PBL_LOG_DBG("State: Fill Non-Antialiased; SW: N/A (but currently: %d)",
               data->stroke_width);
       break;
     case APP_STATE_FILL_AA:
-      PBL_LOG(LOG_LEVEL_DEBUG, "State: Fill Antialiased; SW: N/A (but currently: %d)",
+      PBL_LOG_DBG("State: Fill Antialiased; SW: N/A (but currently: %d)",
               data->stroke_width);
       break;
     case APP_STATE_DRAW_NON_AA_NO_SW:
-      PBL_LOG(LOG_LEVEL_DEBUG, "State: Draw Non-Antialiased; SW: N/A (but currently: %d)",
+      PBL_LOG_DBG("State: Draw Non-Antialiased; SW: N/A (but currently: %d)",
               data->stroke_width);
       break;
     case APP_STATE_DRAW_AA_NO_SW:
-      PBL_LOG(LOG_LEVEL_DEBUG, "State: Draw Antialiased; SW: N/A (but currently: %d)",
+      PBL_LOG_DBG("State: Draw Antialiased; SW: N/A (but currently: %d)",
               data->stroke_width);
       break;
     case APP_STATE_DRAW_NON_AA_SW:
-      PBL_LOG(LOG_LEVEL_DEBUG, "State: Draw Non-Antialiased; SW: %d", data->stroke_width);
+      PBL_LOG_DBG("State: Draw Non-Antialiased; SW: %d", data->stroke_width);
       break;
     case APP_STATE_DRAW_AA_SW:
-      PBL_LOG(LOG_LEVEL_DEBUG, "State: Draw Antialiased; SW: %d", data->stroke_width);
+      PBL_LOG_DBG("State: Draw Antialiased; SW: %d", data->stroke_width);
       break;
     default:
-      PBL_LOG(LOG_LEVEL_DEBUG, "Unknown State");
+      PBL_LOG_DBG("Unknown State");
       break;
   }
 }
@@ -410,8 +410,8 @@ static void layer_update_proc(Layer *layer, GContext* ctx) {
   } else {
     int64_t time_rendered = prv_time_64() - data->time_started;
     if ((data->rendered_frames % 64) == 0) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "## %d frames rendered", (int)data->rendered_frames);
-      PBL_LOG(LOG_LEVEL_DEBUG, "## at %"PRIu32" FPS",
+      PBL_LOG_DBG("## %d frames rendered", (int)data->rendered_frames);
+      PBL_LOG_DBG("## at %"PRIu32" FPS",
               (uint32_t)((uint64_t)data->rendered_frames*1000/time_rendered));
     }
   }

--- a/src/fw/apps/demo_apps/persist_app.c
+++ b/src/fw/apps/demo_apps/persist_app.c
@@ -101,7 +101,7 @@ static void select_callback(MenuLayer *menu_layer, MenuIndex *cell_index, AppDat
     case 1: {
       int num_beers = persist_read_int(COUNT_PKEY);
       int status = persist_write_int(COUNT_PKEY, num_beers+1);
-      PBL_LOG(LOG_LEVEL_DEBUG, "argh %d %d", num_beers, status);
+      PBL_LOG_DBG("argh %d %d", num_beers, status);
       menu_layer_reload_data(menu_layer);
       break;
     }
@@ -170,9 +170,9 @@ static void handle_init() {
   push_window(data);
 
   const int exist_result = persist_exists(COUNT_PKEY);
-  PBL_LOG(LOG_LEVEL_DEBUG, "- exist_result %d", exist_result);
+  PBL_LOG_DBG("- exist_result %d", exist_result);
   if (exist_result == false) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "- writing...");
+    PBL_LOG_DBG("- writing...");
     persist_write_int(COUNT_PKEY, 10);
   }
 }

--- a/src/fw/apps/demo_apps/profile_mutexes_app.c
+++ b/src/fw/apps/demo_apps/profile_mutexes_app.c
@@ -17,7 +17,7 @@ static PebbleMutex *s_mutex;
 static PebbleRecursiveMutex *s_rmutex;
 
 static void profile_mutexes(void) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "INITIALIZING PROFILER FOR MUTEXES!");
+  PBL_LOG_DBG("INITIALIZING PROFILER FOR MUTEXES!");
   PROFILER_INIT;
   PROFILER_START;
 

--- a/src/fw/apps/demo_apps/scroll_app.c
+++ b/src/fw/apps/demo_apps/scroll_app.c
@@ -18,14 +18,14 @@ typedef struct {
 } ScrollAppData;
 
 static void select_click_handler(ClickRecognizerRef recognizer, ScrollAppData *data) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "SELECT clicked!");
+  PBL_LOG_DBG("SELECT clicked!");
   (void)data;
   (void)recognizer;
 }
 
 #if 0
 static void select_long_click_handler(ClickRecognizerRef recognizer, ScrollAppData *data) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "SELECT long clicked!");
+  PBL_LOG_DBG("SELECT long clicked!");
   (void)data;
   (void)recognizer;
 }

--- a/src/fw/apps/demo_apps/simple_menu_app.c
+++ b/src/fw/apps/demo_apps/simple_menu_app.c
@@ -20,12 +20,12 @@ typedef struct {
 static void callback_a(int index, void *ctx) {
   (void)index;
   (void)ctx;
-  PBL_LOG(LOG_LEVEL_DEBUG, "A called back");
+  PBL_LOG_DBG("A called back");
 }
 
 static void other_callback(int index, void *ctx) {
   (void)ctx;
-  PBL_LOG(LOG_LEVEL_DEBUG, "other callback: %d", index);
+  PBL_LOG_DBG("other callback: %d", index);
 }
 
 static void poll_callback(int index, void *ctx) {

--- a/src/fw/apps/demo_apps/stroke_width.c
+++ b/src/fw/apps/demo_apps/stroke_width.c
@@ -89,13 +89,13 @@ static void up_handler(ClickRecognizerRef recognizer, void *context) {
       data->p2.y++;
       break;
     default:
-      PBL_LOG(LOG_LEVEL_ERROR, "Invalid operation type: %d", data->operation);
+      PBL_LOG_ERR("Invalid operation type: %d", data->operation);
       break;
   }
 
   layer_mark_dirty(data->canvas_layer);
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "line(p1(%d, %d), p2(%d, %d), width=%d), angle=%d)",
+  PBL_LOG_DBG("line(p1(%d, %d), p2(%d, %d), width=%d), angle=%d)",
           data->p1.x, data->p1.y, data->p2.x, data->p2.y, data->stroke_width,
           (int)(data->rotation_angle * 360 / TRIG_MAX_ANGLE));
 }
@@ -132,13 +132,13 @@ static void down_handler(ClickRecognizerRef recognizer, void *context) {
       data->p2.y--;
       break;
     default:
-      PBL_LOG(LOG_LEVEL_ERROR, "Invalid operation type: %d", data->operation);
+      PBL_LOG_ERR("Invalid operation type: %d", data->operation);
       break;
   }
 
   layer_mark_dirty(data->canvas_layer);
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "line(p1(%d, %d), p2(%d, %d), width=%d), angle=%d)",
+  PBL_LOG_DBG("line(p1(%d, %d), p2(%d, %d), width=%d), angle=%d)",
           data->p1.x, data->p1.y, data->p2.x, data->p2.y, data->stroke_width,
           (int)(data->rotation_angle * 360 / TRIG_MAX_ANGLE));
 }
@@ -152,7 +152,7 @@ static void select_handler(ClickRecognizerRef recognizer, void *context) {
 
   layer_mark_dirty(data->canvas_layer);
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "current operation type: %d", data->operation);
+  PBL_LOG_DBG("current operation type: %d", data->operation);
 }
 
 static void click_config_provider(void *context) {

--- a/src/fw/apps/demo_apps/swap_layer_demo.c
+++ b/src/fw/apps/demo_apps/swap_layer_demo.c
@@ -91,7 +91,7 @@ typedef struct SwapLayerDemoData {
 
 static LayoutLayer *prv_get_layout_handler(SwapLayer *swap_layer, int8_t rel_position,
                                            void *context) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "getting layer %d", rel_position);
+  PBL_LOG_DBG("getting layer %d", rel_position);
   SwapLayerDemoData *data = context;
 
 

--- a/src/fw/apps/demo_apps/temperature_demo.c
+++ b/src/fw/apps/demo_apps/temperature_demo.c
@@ -140,7 +140,7 @@ static void layer_update_proc(Layer *layer, GContext* ctx) {
   if (first_non_zero_idx < 0) {
     return;
   }
-  PBL_LOG(LOG_LEVEL_DEBUG, "min temp: %d, max temp: %d", data->min_temp, data->max_temp);
+  PBL_LOG_DBG("min temp: %d, max temp: %d", data->min_temp, data->max_temp);
   int temp_range = data->max_temp - data->min_temp;
   temp_range = MAX(10, temp_range);
 

--- a/src/fw/apps/demo_apps/test_args_rx.c
+++ b/src/fw/apps/demo_apps/test_args_rx.c
@@ -13,9 +13,9 @@
 static void s_main(void) {
   const TestArgsData *args = process_manager_get_current_process_args();
   if (args == NULL) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Got no args.");
+    PBL_LOG_DBG("Got no args.");
   } else {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Got argument 0x%x", args->data);
+    PBL_LOG_DBG("Got argument 0x%x", args->data);
   }
 }
 

--- a/src/fw/apps/demo_apps/test_args_tx.c
+++ b/src/fw/apps/demo_apps/test_args_tx.c
@@ -23,7 +23,7 @@ static void prv_launch_receiver_callback(void *data) {
 
 static void s_main(void) {
   s_data.data = 0x43;
-  PBL_LOG(LOG_LEVEL_DEBUG, "Launching again with argument: 0x%x", s_data.data);
+  PBL_LOG_DBG("Launching again with argument: 0x%x", s_data.data);
   launcher_task_add_callback(prv_launch_receiver_callback, &s_data);
 }
 

--- a/src/fw/apps/demo_apps/test_bluetooth_app.c
+++ b/src/fw/apps/demo_apps/test_bluetooth_app.c
@@ -43,7 +43,7 @@ static void send_bluetooth(void* data) {
     return;
   }
 
-  PBL_LOG(LOG_LEVEL_INFO, "sending data");
+  PBL_LOG_INFO("sending data");
   comm_session_send_data(session, 2000, (uint8_t *)0x08000000,
                          comm_session_send_buffer_get_max_payload_length(session),
                          COMM_SESSION_DEFAULT_TIMEOUT);
@@ -54,7 +54,7 @@ static void send_bluetooth(void* data) {
 // =================================================================================
 // You can capture when the user selects a menu icon with a menu item select callback
 static void menu_select_callback(int index, void *ctx) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Hit menu item %d", index);
+  PBL_LOG_DBG("Hit menu item %d", index);
   
   // Here we just change the subtitle to a literal string
   s_app_data->menu_items[index].subtitle = "You've hit select here!";
@@ -75,10 +75,10 @@ static void menu_select_callback(int index, void *ctx) {
       s_pending_count++;
       system_task_add_callback(send_bluetooth, NULL);
     }
-    PBL_LOG(LOG_LEVEL_INFO, "Bluetooth disconnected");
+    PBL_LOG_INFO("Bluetooth disconnected");
 
   } else if (index == 1) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Not implemented");
+    PBL_LOG_DBG("Not implemented");
 
   }
 }

--- a/src/fw/apps/demo_apps/test_core_dump_app.c
+++ b/src/fw/apps/demo_apps/test_core_dump_app.c
@@ -36,14 +36,14 @@ static TestTimersAppData *s_app_data = 0;
 // =================================================================================
 static void stuck_timer_callback(void* data)
 {
-  PBL_LOG(LOG_LEVEL_DEBUG, "STT: Entering infinite loop in timer callback");
+  PBL_LOG_DBG("STT: Entering infinite loop in timer callback");
   while (true) {
     psleep(100);
   }
 }
 
 static void stuck_system_task_callback(void *data) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Entering infinite loop in system task callback");
+  PBL_LOG_DBG("Entering infinite loop in system task callback");
   while (true) {
     psleep(100);
   }
@@ -64,7 +64,7 @@ void OTG_FS_WKUP_IRQHandler(void) {
 // =================================================================================
 // You can capture when the user selects a menu icon with a menu item select callback
 static void menu_select_callback(int index, void *ctx) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Selected menu item %d", index);
+  PBL_LOG_DBG("Selected menu item %d", index);
   
   // Here we just change the subtitle to a literal string
   s_app_data->menu_items[index].subtitle = "You've hit select here!";
@@ -84,7 +84,7 @@ static void menu_select_callback(int index, void *ctx) {
 
     // stuck timer callback
     TimerID timer = new_timer_create();
-    PBL_LOG(LOG_LEVEL_INFO, "Entering infinite loop in Timer callback");
+    PBL_LOG_INFO("Entering infinite loop in Timer callback");
     bool success = new_timer_start(timer, 100, stuck_timer_callback, NULL, 0 /*flags*/);
     PBL_ASSERTN(success);
 
@@ -96,12 +96,12 @@ static void menu_select_callback(int index, void *ctx) {
   } else if (index == 3) {
 
     // stuck app
-    PBL_LOG(LOG_LEVEL_INFO, "Entering infinite loop in App Task");
+    PBL_LOG_INFO("Entering infinite loop in App Task");
     while (true) ;
 
   } else if (index == 4) {
 
-    PBL_LOG(LOG_LEVEL_INFO, "Entering infinite loop in FreeRTOS ISR");
+    PBL_LOG_INFO("Entering infinite loop in FreeRTOS ISR");
 
     NVIC_InitTypeDef NVIC_InitStructure;
     NVIC_InitStructure.NVIC_IRQChannel = OTG_FS_WKUP_IRQn;
@@ -117,7 +117,7 @@ static void menu_select_callback(int index, void *ctx) {
 
   } else if (index == 5) {
 
-    PBL_LOG(LOG_LEVEL_INFO, "Entering infinite loop in non-FreeRTOS ISR.");
+    PBL_LOG_INFO("Entering infinite loop in non-FreeRTOS ISR.");
 
     NVIC_InitTypeDef NVIC_InitStructure;
     NVIC_InitStructure.NVIC_IRQChannel = OTG_FS_WKUP_IRQn;
@@ -133,25 +133,25 @@ static void menu_select_callback(int index, void *ctx) {
 
   } else if (index == 6) {
 
-    PBL_LOG(LOG_LEVEL_INFO, "Forcing bus fault during core dump");
+    PBL_LOG_INFO("Forcing bus fault during core dump");
     core_dump_test_force_bus_fault();
     core_dump_reset(false /* don't force overwrite */);
 
   } else if (index == 7) {
 
-    PBL_LOG(LOG_LEVEL_INFO, "Forcing inf loop during core dump");
+    PBL_LOG_INFO("Forcing inf loop during core dump");
     core_dump_test_force_inf_loop();
     core_dump_reset(false /* don't force overwrite */);
 
   } else if (index == 8) {
 
-    PBL_LOG(LOG_LEVEL_INFO, "Forcing assert loop during core dump");
+    PBL_LOG_INFO("Forcing assert loop during core dump");
     core_dump_test_force_assert();
     core_dump_reset(false /* don't force overwrite */);
 
   } else if (index == 9) {
 
-    PBL_LOG(LOG_LEVEL_INFO, "Calling core_dump FreeRTOS ISR");
+    PBL_LOG_INFO("Calling core_dump FreeRTOS ISR");
     s_call_core_dump_from_isr = true;
 
     NVIC_InitTypeDef NVIC_InitStructure;
@@ -168,17 +168,17 @@ static void menu_select_callback(int index, void *ctx) {
 
   } else if (index == 10) {
 
-    PBL_LOG(LOG_LEVEL_INFO, "Causing bus fault in app");
+    PBL_LOG_INFO("Causing bus fault in app");
     typedef void (*KaboomCallback)(void);
     KaboomCallback kaboom = 0;
     kaboom();
 
   } else if (index == 11) {
-    PBL_LOG(LOG_LEVEL_INFO, "Infinite Loop on system task");
+    PBL_LOG_INFO("Infinite Loop on system task");
     system_task_add_callback(stuck_system_task_callback, NULL);
 
   } else if (index == 12) {
-    PBL_LOG(LOG_LEVEL_INFO, "Generate hard-fault");
+    PBL_LOG_INFO("Generate hard-fault");
 
     // Modify behavior of the ARM so that bus faults generate a hard fault
     SCB->SHCSR &= ~SCB_SHCSR_MEMFAULTENA_Msk;

--- a/src/fw/apps/demo_apps/test_sys_timer_app.c
+++ b/src/fw/apps/demo_apps/test_sys_timer_app.c
@@ -42,7 +42,7 @@ static void timer_callback(void* data)
 {
   int idx = (int)data;
   PBL_ASSERTN(idx >= 0 && idx < NUM_MAX_TIMERS);
-  PBL_LOG(LOG_LEVEL_DEBUG, "STT normal callback %d executed", idx);
+  PBL_LOG_DBG("STT normal callback %d executed", idx);
   s_app_data->fired_time[idx] = rtc_get_ticks();
   return;
 }
@@ -51,7 +51,7 @@ static void timer_callback(void* data)
 // =================================================================================
 static void stuck_timer_callback(void* data)
 {
-  PBL_LOG(LOG_LEVEL_DEBUG, "STT entering infinite loop in callback");
+  PBL_LOG_DBG("STT entering infinite loop in callback");
   while (true) {
     psleep(100);
   }
@@ -63,7 +63,7 @@ static void long_timer_callback(void* data)
 {
   int idx = (int)data;
   PBL_ASSERTN(idx >= 0 && idx < NUM_MAX_TIMERS);
-  PBL_LOG(LOG_LEVEL_DEBUG, "STT long running callback %d executed", idx);
+  PBL_LOG_DBG("STT long running callback %d executed", idx);
   s_app_data->fired_time[idx] = rtc_get_ticks();
 
   psleep(250);
@@ -74,9 +74,9 @@ static void long_timer_callback(void* data)
 // =================================================================================
 // Try and reschedule a regular timer from it's callback
 static void reg_timer_1_callback(void* data) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "STT running reg_timer_1_callback");
+  PBL_LOG_DBG("STT running reg_timer_1_callback");
   if (s_app_data->reg_timers[0].cb != 0) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "STT reg_timer_1_callback rescheduling from callback for every 2 secs. ");
+    PBL_LOG_DBG("STT reg_timer_1_callback rescheduling from callback for every 2 secs. ");
     regular_timer_add_multisecond_callback(&s_app_data->reg_timers[0], 2);
   }
 }
@@ -85,9 +85,9 @@ static void reg_timer_1_callback(void* data) {
 // =================================================================================
 // Try and delete a regular timer from it's callback
 static void reg_timer_2_callback(void* data) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "STT running reg_timer_2_callback");
+  PBL_LOG_DBG("STT running reg_timer_2_callback");
   if (s_app_data->reg_timers[0].cb != 0) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "STT reg_timer_2_callback deleting from callback");
+    PBL_LOG_DBG("STT reg_timer_2_callback deleting from callback");
     regular_timer_remove_callback(&s_app_data->reg_timers[0]);
   }
 }
@@ -98,9 +98,9 @@ static void reg_timer_2_callback(void* data) {
 static int s_reg_timer_3_callback_count = 0;
 static void reg_timer_3_callback(void* data) {
   s_reg_timer_3_callback_count++;
-  PBL_LOG(LOG_LEVEL_DEBUG, "STT running reg_timer_3_callback");
+  PBL_LOG_DBG("STT running reg_timer_3_callback");
   if (s_app_data->reg_timers[0].cb != 0) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "STT reg_timer_3_callback deleting then adding from callback");
+    PBL_LOG_DBG("STT reg_timer_3_callback deleting then adding from callback");
     regular_timer_remove_callback(&s_app_data->reg_timers[0]);
     regular_timer_add_seconds_callback(&s_app_data->reg_timers[0]);
   }
@@ -109,7 +109,7 @@ static void reg_timer_3_callback(void* data) {
 
 // =================================================================================
 static void menu_callback_prefix(int index, void *ctx) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Hit menu item %d", index);
+  PBL_LOG_DBG("Hit menu item %d", index);
 
   // Mark the layer to be updated
   layer_mark_dirty(simple_menu_layer_get_layer(s_app_data->menu_layer));
@@ -118,7 +118,7 @@ static void menu_callback_prefix(int index, void *ctx) {
   for (int i=0; i<NUM_MAX_TIMERS; i++) {
     s_app_data->fired_time[i] = 0;
     if (s_app_data->timer[i] != TIMER_INVALID_ID) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "STT stopping and deleting previous timer %d", i);
+      PBL_LOG_DBG("STT stopping and deleting previous timer %d", i);
       new_timer_stop(s_app_data->timer[i]);
       new_timer_delete(s_app_data->timer[i]);
       s_app_data->timer[i] = TIMER_INVALID_ID;
@@ -133,7 +133,7 @@ static void menu_callback_prefix(int index, void *ctx) {
   // Cancel and delete old regular timers if present
   for (int i=0; i<NUM_MAX_TIMERS; i++) {
     if (s_app_data->reg_timers[i].cb != NULL) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "STT deleting previous regular timer %d", i);
+      PBL_LOG_DBG("STT deleting previous regular timer %d", i);
       regular_timer_remove_callback(&s_app_data->reg_timers[i]);
       s_app_data->reg_timers[i].cb = NULL;
     }
@@ -159,7 +159,7 @@ void single_shot_timer_menu_cb(int index, void *ctx) {
   // Make sure it's marked as scheduled
   scheduled = new_timer_scheduled(s_app_data->timer[timer_idx_0], &expire_ms);
   PBL_ASSERTN(scheduled && expire_ms <= 100);
-  PBL_LOG(LOG_LEVEL_DEBUG, "STT firing in %d ms", (int)expire_ms);
+  PBL_LOG_DBG("STT firing in %d ms", (int)expire_ms);
 
   // Wait for it to fire
   psleep(300);
@@ -185,7 +185,7 @@ void repeating_timer_menu_cb(int index, void *ctx) {
   
   scheduled = new_timer_scheduled(s_app_data->timer[timer_idx_0], &expire_ms);
   PBL_ASSERTN(scheduled && expire_ms <= 500);
-  PBL_LOG(LOG_LEVEL_DEBUG, "STT firing in %d ms", (int)expire_ms);
+  PBL_LOG_DBG("STT firing in %d ms", (int)expire_ms);
 }
 
 // =================================================================================
@@ -348,7 +348,7 @@ void reg_timer_delete_then_add_from_cb_menu_cb(int index, void *ctx) {
   regular_timer_add_seconds_callback(&s_app_data->reg_timers[0]);
 
   // Wait for timer to run at least twice
-  PBL_LOG(LOG_LEVEL_DEBUG, "waiting for callback to run 2 times");
+  PBL_LOG_DBG("waiting for callback to run 2 times");
   psleep(2200);
 
   PBL_ASSERT(s_reg_timer_3_callback_count >= 2, "Callback didn't run at least twice");

--- a/src/fw/apps/demo_apps/text_layout.c
+++ b/src/fw/apps/demo_apps/text_layout.c
@@ -29,7 +29,7 @@ static void select_click_handler(ClickRecognizerRef recognizer, void* callback_p
   (void) recognizer;
   struct AppState* data = (struct AppState*) callback_param;
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "I should be changing the font!");
+  PBL_LOG_DBG("I should be changing the font!");
   if (++s_font_selection > 7) {
     s_font_selection = 0;
   }
@@ -52,7 +52,7 @@ static void select_long_click_handler(ClickRecognizerRef recognizer, struct AppS
   (void) data;
   (void) recognizer;
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "SELECT loooong clicked!");
+  PBL_LOG_DBG("SELECT loooong clicked!");
 }
 #endif
 

--- a/src/fw/apps/demo_apps/text_spacing.c
+++ b/src/fw/apps/demo_apps/text_spacing.c
@@ -47,7 +47,7 @@ static void click_handler(ClickRecognizerRef recognizer, Window *window) {
 
   GSize size_used = text_layer_get_content_size(app_get_current_graphics_context(),
                                                 &data->text_layer);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Line Delta: %d, Size %d x %d, Overflow: %d", data->line_spacing_delta,
+  PBL_LOG_DBG("Line Delta: %d, Size %d x %d, Overflow: %d", data->line_spacing_delta,
           size_used.w, size_used.h, data->overflow_mode);
 }
 
@@ -80,7 +80,7 @@ static void prv_window_load(Window *window) {
 
   GSize size_used = text_layer_get_content_size(app_get_current_graphics_context(),
                                                 &data->text_layer);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Max size used %d %d", size_used.w, size_used.h);
+  PBL_LOG_DBG("Max size used %d %d", size_used.w, size_used.h);
 }
 
 static void push_window(struct AppState *data) {

--- a/src/fw/apps/demo_apps/vibe_and_logs.c
+++ b/src/fw/apps/demo_apps/vibe_and_logs.c
@@ -19,7 +19,7 @@ TimerID s_sys_timer = TIMER_INVALID_ID;
 
 static void app_timer_callback(void *data) {
   for (int i=0; i<40; i++) {
-    PBL_LOG(LOG_LEVEL_INFO, "%d Running app timer callback", i);
+    PBL_LOG_INFO("%d Running app timer callback", i);
     vibes_short_pulse();
   }
   s_app_timer = app_timer_register(100 /* milliseconds */, app_timer_callback, NULL);
@@ -28,7 +28,7 @@ static void app_timer_callback(void *data) {
 #if 0
 static void sys_timer_callback(void* data) {
   for (int i=0; i<1; i++) {
-    PBL_LOG(LOG_LEVEL_INFO, "%d Running sys timer callback", i);
+    PBL_LOG_INFO("%d Running sys timer callback", i);
     vibes_short_pulse();
   }
   new_timer_start(s_sys_timer, 20, sys_timer_callback, NULL, 0);

--- a/src/fw/apps/prf_apps/mfg_als_app.c
+++ b/src/fw/apps/prf_apps/mfg_als_app.c
@@ -82,7 +82,7 @@ static void prv_update_display(void *context) {
         data->state_start_time = rtc_get_ticks();
         data->als_sum = 0;
         data->als_sample_count = 0;
-        PBL_LOG(LOG_LEVEL_INFO, "ALS sampling started");
+        PBL_LOG_INFO("ALS sampling started");
       }
       break;
 
@@ -101,16 +101,16 @@ static void prv_update_display(void *context) {
         // Calculate average and determine pass/fail
         data->als_average = (uint32_t)(data->als_sum / data->als_sample_count);
 
-        PBL_LOG(LOG_LEVEL_INFO, "ALS test complete - Average: %"PRIu32" (samples: %"PRIu32")",
-                data->als_average, data->als_sample_count);
+        PBL_LOG_INFO("ALS test complete - Average: %"PRIu32" (samples: %"PRIu32")",
+                     data->als_average, data->als_sample_count);
 
         if (data->als_average >= ALS_MIN_VALUE && data->als_average <= ALS_MAX_VALUE) {
           data->test_state = ALSStatePass;
-          PBL_LOG(LOG_LEVEL_INFO, "ALS test PASSED");
+          PBL_LOG_INFO("ALS test PASSED");
         } else {
           data->test_state = ALSStateFail;
-          PBL_LOG(LOG_LEVEL_ERROR, "ALS test FAILED - Average %"PRIu32" outside range %d-%d",
-                  data->als_average, ALS_MIN_VALUE, ALS_MAX_VALUE);
+          PBL_LOG_ERR("ALS test FAILED - Average %"PRIu32" outside range %d-%d",
+                      data->als_average, ALS_MIN_VALUE, ALS_MAX_VALUE);
         }
       }
       break;
@@ -147,7 +147,7 @@ static void prv_select_click_handler(ClickRecognizerRef recognizer, void *contex
     data->test_state = ALSStateCountdown;
     data->state_start_time = rtc_get_ticks();
 
-    PBL_LOG(LOG_LEVEL_INFO, "ALS test started - countdown %d ms", COUNTDOWN_MS);
+    PBL_LOG_INFO("ALS test started - countdown %d ms", COUNTDOWN_MS);
   } else if (data->test_state == ALSStatePass || data->test_state == ALSStateFail) {
     // Exit app on second press
     app_window_stack_pop(true);
@@ -200,7 +200,7 @@ static void prv_handle_init(void) {
   // Register evented timer for 100ms updates
   s_timer = evented_timer_register(SAMPLE_INTERVAL_MS, true /* repeating */, prv_update_display, data);
 
-  PBL_LOG(LOG_LEVEL_INFO, "ALS test initialized - range: %d-%d", ALS_MIN_VALUE, ALS_MAX_VALUE);
+  PBL_LOG_INFO("ALS test initialized - range: %d-%d", ALS_MIN_VALUE, ALS_MAX_VALUE);
 }
 
 static void prv_handle_deinit(void) {

--- a/src/fw/apps/prf_apps/mfg_backlight_app.c
+++ b/src/fw/apps/prf_apps/mfg_backlight_app.c
@@ -37,7 +37,7 @@ static void prv_update_proc(struct Layer *layer, GContext* ctx) {
   graphics_context_set_fill_color(ctx, GColorWhite);
   graphics_fill_rect(ctx, &layer->bounds);
 
-  PBL_LOG(LOG_LEVEL_INFO, "backlight id:%d", app_data->test_pattern);
+  PBL_LOG_INFO("backlight id:%d", app_data->test_pattern);
   switch (app_data->test_pattern) {
   case TestPattern_White:
     led_controller_rgb_set_color(BACKLIGHT_COLOR_WHITE);

--- a/src/fw/apps/prf_apps/mfg_charge_app.c
+++ b/src/fw/apps/prf_apps/mfg_charge_app.c
@@ -72,7 +72,7 @@ static void prv_handle_second_tick(struct tm *tick_time, TimeUnits units_changed
   BatteryConstants battery_const;
   ret = battery_get_constants(&battery_const);
   if (ret < 0) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Skipping bad constants reading");
+    PBL_LOG_ERR("Skipping bad constants reading");
     return;
   }
 
@@ -112,7 +112,7 @@ static void prv_handle_second_tick(struct tm *tick_time, TimeUnits units_changed
       // Log battery state every second during charging
       {
         int32_t current_ma = battery_const.i_ua / 1000;
-        PBL_LOG(LOG_LEVEL_INFO, "Charging - V:%"PRId32"mV I:%"PRId32"mA T:%"PRId32"mC pct:%"PRIu8" Time:%"PRIu32"s",
+        PBL_LOG_INFO("Charging - V:%"PRId32"mV I:%"PRId32"mA T:%"PRId32"mC pct:%"PRIu8" Time:%"PRIu32"s",
                 battery_const.v_mv, current_ma, battery_const.t_mc, charge_state.charge_percent,
                 data->seconds_remaining);
       }
@@ -163,7 +163,7 @@ static void prv_handle_second_tick(struct tm *tick_time, TimeUnits units_changed
       // Time's up!
       next_state = ChargeStateFail;
       data->countdown_running = false;
-      PBL_LOG(LOG_LEVEL_ERROR, "Failed charge testing");
+      PBL_LOG_ERR("Failed charge testing");
     }
   }
 

--- a/src/fw/apps/prf_apps/mfg_discharge_app.c
+++ b/src/fw/apps/prf_apps/mfg_discharge_app.c
@@ -216,7 +216,7 @@ static void prv_handle_second_tick(struct tm *tick_time, TimeUnits units_changed
 
         // Log battery state every second during discharge
         int32_t current_ma = battery_const.i_ua / 1000;
-        PBL_LOG(LOG_LEVEL_INFO, "Discharging - V:%"PRId32"mV I:%"PRId32"mA T:%"PRId32"mC pct:%"PRIu8" Time:%"PRIu32"s",
+        PBL_LOG_INFO("Discharging - V:%"PRId32"mV I:%"PRId32"mA T:%"PRId32"mC pct:%"PRIu8" Time:%"PRIu32"s",
                 battery_const.v_mv, current_ma, battery_const.t_mc, charge_state.charge_percent,
                 data->seconds_remaining);
 

--- a/src/fw/apps/prf_apps/mfg_hrm_ctr_leakage_obelix_app.c
+++ b/src/fw/apps/prf_apps/mfg_hrm_ctr_leakage_obelix_app.c
@@ -78,12 +78,12 @@ static void prv_handle_hrm_data(PebbleEvent *e, void *context) {
         snprintf(app_data->status_string, STATUS_STRING_LEN, "HR Sampling... %d", HRM->state->is_wear);
         memset(app_data->ctr_string, 0, CTR_STRING_LEN);
         snprintf(app_data->ctr_string, CTR_STRING_LEN, "HR:%d Q:%d", e->hrm.bpm.bpm, e->hrm.bpm.quality);
-        PBL_LOG(LOG_LEVEL_DEBUG, "%s", app_data->ctr_string);
+        PBL_LOG_DBG("%s", app_data->ctr_string);
       } else if (e->hrm.event_type == HRMEvent_SpO2) {
         snprintf(app_data->status_string, STATUS_STRING_LEN, "SPO2 Sampling... %d", HRM->state->is_wear);
         memset(app_data->leak_string, 0, LEAKAGE_STRING_LEN);
         snprintf(app_data->leak_string, CTR_STRING_LEN, "SPO2:%d Q:%d", e->hrm.spo2.percent, e->hrm.spo2.quality);
-        PBL_LOG(LOG_LEVEL_DEBUG, "%s", app_data->leak_string);
+        PBL_LOG_DBG("%s", app_data->leak_string);
       }
     }
     else {
@@ -101,7 +101,7 @@ static void prv_handle_hrm_data(PebbleEvent *e, void *context) {
                 (int)e->hrm.ctr->ctr[1], (int)(e->hrm.ctr->ctr[1]*100)%100, 
                 (int)e->hrm.ctr->ctr[3], (int)(e->hrm.ctr->ctr[3]*100)%100, 
                 (int)e->hrm.ctr->ctr[5], (int)(e->hrm.ctr->ctr[5]*100)%100);
-        PBL_LOG(LOG_LEVEL_DEBUG, "%s", app_data->ctr_string);
+        PBL_LOG_DBG("%s", app_data->ctr_string);
       } else if (e->hrm.event_type == HRMEvent_Leakage) {
         bool rst = (e->hrm.leakage->leakage[0] <= PPG_GR_LEAK_THS0) && (e->hrm.leakage->leakage[1] <= PPG_GR_LEAK_THS1) 
                 && (e->hrm.leakage->leakage[2] <= PPG_IR_LEAK_THS0) && (e->hrm.leakage->leakage[3] <= PPG_IR_LEAK_THS1)
@@ -116,7 +116,7 @@ static void prv_handle_hrm_data(PebbleEvent *e, void *context) {
                 (int)e->hrm.leakage->leakage[1], (int)(e->hrm.leakage->leakage[1]*100)%100, 
                 (int)e->hrm.leakage->leakage[3], (int)(e->hrm.leakage->leakage[3]*100)%100, 
                 (int)e->hrm.leakage->leakage[5], (int)(e->hrm.leakage->leakage[5]*100)%100);
-        PBL_LOG(LOG_LEVEL_DEBUG, "%s", app_data->leak_string);
+        PBL_LOG_DBG("%s", app_data->leak_string);
       }
     }
     layer_mark_dirty(&app_data->window.layer);

--- a/src/fw/apps/prf_apps/mfg_mag_app.c
+++ b/src/fw/apps/prf_apps/mfg_mag_app.c
@@ -131,7 +131,7 @@ static void prv_update_display(void *context) {
   }
 
   // Log raw magnetometer samples at debug level
-  PBL_LOG(LOG_LEVEL_DEBUG, "Mag (mG): X:%"PRIi16" Y:%"PRIi16" Z:%"PRIi16,
+  PBL_LOG_DBG("Mag (mG): X:%"PRIi16" Y:%"PRIi16" Z:%"PRIi16,
           sample.x, sample.y, sample.z);
 
   uint32_t elapsed = (uint32_t)(rtc_get_ticks() - data->state_start_time);

--- a/src/fw/apps/prf_apps/mfg_mic_asterix_app.c
+++ b/src/fw/apps/prf_apps/mfg_mic_asterix_app.c
@@ -103,7 +103,7 @@ static void da7212_register_write(uint8_t reg, uint8_t value) {
   bool ret;
 
   i2c_use(I2C_DA7212);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Writing DA7212 register 0x%02x with value 0x%02x", reg, value);
+  PBL_LOG_DBG("Writing DA7212 register 0x%02x with value 0x%02x", reg, value);
 
   ret = i2c_write_block(I2C_DA7212, 2, data);
   PBL_ASSERTN(ret);

--- a/src/fw/apps/prf_apps/mfg_mic_getafix_app.c
+++ b/src/fw/apps/prf_apps/mfg_mic_getafix_app.c
@@ -87,14 +87,14 @@ typedef struct {
 // FFT analysis function
 static int prv_find_peak_frequency(int16_t *samples, size_t sample_count) {
   if (sample_count < FFT_SIZE) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Not enough samples for FFT: %zu", sample_count);
+    PBL_LOG_WRN("Not enough samples for FFT: %zu", sample_count);
     return -1;
   }
 
   // Allocate FFT configuration
   kiss_fftr_cfg fft_cfg = kiss_fftr_alloc(FFT_SIZE, 0, NULL, NULL);
   if (!fft_cfg) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to allocate FFT configuration");
+    PBL_LOG_ERR("Failed to allocate FFT configuration");
     return -1;
   }
 
@@ -125,7 +125,7 @@ static int prv_find_peak_frequency(int16_t *samples, size_t sample_count) {
   // Frequency = (bin * sample_rate) / FFT_SIZE
   int peak_freq = (peak_bin * SAMPLE_RATE_HZ) / FFT_SIZE;
 
-  PBL_LOG(LOG_LEVEL_INFO, "Peak found at bin %d, frequency %d Hz, magnitude %ld",
+  PBL_LOG_INFO("Peak found at bin %d, frequency %d Hz, magnitude %ld",
           peak_bin, peak_freq, (long)max_magnitude);
 
   // Clean up
@@ -134,7 +134,7 @@ static int prv_find_peak_frequency(int16_t *samples, size_t sample_count) {
 
   // Check if magnitude is above threshold
   if (max_magnitude < MIN_PEAK_MAGNITUDE) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Peak magnitude too low: %ld", (long)max_magnitude);
+    PBL_LOG_WRN("Peak magnitude too low: %ld", (long)max_magnitude);
     return -1;
   }
 
@@ -263,14 +263,14 @@ static void prv_start_test(void) {
 
   snprintf(data->status_text, STATUS_STR_LEN, "Recording...");
 
-  PBL_LOG(LOG_LEVEL_INFO, "Starting microphone test (channels=%lu, block_size=%lu)",
+  PBL_LOG_INFO("Starting microphone test (channels=%lu, block_size=%lu)",
           (unsigned long)num_channels, (unsigned long)BLOCK_SIZE);
 
   mic_init(MIC);
   mic_set_volume(MIC, 100);  // maximum volume
 
   if (!mic_start(MIC, prv_mic_data_handler, NULL, data->pcm, PCM_BUFFER_SIZE)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to start microphone");
+    PBL_LOG_ERR("Failed to start microphone");
     data->state = TestState_Failed;
     snprintf(data->status_text, STATUS_STR_LEN, "Mic start failed");
   }

--- a/src/fw/apps/prf_apps/mfg_touch_app.c
+++ b/src/fw/apps/prf_apps/mfg_touch_app.c
@@ -100,8 +100,8 @@ static void prv_touch_envent_handler(const TouchEvent *event, void *context) {
 
   data->touch_mark |= 1<<touch_id;
 #if TOUCH_SUPPORT_DEBUG
-  PBL_LOG(LOG_LEVEL_INFO, "start_x:%d start_y:%d off_x:%d off_y:%d", x, y, offset_x, offset_y);
-  PBL_LOG(LOG_LEVEL_INFO, "x:%d y:%d id:%d", (x+offset_x), (y+offset_y), touch_id);
+  PBL_LOG_INFO("start_x:%d start_y:%d off_x:%d off_y:%d", x, y, offset_x, offset_y);
+  PBL_LOG_INFO("x:%d y:%d id:%d", (x+offset_x), (y+offset_y), touch_id);
 #endif
   layer_mark_dirty(&data->window.layer);
 }

--- a/src/fw/apps/prf_apps/recovery_first_use_app/getting_started_button_combo.c
+++ b/src/fw/apps/prf_apps/recovery_first_use_app/getting_started_button_combo.c
@@ -46,7 +46,7 @@ static void prv_mfg_mode_cb(void *data) {
 #endif
 
 static void prv_timeout_expired(void *data) {
-  PBL_LOG(LOG_LEVEL_INFO, "Button combo timeout expired!");
+  PBL_LOG_INFO("Button combo timeout expired!");
 
   // Timeout expired, jump over the app thread to do the thing.
   void (*real_callback)(void*) = data;
@@ -70,7 +70,7 @@ static void prv_update_state(GettingStartedButtonComboState *state) {
 
   for (unsigned int i = 0; i < ARRAY_LENGTH(BUTTON_COMBOS); ++i) {
     if (state->buttons_held_bitset == BUTTON_COMBOS[i].desired_bitset) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Starting timer for combo #%d", i);
+      PBL_LOG_DBG("Starting timer for combo #%d", i);
 
       new_timer_start(state->combo_timer, COMBO_HOLD_MS, prv_timeout_expired,
                       BUTTON_COMBOS[i].callback, 0);
@@ -78,7 +78,7 @@ static void prv_update_state(GettingStartedButtonComboState *state) {
     }
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Stopping combo timer");
+  PBL_LOG_DBG("Stopping combo timer");
 
   // No combo found, cancel the timer. It's harmless to call this if the timer isn't running.
   new_timer_stop(state->combo_timer);

--- a/src/fw/apps/sdk/sdk_app.c
+++ b/src/fw/apps/sdk/sdk_app.c
@@ -89,7 +89,7 @@ static void prv_handle_tick_timer(struct tm *tick_time, TimeUnits units_changed)
 static void prv_launch_last_installed_app(ClickRecognizerRef recognizer, void *data) {
   const AppInstallId app_id = shell_sdk_get_last_installed_app();
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Last installed app is %"PRId32, app_id);
+  PBL_LOG_DBG("Last installed app is %"PRId32, app_id);
 
   if (app_id != INSTALL_ID_INVALID) {
     app_manager_put_launch_app_event(&(AppLaunchEventConfig) { .id = app_id });
@@ -104,10 +104,10 @@ static void prv_launch_timeline(ClickRecognizerRef recognizer, void *data) {
 
   const bool is_up = (click_recognizer_get_button_id(recognizer) == BUTTON_ID_UP);
   if (is_up) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Launching timeline in past mode.");
+    PBL_LOG_DBG("Launching timeline in past mode.");
     s_timeline_args.direction = TimelineIterDirectionPast;
   } else {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Launching timeline in future mode.");
+    PBL_LOG_DBG("Launching timeline in future mode.");
     s_timeline_args.direction = TimelineIterDirectionFuture;
   }
 

--- a/src/fw/apps/system_apps/activity_demo_app.c
+++ b/src/fw/apps/system_apps/activity_demo_app.c
@@ -531,7 +531,7 @@ static void prv_debug_cmd_minute_data(int index, void *context) {
       prv_display_alert(data->debug_card.dialog_text);
       goto exit;
     }
-    PBL_LOG(LOG_LEVEL_DEBUG, "Got %d minutes with UTC of %d (delta of %d min)", (int)chunk,
+    PBL_LOG_DBG("Got %d minutes with UTC of %d (delta of %d min)", (int)chunk,
             (int)utc_start, (int)(utc_start - prior_start) / SECONDS_PER_MINUTE);
     num_records += chunk;
     utc_start += chunk * SECONDS_PER_MINUTE;
@@ -547,7 +547,7 @@ static void prv_debug_cmd_minute_data(int index, void *context) {
 
   // Print detail on the last few minutes
   const int k_print_batch_size = k_size;
-  PBL_LOG(LOG_LEVEL_DEBUG, "Fetching last %d minutes", k_print_batch_size);
+  PBL_LOG_DBG("Fetching last %d minutes", k_print_batch_size);
   utc_start = rtc_get_time() - (k_print_batch_size * SECONDS_PER_MINUTE);
   time_t prior_start = utc_start;
   uint32_t chunk = k_print_batch_size;
@@ -559,7 +559,7 @@ static void prv_debug_cmd_minute_data(int index, void *context) {
     goto exit;
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Got last %d minutes with UTC of %d (delta of %d min)", (int)chunk,
+  PBL_LOG_DBG("Got last %d minutes with UTC of %d (delta of %d min)", (int)chunk,
           (int)utc_start, (int)(utc_start - prior_start) / SECONDS_PER_MINUTE);
 
   const unsigned int k_num_last_minutes = 6;

--- a/src/fw/apps/system_apps/app_fetch_ui.c
+++ b/src/fw/apps/system_apps/app_fetch_ui.c
@@ -68,7 +68,7 @@ static void prv_set_progress(AppFetchUIData *data, int16_t progress) {
 // Launch the desired app
 static void prv_app_fetch_launch_app(AppFetchUIData *data) {
   // Let's launch the application we just fetched.
-  PBL_LOG(LOG_LEVEL_DEBUG, "App Fetch: Putting launch event");
+  PBL_LOG_DBG("App Fetch: Putting launch event");
 
   // if this was launched by the phone, it's probably a new install
   if ((data->next_app_args.common.reason == APP_LAUNCH_PHONE) &&
@@ -172,14 +172,14 @@ static void prv_progress_window_finished(ProgressWindow *window, bool success, v
 
 //! Used to clean up the application's data before exiting
 static void prv_app_fetch_cleanup(AppFetchUIData *data) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "App Fetch: prv_app_fetch_cleanup");
+  PBL_LOG_DBG("App Fetch: prv_app_fetch_cleanup");
   event_service_client_unsubscribe(&data->fetch_event_info);
   event_service_client_unsubscribe(&data->connect_event_info);
 }
 
 //! Used when the app fetch process has failed
 static void prv_app_fetch_failure(AppFetchUIData *data, uint8_t error_code) {
-  PBL_LOG(LOG_LEVEL_WARNING, "App Fetch: prv_app_fetch_failure: %d", error_code);
+  PBL_LOG_WRN("App Fetch: prv_app_fetch_failure: %d", error_code);
 
   if (error_code == AppFetchResultUserCancelled) {
     app_window_stack_pop(true);
@@ -190,13 +190,13 @@ static void prv_app_fetch_failure(AppFetchUIData *data, uint8_t error_code) {
       app_install_entry_is_watchface(&data->install_entry)) {
     // We failed to fetch a watchface and it was our default.
     // Invalidate it and it will be reassigned to one that exists next time around.
-    PBL_LOG(LOG_LEVEL_WARNING, "Default watchface fetch failed, setting INVALID as default");
+    PBL_LOG_WRN("Default watchface fetch failed, setting INVALID as default");
     watchface_set_default_install_id(INSTALL_ID_INVALID);
   } else if ((worker_manager_get_default_install_id() == data->install_entry.install_id) &&
              app_install_entry_has_worker(&data->install_entry)) {
     // We failed to fetch a worker and it was our default.
     // Invalidate it and it will be reassigned to one that is launched next.
-    PBL_LOG(LOG_LEVEL_WARNING, "Default worker fetch failed, setting INVALID as default");
+    PBL_LOG_WRN("Default worker fetch failed, setting INVALID as default");
     worker_manager_set_default_install_id(INSTALL_ID_INVALID);
   }
 
@@ -212,7 +212,7 @@ static void prv_app_fetch_event_handler(PebbleEvent *event, void *context) {
 
   // We have starting the App Fetch Process
   if (af_event->type == AppFetchEventTypeStart) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "App Fetch: Got the start event");
+    PBL_LOG_DBG("App Fetch: Got the start event");
 
   // We have received a new progress event
   } else if (af_event->type == AppFetchEventTypeProgress) {
@@ -265,7 +265,7 @@ static void handle_init(void) {
 
   // retrieve data about the AppInstallId given
   if (!app_install_get_entry_for_install_id(data->next_app_args.app_id, &data->install_entry)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "App Fetch: Error getting entry for id: %"PRIu32"",
+    PBL_LOG_ERR("App Fetch: Error getting entry for id: %"PRIu32"",
         data->next_app_args.app_id);
     return;
   }

--- a/src/fw/apps/system_apps/health/health_data.c
+++ b/src/fw/apps/system_apps/health/health_data.c
@@ -127,7 +127,7 @@ void health_data_update(HealthData *health_data) {
   health_data->num_activity_sessions = ACTIVITY_MAX_ACTIVITY_SESSIONS_COUNT;
   if (!activity_get_sessions(&health_data->num_activity_sessions,
                              health_data->activity_sessions)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Fetching activity sessions failed");
+    PBL_LOG_ERR("Fetching activity sessions failed");
   } else {
     ActivitySession *previous_session = NULL;
     for (unsigned int i = 0; i < health_data->num_activity_sessions; i++) {

--- a/src/fw/apps/system_apps/hrm_demo.c
+++ b/src/fw/apps/system_apps/hrm_demo.c
@@ -108,17 +108,17 @@ static void prv_send_msg(void) {
   if (result == APP_MSG_OK) {
     app_data->ready_to_send = false;
   } else {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Error sending message: %s", prv_translate_error(result));
+    PBL_LOG_DBG("Error sending message: %s", prv_translate_error(result));
   }
 }
 
 static void prv_send_status_and_version(void) {
   AppData *app_data = app_state_get_user_data();
-  PBL_LOG(LOG_LEVEL_DEBUG, "Sending status and version to mobile app");
+  PBL_LOG_DBG("Sending status and version to mobile app");
 
   AppMessageResult result = app_message_outbox_begin(&app_data->out_iter);
   if (result != APP_MSG_OK) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Failed to begin outbox - reason %i %s",
+    PBL_LOG_DBG("Failed to begin outbox - reason %i %s",
             result, prv_translate_error(result));
     return;
   }
@@ -178,7 +178,7 @@ static void prv_handle_hrm_data(PebbleEvent *e, void *context) {
       bpm = hrm->bpm.bpm;
       bpm_quality = hrm->bpm.quality;
     } else if (hrm->event_type == HRMEvent_SubscriptionExpiring) {
-      PBL_LOG(LOG_LEVEL_INFO, "Got subscription expiring event");
+      PBL_LOG_INFO("Got subscription expiring event");
       // Subscribe again if our subscription is expiring
       const uint32_t update_time_s = 1;
       app_data->session = sys_hrm_manager_app_subscribe(APP_ID_HRM_DEMO, update_time_s,
@@ -241,7 +241,7 @@ static void prv_message_sent_cb(DictionaryIterator *iterator, void *context) {
 
 static void prv_message_failed_cb(DictionaryIterator *iterator,
                                AppMessageResult reason, void *context) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Out message send failed - reason %i %s",
+  PBL_LOG_DBG("Out message send failed - reason %i %s",
           reason, prv_translate_error(reason));
   AppData *app_data = app_state_get_user_data();
   app_data->ready_to_send = true;
@@ -285,10 +285,10 @@ static void prv_init(void) {
   const uint32_t outbox_size = 256;
   AppMessageResult result = app_message_open(inbox_size, outbox_size);
   if (result != APP_MSG_OK) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Unable to open app message! %i %s",
+    PBL_LOG_ERR("Unable to open app message! %i %s",
             result, prv_translate_error(result));
   } else {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Successfully opened app message");
+    PBL_LOG_DBG("Successfully opened app message");
   }
 
   if (!sys_hrm_manager_is_hrm_present()) {

--- a/src/fw/apps/system_apps/launcher/default/launcher_app_glance_generic.c
+++ b/src/fw/apps/system_apps/launcher/default/launcher_app_glance_generic.c
@@ -276,7 +276,7 @@ static void prv_generic_glance_dynamic_text_node_update(PBL_UNUSED GContext *ctx
   if (!structured_glance) {
     return;
   } else if (structured_glance->glance.current_slice.type != AppGlanceSliceType_IconAndSubtitle) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Generic glance doesn't know how to handle slice type %d",
+    PBL_LOG_WRN("Generic glance doesn't know how to handle slice type %d",
             structured_glance->glance.current_slice.type);
     return;
   }
@@ -296,7 +296,7 @@ static void prv_generic_glance_dynamic_text_node_update(PBL_UNUSED GContext *ctx
   if (template_string_error.status != TemplateStringErrorStatus_Success) {
     // Zero out the buffer and return
     buffer[0] = '\0';
-    PBL_LOG(LOG_LEVEL_WARNING, "Error at index %zu in evaluating template string: %s",
+    PBL_LOG_WRN("Error at index %zu in evaluating template string: %s",
             template_string_error.index_in_string, subtitle_template_string);
     return;
   }

--- a/src/fw/apps/system_apps/send_text/send_text.c
+++ b/src/fw/apps/system_apps/send_text/send_text.c
@@ -121,7 +121,7 @@ static void prv_open_action_menu(SendTextAppData *data, const char *number) {
       item, TimelineItemActionTypeResponse);
 
   if (!reply_action) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Not opening response menu - unable to load reply action");
+    PBL_LOG_ERR("Not opening response menu - unable to load reply action");
     timeline_item_destroy(item);
     return;
   }

--- a/src/fw/apps/system_apps/settings/settings_bluetooth.c
+++ b/src/fw/apps/system_apps/settings/settings_bluetooth.c
@@ -1,8 +1,6 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define FILE_LOG_COLOR LOG_COLOR_BLUE
-
 #include "settings_bluetooth.h"
 #include "settings_menu.h"
 #include "settings_remote.h"
@@ -290,7 +288,7 @@ void settings_bluetooth_update_remotes(SettingsBluetoothData *data) {
 
 static void prv_settings_bluetooth_event_handler(PebbleEvent *event, void *context) {
   SettingsBluetoothData* settings_data = (SettingsBluetoothData *) context;
-  PBL_LOG_COLOR(LOG_LEVEL_DEBUG, LOG_COLOR_BLUE, "BT EVENT");
+  PBL_LOG_DBG("BT EVENT");
   switch (event->type) {
     case PEBBLE_BT_CONNECTION_EVENT:
       // If BT Settings is open, update BLE device name upon connecting device:
@@ -317,14 +315,14 @@ static void prv_settings_bluetooth_event_handler(PebbleEvent *event, void *conte
         if (!settings_data->did_enable_pairability) {
           bt_pairability_use();
           settings_data->did_enable_pairability = true;
-          PBL_LOG(LOG_LEVEL_INFO, "Enabled advertising - no paired devices");
+          PBL_LOG_INFO("Enabled advertising - no paired devices");
         }
       } else if (!had_remotes && has_remotes) {
         // Device was added, disable advertising
         if (settings_data->did_enable_pairability) {
           bt_pairability_release();
           settings_data->did_enable_pairability = false;
-          PBL_LOG(LOG_LEVEL_INFO, "Disabled advertising - device paired");
+          PBL_LOG_INFO("Disabled advertising - device paired");
         }
       }
       

--- a/src/fw/apps/system_apps/settings/settings_remote.c
+++ b/src/fw/apps/system_apps/settings/settings_remote.c
@@ -105,8 +105,8 @@ static void prv_forget_item(ActionMenu *action_menu,
     default:
       WTF;
   }
-  PBL_LOG(LOG_LEVEL_INFO, "User Forgot BT Pairing (%u)", remote->type);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Name: %s", remote->name);
+  PBL_LOG_INFO("User Forgot BT Pairing (%u)", remote->type);
+  PBL_LOG_DBG("Name: %s", remote->name);
   settings_bluetooth_update_remotes(remote_data->bt_data);
   prv_show_dialog(context);
 }
@@ -137,7 +137,7 @@ static void prv_stop_sharing_heart_rate(ActionMenu *action_menu,
 void settings_remote_menu_push(struct SettingsBluetoothData *bt_data, StoredRemote *stored_remote) {
   SettingsRemoteData *data = app_malloc_check(sizeof(SettingsRemoteData));
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "NAME: %s", stored_remote->name);
+  PBL_LOG_DBG("NAME: %s", stored_remote->name);
   *data = (SettingsRemoteData){};
   data->remote = *stored_remote;
   data->bt_data = bt_data;

--- a/src/fw/apps/system_apps/settings/settings_themes.c
+++ b/src/fw/apps/system_apps/settings/settings_themes.c
@@ -136,7 +136,7 @@ static void prv_push_apps_color_menu(SettingsThemesData *data) {
   if (selected < 0) {
     // Invalid color stored - fall back to default instead of crashing
     // This can happen if an invalid color was synced from the phone
-    PBL_LOG(LOG_LEVEL_WARNING, "Invalid apps menu color, using default");
+    PBL_LOG_WRN("Invalid apps menu color, using default");
     selected = 0;
   }
   OptionMenu * const option_menu = settings_option_menu_create(
@@ -198,7 +198,7 @@ static void prv_push_settings_color_menu(SettingsThemesData *data) {
   if (selected < 0) {
     // Invalid color stored - fall back to default instead of crashing
     // This can happen if an invalid color was synced from the phone
-    PBL_LOG(LOG_LEVEL_WARNING, "Invalid settings menu color, using default");
+    PBL_LOG_WRN("Invalid settings menu color, using default");
     selected = 0;
   }
   OptionMenu * const option_menu = settings_option_menu_create(

--- a/src/fw/apps/system_apps/settings/settings_vibe_patterns.c
+++ b/src/fw/apps/system_apps/settings/settings_vibe_patterns.c
@@ -122,7 +122,7 @@ static void prv_selection_changed_cb(SettingsCallbacks *context, uint16_t new_ro
       WTF;
   }
   if (!score) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Null VibeScore!");
+    PBL_LOG_ERR("Null VibeScore!");
     return;
   }
   vibe_score_do_vibe(score);

--- a/src/fw/apps/system_apps/timeline/timeline.c
+++ b/src/fw/apps/system_apps/timeline/timeline.c
@@ -134,7 +134,7 @@ static bool prv_can_transition_state(TimelineAppData *data, TimelineAppState nex
 
 static bool prv_set_state(TimelineAppData *data, TimelineAppState next_state) {
   const bool can_transition = prv_can_transition_state(data, next_state);
-  PBL_LOG(LOG_LEVEL_DEBUG, "state transition %d->%d valid:%d",
+  PBL_LOG_DBG("state transition %d->%d valid:%d",
           data->state, next_state, can_transition);
   if (can_transition) {
     data->state = next_state;
@@ -1230,7 +1230,7 @@ static bool NOINLINE prv_setup_timeline_app(void) {
         // for some reason we can't find the pin we were asked to launch into
         char uuid_buffer[UUID_STRING_BUFFER_LENGTH];
         uuid_to_string(&args->pin_id, uuid_buffer);
-        PBL_LOG(LOG_LEVEL_ERROR, "Asked to launch into pin but can't find it %s", uuid_buffer);
+        PBL_LOG_ERR("Asked to launch into pin but can't find it %s", uuid_buffer);
         launch_into_pin = false;
         data->launch_into_deep_pin = false;
         // we couldn't find the launch pin, go back to the present

--- a/src/fw/apps/system_apps/timeline/timeline_layer.c
+++ b/src/fw/apps/system_apps/timeline/timeline_layer.c
@@ -676,7 +676,7 @@ static void prv_update_proc(struct Layer *layer, GContext* ctx) {
 
 // when we create a new next or previous item, we want it out of view so we can animate it in
 void timeline_layer_set_next_item(TimelineLayer *layer, int index) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Setting next item with index %d", index);
+  PBL_LOG_DBG("Setting next item with index %d", index);
   TimelineIterState *iter_state = timeline_model_get_iter_state_with_timeline_idx(index);
   if (!iter_state) {
     return;
@@ -688,7 +688,7 @@ void timeline_layer_set_next_item(TimelineLayer *layer, int index) {
 }
 
 void timeline_layer_set_prev_item(TimelineLayer *layer, int index) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Setting prev item with index %d", index);
+  PBL_LOG_DBG("Setting prev item with index %d", index);
   TimelineIterState *iter_state = timeline_model_get_iter_state_with_timeline_idx(index);
   if (!iter_state) {
     return;

--- a/src/fw/apps/system_apps/timeline/timeline_model.c
+++ b/src/fw/apps/system_apps/timeline/timeline_model.c
@@ -102,13 +102,13 @@ static int prv_find_item_by_uuid(Uuid *id) {
 
 #ifdef TIMELINE_DEBUG
 static void prv_log_all_items(void) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "First item: %d, last item: %d", s_model_data->first_index,
+  PBL_LOG_DBG("First item: %d, last item: %d", s_model_data->first_index,
     s_model_data->last_index);
   for (int i = 0; i < TIMELINE_NUM_VISIBLE_ITEMS; i++) {
     TimelineItem *item = &timeline_model_get_iter_state(i)->pin;
-    PBL_LOG(LOG_LEVEL_DEBUG, "ID first byte: 0x%x", item->header.id.byte0);
-    PBL_LOG(LOG_LEVEL_DEBUG, "Address of node: %p", timeline_model_get_iter_state(i)->node);
-    PBL_LOG(LOG_LEVEL_DEBUG, "Timestamp: %ld", item->header.timestamp);
+    PBL_LOG_DBG("ID first byte: 0x%x", item->header.id.byte0);
+    PBL_LOG_DBG("Address of node: %p", timeline_model_get_iter_state(i)->node);
+    PBL_LOG_DBG("Timestamp: %ld", item->header.timestamp);
   }
 }
 #endif
@@ -116,7 +116,7 @@ static void prv_log_all_items(void) {
 static void prv_move_first_index(int delta) {
   s_model_data->first_index = positive_modulo(
       s_model_data->first_index + delta, TIMELINE_NUM_ITEMS_IN_MODEL);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Set origin, initial item: %d, final item: %d",
+  PBL_LOG_DBG("Set origin, initial item: %d, final item: %d",
       s_model_data->first_index, s_model_data->last_index);
 }
 
@@ -204,7 +204,7 @@ void timeline_model_init(time_t timestamp, TimelineModel *model) {
     rv = timeline_iter_init(prv_get_iter(i), timeline_model_get_iter_state(i),
       &s_model_data->timeline, s_model_data->direction, timestamp);
     if (FAILED(rv)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Timeline iterator failed to init!");
+      PBL_LOG_ERR("Timeline iterator failed to init!");
     }
     if (FAILED(rv) || rv == S_NO_MORE_ITEMS) {
       timeline_model_get_iter_state(i)->node = NULL;
@@ -248,7 +248,7 @@ static void prv_remove_index_gracefully(int idx) {
             timeline_model_get_iter_state(i - 1)->node));
     }
     timeline_iter_remove_node(&s_model_data->timeline, node);
-    PBL_LOG(LOG_LEVEL_DEBUG, "Item to delete in view, iterating next");
+    PBL_LOG_DBG("Item to delete in view, iterating next");
   } else if (iter_prev(prv_get_iter(idx))) {
     // prv_get_iter(idx) is at the end, so we have to move prev-wards
     // if prv_get_iter(idx) is at the end, all iters > idx must also be at the end
@@ -257,11 +257,11 @@ static void prv_remove_index_gracefully(int idx) {
       iter_prev(prv_get_iter(i));
     }
     timeline_iter_remove_node(&s_model_data->timeline, node);
-    PBL_LOG(LOG_LEVEL_DEBUG, "Item to delete in view, iterating prev");
+    PBL_LOG_DBG("Item to delete in view, iterating prev");
   } else {
     // if we can't iterate next or prev, we've deleted the only item
     timeline_model_deinit();
-    PBL_LOG(LOG_LEVEL_DEBUG, "Item to delete in view, deiniting ");
+    PBL_LOG_DBG("Item to delete in view, deiniting ");
   }
 }
 

--- a/src/fw/apps/system_apps/timeline/timeline_relbar.c
+++ b/src/fw/apps/system_apps/timeline/timeline_relbar.c
@@ -481,7 +481,7 @@ static void prv_update_rel_bars(TimelineLayer *layer) {
   }
   layer->relbar_layer.curr_rel_bar.rel_bar_type = rel_bar_types[1];
   if (layer->layouts_info[1]) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Current rel bar %d, duration %"PRIu32, rel_bar_types[1],
+    PBL_LOG_DBG("Current rel bar %d, duration %"PRIu32, rel_bar_types[1],
             layer->layouts_info[1]->duration_s);
   }
 }

--- a/src/fw/apps/system_apps/workout/sports.c
+++ b/src/fw/apps/system_apps/workout/sports.c
@@ -76,7 +76,7 @@ static void prv_health_service_event_handler(HealthEventType event, void *contex
 
 static void prv_sync_error_callback(DictionaryResult dict_error, AppMessageResult app_message_error,
                                 void *context) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Sports error! dict: %u, app msg: %u", dict_error,
+  PBL_LOG_DBG("Sports error! dict: %u, app msg: %u", dict_error,
           app_message_error);
 }
 

--- a/src/fw/apps/system_apps/workout/workout_active.c
+++ b/src/fw/apps/system_apps/workout/workout_active.c
@@ -903,7 +903,7 @@ WorkoutActiveWindow *workout_active_create_single_layout(WorkoutMetricType metri
                                                          void *workout_data,
                                                          WorkoutController *workout_controller) {
   if (metric == WorkoutMetricType_None) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid argument");
+    PBL_LOG_ERR("Invalid argument");
     return NULL;
   }
 
@@ -923,7 +923,7 @@ WorkoutActiveWindow *workout_active_create_double_layout(WorkoutMetricType top_m
                                                          void *workout_data,
                                                          WorkoutController *workout_controller) {
   if (top_metric == WorkoutMetricType_None || num_scrollable_metrics == 0 || !scrollable_metrics) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid argument(s)");
+    PBL_LOG_ERR("Invalid argument(s)");
     return NULL;
   }
 
@@ -946,7 +946,7 @@ WorkoutActiveWindow *workout_active_create_tripple_layout(WorkoutMetricType top_
                                                           WorkoutController *workout_controller) {
   if (top_metric == WorkoutMetricType_None || middle_metric == WorkoutMetricType_None ||
       (num_scrollable_metrics != 0 && !scrollable_metrics)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid argument(s)");
+    PBL_LOG_ERR("Invalid argument(s)");
     return NULL;
   }
 

--- a/src/fw/assert.c
+++ b/src/fw/assert.c
@@ -5,6 +5,6 @@
 #include "system/passert.h"
 
 void __assert_func(const char *file, int line, const char *func, const char *e) {
-  PBL_LOG(LOG_LEVEL_ERROR, "assert at line %d, func: %s - %s", line, func, e);
+  PBL_LOG_ERR("assert at line %d, func: %s - %s", line, func, e);
   WTF;
 }

--- a/src/fw/board/boards/board_asterix.c
+++ b/src/fw/board/boards/board_asterix.c
@@ -216,7 +216,7 @@ const Npm1300Config NPM1300_CONFIG = {
 };
 
 void board_early_init(void) {
-  PBL_LOG(LOG_LEVEL_ERROR, "asterix early init");
+  PBL_LOG_ERR("asterix early init");
 
   NRF_NVMC->ICACHECNF |= NVMC_ICACHECNF_CACHEEN_Msk;
 

--- a/src/fw/comm/ble/ble_log.h
+++ b/src/fw/comm/ble/ble_log.h
@@ -3,12 +3,11 @@
 
 #pragma once
 
-#define FILE_LOG_COLOR LOG_COLOR_BLUE
 #include "system/logging.h"
 #include "system/passert.h"
 #include "system/hexdump.h"
 
-#define BLE_LOG_DEBUG(fmt, args...) PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG, fmt, ## args)
-#define BLE_LOG_VERBOSE(fmt, args...) PBL_LOG_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG_VERBOSE, fmt, ## args)
+#define BLE_LOG_DEBUG(fmt, args...) PBL_LOG_D_DBG(LOG_DOMAIN_BT, fmt, ## args)
+#define BLE_LOG_VERBOSE(fmt, args...) PBL_LOG_D_VERBOSE(LOG_DOMAIN_BT, fmt, ## args)
 #define BLE_HEXDUMP(data, length) PBL_HEXDUMP_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG, data, length)
 #define BLE_HEXDUMP_VERBOSE(data, length) PBL_HEXDUMP_D(LOG_DOMAIN_BT, LOG_LEVEL_DEBUG_VERBOSE, data, length)

--- a/src/fw/comm/ble/gap_le_connect_params.c
+++ b/src/fw/comm/ble/gap_le_connect_params.c
@@ -1,8 +1,6 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define FILE_LOG_COLOR LOG_COLOR_BLUE
-
 #include "gap_le_connect_params.h"
 #include "gap_le_connection.h"
 
@@ -157,7 +155,7 @@ static void prv_request_params_update(GAPLEConnection *connection,
     // [MT]: I've hit this once now. When this happened the TI CC2564B became unresponsive.
     // From the iOS side, it appeared as a connection timeout. A little while after this happened,
     // the BT chip auto-reset work-around kicked in.
-    PBL_LOG(LOG_LEVEL_ERROR, "Max attempts reached, giving up. desired_state=%u", state);
+    PBL_LOG_ERR("Max attempts reached, giving up. desired_state=%u", state);
     bluetooth_analytics_handle_param_update_failed();
     return;
   }
@@ -197,7 +195,7 @@ static void prv_watchdog_timer_callback(void *ctx) {
     // Retry with most recently requested latency:
     const ResponseTimeState state = conn_mgr_get_latency_for_le_connection(connection, NULL);
     if (connection->param_update_info.attempts > 0) {
-      PBL_LOG(LOG_LEVEL_INFO, "Conn param request timed out: re-requesting %u", state);
+      PBL_LOG_INFO("Conn param request timed out: re-requesting %u", state);
     }
     prv_request_params_update(connection, state);
   }
@@ -243,7 +241,7 @@ static void prv_evaluate(GAPLEConnection *connection, ResponseTimeState desired_
 
   // Connection parameters are updated, but they don't match the desired parameters.
   // (Re)request a parameter update:
-  PBL_LOG(LOG_LEVEL_INFO, "Connection parameters do not match desired state: %u", desired_state);
+  PBL_LOG_INFO("Connection parameters do not match desired state: %u", desired_state);
   prv_request_params_update(connection, desired_state);
 }
 
@@ -272,7 +270,7 @@ void bt_driver_handle_le_conn_params_update_event(const BleConnectionUpdateCompl
 
   GAPLEConnection *connection = gap_le_connection_by_addr(&event->dev_address);
   if (!connection) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Receiving conn param update but connection is no longer open");
+    PBL_LOG_DBG("Receiving conn param update but connection is no longer open");
     goto unlock;
   }
 

--- a/src/fw/comm/ble/gap_le_scan.c
+++ b/src/fw/comm/ble/gap_le_scan.c
@@ -1,8 +1,6 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define FILE_LOG_COLOR LOG_COLOR_BLUE
-
 #include "bluetooth/gap_le_scan.h"
 #include "kernel/pbl_malloc.h"
 #include "comm/bt_lock.h"
@@ -78,7 +76,7 @@ bool gap_le_stop_scan(void) {
       s_is_scanning = false;
 
       if (s_dropped_reports) {
-        PBL_LOG(LOG_LEVEL_INFO, "LE Scan -- Dropped reports: %" PRIu32, s_dropped_reports);
+        PBL_LOG_INFO("LE Scan -- Dropped reports: %" PRIu32, s_dropped_reports);
       }
     }
   }

--- a/src/fw/comm/ble/gap_le_slave_reconnect.c
+++ b/src/fw/comm/ble/gap_le_slave_reconnect.c
@@ -63,11 +63,11 @@ static void prv_unschedule_adv_if_needed(void) {
 static void prv_evaluate(ReconnectType prev_type) {
   ReconnectType cur_type = prv_current_reconnect_type();
   if (cur_type == prev_type) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Reconnect type unchanged: %d", cur_type);
+    PBL_LOG_DBG("Reconnect type unchanged: %d", cur_type);
     return;
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Reconnect type changed: %d -> %d", prev_type, cur_type);
+  PBL_LOG_DBG("Reconnect type changed: %d -> %d", prev_type, cur_type);
 
   if (cur_type != ReconnectType_None) {
     prv_unschedule_adv_if_needed();
@@ -160,18 +160,18 @@ void gap_le_slave_reconnect_start(void) {
   bt_lock();
   {
     if (prv_is_advertising_for_reconnection()) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Already advertising for reconnection");
+      PBL_LOG_DBG("Already advertising for reconnection");
       goto unlock;
     }
 
     if (gap_le_connect_is_connected_as_slave()) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Already connected as slave");
+      PBL_LOG_DBG("Already connected as slave");
       goto unlock;
     }
 
     if (!bt_persistent_storage_has_active_ble_gateway_bonding() &&
         !bt_persistent_storage_has_ble_ancs_bonding()) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "No bonded master device");
+      PBL_LOG_DBG("No bonded master device");
       goto unlock;
     }
 

--- a/src/fw/comm/ble/gatt.c
+++ b/src/fw/comm/ble/gatt.c
@@ -59,7 +59,7 @@ void bt_driver_cb_gatt_handle_mtu_update(const GattDeviceMtuUpdateEvent *event) 
       goto unlock;
     }
     
-    PBL_LOG(LOG_LEVEL_INFO, "Handle MTU change from %d to %d bytes",
+    PBL_LOG_INFO("Handle MTU change from %d to %d bytes",
             connection->gatt_mtu, event->mtu);
     connection->gatt_mtu = event->mtu;
   }

--- a/src/fw/comm/ble/gatt_client_accessors.c
+++ b/src/fw/comm/ble/gatt_client_accessors.c
@@ -1,7 +1,6 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define FILE_LOG_COLOR LOG_COLOR_BLUE
 #include "system/logging.h"
 
 #include "gatt_client_accessors.h"
@@ -153,7 +152,7 @@ static bool prv_iter_service_node(const GATTServiceNode *service_node,
       if (inc_service_node) {
         callbacks->included_services_iterator(inc_service_node, cb_data);
       } else {
-        PBL_LOG(LOG_LEVEL_DEBUG, "Included Service with handle %u not found!", handle[h]);
+        PBL_LOG_DBG("Included Service with handle %u not found!", handle[h]);
       }
     }
   }
@@ -351,7 +350,7 @@ uint8_t gatt_client_copy_service_refs_by_discovery_generation(
   {
     GAPLEConnection *connection = gap_le_connection_by_device(device);
     if (!connection) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Disconnected in the mean time...");
+      PBL_LOG_ERR("Disconnected in the mean time...");
       goto unlock;
     }
     GATTServiceNode *node = connection->gatt_remote_services;
@@ -382,7 +381,7 @@ uint8_t gatt_client_copy_service_refs_matching_uuid(const BTDeviceInternal *devi
   {
     GAPLEConnection *connection = gap_le_connection_by_device(device);
     if (!connection) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Disconnected in the mean time...");
+      PBL_LOG_ERR("Disconnected in the mean time...");
       goto unlock;
     }
     GATTServiceNode *node = connection->gatt_remote_services;

--- a/src/fw/comm/ble/gatt_client_discovery.c
+++ b/src/fw/comm/ble/gatt_client_discovery.c
@@ -92,7 +92,7 @@ static BTErrno prv_run_next_job(GAPLEConnection *connection) {
   // has finished or error'ed out. That way the watchdog retry mechanism
   // can simply call this routine again to kick off another discovery attempt
 
-  PBL_LOG(LOG_LEVEL_INFO, "Starting BLE Service Discovery: 0x%x to 0x%x",
+  PBL_LOG_INFO("Starting BLE Service Discovery: 0x%x to 0x%x",
           node->hdl.start, node->hdl.end);
   ATTHandleRange hdl = {
     .start = node->hdl.start,
@@ -125,7 +125,7 @@ static bool prv_discovery_handle_timeout(GAPLEConnection *connection, BTErrno *e
   bool retry_started = false;
   BTErrno finalize_result = BTErrnoOK;
   // Executing on NewTimer task, so need to bt_lock():
-  PBL_LOG(LOG_LEVEL_WARNING, "Service Discovery Watchdog Timeout");
+  PBL_LOG_WRN("Service Discovery Watchdog Timeout");
   bt_lock();
   {
     if (!gap_le_connection_is_valid(connection)) {
@@ -201,7 +201,7 @@ static void prv_send_services_added_event(
       list_count(&connection->gatt_remote_services->node) : 0;
 
   if (num_services_changed > BLE_GATT_MAX_SERVICES_CHANGED) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Remote has %u services, more than we can handle.",
+    PBL_LOG_ERR("Remote has %u services, more than we can handle.",
             num_services_changed);
     num_services_changed = BLE_GATT_MAX_SERVICES_CHANGED;
   }

--- a/src/fw/comm/ble/gatt_service_changed.c
+++ b/src/fw/comm/ble/gatt_service_changed.c
@@ -35,7 +35,7 @@ static void prv_rediscover_kernelbg_cb(void *data) {
   const BTErrno e = gatt_client_discovery_rediscover_all(device);
   kernel_free(device);
   if (e != BTErrnoOK) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Service Changed couldn't restart discovery: %i", e);
+    PBL_LOG_ERR("Service Changed couldn't restart discovery: %i", e);
   }
 }
 
@@ -47,13 +47,13 @@ bool gatt_service_changed_client_handle_indication(struct GAPLEConnection *conne
     return false;
   }
   if (value_length != sizeof(ATTHandleRange)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Service Changed Indication incorrect length: %u", value_length);
+    PBL_LOG_ERR("Service Changed Indication incorrect length: %u", value_length);
       // Pretend we ate the indication. There will be no GAPLECharacteristic in the system that will
       // match this ATT handle anyway.
     return true;
   }
   ATTHandleRange *range = (ATTHandleRange *) value;
-  PBL_LOG(LOG_LEVEL_DEBUG, "Service Changed Indication: %x - %x", range->start, range->end);
+  PBL_LOG_DBG("Service Changed Indication: %x - %x", range->start, range->end);
 
   // Initiate rediscovery on KernelBG if the Server is asking us to rediscover everything
   // (See "2.5.2 Attribute Caching" in BT Core Specification)
@@ -108,7 +108,7 @@ void gatt_service_changed_server_handle_fw_update(void) {
 void bt_driver_cb_gatt_service_changed_server_confirmation(
     const GattServerChangedConfirmationEvent *event) {
   if (event->status_code != HciStatusCode_Success) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Service Changed indication confirmation failure (timed out?) %"PRIu32,
+    PBL_LOG_ERR("Service Changed indication confirmation failure (timed out?) %"PRIu32,
             (uint32_t)event->status_code);
   }
 }
@@ -145,7 +145,7 @@ void bt_driver_cb_gatt_service_changed_server_subscribe(
   bt_lock();
   {
     if (subscribed) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Remote subscribed to Service Changed characteristic");
+      PBL_LOG_DBG("Remote subscribed to Service Changed characteristic");
 
       GAPLEConnection *connection = gap_le_connection_by_addr(&event->dev_address);
       if (!connection || connection->has_sent_gatt_service_changed_indication) {
@@ -160,7 +160,7 @@ void bt_driver_cb_gatt_service_changed_server_subscribe(
       }
 #endif
 
-      PBL_LOG(LOG_LEVEL_INFO, "Indicating Service Changed to remote device");
+      PBL_LOG_INFO("Indicating Service Changed to remote device");
 
       // Work-around for iOS issue (see comment above), send the indication after a short delay:
       connection->gatt_service_changed_indication_timer = timer;

--- a/src/fw/comm/ble/kernel_le_client/ams/ams_util.c
+++ b/src/fw/comm/ble/kernel_le_client/ams/ams_util.c
@@ -1,7 +1,6 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define FILE_LOG_COLOR LOG_COLOR_BLUE
 #include "system/logging.h"
 
 #include "ams_util.h"

--- a/src/fw/comm/ble/kernel_le_client/ancs/ancs_util.c
+++ b/src/fw/comm/ble/kernel_le_client/ancs/ancs_util.c
@@ -1,8 +1,6 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define FILE_LOG_COLOR LOG_COLOR_BLUE
-
 #include "ancs_util.h"
 #include "ancs_types.h"
 
@@ -61,7 +59,7 @@ bool ancs_util_get_attr_ptrs(const uint8_t* data, const size_t length, const Fet
 
   const uint8_t* iter = data;
   if (length < sizeof(ANCSAttribute)) {
-    PBL_LOG(LOG_LEVEL_INFO, "ANCS data length is too small. Length: %d, sizeof(ANCSAttribute): %d",
+    PBL_LOG_INFO("ANCS data length is too small. Length: %d, sizeof(ANCSAttribute): %d",
                                                           (int)length, (int)sizeof(ANCSAttribute));
     *out_error = true;
     return false;
@@ -84,7 +82,7 @@ bool ancs_util_get_attr_ptrs(const uint8_t* data, const size_t length, const Fet
         // Check that attribute length is valid
         bool attr_length_invalid = (attr_list[i].max_length != 0) && (attr->length > attr_list[i].max_length);
         if (attr_length_invalid) {
-          PBL_LOG(LOG_LEVEL_INFO, "Length of ANCS attribute %d is invalid: length: %d, max_length: %d",
+          PBL_LOG_INFO("Length of ANCS attribute %d is invalid: length: %d, max_length: %d",
                                                     attr->id, attr->length, attr_list[i].max_length);
           *out_error = true;
           return false;
@@ -100,7 +98,7 @@ bool ancs_util_get_attr_ptrs(const uint8_t* data, const size_t length, const Fet
 
     if (!is_found) {
       // The attribute was unexpected, the dictionary is malformed
-      PBL_LOG(LOG_LEVEL_INFO, "Unexpected ANCS attribute. ID = %d. The dictionary is malformed",
+      PBL_LOG_INFO("Unexpected ANCS attribute. ID = %d. The dictionary is malformed",
               attr->id);
       *out_error = true;
       return false;

--- a/src/fw/comm/ble/kernel_le_client/app_launch/app_launch.c
+++ b/src/fw/comm/ble/kernel_le_client/app_launch/app_launch.c
@@ -1,8 +1,6 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define FILE_LOG_COLOR LOG_COLOR_BLUE
-
 #include "app_launch.h"
 
 #include "comm/ble/gatt_client_operations.h"
@@ -25,7 +23,7 @@ void app_launch_handle_service_discovered(BLECharacteristic *characteristics) {
   PBL_ASSERTN(characteristics);
 
   if (s_app_launch_characteristic != BLE_CHARACTERISTIC_INVALID) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Multiple app launch services!? Will use most recent one.");
+    PBL_LOG_WRN("Multiple app launch services!? Will use most recent one.");
   }
 
   s_app_launch_characteristic = *characteristics;
@@ -56,7 +54,7 @@ bool app_launch_can_handle_characteristic(BLECharacteristic characteristic) {
 void app_launch_handle_read_or_notification(BLECharacteristic characteristic, const uint8_t *value,
                                             size_t value_length, BLEGATTError error) {
   // If error is BLEGATTErrorSuccess, it means the Pebble app responded.
-  PBL_LOG(LOG_LEVEL_INFO, "App relaunch result: %u", error);
+  PBL_LOG_INFO("App relaunch result: %u", error);
   if (error == BLEGATTErrorSuccess) {
     analytics_inc(ANALYTICS_DEVICE_METRIC_BT_PEBBLE_APP_LAUNCH_SUCCESS_COUNT,
                   AnalyticsClient_System);
@@ -79,6 +77,6 @@ void app_launch_trigger(void) {
   }
   BTErrno err = gatt_client_op_read(s_app_launch_characteristic, GAPLEClientKernel);
   if (err != BTErrnoOK) {
-    PBL_LOG(LOG_LEVEL_ERROR, "App relaunch failed: %u", err);
+    PBL_LOG_ERR("App relaunch failed: %u", err);
   }
 }

--- a/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
+++ b/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
@@ -1,8 +1,6 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define FILE_LOG_COLOR LOG_COLOR_BLUE
-
 #include "ppogatt.h"
 #include "ppogatt_internal.h"
 
@@ -284,12 +282,12 @@ static void prv_reset_ack_timeout(PPoGATTClient *client) {
 
 static void prv_roll_back(PPoGATTClient *client, uint32_t sn) {
   if (++client->out.timeouts_counter >= PPOGATT_TIMEOUT_COUNT_MAX) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Resetting because max timeouts reached...");
+    PBL_LOG_ERR("Resetting because max timeouts reached...");
     prv_start_reset(client);
     return;
   }
 
-  PBL_LOG(LOG_LEVEL_WARNING, "Rolling back from (%u, %u) to %"PRIu32,
+  PBL_LOG_WRN("Rolling back from (%u, %u) to %"PRIu32,
           client->out.next_data_sn, client->out.next_expected_ack_sn, sn);
 
   // Go back and send again:
@@ -319,7 +317,7 @@ static void prv_check_timeouts(PPoGATTClient *client) {
       client->state == StateConnectedClosedAwaitingResetCompleteRemoteInitiatedReset) {
     if (prv_has_timeout(client)) {
       // We've timed out waiting for a reset to be completed, start over:
-      PBL_LOG(LOG_LEVEL_INFO, "Timed out waiting for Reset Complete, Resetting again...");
+      PBL_LOG_INFO("Timed out waiting for Reset Complete, Resetting again...");
       prv_start_reset(client);
     }
     return;
@@ -517,11 +515,11 @@ static void prv_start_reset(PPoGATTClient *client) {
       // If we have disconnected too many times, do not disconnect and leave the client in a
       // "stalled" state, so that we have the option to "unstall" by sending a remote reset
       client->state = StateConnectedClosedAwaitingResetCompleteSelfInitiatedResetStalled;
-      PBL_LOG(LOG_LEVEL_WARNING, "Reset request stalled, not disconnecting");
+      PBL_LOG_WRN("Reset request stalled, not disconnecting");
       return;
     }
 
-    PBL_LOG(LOG_LEVEL_ERROR, "Disconnecting because max resets reached...");
+    PBL_LOG_ERR("Disconnecting because max resets reached...");
 
     // Record the time of this disconnect request
     analytics_event_PPoGATT_disconnect(rtc_get_time(), false);
@@ -544,13 +542,13 @@ static void prv_start_reset(PPoGATTClient *client) {
 static void prv_handle_reset_request(PPoGATTClient *client) {
   if (client->state == StateConnectedClosedAwaitingResetCompleteSelfInitiatedReset) {
     // Already in self-initated reset procedure, client should ignore the request from the server.
-    PBL_LOG(LOG_LEVEL_INFO, "Ignoring reset request because local client already requested.");
+    PBL_LOG_INFO("Ignoring reset request because local client already requested.");
     return;
   }
   if (client->state == StateConnectedClosedAwaitingResetCompleteRemoteInitiatedReset) {
     // Already in remote-initiated reset procedure, server retrying?
     // See https://pebbletechnology.atlassian.net/browse/PBL-12424
-    PBL_LOG(LOG_LEVEL_INFO, "Ignoring reset request because remote server already requested.");
+    PBL_LOG_INFO("Ignoring reset request because remote server already requested.");
     return;
   }
   prv_enter_awaiting_reset_complete(client, false /* self_initiated */);
@@ -588,14 +586,14 @@ static void prv_handle_reset_complete(PPoGATTClient *client, const PPoGATTPacket
 
   if (prv_client_supports_enhanced_throughput_features(client)) {
     if (payload_length < sizeof(PPoGATTResetCompleteClientIDPayloadV1)) {
-      PBL_LOG(LOG_LEVEL_WARNING, "Unexpected PPoGatt Reset Complete Payload Size: %"PRIu16,
+      PBL_LOG_WRN("Unexpected PPoGatt Reset Complete Payload Size: %"PRIu16,
               payload_length);
       // Be defensive, and use the original window size
       client->out.tx_window_size = client->out.rx_window_size = PPOGATT_V0_WINDOW_SIZE;
     } else {
       PPoGATTResetCompleteClientIDPayloadV1 *payload =
           (PPoGATTResetCompleteClientIDPayloadV1 *)&packet->payload[0];
-      PBL_LOG(LOG_LEVEL_DEBUG, "PPoGATT Remote RxWindow: %d TxWindow %d",
+      PBL_LOG_DBG("PPoGATT Remote RxWindow: %d TxWindow %d",
               payload->ppogatt_max_rx_window, payload->ppogatt_max_tx_window);
 
       client->out.tx_window_size = MIN(client->out.tx_window_size, payload->ppogatt_max_rx_window);
@@ -603,7 +601,7 @@ static void prv_handle_reset_complete(PPoGATTClient *client, const PPoGATTPacket
     }
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Hurray! PPoGATT Session is opened (Vers: %d TXW: %d RXW: %d)!",
+  PBL_LOG_DBG("Hurray! PPoGATT Session is opened (Vers: %d TXW: %d RXW: %d)!",
           client->version, client->out.tx_window_size, client->out.rx_window_size);
 }
 
@@ -642,9 +640,9 @@ static void prv_handle_ack(PPoGATTClient *client, uint32_t sn) {
     // Don't roll back directly to avoid creating an Sorcerer's Apprentice bug
     // https://en.wikipedia.org/wiki/Sorcerer%27s_Apprentice_Syndrome
     // We'll rely on the ACK timeout for the next data packet to fire and roll back.
-    PBL_LOG(LOG_LEVEL_WARNING, "Received retransmitted Ack for sn:%"PRIu32". Ignoring it.", sn);
+    PBL_LOG_WRN("Received retransmitted Ack for sn:%"PRIu32". Ignoring it.", sn);
   } else {
-    PBL_LOG(LOG_LEVEL_ERROR, "Ack'd packet out of range %"PRIu32", [%u-%u].",
+    PBL_LOG_ERR("Ack'd packet out of range %"PRIu32", [%u-%u].",
             sn, client->out.next_expected_ack_sn, client->out.next_data_sn);
     prv_start_reset(client);
   }
@@ -663,9 +661,9 @@ static void prv_handle_data(PPoGATTClient *client,
 
     client->in.next_expected_data_sn = prv_next_sn(client->in.next_expected_data_sn);
     comm_session_receive_router_write(client->session, packet->payload, payload_length);
-//    PBL_LOG(LOG_LEVEL_DEBUG, "Got PP data (sn=%u, %u bytes)", packet->sn, payload_length);
+//    PBL_LOG_DBG("Got PP data (sn=%u, %u bytes)", packet->sn, payload_length);
   } else {
-    PBL_LOG(LOG_LEVEL_DEBUG, "packet->sn != next_expected_data_sn (%u != %u)",
+    PBL_LOG_DBG("packet->sn != next_expected_data_sn (%u != %u)",
             packet->sn, client->in.next_expected_data_sn);
     // Rely on the server retransmitting on Ack time-out
   }
@@ -675,20 +673,20 @@ static void prv_handle_data(PPoGATTClient *client,
 
 static void prv_handle_data_notification(PPoGATTClient *client,
                                          const uint8_t *value, uint16_t value_length) {
-//  PBL_LOG(LOG_LEVEL_DEBUG, "IN:");
+//  PBL_LOG_DBG("IN:");
 //  PBL_HEXDUMP(LOG_LEVEL_DEBUG, value, value_length);
 
   if (UNLIKELY(value_length == 0)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Zero length packet");
+    PBL_LOG_ERR("Zero length packet");
     return;
   }
   const PPoGATTPacket *packet = (const PPoGATTPacket *) value;
   if (UNLIKELY(packet->type >= PPoGATTPacketTypeInvalidRangeStart)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid type %u", packet->type);
+    PBL_LOG_ERR("Invalid type %u", packet->type);
     return;
   }
   if (UNLIKELY(packet->type) == PPoGATTPacketTypeResetRequest) {
-    PBL_LOG(LOG_LEVEL_INFO, "Got reset request!");
+    PBL_LOG_INFO("Got reset request!");
     prv_handle_reset_request(client);
     return;
   }
@@ -698,7 +696,7 @@ static void prv_handle_data_notification(PPoGATTClient *client,
     } else if (LIKELY(packet->type == PPoGATTPacketTypeAck)) {
       prv_handle_ack(client, packet->sn);
     } else if (UNLIKELY(packet->type == PPoGATTPacketTypeResetComplete)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Got reset complete while open!?");
+      PBL_LOG_ERR("Got reset complete while open!?");
     }
   } else if (client->state == StateConnectedClosedAwaitingResetCompleteSelfInitiatedReset ||
              client->state == StateConnectedClosedAwaitingResetCompleteSelfInitiatedResetStalled ||
@@ -706,10 +704,10 @@ static void prv_handle_data_notification(PPoGATTClient *client,
     if (LIKELY(packet->type == PPoGATTPacketTypeResetComplete)) {
       prv_handle_reset_complete(client, packet, value_length - sizeof(PPoGATTPacket));
     } else {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Resetting, ignoring data/ack packets (%u)", packet->type);
+      PBL_LOG_DBG("Resetting, ignoring data/ack packets (%u)", packet->type);
     }
   } else {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Ignoring all packets in state %u", client->state);
+    PBL_LOG_DBG("Ignoring all packets in state %u", client->state);
   }
 }
 
@@ -722,7 +720,7 @@ static void prv_retry_meta_read(PPoGATTClient *client) {
     return;
   }
 
-  PBL_LOG(LOG_LEVEL_INFO, "Retrying PPoGATT meta read (attempt %u/%u)",
+  PBL_LOG_INFO("Retrying PPoGATT meta read (attempt %u/%u)",
           client->meta_read_retries + 1, PPOGATT_META_READ_RETRY_COUNT_MAX);
 
   client->state = StateDisconnectedReadingMeta;
@@ -739,7 +737,7 @@ static void prv_retry_meta_read(PPoGATTClient *client) {
 
   if (result != BTErrnoOK) {
     // Read failed to start, delete the client
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to initiate meta read retry");
+    PBL_LOG_ERR("Failed to initiate meta read retry");
     prv_delete_client(client, false /* is_disconnected */, DeleteReason_MetaDataReadFailure);
   }
 }
@@ -769,12 +767,12 @@ static void prv_handle_meta_read(PPoGATTClient *client, const uint8_t *value,
     goto handle_error;
   }
   if (uuid_is_invalid(&meta->app_uuid)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid UUID");
+    PBL_LOG_ERR("Invalid UUID");
     goto handle_error;
   }
 #if RECOVERY_FW
   if (!uuid_is_system(&meta->app_uuid)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Found PPoGATT server from non-Pebble app, not connecting in PRF..");
+    PBL_LOG_ERR("Found PPoGATT server from non-Pebble app, not connecting in PRF..");
     goto handle_error;
   }
 #endif
@@ -787,7 +785,7 @@ static void prv_handle_meta_read(PPoGATTClient *client, const uint8_t *value,
   if (/*meta->ppogatt_max_version >= 0x01 &&*/ value_length >= sizeof(PPoGATTMetaV1)) {
     const PPoGATTMetaV1 *meta_v1 = (const PPoGATTMetaV1 *)value;
     if (meta_v1->pp_session_type >= PPoGATTSessionTypeCount) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Invalid session type %u", meta_v1->pp_session_type);
+      PBL_LOG_ERR("Invalid session type %u", meta_v1->pp_session_type);
       goto handle_error;
     }
     session_type = meta_v1->pp_session_type;
@@ -804,8 +802,7 @@ static void prv_handle_meta_read(PPoGATTClient *client, const uint8_t *value,
     // before. The old one seems to go away *after* the new one gets added in the crash scenario.
     PPoGATTClient *existing_client = prv_find_client_with_uuid(&meta->app_uuid);
     if (existing_client) {
-      PBL_LOG(LOG_LEVEL_ERROR,
-              "Found PPoGATT server with same UUID. Keeping only the last one.");
+      PBL_LOG_ERR("Found PPoGATT server with same UUID. Keeping only the last one.");
       prv_delete_client(existing_client, true /* is_disconnected */, DeleteReason_DuplicateServer);
     }
     client->state = StateDisconnectedSubscribingData;
@@ -825,19 +822,19 @@ static void prv_handle_meta_read(PPoGATTClient *client, const uint8_t *value,
 handle_retriable_error:
   // GATT read failed - schedule a retry if we haven't exceeded the max retry count
   if (++client->meta_read_retries < PPOGATT_META_READ_RETRY_COUNT_MAX) {
-    PBL_LOG(LOG_LEVEL_WARNING, "PPoGATT meta read failed (err=%x), scheduling retry %u/%u",
+    PBL_LOG_WRN("PPoGATT meta read failed (err=%x), scheduling retry %u/%u",
             error, client->meta_read_retries, PPOGATT_META_READ_RETRY_COUNT_MAX);
     client->state = StateDisconnectedAwaitingMetaRetry;
     new_timer_start(client->rx_ack_timer, PPOGATT_META_READ_RETRY_DELAY_MS,
                     prv_meta_read_retry_timer_cb, client, 0);
     return;
   }
-  PBL_LOG(LOG_LEVEL_ERROR, "PPoGATT meta read failed after %u retries",
+  PBL_LOG_ERR("PPoGATT meta read failed after %u retries",
           PPOGATT_META_READ_RETRY_COUNT_MAX);
   // Fall through to handle_error
 
 handle_error:
-  PBL_LOG(LOG_LEVEL_ERROR, "Failed handling PPoGATT meta: len=%u ver=%x err=%x",
+  PBL_LOG_ERR("Failed handling PPoGATT meta: len=%u ver=%x err=%x",
           (unsigned int) value_length, value_length ? value[0] : ~0, error);
   prv_delete_client(client, false /* is_disconnected */, DeleteReason_MetaDataInvalid);
 }
@@ -894,7 +891,7 @@ void ppogatt_handle_service_removed(
       BLECharacteristic char1 = num_characteristics > 0 ? characteristics[0] : 0;
       BLECharacteristic char2 = num_characteristics > 1 ? characteristics[1] : 0;
 
-      PBL_LOG(LOG_LEVEL_WARNING, "No ppog client removed? 0x%x 0x%x vs 0x%x 0x%x",
+      PBL_LOG_WRN("No ppog client removed? 0x%x 0x%x vs 0x%x 0x%x",
               (int)meta, (int)data, (int)char1, (int)char2);
     }
   }
@@ -969,14 +966,14 @@ void ppogatt_handle_subscribe(BLECharacteristic characteristic,
     const bool is_subscribed = (subscription_type != BLESubscriptionNone);
     PPoGATTClient *client = prv_find_client_with_characteristic(characteristic, NULL);
     if (!client && is_subscribed) {
-      PBL_LOG(LOG_LEVEL_ERROR, "PPoGATT Client could be found, unsubscribing");
+      PBL_LOG_ERR("PPoGATT Client could be found, unsubscribing");
       // Attempt to unsubscribe to avoid wasting bandwidth:
       gatt_client_subscriptions_subscribe(characteristic, BLESubscriptionNone, GAPLEClientKernel);
       goto unlock;
     }
     PBL_ASSERTN(client->state == StateDisconnectedSubscribingData);
     if (error) {
-      PBL_LOG(LOG_LEVEL_ERROR, "PPoGATT Client failed to subscribe to Data");
+      PBL_LOG_ERR("PPoGATT Client failed to subscribe to Data");
       prv_delete_client(client, false /* is_disconnected */, DeleteReason_SubscribeFailure);
       goto unlock;
     }
@@ -999,7 +996,7 @@ void ppogatt_handle_read_or_notification(BLECharacteristic characteristic, const
     bool is_data = false;
     PPoGATTClient *client = prv_find_client_with_characteristic(characteristic, &is_data);
     if (!client) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Got notification/read for unknown client");
+      PBL_LOG_DBG("Got notification/read for unknown client");
       goto unlock;
     }
     if (is_data) {
@@ -1234,7 +1231,7 @@ static void prv_send_next_packets(PPoGATTClient *client) {
         break;
       } else if (e != BTErrnoOK) {
         // Most likely the LE connection got busted, don't think retrying will help.
-        PBL_LOG(LOG_LEVEL_ERROR, "Write failed %i", e);
+        PBL_LOG_ERR("Write failed %i", e);
         break;
       } else {
         // Packet successfully queued
@@ -1262,10 +1259,10 @@ static void prv_send_next_packets(PPoGATTClient *client) {
       break;
     } else if (e != BTErrnoOK) {
       // Most likely the LE connection got busted, don't think retrying will help.
-      PBL_LOG(LOG_LEVEL_ERROR, "Write failed %i", e);
+      PBL_LOG_ERR("Write failed %i", e);
       break;
     } else {
-//     PBL_LOG(LOG_LEVEL_DEBUG, "OUT:");
+//     PBL_LOG_DBG("OUT:");
 //     PBL_HEXDUMP(LOG_LEVEL_DEBUG, (const uint8_t *) packet, sizeof(PPoGATTPacket) + payload_size);
 
       // Packet successfully queued

--- a/src/fw/comm/bluetooth_analytics.c
+++ b/src/fw/comm/bluetooth_analytics.c
@@ -100,7 +100,7 @@ void bluetooth_analytics_handle_connection_disconnection_event(
     analytics_event_bt_connection_or_disconnection(type, reason);
   } else {
     if (!vers_info) { // We expect version info
-      PBL_LOG(LOG_LEVEL_WARNING, "Le Disconnect but no version info?");
+      PBL_LOG_WRN("Le Disconnect but no version info?");
     } else {
       analytics_event_bt_le_disconnection(reason, vers_info->version_number,
                                           vers_info->company_identifier,
@@ -124,7 +124,7 @@ void bluetooth_analytics_handle_connect(
   bool success = bt_driver_analytics_get_connection_quality(peer_addr, &link_quality, &rssi);
 
   if (success) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Link quality: %x, RSSI: %d", link_quality, rssi);
+    PBL_LOG_DBG("Link quality: %x, RSSI: %d", link_quality, rssi);
     analytics_add(ANALYTICS_DEVICE_METRIC_BLE_LINK_QUALITY_SUM,
                   link_quality, AnalyticsClient_System);
     analytics_add(ANALYTICS_DEVICE_METRIC_BLE_RSSI_SUM,
@@ -167,7 +167,7 @@ void bluetooth_analytics_handle_bt_classic_pairing_error(uint32_t error) {
 }
 
 void bluetooth_analytics_ble_mic_error(uint32_t num_sequential_mic_errors) {
-  PBL_LOG(LOG_LEVEL_INFO, "MIC Error detected ... %"PRIu32" packets", num_sequential_mic_errors);
+  PBL_LOG_INFO("MIC Error detected ... %"PRIu32" packets", num_sequential_mic_errors);
   analytics_event_bt_error(AnalyticsEvent_BtLeMicError, num_sequential_mic_errors);
 }
 
@@ -194,7 +194,7 @@ static bool prv_calc_stats_and_print(const SlaveConnEventStats *orig_stats,
     stats_buf->num_mic_errors =
         serial_distance32(orig_stats->num_mic_errors, stats_buf->num_mic_errors);
 
-    PBL_LOG(LOG_LEVEL_INFO, "%sBytes Conn Stats: Events: %"PRIu32", Sync Errs: %"PRIu32
+    PBL_LOG_INFO("%sBytes Conn Stats: Events: %"PRIu32", Sync Errs: %"PRIu32
       ", Skipped Events: %"PRIu32" Other Errs: %"PRIu32, is_putbytes ? "Put" : "Get",
             stats_buf->num_conn_events, stats_buf->num_sync_errors,
             stats_buf->num_conn_events_skipped, prv_calc_other_errors(stats_buf));

--- a/src/fw/comm/internals/bt_conn_mgr.c
+++ b/src/fw/comm/internals/bt_conn_mgr.c
@@ -1,8 +1,6 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define FILE_LOG_COLOR LOG_COLOR_BLUE
-
 #include <bluetooth/responsiveness.h>
 
 #include "comm/ble/gap_le_connect_params.h"
@@ -145,7 +143,7 @@ static void prv_handle_response_latency_for_le_conn(GAPLEConnection *hdl) {
 
   // actually request the mode if it has changed:
   if (hdl->conn_mgr_info->curr_requested_state != state) {
-    PBL_LOG(LOG_LEVEL_INFO, "LE: Requesting state %d for %d secs, due to %u",
+    PBL_LOG_INFO("LE: Requesting state %d for %d secs, due to %u",
             state, secs_til_max_latency, responsible_consumer);
     gap_le_connect_params_request(hdl, state);
   }
@@ -236,7 +234,7 @@ void conn_mgr_set_ble_conn_response_time_ext(
     uint16_t max_period_secs, ResponsivenessGrantedHandler granted_handler) {
   ConnectionMgrInfo *conn_mgr_info;
   if (!hdl || !((conn_mgr_info = hdl->conn_mgr_info))) {
-    PBL_LOG(LOG_LEVEL_ERROR, "GAP Handle not properly intialized");
+    PBL_LOG_ERR("GAP Handle not properly intialized");
     return;
   }
 

--- a/src/fw/console/control_protocol.c
+++ b/src/fw/console/control_protocol.c
@@ -80,7 +80,7 @@ static void prv_send_configure_ack(PPPControlProtocol *this,
                                    struct LCPPacket *triggering_packet) {
   if (ntoh16(triggering_packet->length) > pulse_link_max_send_size()) {
     // Too big to send and truncation will corrupt the packet.
-    PBL_LOG(LOG_LEVEL_ERROR, "Configure-Request too large to Ack");
+    PBL_LOG_ERR("Configure-Request too large to Ack");
     return;
   }
   struct LCPPacket *packet = pulse_link_send_begin(this->protocol_number);
@@ -94,7 +94,7 @@ static void prv_send_configure_reject(PPPControlProtocol *this,
   if (ntoh16(bad_packet->length) > pulse_link_max_send_size()) {
     // Too big to send and truncation will corrupt the packet.
     // There isn't really anything we can do.
-    PBL_LOG(LOG_LEVEL_ERROR, "Configure-Request too large to Reject");
+    PBL_LOG_ERR("Configure-Request too large to Reject");
     return;
   }
   struct LCPPacket *packet = pulse_link_send_begin(this->protocol_number);
@@ -240,8 +240,7 @@ static void prv_on_configure_ack(PPPControlProtocol *this,
     // If the length is greater than four, there are options in the Ack
     // which means that the Ack'ed options list does not match the
     // options list from the request. The Ack packet is invalid.
-    PBL_LOG(LOG_LEVEL_WARNING,
-            "Configure-Ack received with options list which differs from "
+    PBL_LOG_WRN("Configure-Ack received with options list which differs from "
             "the sent Configure-Request. Discarding.");
     return;
   }
@@ -261,7 +260,7 @@ static void prv_on_configure_ack(PPPControlProtocol *this,
       break;
     case LinkState_AckReceived:
     case LinkState_Opened:
-      PBL_LOG(LOG_LEVEL_WARNING, "Unexpected duplicate Configure-Ack");
+      PBL_LOG_WRN("Unexpected duplicate Configure-Ack");
       prv_send_configure_request(this);
       prv_transition_to(this, LinkState_RequestSent);
       break;
@@ -302,8 +301,7 @@ static void prv_on_configure_nak_or_reject(PPPControlProtocol *this,
       // fallthrough
     case LinkState_AckReceived:
     case LinkState_Opened:
-      PBL_LOG(LOG_LEVEL_WARNING,
-              "Unexpected Configure-Nak/Rej received after Ack");
+      PBL_LOG_WRN("Unexpected Configure-Nak/Rej received after Ack");
       prv_handle_nak_or_reject(this, packet);
       prv_transition_to(this, LinkState_RequestSent);
       break;
@@ -337,7 +335,7 @@ static void prv_on_terminate_ack(PPPControlProtocol *this,
   } else if (this->state->link_state == LinkState_AckReceived) {
     prv_transition_to(this, LinkState_RequestSent);
   } else if (this->state->link_state == LinkState_Opened) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Terminate-Ack received on an open connection");
+    PBL_LOG_WRN("Terminate-Ack received on an open connection");
     prv_send_configure_request(this);
     prv_transition_to(this, LinkState_RequestSent);
   }

--- a/src/fw/console/prompt.c
+++ b/src/fw/console/prompt.c
@@ -386,7 +386,7 @@ static void prv_pulse_done_command(void) {
 
 void pulse2_prompt_packet_handler(void *packet, size_t length) {
   if (prompt_command_is_executing()) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Ignoring prompt command as another command is "
+    PBL_LOG_DBG("Ignoring prompt command as another command is "
             "currently executing");
     return;
   }

--- a/src/fw/console/prompt_commands.c
+++ b/src/fw/console/prompt_commands.c
@@ -135,7 +135,7 @@ void command_dump_flash(const char* address_str, const char* length_str) {
     uint32_t chunk_size = MIN(length, 128);
     flash_read_bytes(buffer, address, chunk_size);
 
-    PBL_LOG(LOG_LEVEL_ALWAYS, "Data at address 0x%"PRIx32, address);
+    PBL_LOG_ALWAYS("Data at address 0x%"PRIx32, address);
     hexdump_log(LOG_LEVEL_ALWAYS, buffer, chunk_size);
 
     address += chunk_size;
@@ -513,14 +513,14 @@ static void prv_flash_stress_callback(void *data) {
   int iters = (int)data;
 
   if (iters == 0) {
-    PBL_LOG(LOG_LEVEL_ALWAYS, "flash stress test complete");
+    PBL_LOG_ALWAYS("flash stress test complete");
     return;
   }
   
   int bufsz = rand32() % 1024;
   uint8_t *buf = kernel_malloc(bufsz);
   if (!buf) {
-    PBL_LOG(LOG_LEVEL_ALWAYS, "flash stress test: malloc of size %d failed", bufsz);
+    PBL_LOG_ALWAYS("flash stress test: malloc of size %d failed", bufsz);
     system_task_add_callback(prv_flash_stress_callback, (void *)(iters - 1));
     return;
   }
@@ -540,11 +540,11 @@ static void prv_flash_stress_callback(void *data) {
  
   uint32_t sector_address = flash_get_sector_base_address(flash_addr + bufsz); // the beginning has already been erased, since we are always smaller than a sector
   if (sector_address != s_flash_stress_last_sector) {
-    PBL_LOG(LOG_LEVEL_ALWAYS, "flash stress test: erasing flash address %lx", sector_address);
+    PBL_LOG_ALWAYS("flash stress test: erasing flash address %lx", sector_address);
     flash_erase_sector_blocking(sector_address);
     s_flash_stress_last_sector = sector_address;
     if (!prv_is_really_erased(sector_address, 0)) {
-      PBL_LOG(LOG_LEVEL_ALWAYS, "flash stress test: flash address %lx erase failed!", sector_address);
+      PBL_LOG_ALWAYS("flash stress test: flash address %lx erase failed!", sector_address);
       miscompare = -1;
       goto bailout;
     }
@@ -566,7 +566,7 @@ static void prv_flash_stress_callback(void *data) {
 
     for (int i = 0; i < bufsz; i++) {
       if (buf[i] != (lfsr_cur & 0xFF)) {
-        PBL_LOG(LOG_LEVEL_ALWAYS, "flash stress test: readback %d: miscompare at offset %d (%lx): expected 0x%02lx, found 0x%02x", j, i, flash_addr + i, lfsr_cur & 0xFF, buf[i]);
+        PBL_LOG_ALWAYS("flash stress test: readback %d: miscompare at offset %d (%lx): expected 0x%02lx, found 0x%02x", j, i, flash_addr + i, lfsr_cur & 0xFF, buf[i]);
         miscompare++;
       }
       lfsr_cur = prv_xorshift32(lfsr_cur);
@@ -579,9 +579,9 @@ bailout:
   kernel_free(buf);
 
   if (miscompare) {
-    PBL_LOG(LOG_LEVEL_ALWAYS, "flash stress test: %d miscompares on %d byte chunk at address %lx!  giving up", miscompare, bufsz, flash_addr);
+    PBL_LOG_ALWAYS("flash stress test: %d miscompares on %d byte chunk at address %lx!  giving up", miscompare, bufsz, flash_addr);
   } else {
-    PBL_LOG(LOG_LEVEL_ALWAYS, "flash stress test: %d bytes at address %lx OK; %d to go", bufsz, flash_addr, iters - 1);
+    PBL_LOG_ALWAYS("flash stress test: %d bytes at address %lx OK; %d to go", bufsz, flash_addr, iters - 1);
     system_task_add_callback(prv_flash_stress_callback, (void *)(iters - 1));
   }
 }
@@ -1166,14 +1166,14 @@ void command_litter_filesystem(const char *s_number, const char *s_size) {
   size_t size = (size_t)atoi(s_size);
   for (int i = 0; i < number; i++) {
     snprintf(name, sizeof(name), "litter%d", i);
-    PBL_LOG(LOG_LEVEL_DEBUG, "Creating %s", name);
+    PBL_LOG_DBG("Creating %s", name);
     int fd = pfs_open(name, OP_FLAG_WRITE, FILE_TYPE_STATIC, size);
     if (i % 5 == 0) {
       pfs_close_and_remove(fd);
-      PBL_LOG(LOG_LEVEL_DEBUG, "Removed %s", name);
+      PBL_LOG_DBG("Removed %s", name);
     } else {
       pfs_close(fd);
-      PBL_LOG(LOG_LEVEL_DEBUG, "Closed %s", name);
+      PBL_LOG_DBG("Closed %s", name);
     }
 
     task_watchdog_bit_set(pebble_task_get_current());

--- a/src/fw/console/pulse_pp.c
+++ b/src/fw/console/pulse_pp.c
@@ -78,7 +78,7 @@ static void prv_send_next(Transport *transport) {
 }
 
 static void prv_reset(Transport *transport) {
-  PBL_LOG(LOG_LEVEL_INFO, "Unimplemented");
+  PBL_LOG_INFO("Unimplemented");
 }
 
 static void prv_granted_kernel_main_cb(void *ctx) {
@@ -142,7 +142,7 @@ void pulse_transport_set_connected(bool is_connected) {
                                             &s_pulse_transport_implementation,
                                             TransportDestinationHybrid);
     if (!s_transport.session) {
-      PBL_LOG(LOG_LEVEL_ERROR, "CommSession couldn't be opened");
+      PBL_LOG_ERR("CommSession couldn't be opened");
       send_event = false;
     }
 
@@ -183,7 +183,7 @@ static void prv_pulse_pp_handle_data(void *data, size_t length) {
   bt_lock();
 
   if (!s_transport.session) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Received PULSE serial data, but session not connected!");
+    PBL_LOG_ERR("Received PULSE serial data, but session not connected!");
     goto unlock;
   }
   comm_session_receive_router_write(s_transport.session, data, length);

--- a/src/fw/console/reliable_transport.c
+++ b/src/fw/console/reliable_transport.c
@@ -155,7 +155,7 @@ void pulse2_reliable_transport_on_command_packet(
   }
 
   if (length < sizeof((ReliablePacket){0}.s)) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Received malformed command packet");
+    PBL_LOG_DBG("Received malformed command packet");
     prv_bounce_ncp_state();
     return;
   }
@@ -164,7 +164,7 @@ void pulse2_reliable_transport_on_command_packet(
   if (packet->is_supervisory) {
     if (packet->s.kind != SupervisoryKind_ReceiveReady &&
         packet->s.kind != SupervisoryKind_Reject) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Received a command packet of type %" PRIu8
+      PBL_LOG_DBG("Received a command packet of type %" PRIu8
               " which is not supported by this implementation.",
               (uint8_t)packet->s.kind);
       // Pretend it is an RR packet
@@ -176,7 +176,7 @@ void pulse2_reliable_transport_on_command_packet(
     }
   } else {  // Information transfer packet
     if (length < sizeof(ReliablePacket)) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Received malformed Information packet");
+      PBL_LOG_DBG("Received malformed Information packet");
       prv_bounce_ncp_state();
       return;
     }
@@ -214,7 +214,7 @@ void pulse2_reliable_transport_on_command_packet(
           }
         }
       } else {
-        PBL_LOG(LOG_LEVEL_DEBUG, "Received truncated or corrupt info packet "
+        PBL_LOG_DBG("Received truncated or corrupt info packet "
                 "field (expeced %" PRIu16 ", got %" PRIu16 " data bytes). "
                 "Discarding.", ntoh16(packet->i.length), (uint16_t)length);
         return;
@@ -231,14 +231,14 @@ void pulse2_reliable_transport_on_response_packet(
   }
 
   if (length < sizeof((ReliablePacket){0}.s)) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Received malformed response packet");
+    PBL_LOG_DBG("Received malformed response packet");
     prv_bounce_ncp_state();
     return;
   }
   ReliablePacket *packet = raw_packet;
 
   if (!packet->is_supervisory) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Received Information packet response; this is "
+    PBL_LOG_DBG("Received Information packet response; this is "
             "not permitted by the protocol (Information packets can only be "
             "commands). Discarding.");
     return;
@@ -248,7 +248,7 @@ void pulse2_reliable_transport_on_response_packet(
 
   if (packet->s.kind != SupervisoryKind_ReceiveReady &&
       packet->s.kind != SupervisoryKind_Reject) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Received a command packet of type %" PRIu8
+    PBL_LOG_DBG("Received a command packet of type %" PRIu8
             " which is not supported by this implementation.",
             (uint8_t)packet->s.kind);
   }
@@ -270,7 +270,7 @@ void pulse2_reliable_retransmit_timer_expired_handler(
                              s_tx_buffer->length);
     prv_start_retransmit_timer(retransmit_sequence_number);
   } else {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Reached maximum number of retransmit attempts.");
+    PBL_LOG_DBG("Reached maximum number of retransmit attempts.");
     prv_bounce_ncp_state();
   }
 }
@@ -296,7 +296,7 @@ void *pulse_reliable_send_begin(const uint16_t app_protocol) {
   xSemaphoreTake(s_tx_lock, portMAX_DELAY);
   if (!s_layer_up) {
     // Transport went down while waiting for the lock
-    PBL_LOG(LOG_LEVEL_DEBUG, "Transport went down while waiting for lock");
+    PBL_LOG_DBG("Transport went down while waiting for lock");
     xSemaphoreGive(s_tx_lock);
     return NULL;
   }
@@ -311,7 +311,7 @@ void pulse_reliable_send_cancel(void *buf) {
 
 void pulse_reliable_send(void *buf, const size_t length) {
   if (!s_layer_up) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Transport went down before send");
+    PBL_LOG_DBG("Transport went down before send");
     return;
   }
   prv_assert_reliable_buffer(buf);

--- a/src/fw/console/serial_console.c
+++ b/src/fw/console/serial_console.c
@@ -32,7 +32,7 @@ static void logging_handle_character(char c, bool* should_context_switch) {
 
   if (c == 0x3) { // CTRL-C
     if (!s_prompt_enabled) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Ignoring prompt request, not yet ready!");
+      PBL_LOG_DBG("Ignoring prompt request, not yet ready!");
       return;
     }
     console_switch_to_prompt();

--- a/src/fw/debug/app_logging.c
+++ b/src/fw/debug/app_logging.c
@@ -63,7 +63,7 @@ void app_log_protocol_msg_callback(CommSession *session, const uint8_t *data, co
     s_app_logging_mode = AppLoggingDisabled;
     break;
   default:
-    PBL_LOG(LOG_LEVEL_WARNING, "Invalid app log command 0x%x", command->commandType);
+    PBL_LOG_WRN("Invalid app log command 0x%x", command->commandType);
   }
 }
 

--- a/src/fw/debug/debug.c
+++ b/src/fw/debug/debug.c
@@ -72,7 +72,7 @@ static bool prv_bt_log_dump_line_cb(uint8_t *message, uint32_t total_length) {
   SendBuffer *sb = comm_session_send_buffer_begin_write(session, ENDPOINT_ID, required_length,
                                                         COMM_SESSION_DEFAULT_TIMEOUT);
   if (!sb) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Failed to get send buffer");
+    PBL_LOG_DBG("Failed to get send buffer");
     return false;
   }
 
@@ -118,7 +118,7 @@ static void prv_flash_logging_bluetooth_dump(
     CommSession *session, int generation, uint32_t cookie) {
   PBL_ASSERT_RUNNING_FROM_EXPECTED_TASK(PebbleTask_KernelBackground);
   if (s_bt_dump_chunk_callback_data.in_progress) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Already in the middle of dumping logs");
+    PBL_LOG_ERR("Already in the middle of dumping logs");
     return;
   }
 
@@ -142,7 +142,7 @@ void dump_log_protocol_msg_callback(CommSession *session, const uint8_t* data, s
   int generation = 0;
   if (data[0] == 0x10 || data[0] == 0x11) {
     if (length != 6) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Invalid dump log message received -- length %u", length);
+      PBL_LOG_ERR("Invalid dump log message received -- length %u", length);
       return;
     }
 
@@ -150,7 +150,7 @@ void dump_log_protocol_msg_callback(CommSession *session, const uint8_t* data, s
     cookie = *((uint32_t*) (data + 2));
   } else {
     if (length != 5) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Invalid dump log message received -- length %u", length);
+      PBL_LOG_ERR("Invalid dump log message received -- length %u", length);
       return;
     }
 
@@ -178,20 +178,19 @@ void debug_init(McuRebootReason mcu_reboot_reason) {
   advanced_logging_init();
 
   // Log the firmware version in the first flash log line:
-  DEBUG_LOG(LOG_LEVEL_INFO, "%s (platform: %u, hw: %s, sn: %s, pcba: %s)",
-      TINTIN_METADATA.version_tag,
-      TINTIN_METADATA.hw_platform,
-      mfg_get_hw_version(),
-      mfg_get_serial_number(),
-      mfg_get_pcba_serial_number());
+  PBL_LOG_ALWAYS("Firmware version: %s", TINTIN_METADATA.version_tag);
+  PBL_LOG_ALWAYS("Platform: %u, hw: %s, sn: %s",
+                 TINTIN_METADATA.hw_platform,
+                 mfg_get_hw_version(),
+                 mfg_get_serial_number());
 
   // Log the firmware build id to flash:
   char build_id_string[64];
   version_copy_current_build_id_hex_string(build_id_string, 64);
-  DEBUG_LOG(LOG_LEVEL_INFO, "BUILD ID: %s", build_id_string);
+  PBL_LOG_ALWAYS("BUILD ID: %s", build_id_string);
 
 #if CAPABILITY_HAS_PBLBOOT
-  DEBUG_LOG(LOG_LEVEL_INFO, "Boot slot: %d", TINTIN_METADATA.is_slot_0 ? 0 : 1);
+  PBL_LOG_ALWAYS("Boot slot: %d", TINTIN_METADATA.is_slot_0 ? 0 : 1);
 #endif
 
   #if MEMFAULT
@@ -209,7 +208,7 @@ void debug_print_last_launched_app(void) {
 
   // check if last app launched was a system app
   if (last_launched_app_slot == (uint32_t)SYSTEM_APP_BANK_ID) {
-    DEBUG_LOG(LOG_LEVEL_INFO, "Last launched app: <System_App>");
+    PBL_LOG_INFO("Last launched app: <System_App>");
   } else if ((last_launched_app_slot != (uint32_t)INVALID_BANK_ID)) {
     PebbleProcessInfo last_launched_app;
     uint8_t build_id[BUILD_ID_EXPECTED_LEN];
@@ -219,7 +218,7 @@ void debug_print_last_launched_app(void) {
                                                                      PebbleTask_App);
 
     if (result == GET_APP_INFO_SUCCESS) {
-      DEBUG_LOG(LOG_LEVEL_INFO, "Last launched app: %s", last_launched_app.name);
+      PBL_LOG_INFO("Last launched app: %s", last_launched_app.name);
       PBL_HEXDUMP(LOG_LEVEL_INFO, build_id, sizeof(build_id));
     }
   }

--- a/src/fw/debug/debug.h
+++ b/src/fw/debug/debug.h
@@ -6,15 +6,6 @@
 #include "drivers/mcu_reboot_reason.h"
 #include <stdint.h>
 
-// TODO: Eventually move debug logging back to hashed logging
-// Currently broken out to directly log strings without hashing
-#ifdef PBL_LOG_ENABLED
-  #define DEBUG_LOG(level, fmt, ...) \
-      pbl_log(level, __FILE__, __LINE__, fmt, ## __VA_ARGS__)
-#else
-  #define DEBUG_LOG(level, fmt, ...)
-#endif
-
 void debug_init(McuRebootReason reason);
 
 void debug_print_last_launched_app(void);

--- a/src/fw/debug/debug_reboot_reason.c
+++ b/src/fw/debug/debug_reboot_reason.c
@@ -125,15 +125,15 @@ void debug_reboot_reason_print(McuRebootReason mcu_reboot_reason) {
   // Error occurred
   case RebootReasonCode_Watchdog:
     show_reset_alert = true;
-    DEBUG_LOG(LOG_LEVEL_INFO, "%s%sWatchdog: Bits 0x%" PRIx8 ", Mask 0x%" PRIx8,
+    PBL_LOG_WRN("%s%sWatchdog: Bits 0x%" PRIx8 ", Mask 0x%" PRIx8,
               restarted_safely_string, rebooted_due_to, reason.data8[0], reason.data8[1]);
 
     if (reason.watchdog.stuck_task_pc != 0) {
-      DEBUG_LOG(LOG_LEVEL_INFO, "Stuck task PC: 0x%" PRIx32 ", LR: 0x%" PRIx32,
+      PBL_LOG_WRN("Stuck task PC: 0x%" PRIx32 ", LR: 0x%" PRIx32,
                 reason.watchdog.stuck_task_pc, reason.watchdog.stuck_task_lr);
 
       if (reason.watchdog.stuck_task_callback) {
-        DEBUG_LOG(LOG_LEVEL_INFO, "Stuck callback: 0x%" PRIx32,
+        PBL_LOG_WRN("Stuck callback: 0x%" PRIx32,
                   reason.watchdog.stuck_task_callback);
       }
     }
@@ -141,13 +141,13 @@ void debug_reboot_reason_print(McuRebootReason mcu_reboot_reason) {
   case RebootReasonCode_StackOverflow:
     show_reset_alert = true;
     PebbleTask task = (PebbleTask) reason.data8[0];
-    DEBUG_LOG(LOG_LEVEL_INFO, "%s%sStackOverflow: Task #%d (%s)", restarted_safely_string,
-              rebooted_due_to, task, pebble_task_get_name(task));
+    PBL_LOG_WRN("%s%sStackOverflow: Task #%d", restarted_safely_string,
+              rebooted_due_to, task);
     break;
   case RebootReasonCode_EventQueueFull:
     show_reset_alert = true;
-    DEBUG_LOG(LOG_LEVEL_INFO, "%s%sEvent Queue Full", restarted_safely_string, rebooted_due_to);
-    DEBUG_LOG(LOG_LEVEL_INFO, "LR: 0x%"PRIx32" Current: 0x%"PRIx32" Dropped: 0x%"PRIx32,
+    PBL_LOG_WRN("%s%sEvent Queue Full", restarted_safely_string, rebooted_due_to);
+    PBL_LOG_WRN("LR: 0x%"PRIx32" Current: 0x%"PRIx32" Dropped: 0x%"PRIx32,
               reason.event_queue.push_lr,
               reason.event_queue.current_event,
               reason.event_queue.dropped_event);
@@ -155,8 +155,8 @@ void debug_reboot_reason_print(McuRebootReason mcu_reboot_reason) {
   }
   // Generic reason string
   if (reason_string) {
-    DEBUG_LOG(LOG_LEVEL_INFO, reason_string, restarted_safely_string, rebooted_due_to,
-              reason.extra.value);
+    pbl_log(LOG_LEVEL_WARNING, __FILE__, __LINE__, restarted_safely_string,
+            rebooted_due_to, reason.extra.value);
   }
 
   analytics_set(ANALYTICS_DEVICE_METRIC_SYSTEM_CRASH_LR, lr, AnalyticsClient_System);
@@ -170,14 +170,14 @@ void debug_reboot_reason_print(McuRebootReason mcu_reboot_reason) {
   launcher_task_add_callback(log_reboot_reason_cb, crash_report);
 
   if (is_unread_coredump_available()) {
-    DEBUG_LOG(LOG_LEVEL_INFO, "Unread coredump file is present!");
+    PBL_LOG_INFO("Unread coredump file is present!");
   }
 
-  DEBUG_LOG(LOG_LEVEL_INFO, "MCU reset reason mask: 0x%x", (int)mcu_reboot_reason.reset_mask);
+  PBL_LOG_INFO("MCU reset reason mask: 0x%x", (int)mcu_reboot_reason.reset_mask);
 #if CAPABILITY_HAS_PMIC
   uint32_t pmic_reset_reason = pmic_get_last_reset_reason();
   if (pmic_reset_reason != 0) {
-    DEBUG_LOG(LOG_LEVEL_INFO, "PMIC reset reason mask: 0x%x", (int)pmic_reset_reason);
+    PBL_LOG_INFO("PMIC reset reason mask: 0x%x", (int)pmic_reset_reason);
   }
 #endif
 

--- a/src/fw/debug/default/flash_logging.c
+++ b/src/fw/debug/default/flash_logging.c
@@ -506,7 +506,7 @@ static void prv_dump_log_system_cb(void *context) {
       status = DumpStatus_DoneSuccess;
     } else {
       status = DumpStatus_InProgress;
-      PBL_LOG(LOG_LEVEL_DEBUG, "Dumping page %d of %d", state->page_index, state->num_pages-1);
+      PBL_LOG_DBG("Dumping page %d of %d", state->page_index, state->num_pages-1);
     }
   }
 
@@ -527,7 +527,7 @@ bool flash_dump_log_file(int generation, DumpLineCallback line_cb,
 
   uint32_t log_start_addr;
   int num_log_pages = prv_get_start_of_log_file(log_file_id, &log_start_addr);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Dumping generation %d, %d pages", generation, num_log_pages);
+  PBL_LOG_DBG("Dumping generation %d, %d pages", generation, num_log_pages);
 
   if (num_log_pages == 0) {
     completed_cb(false);

--- a/src/fw/debug/legacy/debug_db.c
+++ b/src/fw/debug/legacy/debug_db.c
@@ -147,7 +147,7 @@ void debug_db_init(void) {
 
   debug_db_determine_current_index(file_id, &s_current_file_index, &s_current_file_id);
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Found files {%u, %u, %u, %u}, using file %u with new id %u",
+  PBL_LOG_DBG("Found files {%u, %u, %u, %u}, using file %u with new id %u",
         file_id[0], file_id[1], file_id[2], file_id[3], s_current_file_index, s_current_file_id);
 
   debug_db_reformat_header_section();
@@ -168,7 +168,7 @@ bool debug_db_is_generation_valid(int file_generation) {
   }
 
   if (file_header.file_id != (s_current_file_id - file_generation)) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Id: %"PRIu8" Expected: %u", file_header.file_id, (s_current_file_id - file_generation));
+    PBL_LOG_DBG("Id: %"PRIu8" Expected: %u", file_header.file_id, (s_current_file_id - file_generation));
     return false;
   }
 

--- a/src/fw/debug/power_tracking.c
+++ b/src/fw/debug/power_tracking.c
@@ -135,7 +135,7 @@ void power_tracking_start(PowerSystem system) {
   DiscreteSystemProfile *current_profile = &s_discrete_consumer_profiles[system];
 
   if (current_profile->start_ticks != 0) {
-    PBL_LOG(LOG_LEVEL_WARNING, "repeat call to start ticks without stopping from %s", current_profile->name);
+    PBL_LOG_WRN("repeat call to start ticks without stopping from %s", current_profile->name);
     // Someone was careless: two cases:
     // 1) someone forgot to call stop
     // 2) someone re-enters a function that calls start before stop is called.
@@ -156,7 +156,7 @@ void power_tracking_stop(PowerSystem system) {
   DiscreteSystemProfile *current_profile = &s_discrete_consumer_profiles[system];
 
   if (current_profile->start_ticks == 0) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Stop ticks before start called: probably losing profile accuracy in %s", current_profile->name);
+    PBL_LOG_WRN("Stop ticks before start called: probably losing profile accuracy in %s", current_profile->name);
     // Someone was careless: two cases:
     // 1) someone forgot to call start
     // 2) someone re-entered a function that called stop already, so it is called twice.

--- a/src/fw/drivers/ambient/ambient_light_opt3001.c
+++ b/src/fw/drivers/ambient/ambient_light_opt3001.c
@@ -57,16 +57,16 @@ void ambient_light_init(void) {
   uint16_t mf, id;
   bool ok = prv_read_register(OPT3001_MFGID, &mf) && prv_read_register(OPT3001_DEVID, &id);
   if (!ok) {
-    PBL_LOG(LOG_LEVEL_ERROR, "failed to read OPT3001 ID registers");
+    PBL_LOG_ERR("failed to read OPT3001 ID registers");
     return;
   }
 
   if (mf != OPT3001_MFGID_VAL || id != OPT3001_DEVID_VAL) {
-    PBL_LOG(LOG_LEVEL_INFO, "OPT3001 read successfully, but had incorrect manuf %04x, id %04x", mf, id);
+    PBL_LOG_INFO("OPT3001 read successfully, but had incorrect manuf %04x, id %04x", mf, id);
     return;
   }
   
-  PBL_LOG(LOG_LEVEL_INFO, "found OPT3001 with manuf %04x, id %04x", mf, id);
+  PBL_LOG_INFO("found OPT3001 with manuf %04x, id %04x", mf, id);
 
   if (BOARD_CONFIG.als_always_on) {
     prv_write_register(OPT3001_CONFIG, OPT3001_CONFIG_RANGE_AUTO | OPT3001_CONFIG_CONVTIME_100MSEC | OPT3001_CONFIG_MODE_CONTINUOUS);

--- a/src/fw/drivers/ambient/ambient_light_w1160.c
+++ b/src/fw/drivers/ambient/ambient_light_w1160.c
@@ -97,12 +97,12 @@ void ambient_light_init(void) {
 
   rv = prv_read_register(W1160_PDT_ID_REG, &chip_id);
   if (!rv) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Could not read W1160 chip ID");
+    PBL_LOG_ERR("Could not read W1160 chip ID");
     return;
   }
 
   if (chip_id != W1160_CHIP_ID) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Unexpected W1160 chip ID: 0x%02x", chip_id);
+    PBL_LOG_ERR("Unexpected W1160 chip ID: 0x%02x", chip_id);
     return;
   }
 
@@ -133,14 +133,14 @@ uint32_t ambient_light_get_light_level(void) {
 
   rv = prv_write_register(W1160_STATE_REG, W1160_SAMPLING_EN);
   if (!rv) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Could not enable W1160 sampling");
+    PBL_LOG_ERR("Could not enable W1160 sampling");
     return 0UL;
   }
 
   do {
     rv = prv_read_register(W1160_FLAG1_REG, &result[0]);
     if (!rv) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Could not read W1160 FLAG1");
+      PBL_LOG_ERR("Could not read W1160 FLAG1");
       return 0UL;
     }
   } while ((result[0] & W1160_FLG_ALS_DR) == 0U);
@@ -148,13 +148,13 @@ uint32_t ambient_light_get_light_level(void) {
   rv = prv_read_register(W1160_DATA1_ALS_REG, &result[1]);
   rv &= prv_read_register(W1160_DATA2_ALS_REG, &result[0]);
   if (!rv) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Could not obtain W1160 data");
+    PBL_LOG_ERR("Could not obtain W1160 data");
     return 0UL;
   }
 
   rv = prv_write_register(W1160_STATE_REG, W1160_SAMPLING_DIS);
   if (!rv) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Could not disable W1160 sampling");
+    PBL_LOG_ERR("Could not disable W1160 sampling");
     return 0UL;
   }
 

--- a/src/fw/drivers/battery/battery_pmic.c
+++ b/src/fw/drivers/battery/battery_pmic.c
@@ -16,7 +16,7 @@ void battery_init(void) {
 
 int battery_get_millivolts(void) {
   if (!pmic_enable_battery_measure()) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Failed to enable battery measure. "
+    PBL_LOG_WRN("Failed to enable battery measure. "
             "Battery voltage reading will be bogus.");
   }
   ADCVoltageMonitorReading info = battery_read_voltage_monitor();

--- a/src/fw/drivers/battery/battery_tintin.c
+++ b/src/fw/drivers/battery/battery_tintin.c
@@ -70,7 +70,7 @@ static void prv_battery_set_charge_enable(bool charging_enabled) {
     GPIO_WriteBit(BOARD_CONFIG_POWER.chg_en.gpio, BOARD_CONFIG_POWER.chg_en.gpio_pin, charging_enabled?Bit_SET:Bit_RESET);
 
     gpio_release(BOARD_CONFIG_POWER.chg_en.gpio);
-    PBL_LOG(LOG_LEVEL_DEBUG, "Charging:%s", charging_enabled?"enabled":"disabled");
+    PBL_LOG_DBG("Charging:%s", charging_enabled?"enabled":"disabled");
   }
 }
 
@@ -82,7 +82,7 @@ static void prv_battery_set_fast_charge(bool fast_charge_enabled) {
     GPIO_WriteBit(BOARD_CONFIG_POWER.chg_fast.gpio, BOARD_CONFIG_POWER.chg_fast.gpio_pin, fast_charge_enabled?Bit_RESET:Bit_SET);
 
     gpio_release(BOARD_CONFIG_POWER.chg_fast.gpio);
-    PBL_LOG(LOG_LEVEL_DEBUG, "Fastcharge %s", fast_charge_enabled?"enabled":"disabled");
+    PBL_LOG_DBG("Fastcharge %s", fast_charge_enabled?"enabled":"disabled");
   }
 }
 

--- a/src/fw/drivers/display/ice40lp/ice40lp.c
+++ b/src/fw/drivers/display/ice40lp/ice40lp.c
@@ -257,7 +257,7 @@ static bool prv_wait_busy(void) {
   TickType_t max_wait_time_ticks = milliseconds_to_ticks(40);
   bool busy_on_exit = false;
   if (xSemaphoreTake(s_fpga_busy, max_wait_time_ticks) != pdTRUE) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Display not coming out of a busy state.");
+    PBL_LOG_ERR("Display not coming out of a busy state.");
     // Nothing needs to be done to recover the FPGA from a bad state. The
     // falling edge of SCS (to start a new frame) resets the FPGA logic,
     // clearing the error state.
@@ -277,12 +277,10 @@ static void prv_reprogram_display(void) {
 }
 
 static void prv_cdone_low_handler(void *context) {
-  PBL_LOG(LOG_LEVEL_ERROR,
-          "CDONE has gone low. The FPGA has lost its configuration.");
+  PBL_LOG_ERR("CDONE has gone low. The FPGA has lost its configuration.");
 
   if (!mutex_lock_with_timeout(s_display_update_mutex, 200)) {
-    PBL_LOG(LOG_LEVEL_DEBUG,
-            "Couldn't lock out display driver to reprogram FPGA.");
+    PBL_LOG_DBG("Couldn't lock out display driver to reprogram FPGA.");
     return;
   }
   prv_reprogram_display();
@@ -361,7 +359,7 @@ bool display_update_in_progress(void) {
 static void prv_do_display_update(void) {
 
   if (!mutex_lock_with_timeout(s_display_update_mutex, 0)) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Couldn't start update.");
+    PBL_LOG_DBG("Couldn't start update.");
     return;
   }
   if (s_panic_screen_lockout) {
@@ -388,13 +386,12 @@ static void prv_do_display_update(void) {
     // should get it unstuck. If BUSY is still asserted, the FPGA might be
     // unprogrammed or malfunctioning. Either way, reprogramming it should get
     // it back into working order.
-    PBL_LOG(LOG_LEVEL_WARNING,
-            "Reprogramming FPGA because busy is stuck asserted");
+    PBL_LOG_WRN("Reprogramming FPGA because busy is stuck asserted");
     prv_reprogram_display();
     bool is_busy = display_busy();
 #ifdef TARGET_QEMU
     // Bold light-red text on a black background
-#define M(s) PBL_LOG(LOG_LEVEL_ALWAYS, "\033[1;91;40m" s "\033[0m")
+#define M(s) PBL_LOG_ALWAYS("\033[1;91;40m" s "\033[0m")
     if (is_busy) {
       M("################################################");
       M("#             THIS IS A QEMU BUILD             #");
@@ -541,7 +538,7 @@ static void prv_start_dma_transfer(uint8_t *addr, uint32_t length) {
 void display_show_panic_screen(uint32_t error_code) {
   // Lock out display driver from performing further updates
   if (!mutex_lock_with_timeout(s_display_update_mutex, 200)) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Couldn't lock out display driver.");
+    PBL_LOG_DBG("Couldn't lock out display driver.");
     return;
   }
   s_panic_screen_lockout = true;
@@ -559,7 +556,7 @@ void display_show_panic_screen(uint32_t error_code) {
     if (boot_display_show_error_code(error_code)) {
       // Success!
       if (retries > 0) {
-        PBL_LOG(LOG_LEVEL_WARNING, "Took %d retries to display panic screen.",
+        PBL_LOG_WRN("Took %d retries to display panic screen.",
                 retries);
       }
       break;

--- a/src/fw/drivers/display/ice40lp/ice40lp_internal.c
+++ b/src/fw/drivers/display/ice40lp/ice40lp_internal.c
@@ -77,7 +77,7 @@ static bool prv_wait_programmed(void) {
   int timeout = 100 * 10;  // * 100 microseconds
   while (!gpio_input_read(&ICE40LP->cdone)) {
     if (timeout-- == 0) {
-      PBL_LOG(LOG_LEVEL_ERROR, "FPGA CDONE timeout expired!");
+      PBL_LOG_ERR("FPGA CDONE timeout expired!");
       return false;
     }
     delay_us(100);
@@ -139,7 +139,7 @@ static bool prv_try_program(const uint8_t *fpga_bitstream,
 #if !defined(TARGET_QEMU)
   prv_wait_programmed();
   if (!gpio_input_read(&ICE40LP->cdone)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "CDONE not high after programming");
+    PBL_LOG_ERR("CDONE not high after programming");
     return false;
   }
 #endif
@@ -189,24 +189,24 @@ void display_power_enable(void) {
   psleep(2);
 
   if (ICE40LP->use_6v6_rail) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Enabling 6v6 (Display VDDC)");
+    PBL_LOG_DBG("Enabling 6v6 (Display VDDC)");
     set_6V6_power_state(true);
 
     psleep(2);
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Enabling 4v5 (Display VDDP)");
+  PBL_LOG_DBG("Enabling 4v5 (Display VDDP)");
   set_4V5_power_state(true);
 }
 
 void display_power_disable(void) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Disabling 4v5 (Display VDDP)");
+  PBL_LOG_DBG("Disabling 4v5 (Display VDDP)");
   set_4V5_power_state(false);
 
   psleep(2);
 
   if (ICE40LP->use_6v6_rail) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Disabling 6v6 (Display VDDC)");
+    PBL_LOG_DBG("Disabling 6v6 (Display VDDC)");
     set_6V6_power_state(false);
 
     psleep(2);

--- a/src/fw/drivers/display/ice40lp/snowy_boot.c
+++ b/src/fw/drivers/display/ice40lp/snowy_boot.c
@@ -49,7 +49,7 @@ static bool prv_wait_busy(void) {
   int timeout = 50 * 10;
   while (display_busy()) {
     if (timeout-- == 0) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Display busy-wait timeout expired!");
+      PBL_LOG_ERR("Display busy-wait timeout expired!");
       return false;
     }
     delay_us(100);

--- a/src/fw/drivers/flash/flash_api.c
+++ b/src/fw/drivers/flash/flash_api.c
@@ -96,7 +96,7 @@ static status_t prv_try_restart_interrupted_erase(bool is_subsector,
   status_t status = is_subsector? flash_impl_erase_subsector_begin(addr)
                                 : flash_impl_erase_sector_begin(addr);
   if (FAILED(status)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Got error trying to reissue interrupted erase: "
+    PBL_LOG_ERR("Got error trying to reissue interrupted erase: "
             "%"PRIi32, status);
     return status;
   }
@@ -132,7 +132,7 @@ void flash_init(void) {
         &is_subsector, &erase_in_progress_address) == S_TRUE) {
     // An erase was interrupted by e.g. a crash. Retry the erase so the
     // incompletely-erased sector doesn't cause us trouble later on.
-    PBL_LOG(LOG_LEVEL_WARNING, "Flash erase to 0x%"PRIx32" was interrupted "
+    PBL_LOG_WRN("Flash erase to 0x%"PRIx32" was interrupted "
             "last boot. Restarting the erase...", erase_in_progress_address);
 
     // When an erase is interrupted, subsequent erases of the same sector tend to
@@ -145,12 +145,12 @@ void flash_init(void) {
       if (PASSED(status)) {
         break;
       }
-      PBL_LOG(LOG_LEVEL_ERROR, "Flash erase failed, status %"PRIi32, status);
+      PBL_LOG_ERR("Flash erase failed, status %"PRIi32, status);
       if (attempt++ >= MAX_ERASE_RETRIES) {
         // We've tried all we can. No point in croaking; it's not like a reboot
         // is going to fix anything. Best we can do is pretend like nothing is
         // wrong and hope for the best.
-        PBL_LOG(LOG_LEVEL_ERROR, "Giving up on restarting the flash erase.");
+        PBL_LOG_ERR("Giving up on restarting the flash erase.");
         break;
       }
     }
@@ -379,7 +379,7 @@ static uint32_t prv_flash_erase_poll(void) {
   xSemaphoreGive(s_erase_semphr);
   if (status == E_ERROR && saved_ctx.retries < MAX_ERASE_RETRIES) {
     // Try issuing the erase again. It might succeed this time around.
-    PBL_LOG(LOG_LEVEL_DEBUG, "Erase of 0x%"PRIx32" failed (attempt %d)."
+    PBL_LOG_DBG("Erase of 0x%"PRIx32" failed (attempt %d)."
             " Trying again...", saved_ctx.address, saved_ctx.retries);
     return prv_flash_erase_start(
         saved_ctx.address, saved_ctx.on_complete_cb, saved_ctx.cb_context,

--- a/src/fw/drivers/flash/flash_crc.c
+++ b/src/fw/drivers/flash/flash_crc.c
@@ -16,7 +16,7 @@ static size_t prv_allocate_crc_buffer(void **buffer) {
   unsigned int chunk_size = 1024;
   *buffer = kernel_malloc(chunk_size);
   if (!*buffer) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Insufficient memory for a large CRC buffer, going slow");
+    PBL_LOG_WRN("Insufficient memory for a large CRC buffer, going slow");
 
     chunk_size = 128;
     *buffer = kernel_malloc_check(chunk_size);

--- a/src/fw/drivers/flash/flash_erase.c
+++ b/src/fw/drivers/flash/flash_erase.c
@@ -50,7 +50,7 @@ static void prv_async_erase_done_cb(void *ignored, status_t result) {
     // potential for a stack overflow) if the flash_erase_sector calls the
     // completion callback asynchronously.
     if (!new_timer_add_work_callback(prv_erase_next_async, NULL)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Failed to enqueue callback; aborting erase");
+      PBL_LOG_ERR("Failed to enqueue callback; aborting erase");
       prv_unlock_erase_mutex();
       s_erase_state.on_complete(s_erase_state.on_complete_context, E_INTERNAL);
     }

--- a/src/fw/drivers/flash/micron_n25q/flash.c
+++ b/src/fw/drivers/flash/micron_n25q/flash.c
@@ -440,7 +440,7 @@ void flash_write_bytes(const uint8_t* buffer, uint32_t start_addr, uint32_t buff
 void flash_erase_subsector_blocking(uint32_t subsector_addr) {
   assert_usable_state();
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Erasing subsector 0x%"PRIx32" (0x%"PRIx32" - 0x%"PRIx32")",
+  PBL_LOG_DBG("Erasing subsector 0x%"PRIx32" (0x%"PRIx32" - 0x%"PRIx32")",
       subsector_addr,
       subsector_addr & SUBSECTOR_ADDR_MASK,
       (subsector_addr & SUBSECTOR_ADDR_MASK) + SUBSECTOR_SIZE_BYTES);
@@ -478,13 +478,13 @@ void flash_erase_subsector_blocking(uint32_t subsector_addr) {
 void flash_erase_sector_blocking(uint32_t sector_addr) {
   assert_usable_state();
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Erasing sector 0x%"PRIx32" (0x%"PRIx32" - 0x%"PRIx32")",
+  PBL_LOG_DBG("Erasing sector 0x%"PRIx32" (0x%"PRIx32" - 0x%"PRIx32")",
           sector_addr,
           sector_addr & SECTOR_ADDR_MASK,
           (sector_addr & SECTOR_ADDR_MASK) + SECTOR_SIZE_BYTES);
 
   if (flash_sector_is_erased(sector_addr)) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Sector %#"PRIx32" already erased", sector_addr);
+    PBL_LOG_DBG("Sector %#"PRIx32" already erased", sector_addr);
     return;
   }
 
@@ -614,11 +614,11 @@ void debug_flash_dump_registers(void) {
   disable_flash_spi_clock();
   flash_unlock();
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Status Register: 0x%x", status_register);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Lock Register: 0x%x", lock_register);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Flag Status Register: 0x%x", flag_status_register);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Nonvolatile Configuration Register: 0x%x", nonvolatile_config_register);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Volatile Configuration Register: 0x%x", volatile_config_register);
+  PBL_LOG_DBG("Status Register: 0x%x", status_register);
+  PBL_LOG_DBG("Lock Register: 0x%x", lock_register);
+  PBL_LOG_DBG("Flag Status Register: 0x%x", flag_status_register);
+  PBL_LOG_DBG("Nonvolatile Configuration Register: 0x%x", nonvolatile_config_register);
+  PBL_LOG_DBG("Volatile Configuration Register: 0x%x", volatile_config_register);
 #endif
 }
 

--- a/src/fw/drivers/flash/qspi_flash.c
+++ b/src/fw/drivers/flash/qspi_flash.c
@@ -46,10 +46,10 @@ static bool prv_check_whoami(QSPIFlash *dev) {
                     whoami_length);
 
   if (read_whoami == dev->state->part->qspi_id_value) {
-    PBL_LOG(LOG_LEVEL_INFO, "Flash is %s", dev->state->part->name);
+    PBL_LOG_INFO("Flash is %s", dev->state->part->name);
     return true;
   } else {
-    PBL_LOG(LOG_LEVEL_ERROR, "Flash isn't expected %s (whoami: 0x%" PRIx32 ")",
+    PBL_LOG_ERR("Flash isn't expected %s (whoami: 0x%" PRIx32 ")",
             dev->state->part->name, read_whoami);
     return false;
   }
@@ -373,7 +373,7 @@ status_t qspi_flash_write_protection_enable(QSPIFlash *dev) {
   prv_write_enable(dev);
   const bool already_enabled = prv_protection_is_enabled(dev);
   if (already_enabled == false) {
-    PBL_LOG(LOG_LEVEL_INFO, "Enabling flash protection");
+    PBL_LOG_INFO("Enabling flash protection");
     // Enable write protection
     prv_write_cmd_no_addr(dev, dev->state->part->instructions.write_protection_enable);
 

--- a/src/fw/drivers/flash/spansion_s29vs.c
+++ b/src/fw/drivers/flash/spansion_s29vs.c
@@ -537,7 +537,7 @@ status_t flash_impl_read_sync(void *buffer_ptr, FlashAddress start_addr, size_t 
     buffer[bytes_read++] = (uint8_t)(temp_buffer & 0xFF);
   } else if (buffer_size - bytes_read != 0) {
     // Should not reach here
-    PBL_LOG(LOG_LEVEL_DEBUG, "Invalid data length read");
+    PBL_LOG_DBG("Invalid data length read");
   }
 
   flash_impl_release();
@@ -875,7 +875,7 @@ status_t flash_impl_blank_check_subsector(FlashAddress addr) {
 
 bool flash_check_whoami(void) {
   uint16_t manufacturer_id = prv_read_manufacturer_id();
-  PBL_LOG(LOG_LEVEL_DEBUG, "Flash Manufacturer ID: 0x%" PRIx16, manufacturer_id);
+  PBL_LOG_DBG("Flash Manufacturer ID: 0x%" PRIx16, manufacturer_id);
 
   return manufacturer_id == SPANSION_MANUFACTURER_ID || manufacturer_id == MACRONIX_MANUFACTURER_ID;
 }

--- a/src/fw/drivers/hrm/as7000/as7000.c
+++ b/src/fw/drivers/hrm/as7000/as7000.c
@@ -1,7 +1,6 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define FILE_LOG_COLOR LOG_COLOR_GREEN
 #include "as7000.h"
 
 #include "board/board.h"
@@ -37,7 +36,7 @@
 #if PPG_DEBUG
 #define PPG_DBG(...) \
   do { \
-    PBL_LOG(LOG_LEVEL_DEBUG, __VA_ARGS__); \
+    PBL_LOG_DBG(__VA_ARGS__); \
   } while (0);
 #else
 #define PPG_DBG(...)
@@ -360,7 +359,7 @@ static void prv_handle_handshake_pulse(void *unused_data) {
 
   if (num_samples == 0 && should_expect_samples) {
     analytics_inc(ANALYTICS_DEVICE_METRIC_HRM_ACCEL_DATA_MISSING, AnalyticsClient_System);
-    PBL_LOG(LOG_LEVEL_WARNING, "Falling behind: HRM got 0 accel samples");
+    PBL_LOG_WRN("Falling behind: HRM got 0 accel samples");
   }
 
 }
@@ -385,27 +384,27 @@ static void prv_interrupts_enable(HRMDevice *dev, bool enable) {
 static void prv_log_running_apps(HRMDevice *dev) {
   uint8_t app_ids = 0;
   if (!prv_read_register(dev, ADDR_APP_IDS, &app_ids)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to get running apps");
+    PBL_LOG_ERR("Failed to get running apps");
     return;
   }
-  PBL_LOG(LOG_LEVEL_DEBUG, "Running applications:");
+  PBL_LOG_DBG("Running applications:");
   if (app_ids == AS7000AppId_Idle) {
-    PBL_LOG(LOG_LEVEL_DEBUG, " - None (idle)");
+    PBL_LOG_DBG(" - None (idle)");
   } else {
     if (app_ids & AS7000AppId_Loader) {
-      PBL_LOG(LOG_LEVEL_DEBUG, " - Loader");
+      PBL_LOG_DBG(" - Loader");
     }
     if (app_ids & AS7000AppId_HRM) {
-      PBL_LOG(LOG_LEVEL_DEBUG, " - HRM");
+      PBL_LOG_DBG(" - HRM");
     }
     if (app_ids & AS7000AppId_PRV) {
-      PBL_LOG(LOG_LEVEL_DEBUG, " - PRV");
+      PBL_LOG_DBG(" - PRV");
     }
     if (app_ids & AS7000AppId_GSR) {
-      PBL_LOG(LOG_LEVEL_DEBUG, " - GSR");
+      PBL_LOG_DBG(" - GSR");
     }
     if (app_ids & AS7000AppId_NTC) {
-      PBL_LOG(LOG_LEVEL_DEBUG, " - NTC");
+      PBL_LOG_DBG(" - NTC");
     }
   }
 }
@@ -419,7 +418,7 @@ static bool prv_get_and_log_device_info(HRMDevice *dev, AS7000InfoRecord *info,
 
   if (log_version) {
     // print out the version information
-    PBL_LOG(LOG_LEVEL_INFO, "AS7000 enabled! Protocol v%" PRIu8 ".%" PRIu8
+    PBL_LOG_INFO("AS7000 enabled! Protocol v%" PRIu8 ".%" PRIu8
       ", SW v%" PRIu8 ".%" PRIu8 ".%" PRIu8 ", HW Rev %" PRIu8,
             info->protocol_version_major, info->protocol_version_minor,
             HRM_SW_VERSION_PART_MAJOR(info->sw_version_major),
@@ -435,7 +434,7 @@ static bool prv_is_app_running(HRMDevice *dev, AS7000AppId app) {
   if (!prv_read_register(dev, ADDR_APP_IDS, &running_apps)) {
     return false;
   }
-  PBL_LOG(LOG_LEVEL_DEBUG, "Apps running: 0x%"PRIx8, running_apps);
+  PBL_LOG_DBG("Apps running: 0x%"PRIx8, running_apps);
   if (app == AS7000AppId_Idle) {
     // no apps should be running
     return running_apps == AS7000AppId_Idle;
@@ -493,7 +492,7 @@ static void prv_disable(HRMDevice *dev) {
   // Put the INT pin back into a low power state that won't interfere with jtag using the pin
   gpio_analog_init(&dev->int_gpio);
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Shutting down device.");
+  PBL_LOG_DBG("Shutting down device.");
   switch (dev->state->enabled_state) {
     case HRMEnabledState_PoweringOn:
       new_timer_stop(dev->state->timer);
@@ -522,7 +521,7 @@ static void prv_disable(HRMDevice *dev) {
 static void prv_enable(HRMDevice *dev) {
   mutex_assert_held_by_curr_task(dev->state->lock, true);
   if (dev->state->enabled_state == HRMEnabledState_Uninitialized) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Trying to enable HRM before initialization.");
+    PBL_LOG_ERR("Trying to enable HRM before initialization.");
 
   } else if (dev->state->enabled_state == HRMEnabledState_Disabled) {
     led_enable(LEDEnablerHRM);
@@ -537,7 +536,7 @@ static void prv_enable(HRMDevice *dev) {
 
     interval_timer_init(&s_handshake_interval_timer, 900, 1100, 8);
 
-    PBL_LOG(LOG_LEVEL_DEBUG, "Enabling AS7000...");
+    PBL_LOG_DBG("Enabling AS7000...");
   }
 }
 
@@ -552,7 +551,7 @@ static void prv_watchdog_timer_system_cb(void *data) {
 
   // If we have gone too long without getting an interrupt, let's reset the device
   if (s_missing_interrupt_count >= AS7000_MAX_WATCHDOG_INTERRUPTS) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Watchdog logic detected frozen sensor. Resetting now.");
+    PBL_LOG_ERR("Watchdog logic detected frozen sensor. Resetting now.");
     analytics_inc(ANALYTICS_DEVICE_METRIC_HRM_WATCHDOG_TIMEOUT, AnalyticsClient_System);
     prv_disable(dev);
     psleep(SHUT_DOWN_DELAY_MS);
@@ -570,7 +569,7 @@ static void prv_watchdog_timer_cb(void *data) {
     system_task_add_callback(prv_watchdog_timer_system_cb, (void *)dev);
   }
   if (s_missing_interrupt_count > 1) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Missing interrupt count: %"PRIu8" ", s_missing_interrupt_count);
+    PBL_LOG_DBG("Missing interrupt count: %"PRIu8" ", s_missing_interrupt_count);
   }
 }
 
@@ -595,7 +594,7 @@ static void prv_disable_watchdog(HRMDevice *dev) {
 static bool prv_start_loader(HRMDevice *dev) {
   // check if the loader is already running
   if (!prv_is_app_running(dev, AS7000AppId_Loader)) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Switching to loader");
+    PBL_LOG_DBG("Switching to loader");
     // we need to start the loader
     if (!prv_set_running_apps(dev, AS7000AppId_Loader)) {
       return false;
@@ -624,7 +623,7 @@ static bool prv_wait_for_loader_ready(HRMDevice *dev) {
   do {
     uint8_t status = 0;
     if (!prv_read_register(dev, ADDR_LOADER_STATUS, &status)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Failed reading status");
+      PBL_LOG_ERR("Failed reading status");
       return false;
     }
 
@@ -633,34 +632,33 @@ static bool prv_wait_for_loader_ready(HRMDevice *dev) {
       return true;
     } else if ((status != AS7000LoaderStatus_Busy1) && (status != AS7000LoaderStatus_Busy2)) {
       // error
-      PBL_LOG(LOG_LEVEL_ERROR, "Error status: %"PRIx8, status);
+      PBL_LOG_ERR("Error status: %"PRIx8, status);
       return false;
     }
     psleep(1);
   } while (prv_get_time_ms() < end_time_ms);
 
-  PBL_LOG(LOG_LEVEL_ERROR, "Timed out waiting for the loader to be ready!");
+  PBL_LOG_ERR("Timed out waiting for the loader to be ready!");
   return false;
 }
 
 static bool prv_flash_fw(HRMDevice *dev) {
   // switch to the loader
   if (!prv_start_loader(dev)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to start loader");
+    PBL_LOG_ERR("Failed to start loader");
     return false;
   }
 
   // wait for the loader to be ready
   if (!prv_wait_for_loader_ready(dev)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Loader not ready");
+    PBL_LOG_ERR("Loader not ready");
     return false;
   }
 
   const uint32_t image_length =
     resource_size(SYSTEM_APP, RESOURCE_ID_AS7000_FW_IMAGE);
   PBL_ASSERTN(image_length);
-  PBL_LOG(LOG_LEVEL_DEBUG,
-          "Loading FW image (%"PRIu32" bytes encoded)", image_length);
+  PBL_LOG_DBG("Loading FW image (%"PRIu32" bytes encoded)", image_length);
   // Skip over the image header.
   uint32_t cursor = sizeof(AS7000FWUpdateHeader);
   while (cursor < image_length) {
@@ -674,7 +672,7 @@ static bool prv_flash_fw(HRMDevice *dev) {
           SYSTEM_APP, RESOURCE_ID_AS7000_FW_IMAGE, cursor,
           (uint8_t *)&segment_header, sizeof(segment_header)) !=
         sizeof(segment_header)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Failed to read FW image! "
+      PBL_LOG_ERR("Failed to read FW image! "
               "(segment header @ 0x%" PRIx32 ")", cursor);
       return false;
     }
@@ -688,7 +686,7 @@ static bool prv_flash_fw(HRMDevice *dev) {
       if (resource_load_byte_range_system(
             SYSTEM_APP, RESOURCE_ID_AS7000_FW_IMAGE, cursor, chunk, load_length)
           != load_length) {
-        PBL_LOG(LOG_LEVEL_ERROR, "Failed to read FW image! "
+        PBL_LOG_ERR("Failed to read FW image! "
                 "(segment data @ 0x%" PRIx32 ")", cursor);
         return false;
       }
@@ -700,14 +698,14 @@ static bool prv_flash_fw(HRMDevice *dev) {
                   chunk, load_length);
       if (!prv_write_register_block(dev, ADDR_LOADER_STATUS, data_record,
                                     IHEX_RECORD_LENGTH(load_length))) {
-        PBL_LOG(LOG_LEVEL_ERROR, "Failed to write hex record");
+        PBL_LOG_ERR("Failed to write hex record");
         return false;
       }
 
       // Wait for the loader to be ready, indicating that the last
       // record was successfully written.
       if (!prv_wait_for_loader_ready(dev)) {
-        PBL_LOG(LOG_LEVEL_ERROR, "Loader not ready");
+        PBL_LOG_ERR("Loader not ready");
         return false;
       }
 
@@ -725,7 +723,7 @@ static bool prv_flash_fw(HRMDevice *dev) {
   ihex_encode(eof_record, IHEX_TYPE_EOF, 0, NULL, 0);
   if (!prv_write_register_block(dev, ADDR_LOADER_STATUS,
                                 eof_record, IHEX_RECORD_LENGTH(0))) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to write EOF record");
+    PBL_LOG_ERR("Failed to write EOF record");
     return false;
   }
 
@@ -746,49 +744,47 @@ static void prv_enable_system_task_cb(void *context) {
     // Enable was cancelled before this callback fired.
     goto done;
   } else if (dev->state->enabled_state != HRMEnabledState_PoweringOn) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Enable KernelBG callback fired while HRM was in "
+    PBL_LOG_ERR("Enable KernelBG callback fired while HRM was in "
             "an unexpected state: %u", (unsigned int)dev->state->enabled_state);
     WTF;
   }
 
   AS7000InfoRecord info;
   if (!prv_get_and_log_device_info(dev, &info, false /* log_version */)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to query AS7000 device info");
+    PBL_LOG_ERR("Failed to query AS7000 device info");
     goto failed;
   }
 
   if (info.application_id == AS7000AppId_Loader) {
     // This shouldn't happen. The application firmware should have been
     // flashed during boot.
-    PBL_LOG(LOG_LEVEL_ERROR,
-            "AS7000 booted into loader! Something is very wrong.");
+    PBL_LOG_ERR("AS7000 booted into loader! Something is very wrong.");
     goto failed;
   }
 
   // check that we can communicate with this chip
   if (info.protocol_version_major != EXPECTED_PROTOCOL_VERSION_MAJOR) {
     // we don't know how to talk with this chip, so bail
-    PBL_LOG(LOG_LEVEL_ERROR, "Unexpected protocol version!");
+    PBL_LOG_ERR("Unexpected protocol version!");
     goto failed;
   }
 
   if (info.application_id != AS7000AppId_Idle) {
-    PBL_LOG(LOG_LEVEL_ERROR,
-            "Unexpected application running: 0x%" PRIx8, info.application_id);
+    PBL_LOG_ERR("Unexpected application running: 0x%" PRIx8, info.application_id);
     goto failed;
   }
 
   // the INT line should be low
   if (gpio_input_read(&dev->int_gpio)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "INT line is not low!");
+    PBL_LOG_ERR("INT line is not low!");
     goto failed;
   }
 
   // Set the accelerometer sample frequency
-  PBL_LOG(LOG_LEVEL_DEBUG, "Setting accel frequency");
+  PBL_LOG_DBG("Setting accel frequency");
   PBL_ASSERTN(HRM_MANAGER_ACCEL_RATE_MILLIHZ >= 10000 && HRM_MANAGER_ACCEL_RATE_MILLIHZ <= 20000);
   if (!prv_set_accel_sample_frequency(dev, HRM_MANAGER_ACCEL_RATE_MILLIHZ)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to set accel frequency");
+    PBL_LOG_ERR("Failed to set accel frequency");
     goto failed;
   }
 
@@ -810,14 +806,14 @@ static void prv_enable_system_task_cb(void *context) {
       break;
   }
   if (!prv_write_register(dev, ADDR_PRES_DETECT_THRSH, pres_detect_thrsh)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to set presence detection threshold");
+    PBL_LOG_ERR("Failed to set presence detection threshold");
     goto failed;
   }
 
   // start the HRM app
-  PBL_LOG(LOG_LEVEL_DEBUG, "Starting HRM app");
+  PBL_LOG_DBG("Starting HRM app");
   if (!prv_set_running_apps(dev, AS7000AppId_HRM)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to start HRM app!");
+    PBL_LOG_ERR("Failed to start HRM app!");
     goto failed;
   }
 
@@ -827,7 +823,7 @@ static void prv_enable_system_task_cb(void *context) {
 
   // wait for the INT line to go high indicating the Idle app has ended
   if (!prv_wait_int_high(dev)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Timed-out waiting for the Idle app to end but we "
+    PBL_LOG_ERR("Timed-out waiting for the Idle app to end but we "
             "probably just missed it");
     // TODO: The line only goes high for a few ms. If there is any kind of context switch while we
     // wait for the line to go high we will miss this. Let's fix this the right way in PBL-41812
@@ -836,7 +832,7 @@ static void prv_enable_system_task_cb(void *context) {
 
   // wait for the INT line to go low indicating the HRM app is ready
   if (!prv_wait_int_low(dev)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Timed-out waiting for the HRM app to be ready");
+    PBL_LOG_ERR("Timed-out waiting for the HRM app to be ready");
     goto failed;
   }
 
@@ -880,7 +876,7 @@ void hrm_init(HRMDevice *dev) {
   if (update_length == 0) {
     // We don't have a firmware to write so there's no point in booting
     // the HRM.
-    PBL_LOG(LOG_LEVEL_DEBUG, "No HRM FW update available");
+    PBL_LOG_DBG("No HRM FW update available");
     return;
   }
 
@@ -888,10 +884,10 @@ void hrm_init(HRMDevice *dev) {
   if (resource_load_byte_range_system(
         SYSTEM_APP, RESOURCE_ID_AS7000_FW_IMAGE, 0, (uint8_t *)&image_header,
         sizeof(image_header)) != sizeof(image_header)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to read HRM FW image header!");
+    PBL_LOG_ERR("Failed to read HRM FW image header!");
     return;
   }
-  PBL_LOG(LOG_LEVEL_DEBUG, "FW update image is v%" PRIu8 ".%" PRIu8 ".%" PRIu8,
+  PBL_LOG_DBG("FW update image is v%" PRIu8 ".%" PRIu8 ".%" PRIu8,
           HRM_SW_VERSION_PART_MAJOR(image_header.sw_version_major),
           HRM_SW_VERSION_PART_MINOR(image_header.sw_version_major),
           image_header.sw_version_minor);
@@ -899,7 +895,7 @@ void hrm_init(HRMDevice *dev) {
   // Now that we know what version the image is, actually boot up the
   // HRM so we can read off the version.
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Booting AS7000...");
+  PBL_LOG_DBG("Booting AS7000...");
 
   gpio_output_init(&dev->en_gpio, GPIO_OType_PP, GPIO_Speed_2MHz);
 #if HRM_FORCE_FLASH
@@ -921,7 +917,7 @@ void hrm_init(HRMDevice *dev) {
 
   AS7000InfoRecord hrm_info;
   if (!prv_get_and_log_device_info(dev, &hrm_info, true /* log_version */)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to read AS7000 version info!");
+    PBL_LOG_ERR("Failed to read AS7000 version info!");
     goto cleanup;
   }
 
@@ -932,9 +928,9 @@ void hrm_init(HRMDevice *dev) {
     // minor version in the chip is newer than in the update image, but
     // for sanity's sake let's always make sure the HRM firmware is in
     // sync with the version shipped with the Pebble firmware.
-    PBL_LOG(LOG_LEVEL_DEBUG, "AS7000 firmware version mismatch. Flashing...");
+    PBL_LOG_DBG("AS7000 firmware version mismatch. Flashing...");
     if (!prv_flash_fw(dev)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Failed to flash firmware");
+      PBL_LOG_ERR("Failed to flash firmware");
       goto cleanup;
     }
     // We need to wait for the HRM to reboot into the application before
@@ -942,16 +938,15 @@ void hrm_init(HRMDevice *dev) {
     // during boot, it will activate "force loader mode" and fall back
     // into the loader. Since we're waiting anyway, we might as well
     // query the version info again to make sure the update took.
-    PBL_LOG(LOG_LEVEL_DEBUG, "Firmware flashed! Waiting for reboot...");
+    PBL_LOG_DBG("Firmware flashed! Waiting for reboot...");
     gpio_output_set(&dev->en_gpio, true);
     psleep(LOADER_REBOOT_DELAY_MS);
     if (!prv_get_and_log_device_info(dev, &hrm_info, true /* log_version */)) {
-      PBL_LOG(LOG_LEVEL_ERROR,
-              "Failed to read AS7000 version info after flashing!");
+      PBL_LOG_ERR("Failed to read AS7000 version info after flashing!");
       goto cleanup;
     }
   } else {
-    PBL_LOG(LOG_LEVEL_DEBUG, "AS7000 firmware is up to date.");
+    PBL_LOG_DBG("AS7000 firmware is up to date.");
   }
 
 cleanup:
@@ -964,7 +959,7 @@ cleanup:
 
 bool hrm_enable(HRMDevice *dev) {
   if (!dev->state->lock) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Not an HRM Device.");
+    PBL_LOG_DBG("Not an HRM Device.");
     return false;
   }
 
@@ -976,7 +971,7 @@ bool hrm_enable(HRMDevice *dev) {
 
 void hrm_disable(HRMDevice *dev) {
   if (!dev->state->lock) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Not an HRM Device.");
+    PBL_LOG_DBG("Not an HRM Device.");
     return;
   }
 
@@ -992,13 +987,13 @@ bool hrm_is_enabled(HRMDevice *dev) {
 
 void as7000_get_version_info(HRMDevice *dev, AS7000InfoRecord *info_out) {
   if (!dev->state->lock) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Not an HRM Device.");
+    PBL_LOG_DBG("Not an HRM Device.");
     return;
   }
 
   mutex_lock(dev->state->lock);
   if (!prv_get_and_log_device_info(dev, info_out, true /* log_version */)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Failed to read AS7000 version info");
+    PBL_LOG_WRN("Failed to read AS7000 version info");
   }
   mutex_unlock(dev->state->lock);
 }

--- a/src/fw/drivers/hrm/gh3x2x/gh3x2x.c
+++ b/src/fw/drivers/hrm/gh3x2x/gh3x2x.c
@@ -99,7 +99,7 @@ void gh3x2x_print_fmt(const char *fmt, ...) {
   va_start(ap, fmt);
   vsniprintf(buffer, sizeof(buffer), fmt, ap);
   va_end(ap);
-  PBL_LOG(LOG_LEVEL_ALWAYS, "%s", buffer);
+  PBL_LOG_ALWAYS("%s", buffer);
 #endif
 }
 
@@ -107,7 +107,7 @@ void gh3x2x_result_report(uint8_t type, uint32_t val, uint8_t quality) {
   if (type == 1) {
     HRMData hrm_data = {0};
 
-    PBL_LOG(LOG_LEVEL_DEBUG, "GH3X2X BPM %" PRIu32 " (quality=%" PRIu8 ")", val, quality);
+    PBL_LOG_DBG("GH3X2X BPM %" PRIu32 " (quality=%" PRIu8 ")", val, quality);
 
     hrm_data.features = HRMFeature_BPM;
     hrm_data.hrm_bpm = val & 0xff;
@@ -132,7 +132,7 @@ void gh3x2x_result_report(uint8_t type, uint32_t val, uint8_t quality) {
   } else if (type == 2) {
     HRMData hrm_data = {0};
 
-    PBL_LOG(LOG_LEVEL_DEBUG, "GH3X2X SpO2 %" PRIu32 " (quality=%" PRIu8 ")", val, quality);
+    PBL_LOG_DBG("GH3X2X SpO2 %" PRIu32 " (quality=%" PRIu8 ")", val, quality);
 
     hrm_data.features = HRMFeature_SpO2;
     hrm_data.spo2_percent = val & 0xff;
@@ -156,7 +156,7 @@ void gh3x2x_result_report(uint8_t type, uint32_t val, uint8_t quality) {
 
     hrm_manager_new_data_cb(&hrm_data);
   } else {
-    PBL_LOG(LOG_LEVEL_WARNING, "GH3X2X unexpected report type (%" PRIu8 ")", type);
+    PBL_LOG_WRN("GH3X2X unexpected report type (%" PRIu8 ")", type);
   }
 }
 
@@ -219,7 +219,7 @@ void gh3x2x_wear_evt_notify(bool is_wear) {
   if (p_dev) {
     p_dev->state->is_wear = is_wear;
   }
-  PBL_LOG(LOG_LEVEL_DEBUG, "wear notify: %d", is_wear);
+  PBL_LOG_DBG("wear notify: %d", is_wear);
 }
 
 // GH3X2X calibration/factory testing
@@ -322,7 +322,7 @@ void gh3x2x_factory_test_enable(HRMDevice *dev, GH3x2xFTType test_type) {
   uint32_t* ppg_data;
   GH3x2xFTData* p_factory = (GH3x2xFTData*)malloc(sizeof(GH3x2xFTData) + sizeof(uint32_t)*HRM_PPG_FACTORY_TEST_FIFO_LEN*HRM_PPG_CH_NUM);
   if (p_factory == NULL) {
-    PBL_LOG(LOG_LEVEL_ERROR, "malloc failed.");
+    PBL_LOG_ERR("malloc failed.");
     return;
   }
   memset(p_factory, 0, sizeof(GH3x2xFTData));
@@ -437,7 +437,7 @@ bool hrm_enable(HRMDevice *dev) {
 
   ret = Gh3x2xDemoInit();
   if (ret != 0) {
-    PBL_LOG(LOG_LEVEL_ERROR, "GH3X2X failed to initialize");
+    PBL_LOG_ERR("GH3X2X failed to initialize");
     gh3026_reset_pin_ctrl(0);
     return false;
   }

--- a/src/fw/drivers/i2c_definitions.h
+++ b/src/fw/drivers/i2c_definitions.h
@@ -96,4 +96,4 @@ void i2c_init(I2CBus *bus);
 portBASE_TYPE i2c_handle_transfer_event(I2CBus *device, I2CTransferEvent event);
 
 #define I2C_DEBUG(fmt, args...) \
-  PBL_LOG_COLOR_D(LOG_DOMAIN_I2C, LOG_LEVEL_DEBUG, LOG_COLOR_LIGHT_MAGENTA, fmt, ## args)
+  PBL_LOG_D_DBG(LOG_DOMAIN_I2C, fmt, ## args)

--- a/src/fw/drivers/imu/bmi160/bmi160.c
+++ b/src/fw/drivers/imu/bmi160/bmi160.c
@@ -548,7 +548,7 @@ void accel_init(void) {
     prv_run_command(BMI160_CMD_SOFTRESET);
     bmi160_enable_spi_mode();
   } else {
-    PBL_LOG(LOG_LEVEL_WARNING, "Failed to query BMI160");
+    PBL_LOG_WRN("Failed to query BMI160");
   }
 
   prv_set_accel_scale(BMI160_SCALE_4G);
@@ -564,7 +564,7 @@ void accel_power_down(void) {
 
 bool bmi160_query_whoami(void) {
   uint8_t whoami = bmi160_read_reg(BMI160_REG_CHIP_ID);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Read BMI160 whoami byte 0x%"PRIx8", expecting 0x%"PRIx8,
+  PBL_LOG_DBG("Read BMI160 whoami byte 0x%"PRIx8", expecting 0x%"PRIx8,
           whoami, BMI160_CHIP_ID);
   return (whoami == BMI160_CHIP_ID);
 }
@@ -901,7 +901,7 @@ static void prv_disable_double_tap_detection(void) {
 }
 
 void accel_enable_shake_detection(bool on) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "enable shake detection %d", on);
+  PBL_LOG_DBG("enable shake detection %d", on);
   if (s_shake_detection_enabled == on) {
     // the requested change matches what we already have!
     return;
@@ -918,7 +918,7 @@ void accel_enable_shake_detection(bool on) {
 }
 
 void accel_enable_double_tap_detection(bool on) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "enable double tap detection %d", on);
+  PBL_LOG_DBG("enable double tap detection %d", on);
   if (s_double_tap_detection_enabled == on) {
     // the requested change matches what we already have!
     return;

--- a/src/fw/drivers/imu/lis3dh/config.c
+++ b/src/fw/drivers/imu/lis3dh/config.c
@@ -99,7 +99,7 @@ void lis3dh_set_interrupt_axis(AccelAxisType axis, bool double_click) {
       click_cfg = 0x10;
       break;
     default:
-      PBL_LOG(LOG_LEVEL_ERROR, "Unknown axis");
+      PBL_LOG_ERR("Unknown axis");
   }
 
   if (double_click) {
@@ -108,7 +108,7 @@ void lis3dh_set_interrupt_axis(AccelAxisType axis, bool double_click) {
 
   if ((!prv_write_reg(LIS3DH_CTRL_REG1, reg_1))
       || (!prv_write_reg(LIS3DH_CLICK_CFG, click_cfg))) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to write axis selection");
+    PBL_LOG_ERR("Failed to write axis selection");
   }
 }
 
@@ -117,7 +117,7 @@ uint8_t lis3dh_get_click_window() {
 }
 void lis3dh_set_click_window(uint8_t window) {
   if (!prv_write_reg(LIS3DH_TIME_WINDOW, MIN(window, LIS3DH_MAX_CLICK_WINDOW))) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to write click latency");
+    PBL_LOG_ERR("Failed to write click latency");
   }
 }
 
@@ -126,7 +126,7 @@ uint8_t lis3dh_get_click_latency() {
 }
 void lis3dh_set_click_latency(uint8_t latency) {
   if (!prv_write_reg(LIS3DH_TIME_LATENCY, MIN(latency, LIS3DH_MAX_CLICK_LATENCY))) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to write click latency");
+    PBL_LOG_ERR("Failed to write click latency");
   }
 }
 
@@ -135,7 +135,7 @@ uint8_t lis3dh_get_interrupt_threshold() {
 }
 void lis3dh_set_interrupt_threshold(uint8_t threshold) {
   if (!prv_write_reg(LIS3DH_CLICK_THS, MIN(threshold, LIS3DH_MAX_THRESHOLD))) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to set interrupt threshold");
+    PBL_LOG_ERR("Failed to set interrupt threshold");
   }
 }
 
@@ -144,7 +144,7 @@ uint8_t lis3dh_get_interrupt_time_limit() {
 }
 void lis3dh_set_interrupt_time_limit(uint8_t time_limit) {
   if (!prv_write_reg(LIS3DH_TIME_LIMIT, MIN(time_limit, LIS3DH_MAX_TIME_LIMIT))) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to set interrupt time limit");
+    PBL_LOG_ERR("Failed to set interrupt time limit");
   }
 }
 
@@ -173,7 +173,7 @@ AccelSamplingRate accel_get_sampling_rate(void) {
   } else if (odr == (ODR1)) {
     return (ACCEL_SAMPLING_10HZ);
   } else {
-    PBL_LOG(LOG_LEVEL_ERROR, "Unrecognized ODR value %d", odr);
+    PBL_LOG_ERR("Unrecognized ODR value %d", odr);
     return (0);
   }
 }
@@ -195,7 +195,7 @@ bool accel_set_sampling_rate(AccelSamplingRate rate) {
       odr = ODR1;
       break;
     default:
-      PBL_LOG(LOG_LEVEL_ERROR, "Unsupported sampling rate %d", rate);
+      PBL_LOG_ERR("Unsupported sampling rate %d", rate);
       return (false);
   }
 
@@ -209,20 +209,20 @@ bool accel_set_sampling_rate(AccelSamplingRate rate) {
   // Update the click limit based on sampling frequency
   uint8_t time_limit = rate * LIS3DH_TIME_LIMIT_MULT / LIS3DH_TIME_LIMIT_DIV;
   lis3dh_set_interrupt_time_limit(time_limit);
-  PBL_LOG(LOG_LEVEL_DEBUG, "setting click time limit to 0x%x",
+  PBL_LOG_DBG("setting click time limit to 0x%x",
               lis3dh_get_interrupt_time_limit());
 
   // Update click latency
   uint8_t time_latency = rate * LIS3DH_TIME_LATENCY_MULT / LIS3DH_TIME_LATENCY_DIV;
   lis3dh_set_click_latency(time_latency);
-  PBL_LOG(LOG_LEVEL_DEBUG, "setting click time latency to 0x%x",
+  PBL_LOG_DBG("setting click time latency to 0x%x",
               lis3dh_get_click_latency());
   
   // Update click window
   uint32_t time_window = rate * LIS3DH_TIME_WINDOW_MULT / LIS3DH_TIME_WINDOW_DIV;
   time_window = MIN(time_window, 0xff);
   lis3dh_set_click_window(time_window);
-  PBL_LOG(LOG_LEVEL_DEBUG, "setting click time window to 0x%x",
+  PBL_LOG_DBG("setting click time window to 0x%x",
               lis3dh_get_click_window());
   
 
@@ -241,7 +241,7 @@ Lis3dhScale accel_get_scale(void) {
   } else if (fs == 0) {
     return (LIS3DH_SCALE_2G);
   } else {
-    PBL_LOG(LOG_LEVEL_ERROR, "Unrecognized FS value %d", fs);
+    PBL_LOG_ERR("Unrecognized FS value %d", fs);
     return (LIS3DH_SCALE_UNKNOWN);
   }
 }
@@ -263,7 +263,7 @@ bool accel_set_scale(Lis3dhScale scale) {
       fs = 0;
       break;
     default:
-      PBL_LOG(LOG_LEVEL_ERROR, "Unsupported scale %d", scale);
+      PBL_LOG_ERR("Unsupported scale %d", scale);
       return (false);
   }
 
@@ -274,7 +274,7 @@ bool accel_set_scale(Lis3dhScale scale) {
 
   lis3dh_set_interrupt_threshold(scale * LIS3DH_THRESHOLD_MULT
                                 / LIS3DH_THRESHOLD_DIV);
-  PBL_LOG(LOG_LEVEL_DEBUG, "setting click threshold to 0x%x",
+  PBL_LOG_DBG("setting click threshold to 0x%x",
               lis3dh_get_interrupt_threshold());
   return (res);
 }
@@ -327,7 +327,7 @@ void lis3dh_exit_self_test_mode(void) {
 //! factory. Useful as a sanity check to make sure everything came up properly.
 bool lis3dh_sanity_check(void) {
   uint8_t whoami = prv_read_reg(LIS3DH_WHO_AM_I);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Read accel whomai byte 0x%x, expecting 0x%x", whoami, LIS3DH_WHOAMI_BYTE);
+  PBL_LOG_DBG("Read accel whomai byte 0x%x, expecting 0x%x", whoami, LIS3DH_WHOAMI_BYTE);
   return (whoami == LIS3DH_WHOAMI_BYTE);
 }
 
@@ -369,7 +369,7 @@ bool lis3dh_config_set_defaults() {
 
   if (!send_i2c_commands(accel_init_commands, ARRAY_LENGTH(accel_init_commands))) {
     accel_stop();
-    PBL_LOG(LOG_LEVEL_WARNING, "Failed to initialize accelerometer");
+    PBL_LOG_WRN("Failed to initialize accelerometer");
     return false;
   }
 

--- a/src/fw/drivers/imu/lis3dh/lis3dh.c
+++ b/src/fw/drivers/imu/lis3dh/lis3dh.c
@@ -198,7 +198,7 @@ void accel_get_last_data(AccelRawData* data) {
 
 void accel_get_data(AccelRawData* data, int num_samples) {
   if (!s_running) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Accel Not Running");
+    PBL_LOG_ERR("Accel Not Running");
     return;
   }
 
@@ -265,7 +265,7 @@ void accel_power_up(void) {
       }
     }
   }
-  PBL_LOG(LOG_LEVEL_ERROR, "Failed to exit low power mode");
+  PBL_LOG_ERR("Failed to exit low power mode");
 }
 
 void accel_power_down(void) {
@@ -280,7 +280,7 @@ void accel_power_down(void) {
       }
     }
   }
-  PBL_LOG(LOG_LEVEL_ERROR, "Failed to enter low power mode");
+  PBL_LOG_ERR("Failed to enter low power mode");
 }
 
 bool accel_running(void) {
@@ -289,7 +289,7 @@ bool accel_running(void) {
 
 bool accel_start(void) {
   if (!s_initialized) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to start accel, not yet initialized");
+    PBL_LOG_ERR("Failed to start accel, not yet initialized");
     return false;
   }
 
@@ -412,7 +412,7 @@ static void prv_read_samples(void *data) {
 
   AccelRawData accel_raw_data[num_samples];
   if (src_reg & FIFO_OVRN) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Fifo overrun");
+    PBL_LOG_ERR("Fifo overrun");
     analytics_inc(ANALYTICS_DEVICE_METRIC_ACCEL_FIFO_OVERRUN_COUNT, AnalyticsClient_System);
   }
 
@@ -606,7 +606,7 @@ bool accel_self_test(void) {
   AccelRawData data_st;
 
   if (!accel_start()) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Self test failed, could not start accel");
+    PBL_LOG_ERR("Self test failed, could not start accel");
     return false;
   }
 

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -136,7 +136,7 @@ void accel_power_up(void) {
 }
 
 void accel_power_down(void) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Powering down accelerometer");
+  PBL_LOG_DBG("LSM6DSO: Powering down accelerometer");
   s_lsm6dso_enabled = false;
   prv_lsm6dso_chase_target_state();
 }
@@ -144,7 +144,7 @@ void accel_power_down(void) {
 // accel.h implementation
 
 uint32_t accel_set_sampling_interval(uint32_t interval_us) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Requesting update of sampling interval to %lu us",
+  PBL_LOG_DBG("LSM6DSO: Requesting update of sampling interval to %lu us",
           interval_us);
   s_lsm6dso_state_target.sampling_interval_us = interval_us;
   prv_lsm6dso_chase_target_state();
@@ -154,7 +154,7 @@ uint32_t accel_set_sampling_interval(uint32_t interval_us) {
 uint32_t accel_get_sampling_interval(void) { return s_lsm6dso_state.sampling_interval_us; }
 
 void accel_set_num_samples(uint32_t num_samples) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Setting number of samples to %lu", num_samples);
+  PBL_LOG_DBG("LSM6DSO: Setting number of samples to %lu", num_samples);
   s_lsm6dso_state_target.num_samples = num_samples;
   prv_lsm6dso_chase_target_state();
 }
@@ -162,7 +162,7 @@ void accel_set_num_samples(uint32_t num_samples) {
 int accel_peek(AccelDriverSample *data) { return prv_lsm6dso_read_sample(data); }
 
 void accel_enable_shake_detection(bool on) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: %s shake detection.", on ? "Enabling" : "Disabling");
+  PBL_LOG_DBG("LSM6DSO: %s shake detection.", on ? "Enabling" : "Disabling");
   s_lsm6dso_state_target.shake_detection_enabled = on;
   prv_lsm6dso_chase_target_state();
 }
@@ -170,7 +170,7 @@ void accel_enable_shake_detection(bool on) {
 bool accel_get_shake_detection_enabled(void) { return s_lsm6dso_state.shake_detection_enabled; }
 
 void accel_enable_double_tap_detection(bool on) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: %s double tap detection.", on ? "Enabling" : "Disabling");
+  PBL_LOG_DBG("LSM6DSO: %s double tap detection.", on ? "Enabling" : "Disabling");
   s_lsm6dso_state_target.double_tap_detection_enabled = on;
   prv_lsm6dso_chase_target_state();
 }
@@ -180,7 +180,7 @@ bool accel_get_double_tap_detection_enabled(void) {
 }
 
 void accel_set_shake_sensitivity_high(bool sensitivity_high) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Setting shake sensitivity to %s.",
+  PBL_LOG_DBG("LSM6DSO: Setting shake sensitivity to %s.",
           sensitivity_high ? "high" : "normal");
   s_lsm6dso_state_target.shake_sensitivity_high = sensitivity_high;
   prv_lsm6dso_chase_target_state();
@@ -198,7 +198,7 @@ void accel_set_shake_sensitivity_percent(uint8_t percent) {
     prv_lsm6dso_configure_shake(true, s_lsm6dso_state.shake_sensitivity_high);
   }
   
-  PBL_LOG(LOG_LEVEL_INFO, "LSM6DSO: User sensitivity set to %u percent", percent);
+  PBL_LOG_INFO("LSM6DSO: User sensitivity set to %u percent", percent);
 }
 
 // HAL context implementations
@@ -213,11 +213,11 @@ static int32_t prv_lsm6dso_read(void *handle, uint8_t reg_addr, uint8_t *buffer,
   if (!result) {
     s_i2c_error_count++;
     s_consecutive_errors++;
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: I2C read failed (reg=0x%02x, count=%lu)", 
+    PBL_LOG_ERR("LSM6DSO: I2C read failed (reg=0x%02x, count=%lu)", 
             reg_addr, s_consecutive_errors);
     if (s_consecutive_errors >= LSM6DSO_MAX_CONSECUTIVE_FAILURES) {
       s_sensor_health_ok = false;
-      PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Sensor health degraded after %lu failures", 
+      PBL_LOG_ERR("LSM6DSO: Sensor health degraded after %lu failures", 
               s_consecutive_errors);
     }
     return -1;
@@ -242,7 +242,7 @@ static int32_t prv_lsm6dso_write(void *handle, uint8_t reg_addr, const uint8_t *
   if (!result) {
     s_i2c_error_count++;
     s_consecutive_errors++;
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: I2C write failed (reg=0x%02x)", reg_addr);
+    PBL_LOG_ERR("LSM6DSO: I2C write failed (reg=0x%02x)", reg_addr);
     return -1;
   } else {
     s_consecutive_errors = 0;
@@ -270,21 +270,20 @@ static void prv_lsm6dso_init(void) {
   // Verify sensor is present and functioning
   uint8_t whoami;
   if (lsm6dso_device_id_get(&lsm6dso_ctx, &whoami)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to read WHO_AM_I register");
+    PBL_LOG_ERR("LSM6DSO: Failed to read WHO_AM_I register");
     return;
   }
   if (whoami != LSM6DSO_ID) {
-    PBL_LOG(LOG_LEVEL_ERROR,
-            "LSM6DSO: Sensor not detected or malfunctioning (WHO_AM_I=0x%02x, expecting 0x%02x)",
+    PBL_LOG_ERR("LSM6DSO: Sensor not detected or malfunctioning (WHO_AM_I=0x%02x, expecting 0x%02x)",
             whoami, LSM6DSO_ID);
     return;
   }
   
-  PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Sensor detected successfully (WHO_AM_I=0x%02x)", whoami);
+  PBL_LOG_DBG("LSM6DSO: Sensor detected successfully (WHO_AM_I=0x%02x)", whoami);
 
   // Reset sensor to known state
   if (lsm6dso_reset_set(&lsm6dso_ctx, PROPERTY_ENABLE)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to reset sensor");
+    PBL_LOG_ERR("LSM6DSO: Failed to reset sensor");
     return;
   }
   uint8_t rst;
@@ -292,58 +291,58 @@ static void prv_lsm6dso_init(void) {
   do {  // Wait for reset to complete with timeout
     psleep(1);
     if (lsm6dso_reset_get(&lsm6dso_ctx, &rst) != 0) {
-      PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to read reset status");
+      PBL_LOG_ERR("LSM6DSO: Failed to read reset status");
       return;
     }
     reset_timeout--;
   } while (rst && reset_timeout > 0);
   
   if (reset_timeout == 0) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Reset timeout - sensor may be unresponsive");
+    PBL_LOG_ERR("LSM6DSO: Reset timeout - sensor may be unresponsive");
     return;
   }
 
   // Disable I3C interface
   if (lsm6dso_i3c_disable_set(&lsm6dso_ctx, LSM6DSO_I3C_DISABLE)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to disable I3C interface");
+    PBL_LOG_ERR("LSM6DSO: Failed to disable I3C interface");
     return;
   }
 
   // Enable Block Data Update
   if (lsm6dso_block_data_update_set(&lsm6dso_ctx, PROPERTY_ENABLE)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to enable block data update");
+    PBL_LOG_ERR("LSM6DSO: Failed to enable block data update");
     return;
   }
 
   // Enable Auto Increment
   if (lsm6dso_auto_increment_set(&lsm6dso_ctx, PROPERTY_ENABLE)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to enable auto increment");
+    PBL_LOG_ERR("LSM6DSO: Failed to enable auto increment");
     return;
   }
 
   // Set FIFO mode to bypass (will be reconfigured as necessary later)
   if (lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_BYPASS_MODE)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to set FIFO mode to bypass");
+    PBL_LOG_ERR("LSM6DSO: Failed to set FIFO mode to bypass");
     return;
   }
 
   // Set default full scale
   if (lsm6dso_xl_full_scale_set(&lsm6dso_ctx, LSM6DSO_4g)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to set accelerometer full scale");
+    PBL_LOG_ERR("LSM6DSO: Failed to set accelerometer full scale");
     return;
   }
   if (lsm6dso_gy_full_scale_set(&lsm6dso_ctx, LSM6DSO_250dps)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to set gyroscope full scale");
+    PBL_LOG_ERR("LSM6DSO: Failed to set gyroscope full scale");
     return;
   }
 
   // Set output rate to zero (disabling sensors)
   if (lsm6dso_xl_data_rate_set(&lsm6dso_ctx, LSM6DSO_XL_ODR_OFF)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to set accelerometer ODR");
+    PBL_LOG_ERR("LSM6DSO: Failed to set accelerometer ODR");
     return;
   }
   if (lsm6dso_gy_data_rate_set(&lsm6dso_ctx, LSM6DSO_GY_ODR_OFF)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to set gyroscope ODR");
+    PBL_LOG_ERR("LSM6DSO: Failed to set gyroscope ODR");
     return;
   }
 
@@ -358,24 +357,24 @@ static void prv_lsm6dso_init(void) {
   // these to pulsed so that if we miss an interrupt due to timing issues we do
   // not miss subsequent ones.
   if (lsm6dso_data_ready_mode_set(&lsm6dso_ctx, LSM6DSO_DRDY_PULSED)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to set data ready mode");
+    PBL_LOG_ERR("LSM6DSO: Failed to set data ready mode");
     return;
   }
   if (lsm6dso_int_notification_set(&lsm6dso_ctx, LSM6DSO_ALL_INT_PULSED)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to configure interrupt notification");
+    PBL_LOG_ERR("LSM6DSO: Failed to configure interrupt notification");
     return;
   }
 
   s_lsm6dso_initialized = true;
   s_last_successful_read_ms = prv_get_timestamp_ms();
   s_consecutive_errors = 0;
-  PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Initialization complete");
+  PBL_LOG_DBG("LSM6DSO: Initialization complete");
 }
 
 //! Synchronize the LSM6DSO state with the desired target state.
 static void prv_lsm6dso_chase_target_state(void) {
   if (!s_lsm6dso_initialized) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Cannot chase target state before initialization");
+    PBL_LOG_ERR("LSM6DSO: Cannot chase target state before initialization");
     return;
   }
 
@@ -389,7 +388,7 @@ static void prv_lsm6dso_chase_target_state(void) {
 
   if (!should_be_running || !s_lsm6dso_enabled) {
     if (s_lsm6dso_running) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Stopping accelerometer");
+      PBL_LOG_DBG("LSM6DSO: Stopping accelerometer");
       lsm6dso_xl_data_rate_set(&lsm6dso_ctx, LSM6DSO_XL_ODR_OFF);
       s_lsm6dso_running = false;
       s_lsm6dso_state = (lsm6dso_state_t){0};
@@ -464,8 +463,7 @@ static void prv_lsm6dso_chase_target_state(void) {
   // where new target changes during this function execution could be lost.
   // Instead, only sync the fields that were actually processed.
 
-  PBL_LOG(LOG_LEVEL_DEBUG,
-          "LSM6DSO: Reached target state: sampling_interval_us=%lu, num_samples=%lu, "
+  PBL_LOG_DBG("LSM6DSO: Reached target state: sampling_interval_us=%lu, num_samples=%lu, "
           "shake_detection_enabled=%d, shake_high_sensitivity=%d, double_tap_detection_enabled=%d",
           s_lsm6dso_state.sampling_interval_us, s_lsm6dso_state.num_samples,
           s_lsm6dso_state.shake_detection_enabled, s_lsm6dso_state.shake_sensitivity_high,
@@ -487,7 +485,7 @@ static void prv_lsm6dso_configure_interrupts(void) {
     // Also disable all interrupt sources in the sensor to prevent phantom interrupts
     lsm6dso_pin_int1_route_t int1_routes = {0}; // All disabled
     if (lsm6dso_pin_int1_route_set(&lsm6dso_ctx, int1_routes)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to disable INT1 routes while turning off sensor");
+      PBL_LOG_ERR("LSM6DSO: Failed to disable INT1 routes while turning off sensor");
     }
     return;
   }
@@ -515,13 +513,13 @@ static void prv_lsm6dso_configure_interrupts(void) {
 
   // Configure interrupt routing atomically
   if (lsm6dso_pin_int1_route_set(&lsm6dso_ctx, int1_routes)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to configure INT1 routes; re-enabling external interrupt");
+    PBL_LOG_ERR("LSM6DSO: Failed to configure INT1 routes; re-enabling external interrupt");
     routing_configured = false;
   } else {
     // Clear any pending interrupt sources before enabling external interrupt
     lsm6dso_all_sources_t all_sources;
     if (lsm6dso_all_sources_get(&lsm6dso_ctx, &all_sources)) {
-      PBL_LOG(LOG_LEVEL_WARNING, "LSM6DSO: Failed to clear pending interrupt sources after routing update");
+      PBL_LOG_WRN("LSM6DSO: Failed to clear pending interrupt sources after routing update");
     }
   }
 
@@ -529,7 +527,7 @@ static void prv_lsm6dso_configure_interrupts(void) {
   exti_enable(BOARD_CONFIG_ACCEL.accel_ints[0]);
 
   if (!routing_configured) {
-    PBL_LOG(LOG_LEVEL_WARNING, "LSM6DSO: INT1 routing not updated; external interrupt left enabled for recovery");
+    PBL_LOG_WRN("LSM6DSO: INT1 routing not updated; external interrupt left enabled for recovery");
   }
 }
 
@@ -564,17 +562,17 @@ static void prv_lsm6dso_configure_fifo(bool enable) {
     if (watermark == 0) watermark = 1;  // minimum
     if (watermark > LSM6DSO_FIFO_MAX_WATERMARK) watermark = LSM6DSO_FIFO_MAX_WATERMARK;
     
-    PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Setting FIFO watermark to %lu (requested %lu samples)", 
+    PBL_LOG_DBG("LSM6DSO: Setting FIFO watermark to %lu (requested %lu samples)", 
             watermark, s_lsm6dso_state.num_samples);
     
     if (lsm6dso_fifo_watermark_set(&lsm6dso_ctx, (uint16_t)watermark)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to set FIFO watermark");
+      PBL_LOG_ERR("LSM6DSO: Failed to set FIFO watermark");
     }
     
     // Enable accelerometer batching at (approx) current ODR
     lsm6dso_bdr_xl_t batch_rate = prv_get_fifo_batch_rate(s_lsm6dso_state.sampling_interval_us);
     if (lsm6dso_fifo_xl_batch_set(&lsm6dso_ctx, batch_rate)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to set FIFO batch rate");
+      PBL_LOG_ERR("LSM6DSO: Failed to set FIFO batch rate");
     }
     
     // Disable gyro batching to save FIFO space
@@ -590,7 +588,7 @@ static void prv_lsm6dso_configure_fifo(bool enable) {
 
     // Put FIFO in stream mode so we keep collecting samples and get periodic watermark interrupts
     if (lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_STREAM_MODE)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to enable FIFO stream mode");
+      PBL_LOG_ERR("LSM6DSO: Failed to enable FIFO stream mode");
     }
   } else {
     if (s_fifo_in_use) {
@@ -598,13 +596,13 @@ static void prv_lsm6dso_configure_fifo(bool enable) {
       lsm6dso_fifo_xl_batch_set(&lsm6dso_ctx, LSM6DSO_XL_NOT_BATCHED);
       lsm6dso_fifo_gy_batch_set(&lsm6dso_ctx, LSM6DSO_GY_NOT_BATCHED);
       if (lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_BYPASS_MODE)) {
-        PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to disable FIFO");
+        PBL_LOG_ERR("LSM6DSO: Failed to disable FIFO");
       }
     }
   }
 
   s_fifo_in_use = enable;
-  PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: FIFO %s (wm=%lu)", enable ? "enabled" : "disabled",
+  PBL_LOG_DBG("LSM6DSO: FIFO %s (wm=%lu)", enable ? "enabled" : "disabled",
           (unsigned long)s_lsm6dso_state.num_samples);
 }
 
@@ -685,7 +683,7 @@ static void prv_lsm6dso_configure_shake(bool enable, bool sensitivity_high) {
   
   lsm6dso_wkup_threshold_set(&lsm6dso_ctx, (uint8_t)raw);
   
-  PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Shake threshold set to %lu (sensitivity_high=%d, user_percent=%u)", 
+  PBL_LOG_DBG("LSM6DSO: Shake threshold set to %lu (sensitivity_high=%d, user_percent=%u)", 
           raw, sensitivity_high, s_user_sensitivity_percent);
 }
 
@@ -706,14 +704,13 @@ static void prv_lsm6dso_process_interrupts(void) {
 
   uint32_t gap_ms = 0;
   if (previous_interrupt_ms == 0) {
-    PBL_LOG(LOG_LEVEL_INFO, "LSM6DSO: First INT1 service (count=%lu)",
+    PBL_LOG_INFO("LSM6DSO: First INT1 service (count=%lu)",
             (unsigned long)s_interrupt_count);
   } else {
     uint64_t raw_gap_ms = now_ms - previous_interrupt_ms;
     gap_ms = (raw_gap_ms > UINT32_MAX) ? UINT32_MAX : (uint32_t)raw_gap_ms;
     if (gap_ms >= LSM6DSO_INTERRUPT_GAP_LOG_THRESHOLD_MS) {
-      PBL_LOG(LOG_LEVEL_INFO,
-              "LSM6DSO: INT1 gap %lu ms (count=%lu wake=%lu tap=%lu)",
+      PBL_LOG_INFO("LSM6DSO: INT1 gap %lu ms (count=%lu wake=%lu tap=%lu)",
               (unsigned long)gap_ms, (unsigned long)s_interrupt_count,
               (unsigned long)s_wake_event_count, (unsigned long)s_double_tap_event_count);
     }
@@ -738,11 +735,11 @@ static void prv_lsm6dso_process_interrupts(void) {
   } while (read_attempts < max_read_attempts);
   
   if (read_attempts >= max_read_attempts) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to read interrupt sources after retries");
+    PBL_LOG_ERR("LSM6DSO: Failed to read interrupt sources after retries");
     s_consecutive_errors++;
     if (s_consecutive_errors >= LSM6DSO_MAX_CONSECUTIVE_FAILURES) {
       s_sensor_health_ok = false;
-      PBL_LOG(LOG_LEVEL_WARNING, "LSM6DSO: Interrupt processing failed, sensor health degraded");
+      PBL_LOG_WRN("LSM6DSO: Interrupt processing failed, sensor health degraded");
     }
     return;
   }
@@ -753,7 +750,7 @@ static void prv_lsm6dso_process_interrupts(void) {
   // Prevent FIFO overflow by proper watermark management
   // FIFO overflow causes the sensor to stop generating interrupts
   if (all_sources.fifo_ovr || all_sources.fifo_full) {
-    PBL_LOG(LOG_LEVEL_WARNING, "LSM6DSO: FIFO overflow/full detected, clearing FIFO");
+    PBL_LOG_WRN("LSM6DSO: FIFO overflow/full detected, clearing FIFO");
     
     // Properly clear FIFO without losing configuration
     uint16_t current_watermark;
@@ -783,7 +780,7 @@ static void prv_lsm6dso_process_interrupts(void) {
       lsm6dso_fifo_xl_batch_set(&lsm6dso_ctx, current_batch_rate);
       lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_STREAM_MODE);
 
-      PBL_LOG(LOG_LEVEL_INFO, "LSM6DSO: Reduced FIFO watermark from %u to %u to prevent future overflow",
+      PBL_LOG_INFO("LSM6DSO: Reduced FIFO watermark from %u to %u to prevent future overflow",
               current_watermark, reduced_watermark);
     }
 
@@ -811,7 +808,7 @@ static void prv_lsm6dso_process_interrupts(void) {
   if (all_sources.double_tap) {
     s_double_tap_event_count++;
     s_last_double_tap_ms = now_ms;
-    PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Double tap interrupt triggered");
+    PBL_LOG_DBG("LSM6DSO: Double tap interrupt triggered");
     // Handle double tap detection
     axis_t axis;
     if (all_sources.tap_x) {
@@ -821,7 +818,7 @@ static void prv_lsm6dso_process_interrupts(void) {
     } else if (all_sources.tap_z) {
       axis = Z_AXIS;
     } else {
-      PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: No tap axis detected");
+      PBL_LOG_DBG("LSM6DSO: No tap axis detected");
       return;  // No valid tap detected
     }
 
@@ -829,7 +826,7 @@ static void prv_lsm6dso_process_interrupts(void) {
     uint8_t axis_direction = (BOARD_CONFIG_ACCEL.accel_config.axes_inverts[axis] ? -1 : 1) *
                              (all_sources.tap_sign ? -1 : 1);
 
-    PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Double tap interrupt triggered; axis=%d, direction=%d",
+    PBL_LOG_DBG("LSM6DSO: Double tap interrupt triggered; axis=%d, direction=%d",
             axis_offset, axis_direction);
     accel_cb_double_tap_detected(axis_offset, axis_direction);
   }
@@ -863,7 +860,7 @@ static void prv_lsm6dso_process_interrupts(void) {
         int16_t mg_z = prv_get_axis_projection_mg(Z_AXIS, accel_raw);
         prv_note_new_sample_mg(mg_x, mg_y, mg_z);
       }
-      PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Shake detected; axis=%d, direction=%lu", axis, direction);
+      PBL_LOG_DBG("LSM6DSO: Shake detected; axis=%d, direction=%lu", axis, direction);
       accel_cb_shake_detected(axis, direction);
     }
   }
@@ -885,7 +882,7 @@ static bool prv_is_vibing(void) {
 }
 
 static bool prv_lsm6dso_force_reinit(void) {
-  PBL_LOG(LOG_LEVEL_WARNING, "LSM6DSO: Performing forced sensor reinitialization");
+  PBL_LOG_WRN("LSM6DSO: Performing forced sensor reinitialization");
 
   // Stop the watchdog timer before clearing state to prevent double-registration
   regular_timer_remove_callback(&s_interrupt_watchdog_timer);
@@ -901,7 +898,7 @@ static bool prv_lsm6dso_force_reinit(void) {
 
   prv_lsm6dso_init();
   if (!s_lsm6dso_initialized) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Forced reinit failed; sensor still unresponsive");
+    PBL_LOG_ERR("LSM6DSO: Forced reinit failed; sensor still unresponsive");
     return false;
   }
 
@@ -913,18 +910,17 @@ static bool prv_lsm6dso_force_reinit(void) {
 }
 
 static void prv_lsm6dso_interrupt_watchdog_callback(void *data) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Watchdog callback running");
+  PBL_LOG_DBG("LSM6DSO: Watchdog callback running");
   
   // Check if interrupts have stopped for too long
   const uint64_t now_ms = prv_get_timestamp_ms();
   const uint32_t interrupt_age_ms = prv_compute_age_ms(now_ms, s_last_interrupt_ms);
   
-  PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Interrupt age: %" PRIu32 " ms", interrupt_age_ms);
+  PBL_LOG_DBG("LSM6DSO: Interrupt age: %" PRIu32 " ms", interrupt_age_ms);
 
   if ((interrupt_age_ms >= LSM6DSO_INTERRUPT_WATCHDOG_TIMEOUT_MS && s_lsm6dso_state.num_samples > 0) ||
       (interrupt_age_ms >= LSM6DSO_INTERRUPT_WATCHDOG_MS_NO_SAMPLES && s_lsm6dso_state.num_samples == 0)) {
-    PBL_LOG(LOG_LEVEL_WARNING,
-            "LSM6DSO: Interrupt watchdog triggered - no interrupts for %" PRIu32 " ms, count=%lu; forcing reinit",
+    PBL_LOG_WRN("LSM6DSO: Interrupt watchdog triggered - no interrupts for %" PRIu32 " ms, count=%lu; forcing reinit",
             interrupt_age_ms, (unsigned long)s_interrupt_count);
     // Mark sensor as unhealthy
     s_sensor_health_ok = false;
@@ -943,7 +939,7 @@ static void prv_lsm6dso_interrupt_watchdog_callback(void *data) {
         prv_lsm6dso_configure_interrupts();
       }
     } else {
-      PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Forced sensor reinitialization failed");
+      PBL_LOG_ERR("LSM6DSO: Forced sensor reinitialization failed");
     }
   }
 }
@@ -966,7 +962,7 @@ static odr_xl_interval_t prv_get_odr_for_interval(uint32_t interval_us) {
 
 static int32_t prv_lsm6dso_set_sampling_interval(uint32_t interval_us) {
   if (!s_lsm6dso_initialized) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Not initialized, cannot set sampling interval");
+    PBL_LOG_ERR("LSM6DSO: Not initialized, cannot set sampling interval");
     return -1;
   }
 
@@ -984,13 +980,13 @@ static int32_t prv_lsm6dso_set_sampling_interval(uint32_t interval_us) {
 
   lsm6dso_odr_xl_t old_odr;
   if (lsm6dso_xl_data_rate_get(&lsm6dso_ctx, &old_odr) != 0) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: failed to read old ODR");
+    PBL_LOG_ERR("LSM6DSO: failed to read old ODR");
     return -1;
   }
 
   lsm6dso_xl_hm_mode_t old_power_mode;
   if (lsm6dso_xl_power_mode_get(&lsm6dso_ctx, &old_power_mode) != 0) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: failed to read old power mode");
+    PBL_LOG_ERR("LSM6DSO: failed to read old power mode");
     return -1;
   }
 
@@ -1000,7 +996,7 @@ static int32_t prv_lsm6dso_set_sampling_interval(uint32_t interval_us) {
   lsm6dso_xl_hm_mode_t new_power_mode = odr_interval.power_mode;
 
   if (old_odr == odr_interval.odr && old_power_mode == new_power_mode) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: we were already in that sampling mode, so we're good");
+    PBL_LOG_DBG("LSM6DSO: we were already in that sampling mode, so we're good");
     return odr_interval.interval_us;
   }
 
@@ -1008,20 +1004,20 @@ static int32_t prv_lsm6dso_set_sampling_interval(uint32_t interval_us) {
     // Section 6.2.1: you have to power down the accel before switching ULP
     // mode
     if (lsm6dso_xl_data_rate_set(&lsm6dso_ctx, LSM6DSO_XL_ODR_OFF) != 0) {
-      PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: failed to power off before changing power mode");
+      PBL_LOG_ERR("LSM6DSO: failed to power off before changing power mode");
       return -1;
     }
 
     if (lsm6dso_xl_power_mode_set(&lsm6dso_ctx, new_power_mode) != 0) {
-      PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: failed to set power mode");
+      PBL_LOG_ERR("LSM6DSO: failed to set power mode");
       return -1;
     }
 
-    PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: switched to accelerometer power mode lsm6dso_xl_hm_mode_t = %d", new_power_mode);
+    PBL_LOG_DBG("LSM6DSO: switched to accelerometer power mode lsm6dso_xl_hm_mode_t = %d", new_power_mode);
   }
 
   if (lsm6dso_xl_data_rate_set(&lsm6dso_ctx, odr_interval.odr) != 0) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to set ODR");
+    PBL_LOG_ERR("LSM6DSO: Failed to set ODR");
     return -1;
   }
 
@@ -1030,7 +1026,7 @@ static int32_t prv_lsm6dso_set_sampling_interval(uint32_t interval_us) {
     psleep(10); // Allow time for ODR change to stabilize
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "LSM6DSO: Set sampling interval to %lu us (requested %lu us)",
+  PBL_LOG_DBG("LSM6DSO: Set sampling interval to %lu us (requested %lu us)",
           odr_interval.interval_us, interval_us);
   return odr_interval.interval_us;
 }
@@ -1048,7 +1044,7 @@ static void prv_lsm6dso_read_samples(void) {
   // Drain FIFO
   uint16_t fifo_level = 0;
   if (lsm6dso_fifo_data_level_get(&lsm6dso_ctx, &fifo_level) != 0) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to read FIFO level");
+    PBL_LOG_ERR("LSM6DSO: Failed to read FIFO level");
     // Reset FIFO on communication error
     lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_BYPASS_MODE);
     if (s_fifo_in_use) {
@@ -1062,7 +1058,7 @@ static void prv_lsm6dso_read_samples(void) {
 
   // Prevent infinite loops on stuck FIFO
   if (fifo_level > LSM6DSO_FIFO_MAX_WATERMARK) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: FIFO level too high (%u), resetting", fifo_level);
+    PBL_LOG_ERR("LSM6DSO: FIFO level too high (%u), resetting", fifo_level);
     lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_BYPASS_MODE);
     if (s_fifo_in_use) {
       lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_STREAM_MODE);
@@ -1076,7 +1072,7 @@ static void prv_lsm6dso_read_samples(void) {
   for (uint16_t i = 0; i < fifo_level; ++i) {
     uint8_t raw_bytes[7];
     if (lsm6dso_read_reg(&lsm6dso_ctx, LSM6DSO_FIFO_DATA_OUT_TAG, raw_bytes, sizeof(raw_bytes)) != 0) {
-      PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to read FIFO sample (%u/%u)", i, fifo_level);
+      PBL_LOG_ERR("LSM6DSO: Failed to read FIFO sample (%u/%u)", i, fifo_level);
       // Reset FIFO on communication error
       lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_BYPASS_MODE);
       if (s_fifo_in_use) {
@@ -1111,7 +1107,7 @@ static void prv_lsm6dso_read_samples(void) {
 
 static uint8_t prv_lsm6dso_read_sample(AccelDriverSample *data) {
   if (!s_lsm6dso_initialized) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Not initialized, cannot read sample");
+    PBL_LOG_ERR("LSM6DSO: Not initialized, cannot read sample");
     return -1;
   }
 
@@ -1120,7 +1116,7 @@ static uint8_t prv_lsm6dso_read_sample(AccelDriverSample *data) {
 
   int16_t accel_raw[3];
   if (lsm6dso_acceleration_raw_get(&lsm6dso_ctx, accel_raw) != 0) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LSM6DSO: Failed to read accelerometer data");
+    PBL_LOG_ERR("LSM6DSO: Failed to read accelerometer data");
     return -1;
   }
 

--- a/src/fw/drivers/imu/mag3110/mag3110.c
+++ b/src/fw/drivers/imu/mag3110/mag3110.c
@@ -101,7 +101,7 @@ bool mag3110_check_whoami(void) {
   mag3110_read(WHO_AM_I_REG, 1, &whoami);
   mag_release();
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Read compass whoami byte 0x%x, expecting 0x%x",
+  PBL_LOG_DBG("Read compass whoami byte 0x%x, expecting 0x%x",
       whoami, COMPASS_WHOAMI_BYTE);
 
   return (whoami == COMPASS_WHOAMI_BYTE);
@@ -116,7 +116,7 @@ void mag_init(void) {
   s_initialized = true;
 
   if (!mag3110_check_whoami()) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Failed to query Mag");
+    PBL_LOG_WRN("Failed to query Mag");
   }
   gpio_input_init(&BOARD_CONFIG_MAG.mag_int_gpio);
 
@@ -191,7 +191,7 @@ MagReadStatus mag_read_data(MagData *data) {
   // TODO: shouldn't happen at low sample rate, but handle case where some data
   // is overwritten
   if ((raw_data[0] & 0xf0) != 0) {
-    PBL_LOG(LOG_LEVEL_INFO, "Some Mag Sample Data was overwritten, "
+    PBL_LOG_INFO("Some Mag Sample Data was overwritten, "
             "dr_status=0x%x", raw_data[0]);
     rv = MagReadClobbered; // we still need to read the data to clear the int
   }

--- a/src/fw/drivers/imu/mmc5603nj/mmc5603nj.c
+++ b/src/fw/drivers/imu/mmc5603nj/mmc5603nj.c
@@ -54,9 +54,9 @@ static bool s_rotated_180 = false;
 void mag_init(void) {
   s_mag_mutex = mutex_create();
   if (prv_mmc5603nj_init()) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "MMC5603NJ: Initialization complete");
+    PBL_LOG_DBG("MMC5603NJ: Initialization complete");
   } else {
-    PBL_LOG(LOG_LEVEL_ERROR, "MMC5603NJ: Initialization failed");
+    PBL_LOG_ERR("MMC5603NJ: Initialization failed");
   }
 }
 
@@ -80,7 +80,7 @@ void mag_release(void) {
   --s_use_refcount;
   if (s_use_refcount == 0) {
     if (!prv_mmc5603nj_set_sample_rate_hz(0)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "MMC5603NJ: Failed to disable sensor on release");
+      PBL_LOG_ERR("MMC5603NJ: Failed to disable sensor on release");
     }
   }
   mutex_unlock(s_mag_mutex);
@@ -126,11 +126,11 @@ static bool prv_mmc5603nj_read(uint8_t reg_addr, uint8_t data_len, uint8_t *data
   i2c_use(I2C_MMC5603NJ);
   bool rv = i2c_write_block(I2C_MMC5603NJ, 1, &reg_addr);
   if (!rv) {
-    PBL_LOG(LOG_LEVEL_ERROR, "MMC5603NJ: I2C write failed for register 0x%02x", reg_addr);
+    PBL_LOG_ERR("MMC5603NJ: I2C write failed for register 0x%02x", reg_addr);
   }
   rv = i2c_read_block(I2C_MMC5603NJ, data_len, data);
   if (!rv) {
-    PBL_LOG(LOG_LEVEL_ERROR, "MMC5603NJ: I2C data read failed for register 0x%02x", reg_addr);
+    PBL_LOG_ERR("MMC5603NJ: I2C data read failed for register 0x%02x", reg_addr);
   }
   i2c_release(I2C_MMC5603NJ);
   return rv;
@@ -141,7 +141,7 @@ static bool prv_mmc5603nj_write(uint8_t reg_addr, uint8_t data) {
   uint8_t d[2] = {reg_addr, data};
   bool rv = i2c_write_block(I2C_MMC5603NJ, 2, d);
   if (!rv) {
-    PBL_LOG(LOG_LEVEL_ERROR, "MMC5603NJ: I2C write failed for register 0x%02x", reg_addr);
+    PBL_LOG_ERR("MMC5603NJ: I2C write failed for register 0x%02x", reg_addr);
   }
   i2c_release(I2C_MMC5603NJ);
   return rv;
@@ -155,13 +155,13 @@ static bool prv_mmc5603nj_init(void) {
   }
 
   if (!prv_mmc5603nj_check_whoami()) {
-    PBL_LOG(LOG_LEVEL_ERROR, "MMC5603NJ: WHO_AM_I check failed. Wrong device?");
+    PBL_LOG_ERR("MMC5603NJ: WHO_AM_I check failed. Wrong device?");
     return false;
   }
 
   // Reset the device
   if (!prv_mmc5603nj_reset()) {
-    PBL_LOG(LOG_LEVEL_ERROR, "MMC5603NJ: Failed to reset");
+    PBL_LOG_ERR("MMC5603NJ: Failed to reset");
     return false;
   }
 
@@ -183,21 +183,21 @@ static bool prv_mmc5603nj_reset(void) {
   // Software reset
   if (!prv_mmc5603nj_write(MMC5603NJ_REG_CTRL1,
                            MMC5603NJ_CTRL1_BANDWIDTH_6ms6 | MMC5603NJ_CTRL1_SW_RESET)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "MMC5603NJ: Failed to reset device.");
+    PBL_LOG_ERR("MMC5603NJ: Failed to reset device.");
     return false;
   }
   psleep(MMC5603NJ_SW_RESET_DELAY_MS);
 
   // Set operation
   if (!prv_mmc5603nj_write(MMC5603NJ_REG_CTRL0, MMC5603NJ_CTRL0_DO_SET)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "MMC5603NJ: Failed to set coils.");
+    PBL_LOG_ERR("MMC5603NJ: Failed to set coils.");
     return false;
   }
   psleep(MMC5603NJ_SET_DELAY_MS);
 
   // Reset operation
   if (!prv_mmc5603nj_write(MMC5603NJ_REG_CTRL0, MMC5603NJ_CTRL0_DO_RESET)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "MMC5603NJ: Failed to reset coils.");
+    PBL_LOG_ERR("MMC5603NJ: Failed to reset coils.");
     return false;
   }
   psleep(MMC5603NJ_SET_DELAY_MS);
@@ -211,7 +211,7 @@ bool prv_mmc5603nj_set_sample_rate_hz(uint8_t rate_hz) {
     return true;
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "MMC5603NJ: Setting sample rate to %d Hz", rate_hz);
+  PBL_LOG_DBG("MMC5603NJ: Setting sample rate to %d Hz", rate_hz);
 
   // Reset device runtime status (disabling continuous mode/etc)
   if (!prv_mmc5603nj_write(MMC5603NJ_REG_CTRL2, 0x00)) {
@@ -225,14 +225,14 @@ bool prv_mmc5603nj_set_sample_rate_hz(uint8_t rate_hz) {
   if (rate_hz > 0) {
     // Set new sampling rate
     if (!prv_mmc5603nj_write(MMC5603NJ_REG_ODR, rate_hz)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "MMC5603NJ: Failed to update ODR.");
+      PBL_LOG_ERR("MMC5603NJ: Failed to update ODR.");
       return false;
     }
 
     // Retrigger calculation of measurements rates
     if (!prv_mmc5603nj_write(MMC5603NJ_REG_CTRL0,
                              MMC5603NJ_CTRL0_AUTO_SR_EN | MMC5603NJ_CTRL0_CMM_FREQ_EN)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "MMC5603NJ: Failed to trigger measurement calculation update.");
+      PBL_LOG_ERR("MMC5603NJ: Failed to trigger measurement calculation update.");
       return false;
     }
 
@@ -240,7 +240,7 @@ bool prv_mmc5603nj_set_sample_rate_hz(uint8_t rate_hz) {
     if (!prv_mmc5603nj_write(MMC5603NJ_REG_CTRL2, MMC5603NJ_CTRL2_AUTOSET_PRD_100 |
                                                       MMC5603NJ_CTRL2_PRD_SET_EN |
                                                       MMC5603NJ_CTRL2_CMM_EN)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "MMC5603NJ: Failed to start continuous mode.");
+      PBL_LOG_ERR("MMC5603NJ: Failed to start continuous mode.");
       return false;
     }
   }
@@ -249,7 +249,7 @@ bool prv_mmc5603nj_set_sample_rate_hz(uint8_t rate_hz) {
 
 #ifndef RECOVERY_FW
   if (!prv_configure_polling()) {
-    PBL_LOG(LOG_LEVEL_ERROR, "MMC5603NJ: Failed to configure polling");
+    PBL_LOG_ERR("MMC5603NJ: Failed to configure polling");
     return false;
   }
 #endif
@@ -276,7 +276,7 @@ static bool prv_configure_polling(void) {
   if (polling_interval_ms > 0) {
     s_polling_timer = new_timer_create();
     if (s_polling_timer == TIMER_INVALID_ID) {
-      PBL_LOG(LOG_LEVEL_ERROR, "MMC5603NJ: Failed to create polling timer");
+      PBL_LOG_ERR("MMC5603NJ: Failed to create polling timer");
       return false;
     }
     new_timer_start(s_polling_timer, polling_interval_ms, prv_mmc5603nj_polling_callback, NULL,

--- a/src/fw/drivers/led_controller/is31fl3196.c
+++ b/src/fw/drivers/led_controller/is31fl3196.c
@@ -78,7 +78,7 @@ void led_controller_init(void) {
 
   // reset the LED controller
   if (!write_register(RegReset, 0xaa)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "LED Controller is MIA");
+    PBL_LOG_ERR("LED Controller is MIA");
     goto cleanup;
   } else {
     s_initialized = true;

--- a/src/fw/drivers/mic/sf32lb52/pdm.c
+++ b/src/fw/drivers/mic/sf32lb52/pdm.c
@@ -81,7 +81,7 @@ void mic_set_volume(const MicDevice *this, uint16_t volume) {
   MicDeviceState *state = this->state;
   PDM_HandleTypeDef* hpdm = state->hpdm;
   if (state->is_running) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Cannot set volume while microphone is running");
+    PBL_LOG_WRN("Cannot set volume while microphone is running");
     return;
   }
   volume = volume * PDM_AUDIO_RECORD_GAIN_MAX/100;
@@ -94,7 +94,7 @@ static bool prv_allocate_buffers(MicDeviceState *state) {
   // Allocate circular buffer storage
   state->circ_buffer_storage = kernel_malloc(PDM_CIRCULAR_BUF_SIZE_BYTES);
   if (!state->circ_buffer_storage) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to allocate circular buffer storage");
+    PBL_LOG_ERR("Failed to allocate circular buffer storage");
     return false;
   }
   
@@ -182,19 +182,19 @@ static void prv_dma_data_processing(uint8_t* data, uint16_t size)
 {
   // Don't assert on is_running during shutdown - the PDM might send final events
   if (!s_state->is_running) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Microphone stopped, ignoring event");
+    PBL_LOG_ERR("Microphone stopped, ignoring event");
     return;
   }
 
    // Ensure circular buffer storage is allocated
    if (!s_state->circ_buffer_storage) {
-    PBL_LOG(LOG_LEVEL_ERROR, "No circular buffer storage, ignoring data");
+    PBL_LOG_ERR("No circular buffer storage, ignoring data");
     return;
   }
   
   // Ensure we have valid audio buffer info
   if (!s_state->audio_buffer || s_state->audio_buffer_len == 0) {
-    PBL_LOG(LOG_LEVEL_ERROR, "No audio buffer configured, ignoring data");
+    PBL_LOG_ERR("No audio buffer configured, ignoring data");
     return;
   }
   
@@ -204,7 +204,7 @@ static void prv_dma_data_processing(uint8_t* data, uint16_t size)
   if (write_space < size) {
     uint16_t to_drop = size - write_space;
     circular_buffer_consume(&s_state->circ_buffer, to_drop);
-    PBL_LOG(LOG_LEVEL_WARNING, "Dropping %u bytes of old audio", to_drop);
+    PBL_LOG_WRN("Dropping %u bytes of old audio", to_drop);
   }
   circular_buffer_write(&s_state->circ_buffer, data, size);
 
@@ -289,7 +289,7 @@ bool mic_start(const MicDevice *this, MicDataHandlerCB data_handler, void *conte
     return false;
   }
   if (!state->is_initialized) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Microphone not initialized");
+    PBL_LOG_ERR("Microphone not initialized");
     mutex_unlock_recursive(state->mutex);
     return false;
   }

--- a/src/fw/drivers/mic/stm32/dfsdm.c
+++ b/src/fw/drivers/mic/stm32/dfsdm.c
@@ -249,7 +249,7 @@ void mic_stop(MicDevice *this) {
   stop_mode_enable(InhibitorMic);
   this->state->running = false;
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Stopped microphone, dropped samples: %"PRIu32" bytes received: %"PRIu32,
+  PBL_LOG_DBG("Stopped microphone, dropped samples: %"PRIu32" bytes received: %"PRIu32,
           this->state->overflow_cnt,
           this->state->bytes_received);
 

--- a/src/fw/drivers/mic/stm32/pdm.c
+++ b/src/fw/drivers/mic/stm32/pdm.c
@@ -273,7 +273,7 @@ void mic_stop(MicDevice *this) {
   stop_mode_enable(InhibitorMic);
   s_running = false;
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Stopped microphone, dropped samples: %d", s_overflow_cnt);
+  PBL_LOG_DBG("Stopped microphone, dropped samples: %d", s_overflow_cnt);
 
 unlock:
   mutex_unlock_recursive(s_mic_mutex);

--- a/src/fw/drivers/nrf5/qspi.c
+++ b/src/fw/drivers/nrf5/qspi.c
@@ -294,8 +294,7 @@ void qspi_flash_init(QSPIFlash *dev, QSPIFlashPart *part, bool coredump_mode) {
   // QSPI clock is 32MHz, we have dividers from 1 to 16
   PBL_ASSERTN(dev->qspi->clk_freq_hz <= 32000000UL && dev->qspi->clk_freq_hz >= 200000UL);
   if (dev->qspi->clk_freq_hz > 8000000UL) {
-    PBL_LOG(
-        LOG_LEVEL_WARNING,
+    PBL_LOG_WRN(
         "QSPI initialized at %lu Hz, which may cause data corruption if HF clock source switches "
         "(anomaly 244)",
         dev->qspi->clk_freq_hz);

--- a/src/fw/drivers/nrf5/rtc.c
+++ b/src/fw/drivers/nrf5/rtc.c
@@ -136,7 +136,7 @@ static time_t prv_ticks_to_time(RtcTicks ticks) {
 void rtc_set_time(time_t time) {
 #ifdef PBL_LOG_ENABLED
   char buffer[TIME_STRING_BUFFER_SIZE];
-  PBL_LOG(LOG_LEVEL_INFO, "Setting time to %lu <%s>", time, time_t_to_string(buffer, time));
+  PBL_LOG_INFO("Setting time to %lu <%s>", time, time_t_to_string(buffer, time));
 #endif
 
   s_time_base = time;
@@ -174,19 +174,19 @@ static void prv_restore_rtc_time_state(void) {
      * last time we saved.  */
     s_time_base = last_save_time;
     s_time_tick_base = 0;
-    PBL_LOG(LOG_LEVEL_INFO, "Restore RTC: we are on our way up with amnesia");
+    PBL_LOG_INFO("Restore RTC: we are on our way up with amnesia");
   } else {
     RtcIntervalTicks current_ticks = prv_get_rtc_interval_ticks();
     const int32_t ticks_since_last_save = prv_elapsed_ticks(last_save_time_ticks * RTC_TICKS_HZ, current_ticks);
     s_time_base = last_save_time + (ticks_since_last_save / RTC_TICKS_HZ);
     s_time_tick_base = -(((int64_t)current_ticks) % RTC_TICKS_HZ);
-    PBL_LOG(LOG_LEVEL_INFO, "Restore RTC: we are on our way up with interval_ticks = %"PRIu32, current_ticks);
-    PBL_LOG(LOG_LEVEL_INFO, "Restore RTC: saved: %"PRIu32" diff: %"PRIu32, last_save_time_ticks, ticks_since_last_save);
+    PBL_LOG_INFO("Restore RTC: we are on our way up with interval_ticks = %"PRIu32, current_ticks);
+    PBL_LOG_INFO("Restore RTC: saved: %"PRIu32" diff: %"PRIu32, last_save_time_ticks, ticks_since_last_save);
   }
 
   char buffer[TIME_STRING_BUFFER_SIZE];
-  PBL_LOG(LOG_LEVEL_INFO, "Restore RTC: saved_time: %s raw: %lu", time_t_to_string(buffer, last_save_time), last_save_time);
-  PBL_LOG(LOG_LEVEL_INFO, "Restore RTC: current time: %s", time_t_to_string(buffer, s_time_base));
+  PBL_LOG_INFO("Restore RTC: saved_time: %s raw: %lu", time_t_to_string(buffer, last_save_time), last_save_time);
+  PBL_LOG_INFO("Restore RTC: current time: %s", time_t_to_string(buffer, s_time_base));
 }
 
 static RtcIntervalTicks prv_get_last_save_time_ticks(void) {
@@ -319,7 +319,7 @@ void rtc_init(void) {
 #endif
   if (prv_get_rtc_interval_ticks() == 0) {
     s_had_amnesia_on_boot = true;
-    PBL_LOG(LOG_LEVEL_INFO, "RTC appears to have been reset :( hope you have your phone connected");
+    PBL_LOG_INFO("RTC appears to have been reset :( hope you have your phone connected");
   }
 
   nrf_rtc_prescaler_set(BOARD_RTC_INST, NRF_RTC_FREQ_TO_PRESCALER(RTC_TICKS_HZ));
@@ -350,7 +350,7 @@ void rtc_init(void) {
     uint32_t iters = 0;
     while (nrf_rtc_counter_get(BOARD_RTC_INST) != ctr0)
       iters++;
-    PBL_LOG(LOG_LEVEL_INFO, "RTC: 100 RTC ticks took %"PRIu32" iters", iters);
+    PBL_LOG_INFO("RTC: 100 RTC ticks took %"PRIu32" iters", iters);
   }
 #endif
 }

--- a/src/fw/drivers/nrf5/uart.c
+++ b/src/fw/drivers/nrf5/uart.c
@@ -285,7 +285,7 @@ static void _uart_event_handler(const nrfx_uarte_event_t *event, void *ctx) {
     dev->state->rx_dma_index = (dev->state->rx_dma_index + 1) % DMA_BUFFERS;
     nrfx_uarte_rx_buffer_set(&dev->periph, GET_SUBBUF_P(dev, dev->state->rx_dma_index), dev->state->rx_dma_length);
 #ifdef DEBUG_UART
-    PBL_LOG(LOG_LEVEL_INFO, "rxbuf req %p", GET_SUBBUF_P(dev, dev->state->rx_dma_index));
+    PBL_LOG_INFO("rxbuf req %p", GET_SUBBUF_P(dev, dev->state->rx_dma_index));
 #endif
     break;
   case NRFX_UARTE_EVT_RX_BYTE:
@@ -294,7 +294,7 @@ static void _uart_event_handler(const nrfx_uarte_event_t *event, void *ctx) {
   case NRFX_UARTE_EVT_RX_DONE: {
 #ifdef DEBUG_UART
     uint8_t *buf = event->data.rx.p_buffer;
-    PBL_LOG(LOG_LEVEL_INFO, "rxbuf done %p (hopefully %p)", buf, GET_SUBBUF_P(dev, dev->state->rx_prod_index));
+    PBL_LOG_INFO("rxbuf done %p (hopefully %p)", buf, GET_SUBBUF_P(dev, dev->state->rx_prod_index));
 #endif
     dev->state->rx_prod_index = (dev->state->rx_prod_index + 1) % DMA_BUFFERS;
     break;
@@ -314,7 +314,7 @@ static void _uart_event_handler(const nrfx_uarte_event_t *event, void *ctx) {
 
 #ifdef DEBUG_UART
     uint8_t *bufx = buf + ofs;
-    PBL_LOG(LOG_LEVEL_INFO, "consume complete %p with %lu bytes left: : %02x %02x %02x %02x %02x %02x %02x %02x", buf, dev->state->rx_dma_length - ofs,
+    PBL_LOG_INFO("consume complete %p with %lu bytes left: : %02x %02x %02x %02x %02x %02x %02x %02x", buf, dev->state->rx_dma_length - ofs,
       bufx[0], bufx[1], bufx[2], bufx[3], bufx[4], bufx[5], bufx[6], bufx[7]);
 #endif
 
@@ -332,7 +332,7 @@ static void _uart_event_handler(const nrfx_uarte_event_t *event, void *ctx) {
 
 #ifdef DEBUG_UART
     uint8_t *bufx = buf + dev->state->rx_cons_pos;
-    PBL_LOG(LOG_LEVEL_INFO, "consume %ld bytes: %02x %02x %02x %02x %02x %02x %02x %02x", curpos - dev->state->rx_cons_pos,
+    PBL_LOG_INFO("consume %ld bytes: %02x %02x %02x %02x %02x %02x %02x %02x", curpos - dev->state->rx_cons_pos,
       bufx[0], bufx[1], bufx[2], bufx[3], bufx[4], bufx[5], bufx[6], bufx[7]);
 #endif
 
@@ -355,7 +355,7 @@ void uart_start_rx_dma(UARTDevice *dev, void *buffer, uint32_t length) {
    */
   PBL_ASSERTN((((uint32_t) buffer) & 3) == 0);
 #ifdef DEBUG_UART
-  PBL_LOG(LOG_LEVEL_INFO, "start_rx_dma");
+  PBL_LOG_INFO("start_rx_dma");
 #endif
   dev->state->rx_dma_buffer = buffer;
   dev->state->rx_dma_length = length / DMA_BUFFERS;
@@ -376,7 +376,7 @@ void uart_start_rx_dma(UARTDevice *dev, void *buffer, uint32_t length) {
 
 void uart_stop_rx_dma(UARTDevice *dev) {
 #ifdef DEBUG_UART
-  PBL_LOG(LOG_LEVEL_INFO, "stop_rx_dma");
+  PBL_LOG_INFO("stop_rx_dma");
 #endif
   nrfx_uarte_rx_abort(&dev->periph, true, true);
   nrfx_timer_disable(&dev->counter);

--- a/src/fw/drivers/pmic/as3701b.c
+++ b/src/fw/drivers/pmic/as3701b.c
@@ -182,14 +182,14 @@ static void prv_init_pmic_gpio_outputs(void) {
   // Sync the state of the PMIC GPIO output register with the value that we
   // think it has.
   if (!prv_set_pmic_gpio_outputs(0, 0)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Could not initialize PMIC GPIO outputs");
+    PBL_LOG_ERR("Could not initialize PMIC GPIO outputs");
   }
 }
 
 static void prv_handle_charge_state_change(void *null) {
   const bool is_charging = pmic_is_charging();
   const bool is_connected = pmic_is_usb_connected();
-  PBL_LOG(LOG_LEVEL_DEBUG, "AS3701b Interrupt: Charging? %s Plugged? %s",
+  PBL_LOG_DBG("AS3701b Interrupt: Charging? %s Plugged? %s",
       is_charging ? "YES" : "NO", is_connected ? "YES" : "NO");
 
   PebbleEvent event = {
@@ -265,7 +265,7 @@ static void prv_configure_charging(void) {
     }
   }
   if (!success) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Could not set pmic charge current.");
+    PBL_LOG_ERR("Could not set pmic charge current.");
   }
 
   // Set EOC current to 5% of ConstantCurrent
@@ -290,7 +290,7 @@ static void prv_configure_battery_measure(void) {
   bool success = prv_write_register(PmicRegisters_GPIO5_CNTL, 0b10100000) &&
                  prv_set_pmic_gpio_outputs(0, PmicGpio5);
   if (!success) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Could not configure the battery measure control GPIO");
+    PBL_LOG_ERR("Could not configure the battery measure control GPIO");
   }
 }
 
@@ -301,9 +301,9 @@ static bool prv_is_alive(void) {
   }
   const bool found = (chip_id == AS3701B_CHIP_ID);
   if (found) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Found the as3701b");
+    PBL_LOG_DBG("Found the as3701b");
   } else {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Error: read as3701b whoami byte 0x%x, expecting 0x11", chip_id);
+    PBL_LOG_DBG("Error: read as3701b whoami byte 0x%x, expecting 0x11", chip_id);
   }
   return found;
 }
@@ -325,7 +325,7 @@ static uint8_t s_last_reset_reason = 0;
 static void prv_stash_last_reset_reason(void) {
   uint8_t reset_cntl;
   if (!prv_read_register(PmicRegisters_RESET_CNTL, &reset_cntl)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to read the RESET_CNTL register");
+    PBL_LOG_ERR("Failed to read the RESET_CNTL register");
     return;
   }
 
@@ -433,7 +433,7 @@ bool pmic_is_charging(void) {
     // i2c read means we are charging
     return true;
 #else
-    PBL_LOG(LOG_LEVEL_DEBUG, "Failed to read charging status 1 register.");
+    PBL_LOG_DBG("Failed to read charging status 1 register.");
     return false;
 #endif
   }
@@ -453,7 +453,7 @@ bool pmic_is_usb_connected(void) {
     // i2c read means we are connected to a USB cable
     return true;
 #endif
-    PBL_LOG(LOG_LEVEL_WARNING, "Failed to read charging status 2 register.");
+    PBL_LOG_WRN("Failed to read charging status 2 register.");
     return false;
   }
   // ChargerStatus2 (Fig. 98)
@@ -501,11 +501,11 @@ void command_pmic_read_registers(void) {
 void command_pmic_status(void) {
   uint8_t id, rev, buck1;
   pmic_read_chip_info(&id, &rev, &buck1);
-  PBL_LOG(LOG_LEVEL_DEBUG, "ID: 0x%"PRIx8" REV: 0x%"PRIx8" BUCK1: 0x%"PRIx8, id, rev, buck1);
+  PBL_LOG_DBG("ID: 0x%"PRIx8" REV: 0x%"PRIx8" BUCK1: 0x%"PRIx8, id, rev, buck1);
   bool connected = pmic_is_usb_connected();
-  PBL_LOG(LOG_LEVEL_DEBUG, "USB Status: %s", (connected) ? "Connected" : "Disconnected");
+  PBL_LOG_DBG("USB Status: %s", (connected) ? "Connected" : "Disconnected");
   bool charging = pmic_is_charging();
-  PBL_LOG(LOG_LEVEL_DEBUG, "Charging? %s", (charging) ? "true" : "false");
+  PBL_LOG_DBG("Charging? %s", (charging) ? "true" : "false");
 }
 
 void command_pmic_rails(void) {

--- a/src/fw/drivers/pmic/max14690_pmic.c
+++ b/src/fw/drivers/pmic/max14690_pmic.c
@@ -385,7 +385,7 @@ bool pmic_is_charging(void) {
     // i2c read means we are charging
     return true;
 #else
-    PBL_LOG(LOG_LEVEL_DEBUG, "Failed to read charging status A register");
+    PBL_LOG_DBG("Failed to read charging status A register");
     return false;
 #endif
   }
@@ -410,7 +410,7 @@ bool pmic_is_usb_connected(void) {
     // i2c read means we are connected to a USB cable
     return true;
 #else
-    PBL_LOG(LOG_LEVEL_DEBUG, "Failed to read charging status B register");
+    PBL_LOG_DBG("Failed to read charging status B register");
     return false;
 #endif
   }
@@ -440,18 +440,18 @@ static void prv_log_status_registers(const char *preamble) {
 
   if (!prv_read_register(PmicRegisters_STATUSA, &status_a) ||
       !prv_read_register(PmicRegisters_STATUSB, &status_b)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Failed to read status registers");
+    PBL_LOG_WRN("Failed to read status registers");
     return;
   }
 
-  PBL_LOG(LOG_LEVEL_INFO, "%s: StatusA = 0x%"PRIx8"; StatusB = 0x%"PRIx8, preamble, status_a,
+  PBL_LOG_INFO("%s: StatusA = 0x%"PRIx8"; StatusB = 0x%"PRIx8, preamble, status_a,
       status_b);
 }
 
 static void prv_debounce_callback(void* data) {
   bool is_connected = pmic_is_usb_connected();
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Got PMIC debounced interrupt, plugged?: %s bounces: %u",
+  PBL_LOG_DBG("Got PMIC debounced interrupt, plugged?: %s bounces: %u",
           is_connected ? "YES" : "NO", s_interrupt_bounce_count);
   s_interrupt_bounce_count = 0;
 
@@ -493,11 +493,10 @@ static bool prv_is_alive(void) {
   prv_read_register(0x00, &val);
 
   if (val == 0x01) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Found the max14690");
+    PBL_LOG_DBG("Found the max14690");
     return true;
   } else {
-    PBL_LOG(LOG_LEVEL_DEBUG,
-            "Error: read max14690 whomai byte 0x%x, expecting 0x%x", val, 0x01);
+    PBL_LOG_DBG("Error: read max14690 whomai byte 0x%x, expecting 0x%x", val, 0x01);
     return false;
   }
 }

--- a/src/fw/drivers/pmic/npm1300.c
+++ b/src/fw/drivers/pmic/npm1300.c
@@ -184,7 +184,7 @@ static bool prv_write_register(uint16_t register_address, uint8_t datum) {
 static void prv_handle_charge_state_change(void *null) {
   const bool is_charging = pmic_is_charging();
   const bool is_connected = pmic_is_usb_connected();
-  PBL_LOG(LOG_LEVEL_DEBUG, "nPM1300 Interrupt: Charging? %s Plugged? %s",
+  PBL_LOG_DBG("nPM1300 Interrupt: Charging? %s Plugged? %s",
       is_charging ? "YES" : "NO", is_connected ? "YES" : "NO");
 
   if (is_connected && NPM1300_CONFIG.vbus_current_lim0 != 0) {
@@ -193,7 +193,7 @@ static void prv_handle_charge_state_change(void *null) {
     ok &= prv_write_register(PmicRegisters_VBUSIN_TASKUPDATELIMSW,
       PmicRegisters_VBUSIN_TASKUPDATELIMSW__EN);
     if (!ok) {
-      PBL_LOG(LOG_LEVEL_ERROR, "config vbus limite0 failed");
+      PBL_LOG_ERR("config vbus limite0 failed");
     }
   }
 
@@ -238,10 +238,10 @@ bool pmic_init(void) {
 #if PLATFORM_ASTERIX
   uint8_t buck_out;
   if (!prv_read_register(PmicRegisters_BUCK_BUCK1NORMVOUT, &buck_out)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "failed to read BUCK1NORMVOUT");
+    PBL_LOG_ERR("failed to read BUCK1NORMVOUT");
     return false;
   }
-  PBL_LOG(LOG_LEVEL_DEBUG, "found the nPM1300, BUCK1NORMVOUT = 0x%x", buck_out);
+  PBL_LOG_DBG("found the nPM1300, BUCK1NORMVOUT = 0x%x", buck_out);
   
   // work around erratum 27 for nPM1300 rev1, which we tripped in the bootloader (oops)
   ok &= prv_write_register(PmicRegisters_BUCK_BUCK1NORMVOUT, 9 /* 1.9V */);
@@ -252,7 +252,7 @@ bool pmic_init(void) {
   ok &= prv_write_register(PmicRegisters_BUCK_BUCKSWCTRLSEL, 3 /* both of them, load */);
   
   if (!prv_read_register(PmicRegisters_LDSW_LDSWSTATUS, &val)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "failed to read LDSWSTATUS");
+    PBL_LOG_ERR("failed to read LDSWSTATUS");
     return false;
   }
 
@@ -294,7 +294,7 @@ bool pmic_init(void) {
 
   if ((NPM1300_CONFIG.chg_current_ma < 32U) || (NPM1300_CONFIG.chg_current_ma > 800U) ||
       (NPM1300_CONFIG.chg_current_ma % 2U != 0U)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid charge current: %d mA", NPM1300_CONFIG.chg_current_ma);
+    PBL_LOG_ERR("Invalid charge current: %d mA", NPM1300_CONFIG.chg_current_ma);
     return false;
   }
 
@@ -352,7 +352,7 @@ bool pmic_init(void) {
     ok &= prv_write_register(PmicRegisters_BCHARGER_BCHGITERMSEL,
                              PmicRegisters_BCHARGER_BCHGITERMSEL__SEL20);
   } else {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid termination current: %d", NPM1300_CONFIG.term_current_pct);
+    PBL_LOG_ERR("Invalid termination current: %d", NPM1300_CONFIG.term_current_pct);
     return false;
   }
 
@@ -375,7 +375,7 @@ bool pmic_init(void) {
   prv_configure_interrupts();
 
   if (!ok) {
-    PBL_LOG(LOG_LEVEL_ERROR, "one or more PMIC transactions failed");
+    PBL_LOG_ERR("one or more PMIC transactions failed");
   }
 
   return ok;
@@ -384,12 +384,12 @@ bool pmic_init(void) {
 bool pmic_power_off(void) {
   // TODO: review implementation, see GH-238
   if (pmic_is_usb_connected()) {
-    PBL_LOG(LOG_LEVEL_ERROR, "USB is connected, cannot power off");
+    PBL_LOG_ERR("USB is connected, cannot power off");
     return false;
   }
 
   if (!prv_write_register(PmicRegisters_SHIP_TASKENTERSHIPMODE, 1)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to enter ship mode");
+    PBL_LOG_ERR("Failed to enter ship mode");
     return false;
   }
 
@@ -788,7 +788,7 @@ static bool dischg_limit_ma_set(uint32_t dischg_limit_ma) {
       return ret;
     }
   } else {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid discharge limit: %" PRIu32 " mA", dischg_limit_ma);
+    PBL_LOG_ERR("Invalid discharge limit: %" PRIu32 " mA", dischg_limit_ma);
     return false;
   }
 

--- a/src/fw/drivers/pressure/bmp390.c
+++ b/src/fw/drivers/pressure/bmp390.c
@@ -34,9 +34,9 @@ void pressure_init(void) {
 
   rv = prv_read_register(I2C_BMP390, BMP390_CHIP_ID, &result);
   if (!rv || result != BMP390_CHIP_ID_VALUE) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "BMP390 probe failed; rv %d, result 0x%02x", rv, result);
+    PBL_LOG_DBG("BMP390 probe failed; rv %d, result 0x%02x", rv, result);
   } else {
-    PBL_LOG(LOG_LEVEL_DEBUG, "found the BMP390, setting to low power");
+    PBL_LOG_DBG("found the BMP390, setting to low power");
     (void) prv_write_register(I2C_BMP390, BMP390_PWR_CTRL, 0);
   }
 }

--- a/src/fw/drivers/qemu/qemu_accel.c
+++ b/src/fw/drivers/qemu/qemu_accel.c
@@ -56,7 +56,7 @@
 #include <string.h>
 
 
-#define ACCEL_LOG_DEBUG(fmt, args...) PBL_LOG_D(LOG_DOMAIN_ACCEL, LOG_LEVEL_DEBUG, fmt, ## args)
+#define ACCEL_LOG_DEBUG(fmt, args...) PBL_LOG_D_DBG(LOG_DOMAIN_ACCEL, fmt, ## args)
 
 
 static bool s_initialized;
@@ -154,7 +154,7 @@ void qemu_accel_msg_callack(const uint8_t *data, uint32_t len) {
   // Validate the packet
   uint32_t data_bytes = hdr->num_samples * sizeof(AccelRawData);
   if (data_bytes != len - sizeof(QemuProtocolAccelHeader)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid packet received");
+    PBL_LOG_ERR("Invalid packet received");
     return;
   }
   ACCEL_LOG_DEBUG("Got accel msg from host: num samples: %d", hdr->num_samples);

--- a/src/fw/drivers/qemu/qemu_battery.c
+++ b/src/fw/drivers/qemu/qemu_battery.c
@@ -45,11 +45,11 @@ void battery_set_fast_charge(bool fast_charge_enabled) {
 void qemu_battery_msg_callack(const uint8_t *data, uint32_t len) {
   QemuProtocolBatteryHeader *hdr = (QemuProtocolBatteryHeader *)data;
   if (len != sizeof(*hdr)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid packet length");
+    PBL_LOG_ERR("Invalid packet length");
     return;
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Got battery msg: pct: %d, charger_connected:%d",
+  PBL_LOG_DBG("Got battery msg: pct: %d, charger_connected:%d",
         hdr->battery_pct, hdr->charger_connected);
 
   s_percent = MIN(100, hdr->battery_pct);

--- a/src/fw/drivers/qemu/qemu_serial.c
+++ b/src/fw/drivers/qemu/qemu_serial.c
@@ -41,7 +41,7 @@ static QemuSerialGlobals s_qemu_state;
 static void prv_tap_msg_callback(const uint8_t *data, uint32_t len) {
   QemuProtocolTapHeader *hdr = (QemuProtocolTapHeader *)data;
   if (len != sizeof(*hdr)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid packet length");
+    PBL_LOG_ERR("Invalid packet length");
     return;
   }
 
@@ -63,7 +63,7 @@ static void prv_tap_msg_callback(const uint8_t *data, uint32_t len) {
 static void prv_bluetooth_connection_msg_callback(const uint8_t *data, uint32_t len) {
   QemuProtocolBluetoothConnectionHeader *hdr = (QemuProtocolBluetoothConnectionHeader *)data;
   if (len != sizeof(*hdr)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid packet length");
+    PBL_LOG_ERR("Invalid packet length");
     return;
   }
 
@@ -85,7 +85,7 @@ static void prv_bluetooth_connection_msg_callback(const uint8_t *data, uint32_t 
 static void prv_compass_msg_callback(const uint8_t *data, uint32_t len) {
   QemuProtocolCompassHeader *hdr = (QemuProtocolCompassHeader *)data;
   if (len != sizeof(*hdr)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid packet length");
+    PBL_LOG_ERR("Invalid packet length");
     return;
   }
 
@@ -108,11 +108,11 @@ static void prv_compass_msg_callback(const uint8_t *data, uint32_t len) {
 static void prv_time_format_msg_callback(const uint8_t *data, uint32_t len) {
   QemuProtocolTimeFormatHeader *hdr = (QemuProtocolTimeFormatHeader *)data;
   if (len != sizeof(*hdr)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid packet length");
+    PBL_LOG_ERR("Invalid packet length");
     return;
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Got time format msg: is 24 hour: %d", hdr->is_24_hour);
+  PBL_LOG_DBG("Got time format msg: is 24 hour: %d", hdr->is_24_hour);
   clock_set_24h_style(hdr->is_24_hour);
 }
 
@@ -122,11 +122,11 @@ static void prv_time_format_msg_callback(const uint8_t *data, uint32_t len) {
 static void prv_timeline_peek_msg_callback(const uint8_t *data, uint32_t len) {
   QemuProtocolTimelinePeekHeader *hdr = (QemuProtocolTimelinePeekHeader *)data;
   if (len != sizeof(*hdr)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid packet length");
+    PBL_LOG_ERR("Invalid packet length");
     return;
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Got timeline peek msg: enabled: %d", hdr->enabled);
+  PBL_LOG_DBG("Got timeline peek msg: enabled: %d", hdr->enabled);
 #if !RECOVERY_FW && CAPABILITY_HAS_TIMELINE_PEEK
   timeline_peek_set_enabled(hdr->enabled);
 #endif
@@ -136,11 +136,11 @@ static void prv_timeline_peek_msg_callback(const uint8_t *data, uint32_t len) {
 static void prv_content_size_msg_callback(const uint8_t *data, uint32_t len) {
   QemuProtocolContentSizeHeader *hdr = (QemuProtocolContentSizeHeader *)data;
   if (len != sizeof(*hdr)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid packet length");
+    PBL_LOG_ERR("Invalid packet length");
     return;
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Got content size msg: size: %d", hdr->size);
+  PBL_LOG_DBG("Got content size msg: size: %d", hdr->size);
 #if !RECOVERY_FW
   system_theme_set_content_size(hdr->size);
 
@@ -221,11 +221,11 @@ static void prv_process_receive_buffer(void *context) {
     }
 
     // Dispatch the received message
-    PBL_LOG(LOG_LEVEL_DEBUG, "Dispatching msg of len %"PRIu32" for protocol %d", msg_bytes,
+    PBL_LOG_DBG("Dispatching msg of len %"PRIu32" for protocol %d", msg_bytes,
               protocol);
     const QemuMessageHandler* handler = prv_find_handler(protocol);
     if (!handler) {
-      PBL_LOG(LOG_LEVEL_WARNING, "No handler for protocol: %d", protocol);
+      PBL_LOG_WRN("No handler for protocol: %d", protocol);
     } else {
       handler->callback(msg_ptr, msg_bytes);
     }
@@ -247,7 +247,7 @@ static bool prv_uart_irq_handler(UARTDevice *dev, uint8_t byte, const UARTRXErro
   bool success = shared_circular_buffer_write(&s_qemu_state.isr_buffer, &byte, 1,
                                               false/*advance_slackers*/);
   if (!success) {
-    PBL_LOG(LOG_LEVEL_ERROR, "ISR buf too small 0x%x", byte);
+    PBL_LOG_ERR("ISR buf too small 0x%x", byte);
     s_qemu_state.recv_error_count++;
   }
 

--- a/src/fw/drivers/qemu/qemu_serial_private.h
+++ b/src/fw/drivers/qemu/qemu_serial_private.h
@@ -82,8 +82,8 @@ typedef struct {
 #define QEMU_HEADER_LSB        ((uint8_t)(QEMU_HEADER_SIGNATURE & 0x00FF))
 
 
-#define QEMU_LOG_DEBUG(fmt, args...) PBL_LOG_D(LOG_DOMAIN_QEMU_COMM, LOG_LEVEL_DEBUG, fmt, ## args)
-#define QEMU_LOG_ERROR(fmt, args...) PBL_LOG_D(LOG_DOMAIN_QEMU_COMM, LOG_LEVEL_ERROR, fmt, ## args)
+#define QEMU_LOG_DEBUG(fmt, args...) PBL_LOG_D_DBG(LOG_DOMAIN_QEMU_COMM, fmt, ## args)
+#define QEMU_LOG_ERROR(fmt, args...) PBL_LOG_D_ERR(LOG_DOMAIN_QEMU_COMM, fmt, ## args)
 #define QEMU_HEXDUMP(data, length) \
                               PBL_HEXDUMP_D(LOG_DOMAIN_QEMU_COMM, LOG_LEVEL_DEBUG, data, length)
 

--- a/src/fw/drivers/qemu/qemu_serial_util.c
+++ b/src/fw/drivers/qemu/qemu_serial_util.c
@@ -61,7 +61,7 @@ uint8_t *qemu_serial_private_assemble_message(QemuSerialGlobals *state, uint32_t
   if (state->recv_state != QemuRecvState_WaitingHdrSignatureMSB
       && cur_time > state->start_recv_packet_time + QEMU_RECV_PACKET_TIMEOUT_SEC) {
     state->recv_state = QemuRecvState_WaitingHdrSignatureMSB;
-    PBL_LOG(LOG_LEVEL_WARNING, "Resetting receive state - max packet time expired");
+    PBL_LOG_WRN("Resetting receive state - max packet time expired");
   }
 
   state->callback_pending = false;
@@ -73,7 +73,7 @@ uint8_t *qemu_serial_private_assemble_message(QemuSerialGlobals *state, uint32_t
 
   // Log message if we detected any receive errors
   if (state->recv_error_count) {
-    PBL_LOG(LOG_LEVEL_ERROR, "%"PRIu32" receive errors detected", state->recv_error_count);
+    PBL_LOG_ERR("%"PRIu32" receive errors detected", state->recv_error_count);
     state->recv_error_count = 0;
   }
 
@@ -123,7 +123,7 @@ uint8_t *qemu_serial_private_assemble_message(QemuSerialGlobals *state, uint32_t
 
         // Validity checking
         if (state->hdr.len > QEMU_MAX_DATA_LEN) {
-          PBL_LOG(LOG_LEVEL_ERROR, "Invalid header data size %d", state->hdr.len);
+          PBL_LOG_ERR("Invalid header data size %d", state->hdr.len);
           state->recv_state = QemuRecvState_WaitingHdrSignatureMSB;
         } else {
           QEMU_LOG_DEBUG("got header: protocol: %d, len: %d", state->hdr.protocol, state->hdr.len);
@@ -162,7 +162,7 @@ uint8_t *qemu_serial_private_assemble_message(QemuSerialGlobals *state, uint32_t
           bytes_avail -= bytes_read;
           footer.signature = ntohs(footer.signature);
           if (footer.signature != QEMU_FOOTER_SIGNATURE) {
-            PBL_LOG(LOG_LEVEL_WARNING, "Invalid footer signature");
+            PBL_LOG_WRN("Invalid footer signature");
           }
           state->recv_state = QemuRecvState_WaitingHdrSignatureMSB;
         }

--- a/src/fw/drivers/sf32lb52/audio/audec.c
+++ b/src/fw/drivers/sf32lb52/audio/audec.c
@@ -265,7 +265,7 @@ static bool prv_allocate_buffers(AudioDeviceState *state) {
     // Allocate circular buffer storage
     state->circ_buffer_storage = kernel_malloc(CIRCULAR_BUF_SIZE_BYTES);
     if (!state->circ_buffer_storage) {
-        PBL_LOG(LOG_LEVEL_ERROR, "Failed to allocate circular buffer storage");
+        PBL_LOG_ERR("Failed to allocate circular buffer storage");
         return false;
     }
 
@@ -429,7 +429,7 @@ static void prv_dma_request_processing(AudioDeviceState* state) {
     uint32_t available_data = circular_buffer_get_read_space_remaining(&state->circ_buffer);
     uint32_t trans_size = CFG_AUDIO_PLAYBACK_PIPE_SIZE;
     if (available_data < CFG_AUDIO_PLAYBACK_PIPE_SIZE) {
-        PBL_LOG(LOG_LEVEL_DEBUG, "audio data not enough remain:%" PRIu32 "", available_data);
+        PBL_LOG_DBG("audio data not enough remain:%" PRIu32 "", available_data);
         memset(state->queue_buf[HAL_AUDCODEC_DAC_CH0], 0, CFG_AUDIO_PLAYBACK_PIPE_SIZE);
         trans_size = available_data;
     }

--- a/src/fw/drivers/sf32lb52/exti.c
+++ b/src/fw/drivers/sf32lb52/exti.c
@@ -143,7 +143,7 @@ void HAL_GPIO_EXTI_Callback(GPIO_TypeDef *hgpio, uint16_t GPIO_Pin) {
     }
   }
 
-  PBL_LOG(LOG_LEVEL_WARNING, "No handler found for GPIO pin %u", GPIO_Pin);
+  PBL_LOG_WRN("No handler found for GPIO pin %u", GPIO_Pin);
 }
 
 void GPIO1_IRQHandler(void) {

--- a/src/fw/drivers/sf32lb52/qspi.c
+++ b/src/fw/drivers/sf32lb52/qspi.c
@@ -161,10 +161,10 @@ bool qspi_flash_check_whoami(QSPIFlash *dev) {
   uint32_t id = ctx->dev_id;
 
   if (id == dev->state->part->qspi_id_value) {
-    PBL_LOG(LOG_LEVEL_INFO, "Flash is %s", dev->state->part->name);
+    PBL_LOG_INFO("Flash is %s", dev->state->part->name);
     return true;
   } else {
-    PBL_LOG(LOG_LEVEL_ERROR, "Flash isn't expected %s (whoami: 0x%" PRIx32 ")",
+    PBL_LOG_ERR("Flash isn't expected %s (whoami: 0x%" PRIx32 ")",
             dev->state->part->name, id);
     return false;
   }

--- a/src/fw/drivers/sf32lb52/rng.c
+++ b/src/fw/drivers/sf32lb52/rng.c
@@ -30,7 +30,7 @@ bool rng_rand(uint32_t *rand_out) {
 
   status = HAL_RNG_GenerateRandomNumber(&s_rng_hdl, rand_out);
   if (status != HAL_OK) {
-    PBL_LOG(LOG_LEVEL_ERROR, "HAL_RNG_GenerateRandomNumber failed: %d", status);
+    PBL_LOG_ERR("HAL_RNG_GenerateRandomNumber failed: %d", status);
   }
 
   HAL_RCC_DisableModule(RCC_MOD_TRNG);

--- a/src/fw/drivers/sf32lb52/rtc.c
+++ b/src/fw/drivers/sf32lb52/rtc.c
@@ -152,8 +152,7 @@ static void prv_rtc_cal_timer_cb(void* data) {
     // changed externally. Reset calibration state instead of applying a bogus correction.
     if (s_delta_total > MAX_REASONABLE_CORRECTION_SECS ||
         s_delta_total < -MAX_REASONABLE_CORRECTION_SECS) {
-      PBL_LOG(LOG_LEVEL_WARNING,
-              "RTC calibration: delta_sum=%d exceeds max, resetting calibration state",
+      PBL_LOG_WRN("RTC calibration: delta_sum=%d exceeds max, resetting calibration state",
               (int)(s_delta_total * 1000));
       prv_reset_calibration_state();
       return;
@@ -180,8 +179,7 @@ static void prv_rtc_cal_timer_cb(void* data) {
       s_rtc_a = rtc_b;
     }
 
-    PBL_LOG(LOG_LEVEL_DEBUG,
-            "origin: f=%dHz,cycle=%d avr: f=%dHz cycle_ave=%d delta=%d, delta_sum=%d\n",
+    PBL_LOG_DBG("origin: f=%dHz,cycle=%d avr: f=%dHz cycle_ave=%d delta=%d, delta_sum=%d\n",
             (int)(48000000ULL * HAL_RC_CAL_GetLPCycle() / s_rtc_cycle_count_init),
             (int)s_rtc_cycle_count_init,
             (int)(48000000ULL * HAL_RC_CAL_GetLPCycle() / ref_cycle),
@@ -254,8 +252,8 @@ static void prv_rtc_set_time_no_cal_reset(time_t time) {
   HAL_RTC_SetTime(&RTC_Handler, &rtc_time_struct, RTC_FORMAT_BIN);
   HAL_RTC_SetDate(&RTC_Handler, &rtc_date_struct, RTC_FORMAT_BIN);
 
-  PBL_LOG(LOG_LEVEL_INFO, "RTC set time to %lu", time);
-  PBL_LOG(LOG_LEVEL_INFO, "%u:%u:%u, %u/%u/%u (%u)",
+  PBL_LOG_INFO("RTC set time to %lu", time);
+  PBL_LOG_INFO("%u:%u:%u, %u/%u/%u (%u)",
           rtc_time_struct.Hours, rtc_time_struct.Minutes, rtc_time_struct.Seconds,
           rtc_date_struct.Month, rtc_date_struct.Date, rtc_date_struct.Year,
           rtc_date_struct.WeekDay);

--- a/src/fw/drivers/sf32lb52/watchdog.c
+++ b/src/fw/drivers/sf32lb52/watchdog.c
@@ -24,7 +24,7 @@ void watchdog_init(void) {
 
   __HAL_SYSCFG_Enable_WDT_REBOOT(1);
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Initializing WDT with timeout %u seconds", WDT_TIMEOUT_S);
+  PBL_LOG_DBG("Initializing WDT with timeout %u seconds", WDT_TIMEOUT_S);
 }
 
 void watchdog_start(void) {

--- a/src/fw/drivers/stm32f2/clocksource.c
+++ b/src/fw/drivers/stm32f2/clocksource.c
@@ -30,13 +30,13 @@ void clocksource_lse_configure(void) {
   // will normally be running even during standby mode to keep the RTC ticking;
   // it is only disabled when the microcontroller completely loses power.
   if (clocksource_is_lse_started()) {
-    PBL_LOG(LOG_LEVEL_INFO, "LSE oscillator already running");
+    PBL_LOG_INFO("LSE oscillator already running");
   } else {
-    PBL_LOG(LOG_LEVEL_INFO, "Starting LSE oscillator");
+    PBL_LOG_INFO("Starting LSE oscillator");
     RCC_LSEConfig(BOARD_LSE_MODE);
     for (int i = 0; i < LSE_READY_TIMEOUT_MS; ++i) {
       if (RCC_GetFlagStatus(RCC_FLAG_LSERDY) != RESET) {
-        PBL_LOG(LOG_LEVEL_INFO, "LSE oscillator started after %d ms", i);
+        PBL_LOG_INFO("LSE oscillator started after %d ms", i);
         break;
       }
 
@@ -44,7 +44,7 @@ void clocksource_lse_configure(void) {
       watchdog_feed();
     }
     if (RCC_GetFlagStatus(RCC_FLAG_LSERDY) == RESET) {
-      PBL_LOG(LOG_LEVEL_ERROR, "LSE oscillator did not start");
+      PBL_LOG_ERR("LSE oscillator did not start");
     }
   }
 }
@@ -71,7 +71,7 @@ void clocksource_MCO1_enable(bool on) {
     PBL_ASSERTN(s_refcount > 0);
     --s_refcount;
     if (s_refcount == 0) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Disabling MCO1");
+      PBL_LOG_DBG("Disabling MCO1");
       gpio_analog_init(&BOARD_CONFIG_MCO1.an_cfg);
     }
   }

--- a/src/fw/drivers/stm32f2/periph_config.c
+++ b/src/fw/drivers/stm32f2/periph_config.c
@@ -17,7 +17,7 @@
 
 #if PERIPH_CONFIG_DEBUG
 #define PERIPH_CONFIG_LOG(fmt, args...) \
-        PBL_LOG(LOG_LEVEL_DEBUG, fmt, ## args)
+        PBL_LOG_DBG(fmt, ## args)
 #else
 #define PERIPH_CONFIG_LOG(fmt, args...)
 #endif

--- a/src/fw/drivers/stm32f2/rtc.c
+++ b/src/fw/drivers/stm32f2/rtc.c
@@ -60,7 +60,7 @@ static void save_rtc_time_state(RtcIntervalTicks current_rtc_ticks);
 void rtc_calibrate_frequency(uint32_t frequency) {
   RTCCalibConfig config = rtc_calibration_get_config(frequency, LSE_FREQUENCY_HZ * 1000);
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Calibrating RTC by %s%"PRIu32" units",
+  PBL_LOG_DBG("Calibrating RTC by %s%"PRIu32" units",
           (config.sign == RTC_CalibSign_Positive) ? "+" : "-", config.units);
 
   // This is a no-op if RTC_CALIBRATION_TESTING is undefined.
@@ -176,7 +176,7 @@ void rtc_init(void) {
 
 #ifdef PBL_LOG_ENABLED
   char buffer[TIME_STRING_BUFFER_SIZE];
-  PBL_LOG(LOG_LEVEL_DEBUG, "Current time is <%s>", rtc_get_time_string(buffer));
+  PBL_LOG_DBG("Current time is <%s>", rtc_get_time_string(buffer));
 #endif
 }
 
@@ -237,7 +237,7 @@ static RtcTicks get_ticks(void) {
 void rtc_set_time(time_t time) {
 #ifdef PBL_LOG_ENABLED
   char buffer[TIME_STRING_BUFFER_SIZE];
-  PBL_LOG(LOG_LEVEL_INFO, "Setting time to %lu <%s>", time, time_t_to_string(buffer, time));
+  PBL_LOG_INFO("Setting time to %lu <%s>", time, time_t_to_string(buffer, time));
 #endif
 
   s_time_base = time;

--- a/src/fw/drivers/stm32f2/rtc_calibration.c
+++ b/src/fw/drivers/stm32f2/rtc_calibration.c
@@ -12,7 +12,7 @@
 
 RTCCalibConfig rtc_calibration_get_config(uint32_t frequency, uint32_t target) {
   if (frequency == 0) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "RTC frequency invalid - Skipping calibration");
+    PBL_LOG_DBG("RTC frequency invalid - Skipping calibration");
     return (RTCCalibConfig) {
       .sign = RTC_CalibSign_Positive,
       .units = 0
@@ -106,7 +106,7 @@ static void prv_delta_ticks(void) {
   static uint64_t last_tick = 0;
 
   uint64_t rtc_ticks = rtc_get_ticks();
-  PBL_LOG(LOG_LEVEL_INFO, "RTC tick delta: %d", rtc_ticks - last_tick);
+  PBL_LOG_INFO("RTC tick delta: %d", rtc_ticks - last_tick);
 
   last_tick = rtc_ticks;
 }

--- a/src/fw/drivers/stm32f2/system_flash.c
+++ b/src/fw/drivers/stm32f2/system_flash.c
@@ -18,7 +18,7 @@ void system_flash_erase(uint16_t sector) {
                   FLASH_FLAG_PGAERR | FLASH_FLAG_PGPERR|FLASH_FLAG_PGSERR);
 
   if (FLASH_EraseSector(sector, VoltageRange_1) != FLASH_COMPLETE) {
-    PBL_LOG(LOG_LEVEL_ALWAYS, "failed to erase sector %u", sector);
+    PBL_LOG_ALWAYS("failed to erase sector %u", sector);
     return;
   }
 }
@@ -29,7 +29,7 @@ void system_flash_write_byte(uint32_t address, uint8_t data) {
                   FLASH_FLAG_PGAERR | FLASH_FLAG_PGPERR|FLASH_FLAG_PGSERR);
 
   if (FLASH_ProgramByte(address, data) != FLASH_COMPLETE) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "failed to write address %p", (void*) address);
+    PBL_LOG_DBG("failed to write address %p", (void*) address);
     return;
   }
 }

--- a/src/fw/drivers/stm32f4/rtc.c
+++ b/src/fw/drivers/stm32f4/rtc.c
@@ -51,7 +51,7 @@ void rtc_init(void) {
 
 #ifdef PBL_LOG_ENABLED
   char buffer[TIME_STRING_BUFFER_SIZE];
-  PBL_LOG(LOG_LEVEL_DEBUG, "Current time is <%s>", rtc_get_time_string(buffer));
+  PBL_LOG_DBG("Current time is <%s>", rtc_get_time_string(buffer));
 #endif
 }
 

--- a/src/fw/drivers/stm32f412/qspi.c
+++ b/src/fw/drivers/stm32f412/qspi.c
@@ -381,7 +381,7 @@ bool qspi_poll_bit(QSPIPort *dev, uint8_t instruction, uint8_t bit_mask, bool sh
   uint32_t loops = 0;
   while (QSPI_GetFlagStatus(QSPI_FLAG_SM) == RESET) {
     if ((timeout_us != QSPI_NO_TIMEOUT) && (++loops > timeout_us)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Timeout waiting for a bit!?!?");
+      PBL_LOG_ERR("Timeout waiting for a bit!?!?");
       return false;
     }
     delay_us(1);

--- a/src/fw/drivers/touch/cst816/cst816.c
+++ b/src/fw/drivers/touch/cst816/cst816.c
@@ -137,13 +137,13 @@ static bool cst816_fw_update(void) {
     uint16_t fw_offset = 6;
     
     while (length) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "fw start_addr:%d length:%d", start_addr, length);
+      PBL_LOG_DBG("fw start_addr:%d length:%d", start_addr, length);
       uint8_t addr[2] = {start_addr&0xff, start_addr>>8};
       bool rv = prv_write_data(CST816_FW_START_ADDR_REG, addr, 2, 0);
       psleep(CST816_REG_WR_DELAY_TIME);
       if(!prv_write_data(CST816_FW_PAGE_REG, app_bin+fw_offset,
                         length>=CST816_FW_PAGE_SIZE?CST816_FW_PAGE_SIZE:length , 0)) {
-        PBL_LOG(LOG_LEVEL_ERROR, "cst816 update fw error by iic");
+        PBL_LOG_ERR("cst816 update fw error by iic");
         return false;
       }
       psleep(CST816_REG_WR_DELAY_TIME);
@@ -152,7 +152,7 @@ static bool cst816_fw_update(void) {
       psleep(CST816_FW_WR_TIME);
       for (int t=0;; t++) {
         if(t > 50) {
-          PBL_LOG(LOG_LEVEL_ERROR, "cst816 update fw error by writing timeout");
+          PBL_LOG_ERR("cst816 update fw error by writing timeout");
           return false;
         }
         psleep(CST816_RESET_CYCLE_TIME);
@@ -172,14 +172,14 @@ static bool cst816_fw_update(void) {
       uint8_t boot_exit_cmd = CST816_BOOT_EXIT_VAL;
       bool rv = prv_write_data(CST816_BOOT_EXIT_REG, &boot_exit_cmd, 1, 0);
       if (!rv) {
-        PBL_LOG(LOG_LEVEL_ERROR, "exit boot failed");
+        PBL_LOG_ERR("exit boot failed");
         return false;
       }
 
       cst816_hw_reset();
       return true;
     }
-    PBL_LOG(LOG_LEVEL_ERROR, "cst816 update fw error by checksum:%x read:%x", checksum, checksum_read);
+    PBL_LOG_ERR("cst816 update fw error by checksum:%x read:%x", checksum, checksum_read);
   }
 
   return false;
@@ -215,17 +215,17 @@ void touch_sensor_init(void) {
 
   rv = prv_read_data(CST816_CHIP_ID_REG, &chip_id, 1, 1);
   if (!rv) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Could not read CST816 chip ID");
+    PBL_LOG_ERR("Could not read CST816 chip ID");
     return;
   }
 
   rv = prv_read_data(CST816_FW_VERSION_REG, &fw_version, 1, 1);
   if (!rv) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Could not read CST816 firmware version");
+    PBL_LOG_ERR("Could not read CST816 firmware version");
     return;
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "CST816 firmware: 0x%02X", fw_version);
+  PBL_LOG_DBG("CST816 firmware: 0x%02X", fw_version);
 
 #if PLATFORM_OBELIX
   uint8_t target_ver = app_bin[sizeof(app_bin) + CST816_FW_VER_INFO_INDEX];
@@ -237,7 +237,7 @@ void touch_sensor_init(void) {
         return;
       }
     } else {
-      PBL_LOG(LOG_LEVEL_ERROR, "Could not enter CST816 boot mode");
+      PBL_LOG_ERR("Could not enter CST816 boot mode");
       return;
     }
   }

--- a/src/fw/drivers/touch/ewd1000/ewd1000.c
+++ b/src/fw/drivers/touch/ewd1000/ewd1000.c
@@ -302,7 +302,7 @@ static void prv_process_pending_messages(void *context) {
       // TODO: PBL-29944 handle this gracefully by re-initializing - should "never" happen
       PBL_CROAK("Touch controller reset!");
     } else {
-      PBL_LOG(LOG_LEVEL_ERROR, "Got unexpected packet (%"PRIx8")", message.packet_id);
+      PBL_LOG_ERR("Got unexpected packet (%"PRIx8")", message.packet_id);
     }
   }
 }
@@ -365,5 +365,5 @@ void touch_sensor_init(void) {
   // initialize exti
   exti_configure_pin(EWD1000->int_exti, ExtiTrigger_Falling, prv_exti_cb);
   exti_enable(EWD1000->int_exti);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Initialized eWD1000 touch controller");
+  PBL_LOG_DBG("Initialized eWD1000 touch controller");
 }

--- a/src/fw/drivers/vibe/vibe.c
+++ b/src/fw/drivers/vibe/vibe.c
@@ -157,7 +157,7 @@ void vibe_ctl(bool on) {
   }
   s_on = on;
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Vibe status <%s>", on ? "on" : "off");
+  PBL_LOG_DBG("Vibe status <%s>", on ? "on" : "off");
 
   prv_vibe_raw_ctl(on);
 }

--- a/src/fw/drivers/vibe/vibe_aw86225.c
+++ b/src/fw/drivers/vibe/vibe_aw86225.c
@@ -158,7 +158,7 @@ void vibe_init(void) {
   uint8_t chip_id;
   bool ret = prv_read_register(AW862XX_REG_CHIPID, &chip_id);
   if (!ret) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to read AW86225 chip ID");
+    PBL_LOG_ERR("Failed to read AW86225 chip ID");
     return;
   }
 
@@ -173,7 +173,7 @@ void vibe_init(void) {
   prv_modify_reg(AW862XX_REG_SYSCTRL1, AW862XX_SYSCTRL1_VBAT_MODE_MASK, AW862XX_SYSCTRL1_VBAT_MODE_EN);
 
   if (!ret) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to initialize AW86225");
+    PBL_LOG_ERR("Failed to initialize AW86225");
     return;
   }
 

--- a/src/fw/drivers/vibe/vibe_aw8623x.c
+++ b/src/fw/drivers/vibe/vibe_aw8623x.c
@@ -90,13 +90,13 @@ void vibe_init(void) {
   // Verify chip ID
   ret = prv_read_register(AW8623X_IDH, &val);
   if (!ret || val != AW8623X_IDH_CHIPID_H) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to read AW8623X chip ID high byte");
+    PBL_LOG_ERR("Failed to read AW8623X chip ID high byte");
     return;
   }
 
   ret = prv_read_register(AW8623X_IDL, &val);
   if (!ret || val != AW8623X_IDL_CHIPID_L) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to read AW8623X chip ID low byte");
+    PBL_LOG_ERR("Failed to read AW8623X chip ID low byte");
     return;
   }
 

--- a/src/fw/drivers/vibe/vibe_drv2604.c
+++ b/src/fw/drivers/vibe/vibe_drv2604.c
@@ -74,9 +74,9 @@ void vibe_init(void) {
   uint8_t rv;
   bool found = prv_read_register(DRV2604_STATUS, &rv);
   if (found) {
-    PBL_LOG(LOG_LEVEL_INFO, "Found DRV2604 with STATUS register %02x", rv);
+    PBL_LOG_INFO("Found DRV2604 with STATUS register %02x", rv);
   } else {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to read the STATUS register");
+    PBL_LOG_ERR("Failed to read the STATUS register");
   }
   
   /* calibration table maybe should live in the board file? */
@@ -94,7 +94,7 @@ void vibe_init(void) {
 
   for (size_t i = 0; i < sizeof(regs) / sizeof(regs[0]); i++) {
     if (!prv_write_register(regs[i][0], regs[i][1])) {
-      PBL_LOG(LOG_LEVEL_ERROR, "failed to write register %02x on DRV2604", regs[i][0]);
+      PBL_LOG_ERR("failed to write register %02x on DRV2604", regs[i][0]);
       gpio_output_set(&BOARD_CONFIG_VIBE.ctl, false);
       return;
     }
@@ -140,7 +140,7 @@ void vibe_ctl(bool on) {
   }
   s_on = on;
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Vibe status <%s>", on ? "on" : "off");
+  PBL_LOG_DBG("Vibe status <%s>", on ? "on" : "off");
 
   if (!on) {
     prv_write_register(DRV2604_MODE, DRV2604_MODE_STANDBY | DRV2604_MODE_RTP); /* enter standby even if the enable GPIO is not hooked up */

--- a/src/fw/flash_region/flash_region.c
+++ b/src/fw/flash_region/flash_region.c
@@ -34,7 +34,7 @@ static void prv_erase_upkeep(int *erase_count, bool feed_watchdog) {
 
 static void prv_erase_optimal_range(uint32_t min_start, uint32_t max_start,
                                     uint32_t min_end, uint32_t max_end, bool feed_watchdog) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "flash_region_erase_optimal_range, 0x%"PRIx32" 0x%"PRIx32" 0x%"PRIx32" 0x%"PRIx32,
+  PBL_LOG_DBG("flash_region_erase_optimal_range, 0x%"PRIx32" 0x%"PRIx32" 0x%"PRIx32" 0x%"PRIx32,
       min_start, max_start, min_end, max_end);
 
   PBL_ASSERTN(((min_start & (~SUBSECTOR_ADDR_MASK)) == 0) &&

--- a/src/fw/freertos_application.c
+++ b/src/fw/freertos_application.c
@@ -201,7 +201,7 @@ void vApplicationStackOverflowHook(TaskHandle_t task_handle, signed char *name) 
   // area in fault_handling.c has the logic to safely kill those user tasks without forcing
   // a reboot.
   if ((task != PebbleTask_App) && (task != PebbleTask_Worker)) {
-    PBL_LOG_SYNC(LOG_LEVEL_ERROR, "Stack overflow [task: %s]", name);
+    PBL_LOG_SYNC_ERR("Stack overflow [task: %s]", name);
     RebootReason reason = {
       .code = RebootReasonCode_StackOverflow,
       .data8[0] = task

--- a/src/fw/kernel/event_loop.c
+++ b/src/fw/kernel/event_loop.c
@@ -159,17 +159,17 @@ static void launcher_force_quit_app(void *data) {
   if (s_force_quit_was_cancelled) {
     // If you see this in logs after FIRM-556 (general system sluggishness)
     // is fixed, please file a bug!
-    PBL_LOG(LOG_LEVEL_ERROR, "NewTimer event fired for force quit, but the back button was released before we went to deal with it!  Wow, we must have been really slow!  Please file a bug!");
+    PBL_LOG_ERR("NewTimer event fired for force quit, but the back button was released before we went to deal with it!  Wow, we must have been really slow!  Please file a bug!");
     metric_firm_425_back_button_long_presses_cancelled++;
     return;
   }
 
   if (low_power_is_active() || factory_reset_ongoing()) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Forcekill disabled due to low-power or factory-reset");
+    PBL_LOG_DBG("Forcekill disabled due to low-power or factory-reset");
     return;
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Force killing app.");
+  PBL_LOG_DBG("Force killing app.");
   app_manager_force_quit_to_launcher();
 }
 
@@ -209,7 +209,7 @@ static void launcher_handle_button_event(PebbleEvent* e) {
       s_back_quickpress_last = now;
       s_back_quickpress_count++;
       if (s_back_quickpress_count >= BACK_QUICKPRESS_COREDUMP_PRESSES && shell_prefs_can_coredump_on_request()) {
-        PBL_LOG(LOG_LEVEL_INFO, "triggering core dump because you asked for it!");
+        PBL_LOG_INFO("triggering core dump because you asked for it!");
         core_dump_reset(true /* is_forced */);
       }
     }
@@ -496,11 +496,11 @@ static NOINLINE void prv_launcher_main_loop_init(void) {
   // Launch the default worker. If any of the buttons are down, or we hit 2 strikes already,
   // skip this. This insures that we don't enter PRF for a bad worker.
   if (launcher_panic_get_current_error()) {
-    PBL_LOG(LOG_LEVEL_INFO, "Not launching worker because launcher panic");
+    PBL_LOG_INFO("Not launching worker because launcher panic");
   } else if (button_get_state_bits() != 0) {
-    PBL_LOG(LOG_LEVEL_INFO, "Not launching worker because button held");
+    PBL_LOG_INFO("Not launching worker because button held");
   } else if (boot_bit_test(BOOT_BIT_FW_START_FAIL_STRIKE_TWO)) {
-    PBL_LOG(LOG_LEVEL_INFO, "Not launching worker because of 2 strikes");
+    PBL_LOG_INFO("Not launching worker because of 2 strikes");
   } else {
     process_manager_launch_process(&(ProcessLaunchConfig) {
       .id = worker_manager_get_default_install_id(),
@@ -514,7 +514,7 @@ static NOINLINE void prv_launcher_main_loop_init(void) {
 }
 
 void launcher_main_loop(void) {
-  PBL_LOG(LOG_LEVEL_ALWAYS, "Starting Launcher");
+  PBL_LOG_ALWAYS("Starting Launcher");
 
   prv_launcher_main_loop_init();
 

--- a/src/fw/kernel/events.c
+++ b/src/fw/kernel/events.c
@@ -50,9 +50,9 @@ uint32_t s_current_event;
 #if EVENT_DEBUG
 static void prv_queue_dump(QueueHandle_t queue) {
   PebbleEvent event;
-  PBL_LOG(LOG_LEVEL_DEBUG, "Dumping queue:");
+  PBL_LOG_DBG("Dumping queue:");
   while (xQueueReceive(queue, &event, 0) == pdTRUE) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Event type: %u", event.type);
+    PBL_LOG_DBG("Event type: %u", event.type);
   }
   for(;;);
 }
@@ -63,7 +63,7 @@ void events_init(void) {
 
   // This assert is to make sure we don't accidentally bloat our PebbleEvent unecessarily. If you hit this
   // assert and you have a good reason for making the event bigger, feel free to relax the restriction.
-  //PBL_LOG(LOG_LEVEL_DEBUG, "PebbleEvent size is %u", sizeof(PebbleEvent));
+  //PBL_LOG_DBG("PebbleEvent size is %u", sizeof(PebbleEvent));
   // FIXME:
   _Static_assert(sizeof(PebbleEvent) <= 12,
                  "You made the PebbleEvent bigger! It should be no more than 12");
@@ -114,7 +114,7 @@ static uint32_t prv_get_fancy_type_from_event(const PebbleEvent *event) {
 }
 
 static void prv_log_event_put_failure(const char *queue_name, uintptr_t saved_lr, const PebbleEvent *event) {
-  PBL_LOG(LOG_LEVEL_ERROR, "Error, %s queue full. Type %u", queue_name, event->type);
+  PBL_LOG_ERR("Error, %s queue full. Type %u", queue_name, event->type);
 
   RebootReason reason = {
     .code = RebootReasonCode_EventQueueFull,

--- a/src/fw/kernel/fault_handling.c
+++ b/src/fw/kernel/fault_handling.c
@@ -101,8 +101,8 @@ static void prv_log_app_lr_and_pc_system_task(void *data) {
 
   APP_LOG(APP_LOG_LEVEL_ERROR, "%s fault! %s PC: %s LR: %s", process_string, buffer, pc_str, lr_str);
 
-  PBL_LOG(LOG_LEVEL_ERROR, "%s fault! %s", process_string, buffer);
-  PBL_LOG(LOG_LEVEL_ERROR, " --> PC: %s LR: %s", pc_str, lr_str);
+  PBL_LOG_ERR("%s fault! %s", process_string, buffer);
+  PBL_LOG_ERR(" --> PC: %s LR: %s", pc_str, lr_str);
 
   analytics_event_app_crash(&crash_info->app_uuid,
                             (crash_info->pc_known) ? crash_info->pc : 0,
@@ -262,7 +262,7 @@ static void prv_return_to_landing_zone(uintptr_t stacked_pc, uintptr_t stacked_l
 
 static void attempt_handle_stack_overflow(unsigned int* stacked_args) {
   PebbleTask task = pebble_task_get_current();
-  PBL_LOG_SYNC(LOG_LEVEL_ERROR, "Stack overflow [task: %s]", pebble_task_get_name(task));
+  PBL_LOG_SYNC_ERR("Stack overflow [task: %s]", pebble_task_get_name(task));
 
   if (mcu_state_is_thread_privileged()) {
     // We're hosed! We can't recover so just reboot everything.

--- a/src/fw/kernel/panic.c
+++ b/src/fw/kernel/panic.c
@@ -17,7 +17,7 @@ void launcher_panic(uint32_t error_code) {
 
   s_current_error = error_code;
 
-  PBL_LOG(LOG_LEVEL_ERROR, "!!!SAD WATCH 0x%"PRIX32" SAD WATCH!!!", error_code);
+  PBL_LOG_ERR("!!!SAD WATCH 0x%"PRIX32" SAD WATCH!!!", error_code);
 
   if (modal_manager_get_top_window()) {
     modal_manager_pop_all();

--- a/src/fw/kernel/system_message.c
+++ b/src/fw/kernel/system_message.c
@@ -35,11 +35,11 @@ void system_message_send(SystemMessageType type) {
   uint8_t buffer[2] = { 0x00, type };
   CommSession *system_session = comm_session_get_system_session();
   comm_session_send_data(system_session, ENDPOINT_ID, buffer, sizeof(buffer), COMM_SESSION_DEFAULT_TIMEOUT);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Sending sysmsg: %u", type);
+  PBL_LOG_DBG("Sending sysmsg: %u", type);
 }
 
 static void prv_reset_kernel_bg_cb(void *unused) {
-  PBL_LOG(LOG_LEVEL_ALWAYS, "Rebooting to install firmware...");
+  PBL_LOG_ALWAYS("Rebooting to install firmware...");
   RebootReason reason = { RebootReasonCode_SoftwareUpdate, 0 };
   reboot_reason_set(&reason);
   system_reset();
@@ -53,7 +53,7 @@ static void prv_handle_firmware_complete_msg(void) {
   uint32_t timeout = 3000;
 
   // Wait 3 seconds before rebooting so there is time to show the update complete screen
-  PBL_LOG(LOG_LEVEL_ALWAYS, "Delaying reset by 3s so the UI can update...");
+  PBL_LOG_ALWAYS("Delaying reset by 3s so the UI can update...");
   TimerID timer = new_timer_create();  // Don't bother cleaning up this timer, we're going to reset
   PBL_ASSERTN(timer != TIMER_INVALID_ID);
   new_timer_start(timer, timeout, prv_ui_update_reset_delay_timer_callback, NULL, 0);
@@ -86,7 +86,7 @@ static void prv_handle_firmware_status_request(CommSession *session) {
     fw_status_resp.resource_crc = status.crc_of_bytes;
   }
 
-  PBL_LOG(LOG_LEVEL_INFO, "FW Status Resp: res %"PRIu32" : 0x%x fw %"PRIu32" : 0x%x",
+  PBL_LOG_INFO("FW Status Resp: res %"PRIu32" : 0x%x fw %"PRIu32" : 0x%x",
           fw_status_resp.resource_bytes_written, (int)fw_status_resp.resource_crc,
           fw_status_resp.firmware_bytes_written, (int)fw_status_resp.firmware_crc);
 
@@ -99,11 +99,11 @@ void sys_msg_protocol_msg_callback(CommSession *session, const uint8_t* data, si
 
   SystemMessageType t = data[1];
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Received sysmsg: %u", t);
+  PBL_LOG_DBG("Received sysmsg: %u", t);
 
   switch (t) {
   case SysMsgFirmwareAvailable_Deprecated: {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Deprecated available message received.");
+    PBL_LOG_DBG("Deprecated available message received.");
     break;
   }
 
@@ -121,7 +121,7 @@ void sys_msg_protocol_msg_callback(CommSession *session, const uint8_t* data, si
       SysMsgSmoothFirmwareStartPayload *payload = (SysMsgSmoothFirmwareStartPayload *)data;
       bytes_transferred = payload->bytes_already_transferred;
       total_size = bytes_transferred + payload->bytes_to_transfer;
-      PBL_LOG(LOG_LEVEL_INFO, "Starting FW update, %"PRIu32" of %"PRIu32" bytes already "
+      PBL_LOG_INFO("Starting FW update, %"PRIu32" of %"PRIu32" bytes already "
               "transferred", bytes_transferred, total_size);
     }
 
@@ -174,7 +174,7 @@ void sys_msg_protocol_msg_callback(CommSession *session, const uint8_t* data, si
   }
 
   default:
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid message received, type is %u", data[1]);
+    PBL_LOG_ERR("Invalid message received, type is %u", data[1]);
     break;
   }
 }

--- a/src/fw/kernel/system_versions.c
+++ b/src/fw/kernel/system_versions.c
@@ -108,7 +108,7 @@ static void prv_send_watch_versions(CommSession *session) {
   strncpy(versions_msg.iso_locale, i18n_get_locale(), ISO_LOCALE_LENGTH - 1);
   versions_msg.iso_locale[ISO_LOCALE_LENGTH - 1] = '\0';
   versions_msg.lang_version = htons(i18n_get_version());
-  PBL_LOG(LOG_LEVEL_DEBUG, "Sending lang version: %d", versions_msg.lang_version);
+  PBL_LOG_DBG("Sending lang version: %d", versions_msg.lang_version);
 
   // Set the capabilities as zero, effectively saying that we don't support anything.
   versions_msg.capabilities.flags = 0;
@@ -168,7 +168,7 @@ void system_version_protocol_msg_callback(CommSession *session, const uint8_t* d
     break;
   }
   default:
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid message received. First byte is %u", data[0]);
+    PBL_LOG_ERR("Invalid message received. First byte is %u", data[0]);
     break;
   }
 }

--- a/src/fw/kernel/task_timer.c
+++ b/src/fw/kernel/task_timer.c
@@ -300,7 +300,7 @@ TickType_t task_timer_manager_execute_expired_timers(TaskTimerManager *manager) 
         if (next_timer->repeating
             && (int64_t)next_expiry_time < (int64_t)(current_time - next_timer->period_ticks
                                             - 5 * RTC_TICKS_HZ)) {
-          PBL_LOG(LOG_LEVEL_WARNING, "NT: Skipping some callbacks for %p because we fell behind",
+          PBL_LOG_WRN("NT: Skipping some callbacks for %p because we fell behind",
                   next_timer->cb);
         }
       } else {

--- a/src/fw/kernel/util/factory_reset.c
+++ b/src/fw/kernel/util/factory_reset.c
@@ -31,7 +31,7 @@
 static bool s_in_factory_reset = false;
 
 static void prv_factory_reset_non_pfs_data() {
-  PBL_LOG_SYNC(LOG_LEVEL_INFO, "Factory resetting...");
+  PBL_LOG_SYNC_INFO("Factory resetting...");
 
   // This function can block the system task for a long time.
   // Prevent callbacks being added to the system task so it doesn't overflow.

--- a/src/fw/kernel/util/fw_reset.c
+++ b/src/fw/kernel/util/fw_reset.c
@@ -42,17 +42,17 @@ void reset_protocol_msg_callback(CommSession *session, const uint8_t* data, unsi
 
   switch (cmd) {
     case ResetCmdNormal:
-      PBL_LOG(LOG_LEVEL_WARNING, "Rebooting");
+      PBL_LOG_WRN("Rebooting");
       system_reset();
       break;
 
     case ResetCmdCoreDump:
-      PBL_LOG(LOG_LEVEL_INFO, "Core dump + Reboot triggered");
+      PBL_LOG_INFO("Core dump + Reboot triggered");
       core_dump_reset(true /* force overwrite any existing core dump */);
       break;
 
     case ResetCmdIntoRecovery:
-      PBL_LOG(LOG_LEVEL_WARNING, "Rebooting into PRF");
+      PBL_LOG_WRN("Rebooting into PRF");
       prv_reset_into_prf();
       break;
 
@@ -61,7 +61,7 @@ void reset_protocol_msg_callback(CommSession *session, const uint8_t* data, unsi
       break;
 
     default:
-      PBL_LOG(LOG_LEVEL_ERROR, "Invalid reset msg, data[0] %u", data[0]);
+      PBL_LOG_ERR("Invalid reset msg, data[0] %u", data[0]);
       break;
   }
 }

--- a/src/fw/kernel/util/standby.c
+++ b/src/fw/kernel/util/standby.c
@@ -38,7 +38,7 @@ static NORETURN prv_enter_standby(void) {
 #endif
 
 NORETURN enter_standby(RebootReasonCode reason) {
-  PBL_LOG(LOG_LEVEL_ALWAYS, "Preparing to enter standby mode.");
+  PBL_LOG_ALWAYS("Preparing to enter standby mode.");
 
   RebootReason reboot_reason = { reason, 0 };
   reboot_reason_set(&reboot_reason);

--- a/src/fw/main.c
+++ b/src/fw/main.c
@@ -123,19 +123,19 @@ static void print_splash_screen(void)
 {
 
 #if defined(MANUFACTURING_FW)
-  PBL_LOG(LOG_LEVEL_ALWAYS, "PebbleOS - MANUFACTURING MODE");
+  PBL_LOG_ALWAYS("PebbleOS - MANUFACTURING MODE");
 #elif defined(RECOVERY_FW)
-  PBL_LOG(LOG_LEVEL_ALWAYS, "PebbleOS - RECOVERY MODE");
+  PBL_LOG_ALWAYS("PebbleOS - RECOVERY MODE");
 #else
-  PBL_LOG(LOG_LEVEL_ALWAYS, "PebbleOS");
+  PBL_LOG_ALWAYS("PebbleOS");
 #endif
-  PBL_LOG(LOG_LEVEL_ALWAYS, "%s%s",
+  PBL_LOG_ALWAYS("%s%s",
           TINTIN_METADATA.version_tag,
           (TINTIN_METADATA.is_dual_slot && !TINTIN_METADATA.is_recovery_firmware) ?
             (TINTIN_METADATA.is_slot_0 ? " (slot0)" : " (slot1)") :
             "");
-  PBL_LOG(LOG_LEVEL_ALWAYS, "(c) 2013-2025 The PebbleOS contributors");
-  PBL_LOG(LOG_LEVEL_ALWAYS, " ");
+  PBL_LOG_ALWAYS("(c) 2013-2025 The PebbleOS contributors");
+  PBL_LOG_ALWAYS(" ");
 }
 
 #ifdef DUMP_GPIO_CFG_STATE
@@ -372,7 +372,7 @@ static void prv_test_sjlj(void) {
   else
     prv_sjlj_main(r);
   PBL_ASSERT(s_sjlj_num == 3, "SJLJ TRACK INCORRECT @ END");
-  PBL_LOG(LOG_LEVEL_ALWAYS, "sjlj works \\o/");
+  PBL_LOG_ALWAYS("sjlj works \\o/");
 }
 #endif
 
@@ -467,7 +467,7 @@ static NOINLINE void prv_main_task_init(void) {
   GPoint mfg_offset = mfg_info_get_disp_offsets();
   display_set_offset(mfg_offset);
   // Log display offsets for use in contact support logs
-  PBL_LOG(LOG_LEVEL_INFO, "MFG Display Offsets (%"PRIi16",%"PRIi16").", mfg_offset.x, mfg_offset.y);
+  PBL_LOG_INFO("MFG Display Offsets (%"PRIi16",%"PRIi16").", mfg_offset.x, mfg_offset.y);
   
   // Stop boot splash before initializing compositor
   boot_splash_stop();

--- a/src/fw/mfg/mfg_apps/mfg_flash_test.c
+++ b/src/fw/mfg/mfg_apps/mfg_flash_test.c
@@ -30,20 +30,20 @@ static FlashTestErrorType prv_read_verify_byte(uint32_t read_addr,
   flash_read_bytes((uint8_t *)&read_buffer, read_addr, sizeof(read_buffer));
 
   if (disp_logs) {
-    PBL_LOG(LOG_LEVEL_DEBUG, ">> Reading Addr 0x%"PRIx32" value is 0x%"PRIx8,
+    PBL_LOG_DBG(">> Reading Addr 0x%"PRIx32" value is 0x%"PRIx8,
             read_addr, read_buffer);
   }
 
   if (read_buffer != expected_val) {
     switch (err_code) {
       case FLASH_TEST_ERR_ERASE:
-        PBL_LOG(LOG_LEVEL_DEBUG, "ERROR: Did not successfully erase the sector");
+        PBL_LOG_DBG("ERROR: Did not successfully erase the sector");
         break;
       case FLASH_TEST_ERR_STUCK_AT_HIGH:
-        PBL_LOG(LOG_LEVEL_DEBUG, "ERROR: Address bit %d stuck at high", bitpos);
+        PBL_LOG_DBG("ERROR: Address bit %d stuck at high", bitpos);
         break;
       case FLASH_TEST_ERR_STUCK_AT_LOW:
-        PBL_LOG(LOG_LEVEL_DEBUG, "ERROR: Address bit %d stuck at low or shorted", bitpos);
+        PBL_LOG_DBG("ERROR: Address bit %d stuck at low or shorted", bitpos);
         break;
       default:
         break;
@@ -62,17 +62,17 @@ static FlashTestErrorType prv_read_verify_halfword(uint32_t read_addr,
   flash_read_bytes((uint8_t *)&read_buffer, read_addr, sizeof(read_buffer));
 
   if (disp_logs) {
-    PBL_LOG(LOG_LEVEL_DEBUG, ">> Reading Addr 0x%"PRIx32" value is 0x%"PRIx16,
+    PBL_LOG_DBG(">> Reading Addr 0x%"PRIx32" value is 0x%"PRIx16,
             read_addr, read_buffer);
   }
 
   if (read_buffer != expected_val) {
     switch (err_code) {
       case FLASH_TEST_ERR_ERASE:
-        PBL_LOG(LOG_LEVEL_DEBUG, "ERROR: Did not successfully erase the sector");
+        PBL_LOG_DBG("ERROR: Did not successfully erase the sector");
         break;
       case FLASH_TEST_ERR_DATA_WRITE:
-        PBL_LOG(LOG_LEVEL_DEBUG, "ERROR: Did not successfully write the data");
+        PBL_LOG_DBG("ERROR: Did not successfully write the data");
         break;
       default:
         break;
@@ -91,7 +91,7 @@ static FlashTestErrorType prv_write_read_verify_byte(uint32_t write_addr,
   uint8_t read_buffer = 0;
   // Write test pattern
   if (disp_logs) {
-    PBL_LOG(LOG_LEVEL_DEBUG, ">> Writing Addr 0x%"PRIx32" to value 0x%"PRIx8,
+    PBL_LOG_DBG(">> Writing Addr 0x%"PRIx32" to value 0x%"PRIx8,
             write_addr, write_val);
   }
   flash_write_bytes((uint8_t *)&write_buffer, write_addr, sizeof(write_buffer));
@@ -101,12 +101,12 @@ static FlashTestErrorType prv_write_read_verify_byte(uint32_t write_addr,
   flash_read_bytes((uint8_t*) &read_buffer, write_addr, sizeof(read_buffer));
 
   if (disp_logs) {
-    PBL_LOG(LOG_LEVEL_DEBUG, ">> Reading Addr 0x%"PRIx32" value is 0x%"PRIx8,
+    PBL_LOG_DBG(">> Reading Addr 0x%"PRIx32" value is 0x%"PRIx8,
             write_addr, read_buffer);
   }
 
   if (read_buffer != expected_val) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "ERROR: Did not successfully write the data");
+    PBL_LOG_DBG("ERROR: Did not successfully write the data");
     return FLASH_TEST_ERR_DATA_WRITE;
   }
 
@@ -122,7 +122,7 @@ static FlashTestErrorType prv_write_read_verify_halfword(uint32_t write_addr,
 
   // Write test pattern
   if (disp_logs) {
-    PBL_LOG(LOG_LEVEL_DEBUG, ">> Writing Addr 0x%"PRIx32" to value 0x%"PRIx16,
+    PBL_LOG_DBG(">> Writing Addr 0x%"PRIx32" to value 0x%"PRIx16,
             write_addr, write_val);
   }
 
@@ -133,12 +133,12 @@ static FlashTestErrorType prv_write_read_verify_halfword(uint32_t write_addr,
   flash_read_bytes((uint8_t*) &read_buffer, write_addr, sizeof(read_buffer));
 
   if (disp_logs) {
-    PBL_LOG(LOG_LEVEL_DEBUG, ">> Reading Addr 0x%"PRIx32" value is 0x%"PRIx16,
+    PBL_LOG_DBG(">> Reading Addr 0x%"PRIx32" value is 0x%"PRIx16,
             write_addr, read_buffer);
   }
 
   if (read_buffer != expected_val) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "ERROR: Did not successfully write the data");
+    PBL_LOG_DBG("ERROR: Did not successfully write the data");
     return FLASH_TEST_ERR_DATA_WRITE;
   }
 
@@ -157,7 +157,7 @@ static FlashTestErrorType prv_run_data_test(void) {
   FlashTestErrorType status = FLASH_TEST_SUCCESS;
   
   // Test each data bit using walking 1's method by toggling each data line
-  PBL_LOG(LOG_LEVEL_DEBUG, ">START - DATA TEST 1: Data bus test");
+  PBL_LOG_DBG(">START - DATA TEST 1: Data bus test");
 
   // Initialize region that is to be written
   uint16_t data_buffer = 0x0;
@@ -172,27 +172,27 @@ static FlashTestErrorType prv_run_data_test(void) {
   for (data_buffer = 1; data_buffer != 0; data_buffer <<= 1) {
     read_buffer = 0;
     flash_read_bytes((uint8_t*) &read_buffer, addr_region, sizeof(read_buffer));
-    PBL_LOG(LOG_LEVEL_DEBUG, ">> Reading Addr 0x%"PRIx32" value is 0x%"PRIx16,
+    PBL_LOG_DBG(">> Reading Addr 0x%"PRIx32" value is 0x%"PRIx16,
             addr_region, read_buffer);
 
     if (read_buffer != 0xFFFF) {
       // Erase sector only if necessary
       flash_erase_sector_blocking(addr_region);
       flash_read_bytes((uint8_t*) &read_buffer, addr_region, sizeof(read_buffer));
-      PBL_LOG(LOG_LEVEL_DEBUG, ">> Reading Addr 0x%"PRIx32" value is 0x%"PRIx16,
+      PBL_LOG_DBG(">> Reading Addr 0x%"PRIx32" value is 0x%"PRIx16,
               addr_region, read_buffer);
     }
 
     // All data should be set to 0xFFFF upon erase
     if (read_buffer != 0xFFFF) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "ERROR: Did not successfully erase the sector");
+      PBL_LOG_DBG("ERROR: Did not successfully erase the sector");
       return FLASH_TEST_ERR_ERASE;
     }
 
     // Read and compare data that was written
     status = prv_write_read_verify_halfword(addr_region, data_buffer, data_buffer, true);
     if (status != 0) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "ERROR: Data bit %d not returning correct data value", bitpos);
+      PBL_LOG_DBG("ERROR: Data bit %d not returning correct data value", bitpos);
       return status;
     }
 
@@ -200,7 +200,7 @@ static FlashTestErrorType prv_run_data_test(void) {
     addr_region += 4; // increment to the next address to avoid extra erases
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, ">PASS - DATA TEST 1: Data bus test");
+  PBL_LOG_DBG(">PASS - DATA TEST 1: Data bus test");
   return status;
 }
 
@@ -220,12 +220,12 @@ static FlashTestErrorType write_initial_pattern(bool display_logs, bool skip_bas
   uint8_t read_buffer = 0;
   uint32_t bit_offset;
 
-  if (display_logs) { PBL_LOG(LOG_LEVEL_DEBUG, ">>> Initializing data patterns..."); }
-  if (display_logs) { PBL_LOG(LOG_LEVEL_DEBUG, ">>> Erasing sectors..."); }
+  if (display_logs) { PBL_LOG_DBG(">>> Initializing data patterns..."); }
+  if (display_logs) { PBL_LOG_DBG(">>> Erasing sectors..."); }
   if (erase_addr) {
     // only erase the specific erase address
     if (display_logs) {
-      PBL_LOG(LOG_LEVEL_DEBUG, ">> Erasing Addr 0x%"PRIx32, *erase_addr);
+      PBL_LOG_DBG(">> Erasing Addr 0x%"PRIx32, *erase_addr);
     }
     flash_erase_sector_blocking(*erase_addr);
   } else {
@@ -249,11 +249,11 @@ static FlashTestErrorType write_initial_pattern(bool display_logs, bool skip_bas
         // Always erase base address
 
         flash_read_bytes((uint8_t*)&read_buffer, test_addr, sizeof(read_buffer));
-        PBL_LOG(LOG_LEVEL_DEBUG, ">> Testing Addr 0x%"PRIx32", value:0x%x", test_addr, read_buffer);
+        PBL_LOG_DBG(">> Testing Addr 0x%"PRIx32", value:0x%x", test_addr, read_buffer);
 
         if (((read_buffer != 0xFF) && (read_buffer != 0xAA)) || (test_addr == base_addr)) {
           if (display_logs) {
-            PBL_LOG(LOG_LEVEL_DEBUG, ">> Erasing Addr 0x%"PRIx32, test_addr);
+            PBL_LOG_DBG(">> Erasing Addr 0x%"PRIx32, test_addr);
           }
           flash_erase_sector_blocking(test_addr);
 
@@ -270,7 +270,7 @@ static FlashTestErrorType write_initial_pattern(bool display_logs, bool skip_bas
     }
   }
 
-  if (display_logs) { PBL_LOG(LOG_LEVEL_DEBUG, ">>> Erasing sectors...complete"); }
+  if (display_logs) { PBL_LOG_DBG(">>> Erasing sectors...complete"); }
 
   // Write default data pattern to each power-of-two offset within the test region
   for (bit_offset = 1; (bit_offset & addr_mask) != 0; bit_offset <<= 1) {
@@ -299,7 +299,7 @@ static FlashTestErrorType write_initial_pattern(bool display_logs, bool skip_bas
     read_buffer = 0;
     flash_read_bytes((uint8_t*) &read_buffer, test_addr, sizeof(read_buffer));
     if (display_logs) {
-      PBL_LOG(LOG_LEVEL_DEBUG, ">> Reading Addr 0x%"PRIx32" value is 0x%"PRIx8,
+      PBL_LOG_DBG(">> Reading Addr 0x%"PRIx32" value is 0x%"PRIx8,
               test_addr, read_buffer);
     }
 
@@ -308,7 +308,7 @@ static FlashTestErrorType write_initial_pattern(bool display_logs, bool skip_bas
     VERIFY_TEST_STATUS(status);
   }
 
-  if (display_logs) { PBL_LOG(LOG_LEVEL_DEBUG, ">>> Initializing data patterns...complete"); }
+  if (display_logs) { PBL_LOG_DBG(">>> Initializing data patterns...complete"); }
 
   return FLASH_TEST_SUCCESS;
 }
@@ -325,7 +325,7 @@ static FlashTestErrorType prv_run_addr_test (void) {
   ///////////////////////////////////////////////////
   /// Test 1: Check for address bits stuck at high
   ///////////////////////////////////////////////////
-  PBL_LOG(LOG_LEVEL_DEBUG, ">START - ADDR TEST 1: Check for address bits stuck at high");
+  PBL_LOG_DBG(">START - ADDR TEST 1: Check for address bits stuck at high");
 
   // Write data pattern (0xAA) to each power-of-2 offset within the flash
   status = write_initial_pattern(true /*display_logs*/, false /*skip_base_addr*/,
@@ -338,7 +338,7 @@ static FlashTestErrorType prv_run_addr_test (void) {
   // Read initial value
   read_buffer = 0;
   flash_read_bytes((uint8_t*) &read_buffer, test_addr, sizeof(read_buffer));
-  PBL_LOG(LOG_LEVEL_DEBUG, ">> Reading Addr 0x%"PRIx32" value is 0x%"PRIx8,
+  PBL_LOG_DBG(">> Reading Addr 0x%"PRIx32" value is 0x%"PRIx8,
           test_addr, read_buffer);
 
   // Write test pattern to address 0
@@ -358,7 +358,7 @@ static FlashTestErrorType prv_run_addr_test (void) {
     } else if (bit_offset == base_addr) {
       base_addr_pos = bitpos;
       // Skip base address check - that is done later
-      PBL_LOG(LOG_LEVEL_DEBUG, "Skip base address bit position %d", bitpos);
+      PBL_LOG_DBG("Skip base address bit position %d", bitpos);
       bitpos++;
       continue;
     } else {
@@ -366,7 +366,7 @@ static FlashTestErrorType prv_run_addr_test (void) {
     }
 
     if (test_addr >= FLASH_TEST_ADDR_END) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Skipping test address 0x%"PRIx32" which is out of range",
+      PBL_LOG_DBG("Skipping test address 0x%"PRIx32" which is out of range",
               test_addr);
       break;
     }
@@ -383,12 +383,12 @@ static FlashTestErrorType prv_run_addr_test (void) {
   
   // Special case - test bit for base address 
   // - Use an address between FLASH_TEST_ADDR_START and base_addr
-  PBL_LOG(LOG_LEVEL_DEBUG, ">> Testing special case for base address bit %d", base_addr_pos);
+  PBL_LOG_DBG(">> Testing special case for base address bit %d", base_addr_pos);
   // Read initial value
   test_addr = FLASH_REGION_FILESYSTEM_BEGIN;
   uint32_t special_case_addr = test_addr | base_addr;
   if ((test_addr >= base_addr) || (special_case_addr > FLASH_TEST_ADDR_END)) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "ERROR: Cannot test address bit for base_addr");
+    PBL_LOG_DBG("ERROR: Cannot test address bit for base_addr");
     return FLASH_TEST_ERR_ADDR_RANGE;
   }
 
@@ -424,14 +424,14 @@ static FlashTestErrorType prv_run_addr_test (void) {
     return FLASH_TEST_ERR_STUCK_AT_HIGH; 
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, ">PASS - ADDR TEST 1: Check for address bits stuck at high");
+  PBL_LOG_DBG(">PASS - ADDR TEST 1: Check for address bits stuck at high");
 
 
 
   /////////////////////////////////////////////////////////////
   /// Test 2: Check for address bits stuck at low or shorted
   /////////////////////////////////////////////////////////////
-  PBL_LOG(LOG_LEVEL_DEBUG, ">START - ADDR TEST 2: Check for address bits stuck at low or shorted");
+  PBL_LOG_DBG(">START - ADDR TEST 2: Check for address bits stuck at low or shorted");
 
   // NOTE that the previous test only modified the data at base_addr and left all other
   // power-of-2 addresses with the data pattern in them. The write_initial_pattern() method
@@ -457,7 +457,7 @@ static FlashTestErrorType prv_run_addr_test (void) {
     if (test_addr == base_addr) {
       continue;
     }
-    PBL_LOG(LOG_LEVEL_DEBUG, ">> Testing Stuck at Low at Addr 0x%"PRIx32, test_addr);
+    PBL_LOG_DBG(">> Testing Stuck at Low at Addr 0x%"PRIx32, test_addr);
 
     // After we write test_pattern, data should be set to 0x00 since existing data should be 0xAA
     // and we are writing 0x55
@@ -513,7 +513,7 @@ static FlashTestErrorType prv_run_addr_test (void) {
     return FLASH_TEST_ERR_STUCK_AT_LOW;
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, ">PASS - ADDR TEST 2: Check for address bits stuck at low or shorted");
+  PBL_LOG_DBG(">PASS - ADDR TEST 2: Check for address bits stuck at low or shorted");
 
   return FLASH_TEST_SUCCESS;
 }
@@ -538,13 +538,13 @@ static FlashTestErrorType setup_stress_addr_test(void) {
 
   if ((stress_addr1 < FLASH_REGION_FILESYSTEM_BEGIN) ||
       (stress_addr1 >= FLASH_REGION_FILESYSTEM_END)) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "ERROR: Invalid range");
+    PBL_LOG_DBG("ERROR: Invalid range");
     return FLASH_TEST_ERR_ADDR_RANGE;
   }
 
   if ((stress_addr2 < FLASH_REGION_FILESYSTEM_BEGIN) ||
       (stress_addr2 >= FLASH_REGION_FILESYSTEM_END)) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "ERROR: Invalid range");
+    PBL_LOG_DBG("ERROR: Invalid range");
     return FLASH_TEST_ERR_ADDR_RANGE;
   }
 
@@ -557,11 +557,11 @@ static FlashTestErrorType setup_stress_addr_test(void) {
   VERIFY_TEST_STATUS(status);
 
   // Write data to stress address locations
-  PBL_LOG(LOG_LEVEL_DEBUG, ">> Writing Addr 0x%"PRIx32" to value 0x%"PRIx16,
+  PBL_LOG_DBG(">> Writing Addr 0x%"PRIx32" to value 0x%"PRIx16,
           stress_addr1, stress_data1);
   flash_write_bytes((uint8_t *)&stress_data1, stress_addr1, sizeof(stress_data1));
 
-  PBL_LOG(LOG_LEVEL_DEBUG, ">> Writing Addr 0x%"PRIx32" to value 0x%"PRIx16,
+  PBL_LOG_DBG(">> Writing Addr 0x%"PRIx32" to value 0x%"PRIx16,
           stress_addr2, stress_data2);
   flash_write_bytes((uint8_t *)&stress_data2, stress_addr2, sizeof(stress_data2));
 
@@ -571,7 +571,7 @@ static FlashTestErrorType setup_stress_addr_test(void) {
 // Run address read/write stess test - if iterations is 0, then stop only when button is pushed; 
 //   else go until iterations hit
 static FlashTestErrorType prv_run_stress_addr_test(uint32_t iterations) {
-  PBL_LOG(LOG_LEVEL_DEBUG, ">START - STRESS TEST 1");
+  PBL_LOG_DBG(">START - STRESS TEST 1");
 
   uint16_t halfwordcount = 0;
   unsigned int iteration_count = 0;
@@ -605,18 +605,18 @@ static FlashTestErrorType prv_run_stress_addr_test(uint32_t iterations) {
     if (halfwordcount*2 % (256*1024) == 0) {
       // Reading flash words (which are 16 bits) hence double
       if (iterations) {
-        PBL_LOG(LOG_LEVEL_DEBUG, ">> Read 256KB, iteration: %d of %"PRId32,
+        PBL_LOG_DBG(">> Read 256KB, iteration: %d of %"PRId32,
                 iteration_count, iterations);
       } else {
-        PBL_LOG(LOG_LEVEL_DEBUG, ">> Read 256KB, iteration: %d", iteration_count);
+        PBL_LOG_DBG(">> Read 256KB, iteration: %d", iteration_count);
       }
     }
 
     iteration_count++;
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Ran %d iterations", iteration_count);
-  PBL_LOG(LOG_LEVEL_DEBUG, ">PASS - STRESS TEST 1");
+  PBL_LOG_DBG("Ran %d iterations", iteration_count);
+  PBL_LOG_DBG(">PASS - STRESS TEST 1");
 
   return FLASH_TEST_SUCCESS;
 }
@@ -637,7 +637,7 @@ static FlashTestErrorType prv_run_stress_addr_test(uint32_t iterations) {
     } else {                               \
      _tot += (UINT32_MAX - _start) + _end; \
     }                                      \
-    PBL_LOG(LOG_LEVEL_DEBUG, "Read %lu bytes %lu ticks %lu us", x, _tot, _tot / 64); \
+    PBL_LOG_DBG("Read %lu bytes %lu ticks %lu us", x, _tot, _tot / 64); \
 } while (0)
 
 #define SWAP(a, b)     \
@@ -654,7 +654,7 @@ static FlashTestErrorType prv_run_stress_addr_test(uint32_t iterations) {
 static FlashTestErrorType prv_run_perf_data_test(void) {
   uint8_t *read_buffer = (uint8_t *) app_malloc(MAX_READ_BUFF_SIZE);
   if (!read_buffer) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "ERROR: Not enough memory to run test");
+    PBL_LOG_DBG("ERROR: Not enough memory to run test");
     return FLASH_TEST_ERR_OOM;
   }
 
@@ -685,7 +685,7 @@ static FlashTestErrorType prv_run_perf_data_test(void) {
       }
     }
     
-    PBL_LOG(LOG_LEVEL_DEBUG, "Read %lu bytes, median throughput %lu KBps", num_bytes, (num_bytes * 1000 * 64 / ticks[1]));
+    PBL_LOG_DBG("Read %lu bytes, median throughput %lu KBps", num_bytes, (num_bytes * 1000 * 64 / ticks[1]));
   }
   
   app_free(read_buffer);
@@ -737,10 +737,10 @@ FlashTestErrorType run_flash_test_case(FlashTestCaseType test_case_num, uint32_t
   enable_flash_test = false;
 
   if (status == FLASH_TEST_SUCCESS) {
-    PBL_LOG(LOG_LEVEL_DEBUG, ">>>>>PASS FLASH TEST CASE %d<<<<<", test_case_num);
+    PBL_LOG_DBG(">>>>>PASS FLASH TEST CASE %d<<<<<", test_case_num);
   }
   else {
-    PBL_LOG(LOG_LEVEL_DEBUG, ">>>>>FAIL FLASH TEST CASE %d, Status: %d<<<<<", test_case_num, status);
+    PBL_LOG_DBG(">>>>>FAIL FLASH TEST CASE %d, Status: %d<<<<<", test_case_num, status);
   }
   
   // Re-enable watchdog state if previously enabled

--- a/src/fw/mfg/snowy/mfg_info.c
+++ b/src/fw/mfg/snowy/mfg_info.c
@@ -92,9 +92,9 @@ void mfg_info_set_disp_offsets(GPoint p) {
 
 void mfg_info_update_constant_data(void) {
   if (mfg_info_is_boot_fpga_bitstream_written()) {
-    PBL_LOG(LOG_LEVEL_INFO, "Boot FPGA bitstream already in flash.");
+    PBL_LOG_INFO("Boot FPGA bitstream already in flash.");
   } else {
-    PBL_LOG(LOG_LEVEL_INFO, "Writing boot FPGA bitstream to flash...");
+    PBL_LOG_INFO("Writing boot FPGA bitstream to flash...");
     mfg_info_write_boot_fpga_bitstream();
   }
 }

--- a/src/fw/mfg/spalding/boot_fpga.c
+++ b/src/fw/mfg/spalding/boot_fpga.c
@@ -28,7 +28,7 @@ bool mfg_info_is_boot_fpga_bitstream_written(void) {
   if (header.fpga_len != expected_fpga_header.fpga_len ||
       header.fpga_len_complemented != expected_fpga_header.fpga_len_complemented) {
 
-    PBL_LOG(LOG_LEVEL_DEBUG, "Boot FPGA length invalid, needs a rewrite");
+    PBL_LOG_DBG("Boot FPGA length invalid, needs a rewrite");
 
     // The length doesn't even match, we definitely need to update.
     return false;
@@ -40,7 +40,7 @@ bool mfg_info_is_boot_fpga_bitstream_written(void) {
   uint32_t stored_crc = flash_crc32(
       BOOT_FPGA_FLASH_ADDR + sizeof(BootFPGAHeader), sizeof(s_boot_fpga));
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Comparing boot FPGA CRCs, expected 0x%"PRIx32" found 0x%"PRIx32,
+  PBL_LOG_DBG("Comparing boot FPGA CRCs, expected 0x%"PRIx32" found 0x%"PRIx32,
           expected_crc, stored_crc);
 
   return expected_crc == stored_crc;

--- a/src/fw/mfg/spalding/mfg_info.c
+++ b/src/fw/mfg/spalding/mfg_info.c
@@ -106,9 +106,9 @@ void mfg_info_set_model(const char* model) {
 
 void mfg_info_update_constant_data(void) {
   if (mfg_info_is_boot_fpga_bitstream_written()) {
-    PBL_LOG(LOG_LEVEL_INFO, "Boot FPGA bitstream already in flash.");
+    PBL_LOG_INFO("Boot FPGA bitstream already in flash.");
   } else {
-    PBL_LOG(LOG_LEVEL_INFO, "Writing boot FPGA bitstream to flash...");
+    PBL_LOG_INFO("Writing boot FPGA bitstream to flash...");
 
     // Read the mfg data and write it back again. The prv_update_struct function write in a fresh
     // copy of the FPGA image as a side effect.

--- a/src/fw/popups/bluetooth_pairing_ui.c
+++ b/src/fw/popups/bluetooth_pairing_ui.c
@@ -1,8 +1,6 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define FILE_LOG_COLOR LOG_COLOR_BLUE
-
 #include "bluetooth_pairing_ui.h"
 
 #include "applib/fonts/fonts.h"
@@ -484,7 +482,7 @@ static void prv_show_failure_kernel_main_cb(void *unused) {
 }
 
 static void prv_pairing_timeout_timer_callback(void *unused) {
-  PBL_LOG(LOG_LEVEL_WARNING, "SSP timeout fired!");
+  PBL_LOG_WRN("SSP timeout fired!");
   launcher_task_add_callback(prv_show_failure_kernel_main_cb, NULL);
 }
 
@@ -566,7 +564,7 @@ static void prv_handle_confirmation_request(const PairingUserConfirmationCtx *ct
 
 static void prv_handle_pairing_complete(bool success) {
   if (!s_data_ptr) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Dialog was not present, but got complete (%u) event", success);
+    PBL_LOG_WRN("Dialog was not present, but got complete (%u) event", success);
     return;
   }
 
@@ -574,19 +572,18 @@ static void prv_handle_pairing_complete(bool success) {
   if (data->ui_state == BTPairingUIStateAwaitingUserConfirmation) {
     prv_exit_awaiting_user_confirmation(data);
   } else if (data->ui_state != BTPairingUIStateAwaitingResult) {
-    PBL_LOG(LOG_LEVEL_WARNING,
-            "Got completion (%u) but not right state", success);
+    PBL_LOG_WRN("Got completion (%u) but not right state", success);
     return;
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Got Completion! %u", success);
+  PBL_LOG_DBG("Got Completion! %u", success);
   data->ui_state = success ? BTPairingUIStateSuccess : BTPairingUIStateFailed;
   prv_adjust_background_frame_for_state(data);
 
   if (!new_timer_stop(data->timer)) {
     // Timer was already executing...
     if (success) {
-      PBL_LOG(LOG_LEVEL_WARNING, "Timeout cb executing while received successful completion event");
+      PBL_LOG_WRN("Timeout cb executing while received successful completion event");
     }
   }
 
@@ -611,7 +608,7 @@ void bluetooth_pairing_ui_handle_event(PebbleBluetoothPairEvent *event) {
       if (s_data_ptr && s_data_ptr->ctx == event->ctx) {
         prv_handle_pairing_complete(event->success);
       } else {
-        PBL_LOG(LOG_LEVEL_ERROR, "Got complete event for unknown process %p vs %p",
+        PBL_LOG_ERR("Got complete event for unknown process %p vs %p",
                 event->ctx, s_data_ptr ? s_data_ptr->ctx : NULL);
       }
       break;

--- a/src/fw/popups/notifications/notification_window.c
+++ b/src/fw/popups/notifications/notification_window.c
@@ -250,7 +250,7 @@ static void prv_dismiss_all(void *data, ActionMenu *action_menu) {
     notif_list[i].type = notifications_presented_list_get_type(id);
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Dismissing %d notifications", num_notifications);
+  PBL_LOG_DBG("Dismissing %d notifications", num_notifications);
   window_data->window_frozen = true;
   timeline_actions_dismiss_all(notif_list,
                                num_notifications,
@@ -503,14 +503,14 @@ T_STATIC LayoutLayer *prv_get_layout_handler(SwapLayer *swap_layer, int8_t rel_p
 
   if (type == NotificationMobile) {
     if (!notification_storage_get(id, item)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Failed to read notification");
+      PBL_LOG_ERR("Failed to read notification");
       goto cleanup;
     }
   } else if (type == NotificationReminder) {
     // validate reminder
     int rv = reminder_db_read_item(item, id);
     if (rv != S_SUCCESS) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Failed to read reminder");
+      PBL_LOG_ERR("Failed to read reminder");
       goto cleanup;
     }
   }
@@ -628,7 +628,7 @@ static void prv_clear_if_stale_reminder(Uuid *id, NotificationType type, void *c
   const time_t now = rtc_get_time();
 
   if (stale_time <= now && window_data->is_modal) {
-    PBL_LOG(LOG_LEVEL_INFO, "Removing stale reminder from notification popup window");
+    PBL_LOG_INFO("Removing stale reminder from notification popup window");
     prv_remove_notification(window_data, id, true /* close am */);
   }
 }
@@ -756,7 +756,7 @@ static void prv_mute_notification(const ActionMenuItem *action_menu_item,
 
   const char *app_id = attribute_get_string(&item->attr_list, AttributeIdiOSAppIdentifier, "");
   if (!*app_id) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Could not mute notification. Unknown app_id");
+    PBL_LOG_ERR("Could not mute notification. Unknown app_id");
     return;
   }
 
@@ -777,7 +777,7 @@ static void prv_mute_notification(const ActionMenuItem *action_menu_item,
     // This is a very unlikely case. We store some default prefs which includes the mute
     // attribute when we receive the notification so either someone deleted the entry
     // in the DB or the mute attribute (neither of which should happen)
-    PBL_LOG(LOG_LEVEL_WARNING, "Could not mute notification. No prefs or mute attribute");
+    PBL_LOG_WRN("Could not mute notification. No prefs or mute attribute");
   }
 
   ios_notif_pref_db_free_prefs(notif_prefs);
@@ -974,7 +974,7 @@ static void prv_select_single_click_handler(ClickRecognizerRef recognizer, void 
 
   config.root_level = prv_create_action_menu_for_item(item, window_data, source);
   if (config.root_level == NULL) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Couldn't create notification action menu");
+    PBL_LOG_ERR("Couldn't create notification action menu");
     return;
   }
 

--- a/src/fw/popups/phone_ui.c
+++ b/src/fw/popups/phone_ui.c
@@ -435,7 +435,7 @@ static void prv_window_update_proc(Layer *layer, GContext *ctx) {
 
 //! Ring functionality
 static void prv_ring(void *unused) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "RING");
+  PBL_LOG_DBG("RING");
   if (alerts_should_vibrate_for_type(AlertPhoneCall)) {
 #if CAPABILITY_HAS_VIBE_SCORES
     if (!s_phone_ui_data || !s_phone_ui_data->vibe_score) {
@@ -1053,7 +1053,7 @@ static void prv_phone_ui_init(void) {
 
 static bool prv_check_popups_are_blocked(void) {
   if (launcher_popups_are_blocked()) {
-    PBL_LOG(LOG_LEVEL_INFO, "Ignoring call event. Popups are blocked");
+    PBL_LOG_INFO("Ignoring call event. Popups are blocked");
     return true;
   }
   return false;
@@ -1136,7 +1136,7 @@ void phone_ui_handle_missed_call(void) {
 
 void phone_ui_handle_call_start(bool can_decline) {
   if (!s_phone_ui_data) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Can't handle call start, UI isn't setup");
+    PBL_LOG_ERR("Can't handle call start, UI isn't setup");
     return;
   }
 
@@ -1160,7 +1160,7 @@ void phone_ui_handle_call_start(bool can_decline) {
 
 void phone_ui_handle_call_end(bool call_accepted, bool disconnected) {
   if (!s_phone_ui_data) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Can't handle call end, UI isn't setup");
+    PBL_LOG_ERR("Can't handle call end, UI isn't setup");
     return;
   }
 
@@ -1195,7 +1195,7 @@ void phone_ui_handle_call_hide(void) {
 
 void phone_ui_handle_caller_id(PebblePhoneCaller *caller) {
   if (!s_phone_ui_data) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Can't update caller id, UI isn't setup");
+    PBL_LOG_ERR("Can't update caller id, UI isn't setup");
     return;
   }
 

--- a/src/fw/popups/timeline/peek.c
+++ b/src/fw/popups/timeline/peek.c
@@ -495,7 +495,7 @@ void timeline_peek_dismiss(void) {
   } else {
     char uuid_buffer[UUID_STRING_BUFFER_LENGTH];
     uuid_to_string(&item->header.id, uuid_buffer);
-    PBL_LOG(LOG_LEVEL_WARNING, "Failed to dismiss Timeline Peek event %s (status: %"PRIi32")",
+    PBL_LOG_WRN("Failed to dismiss Timeline Peek event %s (status: %"PRIi32")",
             uuid_buffer, rv);
   }
 }

--- a/src/fw/process_management/app_install_manager.c
+++ b/src/fw/process_management/app_install_manager.c
@@ -321,7 +321,7 @@ static void prv_app_install_delete(AppInstallId id, Uuid *uuid, bool app_upgrade
   if (delete_cache) {
     // only log when we actually delete the cache entry. This is so we don't print out 100 logs
     // during an app cache clear
-    PBL_LOG(LOG_LEVEL_INFO, "Deleting app with id %"PRId32"", id);
+    PBL_LOG_INFO("Deleting app with id %"PRId32"", id);
     app_cache_remove_entry(id);
   }
 }
@@ -337,7 +337,7 @@ static void prv_delete_pending_id(AppInstallId *app_id) {
 static void prv_process_pending_deletions(void) {
   prv_delete_pending_id(&s_pending_app_deletion);
   prv_delete_pending_id(&s_pending_worker_deletion);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Finished processing pending deletions");
+  PBL_LOG_DBG("Finished processing pending deletions");
 }
 
 typedef struct InstallCallbackData {
@@ -386,7 +386,7 @@ static void app_install_launcher_task_callback(void *context) {
       if (prv_ids_equal(cur_app_id, to_kill) ||
             ((s_install_callback_data.install_type == APP_DB_CLEARED) &&
              (app_install_id_from_app_db(cur_app_id)))) {
-        PBL_LOG(LOG_LEVEL_DEBUG, "close and delay callbacks for app closing");
+        PBL_LOG_DBG("close and delay callbacks for app closing");
 
         s_install_callback_data.callback_paused_for_app = true;
         s_pending_app_deletion = cur_app_id;
@@ -401,7 +401,7 @@ static void app_install_launcher_task_callback(void *context) {
       if (prv_ids_equal(cur_worker_id, to_kill) ||
           ((s_install_callback_data.install_type == APP_DB_CLEARED) &&
            (app_install_id_from_app_db(cur_worker_id)))) {
-        PBL_LOG(LOG_LEVEL_DEBUG, "close and delay callbacks for worker closing");
+        PBL_LOG_DBG("close and delay callbacks for worker closing");
 
         s_install_callback_data.callback_paused_for_worker = true;
         s_pending_worker_deletion = cur_worker_id;
@@ -418,7 +418,7 @@ static void app_install_launcher_task_callback(void *context) {
     }
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "app_install_invoke_callbacks");
+  PBL_LOG_DBG("app_install_invoke_callbacks");
   app_install_invoke_callbacks(s_install_callback_data.install_type,
                                s_install_callback_data.install_id);
 
@@ -461,7 +461,7 @@ static void app_install_launcher_task_callback(void *context) {
 bool app_install_do_callbacks(InstallEventType event_type, AppInstallId install_id,
     Uuid *uuid, InstallCallbackDoneCallback done_callback, void* callback_data) {
   if (s_install_callback_data.callback_in_progress) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to do app callbacks, already in progress");
+    PBL_LOG_ERR("Failed to do app callbacks, already in progress");
     return false;
   }
 
@@ -664,7 +664,7 @@ static bool prv_app_install_entry_from_resource_registry_entry(const AppRegistry
 
   if (resource_load_byte_range_system(SYSTEM_APP, reg_entry->bin_resource_id, 0,
         (uint8_t *)app_header, sizeof(*app_header)) != sizeof(*app_header)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Stored app with resource id %d not found in resources",
+    PBL_LOG_WRN("Stored app with resource id %d not found in resources",
             reg_entry->bin_resource_id);
     goto done;
   }
@@ -733,7 +733,7 @@ bool app_install_get_entry_for_install_id(AppInstallId install_id, AppInstallEnt
         break;
       case AppInstallStorageInvalid:
       case AppInstallStorageFlash:
-        PBL_LOG(LOG_LEVEL_DEBUG, "Invalid app registry type %d", reg_entry->type);
+        PBL_LOG_DBG("Invalid app registry type %d", reg_entry->type);
         break;
     }
     if (rv) {
@@ -750,7 +750,7 @@ bool app_install_get_entry_for_install_id(AppInstallId install_id, AppInstallEnt
     return rv;
   }
 
-  PBL_LOG(LOG_LEVEL_ERROR, "Failed to get entry for id %"PRId32, install_id);
+  PBL_LOG_ERR("Failed to get entry for id %"PRId32, install_id);
   return false;
 }
 
@@ -784,7 +784,7 @@ static const PebbleProcessMd *prv_get_md_for_reg_entry(const AppRegistryEntry *r
       PebbleProcessInfo app_header;
       if (resource_load_byte_range_system(SYSTEM_APP, reg_entry->bin_resource_id, 0,
             (uint8_t *)&app_header, sizeof(app_header)) != sizeof(app_header)) {
-        PBL_LOG(LOG_LEVEL_WARNING, "Stored app with resource id %d not found in resources",
+        PBL_LOG_WRN("Stored app with resource id %d not found in resources",
                 reg_entry->bin_resource_id);
         return NULL;
       }
@@ -813,7 +813,7 @@ static const PebbleProcessMd *prv_get_md_for_flash_id(AppInstallId id, bool work
   const PebbleTask task = worker ? PebbleTask_Worker : PebbleTask_App;
   if (GET_APP_INFO_SUCCESS !=
       app_storage_get_process_info(&app_header, build_id_buffer, id, task)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Failed to get app from flash with id %"PRIu32, id);
+    PBL_LOG_WRN("Failed to get app from flash with id %"PRIu32, id);
     return NULL;
   }
 
@@ -835,7 +835,7 @@ const PebbleProcessMd *app_install_get_md(AppInstallId id, bool worker) {
   }
 
   // Not a registered app, fail.
-  PBL_LOG(LOG_LEVEL_ERROR, "Can't get PebbleProcessMd for app id %"PRId32, id);
+  PBL_LOG_ERR("Can't get PebbleProcessMd for app id %"PRId32, id);
   return NULL;
 }
 

--- a/src/fw/process_management/app_run_state.c
+++ b/src/fw/process_management/app_run_state.c
@@ -33,10 +33,10 @@ static void prv_send_response(void *data) {
                                             COMM_SESSION_DEFAULT_TIMEOUT);
 
       uuid_to_string(&app_run_state->uuid, uuid_buffer);
-      PBL_LOG(LOG_LEVEL_DEBUG, "AppRunState(0x34) %s sending status: %s - %u",
+      PBL_LOG_DBG("AppRunState(0x34) %s sending status: %s - %u",
               (success ? "success" : "failed"), uuid_buffer, app_run_state->state);
     } else {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Using deprecated launcher_app_message");
+      PBL_LOG_DBG("Using deprecated launcher_app_message");
       const bool is_running = ((app_run_state->state == RUNNING) ? true : false);
       launcher_app_message_send_app_state_deprecated(&app_run_state->uuid, is_running);
     }
@@ -54,7 +54,7 @@ void app_run_state_command(CommSession *session, AppRunStateCommand cmd, const U
   if (install_id == INSTALL_ID_INVALID && cmd != APP_RUN_STATE_STATUS_COMMAND) {
     char uuid_buffer[UUID_STRING_BUFFER_LENGTH];
     uuid_to_string(uuid, uuid_buffer);
-    PBL_LOG(LOG_LEVEL_DEBUG, "No app found with uuid %s", uuid_buffer);
+    PBL_LOG_DBG("No app found with uuid %s", uuid_buffer);
     return;
   }
 
@@ -89,7 +89,7 @@ void app_run_state_command(CommSession *session, AppRunStateCommand cmd, const U
       }
       break;
     default:
-      PBL_LOG(LOG_LEVEL_ERROR, "Unknown command: %d", cmd);
+      PBL_LOG_ERR("Unknown command: %d", cmd);
   }
 }
 
@@ -103,7 +103,7 @@ void app_run_state_protocol_msg_callback(CommSession *session, const uint8_t *da
 
   if (msg->command != APP_RUN_STATE_STATUS_COMMAND) {
     if (length < sizeof(AppStateMessage)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "length mismatch, expected %"PRIu32" byte(s), got %"PRIu32" bytes",
+      PBL_LOG_ERR("length mismatch, expected %"PRIu32" byte(s), got %"PRIu32" bytes",
               (uint32_t) sizeof(AppStateMessage), (uint32_t) length);
       return;
     }

--- a/src/fw/process_management/launcher_app_message.c
+++ b/src/fw/process_management/launcher_app_message.c
@@ -62,7 +62,7 @@ void launcher_app_message_send_app_state_deprecated(const Uuid *uuid, bool runni
 
 static bool prv_has_invalid_length(size_t expected, size_t actual) {
   if (actual < expected) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Too short");
+    PBL_LOG_ERR("Too short");
     return true;
   }
   return false;

--- a/src/fw/process_management/worker_manager.c
+++ b/src/fw/process_management/worker_manager.c
@@ -125,7 +125,7 @@ bool worker_manager_launch_new_worker_with_args(const PebbleProcessMd *app_md, c
 
   // If workers are disabled, don't launch
   if (!s_workers_enabled) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Workers disabled");
+    PBL_LOG_WRN("Workers disabled");
     return false;
   }
 
@@ -148,7 +148,7 @@ bool worker_manager_launch_new_worker_with_args(const PebbleProcessMd *app_md, c
 
   // Error if a worker already launched
   if (pebble_task_get_handle_for_task(PebbleTask_Worker) != NULL) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Worker already launched");
+    PBL_LOG_WRN("Worker already launched");
     return false;
   }
 
@@ -186,21 +186,21 @@ bool worker_manager_launch_new_worker_with_args(const PebbleProcessMd *app_md, c
                                           &worker_segment);
   s_worker_task_context.load_end = worker_segment.start;
   if (!entry_point) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Tried to launch an invalid worker in bank %u!",
+    PBL_LOG_WRN("Tried to launch an invalid worker in bank %u!",
             process_metadata_get_code_bank_num(app_md));
     return false;
   }
 
   // The rest of worker_ram is available for worker state to use as it sees fit.
   if (!worker_state_configure(&worker_ram)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Worker state configuration failed");
+    PBL_LOG_ERR("Worker state configuration failed");
     return false;
   }
   // The remaining space in worker_segment is assigned to the worker's
   // heap. Worker state needs to be configured before initializing the
   // heap as the WorkerState struct holds the worker heap's Heap object.
   Heap *worker_heap = worker_state_get_heap();
-  PBL_LOG(LOG_LEVEL_DEBUG, "Worker heap init %p %p",
+  PBL_LOG_DBG("Worker heap init %p %p",
           worker_segment.start, worker_segment.end);
   heap_init(worker_heap, worker_segment.start, worker_segment.end,
             /* enable_heap_fuzzing */ false);
@@ -224,7 +224,7 @@ bool worker_manager_launch_new_worker_with_args(const PebbleProcessMd *app_md, c
     .puxStackBuffer = stack,
   };
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Starting %s", task_name);
+  PBL_LOG_DBG("Starting %s", task_name);
 
   pebble_task_create(PebbleTask_Worker, &task_params, &s_worker_task_context.task_handle);
 
@@ -282,7 +282,7 @@ void worker_manager_close_current_worker(bool gracefully) {
   // to post another KILL event in a few seconds, thus giving the process a chance to clean up.
   if (!process_manager_make_process_safe_to_kill(PebbleTask_Worker, gracefully)) {
     // Maybe next time...
-    PBL_LOG(LOG_LEVEL_DEBUG, "Worker not ready to exit");
+    PBL_LOG_DBG("Worker not ready to exit");
     return;
   }
 

--- a/src/fw/resource/resource.c
+++ b/src/fw/resource/resource.c
@@ -122,7 +122,7 @@ size_t resource_load_byte_range_system(ResAppNum app_num, uint32_t resource_id,
     // We want to stop the FW from doing this, so we added an assert
     // but in the name of backwards compatibility, we let the app misbehave
     num_bytes = resource.length - offset;
-    PBL_LOG(LOG_LEVEL_DEBUG, "Tried to read past end of resource, reading %d bytes",
+    PBL_LOG_DBG("Tried to read past end of resource, reading %d bytes",
             (int)num_bytes);
   }
 

--- a/src/fw/resource/resource_storage_file.c
+++ b/src/fw/resource/resource_storage_file.c
@@ -64,7 +64,7 @@ static int prv_file_open_by_name(const char *name, uint8_t op_flags) {
   int fd = pfs_open(name, op_flags, FILE_TYPE_STATIC, 0);
 
   if ((fd < 0) && (fd != E_DOES_NOT_EXIST)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Could not open resource pfs file <%s>, fd: %d", name, fd);
+    PBL_LOG_WRN("Could not open resource pfs file <%s>, fd: %d", name, fd);
   }
 
   return fd;
@@ -143,14 +143,14 @@ static void resource_storage_file_init(void) {
     const int fd = prv_file_open_by_name(name, op_flags);
 
     const uint32_t file_length = prv_file_common_get_length_and_close(fd);
-    PBL_LOG(LOG_LEVEL_INFO, "File %s has length %"PRIu32, name, file_length);
+    PBL_LOG_INFO("File %s has length %"PRIu32, name, file_length);
 
     // Now check each entry in the file
     for (uint32_t resource_id = g_file_resource_stores[i].first_resource_id;
          resource_id <= g_file_resource_stores[i].last_resource_id; resource_id++) {
       // TODO PBL-21402
       if (!resource_storage_check(SYSTEM_APP, resource_id, NULL)) {
-        PBL_LOG(LOG_LEVEL_ERROR, "System resource file %"PRIu32" corrupt!!!", resource_id);
+        PBL_LOG_ERR("System resource file %"PRIu32" corrupt!!!", resource_id);
       }
 
       const uint32_t large_file_size_threshold = 200 * 1024;
@@ -198,7 +198,7 @@ static int prv_app_file_open(ResourceStoreEntry *entry, uint8_t op_flags) {
   int fd = pfs_open(filename, op_flags, FILE_TYPE_STATIC, 0);
 
   if ((fd < 0) && (fd != E_DOES_NOT_EXIST)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Could not open resource pfs file <%s>, fd: %d", filename, fd);
+    PBL_LOG_WRN("Could not open resource pfs file <%s>, fd: %d", filename, fd);
   }
 
   return fd;

--- a/src/fw/resource/resource_storage_flash.c
+++ b/src/fw/resource/resource_storage_flash.c
@@ -47,9 +47,9 @@ static void resource_storage_system_bank_init(void) {
   // Increment s_active_bank and call resource_storage_generic_check for each value to find
   // a bank that's valid.
   for (s_active_bank = 0; s_active_bank < ARRAY_LENGTH(s_resource_banks); ++s_active_bank) {
-    PBL_LOG(LOG_LEVEL_INFO, "Checking bank %u for system resources", s_active_bank);
+    PBL_LOG_INFO("Checking bank %u for system resources", s_active_bank);
     if (resource_storage_generic_check(SYSTEM_APP, 0, &entry, &SYSTEM_RESOURCE_VERSION)) {
-      PBL_LOG(LOG_LEVEL_INFO, "Valid system resources found!");
+      PBL_LOG_INFO("Valid system resources found!");
       s_valid_resources_found = true;
       return;
     }
@@ -103,7 +103,7 @@ static uint32_t resource_storage_system_bank_get_crc(ResourceStoreEntry *entry, 
       uint8_t status_reg = pbl_28517_flash_impl_get_status_register(addr);
       uint32_t crc = flash_calculate_legacy_defective_checksum(addr, SECTOR_SIZE_BYTES);
 
-      PBL_LOG(LOG_LEVEL_DEBUG, "PBL-28517 Sector 0x%"PRIx32" Status 0x%"PRIx8" CRC 0x%"PRIx32,
+      PBL_LOG_DBG("PBL-28517 Sector 0x%"PRIx32" Status 0x%"PRIx8" CRC 0x%"PRIx32,
               addr, status_reg, crc);
     }
   }

--- a/src/fw/resource/system_resource.c
+++ b/src/fw/resource/system_resource.c
@@ -31,7 +31,7 @@ void system_resource_init(void) {
         "System resources are missing or corrupt, time to sad watch");
     launcher_panic(ERROR_BAD_RESOURCES);
 #else
-    PBL_LOG(LOG_LEVEL_ERROR, "System resources are missing or corrupt! Going to PRF");
+    PBL_LOG_ERR("System resources are missing or corrupt! Going to PRF");
     fw_reset_into_prf();
 #endif
   }
@@ -48,7 +48,7 @@ FontInfo s_system_fonts_info_table[NUM_SYSTEM_FONTS + 1] KERNEL_READONLY_DATA;
 
 static GFont prv_load_system_font(const char *font_key) {
   if (font_key == NULL) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "GETTING FALLBACK FONT");
+    PBL_LOG_DBG("GETTING FALLBACK FONT");
     // load fallback font
     if (!s_system_fonts_info_table[NUM_SYSTEM_FONTS].loaded) {
       PBL_ASSERTN(text_resources_init_font(SYSTEM_APP, RESOURCE_ID_FONT_FALLBACK_INTERNAL, 0,
@@ -89,7 +89,7 @@ DEFINE_SYSCALL(GFont, sys_font_get_system_font, const char *font_key) {
   if (font_key && PRIVILEGE_WAS_ELEVATED) {
     if (!memory_layout_is_cstring_in_region(memory_layout_get_app_region(), font_key, 100) &&
         !memory_layout_is_cstring_in_region(memory_layout_get_microflash_region(), font_key, 100)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Pointer %p not in app or microflash region", font_key);
+      PBL_LOG_ERR("Pointer %p not in app or microflash region", font_key);
       syscall_failed();
     }
   }

--- a/src/fw/services/common/accel_manager.h
+++ b/src/fw/services/common/accel_manager.h
@@ -11,7 +11,7 @@
 #include <stdint.h>
 
 
-#define ACCEL_LOG_DEBUG(fmt, args...) PBL_LOG_D(LOG_DOMAIN_ACCEL, LOG_LEVEL_DEBUG, fmt, ## args)
+#define ACCEL_LOG_DEBUG(fmt, args...) PBL_LOG_D_DBG(LOG_DOMAIN_ACCEL, fmt, ## args)
 
 typedef void (*AccelDataReadyCallback)(void *context);
 

--- a/src/fw/services/common/analytics/analytics.h
+++ b/src/fw/services/common/analytics/analytics.h
@@ -11,7 +11,7 @@
 
 
 #define ANALYTICS_LOG_DEBUG(fmt, args...) \
-            PBL_LOG_D(LOG_DOMAIN_ANALYTICS, LOG_LEVEL_DEBUG, fmt, ## args)
+            PBL_LOG_D_DBG(LOG_DOMAIN_ANALYTICS, fmt, ## args)
 
 //! Possible values for the client argument when setting/updating a metric. This tells the
 //! analytics code under which "blob" to put the metric. For device metrics, the client argument

--- a/src/fw/services/common/battery/battery_monitor.c
+++ b/src/fw/services/common/battery/battery_monitor.c
@@ -14,8 +14,6 @@
 
 #include <stdint.h>
 
-#define BATT_LOG_COLOR LOG_COLOR_YELLOW
-
 // State machine stuff
 
 typedef void (*Action)(void);
@@ -74,12 +72,12 @@ static void prv_enter_lpm(void) {
     low_power_enter();
   }
 #endif
-  PBL_LOG_COLOR(LOG_LEVEL_INFO, BATT_LOG_COLOR, "Battery low: enter low power mode");
+  PBL_LOG_INFO("Battery low: enter low power mode");
 }
 
 static void prv_resume_normal_operation(void) {
   low_power_exit();
-  PBL_LOG_COLOR(LOG_LEVEL_INFO, BATT_LOG_COLOR, "Battery good: resume normal operation");
+  PBL_LOG_INFO("Battery good: resume normal operation");
 }
 
 static void prv_exit_critical(void) {
@@ -112,7 +110,7 @@ static void prv_standby_timer_callback(void* data) {
 }
 
 static void prv_begin_standby_timer(void) {
-  PBL_LOG_COLOR(LOG_LEVEL_INFO, BATT_LOG_COLOR, "Battery critical: begin standby timer");
+  PBL_LOG_INFO("Battery critical: begin standby timer");
   // If the watch was already running, give them 30s, otherwise just 2s.
   uint32_t standby_timeout = (s_first_run) ? 2000: 30000;
   new_timer_start(s_standby_timer_id, standby_timeout,
@@ -120,7 +118,7 @@ static void prv_begin_standby_timer(void) {
 }
 
 static void system_task_handle_battery_critical(void* data) {
-  PBL_LOG_COLOR(LOG_LEVEL_INFO, BATT_LOG_COLOR, "Battery critical: go to standby mode");
+  PBL_LOG_INFO("Battery critical: go to standby mode");
   if (low_power_is_active()) {
     low_power_standby();
   } else {

--- a/src/fw/services/common/battery/nrf_fuel_gauge/battery_state.c
+++ b/src/fw/services/common/battery/nrf_fuel_gauge/battery_state.c
@@ -117,7 +117,7 @@ static void prv_update_state(void *force_update) {
 
   ret = battery_charge_status_get(&chg_status);
   if (ret < 0) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Could not obtain charge status, skipping update (%d)", ret);
+    PBL_LOG_ERR("Could not obtain charge status, skipping update (%d)", ret);
     return;
   }
 
@@ -135,7 +135,7 @@ static void prv_update_state(void *force_update) {
 
   ret = battery_get_constants(&constants);
   if (ret < 0) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Could not obtain constants, skipping update (%d)", ret);
+    PBL_LOG_ERR("Could not obtain constants, skipping update (%d)", ret);
     return;
   }
 
@@ -176,14 +176,13 @@ static void prv_update_state(void *force_update) {
     s_last_ttf = 0U;
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG_VERBOSE,
-          "Battery state: v_mv: %ld, i_ua: %ld, t_mc: %ld, td: %lu, soc: %u, tte: %lu, ttf: %lu",
+  PBL_LOG_VERBOSE("Battery state: v_mv: %ld, i_ua: %ld, t_mc: %ld, td: %lu, soc: %u, tte: %lu, ttf: %lu",
           constants.v_mv, constants.i_ua, constants.t_mc, (uint32_t)delta,
           s_last_battery_charge_state.pct, s_last_tte, s_last_ttf);
 
   if (update || (((now - s_last_log) / RTC_TICKS_HZ > LOG_MIN_SEC) &&
                  (s_last_battery_charge_state.is_charging || (pct < ALWAYS_UPDATE_PCT)))) {
-    PBL_LOG(LOG_LEVEL_INFO, "Percent: %" PRIu8 ", V: %" PRId32 " mV, I: %" PRId32 " uA, "
+    PBL_LOG_INFO("Percent: %" PRIu8 ", V: %" PRId32 " mV, I: %" PRId32 " uA, "
             "T: %" PRId32 " mC, charging: %s, plugged: %s",
             s_last_battery_charge_state.pct, constants.v_mv, constants.i_ua, constants.t_mc,
             s_last_battery_charge_state.is_charging ? "yes" : "no",

--- a/src/fw/services/common/battery/voltage/battery_state.c
+++ b/src/fw/services/common/battery/voltage/battery_state.c
@@ -93,7 +93,7 @@ static void prv_update_done_charging(void) {
 
   // Amount in mV to drop the "Full" voltage by to briefly stay at 100% once unplugged
   const uint16_t BATTERY_FULL_FUDGE_AMOUNT = 10;
-  PBL_LOG(LOG_LEVEL_DEBUG, "Done charging - Updating curve");
+  PBL_LOG_DBG("Done charging - Updating curve");
   battery_curve_set_full_voltage(s_last_battery_state.voltage - BATTERY_FULL_FUDGE_AMOUNT);
 }
 
@@ -145,7 +145,7 @@ static ConnectionStateID prv_get_connection_state(void) {
     if (charging) {
       // Since we can't be charging and disconnected,
       // just log a warning and pretend we aren't charging.
-      PBL_LOG(LOG_LEVEL_WARNING, "PMIC reported charging while unplugged - ignoring");
+      PBL_LOG_WRN("PMIC reported charging while unplugged - ignoring");
     }
     return ConnectionStateDischargingUnplugged;
   }
@@ -212,7 +212,7 @@ static void prv_update_state(void *force_update) {
 
   s_last_battery_state.percent = new_charge_percent;
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "mV Raw: %"PRIu16" Ratio: %"PRIu32" Percent: %"PRIu32,
+  PBL_LOG_DBG("mV Raw: %"PRIu16" Ratio: %"PRIu32" Percent: %"PRIu32,
           s_last_battery_state.voltage, s_last_battery_state.percent,
           ratio32_to_percent(s_last_battery_state.percent));
 

--- a/src/fw/services/common/bluetooth/bluetooth_ctl.c
+++ b/src/fw/services/common/bluetooth/bluetooth_ctl.c
@@ -1,7 +1,6 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define FILE_LOG_COLOR LOG_COLOR_BLUE
 #include "services/common/bluetooth/bluetooth_ctl.h"
 
 #include <bluetooth/init.h>
@@ -60,7 +59,7 @@ static void prv_put_disconnection_event(void) {
                                         .is_ble = true,
                                         .state = PebbleBluetoothConnectionEventStateDisconnected,
                                     }};
-  PBL_LOG(LOG_LEVEL_DEBUG, "New BT Conn change event, We are now disconnected");
+  PBL_LOG_DBG("New BT Conn change event, We are now disconnected");
   event_put(&event);
 }
 
@@ -74,7 +73,7 @@ static void prv_comm_start(void) {
   dis_get_info(&config->dis_info);
 #if CAPABILITY_HAS_BUILTIN_HRM
   config->is_hrm_supported_and_enabled = ble_hrm_is_supported_and_enabled();
-  PBL_LOG(LOG_LEVEL_INFO, "BLE HRM sharing prefs: is_enabled=%u",
+  PBL_LOG_INFO("BLE HRM sharing prefs: is_enabled=%u",
           config->is_hrm_supported_and_enabled);
 #endif
 #ifdef BT_REQUIRE_EARLY_BONDINGS
@@ -98,7 +97,7 @@ static void prv_comm_start(void) {
     bt_pairability_init();
     analytics_stopwatch_stop(ANALYTICS_DEVICE_METRIC_BT_OFF_TIME);
   } else {
-    PBL_LOG(LOG_LEVEL_ERROR, "BT driver failed to start!");
+    PBL_LOG_ERR("BT driver failed to start!");
     // FIXME: PBL-36163 -- handle this better
   }
 
@@ -127,7 +126,7 @@ static void prv_comm_stop(void) {
 }
 
 static void prv_send_state_change_event(void) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "----> Sending a BT state event");
+  PBL_LOG_DBG("----> Sending a BT state event");
   PebbleEvent event = {
       .type = PEBBLE_BT_STATE_EVENT,
       .bluetooth =
@@ -168,7 +167,7 @@ static void prv_comm_state_change(void *context) {
       prv_send_state_change_event();
     }
   } else if (!s_comm_is_running && s_first_run) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Shutting down the BT stack on boot");
+    PBL_LOG_DBG("Shutting down the BT stack on boot");
     bt_driver_power_down_controller_on_boot();
   }
 
@@ -178,7 +177,7 @@ static void prv_comm_state_change(void *context) {
 
 void bt_ctl_set_enabled(bool enabled) {
   if (!s_comm_initialized) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Error: Bluetooth isn't initialized yet");
+    PBL_LOG_ERR("Error: Bluetooth isn't initialized yet");
     return;
   }
   mutex_lock(s_comm_state_change_mutex);
@@ -189,7 +188,7 @@ void bt_ctl_set_enabled(bool enabled) {
 
 void bt_ctl_set_override_mode(BtCtlModeOverride override) {
   if (!s_comm_initialized) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Error: Bluetooth isn't initialized yet");
+    PBL_LOG_ERR("Error: Bluetooth isn't initialized yet");
     return;
   }
   mutex_lock(s_comm_state_change_mutex);
@@ -205,7 +204,7 @@ static void prv_track_quick_airplane_mode_toggles(bool is_airplane_mode_currentl
   const uint64_t max_interval_secs = 30;
   if (((now_ticks - s_airplane_mode_last_toggle_ticks) < (max_interval_secs * RTC_TICKS_HZ)) &&
       is_airplane_mode_currently_on) {
-    PBL_LOG(LOG_LEVEL_INFO, "Quick airplane mode toggle detected!");
+    PBL_LOG_INFO("Quick airplane mode toggle detected!");
     analytics_inc(ANALYTICS_DEVICE_METRIC_BT_AIRPLANE_MODE_QUICK_TOGGLE_COUNT,
                   AnalyticsClient_System);
   }
@@ -214,7 +213,7 @@ static void prv_track_quick_airplane_mode_toggles(bool is_airplane_mode_currentl
 
 void bt_ctl_set_airplane_mode_async(bool enabled) {
   if (!s_comm_initialized) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Error: Bluetooth isn't initialized yet");
+    PBL_LOG_ERR("Error: Bluetooth isn't initialized yet");
     return;
   }
   mutex_lock(s_comm_state_change_mutex);
@@ -243,7 +242,7 @@ void bt_ctl_init(void) {
 }
 
 static void prv_bt_ctl_reset_bluetooth_callback(void *context) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Resetting Bluetooth");
+  PBL_LOG_DBG("Resetting Bluetooth");
   mutex_lock(s_comm_state_change_mutex);
 
   bool was_already_running = s_comm_is_running;
@@ -265,7 +264,7 @@ void bt_ctl_reset_bluetooth(void) {
   if (bt_ctl_is_bluetooth_active()) {
     system_task_add_callback(prv_bt_ctl_reset_bluetooth_callback, NULL);
   } else {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Bluetooth is disabled, reset aborted");
+    PBL_LOG_DBG("Bluetooth is disabled, reset aborted");
   }
 }
 

--- a/src/fw/services/common/bluetooth/bonding.c
+++ b/src/fw/services/common/bluetooth/bonding.c
@@ -31,12 +31,12 @@ static void prv_finalize_create_bonding(BTBondingID bonding_id,
     connection->is_gateway = is_gateway;
 
     if (!connection->is_gateway) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "New bonding is not gateway?");
+      PBL_LOG_DBG("New bonding is not gateway?");
     }
 
     gap_le_device_name_request(&connection->device);
   } else {
-    PBL_LOG(LOG_LEVEL_ERROR, "Couldn't find connection for bonding!");
+    PBL_LOG_ERR("Couldn't find connection for bonding!");
   }
   bt_unlock();
 }
@@ -49,7 +49,7 @@ static void prv_finalize_create_bonding_cb(void *data) {
 
 void bt_driver_cb_handle_create_bonding(const BleBonding *bonding,
                                         const BTDeviceAddress *addr) {
-  PBL_LOG(LOG_LEVEL_INFO, "Creating new bonding for "BT_DEVICE_ADDRESS_FMT,
+  PBL_LOG_INFO("Creating new bonding for "BT_DEVICE_ADDRESS_FMT,
           BT_DEVICE_ADDRESS_XPLODE(bonding->pairing_info.identity.address));
   const bool should_pin_address = bonding->should_pin_address;
   if (should_pin_address) {
@@ -57,7 +57,7 @@ void bt_driver_cb_handle_create_bonding(const BleBonding *bonding,
   }
   const uint8_t flags = bonding->flags;
   if (flags) {
-    PBL_LOG(LOG_LEVEL_INFO, "flags: 0x02%x", flags);
+    PBL_LOG_INFO("flags: 0x02%x", flags);
   }
   BTBondingID bonding_id = bt_persistent_storage_store_ble_pairing(&bonding->pairing_info,
                                                                    bonding->is_gateway, NULL,

--- a/src/fw/services/common/bluetooth/local_addr.c
+++ b/src/fw/services/common/bluetooth/local_addr.c
@@ -23,7 +23,7 @@ void bt_local_addr_pause_cycling(void) {
   bt_lock();
   {
     if (s_pra_cycling_pause_count == 0) {
-      PBL_LOG(LOG_LEVEL_INFO, "Pausing address cycling (pinned_addr="BT_DEVICE_ADDRESS_FMT")",
+      PBL_LOG_INFO("Pausing address cycling (pinned_addr="BT_DEVICE_ADDRESS_FMT")",
               BT_DEVICE_ADDRESS_XPLODE(s_pinned_addr));
       prv_allow_cycling(false);
     }
@@ -38,7 +38,7 @@ void bt_local_addr_resume_cycling(void) {
     PBL_ASSERTN(s_pra_cycling_pause_count);
     --s_pra_cycling_pause_count;
     if (s_pra_cycling_pause_count == 0) {
-      PBL_LOG(LOG_LEVEL_INFO, "Resuming address cycling (pinned_addr="BT_DEVICE_ADDRESS_FMT")",
+      PBL_LOG_INFO("Resuming address cycling (pinned_addr="BT_DEVICE_ADDRESS_FMT")",
               BT_DEVICE_ADDRESS_XPLODE(s_pinned_addr));
       prv_allow_cycling(true);
     }
@@ -66,8 +66,7 @@ void bt_local_addr_pin(const BTDeviceAddress *addr) {
   bool addresses_match = bt_device_address_equal(addr, &s_pinned_addr);
   bt_unlock();
 
-  PBL_LOG(LOG_LEVEL_INFO,
-          "Requested to pin address to "BT_DEVICE_ADDRESS_FMT " match=%u",
+  PBL_LOG_INFO("Requested to pin address to "BT_DEVICE_ADDRESS_FMT " match=%u",
           BT_DEVICE_ADDRESS_XPLODE_PTR(addr), addresses_match);
 }
 
@@ -92,22 +91,22 @@ void bt_local_addr_init(void) {
     if (bt_driver_id_generate_private_resolvable_address(&s_pinned_addr)) {
       bt_persistent_storage_set_ble_pinned_address(&s_pinned_addr);
     } else {
-      PBL_LOG(LOG_LEVEL_ERROR, "Failed to generate PRA... :(");
+      PBL_LOG_ERR("Failed to generate PRA... :(");
     }
   }
-  PBL_LOG(LOG_LEVEL_INFO, "Pinned address: " BT_DEVICE_ADDRESS_FMT,
+  PBL_LOG_INFO("Pinned address: " BT_DEVICE_ADDRESS_FMT,
           BT_DEVICE_ADDRESS_XPLODE(s_pinned_addr));
 
   if (bt_persistent_storage_has_pinned_ble_pairings()) {
-    PBL_LOG(LOG_LEVEL_INFO, "Bonding that requires address pinning exists, applying pinned addr!");
+    PBL_LOG_INFO("Bonding that requires address pinning exists, applying pinned addr!");
     bt_local_addr_pause_cycling();
     s_cycling_paused_due_to_dependent_bondings = true;
   } else {
 #if RECOVERY_FW
-    PBL_LOG(LOG_LEVEL_INFO, "Pausing address cycling because PRF!");
+    PBL_LOG_INFO("Pausing address cycling because PRF!");
     bt_local_addr_pause_cycling();
 #else
-    PBL_LOG(LOG_LEVEL_INFO, "No bondings found that require address pinning!");
+    PBL_LOG_INFO("No bondings found that require address pinning!");
     bt_driver_set_local_address(true /* allow_cycling */, NULL);
 #endif
   }

--- a/src/fw/services/common/bluetooth/pairability.c
+++ b/src/fw/services/common/bluetooth/pairability.c
@@ -1,7 +1,6 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define FILE_LOG_COLOR LOG_COLOR_BLUE
 #include "system/logging.h"
 #include "system/passert.h"
 
@@ -35,7 +34,7 @@ static void evaluate_pairing_refcount(void *data) {
     return;
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Pairabilty state: LE=%u, Classic=%u",
+  PBL_LOG_DBG("Pairabilty state: LE=%u, Classic=%u",
           s_allow_ble_pairing_refcount, s_allow_bt_pairing_refcount);
 
   bool is_ble_pairable_and_discoverable = (s_allow_ble_pairing_refcount > 0);

--- a/src/fw/services/common/bluetooth/pebble_pairing_service.c
+++ b/src/fw/services/common/bluetooth/pebble_pairing_service.c
@@ -21,7 +21,7 @@ static void prv_convert_pps_request_params(const PebblePairingServiceConnParamSe
       min_1_25ms + pps_params_in->interval_max_delta_1_25ms;
 #if RECOVERY_FW
   if (pps_params_in->slave_latency_events != 0) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Overriding requested slave latency with 0 because PRF");
+    PBL_LOG_DBG("Overriding requested slave latency with 0 because PRF");
   }
   params_out->slave_latency_events = 0;
 #else
@@ -36,7 +36,7 @@ static void prv_handle_set_remote_param_mgmt_settings(GAPLEConnection *connectio
       settings->is_remote_device_managing_connection_parameters;
   connection->is_remote_device_managing_connection_parameters =
       is_remote_device_managing_connection_parameters;
-  PBL_LOG(LOG_LEVEL_INFO, "PPS: is_remote_mgmt=%u",
+  PBL_LOG_INFO("PPS: is_remote_mgmt=%u",
           is_remote_device_managing_connection_parameters);
 
   if (settings_length >= PEBBLE_PAIRING_SERVICE_REMOTE_PARAM_MGTM_SETTINGS_SIZE_WITH_PARAM_SETS) {
@@ -50,8 +50,7 @@ static void prv_handle_set_remote_param_mgmt_settings(GAPLEConnection *connectio
           &settings->connection_parameter_sets[s];
       GAPLEConnectRequestParams *params = &connection->connection_parameter_sets[s];
       prv_convert_pps_request_params(pps_params, params);
-      PBL_LOG(LOG_LEVEL_INFO,
-              "PPS: Updated param set %u: %u-%u, slave lat: %u, supervision timeout: %u",
+      PBL_LOG_INFO("PPS: Updated param set %u: %u-%u, slave lat: %u, supervision timeout: %u",
               s, params->connection_interval_min_1_25ms, params->connection_interval_max_1_25ms,
               params->slave_latency_events, params->supervision_timeout_10ms);
     }
@@ -64,7 +63,7 @@ static void prv_handle_set_remote_param_mgmt_settings(GAPLEConnection *connectio
 static void prv_handle_set_remote_desired_state(GAPLEConnection *connection,
     const PebblePairingServiceRemoteDesiredState *desired_state) {
   const ResponseTimeState remote_desired_state = (ResponseTimeState)desired_state->state;
-  PBL_LOG(LOG_LEVEL_INFO, "PPS: desired_state=%u", remote_desired_state);
+  PBL_LOG_INFO("PPS: desired_state=%u", remote_desired_state);
 
   // "As a safety measure, the watch will reset it back to ResponseTimeMax after 5 minutes."
   const uint16_t max_period_secs = 5 * 60;
@@ -94,13 +93,13 @@ void bt_driver_cb_pebble_pairing_service_handle_connection_parameter_write(
         prv_handle_set_remote_desired_state(connection, &conn_params->remote_desired_state);
         break;
       case PebblePairingServiceConnParamsWriteCmd_EnablePacketLengthExtension:
-        PBL_LOG(LOG_LEVEL_INFO, "Enabling BLE Packet Length Extension");
+        PBL_LOG_INFO("Enabling BLE Packet Length Extension");
         break;
       case PebblePairingServiceConnParamsWriteCmd_InhibitBLESleep:
-        PBL_LOG(LOG_LEVEL_INFO, "BLE Sleep Mode inhibited!");
+        PBL_LOG_INFO("BLE Sleep Mode inhibited!");
         break;
       default:
-        PBL_LOG(LOG_LEVEL_ERROR, "Unknown write_cmd %d", conn_params->cmd);
+        PBL_LOG_ERR("Unknown write_cmd %d", conn_params->cmd);
         break;
     }
   }

--- a/src/fw/services/common/bluetooth/pp_ble_control.c
+++ b/src/fw/services/common/bluetooth/pp_ble_control.c
@@ -1,8 +1,6 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define FILE_LOG_COLOR LOG_COLOR_BLUE
-
 #include "pp_ble_control.h"
 #include "services/common/bluetooth/pairability.h"
 #include "system/logging.h"
@@ -25,7 +23,7 @@ typedef struct PACKED {
 static void prv_handle_set_discoverable_pairable(
     BLEControlCommandSetDiscoverablePairable *cmd_data) {
   bt_pairability_use_ble_for_period(cmd_data->duration);
-  PBL_LOG(LOG_LEVEL_INFO, "Set Discoverable Pairable: %u, %u",
+  PBL_LOG_INFO("Set Discoverable Pairable: %u, %u",
           cmd_data->discoverable_pairable, cmd_data->duration);
 }
 
@@ -36,14 +34,14 @@ void pp_ble_control_protocol_msg_callback(
   PBL_ASSERT_RUNNING_FROM_EXPECTED_TASK(PebbleTask_KernelBackground);
 
   if (length < sizeof(BLEControlCommandSetDiscoverablePairable)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Invalid pp_ble_control_protocol_msg_callback message: %d", length);
+    PBL_LOG_WRN("Invalid pp_ble_control_protocol_msg_callback message: %d", length);
     return;
   }
 
   const uint8_t opcode = *(const uint8_t *) data;
   switch (opcode) {
     case 0 ... 3:
-      PBL_LOG(LOG_LEVEL_INFO, "Deprecated & unsupported opcode: %u", opcode);
+      PBL_LOG_INFO("Deprecated & unsupported opcode: %u", opcode);
       break;
 
     case BLEControlCommandTypeSetDiscoverablePairable: {
@@ -53,7 +51,7 @@ void pp_ble_control_protocol_msg_callback(
       break;
     }
     default:
-      PBL_LOG(LOG_LEVEL_DEBUG, "Unknown opcode %u", opcode);
+      PBL_LOG_DBG("Unknown opcode %u", opcode);
       break;
   }
 }

--- a/src/fw/services/common/clock.c
+++ b/src/fw/services/common/clock.c
@@ -63,7 +63,7 @@ static void prv_handle_timezone_set(TimezoneInfo *tz_info) {
     time_t t0 = rtc_get_time();
     time_t t1 = prv_migrate_local_time_to_UTC(t0);
     rtc_sanitize_time_t(&t1);
-    PBL_LOG(LOG_LEVEL_INFO, "Pivot RTC from localtime to UTC (%lu -> %lu)", t0, t1);
+    PBL_LOG_INFO("Pivot RTC from localtime to UTC (%lu -> %lu)", t0, t1);
     rtc_set_time(t1);  // Pivot RTC from localtime to UTC
     prv_migrate_timezone_info(tz_info->tm_gmtoff);
   }
@@ -313,7 +313,7 @@ static void prv_handle_set_utc_and_timezone_msg(TimezoneCBData *tz_data) {
   if (tz_data->region_name_len == 0) {
     region_name = "[N/A]";
   }
-  PBL_LOG(LOG_LEVEL_INFO, "set_timezone utc_time: %u offset: %d region_name: %s",
+  PBL_LOG_INFO("set_timezone utc_time: %u offset: %d region_name: %s",
           (int) tz_data->utc_time, (int) tz_data->utc_offset_min, region_name);
 
   TimezoneInfo tz_info = prv_get_timezone_info_from_data(tz_data);
@@ -326,7 +326,7 @@ static void prv_handle_set_utc_and_timezone_msg(TimezoneCBData *tz_data) {
 }
 
 static void prv_handle_set_time_msg(time_t new_time) {
-  PBL_LOG(LOG_LEVEL_WARNING, "Mobile app calling deprecated API, time = %d",
+  PBL_LOG_WRN("Mobile app calling deprecated API, time = %d",
           (int)new_time);
   if (clock_is_timezone_set()) {
     new_time = prv_migrate_local_time_to_UTC(new_time);
@@ -369,7 +369,7 @@ void clock_protocol_msg_callback(CommSession *session, const uint8_t* data, unsi
       const size_t header_size = offsetof(TimezoneCBData, region_name);
       const uint8_t *timezone_length_ptr = data + offsetof(TimezoneCBData, region_name_len);
       if (length != (sizeof(uint8_t) + header_size + *timezone_length_ptr)) {
-        PBL_LOG(LOG_LEVEL_WARNING, "Set timezone message invalid length");
+        PBL_LOG_WRN("Set timezone message invalid length");
         return;
       }
 
@@ -378,7 +378,7 @@ void clock_protocol_msg_callback(CommSession *session, const uint8_t* data, unsi
       break;
     }
     default:
-      PBL_LOG(LOG_LEVEL_WARNING, "Invalid message received. First byte is %u", data[0]);
+      PBL_LOG_WRN("Invalid message received. First byte is %u", data[0]);
       break;
   }
 }
@@ -651,7 +651,7 @@ int16_t clock_get_timezone_region_id(void) {
 void clock_set_timezone_by_region_id(uint16_t region_id) {
   TimezoneInfo tz_info;
   prv_clock_get_timezone_info_from_region_id(region_id, rtc_get_time(), &tz_info);
-  PBL_LOG(LOG_LEVEL_INFO, "Set timezone by region id (%u)", region_id);
+  PBL_LOG_INFO("Set timezone by region id (%u)", region_id);
   prv_update_time_info_and_generate_event(NULL, &tz_info);
 }
 

--- a/src/fw/services/common/comm_session/default_kernel_receiver.c
+++ b/src/fw/services/common/comm_session/default_kernel_receiver.c
@@ -56,7 +56,7 @@ static Receiver *prv_default_kernel_receiver_prepare(
   DefaultReceiverImpl *receiver = kernel_zalloc(size_needed);
 
   if (!receiver) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Could not allocate receiver, handler:%p size:%d",
+    PBL_LOG_WRN("Could not allocate receiver, handler:%p size:%d",
             endpoint->handler, (int)size_needed);
     return NULL;
   }
@@ -103,7 +103,7 @@ static void prv_default_kernel_receiver_finish(Receiver *receiver) {
   impl->handler_scheduled = true;
 
   if ((int)impl->total_payload_size != impl->curr_pos) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Got fewer bytes than expected for handler %p",
+    PBL_LOG_WRN("Got fewer bytes than expected for handler %p",
             impl->endpoint->handler);
   }
 

--- a/src/fw/services/common/comm_session/default_kernel_sender.c
+++ b/src/fw/services/common/comm_session/default_kernel_sender.c
@@ -202,8 +202,7 @@ SendBuffer * comm_session_send_buffer_begin_write(CommSession *session, uint16_t
     return NULL;
   }
   if (required_payload_length > DEFAULT_KERNEL_SENDER_MAX_PAYLOAD_SIZE) {
-    PBL_LOG(LOG_LEVEL_WARNING,
-            "Message for endpoint_id %u exceeds maximum length (length=%"PRIu32")",
+    PBL_LOG_WRN("Message for endpoint_id %u exceeds maximum length (length=%"PRIu32")",
             endpoint_id, (uint32_t)required_payload_length);
     return NULL;
   }
@@ -251,8 +250,7 @@ SendBuffer * comm_session_send_buffer_begin_write(CommSession *session, uint16_t
       analytics_inc(ANALYTICS_DEVICE_METRIC_BT_COMM_SESSION_SEND_DATA_FAIL_COUNT,
                     AnalyticsClient_System);
 
-      PBL_LOG(LOG_LEVEL_WARNING,
-              "Failed to get send buffer (bytes=%"PRIu32", endpoint_id=%"PRIu16", to=%"PRIu32")",
+      PBL_LOG_WRN("Failed to get send buffer (bytes=%"PRIu32", endpoint_id=%"PRIu16", to=%"PRIu32")",
               (uint32_t)required_payload_length, endpoint_id, (uint32_t)is_timeout);
       return NULL;
     }

--- a/src/fw/services/common/comm_session/meta_endpoint.c
+++ b/src/fw/services/common/comm_session/meta_endpoint.c
@@ -32,7 +32,7 @@ static void prv_send_meta_response_kernelbg_cb(void *data) {
 }
 
 void meta_endpoint_send_response_async(const MetaResponseInfo *meta_response_info) {
-  PBL_LOG(LOG_LEVEL_ERROR, "Meta protocol error: 0x%x (endpoint=%u)",
+  PBL_LOG_ERR("Meta protocol error: 0x%x (endpoint=%u)",
           meta_response_info->payload.error_code, meta_response_info->payload.endpoint_id);
 
   MetaResponseInfo *meta_response_info_heap_copy = kernel_zalloc_check(sizeof(*meta_response_info));
@@ -41,5 +41,5 @@ void meta_endpoint_send_response_async(const MetaResponseInfo *meta_response_inf
 }
 
 void meta_protocol_msg_callback(CommSession *session, const uint8_t* data, size_t length) {
-  PBL_LOG(LOG_LEVEL_INFO, "Meta endpoint callback called");
+  PBL_LOG_INFO("Meta endpoint callback called");
 }

--- a/src/fw/services/common/comm_session/session.c
+++ b/src/fw/services/common/comm_session/session.c
@@ -119,7 +119,7 @@ void comm_session_reset(CommSession *session) {
   bt_lock();
   {
     if (!comm_session_is_valid(session)) {
-      PBL_LOG(LOG_LEVEL_WARNING, "Already closed!");
+      PBL_LOG_WRN("Already closed!");
       goto unlock;
     }
     session->transport_imp->reset(session->transport);
@@ -153,7 +153,7 @@ static const char *prv_string_for_destination(TransportDestination destination) 
 static void prv_log_session_event(CommSession *session, bool is_open) {
   char uuid_string[UUID_STRING_BUFFER_LENGTH];
   uuid_to_string(prv_get_uuid(session), uuid_string);
-  PBL_LOG(LOG_LEVEL_INFO, "Session event: is_open=%d, destination=%s, app_uuid=%s",
+  PBL_LOG_INFO("Session event: is_open=%d, destination=%s, app_uuid=%s",
           is_open, prv_string_for_destination(session->destination), uuid_string);
 }
 
@@ -181,7 +181,7 @@ CommSession * comm_session_open(Transport *transport, const TransportImplementat
            && !prv_is_transport_type(transport, implementation, CommSessionTransportType_PULSE)) {
         if (!existing_system_session->transport_imp->close) {
           // iAP sessions cannot be closed from the watch' side :(
-          PBL_LOG(LOG_LEVEL_ERROR, "System session already exists and cannot be closed");
+          PBL_LOG_ERR("System session already exists and cannot be closed");
           return NULL;
         }
         // Last system session to connect wins:
@@ -190,7 +190,7 @@ CommSession * comm_session_open(Transport *transport, const TransportImplementat
         // is running over PPoGATT. If the app launches again, it will have no state of what was the
         // previously used transport was, prior to getting killed. Often, iAP ends up winning.
         // However, to the firmware, PPoGATT still appears connected, so we'd end up here.
-        PBL_LOG(LOG_LEVEL_INFO, "System session already exists, closing it now");
+        PBL_LOG_INFO("System session already exists, closing it now");
         existing_system_session->transport_imp->close(existing_system_session->transport);
       }
     }
@@ -198,7 +198,7 @@ CommSession * comm_session_open(Transport *transport, const TransportImplementat
 
   CommSession *session = kernel_malloc(sizeof(CommSession));
   if (!session) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Not enough memory for new CommSession");
+    PBL_LOG_ERR("Not enough memory for new CommSession");
     return NULL;
   }
   *session = (const CommSession) {
@@ -332,7 +332,7 @@ void comm_session_send_next(CommSession *session) {
   if (schedule_func(session)) {
     session->is_send_next_call_pending = true;
   } else {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to schedule comm_session_send_next callback");
+    PBL_LOG_ERR("Failed to schedule comm_session_send_next callback");
   }
 }
 
@@ -358,7 +358,7 @@ bool comm_session_send_data(CommSession *session, uint16_t endpoint_id,
   }
   SendBuffer *sb = comm_session_send_buffer_begin_write(session, endpoint_id, length, timeout_ms);
   if (!sb) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Could not acquire send buffer for %x", endpoint_id);
+    PBL_LOG_WRN("Could not acquire send buffer for %x", endpoint_id);
     return false;
   }
   comm_session_send_buffer_write(sb, data, length);
@@ -392,7 +392,7 @@ static bool prv_find_session_by_app_uuid_comparator(ListNode *found_node, void *
     // On iOS + iAP, we can expect at most one App session, so we assume that the found session is
     // the app one.
     if (ctx->fallback_session) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Fallback session already set!?");
+      PBL_LOG_ERR("Fallback session already set!?");
     }
     ctx->fallback_session = session;
   }
@@ -559,7 +559,7 @@ DEFINE_SYSCALL(void, sys_app_comm_set_responsiveness, SniffInterval interval) {
                                       ResponseTimeMax, 0);
       return;
   }
-  PBL_LOG(LOG_LEVEL_WARNING, "Invalid sniff interval");
+  PBL_LOG_WRN("Invalid sniff interval");
   syscall_failed();
 }
 

--- a/src/fw/services/common/comm_session/session_receive_router.c
+++ b/src/fw/services/common/comm_session/session_receive_router.c
@@ -125,7 +125,7 @@ static bool prv_prepare_receiver(const uint32_t payload_length,
     // - Look into SPP flow control
     // - With PPoGATT: drop packet and rely on automatic retransmission?
 
-    PBL_LOG(LOG_LEVEL_ERROR, "No receiver for endpoint=%"PRIu16" len=%"PRIu32,
+    PBL_LOG_ERR("No receiver for endpoint=%"PRIu16" len=%"PRIu32,
             endpoint_id, payload_length);
     prv_skip_message(rtr, payload_length);
     return true;
@@ -185,8 +185,7 @@ void comm_session_receive_router_write(CommSession *session,
         continue;  // while (data_size)
       }
 
-      PBL_LOG_D(LOG_DOMAIN_COMM, LOG_LEVEL_DEBUG,
-                "Receiving message:  endpoint_id 0x%"PRIx16" (%"PRIu16"), payload_length %"PRIu32,
+      PBL_LOG_D_DBG(LOG_DOMAIN_COMM, "Receiving message:  endpoint_id 0x%"PRIx16" (%"PRIu16"), payload_length %"PRIu32,
                 endpoint_id, endpoint_id, payload_length);
 
       if (prv_prepare_receiver(payload_length, endpoint, endpoint_id, session, rtr)) {

--- a/src/fw/services/common/comm_session/session_remote_version.c
+++ b/src/fw/services/common/comm_session/session_remote_version.c
@@ -102,7 +102,7 @@ static void prv_handle_phone_versions_response(CommSession *session,
   } else if (length >= sizeof(struct VersionsPhoneResponseV1)) {
     request_version = 1;
   } else {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid version request");
+    PBL_LOG_ERR("Invalid version request");
     return;
   }
 
@@ -117,7 +117,7 @@ static void prv_handle_phone_versions_response(CommSession *session,
   // response_version field. That is why we only accept when this field is exactly 2, otherwise we
   // treat it as a V1 response.
   if (request_version >= 2) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Connected to Mobile App %"PRIu8 ".%"PRIu8 "-%"PRIu8,
+    PBL_LOG_DBG("Connected to Mobile App %"PRIu8 ".%"PRIu8 "-%"PRIu8,
             response->major_version, response->minor_version, response->bugfix_version);
 
     // For 3.X mobile applications, they will return additional bits in their response to correspond
@@ -133,8 +133,7 @@ static void prv_handle_phone_versions_response(CommSession *session,
   bt_driver_reconnect_notify_platform_bitfield(platform_bits);
 
   const bool is_system = comm_session_is_system(session);
-  PBL_LOG(LOG_LEVEL_INFO,
-          "Phone app: is_system=%u, plf=0x%"PRIx32", capabilities=0x%"PRIx32,
+  PBL_LOG_INFO("Phone app: is_system=%u, plf=0x%"PRIx32", capabilities=0x%"PRIx32,
           is_system, platform_bits, (uint32_t)capability_flags);
 
   // Only emit for the Pebble app, not 3rd party companion apps:
@@ -158,8 +157,7 @@ void session_remote_version_protocol_msg_callback(CommSession *session_ref,
     }
 
     default:
-      PBL_LOG_D(LOG_DOMAIN_COMM, LOG_LEVEL_ERROR,
-                "Invalid message received. First byte is %u", data[0]);
+      PBL_LOG_D_ERR(LOG_DOMAIN_COMM, "Invalid message received. First byte is %u", data[0]);
       break;
   }
 }

--- a/src/fw/services/common/compositor/compositor.c
+++ b/src/fw/services/common/compositor/compositor.c
@@ -402,7 +402,7 @@ static void prv_animation_teardown(Animation *animation) {
 
 void compositor_transition(const CompositorTransition *compositor_animation) {
   if (s_animation_state.animation != NULL) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Animation <%u> in progress, cancelling",
+    PBL_LOG_DBG("Animation <%u> in progress, cancelling",
             (int) s_animation_state.animation);
 
     animation_destroy(s_animation_state.animation);

--- a/src/fw/services/common/compositor/compositor_dma.c
+++ b/src/fw/services/common/compositor/compositor_dma.c
@@ -29,7 +29,7 @@ void compositor_dma_run(void *to, const void *from, uint32_t size) {
   dma_request_start_direct(COMPOSITOR_DMA, to, from, size, prv_dma_complete_handler, NULL);
 
   if (xSemaphoreTake(s_dma_in_progress, 10) != pdTRUE) {
-    PBL_LOG_SYNC(LOG_LEVEL_ERROR, "DMA Compositing never completed.");
+    PBL_LOG_SYNC_ERR("DMA Compositing never completed.");
     // TODO: This should never be hit, but do we want to queue up a new render
     // event so that there is no visible breakage in low-fps situations?
     dma_request_stop(COMPOSITOR_DMA);

--- a/src/fw/services/common/compositor/screenshot_pp.c
+++ b/src/fw/services/common/compositor/screenshot_pp.c
@@ -145,7 +145,7 @@ void screenshot_send_next_chunk(void* raw_state) {
 
   void *buffer = kernel_zalloc(max_buf_len);
   if (!buffer) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Screenshot aborted, OOM.");
+    PBL_LOG_WRN("Screenshot aborted, OOM.");
     prv_send_error_response(session, SCREENSHOT_OOM_ERROR);
     prv_finish(state);
   }
@@ -162,7 +162,7 @@ void screenshot_send_next_chunk(void* raw_state) {
   if (max_buf_len == 0 /* disconnected */ ||
       !(sb = comm_session_send_buffer_begin_write(session, SCREENSHOT_ENDPOINT_ID,
                                                   session_len, COMM_SESSION_DEFAULT_TIMEOUT))) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Terminating screenshot send early: %"PRIu32, max_buf_len);
+    PBL_LOG_WRN("Terminating screenshot send early: %"PRIu32, max_buf_len);
     prv_finish(state);
     return;
   }
@@ -200,13 +200,13 @@ void screenshot_send_next_chunk(void* raw_state) {
 void screenshot_protocol_msg_callback(CommSession *session, const uint8_t* msg_data, unsigned int msg_len) {
   uint8_t sub_command = msg_data[0];
   if (sub_command != 0x00) {
-    PBL_LOG(LOG_LEVEL_ERROR, "first byte can't be %u", sub_command);
+    PBL_LOG_ERR("first byte can't be %u", sub_command);
     prv_send_error_response(session, SCREENSHOT_MALFORMED_COMMAND);
     return;
   }
 
   if (s_screenshot_in_progress) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Screenshot already in progress.");
+    PBL_LOG_ERR("Screenshot already in progress.");
     // Use a low timeout, if we are already in screenshot_send_next_chunk with the send buffer locked, then this
     // would block for a long time, causing the comm_protocol_dispatch_message()'s 150ms max timeout to trip.
     prv_send_error_response(session, SCREENSHOT_ALREADY_IN_PROGRESS);

--- a/src/fw/services/common/cron.c
+++ b/src/fw/services/common/cron.c
@@ -67,7 +67,7 @@ void cron_service_handle_clock_change(PebbleSetTimeEvent *set_time_info) {
     if (must_recalc || change_diff >= job->clock_change_tolerance) {
       job->cached_execute_time = cron_job_get_execute_time(job);
     }
-    PBL_LOG(LOG_LEVEL_INFO, "Cron job rescheduled for %ld", job->cached_execute_time);
+    PBL_LOG_INFO("Cron job rescheduled for %ld", job->cached_execute_time);
 
     newlist = list_sorted_add(newlist, &job->list_node, prv_sort, true);
   }
@@ -103,7 +103,7 @@ time_t cron_job_schedule(CronJob *job) {
   if (!prv_is_scheduled(job)) {
     s_scheduled_jobs = list_sorted_add(s_scheduled_jobs, &job->list_node, prv_sort, true);
   }
-  PBL_LOG(LOG_LEVEL_DEBUG, "Cron job scheduled for %ld (%+ld)", job->cached_execute_time,
+  PBL_LOG_DBG("Cron job scheduled for %ld (%+ld)", job->cached_execute_time,
           (job->cached_execute_time - now));
 
   mutex_unlock(s_list_mutex);
@@ -131,7 +131,7 @@ time_t cron_job_schedule_after(CronJob *job, CronJob *new_job) {
 
   // insert after in the list, which guarantees it gets executed after
   list_insert_after(&job->list_node, &new_job->list_node);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Cron job scheduled for %ld", job->cached_execute_time);
+  PBL_LOG_DBG("Cron job scheduled for %ld", job->cached_execute_time);
 
   mutex_unlock(s_list_mutex);
 

--- a/src/fw/services/common/ecompass.c
+++ b/src/fw/services/common/ecompass.c
@@ -197,11 +197,11 @@ static int32_t prv_correct_for_roll_and_pitch(AccelRawData *accel_data,
 // Private handlers for compass service
 
 static void prv_calibration_time_expired_cb(void* data) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Calibration time expired, complete, or app exit, "
+  PBL_LOG_DBG("Calibration time expired, complete, or app exit, "
           "dropping back to low frequency");
 
   if (!mag_change_sample_rate(MagSampleRate5Hz)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Forcing reset to enter low freq mode");
+    PBL_LOG_WRN("Forcing reset to enter low freq mode");
     mag_release();
     mag_start_sampling();
   }
@@ -256,7 +256,7 @@ static void prv_compass_data_service_stop(PebbleTask task) {
       mag_release();
     }
   }
-  PBL_LOG(LOG_LEVEL_DEBUG, "subscribers %"PRIu8, s_compass_subscribers_count);
+  PBL_LOG_DBG("subscribers %"PRIu8, s_compass_subscribers_count);
 }
 
 static void prv_compass_data_service_start(PebbleTask task) {
@@ -272,7 +272,7 @@ static void prv_compass_data_service_start(PebbleTask task) {
 
     mag_start_sampling();
   }
-  PBL_LOG(LOG_LEVEL_DEBUG, "subscribers %"PRIu8, s_compass_subscribers_count);
+  PBL_LOG_DBG("subscribers %"PRIu8, s_compass_subscribers_count);
 }
 
 //////////////////////////////////////////////////////////////////////////////////
@@ -288,7 +288,7 @@ void ecompass_handle_battery_state_change_event(PreciseBatteryChargeState new_st
     // we have unplugged the charger, initiate recalibration
     s_charger_plugged = false;
     s_calib_run = false; // trigger a rerun of fast compass calibration
-    PBL_LOG(LOG_LEVEL_DEBUG, "Restarting calibration after charge event");
+    PBL_LOG_DBG("Restarting calibration after charge event");
   }
 }
 
@@ -318,7 +318,7 @@ void ecompass_service_handle(void) {
     if (rv == MagReadCommunicationFail) {
       // heavy hammer fix for now
       // FIXME: move the restart logic to driver
-      PBL_LOG(LOG_LEVEL_WARNING, "Read after %d samples failed, "
+      PBL_LOG_WRN("Read after %d samples failed, "
               "restarting compass", samples_collected);
       mag_release();
       mag_start_sampling();
@@ -363,7 +363,7 @@ void ecompass_service_handle(void) {
         (s_saved_corr_present) ? s_saved_corr : NULL, new_corr);
 
     if (cal_status != MagCalStatusNoSolution) {
-      PBL_LOG(LOG_LEVEL_INFO, "%s : %d %d %d (type = %d)", "Mag Corr",
+      PBL_LOG_INFO("%s : %d %d %d (type = %d)", "Mag Corr",
           (int)new_corr[0], (int)new_corr[1], (int)new_corr[2], (int)cal_status);
     }
 

--- a/src/fw/services/common/ecompass_correction.c
+++ b/src/fw/services/common/ecompass_correction.c
@@ -306,7 +306,7 @@ static MagCalStatus check_correction_value(int16_t *solution,
       if (saved_sample_match == 3) {
         saved_sample_match = 0;
         calib_idx = 0;
-        PBL_LOG(LOG_LEVEL_INFO, "Persisting previous values!");
+        PBL_LOG_INFO("Persisting previous values!");
         return (MagCalStatusSavedSampleMatch); // locked
       }
     }
@@ -355,7 +355,7 @@ MagCalStatus ecomp_corr_add_raw_mag_sample(int16_t *sample,
       s_no_fit_strikes++;
     }
     if (s_no_fit_strikes == 2) {
-      PBL_LOG(LOG_LEVEL_INFO, "Lowering magnetometer distance threshold");
+      PBL_LOG_INFO("Lowering magnetometer distance threshold");
       thresh = THRESH_MIN;
     }
 
@@ -382,7 +382,7 @@ MagCalStatus ecomp_corr_add_raw_mag_sample(int16_t *sample,
   }
 
   // the sample has passed its distance threshold check so add it
-  PBL_LOG(LOG_LEVEL_DEBUG, "---> [%d] Adding %d %d %d \n",
+  PBL_LOG_DBG("---> [%d] Adding %d %d %d \n",
       s_sample_idx, (int)sample[0], (int)sample[1], (int)sample[2]);
   s_sample_idx++;
 

--- a/src/fw/services/common/event_service.c
+++ b/src/fw/services/common/event_service.c
@@ -59,14 +59,14 @@ static void prv_event_service_unsubscribe(PebbleSubscriptionEvent *subscription)
 
   if (s_event_services[subscription->event_type] == NULL) {
     // service does not exist
-    PBL_LOG(LOG_LEVEL_WARNING, "Attempted to unsubscribe from %d, no service found",
+    PBL_LOG_WRN("Attempted to unsubscribe from %d, no service found",
         subscription->event_type);
     return;
   }
 
   if (service->subscribers[subscription->task] == NULL) {
     // not subscribed
-    PBL_LOG(LOG_LEVEL_WARNING, "Attempted to unsubscribe from %d, not subscribed",
+    PBL_LOG_WRN("Attempted to unsubscribe from %d, not subscribed",
         subscription->event_type);
     return;
   }
@@ -91,7 +91,7 @@ static void prv_event_service_subscribe(PebbleSubscriptionEvent *subscription) {
 
   if (service->subscribers[subscription->task]) {
     // already subscribed ?
-    PBL_LOG(LOG_LEVEL_DEBUG, "already subscribed");
+    PBL_LOG_DBG("already subscribed");
     return;
   }
 
@@ -220,7 +220,7 @@ void event_service_handle_event(PebbleEvent *e) {
         continue;
       } else {
         if (!prv_event_service_send_event(service->subscribers[i], e)) {
-          PBL_LOG(LOG_LEVEL_INFO, "Queue full! %d not delivered to task %d!",
+          PBL_LOG_INFO("Queue full! %d not delivered to task %d!",
                   (int)e->type, (int)i);
 #if !RELEASE
           // For 3rd party apps, just close them. For a 1st party app or other task, reboot
@@ -272,7 +272,7 @@ void* event_service_claim_buffer(PebbleEvent *e) {
   if (esb) {
     if (esb->intents_pending & CLAIMED_BIT) {
       // For now only 1 claim at a time is needed, so lets keep things simple and just support that
-      PBL_LOG(LOG_LEVEL_WARNING, "Buffer already claimed");
+      PBL_LOG_WRN("Buffer already claimed");
       return NULL;
     } else {
       esb->intents_pending |= CLAIMED_BIT;
@@ -337,7 +337,7 @@ static int16_t prv_get_plugin_index(const Uuid *uuid) {
 
   char uuid_buffer[UUID_STRING_BUFFER_LENGTH];
   uuid_to_string(uuid, uuid_buffer);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Registered plug-in service %s as index %d", uuid_buffer, result);
+  PBL_LOG_DBG("Registered plug-in service %s as index %d", uuid_buffer, result);
 
 unlock:
   mutex_unlock(s_plugin_list_mutex);

--- a/src/fw/services/common/evented_timer.c
+++ b/src/fw/services/common/evented_timer.c
@@ -256,7 +256,7 @@ bool evented_timer_reschedule(EventedTimerID timer_id, uint32_t timeout_ms) {
   //  already
   EventedTimer* timer = prv_find_timer(timer_id);
   if (!timer) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Attempting to reschedule an invalid timer (id=%u)",
+    PBL_LOG_DBG("Attempting to reschedule an invalid timer (id=%u)",
             (unsigned)timer_id);
     mutex_unlock(s_mutex);
     return false;
@@ -299,7 +299,7 @@ void evented_timer_cancel(EventedTimerID timer_id) {
   // Find this timer and validate it
   EventedTimer* timer = prv_find_timer(timer_id);
   if (!timer) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Attempting to cancel an invalid timer (id=%u)", (unsigned)timer_id);
+    PBL_LOG_DBG("Attempting to cancel an invalid timer (id=%u)", (unsigned)timer_id);
     mutex_unlock(s_mutex);
     return;
   }

--- a/src/fw/services/common/firmware_update.c
+++ b/src/fw/services/common/firmware_update.c
@@ -100,7 +100,7 @@ static bool prv_legacy_handle_progress(PebblePutBytesEvent *event) {
       break;
 
     default:
-      PBL_LOG(LOG_LEVEL_ERROR, "Unexpected Object type %u", event->object_type);
+      PBL_LOG_ERR("Unexpected Object type %u", event->object_type);
       break;
   }
 
@@ -285,7 +285,7 @@ void firmware_update_pb_event_handler(PebblePutBytesEvent *event) {
       break;
 
     case PebblePutBytesEventTypeInitTimeout:
-      PBL_LOG(LOG_LEVEL_WARNING, "Timed out waiting for putbytes request from phone");
+      PBL_LOG_WRN("Timed out waiting for putbytes request from phone");
       prv_firmware_update_finish(true /* failed */);
       break;
 

--- a/src/fw/services/common/get_bytes/get_bytes_storage_coredump.c
+++ b/src/fw/services/common/get_bytes/get_bytes_storage_coredump.c
@@ -76,7 +76,7 @@ GetBytesInfoErrorCode gb_storage_coredump_get_size(GetBytesStorage *storage, uin
 
   // Get the base address in flash
   uint32_t flash_base = prv_coredump_flash_base(data->only_get_new_coredump);
-  PBL_LOG(LOG_LEVEL_DEBUG, "GET_BYTES: checking image %p", (void *)flash_base);
+  PBL_LOG_DBG("GET_BYTES: checking image %p", (void *)flash_base);
   if (flash_base != CORE_DUMP_FLASH_INVALID_ADDR) {
     flash_read_bytes((uint8_t *)&image_hdr, flash_base + sizeof(CoreDumpFlashRegionHeader),
                      sizeof(image_hdr));

--- a/src/fw/services/common/hrm/hrm_manager.c
+++ b/src/fw/services/common/hrm/hrm_manager.c
@@ -30,7 +30,7 @@
 #if HRM_DEBUG
 #define HRM_LOG(fmt, ...) \
   do { \
-    PBL_LOG(LOG_LEVEL_DEBUG, fmt, ## __VA_ARGS__); \
+    PBL_LOG_DBG(fmt, ## __VA_ARGS__); \
   } while (0)
 #define HRM_HEXDUMP(data, length) \
   do { \
@@ -304,7 +304,7 @@ static void prv_update_hrm_enable_system_cb(void *unused) {
 
       // Only subscribe if not already subscribed (prevents leak if hrm_is_enabled is out of sync)
       if (s_manager_state.accel_state) {
-        PBL_LOG(LOG_LEVEL_WARNING, "HRM: accel already subscribed, unsubscribing first");
+        PBL_LOG_WRN("HRM: accel already subscribed, unsubscribing first");
         sys_accel_manager_data_unsubscribe(s_manager_state.accel_state);
         s_manager_state.accel_state = NULL;
       }
@@ -320,10 +320,10 @@ static void prv_update_hrm_enable_system_cb(void *unused) {
         // HRM failed to enable, clean up the accel subscription
         s_manager_state.enable_failure_count++;
         if (s_manager_state.enable_failure_count >= HRM_MAX_ENABLE_FAILURES) {
-          PBL_LOG(LOG_LEVEL_ERROR, "HRM failed to enable %d times, giving up until reboot",
+          PBL_LOG_ERR("HRM failed to enable %d times, giving up until reboot",
                   HRM_MAX_ENABLE_FAILURES);
         } else {
-          PBL_LOG(LOG_LEVEL_ERROR, "HRM failed to enable (attempt %d/%d)",
+          PBL_LOG_ERR("HRM failed to enable (attempt %d/%d)",
                   s_manager_state.enable_failure_count, HRM_MAX_ENABLE_FAILURES);
         }
         sys_accel_manager_data_unsubscribe(s_manager_state.accel_state);
@@ -375,7 +375,7 @@ static void prv_system_task_hrm_handler(void *context) {
   if (available_bytes < sizeof(PebbleHRMEvent)) {
     // No event available to read - this can happen if system task callbacks are queued
     // without corresponding events, or during concurrent access.
-    PBL_LOG(LOG_LEVEL_WARNING, "HRM: system task handler called with no event in buffer "
+    PBL_LOG_WRN("HRM: system task handler called with no event in buffer "
             "(available=%u, needed=%u)", available_bytes, sizeof(PebbleHRMEvent));
     mutex_unlock_recursive(s_manager_state.lock);
     return;
@@ -616,7 +616,7 @@ void hrm_manager_new_data_cb(const HRMData *data) {
 
     // If the prior subscription expired, remove it now
     if (expired_state) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Subscription %"PRIu32" expired", expired_state->session_ref);
+      PBL_LOG_DBG("Subscription %"PRIu32" expired", expired_state->session_ref);
       prv_remove_and_free_subscription(expired_state);
     }
   }
@@ -682,7 +682,7 @@ HRMSessionRef hrm_manager_subscribe_with_callback(AppInstallId app_id, uint32_t 
     HRMSubscriberState * state = prv_get_subscriber_state_from_app_id(current_task, app_id);
     if (state != NULL) {
       session_ref = state->session_ref;
-      PBL_LOG(LOG_LEVEL_DEBUG, "Removing existing subscription for this app");
+      PBL_LOG_DBG("Removing existing subscription for this app");
       prv_remove_and_free_subscription(state);
     }
   }
@@ -864,7 +864,7 @@ void hrm_manager_process_cleanup(PebbleTask task, AppInstallId app_id) {
   }
 
   // Set an expiration time now
-  PBL_LOG(LOG_LEVEL_DEBUG, "Setting expiration time on session for app_id %d", (int)app_id);
+  PBL_LOG_DBG("Setting expiration time on session for app_id %d", (int)app_id);
   sys_hrm_manager_set_update_interval(state->session_ref, state->update_interval_s,
                                       HRM_MANAGER_APP_EXIT_EXPIRATION_SEC);
 }

--- a/src/fw/services/common/i18n/i18n.c
+++ b/src/fw/services/common/i18n/i18n.c
@@ -193,13 +193,13 @@ static bool prv_get_metadata(struct DomainBinding *db) {
   // all metadata is in the "" header entry
   prv_lookup("", db, &header_len, header, HEADER_BUFFER_SIZE);
   if (!header_len) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Could not find header in language pack");
+    PBL_LOG_WRN("Could not find header in language pack");
     goto cleanup;
   }
 
   // Isolate the language substring
   if (!prv_get_property(header, "Language: ", db->iso_locale, ISO_LOCALE_LENGTH)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Could not parse a language from language pack");
+    PBL_LOG_WRN("Could not parse a language from language pack");
     goto cleanup;
   }
 
@@ -211,18 +211,18 @@ static bool prv_get_metadata(struct DomainBinding *db) {
   // Isolate the version value
   char version_str[10] = {0};
   if (!prv_get_property(header, "Project-Id-Version: ", version_str, 10)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Could not parse a version from language pack");
+    PBL_LOG_WRN("Could not parse a version from language pack");
     goto cleanup;
   }
   char *version_end;
   db->lang_version = strtol(version_str, &version_end, 0);
   if (version_end == version_str) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Could not parse a version from language pack");
+    PBL_LOG_WRN("Could not parse a version from language pack");
     goto cleanup;
   }
 
   success = true;
-  PBL_LOG(LOG_LEVEL_INFO, "language: %s, version %d", db->iso_locale, db->lang_version);
+  PBL_LOG_INFO("language: %s, version %d", db->iso_locale, db->lang_version);
 
 cleanup:
   kernel_free(header);
@@ -248,7 +248,7 @@ static bool prv_mapit(const uint32_t resource_id, struct DomainBinding *db) {
     return (db->version.crc != 0);
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "New language detected!");
+  PBL_LOG_DBG("New language detected!");
   db->need_reload = false;
 
   /* save version */
@@ -437,7 +437,7 @@ const char *i18n_get(const char *msgid, const void *owner) {
   size_t len = 0;
   prv_lookup(msgid, db, &len, translated, sizeof(translated));
   if (len >= sizeof(translated)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Truncated string: <%s>", msgid);
+    PBL_LOG_WRN("Truncated string: <%s>", msgid);
   }
 
   if (len) {
@@ -465,7 +465,7 @@ void i18n_get_with_buffer(const char *msgid, char *buffer, size_t length) {
   size_t len = 0;
   prv_lookup(msgid, db, &len, buffer, length);
   if (len >= length) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Truncated string: <%s>", msgid);
+    PBL_LOG_WRN("Truncated string: <%s>", msgid);
   }
 
   if (len) {
@@ -523,7 +523,7 @@ void i18n_free_all(const void *owner) {
 static void prv_resource_changed_handler(void *data) {
   struct DomainBinding *db = (struct DomainBinding *)data;
   // Mark as invalid
-  PBL_LOG(LOG_LEVEL_DEBUG, "lang resource file reloading");
+  PBL_LOG_DBG("lang resource file reloading");
   shell_prefs_set_language_english(false);
   db->need_reload = true;
 
@@ -535,7 +535,7 @@ static void prv_resource_changed_handler(void *data) {
 static void prv_resource_changed_callback(void *data) {
   // We want to not actually handle the reload here, because the PFS lock is still held here.
   // So instead we throw in the reload as an event callback.
-  PBL_LOG(LOG_LEVEL_DEBUG, "lang resource file was modified");
+  PBL_LOG_DBG("lang resource file was modified");
   launcher_task_add_callback(prv_resource_changed_handler, data);
 }
 

--- a/src/fw/services/common/i18n/syscalls.c
+++ b/src/fw/services/common/i18n/syscalls.c
@@ -28,7 +28,7 @@ DEFINE_SYSCALL(void, sys_i18n_get_with_buffer, const char *string,
     }
     if (!memory_layout_is_cstring_in_region(memory_layout_get_app_region(), string, 100) &&
         !memory_layout_is_cstring_in_region(memory_layout_get_microflash_region(), string, 100)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Pointer %p not in app or microflash region", string);
+      PBL_LOG_ERR("Pointer %p not in app or microflash region", string);
       syscall_failed();
     }
     syscall_assert_userspace_buffer(buffer, length);
@@ -45,7 +45,7 @@ DEFINE_SYSCALL(size_t, sys_i18n_get_length, const char *string) {
     }
     if (!memory_layout_is_cstring_in_region(memory_layout_get_app_region(), string, 100) &&
         !memory_layout_is_cstring_in_region(memory_layout_get_microflash_region(), string, 100)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Pointer %p not in app or microflash region", string);
+      PBL_LOG_ERR("Pointer %p not in app or microflash region", string);
       syscall_failed();
     }
   }

--- a/src/fw/services/common/legacy/registry_private.c
+++ b/src/fw/services/common/legacy/registry_private.c
@@ -80,12 +80,12 @@ static int registry_get_next_available_index(Registry* registry) {
 int registry_private_add(const char* key, const uint8_t key_length, const uint8_t* uuid,
     uint8_t description, const uint8_t* value, uint8_t value_length, Registry* registry) {
   if (value_length >= MAX_VALUE_SIZE_BYTES) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Length of record value exceeds maximum length.");
+    PBL_LOG_WRN("Length of record value exceeds maximum length.");
     return -1;
   }
 
   if (key_length > MAX_KEY_SIZE_BYTES) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Length of record key exceeds maximum length.");
+    PBL_LOG_WRN("Length of record key exceeds maximum length.");
     return -1;
   }
 
@@ -95,10 +95,10 @@ int registry_private_add(const char* key, const uint8_t key_length, const uint8_
     if (r->value_length == value_length &&
         r->description == description &&
         memcmp(r->value, value, value_length) == 0) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Key & value already exist.");
+      PBL_LOG_DBG("Key & value already exist.");
       return 0;
     }
-    PBL_LOG(LOG_LEVEL_DEBUG, "Key already exists. Updating record.");
+    PBL_LOG_DBG("Key already exists. Updating record.");
     r->description = description;
     memcpy(r->value, value, value_length);
     r->value_length = value_length;
@@ -109,7 +109,7 @@ int registry_private_add(const char* key, const uint8_t key_length, const uint8_
   int idx = registry_get_next_available_index(registry);
 
   if (idx < 0) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Registry full.");
+    PBL_LOG_WRN("Registry full.");
     return -1;
   }
 
@@ -127,7 +127,7 @@ int registry_private_add(const char* key, const uint8_t key_length, const uint8_
   r->value_length = value_length;
   registry->is_different_from_flash = true;
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Writing new key: %s", r->key);
+  PBL_LOG_DBG("Writing new key: %s", r->key);
 
   return 0;
 }
@@ -289,7 +289,7 @@ void registry_private_write_to_flash(Registry* registry) {
   if (registry->cursor->address == (unsigned)FLASH_CURSOR_UNINITIALIZED) {
     registry->cursor->address = registry->cursor->begin;
   }
-  PBL_LOG(LOG_LEVEL_DEBUG, "Writing registry to flash...");
+  PBL_LOG_DBG("Writing registry to flash...");
 
   prv_assert_valid_cursor(registry->cursor);
 

--- a/src/fw/services/common/light.c
+++ b/src/fw/services/common/light.c
@@ -308,7 +308,7 @@ void light_button_pressed(void) {
 
   s_num_buttons_down++;
   if (s_num_buttons_down > 4) {
-    PBL_LOG(LOG_LEVEL_ERROR, "More buttons were pressed than have been released.");
+    PBL_LOG_ERR("More buttons were pressed than have been released.");
     s_num_buttons_down = 0;
   }
 
@@ -325,7 +325,7 @@ void light_button_released(void) {
 
   s_num_buttons_down--;
   if (s_num_buttons_down < 0) {
-    PBL_LOG(LOG_LEVEL_ERROR, "More buttons were released than have been pressed.");
+    PBL_LOG_ERR("More buttons were released than have been pressed.");
     s_num_buttons_down = 0;
   }
 

--- a/src/fw/services/common/new_timer/new_timer.c
+++ b/src/fw/services/common/new_timer/new_timer.c
@@ -110,7 +110,7 @@ void* new_timer_debug_get_current_callback(void) {
 //=========================================================================================
 // Initialize the timer service
 void new_timer_service_init(void) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "NT: Initializing");
+  PBL_LOG_DBG("NT: Initializing");
 
   vSemaphoreCreateBinary(s_wake_srv_loop);
 

--- a/src/fw/services/common/phone_pp.c
+++ b/src/fw/services/common/phone_pp.c
@@ -80,9 +80,9 @@ static bool get_call_info_from_msg(const uint8_t* msg, unsigned int length,
 
 // MJZ: This has been left here for future debugging
 static void print_call_info(PebbleCallInfo* i) {
-  // PBL_LOG(LOG_LEVEL_DEBUG, "Call Cookie: 0x%"PRIx32, i->cookie);
-  // PBL_LOG(LOG_LEVEL_DEBUG, "Caller Number: %s", i->caller_number);
-  // PBL_LOG(LOG_LEVEL_DEBUG, "Caller Name: %s", i->caller_name);
+  // PBL_LOG_DBG("Call Cookie: 0x%"PRIx32, i->cookie);
+  // PBL_LOG_DBG("Caller Number: %s", i->caller_number);
+  // PBL_LOG_DBG("Caller Name: %s", i->caller_name);
 }
 
 static void prv_put_call_disconnect_event(void) {
@@ -117,11 +117,11 @@ static void prv_send_phone_command_to_handset(uint8_t cmd, uint8_t *data, unsign
   *buffer = cmd;
   memcpy(buffer + sizeof(cmd), data, length);
 
-  // PBL_LOG(LOG_LEVEL_DEBUG, "Sending PhoneCmd: %d", cmd);
+  // PBL_LOG_DBG("Sending PhoneCmd: %d", cmd);
   CommSession *session = comm_session_get_system_session();
   if (!session) {
     // Looks like we disconnected...
-    PBL_LOG(LOG_LEVEL_ERROR, "No CommSession for phone command, ending call");
+    PBL_LOG_ERR("No CommSession for phone command, ending call");
     prv_put_call_disconnect_event();
   } else {
     comm_session_send_data(session, PHONE_CTRL_ENDPOINT, buffer,
@@ -167,7 +167,7 @@ static bool prv_parse_msg_to_event(const uint8_t *iter, size_t length,
       }
       bool result = get_call_info_from_msg(iter, length, &call_info);
       if (!result) {
-        PBL_LOG(LOG_LEVEL_ERROR, "Failed to read caller information from 'Incoming' phone event");
+        PBL_LOG_ERR("Failed to read caller information from 'Incoming' phone event");
         return false;
       }
 
@@ -222,7 +222,7 @@ static bool prv_parse_msg_to_event(const uint8_t *iter, size_t length,
     };
   } else {
     // Try to catch potentially malformed messages.
-    PBL_LOG(LOG_LEVEL_ERROR, "Error parsing phone msg");
+    PBL_LOG_ERR("Error parsing phone msg");
     PBL_HEXDUMP(LOG_LEVEL_INFO, iter, length);
   }
 
@@ -257,7 +257,7 @@ void phone_protocol_msg_callback(CommSession *session, const uint8_t* iter, size
       --length;
       ++num_items;
       if (length < item_length) {
-        PBL_LOG(LOG_LEVEL_ERROR, "Malformed message");
+        PBL_LOG_ERR("Malformed message");
         break;
       }
       prv_parse_msg_and_emit_event(iter, item_length, true /* is_state_response */);

--- a/src/fw/services/common/ping.c
+++ b/src/fw/services/common/ping.c
@@ -65,7 +65,7 @@ static void prv_send_ping_kernel_bg_cb(void *unused) {
       s_last_send_time = rtc_get_time();
       analytics_inc(ANALYTICS_DEVICE_METRIC_PING_SENT_COUNT, AnalyticsClient_System);
     }
-    PBL_LOG(LOG_LEVEL_DEBUG, "Sent ping idle=%d, success=%d", (int)idle, (int)success);
+    PBL_LOG_DBG("Sent ping idle=%d, success=%d", (int)idle, (int)success);
   }
 
   s_is_ping_kernel_bg_callback_scheduled = false;
@@ -108,13 +108,13 @@ void ping_protocol_msg_callback(CommSession *session, const uint8_t* data, size_
   case 0:
   {
     if (length != sizeof(PingMsgV1) && length != sizeof(PingMsgV2) /* idle boolean is optional */) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Invalid Ping, l=%u", length);
+      PBL_LOG_ERR("Invalid Ping, l=%u", length);
       return;
     }
 
     // Ping message
     uint32_t cookie = ntohl(ping->hdr.cookie);
-    PBL_LOG(LOG_LEVEL_DEBUG, "Ping c=%"PRIu32"", cookie);
+    PBL_LOG_DBG("Ping c=%"PRIu32"", cookie);
     launcher_task_add_callback(prv_push_window, NULL);
 
     // Send the pong response
@@ -130,17 +130,17 @@ void ping_protocol_msg_callback(CommSession *session, const uint8_t* data, size_
 
   case 1:
     if (length != sizeof(PongMsg)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Invalid Pong, l=%u", length);
+      PBL_LOG_ERR("Invalid Pong, l=%u", length);
       return;
     }
 
     PongMsg *pong = (PongMsg *)data;
-    PBL_LOG(LOG_LEVEL_DEBUG, "Pong c=%"PRIu32, ntohl(pong->hdr.cookie));
+    PBL_LOG_DBG("Pong c=%"PRIu32, ntohl(pong->hdr.cookie));
     analytics_inc(ANALYTICS_DEVICE_METRIC_PONG_RECEIVED_COUNT, AnalyticsClient_System);
     break;
 
   default:
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid message received. First byte is %u", ping->hdr.cmd);
+    PBL_LOG_ERR("Invalid message received. First byte is %u", ping->hdr.cmd);
     break;
   }
 }

--- a/src/fw/services/common/poll_remote.c
+++ b/src/fw/services/common/poll_remote.c
@@ -152,7 +152,7 @@ void comm_poll_remote_protocol_msg_callback(CommSession *session, const uint8_t*
       break;
     }
     default: {
-      PBL_LOG(LOG_LEVEL_ERROR, "Invalid command.");
+      PBL_LOG_ERR("Invalid command.");
       return;
     }
   }

--- a/src/fw/services/common/prf_update.c
+++ b/src/fw/services/common/prf_update.c
@@ -11,7 +11,7 @@
 // Don't allow PRF updating when we're in PRF
 #ifndef RECOVERY_FW
 static void prv_do_update(void) {
-  PBL_LOG(LOG_LEVEL_INFO, "Updating PRF!");
+  PBL_LOG_INFO("Updating PRF!");
   flash_prf_set_protection(false);
 
   bool saved_sleep_when_idle = flash_get_sleep_when_idle();
@@ -23,7 +23,7 @@ static void prv_do_update(void) {
 
   if (!firmware_storage_check_valid_firmware_description(FLASH_REGION_FIRMWARE_DEST_BEGIN,
                                                          &description)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Invalid recovery firmware CRC in SPI flash!");
+    PBL_LOG_WRN("Invalid recovery firmware CRC in SPI flash!");
     goto done;
   }
 
@@ -33,20 +33,20 @@ static void prv_do_update(void) {
       firmware_storage_read_firmware_header(FLASH_REGION_FIRMWARE_DEST_BEGIN);
   if (!firmware_storage_check_valid_firmware_header(FLASH_REGION_FIRMWARE_DEST_BEGIN,
                                                     &header)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Invalid recovery firmware CRC in SPI flash!");
+    PBL_LOG_WRN("Invalid recovery firmware CRC in SPI flash!");
     goto done;
   }
 
   const uint32_t total_length = header.fw_start + header.fw_length;
 #endif
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Erasing previous PRF...");
+  PBL_LOG_DBG("Erasing previous PRF...");
   flash_region_erase_optimal_range(FLASH_REGION_SAFE_FIRMWARE_BEGIN,
                                    FLASH_REGION_SAFE_FIRMWARE_BEGIN,
                                    FLASH_REGION_SAFE_FIRMWARE_BEGIN + total_length,
                                    FLASH_REGION_SAFE_FIRMWARE_END);
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Copying PRF from scratch to the PRF slot");
+  PBL_LOG_DBG("Copying PRF from scratch to the PRF slot");
   uint8_t buffer[512];
   uint32_t offset = 0;
   while (offset < total_length) {
@@ -61,7 +61,7 @@ static void prv_do_update(void) {
 done:
   flash_prf_set_protection(true);
   flash_sleep_when_idle(saved_sleep_when_idle);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Done!");
+  PBL_LOG_DBG("Done!");
 }
 #endif
 

--- a/src/fw/services/common/put_bytes/put_bytes_storage.c
+++ b/src/fw/services/common/put_bytes/put_bytes_storage.c
@@ -70,7 +70,7 @@ bool pb_storage_init(PutBytesStorage *storage, PutBytesObjectType object_type,
 
   if (object_type >= ARRAY_LENGTH(IMPL_FOR_OBJECT_TYPE) ||
       IMPL_FOR_OBJECT_TYPE[object_type] == NULL) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Unsupported PutBytesObjectType %u", object_type);
+    PBL_LOG_WRN("Unsupported PutBytesObjectType %u", object_type);
     return false;
   }
 
@@ -78,7 +78,7 @@ bool pb_storage_init(PutBytesStorage *storage, PutBytesObjectType object_type,
 
   uint32_t max_size = impl->get_max_size(object_type);
   if (total_size > max_size) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Invalid size for type %u, size: %"PRIu32", max_size: %"PRIu32,
+    PBL_LOG_WRN("Invalid size for type %u, size: %"PRIu32", max_size: %"PRIu32,
             object_type, total_size, max_size);
     return false;
   }

--- a/src/fw/services/common/regular_timer.c
+++ b/src/fw/services/common/regular_timer.c
@@ -97,8 +97,7 @@ static void timer_callback(void* data) {
     // Keep the logging to detect large time jumps (multiple minutes skipped)
     const time_t now_ts = rtc_get_ticks() / configTICK_RATE_HZ;
     if ((now_ts - s_last_minute_fire_ts) > MISSING_MINUTE_CB_LOG_THRESHOLD_S) {
-      PBL_LOG(LOG_LEVEL_WARNING,
-              "Large time jump detected. Previous ts: %lu, Now ts: %lu",
+      PBL_LOG_WRN("Large time jump detected. Previous ts: %lu, Now ts: %lu",
               s_last_minute_fire_ts, now_ts);
     }
     s_last_minute_fire_ts = now_ts;
@@ -219,7 +218,7 @@ bool regular_timer_remove_callback(RegularTimerInfo* cb) {
   mutex_lock(s_callback_list_semaphore);
 
   if (!prv_regular_timer_is_scheduled(cb)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Timer not registered");
+    PBL_LOG_WRN("Timer not registered");
   } else {
     // If currently executing, mark for deletion. do_callbacks will delete it for us once
     // it completes.

--- a/src/fw/services/common/shared_prf_storage/v2_sprf/shared_prf_storage.c
+++ b/src/fw/services/common/shared_prf_storage/v2_sprf/shared_prf_storage.c
@@ -267,7 +267,7 @@ void shared_prf_storage_store_ble_pairing_data(
     const SMPairingInfo *pairing_info, const char *name, bool requires_address_pinning,
     uint8_t flags) {
   if (!pairing_info || sm_is_pairing_info_empty(pairing_info)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "PRF Storage: Attempting to store an NULL or empty pairing info");
+    PBL_LOG_WRN("PRF Storage: Attempting to store an NULL or empty pairing info");
     return;
   }
 
@@ -308,7 +308,7 @@ bool shared_prf_storage_get_bt_classic_pairing_data(BTDeviceAddress *addr_out,
   bool result = false;
   const BTDeviceAddress invalid_address = (BTDeviceAddress) {};
   if (memcmp(&data.bt_classic_data.address, &invalid_address, sizeof(invalid_address)) == 0) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Invalid pairing stored");
+    PBL_LOG_WRN("Invalid pairing stored");
     goto done;
   }
 
@@ -362,7 +362,7 @@ static void prv_shared_prf_storage_store_bt_classic_pairing_data(
 void shared_prf_storage_store_bt_classic_pairing_data(
     BTDeviceAddress *addr, const char *device_name, SM128BitKey *link_key, uint8_t platform_bits) {
   if (!addr || !device_name) {
-    PBL_LOG(LOG_LEVEL_WARNING, "PRF Storage: Can't store this BT classic pairing");
+    PBL_LOG_WRN("PRF Storage: Can't store this BT classic pairing");
     return;
   }
 
@@ -423,7 +423,7 @@ void shared_prf_storage_wipe_all(void) {
 }
 
 static void prv_system_task_prf_update_cb(void *unused) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Syncing pairing information to SPRF");
+  PBL_LOG_DBG("Syncing pairing information to SPRF");
   prv_lock_pending_bonding();
   {
     bool le_bonding_update = s_pending_bondings.has_ble_pairing_pending;

--- a/src/fw/services/common/shared_prf_storage/v3_sprf/shared_prf_storage.c
+++ b/src/fw/services/common/shared_prf_storage/v3_sprf/shared_prf_storage.c
@@ -144,7 +144,7 @@ static void prv_erase_region_and_save(SharedPRFData *data) {
 }
 
 static void prv_invalidate_current_page(void) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Invalidating current page: #%"PRIu32, s_valid_page_idx);
+  PBL_LOG_DBG("Invalidating current page: #%"PRIu32, s_valid_page_idx);
   // First, check if the page is Unpopulated
   SprfMagic magic = prv_get_magic_for_page(s_valid_page_idx);
   if (magic == SprfMagic_UnpopulatedEntry) {
@@ -160,7 +160,7 @@ static void prv_invalidate_current_page(void) {
   // Sanity check to make sure that the page we are moving to is actually empty.
   if ((s_valid_page_idx >= SPRF_NUM_PAGES) ||
       (prv_get_magic_for_page(s_valid_page_idx) != SprfMagic_UnpopulatedEntry)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Ran out of pages or found corrupted next page, erasing region");
+    PBL_LOG_WRN("Ran out of pages or found corrupted next page, erasing region");
     // NOTE: This should not happen often. On boot, we delete and rewrite the region if >75% of
     // regions are filled. In the worst case, this will happen if the user pair/repairs
     // NUM_REGIONS * .25 times without rebooting in between. (e.g. 16 pages.
@@ -182,7 +182,7 @@ static void prv_fetch_struct(SharedPRFData *data_out) {
   flash_read_bytes((uint8_t *)data_out, prv_current_page_flash_addr(), sizeof(*data_out));
 
   if (!prv_valid_struct(data_out)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Shared PRF Storage sector # %"PRIu32" is corrupted. Invalidating"
+    PBL_LOG_WRN("Shared PRF Storage sector # %"PRIu32" is corrupted. Invalidating"
                                " and starting a new one", s_valid_page_idx);
     prv_invalidate_current_page();
     memset(data_out, 0xFF, sizeof(*data_out));
@@ -225,7 +225,7 @@ static void prv_persist_field(uint8_t *field, size_t offset, size_t field_size, 
     prv_write_to_current_page(data, true);
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Overwriting SPRF field at offset %d, size %d",
+  PBL_LOG_DBG("Overwriting SPRF field at offset %d, size %d",
           (int)offset, (int)field_size);
 
   // write the crc first so it's easier to detect a non empty field (we can just read if the CRC is
@@ -250,7 +250,7 @@ static bool prv_fetch_field(uint8_t *field_out, size_t offset, size_t field_size
   flash_read_bytes(field_out, prv_current_page_flash_addr() + offset, field_size);
   if (!prv_field_valid(field_out, field_size)) {
     // If corrupted field, delete entire page
-    PBL_LOG(LOG_LEVEL_WARNING, "Shared PRF Storage sector # %"PRIu32" is corrupted. Invalidating"
+    PBL_LOG_WRN("Shared PRF Storage sector # %"PRIu32" is corrupted. Invalidating"
                                " and starting a new one", s_valid_page_idx);
     prv_invalidate_current_page();
     return false;
@@ -482,7 +482,7 @@ void shared_prf_storage_store_ble_pairing_data(
     const SMPairingInfo *pairing_info, const char *name, bool requires_address_pinning,
     uint8_t flags) {
   if (!pairing_info || sm_is_pairing_info_empty(pairing_info)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "PRF Storage: Attempting to store an NULL or empty pairing info");
+    PBL_LOG_WRN("PRF Storage: Attempting to store an NULL or empty pairing info");
     return;
   }
 

--- a/src/fw/services/common/system_task.c
+++ b/src/fw/services/common/system_task.c
@@ -124,7 +124,7 @@ static void handle_system_task_send_failure(SystemTaskEventCallback cb) {
   register uintptr_t lr __asm("lr");
   uintptr_t saved_lr = lr;
 
-  PBL_LOG(LOG_LEVEL_ERROR, "System task queue full. Dropped cb: %p, current cb: %p", cb, s_current_cb);
+  PBL_LOG_ERR("System task queue full. Dropped cb: %p, current cb: %p", cb, s_current_cb);
 
   RebootReason reason = {
     .code = RebootReasonCode_EventQueueFull,

--- a/src/fw/services/common/tick_timer.c
+++ b/src/fw/services/common/tick_timer.c
@@ -28,7 +28,7 @@ static RegularTimerInfo s_tick_timer_info = {
 void tick_timer_add_subscriber(PebbleTask task) {
   ++s_num_subscribers;
   if (s_num_subscribers == 1) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "starting tick timer");
+    PBL_LOG_DBG("starting tick timer");
     regular_timer_add_seconds_callback(&s_tick_timer_info);
   }
 }
@@ -37,7 +37,7 @@ void tick_timer_remove_subscriber(PebbleTask task) {
   PBL_ASSERTN(s_num_subscribers > 0);
   --s_num_subscribers;
   if (s_num_subscribers == 0) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "stopping tick timer");
+    PBL_LOG_DBG("stopping tick timer");
     regular_timer_remove_callback(&s_tick_timer_info);
   }
 }

--- a/src/fw/services/common/touch/touch.c
+++ b/src/fw/services/common/touch/touch.c
@@ -11,7 +11,7 @@
 #include "system/passert.h"
 #include "util/size.h"
 
-#define TOUCH_DEBUG(fmt, args...) PBL_LOG_D(LOG_DOMAIN_TOUCH, LOG_LEVEL_DEBUG, fmt, ## args)
+#define TOUCH_DEBUG(fmt, args...) PBL_LOG_D_DBG(LOG_DOMAIN_TOUCH, fmt, ## args)
 
 #define TOUCH_QUEUE_LENGTH (2)
 

--- a/src/fw/services/common/vibe_pattern.c
+++ b/src/fw/services/common/vibe_pattern.c
@@ -199,7 +199,7 @@ void vibe_service_set_enabled(bool enable) {
 
 static void prv_timer_callback(void* data) {
   if (s_vibe_queue_head == NULL) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Tried to handle a vibe event with a null vibe queue");
+    PBL_LOG_ERR("Tried to handle a vibe event with a null vibe queue");
     return;
   }
 
@@ -246,14 +246,14 @@ bool prv_vibe_pattern_enqueue_step_raw(uint32_t duration_ms, int32_t strength) {
   mutex_lock(s_vibe_pattern_mutex);
 
   if (s_pattern_in_progress) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Pattern is in progress");
+    PBL_LOG_DBG("Pattern is in progress");
     mutex_unlock(s_vibe_pattern_mutex);
     return false;
   }
 
   VibePatternStep *step = kernel_malloc(sizeof(VibePatternStep));
   if (step == NULL) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Couldn't malloc for a vibe step");
+    PBL_LOG_ERR("Couldn't malloc for a vibe step");
     mutex_unlock(s_vibe_pattern_mutex);
     return false;
   }

--- a/src/fw/services/normal/activity/activity_insights.c
+++ b/src/fw/services/normal/activity/activity_insights.c
@@ -39,7 +39,7 @@
 #include <stdio.h>
 
 #define INSIGHTS_LOG_DEBUG(fmt, args...) \
-        PBL_LOG_D(LOG_DOMAIN_ACTIVITY_INSIGHTS, LOG_LEVEL_DEBUG, fmt, ## args)
+        PBL_LOG_D_DBG(LOG_DOMAIN_ACTIVITY_INSIGHTS, fmt, ## args)
 
 #define SUBTITLE_BUFFER_LENGTH 18
 #define TIME_BUFFER_LENGTH 9
@@ -697,7 +697,7 @@ static bool prv_validate_history_stats(const ActivityInsightMetricHistoryStats *
   // We want to look at the x days before today (which is always index 0), so add 1
   uint32_t history_len = insight_settings->reward.target_qualifying_days + 1;
   if (history_len > ACTIVITY_HISTORY_DAYS) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Insight qualifying history length is too long: %"PRIu32,
+    PBL_LOG_ERR("Insight qualifying history length is too long: %"PRIu32,
             history_len);
     return false;
   }

--- a/src/fw/services/normal/activity/activity_metrics.c
+++ b/src/fw/services/normal/activity/activity_metrics.c
@@ -241,7 +241,7 @@ unlock:
 // We use NOINLINE to reduce the stack requirements during the minute handler (see PBL-38130)
 static void NOINLINE prv_shift_history(time_t utc_now) {
   ActivityState *state = activity_private_state();
-  PBL_LOG(LOG_LEVEL_INFO, "resetting metrics for new day");
+  PBL_LOG_INFO("resetting metrics for new day");
   mutex_lock_recursive(state->mutex);
   {
     SettingsFile *file = activity_private_settings_open();
@@ -737,7 +737,7 @@ bool activity_get_metric(ActivityMetric metric, uint32_t history_len, int32_t *h
       ActivitySettingsValueHistory setting_history = {};
       SettingsFile *file = activity_private_settings_open();
       if (!file) {
-        PBL_LOG(LOG_LEVEL_ERROR, "Settings file DNE. No need to continue getting metric");
+        PBL_LOG_ERR("Settings file DNE. No need to continue getting metric");
         success = false;
         goto unlock;
       }

--- a/src/fw/services/normal/activity/activity_private.h
+++ b/src/fw/services/normal/activity/activity_private.h
@@ -19,7 +19,7 @@
 #include <stdint.h>
 
 #define ACTIVITY_LOG_DEBUG(fmt, args...) \
-        PBL_LOG_D(LOG_DOMAIN_ACTIVITY, LOG_LEVEL_DEBUG, fmt, ## args)
+        PBL_LOG_D_DBG(LOG_DOMAIN_ACTIVITY, fmt, ## args)
 
 #define ACTIVITY_HEXDUMP(data, length) \
         PBL_HEXDUMP_D(LOG_DOMAIN_DATA_ACTIVITY, LOG_LEVEL_DEBUG, data, length)

--- a/src/fw/services/normal/activity/insights_settings.c
+++ b/src/fw/services/normal/activity/insights_settings.c
@@ -170,7 +170,7 @@ void activity_insights_settings_init(void) {
     return;
   }
 
-  PBL_LOG(LOG_LEVEL_ERROR, "Failed to create activity insights settings file");
+  PBL_LOG_ERR("Failed to create activity insights settings file");
 }
 
 uint16_t activity_insights_settings_get_version(void) {
@@ -203,13 +203,13 @@ bool activity_insights_settings_read(const char *insight_name,
     if (settings_file_get(&file,
                           insight_name, strlen(insight_name),
                           settings_out, sizeof(*settings_out)) != S_SUCCESS) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Didn't find insight with key %s", insight_name);
+      PBL_LOG_DBG("Didn't find insight with key %s", insight_name);
       goto close;
     }
 
     if (settings_out->version != ACTIVITY_INSIGHTS_SETTINGS_CURRENT_STRUCT_VERSION) {
       // versions don't match, bail out!
-      PBL_LOG(LOG_LEVEL_WARNING, "activity insights struct version mismatch");
+      PBL_LOG_WRN("activity insights struct version mismatch");
       goto close;
     }
 
@@ -222,7 +222,7 @@ close:
     // Use default value if we didn't find anything else
     for (unsigned i = 0; i < ARRAY_LENGTH(AIS_DEFAULTS); ++i) {
       if (strcmp(insight_name, AIS_DEFAULTS[i].key) == 0) {
-        PBL_LOG(LOG_LEVEL_DEBUG, "Using default for insight %s", insight_name);
+        PBL_LOG_DBG("Using default for insight %s", insight_name);
         *settings_out = AIS_DEFAULTS[i].default_val;
         rv = true;
       }
@@ -243,7 +243,7 @@ bool activity_insights_settings_write(const char *insight_name,
     if (settings_file_set(&file,
                           insight_name, strlen(insight_name),
                           settings, sizeof(*settings)) != S_SUCCESS) {
-      PBL_LOG(LOG_LEVEL_WARNING, "Unable to save insight setting with key %s", insight_name);
+      PBL_LOG_WRN("Unable to save insight setting with key %s", insight_name);
     } else {
       rv = true;
     }

--- a/src/fw/services/normal/activity/kraepelin/kraepelin_algorithm.c
+++ b/src/fw/services/normal/activity/kraepelin/kraepelin_algorithm.c
@@ -42,7 +42,7 @@ Pebble App roject.
 #include "kraepelin_algorithm.h"
 
 #define KALG_LOG_DEBUG(fmt, args...) \
-        PBL_LOG_D(LOG_DOMAIN_ACTIVITY, LOG_LEVEL_DEBUG, fmt, ## args)
+        PBL_LOG_D_DBG(LOG_DOMAIN_ACTIVITY, fmt, ## args)
 
 // Set this to 1 to get text graphs of the overall FFT magnitudes
 #define KALG_LOG_OVERALL_MAGNITUDES 0
@@ -1626,7 +1626,7 @@ static void prv_deep_sleep_update(KAlgState *alg_state, time_t sample_time, uint
       // We reached the end of it last_deep_run_size minutes ago
       end_time = sample_time - (last_deep_run_size * SECONDS_PER_MINUTE);
       uint16_t len_m = MAX((end_time - start_time) / SECONDS_PER_MINUTE, 0);
-      PBL_LOG(LOG_LEVEL_DEBUG, "Detected deep sleep of %"
+      PBL_LOG_DBG("Detected deep sleep of %"
         PRIu16
         " minutes starting at %s ",
               len_m, prv_log_time(alg_state, start_time));
@@ -1638,7 +1638,7 @@ static void prv_deep_sleep_update(KAlgState *alg_state, time_t sample_time, uint
         state->len_m[state->num_sessions] = len_m;
         state->num_sessions++;
       } else {
-        PBL_LOG(LOG_LEVEL_WARNING, "No more room for another deep sleep session");
+        PBL_LOG_WRN("No more room for another deep sleep session");
       }
       // Wait for another session
       state->deep_start_time = KALG_START_TIME_NONE;
@@ -1891,7 +1891,7 @@ static void prv_sleep_activity_update(KAlgState *alg_state, time_t utc_now, uint
 
     // If we got a valid sleep cycle, add it to the totals
     if (!reject_session) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Detected valid sleep cycle of len %d, starting at %s",
+      PBL_LOG_DBG("Detected valid sleep cycle of len %d, starting at %s",
               session_len_m, prv_log_time(alg_state, state->current_stats.start_time));
 
       sessions_cb(context, KAlgActivityType_Sleep, state->current_stats.start_time,
@@ -2088,7 +2088,7 @@ void kalg_activities_update(KAlgState *state, time_t utc_now, uint16_t steps, ui
   // state
   if ((utc_now < state->last_activity_update_utc)
       || (utc_now > (state->last_activity_update_utc + (5 * SECONDS_PER_MINUTE)))) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Resetting state due to time travel");
+    PBL_LOG_WRN("Resetting state due to time travel");
     prv_reset_state(state);
   };
   state->last_activity_update_utc = utc_now;

--- a/src/fw/services/normal/activity/workout_service.c
+++ b/src/fw/services/normal/activity/workout_service.c
@@ -133,7 +133,7 @@ static void prv_handle_movement_update(HealthEventMovementUpdateData *event) {
   const int32_t new_event_steps = event->steps;
   const time_t now_ts = time_get_uptime_seconds();
   if (new_event_steps < wrkt_data->last_event_step_count) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Working out through midnight, resetting last_event_step_count");
+    PBL_LOG_WRN("Working out through midnight, resetting last_event_step_count");
     wrkt_data->last_event_step_count = 0;
   }
 
@@ -352,7 +352,7 @@ bool workout_service_start_workout(ActivitySessionType type) {
     }
 
     if (workout_service_is_workout_ongoing()) {
-      PBL_LOG(LOG_LEVEL_WARNING, "Only 1 workout at a time is supported");
+      PBL_LOG_WRN("Only 1 workout at a time is supported");
       rv = false;
       goto unlock;
     }
@@ -391,7 +391,7 @@ bool workout_service_start_workout(ActivitySessionType type) {
     // Finally tell our algorithm it should stop automatically tracking activities
     activity_algorithm_enable_activity_tracking(false /* disable */);
 
-    PBL_LOG(LOG_LEVEL_INFO, "Starting a workout with type: %d", type);
+    PBL_LOG_INFO("Starting a workout with type: %d", type);
     prv_put_event(PebbleWorkoutEvent_Started);
   }
 unlock:
@@ -407,7 +407,7 @@ bool workout_service_pause_workout(bool should_be_paused) {
   }
 
   if (!workout_service_is_workout_ongoing()) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Workout (un)pause requested but no workout in progress");
+    PBL_LOG_WRN("Workout (un)pause requested but no workout in progress");
     return false;
   }
 
@@ -427,7 +427,7 @@ bool workout_service_pause_workout(bool should_be_paused) {
 
     // Update the global duration since we have changed the pause state
     prv_update_duration();
-    PBL_LOG(LOG_LEVEL_INFO, "Paused a workout with type: %d", wrkt_data->type);
+    PBL_LOG_INFO("Paused a workout with type: %d", wrkt_data->type);
     prv_put_event(PebbleWorkoutEvent_Paused);
   }
   prv_unlock();
@@ -440,7 +440,7 @@ bool workout_service_stop_workout(void) {
   prv_lock();
   {
     if (!workout_service_is_workout_ongoing()) {
-      PBL_LOG(LOG_LEVEL_WARNING, "No workout in progress");
+      PBL_LOG_WRN("No workout in progress");
       rv = false;
       goto unlock;
     }
@@ -477,7 +477,7 @@ bool workout_service_stop_workout(void) {
     // Re-enable automatic activity tracking
     activity_algorithm_enable_activity_tracking(true /* enable */);
 
-    PBL_LOG(LOG_LEVEL_INFO, "Stopping a workout with type: %d",
+    PBL_LOG_INFO("Stopping a workout with type: %d",
             s_workout_data.current_workout->type);
     prv_put_event(PebbleWorkoutEvent_Stopped);
 

--- a/src/fw/services/normal/alarms/alarm.c
+++ b/src/fw/services/normal/alarms/alarm.c
@@ -307,7 +307,7 @@ static void prv_assign_alarm(Alarm *alarm, CronJob *cron) {
   s_next_alarm_cron.cb_data = (void*)(intptr_t)alarm->id;
   s_next_alarm = *alarm;
   s_next_alarm_time = cron_job_schedule(&s_next_alarm_cron);
-  PBL_LOG(LOG_LEVEL_INFO, "Scheduling alarm %u to go off at %d:%d (%ld) (smart:%d)",
+  PBL_LOG_INFO("Scheduling alarm %u to go off at %d:%d (%ld) (smart:%d)",
           alarm->id, alarm->config.hour, alarm->config.minute, s_next_alarm_time,
           alarm->config.is_smart);
 }
@@ -431,7 +431,7 @@ static void prv_snooze_kernel_bg_callback(void *unused) {
 
 // ----------------------------------------------------------------------------------------------
 static void prv_snooze_timer_callback(void *unused) {
-  PBL_LOG(LOG_LEVEL_INFO, "Snooze timeout");
+  PBL_LOG_INFO("Snooze timeout");
   system_task_add_callback(prv_snooze_kernel_bg_callback, NULL);
 }
 
@@ -469,7 +469,7 @@ cleanup:
   kernel_free(file);
 
 
-  PBL_LOG(LOG_LEVEL_INFO, "Alarm %u timeout", id);
+  PBL_LOG_INFO("Alarm %u timeout", id);
   s_most_recent_alarm_recorded = false;
   s_most_recent_alarm_id = rv ? id : ALARM_INVALID_ID;
   prv_clear_snooze_timer();
@@ -514,7 +514,7 @@ static bool prv_alarm_get_config(SettingsFile *file, AlarmId id, AlarmConfig* co
   const int load_size = MIN(size, (int)sizeof(config));
   if (settings_file_get(file, &key, sizeof(key), &config, load_size) == S_SUCCESS) {
     if (config.hour > 23 || config.minute > 59) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Invalid config for id %u! Blowing it out! "
+      PBL_LOG_DBG("Invalid config for id %u! Blowing it out! "
               "Hours %u Minutes %u Kind %u", id, config.hour, config.minute,
               config.kind);
       settings_file_delete(file, &key, sizeof(key));
@@ -770,7 +770,7 @@ void alarm_set_enabled(AlarmId id, bool enable) {
   }
 
   if (id == s_most_recent_alarm_id && !enable) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Canceling snooze timer because alarm was disabled");
+    PBL_LOG_DBG("Canceling snooze timer because alarm was disabled");
     // Harmless if the alarm is not currently snoozing - the snooze timer still exists to be stopped
     prv_clear_snooze_timer();
     s_most_recent_alarm_id = ALARM_INVALID_ID;
@@ -792,7 +792,7 @@ void alarm_delete(AlarmId id) {
   }
 
   if (id == s_most_recent_alarm_id) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Canceling snooze timer on delete");
+    PBL_LOG_DBG("Canceling snooze timer on delete");
     prv_clear_snooze_timer();
     s_most_recent_alarm_id = ALARM_INVALID_ID;
     s_smart_snooze_counter = 0;
@@ -932,7 +932,7 @@ cleanup:
 
 static void prv_snooze_alarm(int snooze_delay_s) {
   prv_clear_snooze_timer();
-  PBL_LOG(LOG_LEVEL_INFO, "Snoozing for %d minutes", snooze_delay_s / SECONDS_PER_MINUTE);
+  PBL_LOG_INFO("Snoozing for %d minutes", snooze_delay_s / SECONDS_PER_MINUTE);
   bool success = new_timer_start(s_snooze_timer_id, snooze_delay_s * MS_PER_SECOND,
                                  prv_snooze_timer_callback, NULL, 0 /* flags*/);
   PBL_ASSERTN(success);
@@ -1077,7 +1077,7 @@ void alarm_handle_clock_change(void) {
       // Check if we've used up most of our smart snooze attempts (within last 2 minutes)
       if (s_smart_snooze_counter >= (SMART_ALARM_MAX_SMART_SNOOZE - 2)) {
         should_force_trigger = true;
-        PBL_LOG(LOG_LEVEL_INFO, "Smart alarm %u at counter %d near deadline, forcing trigger",
+        PBL_LOG_INFO("Smart alarm %u at counter %d near deadline, forcing trigger",
                 s_most_recent_alarm_id, s_smart_snooze_counter);
       } else {
         // Also check if current time is within the smart alarm window past the deadline
@@ -1094,7 +1094,7 @@ void alarm_handle_clock_change(void) {
         // (e.g., alarm at 5:35 AM, current time 11 PM would give time_diff = 1045 min)
         if (time_diff_minutes >= 0 && time_diff_minutes <= (SMART_ALARM_RANGE_S / 60)) {
           should_force_trigger = true;
-          PBL_LOG(LOG_LEVEL_INFO, "Smart alarm %u in window, %d min past deadline, forcing trigger",
+          PBL_LOG_INFO("Smart alarm %u in window, %d min past deadline, forcing trigger",
                   s_most_recent_alarm_id, time_diff_minutes);
         }
       }
@@ -1107,9 +1107,9 @@ void alarm_handle_clock_change(void) {
         s_most_recent_alarm_recorded = true;
         prv_alarm_operation(s_most_recent_alarm_id, prv_record_alarm_op, NULL);
       }
-      PBL_LOG(LOG_LEVEL_INFO, "Clock change during alarm %u, triggered alarm", s_most_recent_alarm_id);
+      PBL_LOG_INFO("Clock change during alarm %u, triggered alarm", s_most_recent_alarm_id);
     } else {
-      PBL_LOG(LOG_LEVEL_INFO, "Clock change during alarm %u, clearing snooze state",
+      PBL_LOG_INFO("Clock change during alarm %u, clearing snooze state",
               s_most_recent_alarm_id);
     }
 

--- a/src/fw/services/normal/analytics/analytics.c
+++ b/src/fw/services/normal/analytics/analytics.c
@@ -155,7 +155,7 @@ void analytics_stopwatch_start_at_rate(AnalyticsMetric metric, uint32_t count_pe
   if (prv_find_stopwatch(metric)) {
     // TODO: Increment this back up to LOG_LEVEL_WARNING when it doesn't happen
     // on every bootup (PBL-5393)
-    PBL_LOG(LOG_LEVEL_DEBUG, "Analytics stopwatch for metric %d already started!", metric);
+    PBL_LOG_DBG("Analytics stopwatch for metric %d already started!", metric);
     goto unlock;
   }
 
@@ -181,7 +181,7 @@ void analytics_stopwatch_stop(AnalyticsMetric metric) {
   if (!stopwatch) {
     // TODO: Incerement this back up to LOG_LEVEL_WARNING when it doesn't happen
     // on every bootup (PBL-5393)
-    PBL_LOG(LOG_LEVEL_DEBUG, "Analytics stopwatch for metric %d already stopped!", metric);
+    PBL_LOG_DBG("Analytics stopwatch for metric %d already stopped!", metric);
     goto unlock;
   }
 

--- a/src/fw/services/normal/analytics/analytics_heartbeat.c
+++ b/src/fw/services/normal/analytics/analytics_heartbeat.c
@@ -222,10 +222,10 @@ static void prv_print_heartbeat(AnalyticsHeartbeat *heartbeat, AnalyticsMetric s
     if (!analytics_metric_is_array(metric)) {
       int64_t val = analytics_heartbeat_get(heartbeat, metric);
       if (val >= 0) {
-        PBL_LOG(LOG_LEVEL_DEBUG, "%3" PRIu32 ": %s: %" PRIu32 " (0x%" PRIx32")",
+        PBL_LOG_DBG("%3" PRIu32 ": %s: %" PRIu32 " (0x%" PRIx32")",
             analytics_metric_offset(metric), name, (uint32_t)val, (uint32_t)val);
       } else {
-        PBL_LOG(LOG_LEVEL_DEBUG, "%3" PRIu32 ": %s: %" PRId32 " (0x%" PRIx32")",
+        PBL_LOG_DBG("%3" PRIu32 ": %s: %" PRId32 " (0x%" PRIx32")",
             analytics_metric_offset(metric), name, (int32_t)val, (int32_t)val);
       }
       continue;
@@ -235,7 +235,7 @@ static void prv_print_heartbeat(AnalyticsHeartbeat *heartbeat, AnalyticsMetric s
     uint32_t written = 0;
     for (uint32_t i = 0; i < analytics_metric_num_elements(metric); i++) {
       if (written > BUF_LENGTH) {
-        PBL_LOG(LOG_LEVEL_DEBUG, "print buffer overflow by %lu bytes",
+        PBL_LOG_DBG("print buffer overflow by %lu bytes",
             BUF_LENGTH - written);
         continue;
       }
@@ -249,30 +249,30 @@ static void prv_print_heartbeat(AnalyticsHeartbeat *heartbeat, AnalyticsMetric s
             "%s%" PRId32 " (0x%" PRIx32 ")", sep, (int32_t)val, (int32_t)val);
       }
     }
-    PBL_LOG(LOG_LEVEL_DEBUG, "%3" PRIu32 ": %s: %s", analytics_metric_offset(metric), name, buf);
+    PBL_LOG_DBG("%3" PRIu32 ": %s: %s", analytics_metric_offset(metric), name, buf);
   }
 }
 
 void analytics_heartbeat_print(AnalyticsHeartbeat *heartbeat) {
   switch (heartbeat->kind) {
   case ANALYTICS_HEARTBEAT_KIND_DEVICE:
-    PBL_LOG(LOG_LEVEL_DEBUG, "Device heartbeat:");
+    PBL_LOG_DBG("Device heartbeat:");
     prv_print_heartbeat(heartbeat, ANALYTICS_DEVICE_METRIC_START, ANALYTICS_DEVICE_METRIC_END);
     break;
   case ANALYTICS_HEARTBEAT_KIND_APP: {
     const Uuid *uuid = analytics_heartbeat_get_uuid(heartbeat);
     char uuid_buf[UUID_STRING_BUFFER_LENGTH];
     uuid_to_string(uuid, uuid_buf);
-    PBL_LOG(LOG_LEVEL_DEBUG, "App heartbeat for %s:", uuid_buf);
+    PBL_LOG_DBG("App heartbeat for %s:", uuid_buf);
     prv_print_heartbeat(heartbeat, ANALYTICS_APP_METRIC_START, ANALYTICS_APP_METRIC_END);
     break;
   }
   default:
-    PBL_LOG(LOG_LEVEL_DEBUG, "Unable to print heartbeat: Unrecognized kind %d", heartbeat->kind);
+    PBL_LOG_DBG("Unable to print heartbeat: Unrecognized kind %d", heartbeat->kind);
   }
 }
 #else
 void analytics_heartbeat_print(AnalyticsHeartbeat *heartbeat) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Turn on ANALYTICS_DEBUG to get heartbeat printing support.");
+  PBL_LOG_DBG("Turn on ANALYTICS_DEBUG to get heartbeat printing support.");
 }
 #endif

--- a/src/fw/services/normal/analytics/analytics_logging.c
+++ b/src/fw/services/normal/analytics/analytics_logging.c
@@ -96,10 +96,10 @@ static DataLoggingSessionRef prv_create_dls(AnalyticsBlobKind kind, uint32_t ite
   DataLoggingSessionRef dls_session = dls_create(
       tag, DATA_LOGGING_BYTE_ARRAY, item_length, buffered, resume, &system_uuid);
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "%s HB Session: %p", kind_str, dls_session);
+  PBL_LOG_DBG("%s HB Session: %p", kind_str, dls_session);
   if (!dls_session) {
     // Data logging full at boot. Reset it and try again 5s later
-    PBL_LOG(LOG_LEVEL_WARNING, "Data logging full at boot. Clearing...");
+    PBL_LOG_WRN("Data logging full at boot. Clearing...");
     // We reset all data logging here, including data logging for applications,
     // because an inability to allocate a new session means all 200+ session
     // IDs are exhausted, likely caused by a misbehaving app_hb. See discussion at:
@@ -219,7 +219,7 @@ static void prv_create_event_session_cb(void *ignored) {
 
 static void prv_handle_log_event(AnalyticsEventBlob *event_blob) {
   if (!s_event_session) {
-    PBL_LOG(LOG_LEVEL_INFO, "Event dropped because session not created yet");
+    PBL_LOG_INFO("Event dropped because session not created yet");
     return;
   }
 

--- a/src/fw/services/normal/analytics/analytics_storage.c
+++ b/src/fw/services/normal/analytics/analytics_storage.c
@@ -46,7 +46,7 @@ void analytics_storage_take_lock(void) {
 bool analytics_storage_has_lock(void) {
   bool has_lock = mutex_is_owned_recursive(s_analytics_storage_mutex);
   if (!has_lock) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Analytics lock is not held when it should be!");
+    PBL_LOG_ERR("Analytics lock is not held when it should be!");
   }
   return has_lock;
 }

--- a/src/fw/services/normal/app_cache.c
+++ b/src/fw/services/normal/app_cache.c
@@ -138,7 +138,7 @@ static void prv_cleanup_app_cache_if_needed(void *data) {
 
   if (pfs_space < APP_SPACE_BUFFER) {
     const uint32_t to_free = (APP_SPACE_BUFFER - pfs_space);
-    PBL_LOG(LOG_LEVEL_DEBUG, "Cache OOS: Need to free %"PRIu32" bytes, PFS avail space: %"PRIu32"",
+    PBL_LOG_DBG("Cache OOS: Need to free %"PRIu32" bytes, PFS avail space: %"PRIu32"",
         to_free, pfs_space);
     app_cache_free_up_space(to_free);
   }
@@ -169,8 +169,7 @@ static bool prv_is_in_list(AppInstallId id, const AppInstallId list[], uint8_t l
 static bool prv_each_free_up_space(SettingsFile *file, SettingsRecordInfo *info, void *context) {
   // check entry is valid
   if ((info->key_len != sizeof(AppInstallId)) || (info->val_len != sizeof(AppCacheEntry))) {
-    PBL_LOG(LOG_LEVEL_WARNING,
-            "Invalid cache entry with key_len: %u and val_len: %u, flushing",
+    PBL_LOG_WRN("Invalid cache entry with key_len: %u and val_len: %u, flushing",
             info->key_len, info->val_len);
     system_task_add_callback(prv_delete_cache_callback, NULL);
     return false; // stop iterating, delete the file and binaries
@@ -288,7 +287,7 @@ status_t app_cache_free_up_space(uint32_t bytes_needed) {
     EvictListNode *node = evict_data.list;
     while (node) {
       EvictListNode *temp = node;
-      PBL_LOG(LOG_LEVEL_DEBUG, "Deleting application binaries for app id: %"PRIu32", size: %"PRIu32,
+      PBL_LOG_DBG("Deleting application binaries for app id: %"PRIu32", size: %"PRIu32,
           node->id, node->size);
       app_cache_remove_entry(node->id);
       node = (EvictListNode *)list_pop_head((ListNode *)node);
@@ -355,7 +354,7 @@ static void prv_app_cache_find_and_delete_orphans(PFSFileListEntry **resource_li
   // entries in the app cache. We can safely delete these files.
   PFSFileListEntry *iter = *resource_list;
   while (iter) {
-    PBL_LOG(LOG_LEVEL_INFO, "Orphaned resource file removed: %s", iter->name);
+    PBL_LOG_INFO("Orphaned resource file removed: %s", iter->name);
     pfs_remove(iter->name);
     iter = (PFSFileListEntry *)iter->list_node.next;
   }

--- a/src/fw/services/normal/app_message/app_message_receiver.c
+++ b/src/fw/services/normal/app_message/app_message_receiver.c
@@ -57,7 +57,7 @@ static bool prv_fwd_prepare(AppMessageReceiver *rcv, CommSession *session,
                                            &kernel_nack_endpoint,
                                            header_bytes_remaining);
   if (!kernel_receiver) {
-    PBL_LOG(LOG_LEVEL_ERROR, "System receiver wasn't able to prepare");
+    PBL_LOG_ERR("System receiver wasn't able to prepare");
     return false;
   }
   rcv->kernel_receiver = kernel_receiver;

--- a/src/fw/services/normal/app_message/app_message_sender.c
+++ b/src/fw/services/normal/app_message/app_message_sender.c
@@ -191,7 +191,7 @@ static void prv_handle_outbox_message(AppOutboxMessage *message) {
 
   const AppMessageSenderError err = prv_sanity_check_msg_and_fill_header(message);
   if (AppMessageSenderErrorSuccess != err) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Outbound app message corrupted %u", err);
+    PBL_LOG_ERR("Outbound app message corrupted %u", err);
     app_outbox_service_consume_message(message, (AppOutboxStatus)err);
     return;
   }

--- a/src/fw/services/normal/app_order_endpoint.c
+++ b/src/fw/services/normal/app_order_endpoint.c
@@ -45,7 +45,7 @@ typedef struct {
 } ResponseInfo;
 
 static void prv_send_result(CommSession *session, uint8_t result) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Sending result of %d", result);
+  PBL_LOG_DBG("Sending result of %d", result);
   comm_session_send_data(session, APP_ORDER_ENDPOINT_ID, (uint8_t*)&result, sizeof(result),
                          COMM_SESSION_DEFAULT_TIMEOUT);
 }
@@ -56,7 +56,7 @@ static void prv_handle_app_order_msg(CommSession *session, const uint8_t *data, 
   uint8_t num_uuids = data[0];
 
   if (num_uuids != (length / UUID_SIZE)) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "invalid length, num_uuids does not match with the length of message");
+    PBL_LOG_DBG("invalid length, num_uuids does not match with the length of message");
     prv_send_result(session, APP_ORDER_RES_INVALID);
   }
 
@@ -70,18 +70,18 @@ void app_order_protocol_msg_callback(CommSession *session, const uint8_t* data, 
 
   // Ensure it is a valid message. There is a list of UUID's after the header.
   if ((length % UUID_SIZE) != header_len) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "invalid length, (length - header_len) not multiple of 16");
+    PBL_LOG_DBG("invalid length, (length - header_len) not multiple of 16");
     prv_send_result(session, APP_ORDER_RES_INVALID);
     return;
   }
 
   switch (data[0]) {
     case APP_ORDER_CMD:
-      PBL_LOG(LOG_LEVEL_DEBUG, "Got APP_ORDER message");
+      PBL_LOG_DBG("Got APP_ORDER message");
       prv_handle_app_order_msg(session, &data[1], length - 1);
       break;
     default:
-      PBL_LOG(LOG_LEVEL_ERROR, "Invalid message received, first byte is %u", data[0]);
+      PBL_LOG_ERR("Invalid message received, first byte is %u", data[0]);
       prv_send_result(session, APP_ORDER_RES_FAILURE);
       break;
   }

--- a/src/fw/services/normal/app_outbox_service.c
+++ b/src/fw/services/normal/app_outbox_service.c
@@ -87,13 +87,13 @@ DEFINE_SYSCALL(void, sys_app_outbox_send, const uint8_t *data, size_t length,
 
   const AppOutboxSenderDef *def = prv_find_def_and_tag_by_handler(sent_handler, NULL);
   if (!def) {
-    PBL_LOG(LOG_LEVEL_ERROR, "AppOutbox sent_handler not allowed <%p>", sent_handler);
+    PBL_LOG_ERR("AppOutbox sent_handler not allowed <%p>", sent_handler);
     syscall_failed();
   }
 
   const size_t max_length = def->max_length;
   if (length > max_length) {
-    PBL_LOG(LOG_LEVEL_ERROR, "AppOutbox max_length exceeded %"PRIu32" vs %"PRIu32,
+    PBL_LOG_ERR("AppOutbox max_length exceeded %"PRIu32" vs %"PRIu32,
             (uint32_t)length, (uint32_t)max_length);
     syscall_failed();
   }

--- a/src/fw/services/normal/audio_endpoint.c
+++ b/src/fw/services/normal/audio_endpoint.c
@@ -48,7 +48,7 @@ static void prv_session_deinit(bool call_stop_handler) {
   bt_unlock();
 
   if (s_dropped_frames > 0) {
-    PBL_LOG(LOG_LEVEL_INFO, "Dropped %"PRIu32" frames during audio transfer", s_dropped_frames);
+    PBL_LOG_INFO("Dropped %"PRIu32" frames during audio transfer", s_dropped_frames);
   }
 }
 
@@ -60,7 +60,7 @@ void audio_endpoint_protocol_msg_callback(CommSession *session, const uint8_t* d
     if (msg->session_id == s_session.id) {
       prv_session_deinit(true /* call_stop_handler */);
     } else {
-      PBL_LOG(LOG_LEVEL_WARNING, "Received mismatching session id: %u vs %u",
+      PBL_LOG_WRN("Received mismatching session id: %u vs %u",
               msg->session_id, s_session.id);
     }
   }
@@ -111,7 +111,7 @@ void audio_endpoint_add_frame(AudioEndpointSessionId session_id, uint8_t *frame,
                                                         0 /* timeout_ms, never block */);
   if (!sb) {
     s_dropped_frames++;
-    PBL_LOG(LOG_LEVEL_DEBUG, "Dropping a frame...");
+    PBL_LOG_DBG("Dropping a frame...");
     return;
   }
 

--- a/src/fw/services/normal/blob_db/api.c
+++ b/src/fw/services/normal/blob_db/api.c
@@ -279,7 +279,7 @@ status_t blob_db_flush(BlobDBId db_id) {
   if (db->flush) {
     status_t rv = db->flush();
     if (rv == S_SUCCESS) {
-      PBL_LOG(LOG_LEVEL_INFO, "Flushing BlobDB with Id %d", db_id);
+      PBL_LOG_INFO("Flushing BlobDB with Id %d", db_id);
       blob_db_event_put(BlobDBEventTypeFlush, db_id, NULL, 0);
     }
     return rv;

--- a/src/fw/services/normal/blob_db/app_db.c
+++ b/src/fw/services/normal/blob_db/app_db.c
@@ -250,7 +250,7 @@ void app_db_init(void) {
     s_next_unique_flash_app_id = (data.max_id + 1);
   }
 
-  PBL_LOG(LOG_LEVEL_INFO, "Found %"PRIu32" apps. Next ID: %"PRIu32" ", data.num_apps,
+  PBL_LOG_INFO("Found %"PRIu32" apps. Next ID: %"PRIu32" ", data.num_apps,
           s_next_unique_flash_app_id);
 
   prv_close_file_and_unlock_mutex();
@@ -276,7 +276,7 @@ status_t app_db_insert(const uint8_t *key, int key_len, const uint8_t *val, int 
     new_install = true;
     app_id = s_next_unique_flash_app_id++;
   } else if (app_fetch_in_progress()) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Got an insert for an app that is currently being fetched, %"PRId32,
+    PBL_LOG_WRN("Got an insert for an app that is currently being fetched, %"PRId32,
             app_id);
     rv = prv_cancel_app_fetch(app_id);
   }
@@ -354,7 +354,7 @@ status_t app_db_delete(const uint8_t *key, int key_len) {
   if (app_id == INSTALL_ID_INVALID) {
     rv = E_DOES_NOT_EXIST;
   } else if (app_fetch_in_progress()) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Tried to delete an app that is currently being fetched, %"PRId32,
+    PBL_LOG_WRN("Tried to delete an app that is currently being fetched, %"PRId32,
             app_id);
     rv = prv_cancel_app_fetch(app_id);
   }
@@ -377,7 +377,7 @@ status_t app_db_delete(const uint8_t *key, int key_len) {
 }
 
 status_t app_db_flush(void) {
-  PBL_LOG(LOG_LEVEL_WARNING, "AppDB Flush initiated");
+  PBL_LOG_WRN("AppDB Flush initiated");
 
   if (app_fetch_in_progress()) {
     // cancels any app fetch
@@ -397,7 +397,7 @@ status_t app_db_flush(void) {
   pfs_remove(SETTINGS_FILE_NAME);
 
   mutex_unlock(s_app_db.mutex);
-  PBL_LOG(LOG_LEVEL_WARNING, "AppDB Flush finished");
+  PBL_LOG_WRN("AppDB Flush finished");
   return S_SUCCESS;
 }
 

--- a/src/fw/services/normal/blob_db/endpoint.c
+++ b/src/fw/services/normal/blob_db/endpoint.c
@@ -96,7 +96,7 @@ static BlobDBResponse prv_interpret_db_ret_val(status_t ret_val) {
     case E_INVALID_OPERATION:
       return BLOB_DB_DATA_STALE;
     default:
-      PBL_LOG(LOG_LEVEL_WARNING, "BlobDB return value caught by default case");
+      PBL_LOG_WRN("BlobDB return value caught by default case");
       return BLOB_DB_GENERAL_FAILURE;
   }
 }
@@ -106,7 +106,7 @@ static const uint8_t *prv_read_ptr(const uint8_t *iter, const uint8_t *iter_end,
 
   // >= because we will be reading more bytes after this point
   if ((buf_len == 0) || ((iter + buf_len) > iter_end)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "BlobDB: read invalid length");
+    PBL_LOG_WRN("BlobDB: read invalid length");
     return NULL;
   }
 
@@ -300,28 +300,28 @@ static void prv_blob_db_msg_decode_and_handle(
     CommSession *session, BlobDBCommand cmd, const uint8_t *data, size_t data_length) {
   switch (cmd) {
     case BLOB_DB_COMMAND_INSERT:
-      PBL_LOG(LOG_LEVEL_DEBUG, "Got INSERT");
+      PBL_LOG_DBG("Got INSERT");
       prv_handle_database_insert(session, data, data_length);
       break;
     case BLOB_DB_COMMAND_DELETE:
-      PBL_LOG(LOG_LEVEL_DEBUG, "Got DELETE");
+      PBL_LOG_DBG("Got DELETE");
       prv_handle_database_delete(session, data, data_length);
       break;
     case BLOB_DB_COMMAND_CLEAR:
-      PBL_LOG(LOG_LEVEL_DEBUG, "Got CLEAR");
+      PBL_LOG_DBG("Got CLEAR");
       prv_handle_database_clear(session, data, data_length);
       break;
     case BLOB_DB_COMMAND_INSERT_WITH_TIMESTAMP:
-      PBL_LOG(LOG_LEVEL_DEBUG, "Got INSERT_WITH_TIMESTAMP");
+      PBL_LOG_DBG("Got INSERT_WITH_TIMESTAMP");
       prv_handle_database_insert_with_timestamp(session, data, data_length);
       break;
     // Commands not implemented.
     case BLOB_DB_COMMAND_READ:
     case BLOB_DB_COMMAND_UPDATE:
-      PBL_LOG(LOG_LEVEL_ERROR, "BlobDB Command not implemented");
+      PBL_LOG_ERR("BlobDB Command not implemented");
       // Fallthrough
     default:
-      PBL_LOG(LOG_LEVEL_ERROR, "Invalid BlobDB message received, cmd is %u", cmd);
+      PBL_LOG_ERR("Invalid BlobDB message received, cmd is %u", cmd);
       prv_send_response(session, prv_try_read_token(data, data_length), BLOB_DB_INVALID_OPERATION);
       break;
   }
@@ -337,7 +337,7 @@ void blob_db_protocol_msg_callback(CommSession *session, const uint8_t* data, si
   // Each BlobDB message is required to have at least a Command and a Token
   static const uint8_t MIN_RAW_DATA_LEN = sizeof(BlobDBCommand) + sizeof(BlobDBToken);
   if (length < MIN_RAW_DATA_LEN) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Got a blob_db message that was too short, len: %zu", length);
+    PBL_LOG_ERR("Got a blob_db message that was too short, len: %zu", length);
     prv_send_response(session, 0, BLOB_DB_INVALID_DATA);
     return;
   }

--- a/src/fw/services/normal/blob_db/endpoint2.c
+++ b/src/fw/services/normal/blob_db/endpoint2.c
@@ -60,7 +60,7 @@ static void prv_handle_get_dirty_databases(CommSession *session,
                                            const uint8_t *data,
                                            uint32_t length) {
   if (length < DIRTY_DATABASES_LENGTH) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Got a dirty databases with an invalid length: %"PRIu32"", length);
+    PBL_LOG_ERR("Got a dirty databases with an invalid length: %"PRIu32"", length);
     return;
   }
 
@@ -88,7 +88,7 @@ static void prv_handle_start_sync(CommSession *session,
                                   const uint8_t *data,
                                   uint32_t length) {
   if (length < START_SYNC_LENGTH) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Got a start sync with an invalid length: %"PRIu32"", length);
+    PBL_LOG_ERR("Got a start sync with an invalid length: %"PRIu32"", length);
     return;
   }
 
@@ -140,12 +140,12 @@ static void prv_handle_wb_write_response(const uint8_t *data,
                       dirty_item->key_len : (int)sizeof(key_str) - 1;
       memcpy(key_str, dirty_item->key, copy_len);
       key_str[copy_len] = '\0';
-      PBL_LOG(LOG_LEVEL_WARNING, "Writeback rejected: key=%s response=%d", key_str, response_code);
+      PBL_LOG_WRN("Writeback rejected: key=%s response=%d", key_str, response_code);
     }
     blob_db_sync_next(sync_session);
   } else {
     // No session
-    PBL_LOG(LOG_LEVEL_WARNING, "received blob db wb response with an invalid token: %d", token);
+    PBL_LOG_WRN("received blob db wb response with an invalid token: %d", token);
   }
 }
 
@@ -153,7 +153,7 @@ static void prv_handle_write_response(CommSession *session,
                                       const uint8_t *data,
                                       uint32_t length) {
   if (length < WRITE_RESPONSE_LENGTH) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Got a write response with an invalid length: %"PRIu32"", length);
+    PBL_LOG_ERR("Got a write response with an invalid length: %"PRIu32"", length);
     return;
   }
 
@@ -164,7 +164,7 @@ static void prv_handle_wb_response(CommSession *session,
                                    const uint8_t *data,
                                    uint32_t length) {
   if (length < WRITEBACK_RESPONSE_LENGTH) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Got a writeback response with an invalid length: %"PRIu32"", length);
+    PBL_LOG_ERR("Got a writeback response with an invalid length: %"PRIu32"", length);
     return;
   }
 
@@ -175,7 +175,7 @@ static void prv_handle_sync_done_response(CommSession *session,
                                           const uint8_t *data,
                                           uint32_t length) {
   if (length < SYNC_DONE_RESPONSE_LENGTH) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Got a sync done response with an invalid length: %"PRIu32"", length);
+    PBL_LOG_ERR("Got a sync done response with an invalid length: %"PRIu32"", length);
     return;
   }
 
@@ -185,7 +185,7 @@ static void prv_handle_sync_done_response(CommSession *session,
   prv_read_token_and_response(data, &token, &response_code);
 
   if (response_code != BLOB_DB_SUCCESS) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Sync Done response error: %d", response_code);
+    PBL_LOG_ERR("Sync Done response error: %d", response_code);
   }
 }
 
@@ -212,7 +212,7 @@ static void prv_handle_dirty_all(CommSession *session, const uint8_t *data, uint
   // Message format: [token (2 bytes)] [db_id (1 byte)]
   static const uint8_t MIN_DIRTY_ALL_LENGTH = sizeof(BlobDBToken) + sizeof(BlobDBId);
   if (length < MIN_DIRTY_ALL_LENGTH) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Got a dirty_all with an invalid length: %"PRIu32"", length);
+    PBL_LOG_ERR("Got a dirty_all with an invalid length: %"PRIu32"", length);
     return;
   }
 
@@ -263,35 +263,35 @@ static void prv_blob_db_msg_decode_and_handle(
     CommSession *session, BlobDBCommand cmd, const uint8_t *data, size_t data_length) {
   switch (cmd) {
     case BLOB_DB_COMMAND_DIRTY_DBS:
-      PBL_LOG(LOG_LEVEL_DEBUG, "Got DIRTY DBs");
+      PBL_LOG_DBG("Got DIRTY DBs");
       prv_handle_get_dirty_databases(session, data, data_length);
       break;
     case BLOB_DB_COMMAND_START_SYNC:
-      PBL_LOG(LOG_LEVEL_DEBUG, "Got SYNC");
+      PBL_LOG_DBG("Got SYNC");
       prv_handle_start_sync(session, data, data_length);
       break;
     case BLOB_DB_COMMAND_WRITE_RESPONSE:
-      PBL_LOG(LOG_LEVEL_DEBUG, "WRITE Response");
+      PBL_LOG_DBG("WRITE Response");
       prv_handle_write_response(session, data, data_length);
       break;
     case BLOB_DB_COMMAND_WRITEBACK_RESPONSE:
-      PBL_LOG(LOG_LEVEL_DEBUG, "WRITEBACK Response");
+      PBL_LOG_DBG("WRITEBACK Response");
       prv_handle_wb_response(session, data, data_length);
       break;
     case BLOB_DB_COMMAND_SYNC_DONE_RESPONSE:
-      PBL_LOG(LOG_LEVEL_DEBUG, "SYNC DONE Response");
+      PBL_LOG_DBG("SYNC DONE Response");
       prv_handle_sync_done_response(session, data, data_length);
       break;
     case BLOB_DB_COMMAND_VERSION:
-      PBL_LOG(LOG_LEVEL_DEBUG, "Got VERSION");
+      PBL_LOG_DBG("Got VERSION");
       prv_handle_version(session, data, data_length);
       break;
     case BLOB_DB_COMMAND_DIRTY_ALL:
-      PBL_LOG(LOG_LEVEL_DEBUG, "Got DIRTY_ALL");
+      PBL_LOG_DBG("Got DIRTY_ALL");
       prv_handle_dirty_all(session, data, data_length);
       break;
     default:
-      PBL_LOG(LOG_LEVEL_ERROR, "Invalid BlobDB2 message received, cmd is %u", cmd);
+      PBL_LOG_ERR("Invalid BlobDB2 message received, cmd is %u", cmd);
       prv_send_error_response(session, cmd, data, BLOB_DB_INVALID_OPERATION);
       break;
   }
@@ -373,7 +373,7 @@ void blob_db_endpoint_send_sync_done(BlobDBId db_id) {
     .db_id = db_id,
   };
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Sending sync done for db: %d", db_id);
+  PBL_LOG_DBG("Sending sync done for db: %d", db_id);
 
   comm_session_send_data(comm_session_get_system_session(),
                          BLOB_DB2_ENDPOINT_ID,
@@ -391,7 +391,7 @@ void blob_db2_protocol_msg_callback(CommSession *session, const uint8_t* data, s
   static const uint8_t MIN_RAW_DATA_LEN = sizeof(BlobDBCommand) + sizeof(BlobDBToken);
   if (length < MIN_RAW_DATA_LEN) {
     // We don't send failure responses for too short messages in endpoint2
-    PBL_LOG(LOG_LEVEL_ERROR, "Got a blob_db2 message that was too short, len: %zu", length);
+    PBL_LOG_ERR("Got a blob_db2 message that was too short, len: %zu", length);
     return;
   }
 

--- a/src/fw/services/normal/blob_db/health_db.c
+++ b/src/fw/services/normal/blob_db/health_db.c
@@ -93,7 +93,7 @@ static status_t prv_file_open_and_lock(SettingsFile *file) {
 
   status_t rv = settings_file_open(file, HEALTH_DB_FILE_NAME, HEALTH_DB_MAX_SIZE);
   if (rv != S_SUCCESS) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to open settings file");
+    PBL_LOG_ERR("Failed to open settings file");
     mutex_unlock(s_mutex);
   }
 
@@ -150,7 +150,7 @@ static void prv_notify_health_listeners(const char *key,
     if (!prv_is_last_processed_timestamp_valid(data->last_processed_timestamp)) {
       return;
     }
-    PBL_LOG(LOG_LEVEL_INFO, "Got MovementData for wday: %d, cur_wday: %d, steps: %"PRIu32"",
+    PBL_LOG_INFO("Got MovementData for wday: %d, cur_wday: %d, steps: %"PRIu32"",
             wday, cur_wday, data->steps);
     activity_metrics_prv_set_metric(ActivityMetricStepCount, wday, data->steps);
     activity_metrics_prv_set_metric(ActivityMetricActiveSeconds, wday, data->active_seconds);
@@ -162,7 +162,7 @@ static void prv_notify_health_listeners(const char *key,
     if (!prv_is_last_processed_timestamp_valid(data->last_processed_timestamp)) {
       return;
     }
-    PBL_LOG(LOG_LEVEL_INFO, "Got SleepData for wday: %d, cur_wday: %d, sleep: %"PRIu32"",
+    PBL_LOG_INFO("Got SleepData for wday: %d, cur_wday: %d, sleep: %"PRIu32"",
             wday, cur_wday, data->sleep_duration);
     activity_metrics_prv_set_metric(ActivityMetricSleepTotalSeconds, wday, data->sleep_duration);
     activity_metrics_prv_set_metric(ActivityMetricSleepRestfulSeconds, wday,
@@ -178,7 +178,7 @@ static void prv_notify_health_listeners(const char *key,
     if (data->num_zones != HRZone_Max) {
       return;
     }
-    PBL_LOG(LOG_LEVEL_INFO, "Got HeartRateZoneData for wday: %d, cur_wday: %d, zone1: %"PRIu32"",
+    PBL_LOG_INFO("Got HeartRateZoneData for wday: %d, cur_wday: %d, zone1: %"PRIu32"",
             wday, cur_wday, data->minutes_in_zone[0]);
     activity_metrics_prv_set_metric(ActivityMetricHeartRateZone1Minutes, wday,
                                     data->minutes_in_zone[0]);
@@ -247,7 +247,7 @@ bool health_db_get_typical_value(ActivityMetric metric,
     case ActivityMetricHeartRateZone1Minutes:
     case ActivityMetricHeartRateZone2Minutes:
     case ActivityMetricHeartRateZone3Minutes:
-      PBL_LOG(LOG_LEVEL_WARNING, "Health DB doesn't know about typical metric %d", metric);
+      PBL_LOG_WRN("Health DB doesn't know about typical metric %d", metric);
       return false;
   }
 
@@ -257,7 +257,7 @@ bool health_db_get_typical_value(ActivityMetric metric,
 bool health_db_get_monthly_average_value(ActivityMetric metric,
                                          int32_t *value_out) {
   if (metric != ActivityMetricStepCount && metric != ActivityMetricSleepTotalSeconds) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Health DB doesn't store an average for metric %d", metric);
+    PBL_LOG_WRN("Health DB doesn't store an average for metric %d", metric);
     return false;
   }
 
@@ -325,18 +325,18 @@ void health_db_init(void) {
 
 status_t health_db_insert(const uint8_t *key, int key_len, const uint8_t *val, int val_len) {
   if (!prv_key_is_valid(key, key_len)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid health db key");
+    PBL_LOG_ERR("Invalid health db key");
     PBL_HEXDUMP(LOG_LEVEL_ERROR, key, key_len);
     return E_INVALID_ARGUMENT;
   } else if (!prv_value_is_valid(key, key_len, val, val_len)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid health db value. Length %d", val_len);
+    PBL_LOG_ERR("Invalid health db value. Length %d", val_len);
     return E_INVALID_ARGUMENT;
   }
 
 #if HEALTH_DB_DEBUG
-  PBL_LOG(LOG_LEVEL_DEBUG, "New health db entry key:");
+  PBL_LOG_DBG("New health db entry key:");
   PBL_HEXDUMP(LOG_LEVEL_DEBUG, key, key_len);
-  PBL_LOG(LOG_LEVEL_DEBUG, "val: ");
+  PBL_LOG_DBG("val: ");
   PBL_HEXDUMP(LOG_LEVEL_DEBUG, val, val_len);
 #endif
 

--- a/src/fw/services/normal/blob_db/ios_notif_pref_db.c
+++ b/src/fw/services/normal/blob_db/ios_notif_pref_db.c
@@ -107,7 +107,7 @@ iOSNotifPrefs* ios_notif_pref_db_get_prefs(const uint8_t *app_id, int key_len) {
     char buffer[key_len + 1];
     strncpy(buffer, (const char *)app_id, key_len);
     buffer[key_len] = '\0';
-    PBL_LOG(LOG_LEVEL_DEBUG, "No prefs found for <%s>", buffer);
+    PBL_LOG_DBG("No prefs found for <%s>", buffer);
     prv_file_close_and_unlock(&file);
     return NULL;
   }
@@ -129,7 +129,7 @@ iOSNotifPrefs* ios_notif_pref_db_get_prefs(const uint8_t *app_id, int key_len) {
     char buffer[key_len + 1];
     strncpy(buffer, (const char *)app_id, key_len);
     buffer[key_len] = '\0';
-    PBL_LOG(LOG_LEVEL_ERROR, "Could not parse serial data for <%s>", buffer);
+    PBL_LOG_ERR("Could not parse serial data for <%s>", buffer);
     prv_free_serialzed_prefs(serialized_prefs);
     return NULL;
   }
@@ -158,7 +158,7 @@ iOSNotifPrefs* ios_notif_pref_db_get_prefs(const uint8_t *app_id, int key_len) {
     char buffer[key_len + 1];
     strncpy(buffer, (const char *)app_id, key_len);
     buffer[key_len] = '\0';
-    PBL_LOG(LOG_LEVEL_ERROR, "Could not deserialize data for <%s>", buffer);
+    PBL_LOG_ERR("Could not deserialize data for <%s>", buffer);
     prv_free_serialzed_prefs(serialized_prefs);
     kernel_free(notif_prefs);
     return NULL;
@@ -197,7 +197,7 @@ status_t ios_notif_pref_db_store_prefs(const uint8_t *app_id, int length, Attrib
     char buffer[length + 1];
     strncpy(buffer, (const char *)app_id, length);
     buffer[length] = '\0';
-    PBL_LOG(LOG_LEVEL_INFO, "Added <%s> to the notif pref db", buffer);
+    PBL_LOG_INFO("Added <%s> to the notif pref db", buffer);
 
     blob_db_sync_record(BlobDBIdiOSNotifPref, app_id, length, rtc_get_time());
   }
@@ -227,7 +227,7 @@ status_t ios_notif_pref_db_insert(const uint8_t *key, int key_len,
     char buffer[key_len + 1];
     strncpy(buffer, (const char *)key, key_len);
     buffer[key_len] = '\0';
-    PBL_LOG(LOG_LEVEL_INFO, "iOS notif pref insert <%s>", buffer);
+    PBL_LOG_INFO("iOS notif pref insert <%s>", buffer);
 
     // All records inserted from the phone are not dirty (the phone is the source of truth)
     rv = settings_file_mark_synced(&file, key, key_len);

--- a/src/fw/services/normal/blob_db/notif_db.c
+++ b/src/fw/services/normal/blob_db/notif_db.c
@@ -38,11 +38,11 @@ status_t notif_db_insert(const uint8_t *key, int key_len, const uint8_t *val, in
   // If the notification already exists, only update the status flags
   if (notification_storage_notification_exists(&notification.header.id)) {
     notification_storage_set_status(&notification.header.id, notification.header.status);
-    PBL_LOG(LOG_LEVEL_INFO, "Notification modified: %s", uuid_string);
+    PBL_LOG_INFO("Notification modified: %s", uuid_string);
     notifications_handle_notification_acted_upon(id);
   } else if (!has_status_bits) {
     notification_storage_store(&notification);
-    PBL_LOG(LOG_LEVEL_INFO, "Notification added: %s", uuid_string);
+    PBL_LOG_INFO("Notification added: %s", uuid_string);
     notifications_handle_notification_added(id);
   }
 

--- a/src/fw/services/normal/blob_db/pin_db.c
+++ b/src/fw/services/normal/blob_db/pin_db.c
@@ -63,8 +63,7 @@ static status_t prv_insert_serialized_item(const uint8_t *key, int key_len, cons
       // String initialized on the heap to reduce stack usage
       char *parent_id_string = kernel_malloc_check(UUID_STRING_BUFFER_LENGTH);
       uuid_to_string(&parent_id, parent_id_string);
-      PBL_LOG(LOG_LEVEL_ERROR,
-              "Pin insert for a pin with no app installed, parent id: %s",
+      PBL_LOG_ERR("Pin insert for a pin with no app installed, parent id: %s",
               parent_id_string);
       kernel_free(parent_id_string);
       goto done;

--- a/src/fw/services/normal/blob_db/reminder_db.c
+++ b/src/fw/services/normal/blob_db/reminder_db.c
@@ -78,7 +78,7 @@ static bool prv_reminder_filter(SerializedTimelineItemHeader *hdr, void *context
 }
 
 status_t reminder_db_next_item_header(TimelineItem *next_item_out) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Finding next item in queue.");
+  PBL_LOG_DBG("Finding next item in queue.");
   TimelineItemId id;
   status_t rv = timeline_item_storage_next_item(&s_storage, &id, prv_reminder_filter);
   if (rv) {
@@ -151,7 +151,7 @@ static status_t prv_insert_reminder(const uint8_t *key, int key_len,
 
   char uuid_buffer[UUID_STRING_BUFFER_LENGTH];
   uuid_to_string((Uuid *)key, uuid_buffer);
-  PBL_LOG(LOG_LEVEL_INFO, "Reminder added: %s", uuid_buffer);
+  PBL_LOG_INFO("Reminder added: %s", uuid_buffer);
 
   if (rv == S_SUCCESS) {
     if (has_reminded) {
@@ -266,6 +266,6 @@ BlobDBDirtyItem* reminder_db_get_dirty_list(void) {
 }
 
 status_t reminder_db_mark_synced(const uint8_t *key, int key_len) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "reminder_db_mark_synced");
+  PBL_LOG_DBG("reminder_db_mark_synced");
   return timeline_item_storage_mark_synced(&s_storage, key, key_len);
 }

--- a/src/fw/services/normal/blob_db/settings_blob_db.c
+++ b/src/fw/services/normal/blob_db/settings_blob_db.c
@@ -197,7 +197,7 @@ static void prv_deferred_sync_callback(void *data) {
 
   // Only sync if we have an active connection to the phone
   if (!comm_session_get_system_session()) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "No connection to phone, skipping settings sync");
+    PBL_LOG_DBG("No connection to phone, skipping settings sync");
     return;
   }
 
@@ -249,7 +249,7 @@ void settings_blob_db_init(void) {
   settings_file_set_change_callback(prv_settings_change_callback);
 
   s_initialized = true;
-  PBL_LOG(LOG_LEVEL_INFO, "Settings BlobDB initialized (%u whitelisted settings)",
+  PBL_LOG_INFO("Settings BlobDB initialized (%u whitelisted settings)",
           (unsigned int) s_num_syncable_settings);
 }
 
@@ -276,7 +276,7 @@ status_t settings_blob_db_insert(const uint8_t *key, int key_len,
                       (size_t)key_len : sizeof(key_str) - 1;
     memcpy(key_str, key, copy_len);
     key_str[copy_len] = '\0';
-    PBL_LOG(LOG_LEVEL_WARNING, "Rejecting non-whitelisted setting: %s", key_str);
+    PBL_LOG_WRN("Rejecting non-whitelisted setting: %s", key_str);
     return E_INVALID_OPERATION;
   }
 
@@ -595,7 +595,7 @@ status_t settings_blob_db_flush(void) {
   }
 
   // SettingsFile writes are already atomic, no explicit flush needed
-  PBL_LOG(LOG_LEVEL_DEBUG, "Settings BlobDB flush (no-op for SettingsFile)");
+  PBL_LOG_DBG("Settings BlobDB flush (no-op for SettingsFile)");
   return S_SUCCESS;
 }
 
@@ -604,7 +604,7 @@ status_t settings_blob_db_mark_all_dirty(void) {
     return E_INTERNAL;
   }
 
-  PBL_LOG(LOG_LEVEL_INFO, "Marking all settings as dirty for full sync");
+  PBL_LOG_INFO("Marking all settings as dirty for full sync");
 
   status_t result = S_SUCCESS;
 
@@ -710,7 +710,7 @@ status_t settings_blob_db_insert_with_timestamp(const uint8_t *key, int key_len,
     // Watch data is newer - reject the insert
     settings_file_close(&file);
     prv_unlock_for_file(is_notif_pref);
-    PBL_LOG(LOG_LEVEL_DEBUG, "Rejecting stale data: watch=%lu phone=%lu",
+    PBL_LOG_DBG("Rejecting stale data: watch=%lu phone=%lu",
             (unsigned long)ctx.last_modified, (unsigned long)timestamp);
     return E_INVALID_OPERATION;
   }

--- a/src/fw/services/normal/blob_db/sync.c
+++ b/src/fw/services/normal/blob_db/sync.c
@@ -37,7 +37,7 @@ static bool prv_session_token_filter_callback(ListNode *node, void *data) {
 }
 
 static void prv_abandon_kernelbg_callback(void *data) {
-  PBL_LOG(LOG_LEVEL_INFO, "Blob DB Sync abandoned after extended timeout");
+  PBL_LOG_INFO("Blob DB Sync abandoned after extended timeout");
   BlobDBSyncSession *session = data;
   blob_db_sync_cancel(session);
 }
@@ -55,7 +55,7 @@ static void prv_timeout_kernelbg_callback(void *data) {
   }
 
   // Retry sending the current item
-  PBL_LOG(LOG_LEVEL_INFO, "Blob DB Sync timeout, retrying (db %d)", session->db_id);
+  PBL_LOG_INFO("Blob DB Sync timeout, retrying (db %d)", session->db_id);
   session->state = BlobDBSyncSessionStateIdle;
   prv_send_writeback(session);
 }
@@ -75,7 +75,7 @@ static void prv_send_writeback(BlobDBSyncSession *session) {
   }
 
   if (!comm_session_get_system_session()) {
-    PBL_LOG(LOG_LEVEL_INFO, "Cancelling sync: No route to phone");
+    PBL_LOG_INFO("Cancelling sync: No route to phone");
     blob_db_sync_cancel(session);
     return;
   }
@@ -93,7 +93,7 @@ static void prv_send_writeback(BlobDBSyncSession *session) {
     blob_db_sync_next(session);
   } else {
     // something went terribly wrong
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to read blob DB during sync. Error code: 0x%"PRIx32, status);
+    PBL_LOG_ERR("Failed to read blob DB during sync. Error code: 0x%"PRIx32, status);
     blob_db_sync_cancel(session);
   }
 
@@ -158,7 +158,7 @@ status_t blob_db_sync_db(BlobDBId db_id) {
   if (db_id >= NumBlobDBs) {
     return E_INVALID_ARGUMENT;
   }
-  PBL_LOG(LOG_LEVEL_INFO, "Starting BlobDB db sync: %d", db_id);
+  PBL_LOG_INFO("Starting BlobDB db sync: %d", db_id);
 
   BlobDBDirtyItem *dirty_list = blob_db_get_dirty_list(db_id);
   if (!dirty_list) {
@@ -193,7 +193,7 @@ status_t blob_db_sync_record(BlobDBId db_id, const void *key, int key_len, time_
   char buffer[key_len + 1];
   strncpy(buffer, (const char *)key, key_len);
   buffer[key_len] = '\0';
-  PBL_LOG(LOG_LEVEL_INFO, "Starting BlobDB record sync: <%s>", buffer);
+  PBL_LOG_INFO("Starting BlobDB record sync: <%s>", buffer);
 
   BlobDBDirtyItem *dirty_list = kernel_zalloc_check(sizeof(BlobDBDirtyItem) + key_len);
   list_init((ListNode *)dirty_list);
@@ -209,7 +209,7 @@ status_t blob_db_sync_record(BlobDBId db_id, const void *key, int key_len, time_
 }
 
 void blob_db_sync_cancel(BlobDBSyncSession *session) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Cancelling session %d sync", session->db_id);
+  PBL_LOG_DBG("Cancelling session %d sync", session->db_id);
   if (regular_timer_is_scheduled(&session->timeout_timer)) {
     regular_timer_remove_callback(&session->timeout_timer);
   }
@@ -222,7 +222,7 @@ void blob_db_sync_cancel(BlobDBSyncSession *session) {
 }
 
 void blob_db_sync_next(BlobDBSyncSession *session) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "blob_db_sync_next");
+  PBL_LOG_DBG("blob_db_sync_next");
 
   // Cancel abandon timer - we got a successful response, so connection is working
   if (regular_timer_is_scheduled(&session->abandon_timer)) {
@@ -246,7 +246,7 @@ void blob_db_sync_next(BlobDBSyncSession *session) {
     if (session->dirty_list) {
       prv_send_writeback(session);
     } else {
-      PBL_LOG(LOG_LEVEL_INFO, "Finished syncing db %d, session type: %d", session->db_id,
+      PBL_LOG_INFO("Finished syncing db %d, session type: %d", session->db_id,
                                                                           session->session_type);
       if (regular_timer_is_scheduled(&session->timeout_timer)) {
         regular_timer_remove_callback(&session->timeout_timer);

--- a/src/fw/services/normal/blob_db/sync_util.c
+++ b/src/fw/services/normal/blob_db/sync_util.c
@@ -27,7 +27,7 @@ bool sync_util_build_dirty_list_cb(SettingsFile *file, SettingsRecordInfo *info,
 
     BlobDBDirtyItem *new_node = kernel_zalloc(sizeof(BlobDBDirtyItem) + info->key_len);
     if (!new_node) {
-      PBL_LOG(LOG_LEVEL_WARNING, "Ran out of memory while building a dirty list");
+      PBL_LOG_WRN("Ran out of memory while building a dirty list");
       return false;
     }
 

--- a/src/fw/services/normal/blob_db/timeline_item_storage.c
+++ b/src/fw/services/normal/blob_db/timeline_item_storage.c
@@ -40,7 +40,7 @@ static bool prv_each_first_item(SettingsFile *file, SettingsRecordInfo *info,
   if (info->val_len < (int)sizeof(SerializedTimelineItemHeader) ||
       info->key_len != UUID_SIZE) { // deleted or malformed values
     if (info->key_len != UUID_SIZE) {
-      PBL_LOG(LOG_LEVEL_WARNING, "Found reminder with invalid key size %d; ignoring.",
+      PBL_LOG_WRN("Found reminder with invalid key size %d; ignoring.",
         info->key_len);
     }
     return true;
@@ -91,7 +91,7 @@ static bool prv_each_find_children(SettingsFile *file, SettingsRecordInfo *info,
       info->key_len != UUID_SIZE) {
     // malformed values; deleted values have their lengths set to 0
     if (info->key_len != UUID_SIZE) {
-      PBL_LOG(LOG_LEVEL_WARNING, "Found malformed item with invalid key/val sizes; ignoring.");
+      PBL_LOG_WRN("Found malformed item with invalid key/val sizes; ignoring.");
     }
     return true;
   }
@@ -236,7 +236,7 @@ void timeline_item_storage_init(TimelineItemStorage *storage,
   };
   status_t rv = settings_file_open(&storage->file, storage->name, storage->max_size);
   if (FAILED(rv)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Unable to create settings file %s, rv = %"PRId32 "!",
+    PBL_LOG_ERR("Unable to create settings file %s, rv = %"PRId32 "!",
             filename, rv);
   }
 }
@@ -255,7 +255,7 @@ status_t timeline_item_storage_insert(TimelineItemStorage *storage,
 
   // Check that the layout has the correct items
   if (!timeline_item_verify_layout_serialized(val, val_len)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Timeline item does not have the correct attributes");
+    PBL_LOG_WRN("Timeline item does not have the correct attributes");
     return E_INVALID_ARGUMENT;
   }
 
@@ -265,7 +265,7 @@ status_t timeline_item_storage_insert(TimelineItemStorage *storage,
   time_t timestamp = timeline_item_get_tz_timestamp(&hdr->common);
   time_t end_timestamp = timestamp + hdr->common.duration * SECONDS_PER_MINUTE;
   if (end_timestamp < (int)(now - storage->max_item_age)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Rejecting stale timeline item %ld seconds old",
+    PBL_LOG_WRN("Rejecting stale timeline item %ld seconds old",
       now - timestamp);
     return E_INVALID_OPERATION;
   }

--- a/src/fw/services/normal/blob_db/watch_app_prefs_db.c
+++ b/src/fw/services/normal/blob_db/watch_app_prefs_db.c
@@ -135,7 +135,7 @@ status_t watch_app_prefs_db_insert(const uint8_t *key, int key_len, const uint8_
   const bool is_valid_reminder_key = prv_is_key_valid(key, key_len, PREF_KEY_REMINDER_APP);
 
   if (!is_valid_send_text_key && !is_valid_weather_key && !is_valid_reminder_key) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Error inserting app_prefs: invalid key");
+    PBL_LOG_ERR("Error inserting app_prefs: invalid key");
     return E_INVALID_ARGUMENT;
   }
 
@@ -143,7 +143,7 @@ status_t watch_app_prefs_db_insert(const uint8_t *key, int key_len, const uint8_
       !prv_validate_received_pref(val_len, sizeof(SerializedSendTextPrefs),
                                   ((SerializedSendTextPrefs *)val)->num_contacts,
                                   sizeof(SerializedSendTextContact))) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Error inserting app_prefs: invalid send text contact list");
+    PBL_LOG_ERR("Error inserting app_prefs: invalid send text contact list");
     return E_INVALID_ARGUMENT;
   }
 
@@ -151,7 +151,7 @@ status_t watch_app_prefs_db_insert(const uint8_t *key, int key_len, const uint8_
       !prv_validate_received_pref(val_len, sizeof(SerializedWeatherAppPrefs),
                                   ((SerializedWeatherAppPrefs *)val)->num_locations,
                                   sizeof(Uuid))) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Error inserting app_prefs: invalid weather list");
+    PBL_LOG_ERR("Error inserting app_prefs: invalid weather list");
     return E_INVALID_ARGUMENT;
   }
 

--- a/src/fw/services/normal/blob_db/weather_db.c
+++ b/src/fw/services/normal/blob_db/weather_db.c
@@ -58,7 +58,7 @@ static bool prv_weather_db_for_each_cb(SettingsFile *file, SettingsRecordInfo *i
   WeatherDBEntry *entry = task_zalloc_check(info->val_len);
   info->get_val(file, entry, info->val_len);
   if (entry->version != WEATHER_DB_CURRENT_VERSION) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Version mismatch! Entry version: %" PRIu8 ", WeatherDB version: %u",
+    PBL_LOG_WRN("Version mismatch! Entry version: %" PRIu8 ", WeatherDB version: %u",
             entry->version, WEATHER_DB_CURRENT_VERSION);
     goto cleanup;
   }
@@ -125,8 +125,7 @@ status_t weather_db_insert(const uint8_t *key, int key_len, const uint8_t *val, 
 
   const WeatherDBEntry *entry = (WeatherDBEntry *)val;
   if (entry->version != WEATHER_DB_CURRENT_VERSION) {
-    PBL_LOG(LOG_LEVEL_WARNING,
-            "Version mismatch on insert! Entry version: %" PRIu8 ", WeatherDB version: %u",
+    PBL_LOG_WRN("Version mismatch on insert! Entry version: %" PRIu8 ", WeatherDB version: %u",
             entry->version, WEATHER_DB_CURRENT_VERSION);
     return E_INVALID_ARGUMENT;
   }
@@ -167,7 +166,7 @@ status_t weather_db_read(const uint8_t *key, int key_len, uint8_t *val_out, int 
   rv = settings_file_get(&s_weather_db.settings_file, key, key_len, val_out, val_out_len);
   if (((WeatherDBEntry*)val_out)->version != WEATHER_DB_CURRENT_VERSION) {
     // We might as well clear out the stale entry
-    PBL_LOG(LOG_LEVEL_WARNING, "Read an old weather DB entry");
+    PBL_LOG_WRN("Read an old weather DB entry");
     settings_file_delete(&s_weather_db.settings_file, key, key_len);
     rv = E_DOES_NOT_EXIST;
   }

--- a/src/fw/services/normal/bluetooth/ble_hrm.c
+++ b/src/fw/services/normal/bluetooth/ble_hrm.c
@@ -117,7 +117,7 @@ void ble_hrm_handle_activity_prefs_heart_rate_is_enabled(bool is_enabled) {
   if (!prv_hw_and_sw_supports_hrm()) {
     return;
   }
-  PBL_LOG(LOG_LEVEL_INFO, "BLE HRM sharing prefs updated: is_enabled=%u", is_enabled);
+  PBL_LOG_INFO("BLE HRM sharing prefs updated: is_enabled=%u", is_enabled);
 
   if (!is_enabled) {
     prv_reset_subscriptions();
@@ -193,7 +193,7 @@ static void prv_ble_hrm_handle_hrm_data(PebbleEvent *e, void *context) {
 }
 
 static void prv_start_hrm_kernel_main(void *unused) {
-  PBL_LOG(LOG_LEVEL_INFO, "BLE HRM sharing started");
+  PBL_LOG_INFO("BLE HRM sharing started");
   s_ble_hrm_session.service_info = (EventServiceInfo) {
     .type = PEBBLE_HRM_EVENT,
     .handler = prv_ble_hrm_handle_hrm_data,
@@ -207,7 +207,7 @@ static void prv_start_hrm_kernel_main(void *unused) {
 }
 
 static void prv_stop_hrm_kernel_main(void *unused) {
-  PBL_LOG(LOG_LEVEL_INFO, "BLE HRM sharing stopped");
+  PBL_LOG_INFO("BLE HRM sharing stopped");
   sys_hrm_manager_unsubscribe(s_ble_hrm_session.manager_session);
   event_service_client_unsubscribe(&s_ble_hrm_session.service_info);
 
@@ -227,7 +227,7 @@ static void prv_push_sharing_request_window_kernel_main_cb(void *ctx) {
 }
 
 static void prv_request_sharing_permission(GAPLEConnection *const connection) {
-  PBL_LOG(LOG_LEVEL_INFO, "Requesting BLE HRM sharing permission");
+  PBL_LOG_INFO("Requesting BLE HRM sharing permission");
   BLEHRMSharingRequest *const sharing_request = kernel_zalloc_check(sizeof(*sharing_request));
   sharing_request->connection = connection;
   launcher_task_add_callback(prv_push_sharing_request_window_kernel_main_cb, sharing_request);
@@ -263,7 +263,7 @@ static void prv_push_reminder_popup_kernel_main_cb(void *unused) {
   ble_hrm_push_reminder_popup();
 
   analytics_event_ble_hrm(BleHrmEventSubtype_SharingTimeoutPopupPresented);
-  PBL_LOG(LOG_LEVEL_INFO, "BLE HRM sharing timeout fired!");
+  PBL_LOG_INFO("BLE HRM sharing timeout fired!");
 }
 
 //! @note executes on timer task
@@ -332,7 +332,7 @@ static void prv_disconnect_to_kill_subscription(GAPLEConnection *connection) {
 }
 
 void ble_hrm_revoke_sharing_permission_for_connection(GAPLEConnection *connection) {
-  PBL_LOG(LOG_LEVEL_INFO, "BLE HRM sharing: revoked for conn %p", connection);
+  PBL_LOG_INFO("BLE HRM sharing: revoked for conn %p", connection);
   bt_lock();
   if (gap_le_connection_is_valid(connection)) {
     prv_update_permission(connection, HrmSharingPermission_Declined);
@@ -355,7 +355,7 @@ void ble_hrm_revoke_all(void) {
 
   // Counting as one -- it's one user action.
   analytics_event_ble_hrm(BleHrmEventSubtype_SharingRevoked);
-  PBL_LOG(LOG_LEVEL_INFO, "BLE HRM sharing: all revoked");
+  PBL_LOG_INFO("BLE HRM sharing: all revoked");
 }
 
 static void prv_update_subscription(GAPLEConnection *connection, bool is_subscribed) {
@@ -363,7 +363,7 @@ static void prv_update_subscription(GAPLEConnection *connection, bool is_subscri
   if (connection->hrm_service_is_subscribed == is_subscribed) {
     return;
   }
-  PBL_LOG(LOG_LEVEL_INFO, "BLE HRM sharing: conn <%p> is_subscribed=%u", connection, is_subscribed);
+  PBL_LOG_INFO("BLE HRM sharing: conn <%p> is_subscribed=%u", connection, is_subscribed);
 
   const bool prev_is_sharing = prv_is_sharing(connection);
   connection->hrm_service_is_subscribed = is_subscribed;
@@ -402,7 +402,7 @@ static void prv_reset_subscriptions(void) {
 
 void ble_hrm_handle_sharing_request_response(bool is_granted,
                                              BLEHRMSharingRequest *sharing_request) {
-  PBL_LOG(LOG_LEVEL_INFO, "BLE HRM sharing permission is_granted=%u", is_granted);
+  PBL_LOG_INFO("BLE HRM sharing permission is_granted=%u", is_granted);
 
   bt_lock();
   GAPLEConnection *connection = sharing_request->connection;
@@ -427,7 +427,7 @@ void bt_driver_cb_hrm_service_update_subscription(const BTDeviceInternal *device
   }
   GAPLEConnection *connection = gap_le_connection_by_device(device);
   if (!connection) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Subscription update but no connection?");
+    PBL_LOG_ERR("Subscription update but no connection?");
     goto unlock;
   }
   prv_update_subscription(connection, is_subscribed);

--- a/src/fw/services/normal/bluetooth/bluetooth_persistent_storage.c
+++ b/src/fw/services/normal/bluetooth/bluetooth_persistent_storage.c
@@ -1,8 +1,6 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define FILE_LOG_COLOR LOG_COLOR_BLUE
-
 #include "services/common/bluetooth/bluetooth_persistent_storage.h"
 #include "services/common/bluetooth/bluetooth_persistent_storage_debug.h"
 
@@ -236,8 +234,7 @@ static GapBondingFileSetStatus prv_file_set(
 
       if (do_perform_update) {
         s_bt_persistent_storage_updates++;
-        PBL_LOG_D(LOG_DOMAIN_BT_PAIRING_INFO, LOG_LEVEL_DEBUG,
-                  "Updating GAP Bonding DB Value <key, val>!");
+        PBL_LOG_D_DBG(LOG_DOMAIN_BT_PAIRING_INFO, "Updating GAP Bonding DB Value <key, val>!");
         PBL_HEXDUMP_D(LOG_DOMAIN_BT_PAIRING_INFO, LOG_LEVEL_DEBUG, (uint8_t *)key, key_len);
         PBL_HEXDUMP_D(LOG_DOMAIN_BT_PAIRING_INFO, LOG_LEVEL_DEBUG, (uint8_t *)data_in, data_len);
         rv = settings_file_set(&fd, key, key_len, (uint8_t*) data_in, data_len);
@@ -250,7 +247,7 @@ static GapBondingFileSetStatus prv_file_set(
 cleanup:
   prv_unlock();
   if (rv != S_SUCCESS) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to update gap bonding db, rv = %"PRId32, rv);
+    PBL_LOG_ERR("Failed to update gap bonding db, rv = %"PRId32, rv);
     return GapBondingFileSetFail;
   }
 
@@ -394,7 +391,7 @@ static void prv_load_local_data_from_prf(void) {
   if (shared_prf_storage_get_root_key(SMRootKeyTypeEncryption, &keys[SMRootKeyTypeEncryption]) &&
       shared_prf_storage_get_root_key(SMRootKeyTypeIdentity, &keys[SMRootKeyTypeIdentity])) {
 #if !defined(RELEASE)
-    PBL_LOG(LOG_LEVEL_INFO, "Loading Root Keys from PRF storage:");
+    PBL_LOG_INFO("Loading Root Keys from PRF storage:");
     PBL_HEXDUMP(LOG_LEVEL_INFO, (const uint8_t *) keys, sizeof(keys));
 #endif
     bt_persistent_storage_set_root_keys(keys);
@@ -406,7 +403,7 @@ static void prv_load_local_data_from_prf(void) {
   // reboot while saving new information to shared PRF
   if (bt_persistent_storage_get_root_key(SMRootKeyTypeEncryption, &keys[SMRootKeyTypeEncryption]) &&
       bt_persistent_storage_get_root_key(SMRootKeyTypeIdentity, &keys[SMRootKeyTypeIdentity])) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Storing Root Keys to PRF storage");
+    PBL_LOG_ERR("Storing Root Keys to PRF storage");
     shared_prf_storage_set_root_keys(keys);
   }
 }
@@ -493,7 +490,7 @@ bool prv_delete_pairing_with_type_by_id(BTBondingID bonding, BtPersistBondingTyp
   }
 
   if (data_out->type != type) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Type mismatch: not deleting pairing. Is the bonding db corrupted?");
+    PBL_LOG_ERR("Type mismatch: not deleting pairing. Is the bonding db corrupted?");
     return false;
   }
 
@@ -671,7 +668,7 @@ bool bt_persistent_storage_set_ble_pinned_address(const BTDeviceAddress *addr) {
                                             addr, addr ? sizeof(*addr) : 0);
   bool success = (rv != GapBondingFileSetFail);
   if (!success) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to store pinned address");
+    PBL_LOG_ERR("Failed to store pinned address");
   } else if (rv == GapBondingFileSetUpdated) {
     shared_prf_storage_set_ble_pinned_address(addr);
   }
@@ -751,7 +748,7 @@ bool bt_persistent_storage_update_ble_device_name(BTBondingID bonding, const cha
   }
 
   if (data.type != BtPersistBondingTypeBLE) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Not getting BLE id %d. Type mismatch", bonding);
+    PBL_LOG_ERR("Not getting BLE id %d. Type mismatch", bonding);
     return false;
   }
 
@@ -930,7 +927,7 @@ bool bt_persistent_storage_get_ble_pairing_by_id(BTBondingID bonding,
   }
 
   if (data.type != BtPersistBondingTypeBLE) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Not getting BT Classic id %d. Type mismatch", bonding);
+    PBL_LOG_ERR("Not getting BT Classic id %d. Type mismatch", bonding);
     return false;
   }
 
@@ -949,7 +946,7 @@ static bool prv_bt_persistent_storage_get_ble_smpairinginfo_by_id(
   }
 
   if (data.type != BtPersistBondingTypeBLE) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Not getting BLE id %d. Type mismatch", bonding);
+    PBL_LOG_ERR("Not getting BLE id %d. Type mismatch", bonding);
     return false;
   }
 
@@ -1424,7 +1421,7 @@ bool bt_persistent_storage_get_bt_classic_pairing_by_id(BTBondingID bonding,
   }
 
   if (data.type != BtPersistBondingTypeBTClassic) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Not getting BT Classic id %d. Type mismatch", bonding);
+    PBL_LOG_ERR("Not getting BT Classic id %d. Type mismatch", bonding);
     return false;
   }
 
@@ -1551,7 +1548,7 @@ bool bt_persistent_storage_is_unfaithful(void) {
 }
 
 void bt_persistent_storage_set_unfaithful(bool is_unfaithful) {
-  PBL_LOG(LOG_LEVEL_INFO, "Marking the watch as %s", is_unfaithful ? "unfaithful" : "faithful");
+  PBL_LOG_INFO("Marking the watch as %s", is_unfaithful ? "unfaithful" : "faithful");
   prv_file_set(&IS_UNFAITHFUL_KEY, sizeof(IS_UNFAITHFUL_KEY),
                &is_unfaithful, sizeof(is_unfaithful));
 }

--- a/src/fw/services/normal/data_logging/dls_list.c
+++ b/src/fw/services/normal/data_logging/dls_list.c
@@ -62,7 +62,7 @@ bool dls_lock_session(DataLoggingSession *session) {
 // ---------------------------------------------------------------------------------------
 // Callback used to free a storage buffer from unprivileged mode.
 static void prv_free_storage_buffer_cb(void *p) {
-  PBL_LOG_D(LOG_DOMAIN_DATA_LOGGING, LOG_LEVEL_DEBUG, "Freeing buffer storage ptr: %p", p);
+  PBL_LOG_D_DBG(LOG_DOMAIN_DATA_LOGGING, "Freeing buffer storage ptr: %p", p);
   task_free(p);
 }
 
@@ -168,7 +168,7 @@ DataLoggingSession *dls_list_find_active_session(uint32_t tag, const Uuid *app_u
 
 void dls_list_remove_session(DataLoggingSession *logging_session) {
   if (uuid_is_system(&logging_session->app_uuid)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Deleting the system data logging session with tag %"PRIu32,
+    PBL_LOG_WRN("Deleting the system data logging session with tag %"PRIu32,
             logging_session->tag);
   }
 
@@ -229,7 +229,7 @@ void dls_list_insert_session(DataLoggingSession *logging_session) {
   logging_session->next = *iter;
   *iter = logging_session;
 
-  PBL_LOG_D(LOG_DOMAIN_DATA_LOGGING, LOG_LEVEL_DEBUG, "Created session: %p id %"PRIu8
+  PBL_LOG_D_DBG(LOG_DOMAIN_DATA_LOGGING, "Created session: %p id %"PRIu8
       " tag %"PRIu32, logging_session, logging_session->comm.session_id, logging_session->tag);
 
   mutex_unlock_recursive(s_list_mutex);
@@ -274,7 +274,7 @@ DataLoggingSession *dls_list_create_session(uint32_t tag, DataLoggingItemType ty
 
   uint32_t num_sessions = prv_get_num_sessions();
   if (num_sessions >= DLS_MAX_NUM_SESSIONS) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Could not allocate additional DataLoggingSession objects");
+    PBL_LOG_WRN("Could not allocate additional DataLoggingSession objects");
     return NULL;
   }
 

--- a/src/fw/services/normal/data_logging/dls_syscalls.c
+++ b/src/fw/services/normal/data_logging/dls_syscalls.c
@@ -26,7 +26,7 @@ DEFINE_SYSCALL(void, sys_data_logging_finish, DataLoggingSessionRef session_ref)
   DataLoggingSession* session = (DataLoggingSession*)session_ref;
 
   if (!dls_is_session_valid(session)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "finish: Invalid session %p", session);
+    PBL_LOG_WRN("finish: Invalid session %p", session);
     return; // TODO: Return error code?
   }
 
@@ -38,11 +38,11 @@ DEFINE_SYSCALL(DataLoggingResult, sys_data_logging_log,
   DataLoggingSession* session = (DataLoggingSession*)session_ref;
 
   if (!dls_is_session_valid(session)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "log: Invalid session %p", session);
+    PBL_LOG_WRN("log: Invalid session %p", session);
     return DATA_LOGGING_INVALID_PARAMS;
   }
   if (data == NULL) {
-    PBL_LOG(LOG_LEVEL_WARNING, "log: NULL data pointer");
+    PBL_LOG_WRN("log: NULL data pointer");
     return DATA_LOGGING_INVALID_PARAMS;
   }
 

--- a/src/fw/services/normal/filesystem/flash_translation.c
+++ b/src/fw/services/normal/filesystem/flash_translation.c
@@ -52,7 +52,7 @@ static void prv_layout_version_add_all_regions(bool revert) {
     s_ftl_size += prv_region_size(i);
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Filesystem: Temporary size - %"PRId32" Kb", (s_ftl_size / 1024));
+  PBL_LOG_DBG("Filesystem: Temporary size - %"PRId32" Kb", (s_ftl_size / 1024));
   pfs_set_size(s_ftl_size, false /* don't erase regions */);
 }
 
@@ -92,8 +92,7 @@ void ftl_add_region(uint32_t region_start, uint32_t region_end, bool erase_new_r
     s_next_region_idx++;
   // failure, should never happen
   } else {
-    PBL_LOG(LOG_LEVEL_WARNING,
-        "Filesystem: Uh oh, we somehow added regions in the wrong order, %"PRIu32" %"PRIu32,
+    PBL_LOG_WRN("Filesystem: Uh oh, we somehow added regions in the wrong order, %"PRIu32" %"PRIu32,
         region_start, region_end);
     return;
   }
@@ -112,7 +111,7 @@ void ftl_add_region(uint32_t region_start, uint32_t region_end, bool erase_new_r
 
 void ftl_populate_region_list(void) {
   uint8_t flash_layout_version = prv_ftl_get_layout_version();
-  PBL_LOG(LOG_LEVEL_INFO, "Filesystem: Old Flash Layout Version: %u", flash_layout_version);
+  PBL_LOG_INFO("Filesystem: Old Flash Layout Version: %u", flash_layout_version);
 
   for (unsigned int i = s_next_region_idx; i < flash_layout_version; i++) {
     ftl_add_region(s_region_list[i].start, s_region_list[i].end, false);
@@ -126,7 +125,7 @@ void ftl_populate_region_list(void) {
     ftl_add_region(s_region_list[i].start, s_region_list[i].end, true);
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Filesystem: New size - %"PRId32" Kb", (s_ftl_size / 1024));
+  PBL_LOG_DBG("Filesystem: New size - %"PRId32" Kb", (s_ftl_size / 1024));
 }
 
 uint32_t ftl_get_size(void) {

--- a/src/fw/services/normal/health_sync_endpoint.c
+++ b/src/fw/services/normal/health_sync_endpoint.c
@@ -58,11 +58,11 @@ static void prv_sync_health_system_task_cb(void *unused) {
 
 static void prv_handle_sync(const uint8_t *msg, size_t len) {
   if (len < sizeof(HealthSyncEndpointSyncMsg)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid SYNC msg received, length: %u", len);
+    PBL_LOG_ERR("Invalid SYNC msg received, length: %u", len);
     return;
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Received health SYNC request");
+  PBL_LOG_DBG("Received health SYNC request");
 
   system_task_add_callback(prv_sync_health_system_task_cb, NULL);
 }
@@ -72,7 +72,7 @@ static void prv_handle_sync(const uint8_t *msg, size_t len) {
 void health_sync_protocol_msg_callback(CommSession *session, const uint8_t *msg, size_t len) {
 #if CAPABILITY_HAS_HEALTH_TRACKING
   if (len < 1) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid message received, length: %u", len);
+    PBL_LOG_ERR("Invalid message received, length: %u", len);
   }
 
   HealthSyncEndpointCmd cmd = *msg;
@@ -82,7 +82,7 @@ void health_sync_protocol_msg_callback(CommSession *session, const uint8_t *msg,
       break;
 
     default:
-      PBL_LOG(LOG_LEVEL_WARNING, "Unexpected command received, 0x%x", cmd);
+      PBL_LOG_WRN("Unexpected command received, 0x%x", cmd);
       return;
   }
 #else

--- a/src/fw/services/normal/legacy/persist_map.c
+++ b/src/fw/services/normal/legacy/persist_map.c
@@ -87,7 +87,7 @@ static int seek_map(int fd, SearchCallback callback, void *data) {
       if (PASSED(read_result) || read_result == E_RANGE) {
         return E_DOES_NOT_EXIST;
       }
-      PBL_LOG(LOG_LEVEL_WARNING, "seek_map failed: %d", read_result);
+      PBL_LOG_WRN("seek_map failed: %d", read_result);
       return read_result;
     } else  if (field.id == EOF_PERSIST_ID_TAG) {
       break;
@@ -103,7 +103,7 @@ static int seek_map(int fd, SearchCallback callback, void *data) {
 static int search_map(SearchCallback callback, void *data) {
   int fd = prv_pmap_open_debug_wrapper(s_map_filename, OP_FLAG_READ, 0, 0);
   if (fd < 0) {
-    PBL_LOG(LOG_LEVEL_WARNING, "pmap search (open) failed: %d", fd);
+    PBL_LOG_WRN("pmap search (open) failed: %d", fd);
     return (fd);
   }
 
@@ -134,11 +134,11 @@ static status_t enlarge_pmap_file(int *fd, size_t new_size) {
   if (buf == NULL) {
     return (E_OUT_OF_MEMORY);
   }
-  PBL_LOG(LOG_LEVEL_DEBUG, "Growing pmap to %d bytes", (int)new_size);
+  PBL_LOG_DBG("Growing pmap to %d bytes", (int)new_size);
   int new_fd = prv_pmap_open_debug_wrapper(s_map_filename, OP_FLAG_OVERWRITE, FILE_TYPE_STATIC,
       new_size);
   if (new_fd < 0) {
-    PBL_LOG(LOG_LEVEL_WARNING, "pmap enlarge (overwrite) failed: %d", new_fd);
+    PBL_LOG_WRN("pmap enlarge (overwrite) failed: %d", new_fd);
     kernel_free(buf);
     return (new_fd);
   }
@@ -164,7 +164,7 @@ static status_t enlarge_pmap_file(int *fd, size_t new_size) {
 
   *fd = prv_pmap_open_debug_wrapper(s_map_filename, OP_FLAG_READ | OP_FLAG_WRITE, 0, 0);
   if (*fd < 0) {
-    PBL_LOG(LOG_LEVEL_WARNING, "pmap enlarge (re-open) failed: %d", *fd);
+    PBL_LOG_WRN("pmap enlarge (re-open) failed: %d", *fd);
   }
   kernel_free(buf);
   return (rv);
@@ -176,7 +176,7 @@ int persist_map_add_uuid(const Uuid *uuid) {
   int fd = prv_pmap_open_debug_wrapper(s_map_filename, OP_FLAG_READ | OP_FLAG_WRITE,
       FILE_TYPE_STATIC, 0);
   if (fd < 0) {
-    PBL_LOG(LOG_LEVEL_WARNING, "pmap add uuid (open) failed: %d", fd);
+    PBL_LOG_WRN("pmap add uuid (open) failed: %d", fd);
     return (fd);
   }
 
@@ -195,7 +195,7 @@ int persist_map_add_uuid(const Uuid *uuid) {
     // user can take is to factory-reset
     if (file_sz > (PMAP_FILE_SIZE * 3)) {
       pfs_close(fd);
-      PBL_LOG(LOG_LEVEL_WARNING, "pmap file is larger than expected, 0x%x 0x%x",
+      PBL_LOG_WRN("pmap file is larger than expected, 0x%x 0x%x",
           (int)file_sz, (int)end_offset);
       return (E_INTERNAL);
     }
@@ -208,7 +208,7 @@ int persist_map_add_uuid(const Uuid *uuid) {
 
   int seek_to;
   if ((seek_to = pfs_seek(fd, end_offset, FSeekSet)) != end_offset) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Bad seek to %d, got %d", end_offset, seek_to);
+    PBL_LOG_WRN("Bad seek to %d, got %d", end_offset, seek_to);
     pfs_close(fd);
     return (seek_to);
   }
@@ -281,13 +281,13 @@ static bool prv_dump_callback(PersistMapIdField *field, void *data) {
   char uuid_string[UUID_STRING_BUFFER_LENGTH];
   uuid_to_string(&field->uuid, uuid_string);
 
-  PBL_LOG(LOG_LEVEL_INFO, "%s -> %d", uuid_string, field->id);
+  PBL_LOG_INFO("%s -> %d", uuid_string, field->id);
 
   return false;
 }
 
 void persist_map_dump(void) {
-  PBL_LOG(LOG_LEVEL_INFO, "Dumping persist map:");
+  PBL_LOG_INFO("Dumping persist map:");
   search_map(prv_dump_callback, NULL);
 }
 
@@ -300,7 +300,7 @@ status_t persist_map_init() {
   if (fd < 0) {
     if ((fd = prv_pmap_open_debug_wrapper(name, OP_FLAG_WRITE, FILE_TYPE_STATIC,
         PMAP_FILE_SIZE)) < 0) {
-      PBL_LOG(LOG_LEVEL_WARNING, "pmap create failed: %d", fd);
+      PBL_LOG_WRN("pmap create failed: %d", fd);
       return (fd);
     }
 

--- a/src/fw/services/normal/music.c
+++ b/src/fw/services/normal/music.c
@@ -93,9 +93,9 @@ bool music_set_connected_server(const MusicServerImplementation *implementation,
     if (s_music_ctx.implementation == NULL) {
       change_type = Connected;
       s_music_ctx.implementation = implementation;
-      PBL_LOG(LOG_LEVEL_INFO, "Music server connected: %s", implementation->debug_name);
+      PBL_LOG_INFO("Music server connected: %s", implementation->debug_name);
     } else {
-      PBL_LOG(LOG_LEVEL_ERROR, "Server <0x%p> connected, but another <0x%p> is already registered",
+      PBL_LOG_ERR("Server <0x%p> connected, but another <0x%p> is already registered",
               implementation, s_music_ctx.implementation);
     }
 
@@ -104,9 +104,9 @@ bool music_set_connected_server(const MusicServerImplementation *implementation,
       // Previously registered server got disconnected
       change_type = Disconnected;
       s_music_ctx.implementation = NULL;
-      PBL_LOG(LOG_LEVEL_INFO, "Music server disconnected: %s", implementation->debug_name);
+      PBL_LOG_INFO("Music server disconnected: %s", implementation->debug_name);
     } else {
-      PBL_LOG(LOG_LEVEL_ERROR, "Unknown server <%p> disconnected", implementation);
+      PBL_LOG_ERR("Unknown server <%p> disconnected", implementation);
     }
   }
 

--- a/src/fw/services/normal/music_endpoint.c
+++ b/src/fw/services/normal/music_endpoint.c
@@ -18,7 +18,7 @@ static bool s_progress_reporting_supported = true;
 static void prv_send_music_command_to_handset(MusicEndpointCmdID cmd) {
   CommSession *session = comm_session_get_system_session();
   if (!session) {
-    PBL_LOG(LOG_LEVEL_ERROR, "No system session");
+    PBL_LOG_ERR("No system session");
     return;
   }
   comm_session_send_data(session, MUSIC_CTRL_ENDPOINT,
@@ -38,7 +38,7 @@ static const uint8_t* prv_read_ptr_and_length_from_buffer(const uint8_t *iter,
 
   iter += 1 + *out_length;
   if (iter > iter_end) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Invalid music message");
+    PBL_LOG_WRN("Invalid music message");
     return NULL;
   }
   return iter;
@@ -181,7 +181,7 @@ void music_protocol_msg_callback(CommSession *session, const uint8_t* msg, size_
       prv_update_player_info(session, msg, length);
       break;
     default:
-      PBL_LOG(LOG_LEVEL_DEBUG, "Invalid command 0x%"PRIx8, msg[0]);
+      PBL_LOG_DBG("Invalid command 0x%"PRIx8, msg[0]);
   }
 }
 

--- a/src/fw/services/normal/notifications/ancs/ancs_filtering.c
+++ b/src/fw/services/normal/notifications/ancs/ancs_filtering.c
@@ -59,7 +59,7 @@ void ancs_filtering_record_app(iOSNotifPrefs **notif_prefs,
       pstring_pstring16_to_string(&app_name_attr->pstr, app_name_buff);
       attribute_list_add_cstring(&new_attr_list, AttributeIdAppName, app_name_buff);
       list_dirty = true;
-      PBL_LOG(LOG_LEVEL_INFO, "Adding app name to app prefs: <%s>", app_name_buff);
+      PBL_LOG_INFO("Adding app name to app prefs: <%s>", app_name_buff);
     }
   }
 
@@ -83,7 +83,7 @@ void ancs_filtering_record_app(iOSNotifPrefs **notif_prefs,
       (last_updated && now > (last_updated->uint32 + SECONDS_PER_DAY))) {
     attribute_list_add_uint32(&new_attr_list, AttributeIdLastUpdated, now);
     list_dirty = true;
-    PBL_LOG(LOG_LEVEL_INFO, "Updating / adding timestamp to app prefs");
+    PBL_LOG_INFO("Updating / adding timestamp to app prefs");
   }
 
   if (list_dirty) {

--- a/src/fw/services/normal/notifications/ancs/ancs_item.c
+++ b/src/fw/services/normal/notifications/ancs/ancs_item.c
@@ -489,7 +489,7 @@ TimelineItem *ancs_item_create_and_populate(ANCSAttribute *notif_attributes[],
 
   if (!item) {
     // Out of memory - we do not croak on out of memory for notifications (PBL-10521)
-    PBL_LOG(LOG_LEVEL_WARNING, "Ignoring ANCS notification (out of memory)");
+    PBL_LOG_WRN("Ignoring ANCS notification (out of memory)");
     return NULL;
   }
 

--- a/src/fw/services/normal/notifications/ancs/nexmo.c
+++ b/src/fw/services/normal/notifications/ancs/nexmo.c
@@ -14,7 +14,7 @@ T_STATIC char* NEXMO_REAUTH_STRING = "Pebble check-in code:";
 bool nexmo_is_reauth_sms(const ANCSAttribute *app_id, const ANCSAttribute *message) {
   if (ancs_notifications_util_is_sms(app_id)) {
     if (strstr((const char *)message->value, NEXMO_REAUTH_STRING)) {
-      PBL_LOG(LOG_LEVEL_INFO, "Got Nexmo Reauth SMS");
+      PBL_LOG_INFO("Got Nexmo Reauth SMS");
       return true;
     }
   }

--- a/src/fw/services/normal/notifications/do_not_disturb_toggle.c
+++ b/src/fw/services/normal/notifications/do_not_disturb_toggle.c
@@ -16,7 +16,7 @@ static bool prv_get_state(void *context) {
 }
 
 static void prv_set_state(bool enabled, void *context) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Manual DND toggle: %s", enabled ? "enabled" : "disabled");
+  PBL_LOG_DBG("Manual DND toggle: %s", enabled ? "enabled" : "disabled");
   do_not_disturb_set_manually_enabled(enabled);
 }
 

--- a/src/fw/services/normal/persist.c
+++ b/src/fw/services/normal/persist.c
@@ -63,7 +63,7 @@ static status_t prv_get_file_name(char *name, size_t buf_len, const Uuid *uuid) 
   int pid = persist_map_auto_id(uuid);
   if (FAILED(pid)) {
     // Attempting to debug persist map failure
-    PBL_LOG(LOG_LEVEL_WARNING, "Failed to get pid! %d", pid);
+    PBL_LOG_WRN("Failed to get pid! %d", pid);
     persist_map_dump();
     return pid;
   }

--- a/src/fw/services/normal/phone_call.c
+++ b/src/fw/services/normal/phone_call.c
@@ -71,14 +71,14 @@ static void prv_schedule_call_watchdog(int poll_interval_ms) {
     // Schedule/reschedule the watchdog
     if (!new_timer_start(s_call_watchdog, poll_interval_ms, prv_timer_callback,
                          NULL, TIMER_START_FLAG_REPEATING)) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Could not start the phone call watchdog timer");
+      PBL_LOG_ERR("Could not start the phone call watchdog timer");
       prv_handle_call_end(true /* Treat this as a disconnection */);
     } else {
-      PBL_LOG(LOG_LEVEL_INFO, "Phone call watchdog timer started");
+      PBL_LOG_INFO("Phone call watchdog timer started");
       pp_get_phone_state_set_enabled(true);
     }
   } else {
-    PBL_LOG(LOG_LEVEL_INFO, "Not starting phone call watchdog, this isn't iOS 8: %d",
+    PBL_LOG_INFO("Not starting phone call watchdog, this isn't iOS 8: %d",
             s_call_source);
   }
 }
@@ -114,14 +114,14 @@ static void prv_call_end_common(void) {
 static void prv_handle_incoming_call(const PebblePhoneEvent *event) {
   // Only 1 call at a time is supported
   if (s_call_in_progress) {
-    PBL_LOG(LOG_LEVEL_INFO, "Ignoring incoming call. A call is already in progress");
+    PBL_LOG_INFO("Ignoring incoming call. A call is already in progress");
     return;
   }
 
   // If we're not on iOS9+, we need to be connected to the mobile app since it tells us when
   // the phone has stopped ringing
   if ((event->source != PhoneCallSource_ANCS) && !s_mobile_app_is_connected) {
-    PBL_LOG(LOG_LEVEL_INFO, "Ignoring incoming call. Mobile app is not connected. Call source: %d ",
+    PBL_LOG_INFO("Ignoring incoming call. Mobile app is not connected. Call source: %d ",
             event->source);
     return;
   }
@@ -144,7 +144,7 @@ static void prv_handle_outgoing_call(PebblePhoneEvent *event) {
     phone_ui_handle_outgoing_call(event->caller);
     analytics_inc(ANALYTICS_DEVICE_METRIC_PHONE_CALL_OUTGOING_COUNT, AnalyticsClient_System);
   } else {
-    // PBL_LOG(LOG_LEVEL_DEBUG, "Ignoring outgoing call. A call is already in progress: %d, "
+    // PBL_LOG_DBG("Ignoring outgoing call. A call is already in progress: %d, "
     //     "the mobile app is connected: %d", s_call_in_progress, s_mobile_app_is_connected);
   }
 }
@@ -155,7 +155,7 @@ static void prv_handle_missed_call(PebblePhoneEvent *event) {
     phone_ui_handle_missed_call();
     analytics_inc(ANALYTICS_DEVICE_METRIC_PHONE_CALL_INCOMING_COUNT, AnalyticsClient_System);
   } else {
-    // PBL_LOG(LOG_LEVEL_DEBUG, "Ignoring missed call. A call is not in progress");
+    // PBL_LOG_DBG("Ignoring missed call. A call is not in progress");
   }
 }
 
@@ -171,7 +171,7 @@ static void prv_handle_call_start(void) {
     }
     analytics_inc(ANALYTICS_DEVICE_METRIC_PHONE_CALL_START_COUNT, AnalyticsClient_System);
   } else {
-    PBL_LOG(LOG_LEVEL_INFO, "Ignoring start call. A call is not in progress");
+    PBL_LOG_INFO("Ignoring start call. A call is not in progress");
   }
 }
 
@@ -182,7 +182,7 @@ static void prv_handle_call_hide(PebblePhoneEvent *event) {
 
   // Make sure this wasn't caused due to an unrelated ANCS removal
   if (prv_call_is_ancs() && (s_call_identifier != event->call_identifier)) {
-    PBL_LOG(LOG_LEVEL_INFO, "Ignoring hide call. Call identifier %"PRIu32" doesn't match %"PRIu32,
+    PBL_LOG_INFO("Ignoring hide call. Call identifier %"PRIu32" doesn't match %"PRIu32,
             s_call_identifier, event->call_identifier);
     return;
   }
@@ -201,7 +201,7 @@ static void prv_handle_call_end(bool disconnected) {
     prv_call_end_common();
     phone_ui_handle_call_end(false /*call accepted*/, disconnected);
   } else if (!disconnected) {
-    PBL_LOG(LOG_LEVEL_INFO, "Ignoring end call. A call is not in progress");
+    PBL_LOG_INFO("Ignoring end call. A call is not in progress");
   }
 }
 
@@ -209,7 +209,7 @@ static void prv_handle_caller_id(PebblePhoneEvent *event) {
   if (s_call_in_progress) {
     phone_ui_handle_caller_id(event->caller);
   } else {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Ignoring caller id. A call is not in progress");
+    PBL_LOG_DBG("Ignoring caller id. A call is not in progress");
   }
 }
 
@@ -224,7 +224,7 @@ T_STATIC void prv_handle_phone_event(PebbleEvent *e, void *context) {
 
   if (!(event.type == PhoneEventType_Incoming && new_timer_scheduled(s_call_watchdog, NULL))) {
     // Be careful not to spam the logs with the new iOS polling implementation
-    PBL_LOG(LOG_LEVEL_INFO, "PebblePhoneEvent: %d, Call in progress: %s, Connected: %s",
+    PBL_LOG_INFO("PebblePhoneEvent: %d, Call in progress: %s, Connected: %s",
       event.type, s_call_in_progress ? "T": "F", s_mobile_app_is_connected ? "T": "F");
   }
 
@@ -312,7 +312,7 @@ void phone_call_service_init() {
 
 void phone_call_answer(void) {
   analytics_inc(ANALYTICS_DEVICE_METRIC_PHONE_CALL_ANSWER_COUNT, AnalyticsClient_System);
-  PBL_LOG(LOG_LEVEL_INFO, "Call accepted");
+  PBL_LOG_INFO("Call accepted");
 
   if (prv_call_is_ancs()) {
     ancs_perform_action(s_call_identifier, ActionIDPositive);
@@ -327,7 +327,7 @@ void phone_call_answer(void) {
 
 void phone_call_decline(void) {
   analytics_inc(ANALYTICS_DEVICE_METRIC_PHONE_CALL_DECLINE_COUNT, AnalyticsClient_System);
-  PBL_LOG(LOG_LEVEL_INFO, "Call declined");
+  PBL_LOG_INFO("Call declined");
 
   if (prv_call_is_ancs()) {
     ancs_perform_action(s_call_identifier, ActionIDNegative);

--- a/src/fw/services/normal/process_management/app_order_storage.c
+++ b/src/fw/services/normal/process_management/app_order_storage.c
@@ -39,7 +39,7 @@ AppMenuOrderStorage *app_order_read_order(void) {
 
   int fd;
   if ((fd = pfs_open(ORDER_FILE, OP_FLAG_READ, 0, 0)) < 0) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "App menu order file does not exist");
+    PBL_LOG_DBG("App menu order file does not exist");
     s_data.file_known_missing = true;
     mutex_unlock(s_data.order_mutex);
     return NULL;
@@ -47,7 +47,7 @@ AppMenuOrderStorage *app_order_read_order(void) {
 
   // Check if it is an valid file
   if ((pfs_get_file_size(fd) % sizeof(AppInstallId)) != sizeof(uint8_t)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Invalid order storage file");
+    PBL_LOG_ERR("Invalid order storage file");
     delete_file = true;
     goto cleanup;
   }
@@ -55,7 +55,7 @@ AppMenuOrderStorage *app_order_read_order(void) {
   // Read the number of AppInstallId's listed in the file
   uint8_t list_length;
   if (pfs_read(fd, &list_length, sizeof(uint8_t)) != sizeof(uint8_t)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Could not read app menu order file");
+    PBL_LOG_ERR("Could not read app menu order file");
     delete_file = true;
     goto cleanup;
   }
@@ -63,7 +63,7 @@ AppMenuOrderStorage *app_order_read_order(void) {
   // Allocate room for the order list array. Free'd by the caller of the function.
   storage = app_malloc(sizeof(AppMenuOrderStorage) + list_length * sizeof(AppInstallId));
   if (!storage) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to malloc stored order install_id list");
+    PBL_LOG_ERR("Failed to malloc stored order install_id list");
     goto cleanup;
   }
 
@@ -71,7 +71,7 @@ AppMenuOrderStorage *app_order_read_order(void) {
   const int read_size = list_length * sizeof(AppInstallId);
   int rd_sz;
   if ((rd_sz = pfs_read(fd, (uint8_t *)storage->id_list, read_size)) != read_size) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Corrupted ordered install_id list (Rd %d of %d bytes)",
+    PBL_LOG_ERR("Corrupted ordered install_id list (Rd %d of %d bytes)",
         rd_sz, read_size);
     app_free(storage);
     storage = NULL;
@@ -105,7 +105,7 @@ static void prv_app_order_write_order(AppMenuOrderStorage *storage) {
   }
 
   if (fd < 0) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Could not create app menu order file");
+    PBL_LOG_ERR("Could not create app menu order file");
     goto cleanup;
   }
 
@@ -113,7 +113,7 @@ static void prv_app_order_write_order(AppMenuOrderStorage *storage) {
   int wrote_storage_bytes = pfs_write(fd, (uint8_t *)storage, storage_size);
 
   if (wrote_storage_bytes != storage_size) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to write all bytes of order list");
+    PBL_LOG_ERR("Failed to write all bytes of order list");
   }
 
   pfs_close(fd);

--- a/src/fw/services/normal/process_management/app_storage.c
+++ b/src/fw/services/normal/process_management/app_storage.c
@@ -65,7 +65,7 @@ AppStorageGetAppInfoResult app_storage_get_process_info(PebbleProcessInfo* app_i
        app_info->sdk_version.minor <= PROCESS_INFO_CURRENT_SDK_VERSION_MINOR);
 
   if (is_sdk_compatible == false) {
-    PBL_LOG(LOG_LEVEL_WARNING, "App requires support for SDK version (%u.%u), we only support version (%u.%u).",
+    PBL_LOG_WRN("App requires support for SDK version (%u.%u), we only support version (%u.%u).",
             app_info->sdk_version.major, app_info->sdk_version.minor,
             PROCESS_INFO_CURRENT_SDK_VERSION_MAJOR, PROCESS_INFO_CURRENT_SDK_VERSION_MINOR);
 
@@ -74,7 +74,7 @@ AppStorageGetAppInfoResult app_storage_get_process_info(PebbleProcessInfo* app_i
   }
 
   if (app_info->virtual_size > APP_MAX_SIZE) {
-    PBL_LOG(LOG_LEVEL_WARNING, "App size (%u) larger than bank size; invalid app.", app_info->virtual_size);
+    PBL_LOG_WRN("App size (%u) larger than bank size; invalid app.", app_info->virtual_size);
     // The app's metadata indicates an app larger than the maximum bank size
     return GET_APP_INFO_APP_TOO_LARGE;
   }

--- a/src/fw/services/normal/process_management/process_loader_storage.c
+++ b/src/fw/services/normal/process_management/process_loader_storage.c
@@ -27,7 +27,7 @@ static bool prv_verify_checksum(const PebbleProcessInfo* app_info, const uint8_t
                                                              app_size);
 
   if (app_info->crc != calculated_crc) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Calculated App CRC is 0x%"PRIx32", expected 0x%"PRIx32"!",
+    PBL_LOG_WRN("Calculated App CRC is 0x%"PRIx32", expected 0x%"PRIx32"!",
             calculated_crc, app_info->crc);
     return false;
   } else {
@@ -43,7 +43,7 @@ static void * prv_offset_to_address(MemorySegment *segment, size_t offset) {
 static bool prv_intialize_sdk_process(PebbleTask task, const PebbleProcessInfo *info,
                                       MemorySegment *destination) {
   if (!prv_verify_checksum(info, destination->start)) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Calculated CRC does not match, aborting...");
+    PBL_LOG_DBG("Calculated CRC does not match, aborting...");
     return false;
   }
 
@@ -92,8 +92,7 @@ static bool prv_load_from_flash(const PebbleProcessMd *app_md, PebbleTask task,
   const size_t load_size = app_storage_get_process_load_size(&info);
 
   if (load_size > memory_segment_get_size(destination)) {
-    PBL_LOG(LOG_LEVEL_ERROR,
-            "App/Worker exceeds available program space: %"PRIu16" + (%"PRIu32" * 4) = %zu",
+    PBL_LOG_ERR("App/Worker exceeds available program space: %"PRIu16" + (%"PRIu32" * 4) = %zu",
             info.load_size, info.num_reloc_entries, load_size);
     return false;
   }
@@ -104,12 +103,12 @@ static bool prv_load_from_flash(const PebbleProcessMd *app_md, PebbleTask task,
   app_storage_get_file_name(process_name, sizeof(process_name), app_id, task);
 
   if ((fd = pfs_open(process_name, OP_FLAG_READ, 0, 0)) < S_SUCCESS) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Process open failed for process %s, fd = %d", process_name, fd);
+    PBL_LOG_ERR("Process open failed for process %s, fd = %d", process_name, fd);
     return (false);
   }
 
   if (pfs_read(fd, destination->start, load_size) != (int)load_size) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Process read failed for process %s, fd = %d", process_name, fd);
+    PBL_LOG_ERR("Process read failed for process %s, fd = %d", process_name, fd);
     pfs_close(fd);
     return (false);
   }
@@ -132,8 +131,7 @@ static bool prv_load_from_resource(const PebbleProcessMdResource *app_md,
   const size_t load_size = app_storage_get_process_load_size(&info);
 
   if (load_size > memory_segment_get_size(destination)) {
-    PBL_LOG(LOG_LEVEL_ERROR,
-        "App/Worker exceeds available program space: %"PRIu16" + (%"PRIu32" * 4) = %zu",
+    PBL_LOG_ERR("App/Worker exceeds available program space: %"PRIu16" + (%"PRIu32" * 4) = %zu",
         info.load_size, info.num_reloc_entries, load_size);
     return false;
   }

--- a/src/fw/services/normal/settings/settings_raw_iter.c
+++ b/src/fw/services/normal/settings/settings_raw_iter.c
@@ -32,8 +32,7 @@ static uint8_t *read_file_into_ram(SettingsRawIter *iter) {
     contents = kernel_calloc(1, read_size);
   }
   if (contents == NULL) {
-    PBL_LOG(LOG_LEVEL_ERROR,
-            "Could not allocate %d bytes for corrupt file of size %d.",
+    PBL_LOG_ERR("Could not allocate %d bytes for corrupt file of size %d.",
             read_size, file_size);
     return NULL;
   }
@@ -44,27 +43,25 @@ static uint8_t *read_file_into_ram(SettingsRawIter *iter) {
   int start_offset = end_offset - read_size;
   int status = pfs_seek(iter->fd, start_offset, FSeekSet);
   if (status < 0) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Debug seek failed: %d", status);
+    PBL_LOG_ERR("Debug seek failed: %d", status);
     kernel_free(contents);
     return NULL;
   }
   int actual_read_size = pfs_read(iter->fd, contents, read_size);
-  PBL_LOG(LOG_LEVEL_INFO,
-          "Read %d (expected %d) bytes of file %s (size %d), around offset %d.",
+  PBL_LOG_INFO("Read %d (expected %d) bytes of file %s (size %d), around offset %d.",
           actual_read_size, read_size, iter->file_name, file_size, pos);
   return contents;
 }
 
 static NORETURN fatal_logic_error(SettingsRawIter *iter) {
-  PBL_LOG(LOG_LEVEL_ERROR,
-          "settings_raw_iter logic error. "
+  PBL_LOG_ERR("settings_raw_iter logic error. "
           "Attempting to read affected file into RAM for easier debugging...");
   uint8_t *contents = read_file_into_ram(iter);
-  PBL_LOG(LOG_LEVEL_INFO, "Removing affected file %s...", iter->file_name);
+  PBL_LOG_INFO("Removing affected file %s...", iter->file_name);
   // Remove the file that caused us to get into this state before we reboot,
   // that way we should be able to avoid getting into a reboot loop.
   pfs_close_and_remove(iter->fd);
-  PBL_LOG(LOG_LEVEL_INFO, "Data at address %p. Rebooting...", contents);
+  PBL_LOG_INFO("Data at address %p. Rebooting...", contents);
   PBL_CROAK("Internal logic error.");
 }
 
@@ -75,7 +72,7 @@ static int sfs_seek(SettingsRawIter *iter, int amount, int whence) {
   }
 
   int pos = pfs_seek(iter->fd, 0, FSeekCur);
-  PBL_LOG(LOG_LEVEL_ERROR, "Could not seek by %d from whence %d at pos %d: %"PRId32,
+  PBL_LOG_ERR("Could not seek by %d from whence %d at pos %d: %"PRId32,
           amount, whence, pos, status);
   fatal_logic_error(iter);
 }
@@ -91,7 +88,7 @@ static int sfs_read(SettingsRawIter *iter, uint8_t *data, int data_len) {
   }
 
   int pos = pfs_seek(iter->fd, 0, FSeekCur);
-  PBL_LOG(LOG_LEVEL_ERROR, "Could not read data to %p of length %d at pos %d: %"PRId32,
+  PBL_LOG_ERR("Could not read data to %p of length %d at pos %d: %"PRId32,
           data, data_len, pos, status);
   fatal_logic_error(iter);
 }
@@ -103,7 +100,7 @@ static int sfs_write(SettingsRawIter *iter, const uint8_t *data, int data_len) {
   }
 
   int pos = pfs_seek(iter->fd, 0, FSeekCur);
-  PBL_LOG(LOG_LEVEL_ERROR, "Could not write from %p, %d bytes at pos %d: %"PRId32,
+  PBL_LOG_ERR("Could not write from %p, %d bytes at pos %d: %"PRId32,
           data, data_len, pos, status);
   fatal_logic_error(iter);
 }
@@ -215,7 +212,7 @@ void settings_raw_iter_write_byte(SettingsRawIter *iter, int offset, uint8_t byt
 void settings_raw_iter_deinit(SettingsRawIter *iter) {
   int status = pfs_close(iter->fd);
   if (status < 0) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Could not close settings file");
+    PBL_LOG_WRN("Could not close settings file");
   }
 }
 

--- a/src/fw/services/normal/stationary.c
+++ b/src/fw/services/normal/stationary.c
@@ -99,8 +99,7 @@ static void prv_update_stationary_enabled(void *data) {
 }
 
 void stationary_handle_battery_connection_change_event(void) {
-  PBL_LOG_D(DEBUG_STATIONARY, LOG_LEVEL_DEBUG,
-            "Stationary mode battery state change event received");
+  PBL_LOG_D_DBG(DEBUG_STATIONARY, "Stationary mode battery state change event received");
   if (battery_is_usb_connected()) {
     analytics_event_stationary_state_change(rtc_get_time(), StationaryAnalyticsEnterCharging);
   } else {
@@ -123,8 +122,7 @@ static void prv_button_down_handler(PebbleEvent *event, void *data) {
 static void prv_watch_is_motionless(void) {
   // Check if we should enable stationary mode and disabled unneeded features
   if (s_stationary_count_down > 0) {
-    PBL_LOG_D(DEBUG_STATIONARY, LOG_LEVEL_DEBUG,
-              "Countdown to stationary: %d", s_stationary_count_down);
+    PBL_LOG_D_DBG(DEBUG_STATIONARY, "Countdown to stationary: %d", s_stationary_count_down);
     s_stationary_count_down--;
   } else {
     analytics_inc(ANALYTICS_DEVICE_METRIC_STATIONARY_TIME_MINUTES, AnalyticsClient_System);
@@ -200,7 +198,7 @@ static void prv_reset_stationary_counter(void) {
 }
 
 static void prv_enter_awake_state(void) {
-  PBL_LOG(LOG_LEVEL_INFO, "Exiting stationary: Setting run level to normal");
+  PBL_LOG_INFO("Exiting stationary: Setting run level to normal");
   analytics_event_stationary_state_change(rtc_get_time(), StationaryAnalyticsExitNormally);
   prv_reset_stationary_counter();
   s_current_state = StationaryStateAwake;
@@ -209,7 +207,7 @@ static void prv_enter_awake_state(void) {
 //! The accelerometer tap threshold will be set very low, so a small motion will wake
 //! the watch back up
 static void prv_enter_stationary_state(void) {
-  PBL_LOG(LOG_LEVEL_INFO, "Entering stationary: Changing run level");
+  PBL_LOG_INFO("Entering stationary: Changing run level");
   if (s_current_state == StationaryStatePeeking) {
     analytics_event_stationary_state_change(rtc_get_time(), StationaryAnalyticsEnterFromPeek);
   } else if (s_current_state == StationaryStateAwake) {
@@ -339,7 +337,7 @@ static void prv_handle_action(StationaryAction action) {
   // we need to be on kernel main so that we subscribe to event services
   // for kernel main
   PBL_ASSERT_TASK(PebbleTask_KernelMain);
-  PBL_LOG_D(DEBUG_STATIONARY, LOG_LEVEL_DEBUG, "Stationary: state %d action %d",
+  PBL_LOG_D_DBG(DEBUG_STATIONARY, "Stationary: state %d action %d",
             s_current_state, action);
 
   static StationaryActionHandler const prv_action_jump_table[] = {

--- a/src/fw/services/normal/timeline/actions_endpoint.c
+++ b/src/fw/services/normal/timeline/actions_endpoint.c
@@ -114,7 +114,7 @@ static PebbleSysNotificationActionResult *prv_action_result_create_from_serial_d
   PebbleSysNotificationActionResult *action_result =
       kernel_zalloc(sizeof(PebbleSysNotificationActionResult) + alloc_size);
   if (!action_result) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Failed to allocate memory for action result");
+    PBL_LOG_WRN("Failed to allocate memory for action result");
     return NULL;
   }
 
@@ -165,7 +165,7 @@ void timeline_action_endpoint_invoke_action(const Uuid *id, TimelineItemActionTy
 
   char uuid_string[UUID_STRING_BUFFER_LENGTH];
   uuid_to_string(id, uuid_string);
-  PBL_LOG(LOG_LEVEL_INFO, "Send action to phone (Item ID: %s; Action ID: %d)",
+  PBL_LOG_INFO("Send action to phone (Item ID: %s; Action ID: %d)",
       uuid_string, action_id);
 
   PBL_HEXDUMP(LOG_LEVEL_DEBUG, (uint8_t *)&invoke_action_data->msg, invoke_action_data->length);
@@ -183,22 +183,22 @@ void timeline_action_endpoint_invoke_action(const Uuid *id, TimelineItemActionTy
 void timeline_action_endpoint_protocol_msg_callback(CommSession *session,
     const uint8_t* data, size_t length) {
   if (length < sizeof(ResponseHeader)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Invalid phone response message length %d", (int) length);
+    PBL_LOG_WRN("Invalid phone response message length %d", (int) length);
     return;
   }
 
   ResponseHeader *header = (ResponseHeader *) data;
   if (header->command != CommandPhoneResponse && header->command != CommandPhoneActionResponse) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Invalid command id");
+    PBL_LOG_WRN("Invalid command id");
     return;
   }
 
   if (uuid_is_system(&header->item_id)) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Automatic SMS msg response: 0x%02X", header->response);
+    PBL_LOG_DBG("Automatic SMS msg response: 0x%02X", header->response);
     return;
   }
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Action Endpoint Response: 0x%02X", header->response);
+  PBL_LOG_DBG("Action Endpoint Response: 0x%02X", header->response);
 
   PebbleSysNotificationActionResult *action_result = NULL;
 

--- a/src/fw/services/normal/timeline/attribute.c
+++ b/src/fw/services/normal/timeline/attribute.c
@@ -313,7 +313,7 @@ bool attribute_deserialize_list(char **buffer, char *const buf_end,
   for (int i = 0; i < attr_list.num_attributes; i++) {
     if (!prv_deserialize_attribute(buffer, buf_end, cursor, payload_end,
                                    &attr_list.attributes[i])) {
-      PBL_LOG(LOG_LEVEL_WARNING, "Encountered unknown attribute");
+      PBL_LOG_WRN("Encountered unknown attribute");
       break;
     }
   }
@@ -418,14 +418,14 @@ size_t attribute_list_get_string_buffer_size(const AttributeList *list) {
 
 void attribute_list_add_cstring(AttributeList *list, AttributeId id, const char *cstring) {
   if (prv_attribute_type(id) != AttributeTypeString) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Adding attribute with type cstring for non-cstring attribute");
+    PBL_LOG_WRN("Adding attribute with type cstring for non-cstring attribute");
   }
   prv_add_attribute(list, id)->cstring = (char*) cstring;
 }
 
 void attribute_list_add_uint32(AttributeList *list, AttributeId id, uint32_t uint32) {
   if (prv_attribute_type(id) != AttributeTypeUint32) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Adding attribute with type uint32 for non-uint32_t attribute");
+    PBL_LOG_WRN("Adding attribute with type uint32 for non-uint32_t attribute");
   }
   prv_add_attribute(list, id)->uint32 = uint32;
 }
@@ -433,7 +433,7 @@ void attribute_list_add_uint32(AttributeList *list, AttributeId id, uint32_t uin
 void attribute_list_add_resource_id(AttributeList *list, AttributeId id,
                                     uint32_t resource_id) {
   if (prv_attribute_type(id) != AttributeTypeResourceId) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Adding attribute with type ResourceId for non-ResourceId " \
+    PBL_LOG_WRN("Adding attribute with type ResourceId for non-ResourceId " \
             "attribute");
   }
   prv_add_attribute(list, id)->uint32 = resource_id;
@@ -441,7 +441,7 @@ void attribute_list_add_resource_id(AttributeList *list, AttributeId id,
 
 void attribute_list_add_uint8(AttributeList *list, AttributeId id, uint8_t uint8) {
   if (prv_attribute_type(id) != AttributeTypeUint8) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Adding attribute with type uint8 for non-uint8_t attribute");
+    PBL_LOG_WRN("Adding attribute with type uint8 for non-uint8_t attribute");
   }
   prv_add_attribute(list, id)->uint8 = uint8;
 }

--- a/src/fw/services/normal/timeline/attributes_actions.c
+++ b/src/fw/services/normal/timeline/attributes_actions.c
@@ -141,7 +141,7 @@ bool attributes_actions_deep_copy(AttributeList *src_attr_list,
     rv = attribute_list_copy(dest_attr_list, src_attr_list,
                              buffer, MIN(buffer + attr_list_size, buf_end));
     if (!rv) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Error deep-copying pin attribute list");
+      PBL_LOG_ERR("Error deep-copying pin attribute list");
       return false;
     }
   }
@@ -149,7 +149,7 @@ bool attributes_actions_deep_copy(AttributeList *src_attr_list,
     rv = prv_action_group_copy(dest_action_group, src_action_group,
                                buffer + attr_list_size, buf_end);
     if (!rv) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Error deep-copying pin action group");
+      PBL_LOG_ERR("Error deep-copying pin action group");
       return false;
     }
   }

--- a/src/fw/services/normal/timeline/event.c
+++ b/src/fw/services/normal/timeline/event.c
@@ -71,11 +71,11 @@ static uint32_t prv_calc_timeout(const TimelineItem *item) {
 
 static void prv_set_timer(unsigned int timeout_ms) {
   if (!timeout_ms) {
-    PBL_LOG(LOG_LEVEL_INFO, "Not setting timer.");
+    PBL_LOG_INFO("Not setting timer.");
   } else if (new_timer_start(s_timer, timeout_ms, prv_new_timer_callback, NULL, 0)) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Set timer for %u", timeout_ms);
+    PBL_LOG_DBG("Set timer for %u", timeout_ms);
   } else {
-    PBL_LOG(LOG_LEVEL_ERROR, "Could not start timer.");
+    PBL_LOG_ERR("Could not start timer.");
   }
 }
 
@@ -130,7 +130,7 @@ static void prv_update_status(void) {
   uint32_t timeout_ms = 0;
   if ((rv != S_SUCCESS) && (rv != S_NO_MORE_ITEMS)) {
     // A failure occurred. Call the update functions with a NULL item
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to find next event.");
+    PBL_LOG_ERR("Failed to find next event.");
   } else if (rv != S_NO_MORE_ITEMS) {
     // Calculate the timeout before the item buffer is re-used
     timeout_ms = prv_calc_timeout(&item);

--- a/src/fw/services/normal/timeline/item.c
+++ b/src/fw/services/normal/timeline/item.c
@@ -163,7 +163,7 @@ bool timeline_item_deserialize_item(TimelineItem *item_out,
                                              header->payload_length,
                                              &string_alloc_size,
                                              (uint8_t **) &buffer)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to get timeline item");
+    PBL_LOG_ERR("Failed to get timeline item");
     goto cleanup;
   }
 
@@ -174,7 +174,7 @@ bool timeline_item_deserialize_item(TimelineItem *item_out,
                                          string_alloc_size,
                                          payload,
                                          header->payload_length)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to deserialize payload");
+    PBL_LOG_ERR("Failed to deserialize payload");
     goto cleanup;
   }
 
@@ -265,12 +265,12 @@ bool timeline_item_verify_layout_serialized(const uint8_t *val, int val_len) {
   const uint8_t *cursor = val + sizeof(SerializedTimelineItemHeader);
   const uint8_t *val_end = val + val_len;
   if (!attribute_check_serialized_list(cursor, val_end, hdr->num_attributes, has_attribute)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Could not deserialize attributes to verify");
+    PBL_LOG_ERR("Could not deserialize attributes to verify");
     return false;
   }
   // verify that the layout of the item has the attribute it requires
   LayoutId layout = hdr->common.layout;
-  PBL_LOG(LOG_LEVEL_DEBUG, "Number of attributes: %d for layout: %d", hdr->num_attributes, layout);
+  PBL_LOG_DBG("Number of attributes: %d for layout: %d", hdr->num_attributes, layout);
   return layout_verify(has_attribute, layout);
 }
 

--- a/src/fw/services/normal/timeline/reminders.c
+++ b/src/fw/services/normal/timeline/reminders.c
@@ -80,25 +80,25 @@ static status_t prv_set_timer(Reminder *item) {
   s_next_reminder_id = item->header.id;
   if (new_timer_start(s_reminder_timer, timeout_ms, prv_new_timer_callback,
                       &s_next_reminder_id, 0)) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Set timer for %"PRIu32, timeout_ms);
+    PBL_LOG_DBG("Set timer for %"PRIu32, timeout_ms);
     return S_SUCCESS;
   } else {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Could not set timer.");
+    PBL_LOG_DBG("Could not set timer.");
     return E_ERROR;
   }
 }
 
 status_t reminders_update_timer(void) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Attempting to update timer.");
+  PBL_LOG_DBG("Attempting to update timer.");
   if (!new_timer_stop(s_reminder_timer)) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Updated timer while callback running.");
+    PBL_LOG_DBG("Updated timer while callback running.");
     return S_SUCCESS;
   }
 
   TimelineItem item = {{{0}}};
   status_t rv = reminder_db_next_item_header(&item);
   if (rv == S_NO_MORE_ITEMS) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "No more reminders to add to queue.");
+    PBL_LOG_DBG("No more reminders to add to queue.");
     return S_SUCCESS;
   } else if (rv) {
     return rv;

--- a/src/fw/services/normal/timeline/timeline.c
+++ b/src/fw/services/normal/timeline/timeline.c
@@ -342,15 +342,15 @@ bool timeline_item_should_show(CommonTimelineItemHeader *header, TimelineIterDir
 #ifdef TIMELINE_SERVICE_DEBUG
 static void prv_debug_print_pins(TimelineNode *node0) {
   TimelineNode *node = (TimelineNode *)list_get_head((ListNode *)node0);
-  PBL_LOG(LOG_LEVEL_DEBUG, "= = = = = = = =");
+  PBL_LOG_DBG("= = = = = = = =");
   while (node) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "======");
-    PBL_LOG(LOG_LEVEL_DEBUG, "Node with id %x%x...", node->id.byte0, node->id.byte1);
-    PBL_LOG(LOG_LEVEL_DEBUG, "Index %d", node->index);
-    PBL_LOG(LOG_LEVEL_DEBUG, "Timestamp %ld", node->timestamp);
-    PBL_LOG(LOG_LEVEL_DEBUG, "Duration %hu", node->duration);
-    PBL_LOG(LOG_LEVEL_DEBUG, "All day? %s", node->all_day ? "True": "False");
-    PBL_LOG(LOG_LEVEL_DEBUG, "Address %p", node);
+    PBL_LOG_DBG("======");
+    PBL_LOG_DBG("Node with id %x%x...", node->id.byte0, node->id.byte1);
+    PBL_LOG_DBG("Index %d", node->index);
+    PBL_LOG_DBG("Timestamp %ld", node->timestamp);
+    PBL_LOG_DBG("Duration %hu", node->duration);
+    PBL_LOG_DBG("All day? %s", node->all_day ? "True": "False");
+    PBL_LOG_DBG("Address %p", node);
     node = (TimelineNode *)node->node.next;
   }
 }
@@ -463,11 +463,11 @@ static void prv_put_outgoing_call_event(uint32_t call_identifier, const char *ca
 //////////////////////////////////////////////////
 
 status_t timeline_init(TimelineNode **timeline) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Starting to build list.");
+  PBL_LOG_DBG("Starting to build list.");
   status_t rv = pin_db_each(prv_each, timeline);
   prv_prune_ordered_timeline_list(timeline);
   prv_set_indices(*timeline);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Finished building list.");
+  PBL_LOG_DBG("Finished building list.");
 #ifdef TIMELINE_SERVICE_DEBUG
   prv_debug_print_pins(*timeline);
 #endif
@@ -736,7 +736,7 @@ static void prv_perform_ancs_negative_action(const TimelineItem *item,
   uint32_t ancs_uid = attribute_get_uint32(&action->attr_list, AttributeIdAncsId,
                                            item->header.ancs_uid);
 
-  PBL_LOG(LOG_LEVEL_INFO, "Perform ancs notification action (%"PRIu32", %"PRIu8")", ancs_uid,
+  PBL_LOG_INFO("Perform ancs notification action (%"PRIu32", %"PRIu8")", ancs_uid,
           action_id);
   ancs_perform_action(ancs_uid, action_id);
 
@@ -762,7 +762,7 @@ static void prv_get_pin_and_push_pin_window(void *data) {
   if (pin && pin_db_get(parent_id, pin) == S_SUCCESS) {
     timeline_pin_window_push_modal(pin);
   } else {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to fetch parent pin");
+    PBL_LOG_ERR("Failed to fetch parent pin");
   }
   kernel_free(parent_id);
 }
@@ -828,7 +828,7 @@ void timeline_invoke_action(const TimelineItem *item, const TimelineItemAction *
       AppInstallId install_id = app_install_get_id_for_uuid(&item->header.parent_id);
       if (install_id == INSTALL_ID_INVALID) {
         // This should never happen... but we're not quite there yet
-        PBL_LOG(LOG_LEVEL_ERROR, "Could not find parent app %s for pin", uuid_buffer);
+        PBL_LOG_ERR("Could not find parent app %s for pin", uuid_buffer);
         return;
       }
       // fetch the relevant attribute
@@ -839,7 +839,7 @@ void timeline_invoke_action(const TimelineItem *item, const TimelineItemAction *
         .common.args = (void *)(uintptr_t)launch_code,
         .common.reason = APP_LAUNCH_TIMELINE_ACTION,
       });
-      PBL_LOG(LOG_LEVEL_INFO, "Opening watch app %s", uuid_buffer);
+      PBL_LOG_INFO("Opening watch app %s", uuid_buffer);
 
       // Wait for the app we just launched to have something to render before hiding all modals.
       // If we don't we'll end up with flashing in a blank framebuffer.
@@ -861,7 +861,7 @@ void timeline_invoke_action(const TimelineItem *item, const TimelineItemAction *
       if (parent_id) {
         *parent_id = item->header.parent_id;
         launcher_task_add_callback(prv_get_pin_and_push_pin_window, parent_id);
-        PBL_LOG(LOG_LEVEL_INFO, "Opening parent pin %s", uuid_buffer);
+        PBL_LOG_INFO("Opening parent pin %s", uuid_buffer);
       }
       break;
     }
@@ -920,7 +920,7 @@ void timeline_invoke_action(const TimelineItem *item, const TimelineItemAction *
       prv_perform_health_response_action(item, action);
       break;
     default:
-      PBL_LOG(LOG_LEVEL_ERROR, "Action type not implemented: %d", action->type);
+      PBL_LOG_ERR("Action type not implemented: %d", action->type);
       break;
   }
 }

--- a/src/fw/services/normal/timeline/timeline_actions.c
+++ b/src/fw/services/normal/timeline/timeline_actions.c
@@ -266,7 +266,7 @@ static void prv_timeout_handler(void *context) {
   // we failed to perform action since we timed out.
   const char *msg = i18n_noop("Failed");
   const bool succeeded = false;
-  PBL_LOG(LOG_LEVEL_INFO, "Timed out waiting for action result");
+  PBL_LOG_INFO("Timed out waiting for action result");
   prv_show_result_window_with_progress(data, TIMELINE_RESOURCE_GENERIC_WARNING, msg, succeeded);
 }
 
@@ -352,7 +352,7 @@ static void prv_handle_chaining_response(ActionResultData *data, PebbleEvent *ev
 
   TimelineItem *item = timeline_item_copy(data->chaining_data.notif);
   if (!item) {
-    PBL_LOG(LOG_LEVEL_WARNING, "No notification in chaining data");
+    PBL_LOG_WRN("No notification in chaining data");
     prv_cleanup_action_result(data, false /* succeeded */);
     return;
   }
@@ -390,7 +390,7 @@ static void prv_cleanup_do_response_menu(ActionMenu *action_menu, const ActionMe
 static void prv_handle_do_response_response(ActionResultData *data) {
   TimelineItem *item = timeline_item_copy(data->chaining_data.notif);
   if (!item) {
-    PBL_LOG(LOG_LEVEL_WARNING, "No notification in chaining data");
+    PBL_LOG_WRN("No notification in chaining data");
     prv_cleanup_action_result(data, false /* succeeded */);
     return;
   }
@@ -435,7 +435,7 @@ static void prv_action_handle_response(PebbleEvent *e, void *context) {
 
   char uuid_string[UUID_STRING_BUFFER_LENGTH];
   uuid_to_string(&action_result->id, uuid_string);
-  PBL_LOG(LOG_LEVEL_INFO, "Received action result: Item ID - %s; type - %"
+  PBL_LOG_INFO("Received action result: Item ID - %s; type - %"
           PRIu8, uuid_string, (uint8_t)action_result->type);
 
   // Each action result can only service one response event
@@ -481,7 +481,7 @@ static void prv_action_handle_response(PebbleEvent *e, void *context) {
       break;
     default:
       prv_cleanup_action_result(data, false /* success */);
-      PBL_LOG(LOG_LEVEL_WARNING, "Unknown Action Response");
+      PBL_LOG_WRN("Unknown Action Response");
       break;
   }
 }
@@ -693,7 +693,7 @@ T_STATIC ActionResultData *prv_invoke_action(ActionMenu *action_menu,
 #endif
   }
 
-  PBL_LOG(LOG_LEVEL_ERROR, "Unsupported action type %d", action->type);
+  PBL_LOG_ERR("Unsupported action type %d", action->type);
   if (action_menu) {
     action_menu_close(action_menu, true);
   }
@@ -750,7 +750,7 @@ static void prv_action_menu_cb(ActionMenu *action_menu, const ActionMenuItem *it
     case TimelineItemTypeUnknown:
     case TimelineItemTypeOutOfRange:
     default:
-      PBL_LOG(LOG_LEVEL_ERROR, "Performing action on invalid TimelineItem with type: %d",
+      PBL_LOG_ERR("Performing action on invalid TimelineItem with type: %d",
               pin->header.type);
       action_menu_close(action_menu, true);
       return;
@@ -921,7 +921,7 @@ static bool prv_is_reply_option_supported(ReplyOption option, TimelineItemAction
       // If this attribute isn't found, we want to support emoji by default
       return attribute_get_uint8(&action->attr_list, AttributeIdEmojiSupported, true);
     default:
-      PBL_LOG(LOG_LEVEL_WARNING, "Unknown reply option");
+      PBL_LOG_WRN("Unknown reply option");
       return false;
   }
 }
@@ -1210,12 +1210,12 @@ void timeline_actions_dismiss_all(NotificationInfo *notif_list, int num_notifica
     TimelineItem item;
     if (notif_list[i].type == NotificationReminder) {
       if (reminder_db_read_item(&item, &notif_list[i].id) != S_SUCCESS) {
-        PBL_LOG(LOG_LEVEL_ERROR, "Trying to dismiss all an invalid reminder");
+        PBL_LOG_ERR("Trying to dismiss all an invalid reminder");
         continue;
       }
     } else if (notif_list[i].type == NotificationMobile) {
       if (!notification_storage_get(&notif_list[i].id, &item)) {
-        PBL_LOG(LOG_LEVEL_ERROR, "Trying to dismiss all an invalid notification");
+        PBL_LOG_ERR("Trying to dismiss all an invalid notification");
         continue;
       }
     }
@@ -1238,7 +1238,7 @@ void timeline_actions_dismiss_all(NotificationInfo *notif_list, int num_notifica
   timeline_enable_ancs_bulk_action_mode(false);
 
   if (!performed_actions) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Didn't take any actions, cleaning up");
+    PBL_LOG_DBG("Didn't take any actions, cleaning up");
     const bool success = false;
     prv_cleanup_action_result(data, success);
   }

--- a/src/fw/services/normal/timezone_database.c
+++ b/src/fw/services/normal/timezone_database.c
@@ -179,7 +179,7 @@ bool timezone_database_load_dst_rule(uint8_t dst_id, TimezoneDSTRule *start, Tim
   // First half of the DST rule pair
   if (!prv_database_read(dst_rule_pair_offset, start, DST_RULE_BYTES) ||
       !prv_database_read(dst_rule_pair_offset + DST_RULE_BYTES, end, DST_RULE_BYTES)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Failed to load timezone for DST ID %"PRIu8, dst_id);
+    PBL_LOG_WRN("Failed to load timezone for DST ID %"PRIu8, dst_id);
     return false;
   }
 

--- a/src/fw/services/normal/vibes/vibe_client.c
+++ b/src/fw/services/normal/vibes/vibe_client.c
@@ -23,7 +23,7 @@ VibeScore *vibe_client_get_score(VibeClient client) {
   }
   VibeScore *score = vibe_score_create_with_resource(vibe_score_info_get_resource_id(id));
   if (!score) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Got a null VibeScore resource!");
+    PBL_LOG_ERR("Got a null VibeScore resource!");
   }
   return score;
 }

--- a/src/fw/services/normal/voice/voice_speex.c
+++ b/src/fw/services/normal/voice/voice_speex.c
@@ -22,7 +22,7 @@
 // External Speex mode declarations
 extern const SpeexMode speex_wb_mode;
 
-#define VOICE_SPEEX_LOG(fmt, args...) PBL_LOG_D(LOG_DOMAIN_VOICE, LOG_LEVEL_DEBUG, fmt, ## args)
+#define VOICE_SPEEX_LOG(fmt, args...) PBL_LOG_D_DBG(LOG_DOMAIN_VOICE, fmt, ## args)
 
 // Speex bitstream version
 #define SPEEX_BITSTREAM_VERSION 4

--- a/src/fw/services/normal/voice_endpoint.c
+++ b/src/fw/services/normal/voice_endpoint.c
@@ -30,7 +30,7 @@ static bool prv_handle_result_common(VoiceEndpointResult result,
                                                                  VEAttributeIdAppUuid,
                                                                  attr_list_size);
   if (app_initiated && !uuid_attr) {
-    PBL_LOG(LOG_LEVEL_WARNING, "No app UUID found for dictation response from app-initiated "
+    PBL_LOG_WRN("No app UUID found for dictation response from app-initiated "
         "session");
     voice_handle_dictation_result(VoiceEndpointResultFailInvalidMessage, session_id, NULL,
                                   app_initiated, NULL);
@@ -45,7 +45,7 @@ static bool prv_handle_result_common(VoiceEndpointResult result,
   }
 
   if (attr_list->num_attributes == 0) {
-    PBL_LOG(LOG_LEVEL_WARNING, "No attributes in message");
+    PBL_LOG_WRN("No attributes in message");
     voice_handle_dictation_result(VoiceEndpointResultFailInvalidMessage, session_id, NULL,
                                   app_initiated, app_uuid);
     return false;
@@ -69,7 +69,7 @@ static void prv_handle_dictation_result(VoiceSessionResultMsg *msg, size_t size)
       VEAttributeIdTranscription, attr_list_size);
 
   if (!transcription_attr || transcription_attr->length == 0) {
-    PBL_LOG(LOG_LEVEL_WARNING, "No transcription attribute found");
+    PBL_LOG_WRN("No transcription attribute found");
     voice_handle_dictation_result(VoiceEndpointResultFailInvalidMessage, msg->session_id, NULL,
                                   app_initiated, app_uuid);
     return;
@@ -79,7 +79,7 @@ static void prv_handle_dictation_result(VoiceSessionResultMsg *msg, size_t size)
   bool valid = transcription_validate(transcription, transcription_attr->length);
 
   if (!valid) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Unrecognized transcription format received");
+    PBL_LOG_WRN("Unrecognized transcription format received");
     voice_handle_dictation_result(VoiceEndpointResultFailInvalidRecognizerResponse,
                                   msg->session_id, NULL, app_initiated, app_uuid);
   }
@@ -97,7 +97,7 @@ static void prv_handle_nlp_result(VoiceSessionResultMsg *msg, size_t size) {
     return;
   }
   if (app_uuid) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Got an app UUID in a NLP result msg. Ignoring and continuing");
+    PBL_LOG_WRN("Got an app UUID in a NLP result msg. Ignoring and continuing");
   }
 
 
@@ -114,7 +114,7 @@ static void prv_handle_nlp_result(VoiceSessionResultMsg *msg, size_t size) {
       VEAttributeIdReminder, attr_list_size);
 
   if (!reminder_attr || reminder_attr->length == 0) {
-    PBL_LOG(LOG_LEVEL_WARNING, "No reminder attribute found");
+    PBL_LOG_WRN("No reminder attribute found");
     voice_handle_nlp_result(VoiceEndpointResultFailInvalidMessage, msg->session_id, NULL, 0);
     return;
   }
@@ -138,7 +138,7 @@ void voice_endpoint_protocol_msg_callback(CommSession *session, const uint8_t* d
         // Validate result enum value to prevent crashes from invalid values
         VoiceEndpointResult result = msg->result;
         if (result > VoiceEndpointResultFailInvalidMessage) {
-          PBL_LOG(LOG_LEVEL_ERROR, "Invalid VoiceEndpointResult value: %d, treating as invalid message", 
+          PBL_LOG_ERR("Invalid VoiceEndpointResult value: %d, treating as invalid message", 
                   (int)result);
           result = VoiceEndpointResultFailInvalidMessage;
         }
@@ -146,7 +146,7 @@ void voice_endpoint_protocol_msg_callback(CommSession *session, const uint8_t* d
         bool app_initiated = (msg->flags.app_initiated == 1);
         voice_handle_session_setup_result(result, msg->session_type, app_initiated);
       } else {
-        PBL_LOG(LOG_LEVEL_WARNING, "Invalid size for session setup result message");
+        PBL_LOG_WRN("Invalid size for session setup result message");
       }
       break;
     }
@@ -155,7 +155,7 @@ void voice_endpoint_protocol_msg_callback(CommSession *session, const uint8_t* d
         VoiceSessionResultMsg *msg = (VoiceSessionResultMsg *) data;
         prv_handle_dictation_result(msg, size);
       } else {
-        PBL_LOG(LOG_LEVEL_WARNING, "Invalid size for dictation result message %zu", size);
+        PBL_LOG_WRN("Invalid size for dictation result message %zu", size);
       }
       break;
     }
@@ -164,13 +164,13 @@ void voice_endpoint_protocol_msg_callback(CommSession *session, const uint8_t* d
         VoiceSessionResultMsg *msg = (VoiceSessionResultMsg *) data;
         prv_handle_nlp_result(msg, size);
       } else {
-        PBL_LOG(LOG_LEVEL_WARNING, "Invalid size for dictation result message %zu", size);
+        PBL_LOG_WRN("Invalid size for dictation result message %zu", size);
       }
       break;
     }
     default:
       // Ignore invalid message ID
-      PBL_LOG(LOG_LEVEL_WARNING, "Invalid message ID");
+      PBL_LOG_WRN("Invalid message ID");
       break;
   }
 

--- a/src/fw/services/normal/wakeup.c
+++ b/src/fw/services/normal/wakeup.c
@@ -182,7 +182,7 @@ static void prv_wakeup_timer_next_pending(void) {
       settings_file_each(&wakeup_settings, prv_find_next_wakeup_id_callback, NULL);
       settings_file_close(&wakeup_settings);
     } else {
-      PBL_LOG(LOG_LEVEL_ERROR, "Error: could not open APP_WAKEUP settings");
+      PBL_LOG_ERR("Error: could not open APP_WAKEUP settings");
     }
   }
   mutex_unlock(s_mutex);
@@ -321,7 +321,7 @@ void wakeup_init(void) {
 
   SettingsFile wakeup_settings;
   if (settings_file_open(&wakeup_settings, SETTINGS_FILE_NAME, SETTINGS_FILE_SIZE) != S_SUCCESS) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Error: could not open wakeup settings");
+    PBL_LOG_ERR("Error: could not open wakeup settings");
     return;
   }
 
@@ -330,11 +330,11 @@ void wakeup_init(void) {
   bool event_found = false;
   settings_file_each(&wakeup_settings, prv_check_for_events, &event_found);
   if (event_found) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Rewriting wakeup file");
+    PBL_LOG_DBG("Rewriting wakeup file");
     // Update settings file removing expired events
     settings_file_rewrite(&wakeup_settings, prv_update_events_callback, &missed_events);
   } else {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Not rewriting wakeup file because no entries were found");
+    PBL_LOG_DBG("Not rewriting wakeup file because no entries were found");
   }
   settings_file_close(&wakeup_settings);
 
@@ -625,7 +625,7 @@ void wakeup_migrate_timezone(int utc_diff) {
       settings_file_rewrite(&wakeup_settings, prv_migrate_events_callback, (void*)&utc_diff);
       settings_file_close(&wakeup_settings);
     } else {
-      PBL_LOG(LOG_LEVEL_ERROR, "Error: could not open wakeup settings");
+      PBL_LOG_ERR("Error: could not open wakeup settings");
     }
   }
   mutex_unlock(s_mutex);
@@ -643,7 +643,7 @@ static void prv_wakeup_rewrite_kernel_bg_cb(void *data) {
       settings_file_rewrite(&wakeup_settings, prv_update_events_callback, &missed_events);
       settings_file_close(&wakeup_settings);
     } else {
-      PBL_LOG(LOG_LEVEL_ERROR, "Error: could not open wakeup settings");
+      PBL_LOG_ERR("Error: could not open wakeup settings");
     }
   }
   mutex_unlock(s_mutex);

--- a/src/fw/services/normal/weather/weather_service.c
+++ b/src/fw/services/normal/weather/weather_service.c
@@ -49,14 +49,13 @@ static bool prv_fill_forecast_from_entry(WeatherDBEntry *entry,
   const uint16_t location_pstring_length = location_pstring->str_length;
 
   if (!is_valid_entry_update_time || (location_pstring_length == 0)) {
-    PBL_LOG(LOG_LEVEL_ERROR,
-            "Invalid entry. Valid UT: %u, location length: %"PRIu16,
+    PBL_LOG_ERR("Invalid entry. Valid UT: %u, location length: %"PRIu16,
             is_valid_entry_update_time, location_pstring_length);
     return false;
   }
 
   if (prv_entry_update_time_too_old_to_be_valid(entry->last_update_time_utc)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Weather entry too old to fill forecast");
+    PBL_LOG_WRN("Weather entry too old to fill forecast");
     return false;
   }
 
@@ -106,7 +105,7 @@ static void prv_add_to_list_if_valid(WeatherDBKey *key, WeatherDBEntry *entry,
 
   if (!prv_get_location_index(key, prefs, &location_index)) {
     uuid_to_string(key, key_string_buffer);
-    PBL_LOG(LOG_LEVEL_WARNING, "Weather location %s has no known ordering! Skipping",
+    PBL_LOG_WRN("Weather location %s has no known ordering! Skipping",
             key_string_buffer);
     return; // location not found in ordering list, skip over
   }
@@ -117,7 +116,7 @@ static void prv_add_to_list_if_valid(WeatherDBKey *key, WeatherDBEntry *entry,
 
   if (!prv_fill_forecast_from_entry(entry, forecast)) {
     uuid_to_string(key, key_string_buffer);
-    PBL_LOG(LOG_LEVEL_WARNING, "Could not create forecast from %s's entry", key_string_buffer);
+    PBL_LOG_WRN("Could not create forecast from %s's entry", key_string_buffer);
     task_free(node);
     return;
   }
@@ -137,7 +136,7 @@ static void prv_add_to_list_if_valid(WeatherDBKey *key, WeatherDBEntry *entry,
 static bool prv_get_default_location_key(WeatherDBKey *key_out) {
   SerializedWeatherAppPrefs *prefs = watch_app_prefs_get_weather();
   if (!prefs) {
-    PBL_LOG(LOG_LEVEL_ERROR, "No SerializedWeatherAppPrefs available!");
+    PBL_LOG_ERR("No SerializedWeatherAppPrefs available!");
     return false;
   }
 
@@ -295,7 +294,7 @@ bool weather_service_supported_by_phone(void) {
   PebbleProtocolCapabilities capabilities;
   bt_persistent_storage_get_cached_system_capabilities(&capabilities);
   if (!capabilities.weather_app_support) {
-    PBL_LOG(LOG_LEVEL_WARNING, "No weather support on phone");
+    PBL_LOG_WRN("No weather support on phone");
   }
   return capabilities.weather_app_support;
 }

--- a/src/fw/services/prf/bluetooth/bluetooth_persistent_storage.c
+++ b/src/fw/services/prf/bluetooth/bluetooth_persistent_storage.c
@@ -86,7 +86,7 @@ BTBondingID bt_persistent_storage_store_ble_pairing(const SMPairingInfo *new_pai
       // Treat re-pairing an existing device as an "update" instead of deletion+addition,
       // because there is only one bonding ID that gets re-used, a deletion would otherwise cause a
       // disconnection to happen. See PBL-24737.
-      PBL_LOG(LOG_LEVEL_INFO, "Re-pairing previously paired LE device");
+      PBL_LOG_INFO("Re-pairing previously paired LE device");
       is_updating_existing = true;
     } else {
       // Since we only have one slot, this means we are about to delete what was
@@ -108,7 +108,7 @@ bool bt_persistent_storage_update_ble_device_name(BTBondingID bonding, const cha
   bool requires_address_pinning = false;
   uint8_t flags = 0;
   if (!shared_prf_storage_get_ble_pairing_data(&data, NULL, &requires_address_pinning, &flags)) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Tried to store device name, but pairing no longer around.");
+    PBL_LOG_ERR("Tried to store device name, but pairing no longer around.");
     return false;
   }
   // In PRF, only the gateway should get paired, so default to "true":

--- a/src/fw/services/services.c
+++ b/src/fw/services/services.c
@@ -31,7 +31,7 @@ void services_init(void) {
 
 void services_set_runlevel(RunLevel runlevel) {
   PBL_ASSERT(runlevel < RunLevel_COUNT, "Unknown runlevel %d", runlevel);
-  PBL_LOG(LOG_LEVEL_INFO, "Setting runlevel to %d", runlevel);
+  PBL_LOG_INFO("Setting runlevel to %d", runlevel);
   services_common_set_runlevel(runlevel);
 #ifndef RECOVERY_FW
   services_normal_set_runlevel(runlevel);

--- a/src/fw/shell/normal/app_idle_timeout.c
+++ b/src/fw/shell/normal/app_idle_timeout.c
@@ -24,7 +24,7 @@ static void prv_kernel_callback_watchface_launch(void* data) {
 }
 
 static void prv_timeout_expired(void *cb_data) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "App idle timeout hit! launching watchface");
+  PBL_LOG_DBG("App idle timeout hit! launching watchface");
   launcher_task_add_callback(prv_kernel_callback_watchface_launch, NULL);
 }
 

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -652,7 +652,7 @@ static bool prv_is_valid_apps_theme_color(GColor color) {
 static bool prv_set_s_settings_menu_highlight_color(GColor *color) {
 #if PBL_COLOR
   if (!prv_is_valid_settings_theme_color(*color)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Invalid settings menu highlight color 0x%02x, using default",
+    PBL_LOG_WRN("Invalid settings menu highlight color 0x%02x, using default",
             color->argb);
     s_settings_menu_highlight_color = GColorCobaltBlue;
     return false;  // Reject invalid value
@@ -667,7 +667,7 @@ static bool prv_set_s_settings_menu_highlight_color(GColor *color) {
 static bool prv_set_s_apps_menu_highlight_color(GColor *color) {
 #if PBL_COLOR
   if (!prv_is_valid_apps_theme_color(*color)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Invalid apps menu highlight color 0x%02x, using default",
+    PBL_LOG_WRN("Invalid apps menu highlight color 0x%02x, using default",
             color->argb);
     s_apps_menu_highlight_color = GColorVividCerulean;
     return false;  // Reject invalid value
@@ -797,7 +797,7 @@ static const PrefsTableEntry *prv_prefs_entry(const uint8_t *key, size_t key_len
       return entry;
     }
   }
-  PBL_LOG(LOG_LEVEL_WARNING, "Unrecognized key: %s", (const char *)key);
+  PBL_LOG_WRN("Unrecognized key: %s", (const char *)key);
   return NULL;
 }
 
@@ -806,7 +806,7 @@ static const PrefsTableEntry *prv_prefs_entry(const uint8_t *key, size_t key_len
 // Set the backing store for a pref
 static bool prv_set_pref_backing(const PrefsTableEntry *entry, const void *value, int value_len) {
   if (value_len != entry->value_len) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Attempt to set %s using invalid value_len of %"PRIu32"",
+    PBL_LOG_WRN("Attempt to set %s using invalid value_len of %"PRIu32"",
             entry->key, (uint32_t)value_len);
     return false;
   }
@@ -819,7 +819,7 @@ static bool prv_set_pref_backing(const PrefsTableEntry *entry, const void *value
       // Keys in the backing store include the null terminator, so we add 1 to key_len
       rv = settings_file_set(&file, entry->key, strlen(entry->key) + 1, value, value_len);
       if (rv != S_SUCCESS) {
-        PBL_LOG(LOG_LEVEL_WARNING, "Failed to set pref '%s' (%"PRIi32")", entry->key, (int32_t)rv);
+        PBL_LOG_WRN("Failed to set pref '%s' (%"PRIi32")", entry->key, (int32_t)rv);
       }
       settings_file_close(&file);
     }
@@ -886,7 +886,7 @@ bool prefs_private_read_backing(const uint8_t *key, size_t key_len, void *value,
   }
 
   if (value_len != entry->value_len) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Attempt to read %s using invalid value_len of %"PRIu32"",
+    PBL_LOG_WRN("Attempt to read %s using invalid value_len of %"PRIu32"",
             entry->key, (uint32_t)value_len);
     return false;
   }
@@ -1369,7 +1369,7 @@ AppInstallId watchface_get_default_install_id(void) {
 
 void system_theme_set_content_size(PreferredContentSize content_size) {
   if (content_size >= NumPreferredContentSizes) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Ignoring attempt to set content size to invalid size %d",
+    PBL_LOG_WRN("Ignoring attempt to set content size to invalid size %d",
             content_size);
     return;
   }

--- a/src/fw/shell/normal/prefs_sync.c
+++ b/src/fw/shell/normal/prefs_sync.c
@@ -32,22 +32,22 @@ static void prv_try_start_sync(void) {
   }
 
   if (!settings_blob_db_phone_supports_sync()) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Phone doesn't support settings sync");
+    PBL_LOG_DBG("Phone doesn't support settings sync");
     return;
   }
 
-  PBL_LOG(LOG_LEVEL_INFO, "Starting settings sync via BlobDB");
+  PBL_LOG_INFO("Starting settings sync via BlobDB");
 
   status_t status = blob_db_sync_db(BlobDBIdSettings);
 
   if (status == S_SUCCESS) {
-    PBL_LOG(LOG_LEVEL_INFO, "Settings sync started");
+    PBL_LOG_INFO("Settings sync started");
   } else if (status == S_NO_ACTION_REQUIRED) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "No settings need syncing");
+    PBL_LOG_DBG("No settings need syncing");
   } else if (status == E_BUSY) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Settings sync already in progress");
+    PBL_LOG_DBG("Settings sync already in progress");
   } else {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to start settings sync: 0x%"PRIx32"", status);
+    PBL_LOG_ERR("Failed to start settings sync: 0x%"PRIx32"", status);
   }
 }
 
@@ -57,11 +57,11 @@ static void prv_connection_handler(PebbleEvent *event, void *context) {
   s_is_connected = connected;
 
   if (connected) {
-    PBL_LOG(LOG_LEVEL_INFO, "Phone connected, will sync when capabilities received");
+    PBL_LOG_INFO("Phone connected, will sync when capabilities received");
     // Try to sync - capabilities may already be cached from previous connection
     prv_try_start_sync();
   } else {
-    PBL_LOG(LOG_LEVEL_INFO, "Phone disconnected");
+    PBL_LOG_INFO("Phone disconnected");
   }
 }
 
@@ -69,7 +69,7 @@ static void prv_connection_handler(PebbleEvent *event, void *context) {
 static void prv_capabilities_handler(PebbleEvent *event, void *context) {
   // Check if the settings_sync_support capability changed
   if (event->capabilities.flags_diff.settings_sync_support) {
-    PBL_LOG(LOG_LEVEL_INFO, "Settings sync capability changed, checking if we can sync");
+    PBL_LOG_INFO("Settings sync capability changed, checking if we can sync");
     prv_try_start_sync();
   }
 }
@@ -78,7 +78,7 @@ static void prv_capabilities_handler(PebbleEvent *event, void *context) {
 
 void prefs_sync_init(void) {
   if (s_sync_initialized) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Prefs sync already initialized");
+    PBL_LOG_WRN("Prefs sync already initialized");
     return;
   }
 
@@ -101,7 +101,7 @@ void prefs_sync_init(void) {
 
   s_sync_initialized = true;
 
-  PBL_LOG(LOG_LEVEL_INFO, "Prefs sync initialized (using BlobDB ID 0x0F)");
+  PBL_LOG_INFO("Prefs sync initialized (using BlobDB ID 0x0F)");
 }
 
 void prefs_sync_deinit(void) {
@@ -116,37 +116,37 @@ void prefs_sync_deinit(void) {
   s_sync_initialized = false;
   s_is_connected = false;
 
-  PBL_LOG(LOG_LEVEL_INFO, "Prefs sync deinitialized");
+  PBL_LOG_INFO("Prefs sync deinitialized");
 }
 
 void prefs_sync_trigger(void) {
   if (!s_sync_initialized) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Prefs sync not initialized");
+    PBL_LOG_WRN("Prefs sync not initialized");
     return;
   }
   
   if (!s_is_connected) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Not connected to phone, cannot sync");
+    PBL_LOG_WRN("Not connected to phone, cannot sync");
     return;
   }
   
   // Check if the phone supports settings sync
   if (!settings_blob_db_phone_supports_sync()) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Phone doesn't support settings sync");
+    PBL_LOG_WRN("Phone doesn't support settings sync");
     return;
   }
   
-  PBL_LOG(LOG_LEVEL_INFO, "Manually triggering settings sync via BlobDB");
+  PBL_LOG_INFO("Manually triggering settings sync via BlobDB");
   
   status_t status = blob_db_sync_db(BlobDBIdSettings);
   
   if (status == S_SUCCESS) {
-    PBL_LOG(LOG_LEVEL_INFO, "Settings sync started");
+    PBL_LOG_INFO("Settings sync started");
   } else if (status == S_NO_ACTION_REQUIRED) {
-    PBL_LOG(LOG_LEVEL_INFO, "No settings need syncing");
+    PBL_LOG_INFO("No settings need syncing");
   } else if (status == E_BUSY) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Settings sync already in progress");
+    PBL_LOG_WRN("Settings sync already in progress");
   } else {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to start settings sync: 0x%"PRIx32"", status);
+    PBL_LOG_ERR("Failed to start settings sync: 0x%"PRIx32"", status);
   }
 }

--- a/src/fw/shell/normal/shell_event_loop.c
+++ b/src/fw/shell/normal/shell_event_loop.c
@@ -85,7 +85,7 @@ void shell_event_loop_handle_event(PebbleEvent *e) {
 
     case PEBBLE_ALARM_CLOCK_EVENT:
       analytics_inc(ANALYTICS_DEVICE_METRIC_ALARM_SOUNDED_COUNT, AnalyticsClient_System);
-      PBL_LOG(LOG_LEVEL_INFO, "Alarm event in the shell event loop");
+      PBL_LOG_INFO("Alarm event in the shell event loop");
       stationary_wake_up();
       alarm_popup_push_window(&e->alarm_clock);
       return;

--- a/src/fw/shell/normal/watchface.c
+++ b/src/fw/shell/normal/watchface.c
@@ -74,11 +74,11 @@ static void prv_launch_up_down(ClickRecognizerRef recognizer, void *data) {
   static TimelineArgs s_timeline_args;
   const bool is_up = (click_recognizer_get_button_id(recognizer) == BUTTON_ID_UP);
   if (is_up) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Launching timeline in past mode.");
+    PBL_LOG_DBG("Launching timeline in past mode.");
     s_timeline_args.direction = TimelineIterDirectionPast;
     analytics_inc(ANALYTICS_DEVICE_METRIC_TIMELINE_PAST_LAUNCH_COUNT, AnalyticsClient_System);
   } else {
-    PBL_LOG(LOG_LEVEL_DEBUG, "Launching timeline in future mode.");
+    PBL_LOG_DBG("Launching timeline in future mode.");
     s_timeline_args.direction = TimelineIterDirectionFuture;
     analytics_inc(ANALYTICS_DEVICE_METRIC_TIMELINE_FUTURE_LAUNCH_COUNT, AnalyticsClient_System);
   }
@@ -153,7 +153,7 @@ void watchface_handle_button_event(PebbleEvent *e) {
 }
 
 static void prv_watchface_launch_low_power(void) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Switching default watchface to low_power_mode watchface");
+  PBL_LOG_DBG("Switching default watchface to low_power_mode watchface");
   app_manager_put_launch_app_event(&(AppLaunchEventConfig) {
     .id = APP_ID_LOW_POWER_FACE,
   });

--- a/src/fw/shell/normal/watchface_metrics.c
+++ b/src/fw/shell/normal/watchface_metrics.c
@@ -62,7 +62,7 @@ static void prv_ensure_open(void) {
     status_t status = settings_file_open(&s_settings_file, WATCHFACE_METRICS_FILE,
                                          WATCHFACE_METRICS_MAX_SIZE);
     if (status != S_SUCCESS) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Failed to open watchface metrics file: %d", (int)status);
+      PBL_LOG_ERR("Failed to open watchface metrics file: %d", (int)status);
       return;
     }
     s_initialized = true;
@@ -131,7 +131,7 @@ static void prv_save_data_system_task_cb(void *context) {
                                       WATCHFACE_METRICS_KEY, strlen(WATCHFACE_METRICS_KEY),
                                       &data, sizeof(data));
   if (status != S_SUCCESS) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to save watchface metrics: %d", (int)status);
+    PBL_LOG_ERR("Failed to save watchface metrics: %d", (int)status);
   }
 
   mutex_unlock(s_mutex);
@@ -165,7 +165,7 @@ static void prv_periodic_save_callback(void *data) {
   if (s_state.current_total_secs != s_state.last_saved_secs) {
     prv_save_data(&s_state.current_uuid, s_state.current_total_secs);
     s_state.last_saved_secs = s_state.current_total_secs;
-    PBL_LOG(LOG_LEVEL_DEBUG, "Watchface metrics: periodic save, total: %lu secs",
+    PBL_LOG_DBG("Watchface metrics: periodic save, total: %lu secs",
             (unsigned long)s_state.current_total_secs);
   }
 
@@ -207,11 +207,11 @@ void watchface_metrics_start(const Uuid *uuid) {
   uint32_t previous_time = 0;
   if (prv_load_data(uuid, &previous_time)) {
     s_state.current_total_secs = previous_time;
-    PBL_LOG(LOG_LEVEL_DEBUG, "Watchface metrics: resuming, previous total: %lu secs",
+    PBL_LOG_DBG("Watchface metrics: resuming, previous total: %lu secs",
             (unsigned long)previous_time);
   } else {
     s_state.current_total_secs = 0;
-    PBL_LOG(LOG_LEVEL_DEBUG, "Watchface metrics: new watchface, starting from 0");
+    PBL_LOG_DBG("Watchface metrics: new watchface, starting from 0");
   }
 
   s_state.last_saved_secs = s_state.current_total_secs;
@@ -234,7 +234,7 @@ void watchface_metrics_stop(void) {
   prv_save_data(&s_state.current_uuid, s_state.current_total_secs);
   s_state.last_saved_secs = s_state.current_total_secs;
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Watchface metrics: stopped, session: %lu secs, total: %lu secs",
+  PBL_LOG_DBG("Watchface metrics: stopped, session: %lu secs, total: %lu secs",
           (unsigned long)elapsed_secs, (unsigned long)s_state.current_total_secs);
 
   s_state.tracking = false;

--- a/src/fw/shell/sdk/prefs.c
+++ b/src/fw/shell/sdk/prefs.c
@@ -174,7 +174,7 @@ void system_theme_set_content_size(PreferredContentSize content_size) {
   mutex_lock(s_mutex);
   const uint8_t content_size_uint = content_size;
   if (content_size >= NumPreferredContentSizes) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Ignoring attempt to set content size to invalid size %d",
+    PBL_LOG_WRN("Ignoring attempt to set content size to invalid size %d",
             content_size);
   } else if (prv_pref_set(PREF_KEY_CONTENT_SIZE, &content_size_uint, sizeof(content_size_uint))) {
     s_content_size = content_size;

--- a/src/fw/shell/system_theme.c
+++ b/src/fw/shell/system_theme.c
@@ -122,10 +122,10 @@ static const SystemThemeTextStyle s_text_styles[NumPreferredContentSizes] = {
 
 static const char *prv_get_font_for_size(PreferredContentSize content_size, TextStyleFont font) {
   if (content_size >= NumPreferredContentSizes) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Requested a content size that is out of bounds (%d)", content_size);
+    PBL_LOG_ERR("Requested a content size that is out of bounds (%d)", content_size);
     goto fail;
   } else if (font >= TextStyleFontCount) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Requested a style font that is out of bounds (%d)", font);
+    PBL_LOG_ERR("Requested a style font that is out of bounds (%d)", font);
     goto fail;
   }
   return s_text_styles[content_size].fonts[font];

--- a/src/fw/syscall/event_syscalls.c
+++ b/src/fw/syscall/event_syscalls.c
@@ -13,7 +13,7 @@
 
 static void prv_put_event_from_process(PebbleTask task, PebbleEvent *event) {
   if (!event_try_put_from_process(task, event)) {
-    PBL_LOG(LOG_LEVEL_WARNING, "%s: From app queue is full! Dropped %p! Killing App",
+    PBL_LOG_WRN("%s: From app queue is full! Dropped %p! Killing App",
         (task == PebbleTask_App ? "App" : "Worker"), event);
     syscall_failed();
   }

--- a/src/fw/syscall/syscall.c
+++ b/src/fw/syscall/syscall.c
@@ -26,7 +26,7 @@ DEFINE_SYSCALL(int, sys_test, int arg) {
   uint32_t ipsr;
   __asm volatile("mrs %0, ipsr" : "=r" (ipsr));
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Inside test kernel function! Privileged? %s Arg %u IPSR: %"PRIu32,
+  PBL_LOG_DBG("Inside test kernel function! Privileged? %s Arg %u IPSR: %"PRIu32,
           bool_to_str(mcu_state_is_privileged()), arg, ipsr);
 
   return arg * 2;

--- a/src/fw/syscall/syscall_internal.c
+++ b/src/fw/syscall/syscall_internal.c
@@ -45,7 +45,7 @@ NORETURN syscall_failed(void) {
 
   PBL_ASSERT(mcu_state_is_privileged(), "Insufficient Privileges!");
 
-  PBL_LOG(LOG_LEVEL_WARNING, "Bad syscall!");
+  PBL_LOG_WRN("Bad syscall!");
 
   sys_app_fault(saved_lr);
 
@@ -65,7 +65,7 @@ void syscall_assert_userspace_buffer(const void* buf, size_t num_bytes) {
   }
 
   APP_LOG(APP_LOG_LEVEL_ERROR, "syscall failure! %p..%p is not in app space.", buf, (char *)buf + num_bytes);
-  PBL_LOG(LOG_LEVEL_ERROR, "syscall failure! %p..%p is not in app space.", buf, (char *)buf + num_bytes);
+  PBL_LOG_ERR("syscall failure! %p..%p is not in app space.", buf, (char *)buf + num_bytes);
   syscall_failed();
 }
 

--- a/src/fw/system/bootbits.c
+++ b/src/fw/system/bootbits.c
@@ -37,7 +37,7 @@ void boot_bit_init(void) {
   // in-memory value is probably scrambled and should be reset.
   uint32_t crc32_computed = crc32(0, retained, NRF_RETAINED_REGISTER_CRC * 4);
   if (crc32_computed != retained[NRF_RETAINED_REGISTER_CRC]) {
-    PBL_LOG(LOG_LEVEL_WARNING, "Retained register CRC failed: expected CRC %08lx, got CRC %08lx.  Clearing bootbits!", crc32_computed, retained[NRF_RETAINED_REGISTER_CRC]);
+    PBL_LOG_WRN("Retained register CRC failed: expected CRC %08lx, got CRC %08lx.  Clearing bootbits!", crc32_computed, retained[NRF_RETAINED_REGISTER_CRC]);
     memset(retained, 0, sizeof(retained));
   }
 
@@ -64,7 +64,7 @@ bool boot_bit_test(BootBitValue bit) {
 }
 
 void boot_bit_dump(void) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "0x%"PRIx32, retained_read(RTC_BKP_BOOTBIT_DR));
+  PBL_LOG_DBG("0x%"PRIx32, retained_read(RTC_BKP_BOOTBIT_DR));
 }
 
 uint32_t boot_bits_get(void) {
@@ -113,7 +113,7 @@ bool boot_bit_test(BootBitValue bit) {
 }
 
 void boot_bit_dump(void) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "0x%"PRIx32, HAL_Get_backup(RTC_BKP_BOOTBIT_DR));
+  PBL_LOG_DBG("0x%"PRIx32, HAL_Get_backup(RTC_BKP_BOOTBIT_DR));
 }
 
 uint32_t boot_bits_get(void) {
@@ -164,7 +164,7 @@ bool boot_bit_test(BootBitValue bit) {
 }
 
 void boot_bit_dump(void) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "0x%"PRIx32, RTC_ReadBackupRegister(RTC_BKP_BOOTBIT_DR));
+  PBL_LOG_DBG("0x%"PRIx32, RTC_ReadBackupRegister(RTC_BKP_BOOTBIT_DR));
 }
 
 uint32_t boot_bits_get(void) {

--- a/src/fw/system/firmware_storage.c
+++ b/src/fw/system/firmware_storage.c
@@ -27,7 +27,7 @@ bool firmware_storage_check_valid_firmware_description(
   }
 
   // Log around this operation, as it can take some time (hundreds of ms)
-  PBL_LOG(LOG_LEVEL_DEBUG, "CRCing recovery...");
+  PBL_LOG_DBG("CRCing recovery...");
 
   start_address += sizeof(FirmwareDescription);
 #if CAPABILITY_HAS_DEFECTIVE_FW_CRC
@@ -37,7 +37,7 @@ bool firmware_storage_check_valid_firmware_description(
   const uint32_t calculated_crc = flash_crc32(start_address, firmware_description->firmware_length);
 #endif
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "CRCing recovery... done");
+  PBL_LOG_DBG("CRCing recovery... done");
 
   return calculated_crc == firmware_description->checksum;
 }
@@ -58,11 +58,11 @@ bool firmware_storage_check_valid_firmware_header(
   }
 
   // Log around this operation, as it can take some time (hundreds of ms)
-  PBL_LOG(LOG_LEVEL_DEBUG, "CRCing recovery...");
+  PBL_LOG_DBG("CRCing recovery...");
 
   const uint32_t calculated_crc = flash_crc32(address + header->fw_start, header->fw_length);
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "CRCing recovery... done");
+  PBL_LOG_DBG("CRCing recovery... done");
 
   return calculated_crc == header->fw_crc;
 }

--- a/src/fw/system/passert.c
+++ b/src/fw/system/passert.c
@@ -55,7 +55,7 @@ NORETURN passert_failed(const char* filename, int line_number, const char* messa
 
 NORETURN passert_failed_hashed(uint32_t packed_loghash, ...) {
   uintptr_t saved_lr = (uintptr_t) __builtin_return_address(0);
-  PBL_LOG(LOG_LEVEL_ALWAYS, "ASSERTION at LR 0x%x", saved_lr);
+  PBL_LOG_ALWAYS("ASSERTION at LR 0x%x", saved_lr);
 
   va_list fmt_args;
   va_start(fmt_args, packed_loghash);
@@ -68,7 +68,7 @@ NORETURN passert_failed_hashed(uint32_t packed_loghash, ...) {
 }
 
 NORETURN passert_failed_hashed_with_lr(uint32_t lr, uint32_t packed_loghash, ...) {
-  PBL_LOG(LOG_LEVEL_ALWAYS, "ASSERTION at LR 0x%"PRIx32, lr);
+  PBL_LOG_ALWAYS("ASSERTION at LR 0x%"PRIx32, lr);
 
   va_list fmt_args;
   va_start(fmt_args, packed_loghash);
@@ -81,7 +81,7 @@ NORETURN passert_failed_hashed_with_lr(uint32_t lr, uint32_t packed_loghash, ...
 }
 
 NORETURN passert_failed_hashed_no_message_with_lr(uint32_t lr) {
-  PBL_LOG(LOG_LEVEL_ALWAYS, "ASSERTION at LR 0x%"PRIx32, lr);
+  PBL_LOG_ALWAYS("ASSERTION at LR 0x%"PRIx32, lr);
 
   trigger_fault(RebootReasonCode_Assert, lr);
 }
@@ -101,7 +101,7 @@ NORETURN passert_failed_no_message(const char* filename, int line_number) {
 
 NORETURN wtf(void) {
   uintptr_t saved_lr = (uintptr_t) __builtin_return_address(0);
-  PBL_LOG(LOG_LEVEL_ALWAYS, "*** WTF %p", (void *)saved_lr);
+  PBL_LOG_ALWAYS("*** WTF %p", (void *)saved_lr);
   trigger_fault(RebootReasonCode_Assert, saved_lr);
 }
 
@@ -109,7 +109,7 @@ void passert_check_task(PebbleTask expected_task) {
   uintptr_t saved_lr = (uintptr_t) __builtin_return_address(0);
 
   if (pebble_task_get_current() != expected_task) {
-    PBL_LOG(LOG_LEVEL_ALWAYS, "LR: %p. Incorrect task! Expected <%s> got <%s>",
+    PBL_LOG_ALWAYS("LR: %p. Incorrect task! Expected <%s> got <%s>",
             (void*) saved_lr, pebble_task_get_name(expected_task),
             pebble_task_get_name(pebble_task_get_current()));
     trigger_fault(RebootReasonCode_Assert, saved_lr);
@@ -120,7 +120,7 @@ void passert_check_not_task(PebbleTask unexpected_task) {
   uintptr_t saved_lr = (uintptr_t) __builtin_return_address(0);
 
   if (pebble_task_get_current() == unexpected_task) {
-    PBL_LOG(LOG_LEVEL_ALWAYS, "LR: %p. Incorrect task! Can't be <%s>",
+    PBL_LOG_ALWAYS("LR: %p. Incorrect task! Can't be <%s>",
             (void*) saved_lr, pebble_task_get_name(unexpected_task));
     trigger_fault(RebootReasonCode_Assert, saved_lr);
   }
@@ -138,7 +138,7 @@ void assert_failed(uint8_t* file, uint32_t line) {
 extern void command_dump_malloc_kernel(void);
 
 NORETURN croak_oom(size_t bytes, int saved_lr, Heap *heap_ptr) {
-  PBL_LOG(LOG_LEVEL_ALWAYS, "CROAK OOM: Failed to alloc %d bytes at LR: 0x%x",
+  PBL_LOG_ALWAYS("CROAK OOM: Failed to alloc %d bytes at LR: 0x%x",
                bytes, saved_lr);
 
 #ifdef MALLOC_INSTRUMENTATION
@@ -150,7 +150,7 @@ NORETURN croak_oom(size_t bytes, int saved_lr, Heap *heap_ptr) {
 
 #if MICRO_FAMILY_NRF52840
 NORETURN app_error_fault_handler(uint32_t id, uint32_t pc, uint32_t info) {
-  PBL_LOG(LOG_LEVEL_ALWAYS, "nRF error %ld (pc %ld, info %ld)", id, pc, info);
+  PBL_LOG_ALWAYS("nRF error %ld (pc %ld, info %ld)", id, pc, info);
   trigger_fault(RebootReasonCode_Assert, pc);
 }
 

--- a/src/fw/system/profiler.c
+++ b/src/fw/system/profiler.c
@@ -24,7 +24,7 @@
 #define PROF_LOG(buf, sz, fmt, ...) \
   do {                                        \
     snprintf(buf, sz, fmt, ## __VA_ARGS__); \
-    PBL_LOG(LOG_LEVEL_DEBUG, "%s", buf);      \
+    PBL_LOG_DBG("%s", buf);      \
   } while (0)
 #else
 #define PROF_LOG(buf, sz, fmt, ...) dbgserial_putstr_fmt(buf, sz, fmt, ## __VA_ARGS__)

--- a/src/fw/system/reboot_reason.c
+++ b/src/fw/system/reboot_reason.c
@@ -29,7 +29,7 @@ void reboot_reason_set(RebootReason *reason) {
     // It's not safe to log if we're called from an ISR or from a FreeRTOS critical section (basepri != 0)
     if (!mcu_state_is_isr() && __get_BASEPRI() == 0
             && xTaskGetSchedulerState() == taskSCHEDULER_RUNNING) {
-      PBL_LOG(LOG_LEVEL_WARNING, "Reboot reason is already set");
+      PBL_LOG_WRN("Reboot reason is already set");
     }
     return;
   }
@@ -45,7 +45,7 @@ void reboot_reason_set(RebootReason *reason) {
     // It's not safe to log if we're called from an ISR or from a FreeRTOS critical section (basepri != 0)
     if (!mcu_state_is_isr() && __get_BASEPRI() == 0
             && xTaskGetSchedulerState() == taskSCHEDULER_RUNNING) {
-      PBL_LOG(LOG_LEVEL_WARNING, "Reboot reason is already set");
+      PBL_LOG_WRN("Reboot reason is already set");
     }
     return;
   }
@@ -61,7 +61,7 @@ void reboot_reason_set(RebootReason *reason) {
     // It's not safe to log if we're called from an ISR or from a FreeRTOS critical section (basepri != 0)
     if (!mcu_state_is_isr() && __get_BASEPRI() == 0
             && xTaskGetSchedulerState() == taskSCHEDULER_RUNNING) {
-      PBL_LOG(LOG_LEVEL_WARNING, "Reboot reason is already set");
+      PBL_LOG_WRN("Reboot reason is already set");
     }
     return;
   }

--- a/src/fw/system/testinfra.c
+++ b/src/fw/system/testinfra.c
@@ -25,7 +25,7 @@ void notify_system_ready_for_communication(void) {
 
 #if IS_BIGBOARD
 NORETURN test_infra_quarantine_board(const char *quarantine_reason) {
-  PBL_LOG(LOG_LEVEL_INFO, "Quarantine Board: %s", quarantine_reason);
+  PBL_LOG_INFO("Quarantine Board: %s", quarantine_reason);
   boot_bit_set(BOOT_BIT_FORCE_PRF);
   core_dump_reset(true /* is_forced */);
 }

--- a/src/fw/util/generic_attribute.c
+++ b/src/fw/util/generic_attribute.c
@@ -14,7 +14,7 @@ GenericAttribute *generic_attribute_find_attribute(GenericAttributeList *attr_li
 
     // Check that we do not read past the end of the buffer
     if ((cursor + sizeof(GenericAttribute) >= end) || (attribute->data + attribute->length > end)) {
-      PBL_LOG(LOG_LEVEL_WARNING, "Attribute list is invalid");
+      PBL_LOG_WRN("Attribute list is invalid");
       return NULL;
     }
 

--- a/src/fw/util/pstring.c
+++ b/src/fw/util/pstring.c
@@ -164,16 +164,16 @@ PascalString16 *pstring_get_pstring16_from_list(PascalString16List *pstring16_li
 }
 
 void pstring_print_pstring(PascalString16 *pstring) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Length: %i ", pstring->str_length);
+  PBL_LOG_DBG("Length: %i ", pstring->str_length);
   char *buffer = task_malloc_check(sizeof(char) * (pstring->str_length + 1));
   pstring_pstring16_to_string(pstring, buffer);
-  PBL_LOG(LOG_LEVEL_DEBUG, "%s", buffer);
+  PBL_LOG_DBG("%s", buffer);
   task_free(buffer);
   buffer = NULL;
 }
 
 void pstring_print_pstring16list(PascalString16List *list) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Data size: %i ", (list->pstrings)->data_size);
+  PBL_LOG_DBG("Data size: %i ", (list->pstrings)->data_size);
   PascalString16 *pstring;
   for (int i = 0; i < list->count; i++) {
     pstring = pstring_get_pstring16_from_list(list, i);

--- a/src/fw/util/shared_circular_buffer.c
+++ b/src/fw/util/shared_circular_buffer.c
@@ -86,7 +86,7 @@ bool shared_circular_buffer_write(SharedCircularBuffer* buffer, const uint8_t* d
 
   // If no clients, no need to write
   if (!buffer->clients) {
-    PBL_LOG(LOG_LEVEL_WARNING, "no readers");
+    PBL_LOG_WRN("no readers");
     return false;
   }
 

--- a/tests/fakes/fake_app_timer.h
+++ b/tests/fakes/fake_app_timer.h
@@ -109,7 +109,7 @@ static void prv_unlink_and_free_timer(FakeAppTimer *timer) {
       prev_timer = prev_timer->next;
     }
     if (!prev_timer) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Tried to unlink and free non-existing timer %p", timer);
+      PBL_LOG_ERR("Tried to unlink and free non-existing timer %p", timer);
       return;
     }
     prev_timer->next = timer->next;

--- a/tests/fakes/fake_session.c
+++ b/tests/fakes/fake_session.c
@@ -97,7 +97,7 @@ void comm_session_close(CommSession *session, CommSessionCloseReason reason) {
 void comm_session_receive_router_write(CommSession *session,
                                        const uint8_t *received_data,
                                        size_t num_bytes_to_copy) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Received Data:");
+  PBL_LOG_DBG("Received Data:");
   PBL_HEXDUMP(LOG_LEVEL_DEBUG, received_data, num_bytes_to_copy);
 }
 
@@ -340,7 +340,7 @@ static void prv_fake_transport_send_next(Transport *transport) {
     if (fake_transport->sent_cb) {
       fake_transport->sent_cb(pp_header.endpoint_id, buffer, pp_header.length);
     } else {
-      PBL_LOG(LOG_LEVEL_DEBUG, "Sending Data to PP endpoint %u (0x%x):",
+      PBL_LOG_DBG("Sending Data to PP endpoint %u (0x%x):",
               pp_header.endpoint_id, pp_header.endpoint_id);
       PBL_HEXDUMP(LOG_LEVEL_DEBUG, buffer, pp_header.length);
 

--- a/tests/fw/applib/test_app_message.c
+++ b/tests/fw/applib/test_app_message.c
@@ -201,7 +201,7 @@ static void prv_receive_test_data(uint8_t transaction_id, const bool oversized) 
   message->transaction_id = transaction_id;
   message->payload->push.uuid = s_remote_app_uuid;
   memcpy(&message->payload->push.dictionary, s_expected_buffer, dict_length);
-  PBL_LOG(LOG_LEVEL_DEBUG, "message->transaction_id = %"PRIu32, message->transaction_id);
+  PBL_LOG_DBG("message->transaction_id = %"PRIu32, message->transaction_id);
 
   CommSession *session = s_fake_app_comm_session;
   app_message_app_protocol_msg_callback(session, buffer, message_length, NULL);
@@ -211,7 +211,7 @@ static void prv_receive_ack_nack_callback(uint16_t endpoint_id,
 					  const uint8_t* data, unsigned int length) {
   AppMessage *message = (AppMessage*)data;
   cl_assert(length == sizeof(AppMessage));
-  PBL_LOG(LOG_LEVEL_DEBUG, "message %"PRIu32", id1 %"PRIu32", id2 %"PRIu32, message->transaction_id,
+  PBL_LOG_DBG("message %"PRIu32", id1 %"PRIu32", id2 %"PRIu32, message->transaction_id,
       TEST_TRANSACTION_ID_1, TEST_TRANSACTION_ID_2);
   if (message->transaction_id == TEST_TRANSACTION_ID_1) {
     cl_assert_equal_b(s_ack_received_for_id_1, false);

--- a/tests/fw/applib/test_persist.c
+++ b/tests/fw/applib/test_persist.c
@@ -269,7 +269,7 @@ void test_persist__legacy2_max_usage(void) {
 
   PBL_LOG_VERBOSE("n = %d", n);
   for (int i = 0; i < n; ++i) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "i = %d", i);
+    PBL_LOG_DBG("i = %d", i);
     cl_assert_equal_i(persist_write_data(i, &buffer, sizeof(buffer)), sizeof(buffer));
   }
 

--- a/tests/fw/comm/test_ancs_app_storage.c
+++ b/tests/fw/comm/test_ancs_app_storage.c
@@ -117,7 +117,7 @@ void test_ancs_app_storage__hash_collisions(void) {
       app_data.display_name = name;
       app_data.is_meta_changed = true;
       uint32_t key = get_key(name);
-      PBL_LOG(LOG_LEVEL_DEBUG, "name: %s, key: %u", name, (unsigned) key);
+      PBL_LOG_DBG("name: %s, key: %u", name, (unsigned) key);
       ancs_app_storage_save(&app_data);
     }
   }
@@ -164,7 +164,7 @@ void test_ancs_app_storage__iter(void) {
 
   ANCSAppData app_data_out = { 0 };
   for (unsigned int i = 0; i < ARRAY_LENGTH(apps); ++i) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "i: %d, name: %s", i, apps[i].bundle_id);
+    PBL_LOG_DBG("i: %d, name: %s", i, apps[i].bundle_id);
     ancs_app_storage_load(apps[i].bundle_id, &app_data_out);
 
     cl_assert_equal_s(apps[i].bundle_id, app_data_out.bundle_id);
@@ -176,7 +176,7 @@ void test_ancs_app_storage__iter(void) {
 
   ancs_app_storage_iter_begin();
   for (unsigned int i = 0; ancs_app_storage_next(&app_data_out); ++i) {
-    PBL_LOG(LOG_LEVEL_DEBUG, "i: %d, name: %s, name_out: %s", i, apps[i].bundle_id, app_data_out.bundle_id);
+    PBL_LOG_DBG("i: %d, name: %s, name_out: %s", i, apps[i].bundle_id, app_data_out.bundle_id);
     cl_assert_equal_s(apps[i].bundle_id, app_data_out.bundle_id);
   }
 }

--- a/tests/fw/services/activity/kraepelin_reference/ProjectK_worker.c
+++ b/tests/fw/services/activity/kraepelin_reference/ProjectK_worker.c
@@ -525,7 +525,7 @@ void ref_minute_stats(uint8_t *orientation, uint8_t *vmc) {
   }
   uint32_t kcals_min = calc_x1000_kcal(r_c_ary);
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "minute_stats vmc: %d, orientation:0x%x, calories: %d",
+  PBL_LOG_DBG("minute_stats vmc: %d, orientation:0x%x, calories: %d",
           (int)*vmc, (int)*orientation, (int)kcals_min);
 
   reset_summ_metrics();

--- a/tests/fw/services/activity/kraepelin_reference/raw_stats.c
+++ b/tests/fw/services/activity/kraepelin_reference/raw_stats.c
@@ -560,7 +560,7 @@ int16_t calc_stepc_5sec(int16_t *work_ary, int16_t dlen_smp, int16_t dlenpwr_ary
       // stepc_tmp = max_mag_hz - ((uint16_t) (rand()%2));
       stepc_tmp = max_mag_hz;
     }
-  PBL_LOG(LOG_LEVEL_DEBUG, "steps: %d, freq: %d, vmc: %d, score: %d", stepc_tmp, max_mag_hz,
+  PBL_LOG_DBG("steps: %d, freq: %d, vmc: %d, score: %d", stepc_tmp, max_mag_hz,
           real_vmc_5s, score0);
   return stepc_tmp;
 }

--- a/tests/fw/services/activity/test_activity.c
+++ b/tests/fw/services/activity/test_activity.c
@@ -929,7 +929,7 @@ static bool prv_activity_iterate_cb(HealthActivity activity, time_t time_start, 
   local_tm = localtime(&time_end);
   strftime(time_end_text, sizeof(time_end_text),  "%F %r", local_tm);
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Got activity: %d %s to %s (%d min)", (int)activity, time_start_text,
+  PBL_LOG_DBG("Got activity: %d %s to %s (%d min)", (int)activity, time_start_text,
           time_end_text, (int)((time_end - time_start) / SECONDS_PER_MINUTE));
 
 
@@ -965,7 +965,7 @@ static void prv_sleep_sessions_using_health_service(uint32_t *session_entries,
   health_service_activities_iterate(HealthActivityMaskAll, now - (2 * SECONDS_PER_DAY), now,
                                     direction, prv_activity_iterate_cb,
                                     NULL);
-  PBL_LOG(LOG_LEVEL_DEBUG, "Found %"PRIu32" activities", s_health_sessions_count);
+  PBL_LOG_DBG("Found %"PRIu32" activities", s_health_sessions_count);
   *session_entries = s_health_sessions_count;
 }
 

--- a/tests/fw/services/activity/test_activity_algorithm_kraepelin.c
+++ b/tests/fw/services/activity/test_activity_algorithm_kraepelin.c
@@ -138,7 +138,7 @@ void activity_sessions_prv_add_activity_session(ActivitySession *session) {
 
   // If no more room, fail
   if (s_activity_sessions_count >= ACTIVITY_MAX_ACTIVITY_SESSIONS_COUNT) {
-    PBL_LOG(LOG_LEVEL_WARNING, "No more room for additional activities");
+    PBL_LOG_WRN("No more room for additional activities");
     return;
   }
 

--- a/tests/fw/services/activity/test_kraepelin_algorithm.c
+++ b/tests/fw/services/activity/test_kraepelin_algorithm.c
@@ -469,7 +469,7 @@ static uint32_t prv_feed_reference_samples(AccelRawData *data, int num_samples) 
   steps = ref_finish_epoch();
   ref_minute_stats(&orientation, &vmc);
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "processed %d samples (%d seconds) of data: %d steps",
+  PBL_LOG_DBG("processed %d samples (%d seconds) of data: %d steps",
           num_samples, num_samples / KALG_SAMPLE_HZ, steps);
   return steps;
 }

--- a/tests/fw/services/comm_session/test_session_receive_router.c
+++ b/tests/fw/services/comm_session/test_session_receive_router.c
@@ -184,7 +184,7 @@ static void prv_system_test_receiver_write(Receiver *receiver,
   memcpy(s_write_buffer + s_write_length, data, length);
   s_write_length += length;
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "Wrote %zu bytes", length);
+  PBL_LOG_DBG("Wrote %zu bytes", length);
 }
 
 static void prv_system_test_receiver_finish(Receiver *receiver) {

--- a/tests/fw/services/health/test_health.c
+++ b/tests/fw/services/health/test_health.c
@@ -758,7 +758,7 @@ void test_health__metric_hr_averaged_accessible(void) {
                                                            test->in.time_start,
                                                            test->in.time_end,
                                                            test->in.scope);
-    PBL_LOG(LOG_LEVEL_DEBUG, "%s\nMetric: %d, start: %d, end: %d, Scope: %d",
+    PBL_LOG_DBG("%s\nMetric: %d, start: %d, end: %d, Scope: %d",
             test->desc, (int)test->in.metric, (int)test->in.time_start,
             (int)test->in.time_end, (int)test->in.scope);
     cl_assert_equal_i(accessible, tests[i].out.accessible);
@@ -844,7 +844,7 @@ void test_health__metric_hr_aggregate_averaged_accessible(void) {
                                                                      test->in.time_end,
                                                                      test->in.aggregation,
                                                                      test->in.scope);
-    PBL_LOG(LOG_LEVEL_DEBUG, "%s\nMetric: %d, start: %d, end: %d, Aggregation: %d, Scope: %d",
+    PBL_LOG_DBG("%s\nMetric: %d, start: %d, end: %d, Aggregation: %d, Scope: %d",
             test->desc, (int)test->in.metric, (int)test->in.time_start,
             (int)test->in.time_end, (int)test->in.aggregation, (int)test->in.scope);
     cl_assert_equal_i(accessible, tests[i].out.accessible);
@@ -1538,7 +1538,7 @@ void DISABLED_test_health__min_max_avg_full_days(void) {
   bool yesterday_was_weekend = (yesterday_day_in_week == Sunday)
                                || (yesterday_day_in_week == Saturday);
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "yesterday day in week: %d", yesterday_day_in_week);
+  PBL_LOG_DBG("yesterday day in week: %d", yesterday_day_in_week);
 
   // ----------------------------------------
   // Let's fill in some known data for the daily totals and accumulate the stats
@@ -1569,7 +1569,7 @@ void DISABLED_test_health__min_max_avg_full_days(void) {
     HealthValue value = 1000 + (i * 50);
     s_sys_activity_get_metric_values.out.history[i] = value;
 
-    PBL_LOG(LOG_LEVEL_DEBUG, "Day #%d, day_of_week: %d, value: %"PRIi32" ", i, day_in_week,
+    PBL_LOG_DBG("Day #%d, day_of_week: %d, value: %"PRIi32" ", i, day_in_week,
              value);
     // Day 0 is not included in the stats
     if (i == 0) {
@@ -1590,7 +1590,7 @@ void DISABLED_test_health__min_max_avg_full_days(void) {
     // Update stats
     if (day_in_week == yesterday_day_in_week) {
       prv_update_stats(&weekly_stats, value);
-      PBL_LOG(LOG_LEVEL_DEBUG, "Updating weekly stats with %"PRIi32": sum: %"PRIi32", "
+      PBL_LOG_DBG("Updating weekly stats with %"PRIi32": sum: %"PRIi32", "
                "avg: %"PRIi32" ", value, weekly_stats.sum, weekly_stats.avg);
     }
     if (day_in_week == Sunday || day_in_week == Saturday) {
@@ -1667,7 +1667,7 @@ void DISABLED_test_health__min_max_avg_full_days(void) {
       HealthValue result;
       result = health_service_aggregate_averaged(HealthMetricHeartRateBPM,
                                                  time_start, time_end, agg, scope);
-      PBL_LOG(LOG_LEVEL_INFO, "Testing %-16s %-16s exp_value: %5"PRIi32", act_value: "
+      PBL_LOG_INFO("Testing %-16s %-16s exp_value: %5"PRIi32", act_value: "
               "%5"PRIi32" " , scope_str, agg_str, exp_value, result);
 
       if (scope != HealthServiceTimeScopeOnce) {
@@ -1738,7 +1738,7 @@ void test_health__heart_rate_scope_once(void) {
 
     s_sys_activity_get_minute_history_values.stage = 0;
     if (agg == HealthAggregationMin) {
-      PBL_LOG(LOG_LEVEL_DEBUG, "foo");
+      PBL_LOG_DBG("foo");
     }
     HealthValue result = health_service_aggregate_averaged(HealthMetricHeartRateBPM,
                                                            time_start, time_end,

--- a/tests/fw/services/protobuf_log/test_protobuf_log.c
+++ b/tests/fw/services/protobuf_log/test_protobuf_log.c
@@ -35,7 +35,7 @@
 #define WRITE_TO_FILE 0
 
 #define LOG(fmt, args...) \
-        PBL_LOG(LOG_LEVEL_DEBUG, fmt, ## args)
+        PBL_LOG_DBG(fmt, ## args)
 
 extern uint32_t prv_hr_quality_int(HRMQuality quality);
 

--- a/tests/fw/services/test_app_cache.c
+++ b/tests/fw/services/test_app_cache.c
@@ -485,7 +485,7 @@ void test_app_cache__free_up_space_save_defaults(void) {
   prv_cleanup();
   to_free = SIZE_SUM - after_free;
   before_size = app_cache_get_size();
-  PBL_LOG(LOG_LEVEL_DEBUG, "%d %d %d", to_free, after_free, before_size);
+  PBL_LOG_DBG("%d %d %d", to_free, after_free, before_size);
   cl_assert(before_size >= to_free);
   cl_assert_equal_i(S_SUCCESS, app_cache_free_up_space(to_free));
   fake_system_task_callbacks_invoke_pending();

--- a/tests/fw/services/test_app_fetch_endpoint.c
+++ b/tests/fw/services/test_app_fetch_endpoint.c
@@ -121,7 +121,7 @@ static void prv_check_valid_app_fetch_request(uint16_t endpoint_id, const uint8_
     unsigned int data_length) {
 
   // AppFetchRequest request = *(AppFetchRequest *)data;
-  PBL_LOG(LOG_LEVEL_DEBUG, "sizeof: %lu length: %u", sizeof(AppFetchRequest), data_length);
+  PBL_LOG_DBG("sizeof: %lu length: %u", sizeof(AppFetchRequest), data_length);
   AppFetchRequest request = *(AppFetchRequest *)data;
 
   cl_assert_equal_i(endpoint_id, APP_FETCH_ENDPOINT_ID);

--- a/tests/fw/services/test_pfs.c
+++ b/tests/fw/services/test_pfs.c
@@ -683,7 +683,7 @@ void test_pfs__migration(void) {
   int original_page_count = num_pages();
   ftl_populate_region_list();
   // make sure something was added
-  PBL_LOG(LOG_LEVEL_DEBUG, "original pages %u, num pages: %u", original_page_count, num_pages());
+  PBL_LOG_DBG("original pages %u, num pages: %u", original_page_count, num_pages());
   cl_assert(original_page_count < num_pages());
 
   for (int i = 0; i < original_page_count; i++) {

--- a/tests/fw/services/test_put_bytes.c
+++ b/tests/fw/services/test_put_bytes.c
@@ -170,7 +170,7 @@ static void prv_receive_data(CommSession *session, const uint8_t* data, size_t l
     g_put_bytes_receiver_impl.write(r, data, length);
     g_put_bytes_receiver_impl.finish(r);
   } else {
-    PBL_LOG(LOG_LEVEL_ERROR, "No receiver returned!");
+    PBL_LOG_ERR("No receiver returned!");
   }
 }
 

--- a/tests/fw/test_alarm_smart.c
+++ b/tests/fw/test_alarm_smart.c
@@ -185,7 +185,7 @@ void test_alarm_smart__trigger_15_min_early_light_sleep(void) {
     s_sleep_state_seconds += 5 * SECONDS_PER_MINUTE;
     s_last_vmc = i == 2 ? 1 : 0;
     prv_set_time(s_current_day, 10, (i + 1) * 5);
-    PBL_LOG(LOG_LEVEL_DEBUG, "Iteration #%d, sleep %d seconds", i, s_sleep_state_seconds);
+    PBL_LOG_DBG("Iteration #%d, sleep %d seconds", i, s_sleep_state_seconds);
     stub_new_timer_invoke(1);
     if (i < num_checks - 1) {
       // Smart alarm non-trigger checks
@@ -229,7 +229,7 @@ void test_alarm_smart__trigger_at_timeout(void) {
     s_sleep_state_seconds = (i + 1) * 5 * SECONDS_PER_MINUTE;
     s_last_vmc = (i == 5);
     prv_set_time(s_current_day, 10, i * 5);
-    PBL_LOG(LOG_LEVEL_DEBUG, "Iteration #%d, sleep %d seconds", i, s_sleep_state_seconds);
+    PBL_LOG_DBG("Iteration #%d, sleep %d seconds", i, s_sleep_state_seconds);
     stub_new_timer_invoke(1);
     if (i < num_checks - 1) {
       // Smart alarm non-trigger checks

--- a/tests/fw/test_battery_monitor.c
+++ b/tests/fw/test_battery_monitor.c
@@ -406,12 +406,12 @@ void test_battery_monitor__increase_discharging(void) {
 
   // Should be stable by now
   // Shouldn't update percent (actually, shouldn't even send events.)
-  PBL_LOG(LOG_LEVEL_DEBUG, "Shouldn't be any updates");
-  PBL_LOG(LOG_LEVEL_DEBUG, "▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼");
+  PBL_LOG_DBG("Shouldn't be any updates");
+  PBL_LOG_DBG("▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼");
   fake_battery_set_millivolts(high_mv);
   periodic_timer_trigger(20);
   cl_assert_equal_i(battery_get_charge_state().charge_percent, 50);
-  PBL_LOG(LOG_LEVEL_DEBUG, "▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲");
+  PBL_LOG_DBG("▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲");
 
   // Should still update if it goes lower
   fake_battery_set_millivolts(lower_mv);

--- a/tests/fw/test_data_logging.c
+++ b/tests/fw/test_data_logging.c
@@ -90,7 +90,7 @@ static uint32_t s_prev_send_data_bytes;
 
 static void prv_transport_sent_data_cb(uint16_t endpoint_id,
                                        const uint8_t* data, unsigned int data_length) {
-  PBL_LOG(LOG_LEVEL_INFO, "Received %d bytes of data from watch", data_length);
+  PBL_LOG_INFO("Received %d bytes of data from watch", data_length);
   if (data_length >= sizeof(s_prev_send_data_hdr)) {
     memcpy(&s_prev_send_data_hdr, data, sizeof(s_prev_send_data_hdr));
     data_length -= sizeof(s_prev_send_data_hdr);
@@ -112,7 +112,7 @@ static void prv_init_fake_flash(void) {
   pfs_init(false);
   pfs_format(false /* write erase headers */);
 
-  PBL_LOG(LOG_LEVEL_INFO, "\nFile system size: %d, avail: %d", (int)pfs_get_size(),
+  PBL_LOG_INFO("\nFile system size: %d, avail: %d", (int)pfs_get_size(),
           (int)get_available_pfs_space());
 }
 
@@ -168,7 +168,7 @@ static void prv_check_session_data(DataLoggingSessionRef logging_session, uint32
 // log some random data, return its crc32
 static uint32_t prv_log_random_data(DataLoggingSessionRef logging_session, int item_size,
                                     int num_items) {
-  PBL_LOG(LOG_LEVEL_INFO, "Logging %d bytes", item_size * num_items);
+  PBL_LOG_INFO("Logging %d bytes", item_size * num_items);
   uint8_t *random_buf;
   uint32_t random_crc = prv_get_random_buffer(&random_buf, item_size * num_items);
 
@@ -323,11 +323,11 @@ void test_data_logging__fill_quota(void) {
   int total_bytes = 0;
   for (int i = 0; i < num_sessions; i++) {
     uint32_t size = dls_test_get_num_bytes(logging_sessions[i]);
-    PBL_LOG(LOG_LEVEL_INFO, "Size of session %d: %d", i, size);
+    PBL_LOG_INFO("Size of session %d: %d", i, size);
     total_bytes += size;
   }
 
-  PBL_LOG(LOG_LEVEL_INFO, "total bytes: %d", total_bytes);
+  PBL_LOG_INFO("total bytes: %d", total_bytes);
   cl_assert(total_bytes < DLS_TOTAL_STORAGE_BYTES);
 
   // We should still be able to create more sessions up to the max
@@ -342,11 +342,11 @@ void test_data_logging__fill_quota(void) {
   total_bytes = 0;
   for (int i = 0; i < num_sessions; i++) {
     uint32_t size = dls_test_get_num_bytes(logging_sessions[i]);
-    PBL_LOG(LOG_LEVEL_INFO, "Size of session %d: %d", i, size);
+    PBL_LOG_INFO("Size of session %d: %d", i, size);
     total_bytes += size;
   }
 
-  PBL_LOG(LOG_LEVEL_INFO, "total bytes: %d", total_bytes);
+  PBL_LOG_INFO("total bytes: %d", total_bytes);
   cl_assert(total_bytes < DLS_TOTAL_STORAGE_BYTES);
 }
 

--- a/tests/fw/test_flash_logging.c
+++ b/tests/fw/test_flash_logging.c
@@ -122,7 +122,7 @@ static bool prv_flash_log_line_dump(uint8_t *msg, uint32_t tot_len) {
 bool s_completed = false;
 bool s_completed_success = false;
 static void prv_flash_log_dump_completed_cb(bool success) {
-  PBL_LOG(LOG_LEVEL_DEBUG, "Called prv_flash_log_dump_completed_cb(%d)", (int)success);
+  PBL_LOG_DBG("Called prv_flash_log_dump_completed_cb(%d)", (int)success);
   s_completed = true;
   s_completed_success = success;
 }
@@ -310,7 +310,7 @@ static bool flash_log_line_dump_long_lived(uint8_t *msg, uint32_t tot_len) {
   memcpy(&buf, (char*)msg, tot_len);
   buf[tot_len] = '\0';
 
-  PBL_LOG(LOG_LEVEL_DEBUG, "flash_log_line_dump_long_lived: got %s", buf);
+  PBL_LOG_DBG("flash_log_line_dump_long_lived: got %s", buf);
 
   int curr_val;
   int filled = sscanf(buf, "Loop Counter %d", &curr_val);
@@ -321,7 +321,7 @@ static bool flash_log_line_dump_long_lived(uint8_t *msg, uint32_t tot_len) {
   }
 
   s_long_lived_last_val = curr_val;
-  PBL_LOG(LOG_LEVEL_DEBUG, "flash_log_line_dump_long_lived: got %s, last_val:%d", buf,
+  PBL_LOG_DBG("flash_log_line_dump_long_lived: got %s, last_val:%d", buf,
           s_long_lived_last_val);
 
   return (true);

--- a/third_party/memfault/port/src/memfault_chunk_collector.c
+++ b/third_party/memfault/port/src/memfault_chunk_collector.c
@@ -34,7 +34,7 @@ static void prv_create_dls_session() {
 static void prv_memfault_gather_chunks() {
   if (!dls_initialized()) {
     // We need to wait until data logging is initialized before we can add chunks
-    PBL_LOG(LOG_LEVEL_ERROR, "!dls_initialized");
+    PBL_LOG_ERR("!dls_initialized");
     return;
   }
 
@@ -42,7 +42,7 @@ static void prv_memfault_gather_chunks() {
   // yet, so do it here.
   prv_create_dls_session();
   if (s_chunks_session == NULL) {
-    PBL_LOG(LOG_LEVEL_ERROR, "!s_chunks_session");
+    PBL_LOG_ERR("!s_chunks_session");
     return;
   }
 

--- a/third_party/memfault/port/src/memfault_platform_port.c
+++ b/third_party/memfault/port/src/memfault_platform_port.c
@@ -81,7 +81,7 @@ void memfault_platform_log_raw(const char *fmt, ...) {
   va_start(args, fmt);
 
   vsnprintf(log_buf, sizeof(log_buf), fmt, args);
-  PBL_LOG(LOG_LEVEL_DEBUG, "%s", log_buf);
+  PBL_LOG_DBG("%s", log_buf);
 
   va_end(args);
 }

--- a/third_party/nimble/port/include/console/console.h
+++ b/third_party/nimble/port/include/console/console.h
@@ -6,6 +6,6 @@
 
 #include "system/logging.h"
 
-#define console_printf(_fmt, ...) PBL_LOG_D(LOG_DOMAIN_BT_STACK, LOG_LEVEL_INFO, _fmt, ##__VA_ARGS__)
+#define console_printf(_fmt, ...) PBL_LOG_D_INFO(LOG_DOMAIN_BT_STACK, _fmt, ##__VA_ARGS__)
 
 #endif /* __CONSOLE_H__ */

--- a/third_party/nimble/transport/chipset/cc2564.c
+++ b/third_party/nimble/transport/chipset/cc2564.c
@@ -36,7 +36,7 @@ static bool ble_run_bts(const ResAppNum bts_file) {
   size_t bts_len = 0;
 
   if (!resource_is_valid(SYSTEM_APP, bts_file)) {
-    PBL_LOG_D(LOG_DOMAIN_BT_STACK, LOG_LEVEL_ERROR, "Can't load BT service pack: bad system resources!");
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT_STACK, "Can't load BT service pack: bad system resources!");
     return false;
   }
 
@@ -52,12 +52,12 @@ static bool ble_run_bts(const ResAppNum bts_file) {
 
     // TODO: re-add sleep mode config and deal with entering/exiting sleep mode
     if (command->opcode == HCI_VS_SLEEP_MODE_CONFIG) {
-      PBL_LOG_D(LOG_DOMAIN_BT_STACK, LOG_LEVEL_INFO, "ble_bts: Skipping opcode 0x%X", command->opcode);
+      PBL_LOG_D_INFO(LOG_DOMAIN_BT_STACK, "ble_bts: Skipping opcode 0x%X", command->opcode);
       continue;
     }
 
     if (command->opcode == HCI_VS_UPDATE_UART_HCI_BAUDRATE) {
-      PBL_LOG_D(LOG_DOMAIN_BT_STACK, LOG_LEVEL_INFO, "ble_bts: Setting baud rate to %d", HCI_BAUD_RATE);
+      PBL_LOG_D_INFO(LOG_DOMAIN_BT_STACK, "ble_bts: Setting baud rate to %d", HCI_BAUD_RATE);
       BTSHCIUpdateBaudRateCommand baud_rate_command = {
           .opcode = HCI_VS_UPDATE_UART_HCI_BAUDRATE,
           .size = sizeof(uint32_t),
@@ -92,7 +92,7 @@ bool ble_chipset_start(void) {
   // HACK: this is just here to let the service pack commands get processed before we continue
   psleep(500);
 
-  PBL_LOG_D(LOG_DOMAIN_BT_STACK, LOG_LEVEL_INFO, "bts files sent");
+  PBL_LOG_D_INFO(LOG_DOMAIN_BT_STACK, "bts files sent");
 
   return true;
 }

--- a/third_party/nimble/transport/hci_sf32lb52.c
+++ b/third_party/nimble/transport/hci_sf32lb52.c
@@ -78,7 +78,7 @@ void prv_hci_trace(uint8_t type, const uint8_t *data, uint16_t len, uint8_t h4tl
     break;
   }
 
-  PBL_LOG_D(LOG_DOMAIN_BT_STACK, LOG_LEVEL_DEBUG, "%s, %s %" PRIu16, type_str,
+  PBL_LOG_D_DBG(LOG_DOMAIN_BT_STACK, "%s, %s %" PRIu16, type_str,
             (h4tl_packet == H4TL_PACKET_HOST) ? "TX" : "RX", len);
   PBL_HEXDUMP_D(LOG_DOMAIN_BT_STACK, LOG_LEVEL_DEBUG, data, len);
 }
@@ -163,13 +163,13 @@ static int prv_config_ipc(void) {
 
   s_ipc_port = ipc_queue_init(&q_cfg);
   if (s_ipc_port == IPC_QUEUE_INVALID_HANDLE) {
-    PBL_LOG_D(LOG_DOMAIN_BT_STACK, LOG_LEVEL_ERROR, "ipc_queue_init failed");
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT_STACK, "ipc_queue_init failed");
     return -1;
   }
 
   ret = ipc_queue_open(s_ipc_port);
   if (ret != 0) {
-    PBL_LOG_D(LOG_DOMAIN_BT_STACK, LOG_LEVEL_ERROR, "ipc_queue_open failed (%" PRId32 ")", ret);
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT_STACK, "ipc_queue_open failed (%" PRId32 ")", ret);
     return -1;
   }
 
@@ -190,7 +190,7 @@ static int prv_hci_frame_cb(uint8_t pkt_type, void *data) {
     cmd_complete = (void *)ev->data;
 
     if (ev->opcode == BLE_HCI_EVCODE_COMMAND_COMPLETE) {
-      PBL_LOG_D(LOG_DOMAIN_BT_STACK, LOG_LEVEL_DEBUG, "CMD complete %x", cmd_complete->opcode);
+      PBL_LOG_D_DBG(LOG_DOMAIN_BT_STACK, "CMD complete %x", cmd_complete->opcode);
       // NOTE: do not confuse NimBLE with SF32LB52 vendor specific command
       if (cmd_complete->opcode == BLE_HCI_EXT_SF32LB52_BLE_READY) {
         break;
@@ -281,7 +281,7 @@ int ble_transport_to_ll_cmd_impl(void *buf) {
 
   written = ipc_queue_write(s_ipc_port, &h4_cmd, 1, IPC_TIMEOUT_TICKS);
   if (written != 1U) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to write HCI CMD header");
+    PBL_LOG_ERR("Failed to write HCI CMD header");
     err = BLE_ERR_MEM_CAPACITY;
     goto exit;
   }
@@ -289,7 +289,7 @@ int ble_transport_to_ll_cmd_impl(void *buf) {
   written = ipc_queue_write(s_ipc_port, cmd, sizeof(*cmd) + cmd->length,
                             IPC_TIMEOUT_TICKS);
   if (written != sizeof(*cmd) + cmd->length) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to write HCI CMD data");
+    PBL_LOG_ERR("Failed to write HCI CMD data");
     err = BLE_ERR_MEM_CAPACITY;
     goto exit;
   }
@@ -310,7 +310,7 @@ int ble_transport_to_ll_acl_impl(struct os_mbuf *om) {
 
   written = ipc_queue_write(s_ipc_port, &h4_cmd, 1U, IPC_TIMEOUT_TICKS);
   if (written != 1U) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to write HCI ACL header");
+    PBL_LOG_ERR("Failed to write HCI ACL header");
     err = BLE_ERR_MEM_CAPACITY;
     goto exit;
   }
@@ -319,7 +319,7 @@ int ble_transport_to_ll_acl_impl(struct os_mbuf *om) {
   while (x != NULL) {
     written = ipc_queue_write(s_ipc_port, x->om_data, x->om_len, IPC_TIMEOUT_TICKS);
     if (written != x->om_len) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Failed to write HCI ACL data");
+      PBL_LOG_ERR("Failed to write HCI ACL data");
       err = BLE_ERR_MEM_CAPACITY;
       goto exit;
     }
@@ -343,7 +343,7 @@ int ble_transport_to_ll_iso_impl(struct os_mbuf *om) {
 
   written = ipc_queue_write(s_ipc_port, &h4_cmd, 1, IPC_TIMEOUT_TICKS);
   if (written != 1U) {
-    PBL_LOG(LOG_LEVEL_ERROR, "Failed to write HCI ISO header");
+    PBL_LOG_ERR("Failed to write HCI ISO header");
     err = BLE_ERR_MEM_CAPACITY;
     goto exit;
   }
@@ -352,7 +352,7 @@ int ble_transport_to_ll_iso_impl(struct os_mbuf *om) {
   while (x != NULL) {
     written = ipc_queue_write(s_ipc_port, x->om_data, x->om_len, IPC_TIMEOUT_TICKS);
     if (written != x->om_len) {
-      PBL_LOG(LOG_LEVEL_ERROR, "Failed to write HCI ISO data");
+      PBL_LOG_ERR("Failed to write HCI ISO data");
       err = BLE_ERR_MEM_CAPACITY;
       goto exit;
     }

--- a/third_party/nimble/transport/hci_uart_transport.c
+++ b/third_party/nimble/transport/hci_uart_transport.c
@@ -132,7 +132,7 @@ static bool prv_uart_rx_irq_handler(UARTDevice *dev, uint8_t data,
   BaseType_t should_context_switch = false;
 
   if (err_flags->framing_error || err_flags->overrun_error) {
-    PBL_LOG_D(LOG_DOMAIN_BT_STACK, LOG_LEVEL_ERROR, "Bluetooth UART overrun:%d framing:%d",
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT_STACK, "Bluetooth UART overrun:%d framing:%d",
               err_flags->overrun_error, err_flags->framing_error);
   }
 
@@ -168,7 +168,7 @@ static void prv_rx_task_main(void *unused) {
 
       consumed_bytes = hci_h4_sm_rx(&hci_uart_h4sm, read_buf, bytes_remaining);
       if (consumed_bytes <= 0) {
-        PBL_LOG_D(LOG_DOMAIN_BT_STACK, LOG_LEVEL_ERROR, "hci_h4_sm_rx rc=%d", consumed_bytes);
+        PBL_LOG_D_ERR(LOG_DOMAIN_BT_STACK, "hci_h4_sm_rx rc=%d", consumed_bytes);
         break;
       }
 

--- a/third_party/nimble/wscript
+++ b/third_party/nimble/wscript
@@ -128,7 +128,6 @@ def build(bld):
     bld.objects(
         source=nimble_sources,
         target='nimble',
-        defines=['FILE_LOG_COLOR=LOG_COLOR_BLUE'],
         use=nimble_use,
         includes=nimble_includes,
         export_includes=nimble_includes,


### PR DESCRIPTION
- Use level-named macros, e.g. PBL_LOG_INFO(...) instead of PBL_LOG(LOG_LEVEL_INFO, ...)
- Each level has a default color (e.g. info->green, error->red...)
- Removed usage of colored logs (it's just confusing)