### PR TITLE
fw/battery_monitor: cancel standby timer when exiting critical state

### DIFF
--- a/src/fw/services/common/battery/battery_monitor.c
+++ b/src/fw/services/common/battery/battery_monitor.c
@@ -81,6 +81,10 @@ static void prv_resume_normal_operation(void) {
 }
 
 static void prv_exit_critical(void) {
+  // Cancel the standby timer so we don't enter standby if we're no longer critical
+  // (e.g. charger was plugged in before the timer expired).
+  new_timer_stop(s_standby_timer_id);
+
   // Checking the state here is a bit of a hack because the state machine does not have proper
   // transition actions, only entry/exit actions.
   // We check that the state is PowerStateGood because the state machine does not transition through


### PR DESCRIPTION
If the charger is plugged in while the standby timer is running (e.g. battery hit 0% then charger connected before timeout), the timer was not cancelled. This caused the device to enter standby even while plugged in or charging.

Fix by stopping the standby timer in prv_exit_critical().

Fixes FIRM-1222