### PR TITLE
fw/apps/system_apps/notifications_app: fix dismissed notification not…

### DIFF
--- a/src/fw/apps/system_apps/notifications_app.c
+++ b/src/fw/apps/system_apps/notifications_app.c
@@ -627,7 +627,8 @@ static void prv_handle_notification_removed(Uuid *id) {
 }
 
 static void prv_handle_notification_acted_upon(Uuid *id) {
-  app_notification_window_handle_notification_acted_upon_by_id(id);
+  prv_remove_notification(s_data, id);
+  app_notification_window_remove_notification_by_id(id);
 }
 
 static void prv_handle_notification_added(Uuid *id) {
@@ -658,6 +659,16 @@ static void prv_handle_notification(PebbleEvent *e, void *context) {
       case NotificationActedUpon:
         prv_handle_notification_acted_upon(id);
         break;
+      case NotificationActionResult: {
+        PebbleSysNotificationActionResult *action_result = e->sys_notification.action_result;
+        if (action_result &&
+            (action_result->type == ActionResultTypeSuccess ||
+             action_result->type == ActionResultTypeSuccessANCSDismiss)) {
+          prv_remove_notification(s_data, &action_result->id);
+          app_notification_window_remove_notification_by_id(&action_result->id);
+        }
+        break;
+      }
       default:
         break;
         // Not implemented


### PR DESCRIPTION
… removed from list

When dismissing a notification via long-press center button from the detail view, the dismiss animation played but the notification remained in the list. Two issues were at play:

1. prv_handle_notification_acted_upon only forwarded to the notification window's swap layer reload but never removed the notification from the app's own list. Now it removes from both the app's list and the notification window's presented list, matching the behavior of prv_handle_notification_removed.

2. The event handler did not handle NotificationActionResult events. When dismissing via long-press, a NotificationActionResult event is generated (not NotificationActedUpon). The notification window handled this event, but the notifications app ignored it, leaving its list stale.


Fixes FIRM-1347