### PR TITLE
fw/applib/pbl_std: fix strftime return type to match C standard

### DIFF
--- a/src/fw/applib/pbl_std/pbl_std.c
+++ b/src/fw/applib/pbl_std/pbl_std.c
@@ -155,12 +155,12 @@ struct tm *pbl_override_localtime(const time_t *timep) {
 }
 
 
-int pbl_strftime(char* s, size_t maxsize, const char* format, const struct tm* tim_p) {
+size_t pbl_strftime(char* s, size_t maxsize, const char* format, const struct tm* tim_p) {
   char *locale = app_state_get_locale_info()->app_locale_time;
   return sys_strftime(s, maxsize, format, tim_p, locale);
 }
 
-DEFINE_SYSCALL(int, sys_strftime, char* s, size_t maxsize, const char* format,
+DEFINE_SYSCALL(size_t, sys_strftime, char* s, size_t maxsize, const char* format,
                                   const struct tm* tim_p, char *locale) {
 
   if (PRIVILEGE_WAS_ELEVATED) {

--- a/src/fw/applib/pbl_std/pbl_std.h
+++ b/src/fw/applib/pbl_std/pbl_std.h
@@ -80,7 +80,7 @@ uint16_t pbl_override_time_ms_legacy(time_t *t_loc, uint16_t *out_ms);
 //! @param tm_p A pointer to a struct tm containing a broken out time value
 //! @return The number of bytes placed in the array s, not including the null byte,
 //!   0 if the value does not fit.
-int pbl_strftime(char* s, size_t maxsize, const char* format, const struct tm* tm_p);
+size_t pbl_strftime(char* s, size_t maxsize, const char* format, const struct tm* tm_p);
 
 //! Returns the current UTC time in Unix Timestamp Format with Milliseconds
 //!     @param t_utc if provided receives current UTC Unix Time seconds portion

--- a/src/fw/syscall/syscall.h
+++ b/src/fw/syscall/syscall.h
@@ -176,7 +176,7 @@ void sys_data_logging_finish(DataLoggingSessionRef logging_session);
 DataLoggingResult sys_data_logging_log(DataLoggingSessionRef logging_session, const void *data, uint32_t num_items);
 
 bool sys_clock_is_24h_style(void);
-int sys_strftime(char* s, size_t maxsize, const char* format, const struct tm* tim_p, char *locale);
+size_t sys_strftime(char* s, size_t maxsize, const char* format, const struct tm* tim_p, char *locale);
 
 BatteryChargeState sys_battery_get_charge_state(void);
 

--- a/tests/fw/applib/test_pbl_std.c
+++ b/tests/fw/applib/test_pbl_std.c
@@ -33,7 +33,7 @@ time_t sys_time_utc_to_local(time_t t) {
   return t;
 }
 
-int localized_strftime(char* s, size_t maxsize, const char* format,
+size_t localized_strftime(char* s, size_t maxsize, const char* format,
     const struct tm* tim_p, char *locale) { return 0; }
 
 const char *get_timezone_abbr(void) {


### PR DESCRIPTION
Change pbl_strftime, sys_strftime, and test stub return types from int to size_t to match the C standard strftime signature and the existing localized_strftime implementation. Fixes
-Wbuiltin-declaration-mismatch warning in the generated SDK header.