### PR TITLE
wscript: Quote QEMU binary in qemu_launch

### DIFF
--- a/wscript
+++ b/wscript
@@ -1,5 +1,6 @@
 import json
 import os
+import shlex
 import subprocess
 import sys
 import pexpect
@@ -1223,7 +1224,7 @@ def qemu_launch(ctx):
         qemu_bin = 'qemu-system-arm'
         
     cmd_line = (
-        qemu_bin + " "
+        shlex.quote(qemu_bin) + " "
         "-rtc base=localtime "
         "-monitor stdio "
         "-s "


### PR DESCRIPTION
Use shlex.quote to escape the qemu binary path and avoid shell splitting when the path contains spaces or special characters