### PR TITLE
fw: add new PPS characteristic to reset PPoGATT

### DIFF
--- a/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
+++ b/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
@@ -1336,6 +1336,25 @@ unlock:
 
 // -------------------------------------------------------------------------------------------------
 
+void ppogatt_reset_all(void) {
+  bt_lock();
+  {
+    PPoGATTClient *client = s_ppogatt_head;
+    while (client) {
+      if (client->state >= StateConnectedClosedAwaitingResetCompleteSelfInitiatedReset) {
+        // Clear counters since this is an explicit re-init request from the phone
+        client->resets_counter = 0;
+        s_disconnect_counter = 0;
+        prv_start_reset(client);
+      }
+      client = (PPoGATTClient *) client->node.next;
+    }
+  }
+  bt_unlock();
+}
+
+// -------------------------------------------------------------------------------------------------
+
 void ppogatt_destroy(void) {
   bt_lock();
   {

--- a/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.h
+++ b/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.h
@@ -44,5 +44,9 @@ void ppogatt_reset(struct Transport *transport);
 
 void ppogatt_destroy(void);
 
+//! Resets all active PPoGATT clients. Called when the phone explicitly requests
+//! PPoG session re-initialization (e.g. after the phone app has restarted).
+void ppogatt_reset_all(void);
+
 //! Interface for analytics
 void ppogatt_reset_disconnect_counter(void);

--- a/src/fw/services/common/bluetooth/pebble_pairing_service.c
+++ b/src/fw/services/common/bluetooth/pebble_pairing_service.c
@@ -6,6 +6,7 @@
 #include "comm/ble/gap_le_connect_params.h"
 #include "comm/ble/gap_le_connection.h"
 #include "comm/ble/kernel_le_client/app_launch/app_launch.h"
+#include "comm/ble/kernel_le_client/ppogatt/ppogatt.h"
 #include "comm/bt_conn_mgr.h"
 #include "comm/bt_lock.h"
 #include "kernel/pbl_malloc.h"
@@ -109,4 +110,8 @@ unlock:
 
 void bt_driver_cb_pebble_pairing_service_handle_ios_app_termination_detected(void) {
   app_launch_trigger();
+}
+
+void bt_driver_cb_pebble_pairing_service_handle_ppog_reinit(void) {
+  ppogatt_reset_all();
 }

--- a/src/include/bluetooth/pebble_pairing_service.h
+++ b/src/include/bluetooth/pebble_pairing_service.h
@@ -12,6 +12,7 @@
 // Note: UUID 4 was used by the 3.14-rc Android App for V0 of the Connection Param characteristic
 // but never shipped externally
 #define PEBBLE_BT_PAIRING_SERVICE_CONNECTION_PARAMETERS_UUID PEBBLE_BT_UUID_EXPAND(5)
+#define PEBBLE_BT_PAIRING_SERVICE_PPOG_REINIT_UUID PEBBLE_BT_UUID_EXPAND(6)
 
 typedef enum {
   PebblePairingServiceGATTError_UnknownCommandID =
@@ -226,3 +227,8 @@ extern void bt_driver_cb_pebble_pairing_service_handle_connection_parameter_writ
     const BTDeviceInternal *device,
     const PebblePairingServiceConnParamsWrite *conn_params,
     size_t conn_params_length);
+
+//! Indicate to the FW that the phone has requested a PPoG session re-initialization.
+//! This is used when the phone app has restarted and needs the watch to re-initialize
+//! the PPoG session.
+extern void bt_driver_cb_pebble_pairing_service_handle_ppog_reinit(void);


### PR DESCRIPTION
We sometimes run into the case where the watch is subscribed to the PPoG data characteristic on the phone, and a PPoG session is initialized - then the phone app dies. But the BLE connection still lives (because of ANCS), and the watch does not realize that the PPoG session is dead until it next attempts to send a PP packet.

When the phone app restarts, it is waiting for the watch to initalize a PPoG session, which doesn't happen. We need a way for the phone to tell the watch that it needs to re-initialize PPoG.

Proposed solution:

- Add a new characteristic in the Pebble Pairing Service
- UUID 00000006-328E-0FBB-C642-1AA6699BDADA
- Writable with response.
- Characteristic value is 1 byte, boolean flag, set to 1 when the phone wants the watch to re-initialize PPoGATT

The mobile app will always write to this when connecting on iOS but will not use it on Android, where it isn't required.

Mobile can also remove some of the existing workarounds, e.g., sending PPoGATT resets at various times, when this characteristic is supported on the watch.

Fixes FIRM-1268