### PR TITLE
fw/apps/system/settings: fix text and background colors after coloring removal

### DIFF
--- a/src/fw/apps/system_apps/settings/settings.c
+++ b/src/fw/apps/system_apps/settings/settings.c
@@ -36,7 +36,7 @@ static void prv_draw_row_callback(GContext *ctx, const Layer *cell_layer,
   const char *title = i18n_get(category_title, data);
   menu_layer_set_highlight_colors(&(data->menu_layer),
                                 shell_prefs_get_settings_menu_highlight_color(),
-                                GColorWhite);
+                                GColorBlack);
   menu_layer_set_scroll_wrap_around(&(data->menu_layer),
                                 shell_prefs_get_menu_scroll_wrap_around_enable());
   menu_layer_set_scroll_vibe_on_wrap(&(data->menu_layer),
@@ -92,7 +92,7 @@ static void prv_window_load(Window *window) {
   });
   menu_layer_set_highlight_colors(menu_layer,
                                   shell_prefs_get_settings_menu_highlight_color(),
-                                  GColorWhite);
+                                  GColorBlack);
   menu_layer_set_click_config_onto_window(menu_layer, &data->window);
   menu_layer_set_scroll_wrap_around(menu_layer, shell_prefs_get_menu_scroll_wrap_around_enable());
   menu_layer_set_scroll_vibe_on_wrap(menu_layer, shell_prefs_get_menu_scroll_vibe_behavior() == MenuScrollVibeOnWrapAround);
@@ -117,7 +117,7 @@ static void handle_init(void) {
     .load = prv_window_load,
     .unload = prv_window_unload,
   });
-  window_set_background_color(window, GColorBlack);
+  window_set_background_color(window, GColorWhite);
   app_window_stack_push(window, true);
 }
 


### PR DESCRIPTION
Commit 06926f11 removed the custom normal colors but left the highlight foreground as GColorWhite and the window background as GColorBlack, inconsistent with the new white background theme.