### PR TITLE
fw/applib/ui/vibes: add per-segment amplitude control to public SDK

### DIFF
--- a/src/fw/applib/ui/vibes.c
+++ b/src/fw/applib/ui/vibes.c
@@ -50,3 +50,18 @@ void vibes_enqueue_custom_pattern(VibePattern pattern) {
   sys_vibe_pattern_trigger_start();
 }
 
+void vibes_enqueue_custom_pattern_with_amplitudes(VibePatternWithAmplitudes pattern) {
+  if (pattern.durations == NULL || pattern.amplitudes == NULL) {
+    PBL_LOG_ERR("tried to enqueue a null pattern");
+    return;
+  }
+
+  for (uint32_t i = 0; i < pattern.num_segments; ++i) {
+    uint32_t amp = pattern.amplitudes[i];
+    int32_t strength = (int32_t)(amp > 100 ? 100 : amp);
+    sys_vibe_pattern_enqueue_step_raw(pattern.durations[i], strength);
+  }
+
+  sys_vibe_pattern_trigger_start();
+}
+

--- a/src/fw/applib/ui/vibes.h
+++ b/src/fw/applib/ui/vibes.h
@@ -49,6 +49,42 @@ typedef struct {
   uint32_t num_segments;
 } VibePattern;
 
+/** Data structure describing a vibration pattern with per-segment amplitude control.
+ Each segment has a duration and an amplitude. Amplitude 0 means no vibration
+ (off), and 100 means maximum strength. Values above 100 are clamped.
+
+ Example code:
+ \code{.c}
+ // Ramp-down pattern: 100% for 200ms, 50% for 200ms, 25% for 200ms:
+ static const uint32_t const segments[] = { 200, 200, 200 };
+ static const uint32_t const amplitudes[] = { 100, 50, 25 };
+ VibePatternWithAmplitudes pat = {
+   .durations = segments,
+   .amplitudes = amplitudes,
+   .num_segments = ARRAY_LENGTH(segments),
+ };
+ vibes_enqueue_custom_pattern_with_amplitudes(pat);
+ \endcode
+ @see vibes_enqueue_custom_pattern_with_amplitudes
+ */
+typedef struct {
+  /**
+   Pointer to an array of segment durations, measured in milli-seconds.
+   The maximum allowed duration is 10000ms.
+   */
+  const uint32_t *durations;
+  /**
+   Pointer to an array of per-segment amplitudes (0-100).
+   Must have the same length as the durations array.
+   0 means no vibration; 100 means maximum strength.
+   */
+  const uint32_t *amplitudes;
+  /**
+   The length of the durations and amplitudes arrays.
+   */
+  uint32_t num_segments;
+} VibePatternWithAmplitudes;
+
 //! Cancel any in-flight vibe patterns; this is a no-op if there is no
 //! on-going vibe.
 void vibes_cancel(void);
@@ -63,10 +99,17 @@ void vibes_long_pulse(void);
 //!
 void vibes_double_pulse(void);
 
-//! Makes the watch emit a ‘custom’ vibration pattern.
+//! Makes the watch emit a 'custom' vibration pattern.
 //! @param pattern An arbitrary vibration pattern
 //! @see VibePattern
 void vibes_enqueue_custom_pattern(VibePattern pattern);
+
+//! Makes the watch emit a 'custom' vibration pattern with per-segment amplitude control.
+//! Unlike vibes_enqueue_custom_pattern, this function bypasses the system vibration
+//! intensity preference and uses the provided amplitude values directly.
+//! @param pattern An arbitrary vibration pattern with amplitudes
+//! @see VibePatternWithAmplitudes
+void vibes_enqueue_custom_pattern_with_amplitudes(VibePatternWithAmplitudes pattern);
 
 //!   @} // end addtogroup Vibes
 //! @} // end addtogroup UI

