### PR TITLE
fw/applib/graphics: fix bitblt overflow for display widths > 255

### DIFF
--- a/src/fw/applib/graphics/1_bit/bitblt_private.c
+++ b/src/fw/applib/graphics/1_bit/bitblt_private.c
@@ -108,7 +108,7 @@ void bitblt_bitmap_into_bitmap_tiled_palette_to_1bit(GBitmap* dest_bitmap,
     RowLookUp look_up = look_ups[dest_y % 2];
 
     int16_t src_x = src_begin_x + src_origin_offset.x;
-    uint8_t row_bits_left = dest_rect.size.w;
+    int16_t row_bits_left = dest_rect.size.w;
     uint32_t *dest_block = (uint32_t *)dest_block_x_begin + (dest_y * dest_row_length_words);
 
     const uint32_t *dest_block_end = dest_block + num_dest_blocks_per_row;

--- a/src/fw/applib/graphics/8_bit/bitblt_private.c
+++ b/src/fw/applib/graphics/8_bit/bitblt_private.c
@@ -289,7 +289,7 @@ void bitblt_bitmap_into_bitmap_tiled_1bit_to_8bit(GBitmap* dest_bitmap,
       MIN(32, src_bitmap->bounds.size.w + src_line_start_idx - (src_origin_offset.x % 32));
     const uint8_t src_line_wrap_end_idx = MIN(32, src_bitmap->bounds.size.w + src_line_wrap_idx);
 
-    uint8_t row_bits_left = dest_rect.size.w;
+    int16_t row_bits_left = dest_rect.size.w;
     uint32_t * const src_block_begin =
         (uint32_t *)src_block_x_begin + (src_y * src_row_length_words);
     uint32_t *src_block = src_block_begin;

--- a/src/fw/applib/graphics/bitblt.c
+++ b/src/fw/applib/graphics/bitblt.c
@@ -59,7 +59,7 @@ void bitblt_bitmap_into_bitmap_tiled_1bit_to_1bit(GBitmap* dest_bitmap,
 
     int8_t src_dest_shift = 32 + dest_shift_at_line_begin - src_shift_at_line_begin;
     uint8_t dest_shift = dest_shift_at_line_begin;
-    uint8_t row_bits_left = dest_rect.size.w;
+    int16_t row_bits_left = dest_rect.size.w;
     uint32_t *dest_block = (uint32_t *)dest_block_x_begin + (dest_y * dest_row_length_words);
     uint32_t * const src_block_begin = (uint32_t *)src_block_x_begin + (src_y * src_row_length_words);
     uint32_t *src_block = src_block_begin;


### PR DESCRIPTION
## Summary

- Fix `uint8_t` overflow in tiled bitblt functions that causes scroll layer (and any 1-bit bitmap rendering) to crash on displays wider than 255 pixels (e.g. Gabbro at 260x260)
- The `row_bits_left` variable silently truncated widths > 255, causing `PBL_ASSERTN(number_of_bits <= row_bits_left)` to fire when drawing scroll layer shadow bitmaps
- Changed the type from `uint8_t` to `int16_t` (matching `GRect.size.w`) in all three affected bitblt functions

Fixes #903

## Test plan

- [ ] Verify scroll layer no longer crashes on Gabbro (260x260) emulator
- [ ] Verify existing bitblt and scroll layer tests still pass
- [ ] Test with the [MRE from the issue](https://github.com/HarrisonAllen/pebbleland-snippets/tree/main/scroll-layer-crash) on Gabbro

🤖 Generated with [Claude Code](https://claude.com/claude-code)