### PR TITLE
ci: fix build workflows stalling when no paths match

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -5,20 +5,35 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    paths:
-      - '.github/workflows/build-firmware.yml'
-      - 'resources/**'
-      - 'sdk/**'
-      - 'src/**'
-      - 'stored_apps/**'
-      - 'tools/**'
-      - 'third_party/**'
-      - 'waftools/**'
-      - 'waf'
-      - 'wscript'
 
 jobs:
+  changes:
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: read
+    outputs:
+      should-build: ${{ github.event_name == 'push' || steps.filter.outputs.src == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            src:
+              - '.github/workflows/build-firmware.yml'
+              - 'resources/**'
+              - 'sdk/**'
+              - 'src/**'
+              - 'stored_apps/**'
+              - 'tools/**'
+              - 'third_party/**'
+              - 'waftools/**'
+              - 'waf'
+              - 'wscript'
+
   build:
+    needs: changes
+    if: needs.changes.outputs.should-build == 'true'
     runs-on: ubuntu-24.04
 
     container:
@@ -95,4 +110,12 @@ jobs:
           files: |
             build/src/fw/tintin_fw_loghash_dict.json
           path-format: ${{ steps.build_id.outputs.BUILD_ID }}-${{ github.sha }}-normal.json
+
+  build-status:
+    needs: [changes, build]
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - if: needs.build.result == 'failure' || needs.build.result == 'cancelled'
+        run: exit 1
 

--- a/.github/workflows/build-prf.yml
+++ b/.github/workflows/build-prf.yml
@@ -5,18 +5,33 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    paths:
-      - '.github/workflows/build-prf.yml'
-      - 'resources/**'
-      - 'src/**'
-      - 'tools/**'
-      - 'third_party/**'
-      - 'waftools/**'
-      - 'waf'
-      - 'wscript'
 
 jobs:
+  changes:
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: read
+    outputs:
+      should-build: ${{ github.event_name == 'push' || steps.filter.outputs.src == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            src:
+              - '.github/workflows/build-prf.yml'
+              - 'resources/**'
+              - 'src/**'
+              - 'tools/**'
+              - 'third_party/**'
+              - 'waftools/**'
+              - 'waf'
+              - 'wscript'
+
   build:
+    needs: changes
+    if: needs.changes.outputs.should-build == 'true'
     runs-on: ubuntu-24.04
 
     container:
@@ -101,3 +116,11 @@ jobs:
           files: |
             build/prf/src/fw/tintin_fw_loghash_dict.json
           path-format: ${{ steps.build_id.outputs.BUILD_ID }}-${{ github.sha }}-prf.json
+
+  build-status:
+    needs: [changes, build]
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - if: needs.build.result == 'failure' || needs.build.result == 'cancelled'
+        run: exit 1

--- a/.github/workflows/build-qemu-sdkshell.yml
+++ b/.github/workflows/build-qemu-sdkshell.yml
@@ -5,20 +5,35 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    paths:
-      - '.github/workflows/build-qemu-sdkshell.yml'
-      - 'resources/**'
-      - 'sdk/**'
-      - 'src/**'
-      - 'stored_apps/**'
-      - 'tools/**'
-      - 'third_party/**'
-      - 'waftools/**'
-      - 'waf'
-      - 'wscript'
 
 jobs:
+  changes:
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: read
+    outputs:
+      should-build: ${{ github.event_name == 'push' || steps.filter.outputs.src == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            src:
+              - '.github/workflows/build-qemu-sdkshell.yml'
+              - 'resources/**'
+              - 'sdk/**'
+              - 'src/**'
+              - 'stored_apps/**'
+              - 'tools/**'
+              - 'third_party/**'
+              - 'waftools/**'
+              - 'waf'
+              - 'wscript'
+
   build:
+    needs: changes
+    if: needs.changes.outputs.should-build == 'true'
     runs-on: ubuntu-24.04
 
     container:
@@ -69,3 +84,11 @@ jobs:
           path: |
             build/qemu_micro_flash.bin
             build/qemu_spi_flash.bin
+
+  build-status:
+    needs: [changes, build]
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - if: needs.build.result == 'failure' || needs.build.result == 'cancelled'
+        run: exit 1

--- a/.github/workflows/build-qemu.yml
+++ b/.github/workflows/build-qemu.yml
@@ -5,20 +5,35 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    paths:
-      - '.github/workflows/build-qemu.yml'
-      - 'resources/**'
-      - 'sdk/**'
-      - 'src/**'
-      - 'stored_apps/**'
-      - 'tools/**'
-      - 'third_party/**'
-      - 'waftools/**'
-      - 'waf'
-      - 'wscript'
 
 jobs:
+  changes:
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: read
+    outputs:
+      should-build: ${{ github.event_name == 'push' || steps.filter.outputs.src == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            src:
+              - '.github/workflows/build-qemu.yml'
+              - 'resources/**'
+              - 'sdk/**'
+              - 'src/**'
+              - 'stored_apps/**'
+              - 'tools/**'
+              - 'third_party/**'
+              - 'waftools/**'
+              - 'waf'
+              - 'wscript'
+
   build:
+    needs: changes
+    if: needs.changes.outputs.should-build == 'true'
     runs-on: ubuntu-24.04
 
     container:
@@ -69,3 +84,11 @@ jobs:
           path: |
             build/qemu_micro_flash.bin
             build/qemu_spi_flash.bin
+
+  build-status:
+    needs: [changes, build]
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - if: needs.build.result == 'failure' || needs.build.result == 'cancelled'
+        run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,23 +5,38 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    paths:
-      - '.github/workflows/test.yml'
-      - 'resources/**'
-      - 'sdk/**'
-      - 'src/**'
-      - 'stored_apps/**'
-      - 'tools/**'
-      - 'third_party/**'
-      - 'waftools/**'
-      - 'waf'
-      - 'wscript'
 
 env:
   TEST_BOARD: 'snowy_bb2'
 
 jobs:
+  changes:
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: read
+    outputs:
+      should-test: ${{ github.event_name == 'push' || steps.filter.outputs.src == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            src:
+              - '.github/workflows/test.yml'
+              - 'resources/**'
+              - 'sdk/**'
+              - 'src/**'
+              - 'stored_apps/**'
+              - 'tools/**'
+              - 'third_party/**'
+              - 'waftools/**'
+              - 'waf'
+              - 'wscript'
+
   build:
+    needs: changes
+    if: needs.changes.outputs.should-test == 'true'
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/pebble-dev/pebbleos-docker:v1
@@ -59,3 +74,11 @@ jobs:
         with:
           name: failed_diff_images
           path: build/test/tests/failed/*-diff.png
+
+  test-status:
+    needs: [changes, build]
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - if: needs.build.result == 'failure' || needs.build.result == 'cancelled'
+        run: exit 1


### PR DESCRIPTION
When a PR doesn't change any files in the paths filter list, the workflow never triggers and no status is reported, causing PRs to stall on required checks.

Replace the trigger-level paths filter with a lightweight change detection job (dorny/paths-filter) and a status gate job that always reports a result. The build is still skipped when irrelevant files change, but the gate job ensures a status is always posted.