### PR TITLE
python_libs: fix setuptools issues

### DIFF
--- a/python_libs/pblprog/pebble/__init__.py
+++ b/python_libs/pblprog/pebble/__init__.py
@@ -1,4 +1,3 @@
 # SPDX-FileCopyrightText: 2024 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-__import__('pkg_resources').declare_namespace(__name__)

--- a/python_libs/pebble-commander/pebble/__init__.py
+++ b/python_libs/pebble-commander/pebble/__init__.py
@@ -1,4 +1,3 @@
 # SPDX-FileCopyrightText: 2024 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-__import__('pkg_resources').declare_namespace(__name__)

--- a/python_libs/pebble-loghash/pebble/__init__.py
+++ b/python_libs/pebble-loghash/pebble/__init__.py
@@ -1,7 +1,3 @@
 # SPDX-FileCopyrightText: 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Namespace module
-"""
-__import__('pkg_resources').declare_namespace(__name__)

--- a/python_libs/pulse2/pebble/__init__.py
+++ b/python_libs/pulse2/pebble/__init__.py
@@ -1,4 +1,3 @@
 # SPDX-FileCopyrightText: 2024 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
Removed the __import__('pkg_resources').declare_namespace(__name__) call from each. The pebble namespace package now uses Python's implicit namespace package mechanism (PEP 420), which doesn't require setuptools/pkg_resources and works with Python 3.3+.