### PR TITLE
fw/services/common/compositor: fix reversed bezel-mode animation direction [FIRM-1460]

### DIFF
--- a/src/fw/services/common/compositor/compositor.c
+++ b/src/fw/services/common/compositor/compositor.c
@@ -634,7 +634,7 @@ void compositor_scaled_app_fb_copy_offset(const GRect update_rect, bool copy_rel
         update_rect.size.w - bezel_width,
         update_rect.size.h - app_offset_y
       );
-      dst_offset = GPoint(bezel_width - update_rect.origin.x, app_offset_y - update_rect.origin.y);
+      dst_offset = GPoint(bezel_width + update_rect.origin.x, app_offset_y + update_rect.origin.y);
     }
 
     if (src_rect.size.w > 0 && src_rect.size.h > 0) {


### PR DESCRIPTION
The bezel-mode dst_offset calculation in compositor_scaled_app_fb_copy_offset()
subtracted update_rect.origin from the bezel offset, inverting the slide
direction when the origin was nonzero. Change to addition so the app content
slides in the correct direction, matching native and upscaled app behavior.