### PR TITLE
fw/drivers/hrm/gh3x2x: turn off HRM sensor in PRF

### DIFF
--- a/src/fw/drivers/wscript_build
+++ b/src/fw/drivers/wscript_build
@@ -1646,29 +1646,18 @@ if bld.get_hrm() == 'AS7000':
         ],
     )
 elif bld.get_hrm() == 'GH3X2X':
-    # GH3X2X blobs blow up flash usage, avoid building for normal PRF
-    if bld.variant == 'prf' and not bld.env.IS_MFG:
-        bld.objects(
-            name='driver_hrm',
-            source=[
-                'stubs/hrm.c',
-            ],
-            use=[
-                'fw_includes',
-            ],
-        )
-    else:
+    includes = ['fw_includes']
+    if bld.variant != 'prf' or bld.env.IS_MFG:
         bld.env.DEFINES.append('HRM_USE_GH3X2X')
-        bld.objects(
-            name='driver_hrm',
-            source=[
-                'hrm/gh3x2x/gh3x2x.c',
-            ],
-            use=[
-                'fw_includes',
-                'gh3x2x',
-            ],
-        )
+        includes += ['gh3x2x']
+
+    bld.objects(
+        name='driver_hrm',
+        source=[
+            'hrm/gh3x2x/gh3x2x.c',
+        ],
+        use=includes
+    )
 elif bld.get_hrm() == 'STUB':
     bld.objects(
         name='driver_hrm',


### PR DESCRIPTION
When the Obelix watch reboots into PRF with the HRM sensor still ON, it stays ON because the PRF build uses a stub HRM driver that doesn't touch the hardware. The Goodix library is too large for the PRF partition, but we still need to put the HRM into reset.

Guard Goodix library-dependent code in gh3x2x.c with #ifdef HRM_USE_GH3X2X (already only defined for non-PRF builds), and build the driver directly for PRF instead of using the no-op stub. Without the define, only the reset pin control is compiled, putting the HRM sensor into reset on init.

Fixes FIRM-1343