### PR TITLE
fw/applib/ui/dialogs: fix animation origin

### DIFF
--- a/src/fw/applib/ui/dialogs/dialog_private.c
+++ b/src/fw/applib/ui/dialogs/dialog_private.c
@@ -114,12 +114,14 @@ bool dialog_init_icon_layer(Dialog *dialog, KinoReel *image,
   layer_set_clips(&icon_layer->layer, false);
 
   GRect from = icon_rect;
-  // Animate from off screen. We need to be at least -80, since that is our largest icon size.
-  const int16_t DISP_OFFSET = 80;
+  // Animate from off screen
+  GRect bounds;
+  Layer *window_layer = window_get_root_layer(&dialog->window);
+  layer_get_bounds(window_layer, &bounds);
   if (dialog->icon_anim_direction == DialogIconAnimationFromLeft) {
-    from.origin.x = -DISP_OFFSET;
+    from.origin.x = bounds.origin.x - icon_rect.size.w;
   } else if (dialog->icon_anim_direction == DialogIconAnimationFromRight) {
-    from.origin.x = DISP_OFFSET;
+    from.origin.x = bounds.origin.x + bounds.size.w;
   }
 
   const int16_t ICON_TARGET_PT_X = icon_rect.size.w;


### PR DESCRIPTION
Animation from left was okay (given all icons are < 80w), but right, the default, was not. Make both start off screen based on layer bounds and icon size.