### PR TITLE
feature: Add a feature to disable motion backlight during quiet time

### DIFF
--- a/src/fw/apps/system/settings/quiet_time.c
+++ b/src/fw/apps/system/settings/quiet_time.c
@@ -42,6 +42,7 @@ enum QuietTimeItem {
   QuietTimeItemWeekendScheduled,
   QuietTimeItemInterruptions,
   QuietTimeItemNotifications,
+  QuietTimeItemMotionBacklight,
   QuietTimeItem_Count,
 };
 
@@ -296,6 +297,11 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
       title = i18n_get("Notifications", data);
       strncpy(subtitle, prv_get_dnd_notifications_enable(data), buffer_length);
       break;
+    case QuietTimeItemMotionBacklight:
+      title = i18n_get("Motion Backlight", data);
+      strncpy(subtitle, alerts_preferences_dnd_get_motion_backlight() ?
+                  i18n_get("On", data) : i18n_get("Off", data), buffer_length);
+      break;
     default:
         WTF;
   }
@@ -324,6 +330,9 @@ static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
       break;
     case QuietTimeItemNotifications:
       prv_cycle_dnd_notification_mode();
+      break;
+    case QuietTimeItemMotionBacklight:
+      alerts_preferences_dnd_set_motion_backlight(!alerts_preferences_dnd_get_motion_backlight());
       break;
     default:
         WTF;

--- a/src/fw/kernel/event_loop.c
+++ b/src/fw/kernel/event_loop.c
@@ -64,6 +64,7 @@
 #include "services/normal/alarms/alarm.h"
 #include "services/normal/app_fetch_endpoint.h"
 #include "services/normal/blob_db/api.h"
+#include "services/normal/notifications/alerts_preferences.h"
 #include "services/normal/notifications/do_not_disturb.h"
 #include "services/normal/stationary.h"
 #include "services/normal/timeline/reminders.h"
@@ -288,7 +289,14 @@ static NOINLINE void prv_minimal_event_handler(PebbleEvent* e) {
     case PEBBLE_ACCEL_SHAKE_EVENT:
       analytics_inc(ANALYTICS_DEVICE_METRIC_ACCEL_SHAKE_COUNT, AnalyticsClient_System);
       if (backlight_is_motion_enabled()) {
-        light_enable_interaction();
+#ifndef RECOVERY_FW
+        const bool dnd_suppresses_backlight = do_not_disturb_is_active() &&
+                                             !alerts_preferences_dnd_get_motion_backlight();
+        if (!dnd_suppresses_backlight)
+#endif
+        {
+          light_enable_interaction();
+        }
       }
       return;
 

--- a/src/fw/services/normal/notifications/alerts_preferences.c
+++ b/src/fw/services/normal/notifications/alerts_preferences.c
@@ -34,6 +34,9 @@ static AlertMask s_dnd_interruptions_mask = AlertMaskAllOff;
 #define PREF_KEY_DND_SHOW_NOTIFICATIONS "dndShowNotifications"
 static DndNotificationMode s_dnd_show_notifications = DndNotificationModeShow;
 
+#define PREF_KEY_DND_MOTION_BACKLIGHT "dndMotionBacklight"
+static bool s_dnd_motion_backlight = true;
+
 #define PREF_KEY_VIBE "vibe"
 static bool s_vibe_on_notification = true;
 
@@ -271,6 +274,7 @@ void alerts_preferences_init(void) {
   RESTORE_PREF(PREF_KEY_DND_SMART_ENABLED, s_do_not_disturb_smart_dnd_enabled);
   RESTORE_PREF(PREF_KEY_DND_INTERRUPTIONS_MASK, s_dnd_interruptions_mask);
   RESTORE_PREF(PREF_KEY_DND_SHOW_NOTIFICATIONS, s_dnd_show_notifications);
+  RESTORE_PREF(PREF_KEY_DND_MOTION_BACKLIGHT, s_dnd_motion_backlight);
   RESTORE_PREF(PREF_KEY_LEGACY_DND_SCHEDULE, s_legacy_dnd_schedule);
   RESTORE_PREF(PREF_KEY_LEGACY_DND_SCHEDULE_ENABLED, s_legacy_dnd_schedule_enabled);
   RESTORE_PREF(s_dnd_schedule_keys[WeekdaySchedule].schedule_pref_key,
@@ -446,6 +450,15 @@ void alerts_preferences_dnd_set_show_notifications(DndNotificationMode mode) {
 
 DndNotificationMode alerts_preferences_dnd_get_show_notifications(void) {
   return s_dnd_show_notifications;
+}
+
+void alerts_preferences_dnd_set_motion_backlight(bool enable) {
+  s_dnd_motion_backlight = enable;
+  SET_PREF(PREF_KEY_DND_MOTION_BACKLIGHT, s_dnd_motion_backlight);
+}
+
+bool alerts_preferences_dnd_get_motion_backlight(void) {
+  return s_dnd_motion_backlight;
 }
 
 bool alerts_preferences_dnd_is_manually_enabled(void) {

--- a/src/fw/services/normal/notifications/alerts_preferences.h
+++ b/src/fw/services/normal/notifications/alerts_preferences.h
@@ -33,6 +33,13 @@ void alerts_preferences_dnd_set_show_notifications(DndNotificationMode mode);
 //! @return The notification display mode when DND is active
 DndNotificationMode alerts_preferences_dnd_get_show_notifications(void);
 
+//! Set whether the backlight should turn on with motion when DND is active
+//! @param enable true to allow motion backlight, false to suppress it
+void alerts_preferences_dnd_set_motion_backlight(bool enable);
+
+//! @return Whether motion backlight is enabled when DND is active
+bool alerts_preferences_dnd_get_motion_backlight(void);
+
 //! Checks whether a given "first use" dialog has been shown and sets it as complete
 //! @param source The "first use" bit to check
 //! @return true if the dialog has already been shown, false otherwise


### PR DESCRIPTION
I found that I was blinding myself during the night while half asleep if the backlight turned on if I turned over. Added a setting to inhibit motion backlight when quiet time is enabled so that having a DND schedule with this setting off prevents this happening.