### PR TITLE
ci: add Apache-2.0 SPDX license header check to compliance workflow

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -16,5 +16,46 @@ jobs:
       - name: Install GitLint
         run: pip install gitlint
 
-      - name: Run GitLint 
+      - name: Run GitLint
         run: gitlint --commits "${{ github.event.pull_request.base.sha }}..HEAD"
+
+  license:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Check SPDX license headers
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          errors=0
+
+          # collect submodule paths to skip
+          submodules=$(git config --file .gitmodules --get-regexp '\.path$' \
+            | awk '{print $2}')
+
+          for file in $(git diff --name-only --diff-filter=d "$base"...HEAD -- \
+            '*.c' '*.h' '*.S' '*.py' '*.sh'); do
+            # skip files inside git submodules
+            skip=false
+            for sm in $submodules; do
+              case "$file" in "$sm"/*) skip=true; break ;; esac
+            done
+            if $skip; then continue; fi
+
+            if ! head -10 "$file" | grep -q "SPDX-License-Identifier: Apache-2.0"; then
+              echo "::error file=$file::Missing 'SPDX-License-Identifier: Apache-2.0' header"
+              errors=$((errors + 1))
+            fi
+          done
+
+          if [ "$errors" -ne 0 ]; then
+            echo ""
+            echo "$errors file(s) missing Apache-2.0 SPDX license header."
+            echo "Expected within the first 10 lines:"
+            echo "  /* SPDX-License-Identifier: Apache-2.0 */"
+            exit 1
+          fi


### PR DESCRIPTION
Verifies that source files (.c, .h, .S, .py, .sh) changed in a PR contain an SPDX-License-Identifier: Apache-2.0 header. Files inside git submodules are excluded, but glue code in third_party/ is checked.