### PR TITLE
fw/drivers/pmic: replace npm1300 platform ifdefs with board-level config

### DIFF
--- a/src/fw/board/boards/board_asterix.c
+++ b/src/fw/board/boards/board_asterix.c
@@ -207,12 +207,32 @@ IRQ_MAP_NRFX(PWM0, nrfx_pwm_0_irq_handler);
 IRQ_MAP_NRFX(RTC1, rtc_irq_handler);
 
 const Npm1300Config NPM1300_CONFIG = {
-  // 128mA = ~1C (rapid charge)
-  .chg_current_ma = 128,
-  .dischg_limit_ma = 200,
-  .term_current_pct = 10,
-  .thermistor_beta = 3380,
-  .vterm_setting = NPM1300_VTERM_4V20,
+    .chg_current_ma = 128,        // 128mA = ~1C (rapid charge)
+    .dischg_limit_ma = 200,       // ~1.6C burst, hardware protection floor
+    .term_current_pct = 10,       // 12.8mA
+    .thermistor_beta = 3380,      // 10kΩ
+    .vterm_setting = NPM1300_VTERM_4V20,
+
+    // Buck1 (1.8V)
+    .buck1_enable = true,
+    .buck1_voltage_sel = 8,       // 1.8V
+
+    // Buck2 (3.0V)
+    .buck2_enable = true,
+    .buck2_voltage_sel = 20,      // 3.0V
+    .buck_sw_ctrl_sel = 3,        // both of them, load
+    .configure_buck_sw_ctrl = false, // Already configured by Erratum 27 workaround
+
+    // LDSW1 disabled (not used)
+    .ldsw1_enable = false,
+    .ldsw1_voltage_sel = 0,
+
+    // LDSW2 (1.8V LDO)
+    .ldsw2_enable = true,
+    .ldsw2_mode = NPM1300_LDO2_MODE_LDO,
+    .ldsw2_voltage_sel = 8,       // 1.8V
+
+    .apply_erratum_27_workaround = true,
 };
 
 void board_early_init(void) {

--- a/src/fw/board/boards/board_asterix.c
+++ b/src/fw/board/boards/board_asterix.c
@@ -10,7 +10,6 @@
 #include "drivers/nrf5/i2c_hal_definitions.h"
 #include "drivers/nrf5/spi_definitions.h"
 #include "drivers/nrf5/uart_definitions.h"
-#include "drivers/pmic/npm1300.h"
 #include "drivers/pwm.h"
 #include "drivers/qspi_definitions.h"
 #include "drivers/rtc.h"
@@ -213,6 +212,7 @@ const Npm1300Config NPM1300_CONFIG = {
   .dischg_limit_ma = 200,
   .term_current_pct = 10,
   .thermistor_beta = 3380,
+  .vterm_setting = NPM1300_VTERM_4V20,
 };
 
 void board_early_init(void) {

--- a/src/fw/board/boards/board_asterix.c
+++ b/src/fw/board/boards/board_asterix.c
@@ -206,31 +206,37 @@ IRQ_MAP_NRFX(PWM0, nrfx_pwm_0_irq_handler);
 
 IRQ_MAP_NRFX(RTC1, rtc_irq_handler);
 
+enum {
+  ASTERIX_NPM1300_CHARGE_CURRENT_MA = 128,
+  ASTERIX_NPM1300_DISCHARGE_LIMIT_MA = 200,
+  ASTERIX_NPM1300_THERMISTOR_BETA = 3380,
+};
+
 const Npm1300Config NPM1300_CONFIG = {
-    .chg_current_ma = 128,        // 128mA = ~1C (rapid charge)
-    .dischg_limit_ma = 200,       // ~1.6C burst, hardware protection floor
-    .term_current_pct = 10,       // 12.8mA
-    .thermistor_beta = 3380,      // 10kΩ
+    .chg_current_ma = ASTERIX_NPM1300_CHARGE_CURRENT_MA,   // ~1C rapid charge
+    .dischg_limit_ma = ASTERIX_NPM1300_DISCHARGE_LIMIT_MA, // ~1.6C burst, HW protection floor
+    .term_current_pct = NPM1300_TERM_CURRENT_10_PERCENT,   // 12.8mA
+    .thermistor_beta = ASTERIX_NPM1300_THERMISTOR_BETA,    // 10kΩ
     .vterm_setting = NPM1300_VTERM_4V20,
 
     // Buck1 (1.8V)
     .buck1_enable = true,
-    .buck1_voltage_sel = 8,       // 1.8V
+    .buck1_voltage_sel = NPM1300_VOLTAGE_SEL_1V8,
 
     // Buck2 (3.0V)
     .buck2_enable = true,
-    .buck2_voltage_sel = 20,      // 3.0V
-    .buck_sw_ctrl_sel = 3,        // both of them, load
+    .buck2_voltage_sel = NPM1300_VOLTAGE_SEL_3V0,
+    .buck_sw_ctrl_sel = NPM1300_BUCK_SW_CTRL_SEL_BUCK1_BUCK2,
     .configure_buck_sw_ctrl = false, // Already configured by Erratum 27 workaround
 
     // LDSW1 disabled (not used)
     .ldsw1_enable = false,
-    .ldsw1_voltage_sel = 0,
+    .ldsw1_voltage_sel = NPM1300_VOLTAGE_SEL_DISABLED,
 
     // LDSW2 (1.8V LDO)
     .ldsw2_enable = true,
     .ldsw2_mode = NPM1300_LDO2_MODE_LDO,
-    .ldsw2_voltage_sel = 8,       // 1.8V
+    .ldsw2_voltage_sel = NPM1300_VOLTAGE_SEL_1V8,
 
     .apply_erratum_27_workaround = true,
 };

--- a/src/fw/board/boards/board_getafix.c
+++ b/src/fw/board/boards/board_getafix.c
@@ -468,6 +468,7 @@ const Npm1300Config NPM1300_CONFIG = {
   .thermistor_beta = 3380,
   .vbus_current_lim0 = 500,
   .vbus_current_startup = 500,
+  .vterm_setting = NPM1300_VTERM_4V45,
 };
 
 const BoardConfigPower BOARD_CONFIG_POWER = {

--- a/src/fw/board/boards/board_getafix.c
+++ b/src/fw/board/boards/board_getafix.c
@@ -461,14 +461,36 @@ const BoardConfigActuator BOARD_CONFIG_VIBE = {
 };
 
 const Npm1300Config NPM1300_CONFIG = {
-  // 70mA = 1C (max limit from datasheet)
-  .chg_current_ma = 70,
-  .dischg_limit_ma = 200,
-  .term_current_pct = 10,
-  .thermistor_beta = 3380,
-  .vbus_current_lim0 = 500,
-  .vbus_current_startup = 500,
-  .vterm_setting = NPM1300_VTERM_4V45,
+
+    .chg_current_ma = 70,         // 70mA = 1C (max limit from datasheet)
+    .dischg_limit_ma = 200,       // ~2.8C burst, hardware protection floor
+    .term_current_pct = 10,       // 7mA 
+    .thermistor_beta = 3380,      // 10kΩ 
+    .vbus_current_lim0 = 500,     // USB 2.0 max
+    .vbus_current_startup = 500,  // Match steady-state, avoid re-negotiation
+    .vterm_setting = NPM1300_VTERM_4V45,
+
+    // Buck1 disabled after switching to SW control via Erratum 27 workaround
+    .buck1_enable = false,
+    .buck1_voltage_sel = 8,       // 1.8V
+
+    // Buck2 disabled
+    .buck2_enable = false,
+    .buck2_voltage_sel = 0,
+    .buck_sw_ctrl_sel = 1,        // BUCK1 remains SW-controlled after workaround
+    .configure_buck_sw_ctrl = false, // Already configured by Erratum 27 workaround
+
+    // LDSW1 (1.8V LDO)
+    .ldsw1_enable = true,
+    .ldsw1_mode = NPM1300_LDO2_MODE_LDO,
+    .ldsw1_voltage_sel = 8,       // 1.8V
+
+    // LDSW2 (3.3V LDSW for PDM, initially disabled)
+    .ldsw2_enable = false,
+    .ldsw2_mode = NPM1300_LDO2_MODE_LDSW,
+    .ldsw2_voltage_sel = 0,
+
+    .apply_erratum_27_workaround = true,
 };
 
 const BoardConfigPower BOARD_CONFIG_POWER = {

--- a/src/fw/board/boards/board_getafix.c
+++ b/src/fw/board/boards/board_getafix.c
@@ -460,35 +460,42 @@ const BoardConfigActuator BOARD_CONFIG_VIBE = {
     .ctl = {hwp_gpio1, 20, false},
 };
 
-const Npm1300Config NPM1300_CONFIG = {
+enum {
+  GETAFIX_NPM1300_CHARGE_CURRENT_MA = 70,
+  GETAFIX_NPM1300_DISCHARGE_LIMIT_MA = 200,
+  GETAFIX_NPM1300_THERMISTOR_BETA = 3380,
+  GETAFIX_NPM1300_VBUS_CURRENT_LIMIT_MA = 500,
+  GETAFIX_NPM1300_VBUS_STARTUP_CURRENT_MA = GETAFIX_NPM1300_VBUS_CURRENT_LIMIT_MA,
+};
 
-    .chg_current_ma = 70,         // 70mA = 1C (max limit from datasheet)
-    .dischg_limit_ma = 200,       // ~2.8C burst, hardware protection floor
-    .term_current_pct = 10,       // 7mA 
-    .thermistor_beta = 3380,      // 10kΩ 
-    .vbus_current_lim0 = 500,     // USB 2.0 max
-    .vbus_current_startup = 500,  // Match steady-state, avoid re-negotiation
+const Npm1300Config NPM1300_CONFIG = {
+    .chg_current_ma = GETAFIX_NPM1300_CHARGE_CURRENT_MA,     // 1C, max per datasheet
+    .dischg_limit_ma = GETAFIX_NPM1300_DISCHARGE_LIMIT_MA,   // ~2.8C burst, HW protection floor
+    .term_current_pct = NPM1300_TERM_CURRENT_10_PERCENT,     // 7mA
+    .thermistor_beta = GETAFIX_NPM1300_THERMISTOR_BETA,      // 10kΩ
+    .vbus_current_lim0 = GETAFIX_NPM1300_VBUS_CURRENT_LIMIT_MA,      // USB 2.0 max
+    .vbus_current_startup = GETAFIX_NPM1300_VBUS_STARTUP_CURRENT_MA, // Match steady-state
     .vterm_setting = NPM1300_VTERM_4V45,
 
     // Buck1 disabled after switching to SW control via Erratum 27 workaround
     .buck1_enable = false,
-    .buck1_voltage_sel = 8,       // 1.8V
+    .buck1_voltage_sel = NPM1300_VOLTAGE_SEL_1V8,
 
     // Buck2 disabled
     .buck2_enable = false,
-    .buck2_voltage_sel = 0,
-    .buck_sw_ctrl_sel = 1,        // BUCK1 remains SW-controlled after workaround
+    .buck2_voltage_sel = NPM1300_VOLTAGE_SEL_DISABLED,
+    .buck_sw_ctrl_sel = NPM1300_BUCK_SW_CTRL_SEL_BUCK1,
     .configure_buck_sw_ctrl = false, // Already configured by Erratum 27 workaround
 
     // LDSW1 (1.8V LDO)
     .ldsw1_enable = true,
     .ldsw1_mode = NPM1300_LDO2_MODE_LDO,
-    .ldsw1_voltage_sel = 8,       // 1.8V
+    .ldsw1_voltage_sel = NPM1300_VOLTAGE_SEL_1V8,
 
     // LDSW2 (3.3V LDSW for PDM, initially disabled)
     .ldsw2_enable = false,
     .ldsw2_mode = NPM1300_LDO2_MODE_LDSW,
-    .ldsw2_voltage_sel = 0,
+    .ldsw2_voltage_sel = NPM1300_VOLTAGE_SEL_DISABLED,
 
     .apply_erratum_27_workaround = true,
 };

--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -580,35 +580,43 @@ const BoardConfigActuator BOARD_CONFIG_VIBE = {
     .ctl = {hwp_gpio1, 1, false},
 };
 
+enum {
+  OBELIX_NPM1300_CHARGE_CURRENT_MA = 190,
+  OBELIX_NPM1300_DISCHARGE_LIMIT_MA = 200,
+  OBELIX_NPM1300_THERMISTOR_BETA = 3380,
+  OBELIX_NPM1300_VBUS_CURRENT_LIMIT_MA = 500,
+  OBELIX_NPM1300_VBUS_STARTUP_CURRENT_MA = OBELIX_NPM1300_VBUS_CURRENT_LIMIT_MA,
+};
+
 // TODO(OBELIX): Adjust to final battery parameters
 const Npm1300Config NPM1300_CONFIG = {
-    .chg_current_ma = 190,        // 190mA = 1C (rapid charge, max limit from datasheet)
-    .dischg_limit_ma = 200,       // ~1.05C burst, hardware protection floor
-    .term_current_pct = 10,       // 19mA
-    .thermistor_beta = 3380,      // 10kΩ
-    .vbus_current_lim0 = 500,     // USB 2.0 max
-    .vbus_current_startup = 500,  // Match steady-state, avoid re-negotiation
+    .chg_current_ma = OBELIX_NPM1300_CHARGE_CURRENT_MA,      // 1C rapid charge, max per datasheet
+    .dischg_limit_ma = OBELIX_NPM1300_DISCHARGE_LIMIT_MA,    // ~1.05C burst, HW protection floor
+    .term_current_pct = NPM1300_TERM_CURRENT_10_PERCENT,     // 19mA
+    .thermistor_beta = OBELIX_NPM1300_THERMISTOR_BETA,       // 10kΩ
+    .vbus_current_lim0 = OBELIX_NPM1300_VBUS_CURRENT_LIMIT_MA,      // USB 2.0 max
+    .vbus_current_startup = OBELIX_NPM1300_VBUS_STARTUP_CURRENT_MA, // Match steady-state
     .vterm_setting = NPM1300_VTERM_4V35,
 
     // Buck1 disabled after switching to SW control via Erratum 27 workaround
     .buck1_enable = false,
-    .buck1_voltage_sel = 8,       // 1.8V (don't-care, disabled)
+    .buck1_voltage_sel = NPM1300_VOLTAGE_SEL_1V8, // 1.8V (don't-care, disabled)
     // Buck2 disabled (unused?)
     .buck2_enable = false,
-    .buck2_voltage_sel = 0,
-    .buck_sw_ctrl_sel = 1,        // BUCK1 remains SW-controlled after workaround
+    .buck2_voltage_sel = NPM1300_VOLTAGE_SEL_DISABLED,
+    .buck_sw_ctrl_sel = NPM1300_BUCK_SW_CTRL_SEL_BUCK1,
 
     .configure_buck_sw_ctrl = false, // Already configured by Erratum 27 workaround
 
     // LDSW1 enabled: 1.8V LDO
     .ldsw1_enable = true,
     .ldsw1_mode = NPM1300_LDO2_MODE_LDO,
-    .ldsw1_voltage_sel = 8,       // 1.8V
+    .ldsw1_voltage_sel = NPM1300_VOLTAGE_SEL_1V8,
     
     // LDSW2 disabled: 3.3V LDO configured but disabled
     .ldsw2_enable = false,
     .ldsw2_mode = NPM1300_LDO2_MODE_LDO,
-    .ldsw2_voltage_sel = 23,      // 3.3V
+    .ldsw2_voltage_sel = NPM1300_VOLTAGE_SEL_3V3,
 
     .apply_erratum_27_workaround = true,
 };

--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -589,6 +589,7 @@ const Npm1300Config NPM1300_CONFIG = {
   .thermistor_beta = 3380,
   .vbus_current_lim0 = 500,
   .vbus_current_startup = 500,
+  .vterm_setting = NPM1300_VTERM_4V35,
 };
 
 static const I2CSlavePort s_i2c_w1160 = {

--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -582,14 +582,35 @@ const BoardConfigActuator BOARD_CONFIG_VIBE = {
 
 // TODO(OBELIX): Adjust to final battery parameters
 const Npm1300Config NPM1300_CONFIG = {
-  // 190mA = 1C (rapid charge, max limit from datasheet)
-  .chg_current_ma = 190,
-  .dischg_limit_ma = 200,
-  .term_current_pct = 10,
-  .thermistor_beta = 3380,
-  .vbus_current_lim0 = 500,
-  .vbus_current_startup = 500,
-  .vterm_setting = NPM1300_VTERM_4V35,
+    .chg_current_ma = 190,        // 190mA = 1C (rapid charge, max limit from datasheet)
+    .dischg_limit_ma = 200,       // ~1.05C burst, hardware protection floor
+    .term_current_pct = 10,       // 19mA
+    .thermistor_beta = 3380,      // 10kΩ
+    .vbus_current_lim0 = 500,     // USB 2.0 max
+    .vbus_current_startup = 500,  // Match steady-state, avoid re-negotiation
+    .vterm_setting = NPM1300_VTERM_4V35,
+
+    // Buck1 disabled after switching to SW control via Erratum 27 workaround
+    .buck1_enable = false,
+    .buck1_voltage_sel = 8,       // 1.8V (don't-care, disabled)
+    // Buck2 disabled (unused?)
+    .buck2_enable = false,
+    .buck2_voltage_sel = 0,
+    .buck_sw_ctrl_sel = 1,        // BUCK1 remains SW-controlled after workaround
+
+    .configure_buck_sw_ctrl = false, // Already configured by Erratum 27 workaround
+
+    // LDSW1 enabled: 1.8V LDO
+    .ldsw1_enable = true,
+    .ldsw1_mode = NPM1300_LDO2_MODE_LDO,
+    .ldsw1_voltage_sel = 8,       // 1.8V
+    
+    // LDSW2 disabled: 3.3V LDO configured but disabled
+    .ldsw2_enable = false,
+    .ldsw2_mode = NPM1300_LDO2_MODE_LDO,
+    .ldsw2_voltage_sel = 23,      // 3.3V
+
+    .apply_erratum_27_workaround = true,
 };
 
 static const I2CSlavePort s_i2c_w1160 = {

--- a/src/fw/drivers/pmic/npm1300.c
+++ b/src/fw/drivers/pmic/npm1300.c
@@ -335,24 +335,13 @@ bool pmic_init(void) {
   ok &= prv_write_register(PmicRegisters_BCHARGER_TASKCLEARCHGERR, 1);
   ok &= prv_write_register(PmicRegisters_BCHARGER_TASKRELEASEERROR, 1);
 
-  // FIXME: this needs to be configurable at board level
-#if PLATFORM_OBELIX
+
   ok &= prv_write_register(PmicRegisters_ADC_ADCNTCRSEL, PmicRegisters_ADC_ADCNTCRSEL__ADCNTCRSEL_10K);
 
-  ok &= prv_write_register(PmicRegisters_BCHARGER_BCHGVTERM, PmicRegisters_BCHARGER_BCHGVTERM__BCHGVTERMNORM_4V35);
+  ok &= prv_write_register(PmicRegisters_BCHARGER_BCHGVTERM, NPM1300_CONFIG.vterm_setting);
   ok &= prv_write_register(PmicRegisters_BCHARGER_BCHGVTERMR, PmicRegisters_BCHARGER_BCHGVTERMR__BCHGVTERMREDUCED_4V00);
-#elif PLATFORM_GETAFIX
-  ok &= prv_write_register(PmicRegisters_ADC_ADCNTCRSEL, PmicRegisters_ADC_ADCNTCRSEL__ADCNTCRSEL_10K);
 
-  ok &= prv_write_register(PmicRegisters_BCHARGER_BCHGVTERM, PmicRegisters_BCHARGER_BCHGVTERM__BCHGVTERMNORM_4V45);
-  ok &= prv_write_register(PmicRegisters_BCHARGER_BCHGVTERMR, PmicRegisters_BCHARGER_BCHGVTERMR__BCHGVTERMREDUCED_4V00);
-#elif PLATFORM_ASTERIX
-  ok &= prv_write_register(PmicRegisters_ADC_ADCNTCRSEL, PmicRegisters_ADC_ADCNTCRSEL__ADCNTCRSEL_10K);
-
-  ok &= prv_write_register(PmicRegisters_BCHARGER_BCHGVTERM, PmicRegisters_BCHARGER_BCHGVTERM__BCHGVTERMNORM_4V20);
-  ok &= prv_write_register(PmicRegisters_BCHARGER_BCHGVTERMR, PmicRegisters_BCHARGER_BCHGVTERMR__BCHGVTERMREDUCED_4V00);
-#endif
-
+  // TODO:
   // FIXME: this needs to be configurable at board level
 #if PLATFORM_OBELIX
   //3.3V @ LDO2

--- a/src/fw/drivers/pmic/npm1300.c
+++ b/src/fw/drivers/pmic/npm1300.c
@@ -270,46 +270,78 @@ bool pmic_init(void) {
 
   s_debounce_charger_timer = new_timer_create();
 
-  // TODO(NPM1300): This needs to be configurable at board level
-#if PLATFORM_ASTERIX
-  // Anomaly 27: set BUCK1/BUCK2 to SW control with workaround
-  ok &= prv_buck_set_sw_ctrl(PmicRegisters_BUCK_BUCK1NORMVOUT,
-                              PmicRegisters_BUCK_BUCK1VOUTSTATUS,
-                              PmicRegisters_BUCK_BUCKSWCTRLSEL__BUCK1SWCTRLSEL_SWCTRL,
-                              8 /* 1.8V */);
-  ok &= prv_buck_set_sw_ctrl(PmicRegisters_BUCK_BUCK2NORMVOUT,
-                              PmicRegisters_BUCK_BUCK2VOUTSTATUS,
-                              PmicRegisters_BUCK_BUCKSWCTRLSEL__BUCK2SWCTRLSEL_SWCTRL,
-                              20 /* 3.0V */);
-  
-  if (!prv_read_register(PmicRegisters_LDSW_LDSWSTATUS, &val)) {
-    PBL_LOG_ERR("failed to read LDSWSTATUS");
-    return false;
+  prv_read_register(PmicRegisters_BUCK_BUCK1NORMVOUT, &val);
+  PBL_LOG_DBG("found the nPM1300, BUCK1NORMVOUT = 0x%x", val);
+
+  if (NPM1300_CONFIG.apply_erratum_27_workaround) {
+    if ((NPM1300_CONFIG.buck_sw_ctrl_sel &
+         PmicRegisters_BUCK_BUCKSWCTRLSEL__BUCK1SWCTRLSEL_SWCTRL) != 0 &&
+        NPM1300_CONFIG.buck1_voltage_sel != 0) {
+      ok &= prv_buck_set_sw_ctrl(PmicRegisters_BUCK_BUCK1NORMVOUT,
+                                 PmicRegisters_BUCK_BUCK1VOUTSTATUS,
+                                 PmicRegisters_BUCK_BUCKSWCTRLSEL__BUCK1SWCTRLSEL_SWCTRL,
+                                 NPM1300_CONFIG.buck1_voltage_sel);
+    }
+
+    if ((NPM1300_CONFIG.buck_sw_ctrl_sel &
+         PmicRegisters_BUCK_BUCKSWCTRLSEL__BUCK2SWCTRLSEL_SWCTRL) != 0 &&
+        NPM1300_CONFIG.buck2_voltage_sel != 0) {
+      ok &= prv_buck_set_sw_ctrl(PmicRegisters_BUCK_BUCK2NORMVOUT,
+                                 PmicRegisters_BUCK_BUCK2VOUTSTATUS,
+                                 PmicRegisters_BUCK_BUCKSWCTRLSEL__BUCK2SWCTRLSEL_SWCTRL,
+                                 NPM1300_CONFIG.buck2_voltage_sel);
+    }
   }
 
-  if ((val & PmicRegisters_LDSW_LDSWSTATUS__LDSW2PWRUPLDO) == 0U) {
-    ok &= prv_write_register(PmicRegisters_LDSW_TASKLDSW2CLR, 0x01);
-    ok &= prv_write_register(PmicRegisters_LDSW_LDSW2VOUTSEL, 8 /* 1.8V */);
-    ok &= prv_write_register(PmicRegisters_LDSW_LDSW2LDOSEL, 1 /* LDO */);
-    ok &= prv_write_register(PmicRegisters_LDSW_TASKLDSW2SET, 0x01);
+  // Configure Bucks
+  if (NPM1300_CONFIG.buck1_voltage_sel != 0) {
+    ok &= prv_write_register(PmicRegisters_BUCK_BUCK1NORMVOUT, NPM1300_CONFIG.buck1_voltage_sel);
+  }
+
+  if (!NPM1300_CONFIG.buck1_enable) {
+    // Disable if not enabled (matching original Obelix behavior)
+    ok &= prv_write_register(PmicRegisters_BUCK_BUCK1ENACLR, 1);
+  }
+
+  if (NPM1300_CONFIG.buck2_voltage_sel != 0 && NPM1300_CONFIG.buck2_enable) {
+    ok &= prv_write_register(PmicRegisters_BUCK_BUCK2NORMVOUT, NPM1300_CONFIG.buck2_voltage_sel);
+  }
+
+  if (NPM1300_CONFIG.configure_buck_sw_ctrl) {
+    ok &= prv_write_register(PmicRegisters_BUCK_BUCKSWCTRLSEL, NPM1300_CONFIG.buck_sw_ctrl_sel);
+  }
+
+  // Configure LDSW1
+  if (NPM1300_CONFIG.ldsw1_enable) {
+    ok &= prv_write_register(PmicRegisters_LDSW_LDSW1LDOSEL, NPM1300_CONFIG.ldsw1_mode);
+    ok &= prv_write_register(PmicRegisters_LDSW_LDSW1VOUTSEL, NPM1300_CONFIG.ldsw1_voltage_sel);
+    ok &= prv_write_register(PmicRegisters_LDSW_TASKLDSW1SET, 1);
   } else {
-    ok &= prv_write_register(PmicRegisters_LDSW_LDSW2VOUTSEL, 8 /* 1.8V */);
+    ok &= prv_write_register(PmicRegisters_LDSW_TASKLDSW1CLR, 1);
   }
-#endif
 
-// FIXME(OBELIX,GETAFIX): Needs to be configurable at board level
-#if PLATFORM_OBELIX || PLATFORM_GETAFIX
-  // Anomaly 27: set BUCK1 to SW control with workaround, then disable it
-  ok &= prv_buck_set_sw_ctrl(PmicRegisters_BUCK_BUCK1NORMVOUT,
-                              PmicRegisters_BUCK_BUCK1VOUTSTATUS,
-                              PmicRegisters_BUCK_BUCKSWCTRLSEL__BUCK1SWCTRLSEL_SWCTRL,
-                              8 /* 1.8V */);
-  ok &= prv_write_register(PmicRegisters_BUCK_BUCK1ENACLR, 1);
-  //enable 1.8V@LDO1
-  ok &= prv_write_register(PmicRegisters_LDSW_LDSW1LDOSEL, 1);  //LDO
-  ok &= prv_write_register(PmicRegisters_LDSW_LDSW1VOUTSEL, 8);  //1.8V
-  ok &= prv_write_register(PmicRegisters_LDSW_TASKLDSW1SET, 1); //enable
-#endif
+  // Configure LDSW2
+  if (NPM1300_CONFIG.ldsw2_enable) {
+    // Asterix logic checks if already powered up to avoid glitching/resetting if already on
+    uint8_t status = 0;
+    prv_read_register(PmicRegisters_LDSW_LDSWSTATUS, &status);
+    if ((status & PmicRegisters_LDSW_LDSWSTATUS__LDSW2PWRUPLDO) == 0) {
+      // Not powered up, perform full setup
+      ok &= prv_write_register(PmicRegisters_LDSW_TASKLDSW2CLR, 1);
+      ok &= prv_write_register(PmicRegisters_LDSW_LDSW2LDOSEL, NPM1300_CONFIG.ldsw2_mode);
+      ok &= prv_write_register(PmicRegisters_LDSW_LDSW2VOUTSEL, NPM1300_CONFIG.ldsw2_voltage_sel);
+      ok &= prv_write_register(PmicRegisters_LDSW_TASKLDSW2SET, 1);
+    } else {
+      // Already powered up, just update voltage
+      ok &= prv_write_register(PmicRegisters_LDSW_LDSW2VOUTSEL, NPM1300_CONFIG.ldsw2_voltage_sel);
+    }
+  } else {
+    ok &= prv_write_register(PmicRegisters_LDSW_LDSW2LDOSEL, NPM1300_CONFIG.ldsw2_mode);
+    if (NPM1300_CONFIG.ldsw2_voltage_sel != 0) {
+      ok &= prv_write_register(PmicRegisters_LDSW_LDSW2VOUTSEL, NPM1300_CONFIG.ldsw2_voltage_sel);
+    }
+    ok &= prv_write_register(PmicRegisters_LDSW_TASKLDSW2CLR, 1);
+  }
 
   ok &= prv_write_register(PmicRegisters_MAIN_EVENTSBCHARGER1CLR, PmicRegisters_MAIN_EVENTSBCHARGER1__EVENTCHGCOMPLETED);
   ok &= prv_write_register(PmicRegisters_MAIN_INTENEVENTSBCHARGER1SET, PmicRegisters_MAIN_EVENTSBCHARGER1__EVENTCHGCOMPLETED);
@@ -339,20 +371,8 @@ bool pmic_init(void) {
   ok &= prv_write_register(PmicRegisters_ADC_ADCNTCRSEL, PmicRegisters_ADC_ADCNTCRSEL__ADCNTCRSEL_10K);
 
   ok &= prv_write_register(PmicRegisters_BCHARGER_BCHGVTERM, NPM1300_CONFIG.vterm_setting);
-  ok &= prv_write_register(PmicRegisters_BCHARGER_BCHGVTERMR, PmicRegisters_BCHARGER_BCHGVTERMR__BCHGVTERMREDUCED_4V00);
-
-  // TODO:
-  // FIXME: this needs to be configurable at board level
-#if PLATFORM_OBELIX
-  //3.3V @ LDO2
-  ok &= prv_write_register(PmicRegisters_LDSW_LDSW2LDOSEL, PmicRegisters_LDSW_LDSW2LDOSEL__LDO_MODE);
-  ok &= prv_write_register(PmicRegisters_LDSW_LDSW2VOUTSEL, PmicRegisters_LDSW_LDSW2VOUTSEL__3V3);
-  ok &= prv_write_register(PmicRegisters_LDSW_TASKLDSW2CLR, 1);
-#elif PLATFORM_GETAFIX
-  // LDSW2 (3.3V for PDM)
-  ok &= prv_write_register(PmicRegisters_LDSW_LDSW2LDOSEL, PmicRegisters_LDSW_LDSW2LDOSEL__LDSW_MODE);
-  ok &= prv_write_register(PmicRegisters_LDSW_TASKLDSW2CLR, 1);
-#endif
+  ok &= prv_write_register(PmicRegisters_BCHARGER_BCHGVTERMR,
+                           PmicRegisters_BCHARGER_BCHGVTERMR__BCHGVTERMREDUCED_4V00);
 
   val = (uint8_t)(NPM1300_CONFIG.chg_current_ma / 4U);
   ok &= prv_write_register(PmicRegisters_BCHARGER_BCHGISETMSB, val);

--- a/src/fw/drivers/pmic/npm1300.c
+++ b/src/fw/drivers/pmic/npm1300.c
@@ -274,27 +274,25 @@ bool pmic_init(void) {
   PBL_LOG_DBG("found the nPM1300, BUCK1NORMVOUT = 0x%x", val);
 
   if (NPM1300_CONFIG.apply_erratum_27_workaround) {
-    if ((NPM1300_CONFIG.buck_sw_ctrl_sel &
-         PmicRegisters_BUCK_BUCKSWCTRLSEL__BUCK1SWCTRLSEL_SWCTRL) != 0 &&
-        NPM1300_CONFIG.buck1_voltage_sel != 0) {
+    if ((NPM1300_CONFIG.buck_sw_ctrl_sel & NPM1300_BUCK_SW_CTRL_SEL_BUCK1) != 0 &&
+        NPM1300_CONFIG.buck1_voltage_sel != NPM1300_VOLTAGE_SEL_DISABLED) {
       ok &= prv_buck_set_sw_ctrl(PmicRegisters_BUCK_BUCK1NORMVOUT,
                                  PmicRegisters_BUCK_BUCK1VOUTSTATUS,
-                                 PmicRegisters_BUCK_BUCKSWCTRLSEL__BUCK1SWCTRLSEL_SWCTRL,
+                                 NPM1300_BUCK_SW_CTRL_SEL_BUCK1,
                                  NPM1300_CONFIG.buck1_voltage_sel);
     }
 
-    if ((NPM1300_CONFIG.buck_sw_ctrl_sel &
-         PmicRegisters_BUCK_BUCKSWCTRLSEL__BUCK2SWCTRLSEL_SWCTRL) != 0 &&
-        NPM1300_CONFIG.buck2_voltage_sel != 0) {
+    if ((NPM1300_CONFIG.buck_sw_ctrl_sel & NPM1300_BUCK_SW_CTRL_SEL_BUCK2) != 0 &&
+        NPM1300_CONFIG.buck2_voltage_sel != NPM1300_VOLTAGE_SEL_DISABLED) {
       ok &= prv_buck_set_sw_ctrl(PmicRegisters_BUCK_BUCK2NORMVOUT,
                                  PmicRegisters_BUCK_BUCK2VOUTSTATUS,
-                                 PmicRegisters_BUCK_BUCKSWCTRLSEL__BUCK2SWCTRLSEL_SWCTRL,
+                                 NPM1300_BUCK_SW_CTRL_SEL_BUCK2,
                                  NPM1300_CONFIG.buck2_voltage_sel);
     }
   }
 
   // Configure Bucks
-  if (NPM1300_CONFIG.buck1_voltage_sel != 0) {
+  if (NPM1300_CONFIG.buck1_voltage_sel != NPM1300_VOLTAGE_SEL_DISABLED) {
     ok &= prv_write_register(PmicRegisters_BUCK_BUCK1NORMVOUT, NPM1300_CONFIG.buck1_voltage_sel);
   }
 
@@ -303,7 +301,8 @@ bool pmic_init(void) {
     ok &= prv_write_register(PmicRegisters_BUCK_BUCK1ENACLR, 1);
   }
 
-  if (NPM1300_CONFIG.buck2_voltage_sel != 0 && NPM1300_CONFIG.buck2_enable) {
+  if (NPM1300_CONFIG.buck2_voltage_sel != NPM1300_VOLTAGE_SEL_DISABLED &&
+      NPM1300_CONFIG.buck2_enable) {
     ok &= prv_write_register(PmicRegisters_BUCK_BUCK2NORMVOUT, NPM1300_CONFIG.buck2_voltage_sel);
   }
 
@@ -324,7 +323,10 @@ bool pmic_init(void) {
   if (NPM1300_CONFIG.ldsw2_enable) {
     // Asterix logic checks if already powered up to avoid glitching/resetting if already on
     uint8_t status = 0;
-    prv_read_register(PmicRegisters_LDSW_LDSWSTATUS, &status);
+    if (!prv_read_register(PmicRegisters_LDSW_LDSWSTATUS, &status)) {
+      PBL_LOG_ERR("failed to read LDSWSTATUS");
+      return false;
+    }
     if ((status & PmicRegisters_LDSW_LDSWSTATUS__LDSW2PWRUPLDO) == 0) {
       // Not powered up, perform full setup
       ok &= prv_write_register(PmicRegisters_LDSW_TASKLDSW2CLR, 1);
@@ -337,7 +339,7 @@ bool pmic_init(void) {
     }
   } else {
     ok &= prv_write_register(PmicRegisters_LDSW_LDSW2LDOSEL, NPM1300_CONFIG.ldsw2_mode);
-    if (NPM1300_CONFIG.ldsw2_voltage_sel != 0) {
+    if (NPM1300_CONFIG.ldsw2_voltage_sel != NPM1300_VOLTAGE_SEL_DISABLED) {
       ok &= prv_write_register(PmicRegisters_LDSW_LDSW2VOUTSEL, NPM1300_CONFIG.ldsw2_voltage_sel);
     }
     ok &= prv_write_register(PmicRegisters_LDSW_TASKLDSW2CLR, 1);
@@ -386,10 +388,10 @@ bool pmic_init(void) {
       NPM1300_CONFIG.vbus_current_startup/NPM1300_VBUS_CURRENT_DIVISOR);
   }
 
-  if (NPM1300_CONFIG.term_current_pct == 10U) {
+  if (NPM1300_CONFIG.term_current_pct == NPM1300_TERM_CURRENT_10_PERCENT) {
     ok &= prv_write_register(PmicRegisters_BCHARGER_BCHGITERMSEL,
                              PmicRegisters_BCHARGER_BCHGITERMSEL__SEL10);
-  } else if(NPM1300_CONFIG.term_current_pct == 20U) {
+  } else if (NPM1300_CONFIG.term_current_pct == NPM1300_TERM_CURRENT_20_PERCENT) {
     ok &= prv_write_register(PmicRegisters_BCHARGER_BCHGITERMSEL,
                              PmicRegisters_BCHARGER_BCHGITERMSEL__SEL20);
   } else {

--- a/src/fw/drivers/pmic/npm1300.h
+++ b/src/fw/drivers/pmic/npm1300.h
@@ -36,6 +36,37 @@ typedef struct {
   uint16_t vbus_current_lim0;
   //! Vbus current limite startup
   uint16_t vbus_current_startup;
+
+  //! Buck1 voltage (0 = disabled)
+  uint8_t buck1_voltage_sel;
+  //! Buck2 voltage (0 = disabled)
+  uint8_t buck2_voltage_sel;
+  //! Buck SW control selection
+  uint8_t buck_sw_ctrl_sel;
+  //! Configure Buck SW control (even if 0)
+  bool configure_buck_sw_ctrl;
+  //! Enable Buck1
+  bool buck1_enable;
+  //! Enable Buck2
+  bool buck2_enable;
+
+  //! Apply Erratum 27 workaround
+  //: I assume this is a specific sequence on startup
+  bool apply_erratum_27_workaround;
+
+  //! LDSW1 mode (LDO or Load Switch)
+  Npm1300Ldo2Mode_t ldsw1_mode;
+  //! LDSW1 voltage selection
+  uint8_t ldsw1_voltage_sel;
+  //! Enable LDSW1
+  bool ldsw1_enable;
+
+  //! LDSW2 mode (LDO or Load Switch)
+  Npm1300Ldo2Mode_t ldsw2_mode;
+  //! LDSW2 voltage selection
+  uint8_t ldsw2_voltage_sel;
+  //! Enable LDSW2
+  bool ldsw2_enable;
 } Npm1300Config;
 
 typedef enum {

--- a/src/fw/drivers/pmic/npm1300.h
+++ b/src/fw/drivers/pmic/npm1300.h
@@ -3,8 +3,27 @@
 
 #pragma once
 
+//! Vterm setting
+typedef enum {
+  NPM1300_VTERM_4V00 = 0x4U,
+  NPM1300_VTERM_4V20 = 0x8U,
+  NPM1300_VTERM_4V35 = 0xBU,
+  NPM1300_VTERM_4V45 = 0xDU,
+} Npm1300Vterm_t;
+
+//! LDO2 mode
+typedef enum {
+  NPM1300_LDO2_MODE_LDSW = 0,
+  NPM1300_LDO2_MODE_LDO = 1,
+} Npm1300Ldo2Mode_t;
+
+
 //! nPM1300 configuration
 typedef struct {
+  
+  //! Vterm setting
+  Npm1300Vterm_t vterm_setting;
+
   //! Charge current (32-800mA, 2mA steps)
   uint16_t chg_current_ma;
   //! Discharge limit (200mA or 1000mA)

--- a/src/fw/drivers/pmic/npm1300.h
+++ b/src/fw/drivers/pmic/npm1300.h
@@ -17,6 +17,29 @@ typedef enum {
   NPM1300_LDO2_MODE_LDO = 1,
 } Npm1300Ldo2Mode_t;
 
+//! Termination current as a percentage of charge current
+typedef enum {
+  NPM1300_TERM_CURRENT_10_PERCENT = 10U,
+  NPM1300_TERM_CURRENT_20_PERCENT = 20U,
+} Npm1300TermCurrentPct_t;
+
+//! Voltage selector values used by current board configurations
+typedef enum {
+  NPM1300_VOLTAGE_SEL_DISABLED = 0U,
+  NPM1300_VOLTAGE_SEL_1V8 = 8U,
+  NPM1300_VOLTAGE_SEL_3V0 = 20U,
+  NPM1300_VOLTAGE_SEL_3V3 = 23U,
+} Npm1300VoltageSel_t;
+
+//! Buck software-control selector bits
+typedef enum {
+  NPM1300_BUCK_SW_CTRL_SEL_NONE = 0U,
+  NPM1300_BUCK_SW_CTRL_SEL_BUCK1 = 0x01U,
+  NPM1300_BUCK_SW_CTRL_SEL_BUCK2 = 0x02U,
+  NPM1300_BUCK_SW_CTRL_SEL_BUCK1_BUCK2 =
+      NPM1300_BUCK_SW_CTRL_SEL_BUCK1 | NPM1300_BUCK_SW_CTRL_SEL_BUCK2,
+} Npm1300BuckSwCtrlSel_t;
+
 
 //! nPM1300 configuration
 typedef struct {


### PR DESCRIPTION

Issue #233

### Why

The npm1300 driver used hardcoded `#if PLATFORM_XXX`. Several `TODO` and `FIXME` comments in the code already acknowledged this needed to be cleaned up. Adding a new board meant editing the driver itself, which is fragile and hard to review.

### What

All platform-specific PMIC configuration is moved into new fields in `Npm1300Config` (voltages, enable flags, modes, SW control, erratum workaround). Each board file (`board_asterix.c`, `board_obelix.c`, `board_getafix.c`) now declares its own complete power rail config, and the driver in `npm1300.c` applies it generically without any `#if PLATFORM_*`.

### Note
The patch compiles cleanly but has not been tested on hardware. 
Also note that some magic values remain in this part of the codebase