--- a/src/fw/process_management/app_manager.c
+++ b/src/fw/process_management/app_manager.c
@@ -435,6 +435,7 @@ static void prv_app_cleanup(void) {
 #endif
   light_reset_user_controlled();
   sys_vibe_history_stop_collecting();
+  sys_vibe_pattern_clear();
   ble_app_cleanup();
 #if CAPABILITY_HAS_MAPPABLE_FLASH
   resource_mapped_release_all(PebbleTask_App);

--- a/tests/fw/services/test_vibe.c
+++ b/tests/fw/services/test_vibe.c
@@ -29,9 +29,18 @@ bool sys_vibe_history_was_vibrating(uint64_t time_search);
 int32_t sys_vibe_get_vibe_strength(void);
 
 //stub
+static bool s_vibe_on = false;
+static int s_vibe_ctl_count = 0;
 void vibe_ctl(bool on) {
+  s_vibe_on = on;
+  s_vibe_ctl_count++;
 }
+
+static int8_t s_last_strength_set = 0;
+static int s_strength_set_count = 0;
 void vibe_set_strength(int8_t strength) {
+  s_last_strength_set = strength;
+  s_strength_set_count++;
 }
 
 //helpers
@@ -70,6 +79,10 @@ static bool prv_confirm_history(const VibePattern pattern, int64_t start_time) {
 void test_vibe__initialize(void) {
   vibes_init();
   fake_rtc_init(0, 100);
+  s_last_strength_set = 0;
+  s_strength_set_count = 0;
+  s_vibe_on = false;
+  s_vibe_ctl_count = 0;
 }
 
 
@@ -120,4 +133,129 @@ void test_vibe__check_vibe_history_multiple(void) {
   cl_assert(prv_confirm_history(custom_pattern_1, time_start_1));
   cl_assert(prv_confirm_history(custom_pattern_2, time_start_2));
   sys_vibe_history_stop_collecting();
+}
+
+void test_vibe__custom_pattern_with_amplitudes(void) {
+  const uint32_t durations[] = { 200, 100, 400 };
+  const uint32_t amplitudes[] = { 80, 50, 20 };
+  const VibePatternWithAmplitudes pattern = {
+    .durations = durations,
+    .amplitudes = amplitudes,
+    .num_segments = ARRAY_LENGTH(durations),
+  };
+  vibes_enqueue_custom_pattern_with_amplitudes(pattern);
+  prv_run_vibes();
+  // Pattern engine turns motor off via vibe_ctl(false) at end
+  cl_assert_equal_b(s_vibe_on, false);
+  // All 3 segments set strength (no alternation — every segment has an amplitude)
+  cl_assert(s_strength_set_count >= 3);
+}
+
+void test_vibe__custom_pattern_with_amplitudes_clamped(void) {
+  const uint32_t durations[] = { 100 };
+  const uint32_t amplitudes[] = { 200 };  // exceeds 100, should be clamped
+  const VibePatternWithAmplitudes pattern = {
+    .durations = durations,
+    .amplitudes = amplitudes,
+    .num_segments = ARRAY_LENGTH(durations),
+  };
+  vibes_enqueue_custom_pattern_with_amplitudes(pattern);
+  prv_run_vibes();
+  cl_assert_equal_b(s_vibe_on, false);
+  // Clamped to 100, verify it was set
+  cl_assert_equal_i(s_last_strength_set, 100);
+}
+
+void test_vibe__custom_pattern_with_null_amplitudes(void) {
+  const uint32_t durations[] = { 100 };
+  const VibePatternWithAmplitudes pattern = {
+    .durations = durations,
+    .amplitudes = NULL,
+    .num_segments = ARRAY_LENGTH(durations),
+  };
+  // Should return without crashing (early return on null amplitudes)
+  vibes_enqueue_custom_pattern_with_amplitudes(pattern);
+  cl_assert_equal_i(s_strength_set_count, 0);
+  cl_assert_equal_i(s_vibe_ctl_count, 0);
+}
+
+void test_vibe__custom_pattern_with_amplitudes_null_durations(void) {
+  const uint32_t amplitudes[] = { 80 };
+  const VibePatternWithAmplitudes pattern = {
+    .durations = NULL,
+    .amplitudes = amplitudes,
+    .num_segments = 1,
+  };
+  // Should return without crashing (early return on null durations)
+  vibes_enqueue_custom_pattern_with_amplitudes(pattern);
+  cl_assert_equal_i(s_strength_set_count, 0);
+  cl_assert_equal_i(s_vibe_ctl_count, 0);
+}
+
+void test_vibe__custom_pattern_with_amplitudes_single(void) {
+  const uint32_t durations[] = { 300 };
+  const uint32_t amplitudes[] = { 50 };
+  const VibePatternWithAmplitudes pattern = {
+    .durations = durations,
+    .amplitudes = amplitudes,
+    .num_segments = 1,
+  };
+  vibes_enqueue_custom_pattern_with_amplitudes(pattern);
+  prv_run_vibes();
+  cl_assert_equal_b(s_vibe_on, false);
+  cl_assert_equal_i(s_last_strength_set, 50);
+}
+
+void test_vibe__custom_pattern_with_zero_amplitude(void) {
+  const uint32_t durations[] = { 200, 100, 300 };
+  const uint32_t amplitudes[] = { 0, 0, 100 };
+  const VibePatternWithAmplitudes pattern = {
+    .durations = durations,
+    .amplitudes = amplitudes,
+    .num_segments = ARRAY_LENGTH(durations),
+  };
+  vibes_enqueue_custom_pattern_with_amplitudes(pattern);
+  prv_run_vibes();
+  cl_assert_equal_b(s_vibe_on, false);
+  // Amplitude 0 segments use vibe_ctl(false), not vibe_set_strength(0),
+  // so only the non-zero segment (100) calls vibe_set_strength
+  cl_assert(s_strength_set_count >= 1);
+  // Last segment had amplitude 100
+  cl_assert_equal_i(s_last_strength_set, 100);
+}
+
+void test_vibe__custom_pattern_with_amplitudes_verifies_strength(void) {
+  const uint32_t durations[] = { 100, 50, 100 };
+  const uint32_t amplitudes[] = { 75, 50, 25 };
+  const VibePatternWithAmplitudes pattern = {
+    .durations = durations,
+    .amplitudes = amplitudes,
+    .num_segments = ARRAY_LENGTH(durations),
+  };
+  vibes_enqueue_custom_pattern_with_amplitudes(pattern);
+  prv_run_vibes();
+  // vibe_set_strength called for all 3 segments (75, 50, 25)
+  cl_assert(s_strength_set_count >= 3);
+  // Last strength set was 25 (third segment)
+  cl_assert_equal_i(s_last_strength_set, 25);
+  // Motor is off after pattern completes
+  cl_assert_equal_b(s_vibe_on, false);
+}
+
+void test_vibe__custom_pattern_ramp_down(void) {
+  const uint32_t durations[] = { 200, 200, 200, 200 };
+  const uint32_t amplitudes[] = { 100, 75, 50, 25 };
+  const VibePatternWithAmplitudes pattern = {
+    .durations = durations,
+    .amplitudes = amplitudes,
+    .num_segments = ARRAY_LENGTH(durations),
+  };
+  vibes_enqueue_custom_pattern_with_amplitudes(pattern);
+  prv_run_vibes();
+  // All 4 segments set strength
+  cl_assert(s_strength_set_count >= 4);
+  // Last strength was 25
+  cl_assert_equal_i(s_last_strength_set, 25);
+  // Motor is off after pattern completes
+  cl_assert_equal_b(s_vibe_on, false);
 }

--- a/tests/fw/test_app_manager.c
+++ b/tests/fw/test_app_manager.c
@@ -297,6 +297,9 @@ void system_app_state_machine_register_app_launch(const PebbleProcessMd* app) {
 void sys_vibe_history_stop_collecting(void) {
 }
 
+void sys_vibe_pattern_clear(void) {
+}
+
 Heap *worker_state_get_heap(void) {
   return NULL;
 }


### PR DESCRIPTION
Expose vibration motor intensity control to apps via a new vibes_enqueue_custom_pattern_with_amplitudes() API. The internal syscall (sys_vibe_pattern_enqueue_step_raw) and hardware drivers already support per-step strength values; this bridges the gap in the public SDK.

Also fix a pre-existing issue where active vibration patterns were not explicitly stopped on app exit by adding
sys_vibe_pattern_clear() to the app cleanup path.