### PR TITLE
treewide: revert ruff lint for sdk files

### DIFF
--- a/sdk/tools/inject_metadata.py
+++ b/sdk/tools/inject_metadata.py
@@ -8,9 +8,12 @@ from struct import pack, unpack
 import os
 import os.path
 import sys
+import time
 
 from subprocess import Popen, PIPE
 from shutil import copy2
+from binascii import crc32
+from struct import pack
 from pbpack import ResourcePack
 
 
@@ -142,7 +145,7 @@ def inject_metadata(
 
             # Carve off the first column, since it sometimes has a space in it which screws up the
             # split.
-            if "]" not in line:
+            if not "]" in line:
                 continue
             line = line[line.index("]") + 1 :]
 

--- a/sdk/waftools/pebble_sdk.py
+++ b/sdk/waftools/pebble_sdk.py
@@ -11,9 +11,12 @@ if extras_dir not in sys.path:
     sys.path.insert(0, extras_dir)
 
 from waflib.Configure import conf
+from waflib.Errors import ConfigurationError
 from waflib import Logs
+import sdk_paths
 from generate_appinfo import generate_appinfo_c
 from process_sdk_resources import generate_resources
+import report_memory_usage
 from sdk_helpers import (
     configure_libraries,
     configure_platform,

--- a/sdk/waftools/pebble_sdk_common.py
+++ b/sdk/waftools/pebble_sdk_common.py
@@ -12,6 +12,7 @@ from waflib.Task import Task
 from waflib.TaskGen import after_method, before_method, feature
 from waflib.Tools import c, c_preproc
 
+import ldscript, process_bundle, process_headers, process_js, report_memory_usage, xcode_pebble
 from pebble_sdk_platform import maybe_import_internal
 from sdk_helpers import (
     append_to_attr,
@@ -290,7 +291,7 @@ def setup_pebble_cprogram(task_gen):
 
     for lib in task_gen.bld.env.LIB_JSON:
         # Skip binary check for non-Pebble libs
-        if "pebble" not in lib:
+        if not "pebble" in lib:
             continue
 
         if hasattr(task_gen.bld, "conf") and hasattr(task_gen.bld.conf, "srcnode"):

--- a/sdk/waftools/pebble_sdk_lib.py
+++ b/sdk/waftools/pebble_sdk_lib.py
@@ -12,6 +12,7 @@ extras_dir = os.path.dirname(os.path.abspath(__file__))
 if extras_dir not in sys.path:
     sys.path.insert(0, extras_dir)
 
+import sdk_paths
 
 from process_sdk_resources import generate_resources
 from sdk_helpers import (

--- a/sdk/waftools/process_js.py
+++ b/sdk/waftools/process_js.py
@@ -7,9 +7,10 @@ import subprocess
 from string import Template
 from waflib.Errors import WafError
 from waflib.TaskGen import before_method, feature
-from waflib import Context, Logs, Task
+from waflib import Context, Logs, Node, Task
 
-from sdk_helpers import find_sdk_component
+from sdk_helpers import find_sdk_component, get_node_from_abspath
+from sdk_helpers import process_package
 
 
 @feature("rockyjs")

--- a/sdk/waftools/process_message_keys.py
+++ b/sdk/waftools/process_message_keys.py
@@ -87,7 +87,7 @@ def configure(conf):
 
     combined_key_list = key_list + list(key_dict.keys())
     for lib in conf.env.LIB_JSON:
-        if "pebble" not in lib or "messageKeys" not in lib["pebble"]:
+        if not "pebble" in lib or not "messageKeys" in lib["pebble"]:
             continue
         lib_keys = lib["pebble"]["messageKeys"]
         if isinstance(lib_keys, list):

--- a/sdk/waftools/process_sdk_resources.py
+++ b/sdk/waftools/process_sdk_resources.py
@@ -7,6 +7,12 @@ from waflib import Node
 from resources.find_resource_filename import find_most_specific_filename
 from resources.types.resource_object import ResourceObject
 from resources.resource_map import resource_generator
+import resources.resource_map.resource_generator_bitmap
+import resources.resource_map.resource_generator_font
+import resources.resource_map.resource_generator_js
+import resources.resource_map.resource_generator_pbi
+import resources.resource_map.resource_generator_png
+import resources.resource_map.resource_generator_raw
 from sdk_helpers import is_sdk_2x, validate_resource_not_larger_than
 
 

--- a/sdk/waftools/process_timeline_resources.py
+++ b/sdk/waftools/process_timeline_resources.py
@@ -3,7 +3,7 @@
 
 import json
 import struct
-from waflib import Node, Task
+from waflib import Node, Task, TaskGen
 from waflib.TaskGen import before_method, feature
 
 from resources.types.resource_definition import ResourceDefinition

--- a/sdk/waftools/report_memory_usage.py
+++ b/sdk/waftools/report_memory_usage.py
@@ -8,10 +8,12 @@ from waflib.TaskGen import after_method, feature
 from binutils import size
 from memory_reports import (
     app_memory_report,
+    app_resource_memory_error,
     app_appstore_resource_memory_error,
     bytecode_memory_report,
     simple_memory_report,
 )
+from sdk_helpers import is_sdk_2x
 
 
 class memory_usage_report(Task.Task):

--- a/sdk/waftools/sdk_helpers.py
+++ b/sdk/waftools/sdk_helpers.py
@@ -4,11 +4,12 @@
 import json
 import os
 import struct
+import re
 
 from waflib import Logs
 
 from pebble_package import LibraryPackage
-from pebble_sdk_platform import pebble_platforms
+from pebble_sdk_platform import pebble_platforms, maybe_import_internal
 from pebble_sdk_version import set_env_sdk_version
 from resources.types.resource_object import ResourceObject
 
@@ -263,7 +264,7 @@ def process_package(ctx, package, root_lib_node=None):
                     with open(package.abspath()) as f:
                         info = json.load(f)
                     if not dict(ctx.env.PROJECT_INFO).get("enableMultiJS", False):
-                        if "pebble" not in info:
+                        if not "pebble" in info:
                             continue
                     packages_str += "      '{}': '{}'\n".format(
                         info["name"], info["version"]

--- a/tools/generate_native_sdk/exports.py
+++ b/tools/generate_native_sdk/exports.py
@@ -3,6 +3,7 @@
 
 import json
 import logging
+import os
 
 INTERNAL_REVISION = 999
 

--- a/tools/generate_native_sdk/generate_pebble_native_sdk_files.py
+++ b/tools/generate_native_sdk/generate_pebble_native_sdk_files.py
@@ -28,7 +28,7 @@ try:
     from ..pebble_sdk_platform import pebble_platforms, maybe_import_internal
 except ImportError:
     os.sys.path.append(path.dirname(path.dirname(__file__)))
-    from pebble_sdk_platform import pebble_platforms
+    from pebble_sdk_platform import pebble_platforms, maybe_import_internal
 
 SRC_DIR = "src"
 INCLUDE_DIR = "include"
@@ -61,9 +61,10 @@ def generate_shim_files(
 ):
     if internal_sdk_build:
         try:
-            pass
+            from .. import pebble_sdk_platform_internal
         except ValueError:
             os.sys.path.append(path.dirname(path.dirname(__file__)))
+            import pebble_sdk_platform_internal
 
     try:
         platform_info = pebble_platforms.get(platform_name)

--- a/tools/generate_native_sdk/parse_c_decl.py
+++ b/tools/generate_native_sdk/parse_c_decl.py
@@ -13,7 +13,7 @@ dump_tree = False
 
 def add_clang_compat_module_to_sys_path_if_needed():
     try:
-        pass
+        import clang.cindex
     except:
         sys.path.append(os.path.join(os.path.dirname(__file__), "clang_compat"))
         logging.info("Importing clang python compatibility module")

--- a/tools/resources/find_resource_filename.py
+++ b/tools/resources/find_resource_filename.py
@@ -5,6 +5,7 @@ from pebble_sdk_platform import pebble_platforms, maybe_import_internal
 
 import os
 import os.path
+import sys
 from glob import glob
 
 __author__ = "katharine"

--- a/tools/resources/resource_map/resource_generator.py
+++ b/tools/resources/resource_map/resource_generator.py
@@ -84,7 +84,7 @@ class ResourceGenerator(ResourceGeneratorBase):
         """
         Stub implementation of generate_object. Subclasses must override this method.
         """
-        raise NotImplementedError("%r missing a generate_object implementation" % cls)
+        raise NotImplemented("%r missing a generate_object implementation" % cls)
 
 
 def definitions_from_dict(bld, definition_dict, resource_source_path):

--- a/tools/resources/resource_map/resource_generator_vibe.py
+++ b/tools/resources/resource_map/resource_generator_vibe.py
@@ -4,6 +4,7 @@
 from resources.types.resource_object import ResourceObject
 from resources.resource_map.resource_generator import ResourceGenerator
 
+from pebble_sdk_platform import pebble_platforms
 
 import json2vibe
 

--- a/tools/resources/types/resource_definition.py
+++ b/tools/resources/types/resource_definition.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2024 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 
 from resources.types.resource_declaration import ResourceDeclaration
 

--- a/tools/resources/waftools/generate_builtin.py
+++ b/tools/resources/waftools/generate_builtin.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-from waflib import Task, TaskGen
+from waflib import Node, Task, TaskGen
 
 from resources.types.resource_ball import ResourceBall
 from resources.types.resource_definition import StorageType

--- a/tools/resources/waftools/generate_pbpack.py
+++ b/tools/resources/waftools/generate_pbpack.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-from waflib import Task, TaskGen
+from waflib import Node, Task, TaskGen
 
 from resources.types.resource_ball import ResourceBall
 from resources.types.resource_definition import StorageType

--- a/tools/resources/waftools/generate_resource_ball.py
+++ b/tools/resources/waftools/generate_resource_ball.py
@@ -4,6 +4,7 @@
 from waflib import Node, Task, TaskGen
 
 from resources.resource_map import resource_generator
+from resources.resource_map.resource_generator_js import JsResourceGenerator
 from resources.types.resource_definition import StorageType
 from resources.types.resource_object import ResourceObject
 from resources.types.resource_ball import ResourceBall

--- a/tools/resources/waftools/generate_version_header.py
+++ b/tools/resources/waftools/generate_version_header.py
@@ -1,8 +1,9 @@
 # SPDX-FileCopyrightText: 2024 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-from waflib import Task, TaskGen
+from waflib import Node, Task, TaskGen
 
+from resources.types.resource_ball import ResourceBall
 
 from pbpack import ResourcePack
 


### PR DESCRIPTION
some things that ruff sees as "unused" are actually quite important for the SDK