### PR TITLE
ci: conditionally run S3 upload only in upstream repository

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Upload log hash dictionary
         uses: Noelware/s3-action@2.3.1
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && github.repository == 'coredevices/PebbleOS' }}
         with:
           access-key-id: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
           secret-key: ${{ secrets.LOG_HASH_BUCKET_SECRET }}

--- a/.github/workflows/build-prf.yml
+++ b/.github/workflows/build-prf.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload log hash dictionary
         uses: Noelware/s3-action@2.3.1
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && github.repository == 'coredevices/PebbleOS' }}
         with:
           access-key-id: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
           secret-key: ${{ secrets.LOG_HASH_BUCKET_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,7 @@ jobs:
 
       - name: Upload log hash dictionary
         uses: Noelware/s3-action@2.3.1
+        if: ${{ github.repository == 'coredevices/PebbleOS' }}
         with:
           access-key-id: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
           secret-key: ${{ secrets.LOG_HASH_BUCKET_SECRET }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to ensure that the "Upload log hash dictionary" step only runs for the `coredevices/PebbleOS` repository. This change prevents the upload step from executing on forks or other repositories, improving security and workflow correctness.

Workflow condition updates:

* [`.github/workflows/build-firmware.yml`](diffhunk://#diff-002f0cf6de5b59906143def2851a94115b1ce39b58995b2ce87ec84efc63d3c2L105-R105): Modified the condition for the log hash dictionary upload step to require both a `push` event and that the repository is `coredevices/PebbleOS`.
* [`.github/workflows/build-prf.yml`](diffhunk://#diff-e044eeea24fad1b6f15c75ab10b8e213083e21b3b24e9688671bd9a3241e3182L111-R111): Updated the upload step to only run on `push` events in the `coredevices/PebbleOS` repository.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R189): Added a repository check so the upload step only runs for `coredevices/PebbleOS`.