### PR TITLE
sdk: add missing imports for waf build tools

### DIFF
--- a/sdk/waftools/pebble_sdk.py
+++ b/sdk/waftools/pebble_sdk.py
@@ -12,8 +12,10 @@ if extras_dir not in sys.path:
 
 from waflib.Configure import conf
 from waflib import Logs
+import sdk_paths  # noqa: F401
 from generate_appinfo import generate_appinfo_c
 from process_sdk_resources import generate_resources
+import report_memory_usage  # noqa: F401
 from sdk_helpers import (
     configure_libraries,
     configure_platform,

--- a/sdk/waftools/pebble_sdk_common.py
+++ b/sdk/waftools/pebble_sdk_common.py
@@ -12,6 +12,7 @@ from waflib.Task import Task
 from waflib.TaskGen import after_method, before_method, feature
 from waflib.Tools import c, c_preproc
 
+import ldscript, process_bundle, process_headers, process_js, report_memory_usage  # noqa: F401
 from pebble_sdk_platform import maybe_import_internal
 from sdk_helpers import (
     append_to_attr,

--- a/sdk/waftools/pebble_sdk_lib.py
+++ b/sdk/waftools/pebble_sdk_lib.py
@@ -12,6 +12,7 @@ extras_dir = os.path.dirname(os.path.abspath(__file__))
 if extras_dir not in sys.path:
     sys.path.insert(0, extras_dir)
 
+import sdk_paths  # noqa: F401
 
 from process_sdk_resources import generate_resources
 from sdk_helpers import (

--- a/sdk/waftools/process_js.py
+++ b/sdk/waftools/process_js.py
@@ -9,7 +9,8 @@ from waflib.Errors import WafError
 from waflib.TaskGen import before_method, feature
 from waflib import Context, Logs, Task
 
-from sdk_helpers import find_sdk_component
+from sdk_helpers import find_sdk_component, get_node_from_abspath  # noqa: F401
+from sdk_helpers import process_package  # noqa: F401
 
 
 @feature("rockyjs")

--- a/sdk/waftools/process_sdk_resources.py
+++ b/sdk/waftools/process_sdk_resources.py
@@ -8,6 +8,12 @@ from resources.find_resource_filename import find_most_specific_filename
 from resources.types.resource_definition import ResourceDefinition
 from resources.types.resource_object import ResourceObject
 from resources.resource_map import resource_generator
+import resources.resource_map.resource_generator_bitmap  # noqa: F401
+import resources.resource_map.resource_generator_font  # noqa: F401
+import resources.resource_map.resource_generator_js  # noqa: F401
+import resources.resource_map.resource_generator_pbi  # noqa: F401
+import resources.resource_map.resource_generator_png  # noqa: F401
+import resources.resource_map.resource_generator_raw  # noqa: F401
 from sdk_helpers import is_sdk_2x, validate_resource_not_larger_than
 
 

--- a/sdk/waftools/report_memory_usage.py
+++ b/sdk/waftools/report_memory_usage.py
@@ -8,10 +8,12 @@ from waflib.TaskGen import after_method, feature
 from binutils import size
 from memory_reports import (
     app_memory_report,
+    app_resource_memory_error,  # noqa: F401
     app_appstore_resource_memory_error,
     bytecode_memory_report,
     simple_memory_report,
 )
+from sdk_helpers import is_sdk_2x  # noqa: F401
 
 
 class memory_usage_report(Task.Task):

--- a/tools/resources/resource_map/resource_generator_vibe.py
+++ b/tools/resources/resource_map/resource_generator_vibe.py
@@ -4,6 +4,7 @@
 from resources.types.resource_object import ResourceObject
 from resources.resource_map.resource_generator import ResourceGenerator
 
+from pebble_sdk_platform import pebble_platforms  # noqa: F401
 
 import json2vibe
 

--- a/tools/resources/waftools/generate_resource_ball.py
+++ b/tools/resources/waftools/generate_resource_ball.py
@@ -4,6 +4,7 @@
 from waflib import Node, Task, TaskGen
 
 from resources.resource_map import resource_generator
+from resources.resource_map.resource_generator_js import JsResourceGenerator  # noqa: F401
 from resources.types.resource_definition import StorageType
 from resources.types.resource_object import ResourceObject
 from resources.types.resource_ball import ResourceBall

--- a/tools/resources/waftools/generate_version_header.py
+++ b/tools/resources/waftools/generate_version_header.py
@@ -3,6 +3,7 @@
 
 from waflib import Task, TaskGen
 
+from resources.types.resource_ball import ResourceBall  # noqa: F401
 
 from pbpack import ResourcePack
 


### PR DESCRIPTION
These modules are loaded dynamically by waf but need explicit imports to ensure they are available when the build system resolves task generators, resource generators, and helper functions.