### PR TITLE
fw/services/normal: force display refresh on orientation change [FIRM-1381]

### DIFF
--- a/src/fw/services/normal/orientation_manager.c
+++ b/src/fw/services/normal/orientation_manager.c
@@ -1,3 +1,6 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 #if CAPABILITY_HAS_ORIENTATION_MANAGER
 #include "services/normal/orientation_manager.h"
 #include "system/passert.h"

--- a/src/fw/services/normal/orientation_manager.c
+++ b/src/fw/services/normal/orientation_manager.c
@@ -6,6 +6,8 @@
 #include "drivers/accel.h"
 #include "drivers/button.h"
 #include "drivers/imu/mmc5603nj/mmc5603nj.h"
+#include "kernel/events.h"
+#include "process_management/process_manager.h"
 
 
 void prv_change_orientation(bool rotated) {
@@ -17,6 +19,14 @@ void prv_change_orientation(bool rotated) {
 
 void orientation_handle_prefs_changed(void) {
   prv_change_orientation(display_orientation_is_left());
+
+  // Force the running app to re-render so the display reflects the new orientation immediately.
+  // Without this, phone-originated orientation changes (via settings blob DB sync) would not
+  // be visible until the next natural redraw (e.g. button press or watchface tick).
+  PebbleEvent event = {
+    .type = PEBBLE_RENDER_REQUEST_EVENT,
+  };
+  process_manager_send_event_to_process(PebbleTask_App, &event);
 }
 
 void orientation_manager_enable(bool on) {

--- a/src/fw/services/normal/orientation_manager.h
+++ b/src/fw/services/normal/orientation_manager.h
@@ -1,3 +1,6 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 #if CAPABILITY_HAS_ORIENTATION_MANAGER
 #include "shell/prefs.h"
 


### PR DESCRIPTION
When display orientation is changed from the phone via settings blob DB sync, the hardware rotation flag is updated but no new frame is pushed to the display. This leaves the screen stale until the next natural redraw (e.g. button press or watchface tick).

Send a PEBBLE_RENDER_REQUEST_EVENT to the running app after orientation changes so the compositor immediately re-renders and flushes a fresh frame with the new rotation applied.