### PR TITLE
Fix deferred app render handling during modal transitions

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -4,9 +4,16 @@ ignore-merge-commits=false
 ignore-fixup-commits=false
 ignore-fixup-amend-commits=false
 ignore-squash-commits=false
+regex-style-search=true
 
 [title-match-regex]
-regex=[a-z0-9/]+: .*
+# Format: "area: description" where area is either:
+# - A path with at least one / (e.g., fw/drivers/hrm, third_party/nonfree)
+# - One of the known short areas: ci, treewide, platform, sdk, tools, resources,
+#   docs, waftools, settings, libc, tests, notifications, build, wscript, fw,
+#   third_party, ancs, compositor, console, kernel, health
+# Conventional commit types like feat:, fix:, chore: are NOT allowed.
+regex=^([a-z0-9_]+/[a-z0-9_/]*|ci|treewide|platform|sdk|tools|resources|docs|waftools|settings|libc|tests|notifications|build|wscript|fw|third_party|ancs|compositor|console|kernel|health|gitlint|readme|requirements|python_libs|pbl-tool|pbl|moddable|libutil|iconography|gitignore|capabilities|asterix|activity|accel): .*
 
 [title-max-length]
 line-length=100

--- a/src/fw/services/common/compositor/compositor.c
+++ b/src/fw/services/common/compositor/compositor.c
@@ -413,7 +413,13 @@ void compositor_transition(const CompositorTransition *compositor_animation) {
   }
 
   if (!prv_should_render() || s_deferred_render.animation.pending) {
-    if (s_deferred_render.app.pending) {
+    // If we're transitioning to a modal, cancel any deferred app render since the modal
+    // will cover the app framebuffer. Release the app framebuffer to inform the app
+    // that the render is complete.
+    const ModalProperty properties = modal_manager_get_properties();
+    const bool is_modal_existing = (properties & ModalProperty_Exists);
+    const bool is_modal_transparent = (properties & ModalProperty_Transparent);
+    if (is_modal_existing && !is_modal_transparent && s_deferred_render.app.pending) {
       s_deferred_render.app.pending = false;
       prv_release_app_framebuffer();
     }
@@ -460,6 +466,15 @@ void compositor_transition(const CompositorTransition *compositor_animation) {
 
     // We can start animating immediately if we're going to a modal window. This is because
     // modal window content is drawn on demand so it's always available.
+
+    // When transitioning to a modal, cancel any deferred app render since the modal
+    // will cover the app framebuffer. Release the app framebuffer to inform the app
+    // that the render is complete. Only do this if there's actually a deferred render.
+    if (s_deferred_render.app.pending) {
+      s_deferred_render.app.pending = false;
+      prv_release_app_framebuffer();
+    }
+
     if (compositor_animation) {
       s_state = CompositorState_Transitioning;
       animation_schedule(s_animation_state.animation);

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,106 @@
+# Running Tests
+
+## Cross-Platform Test Fixtures
+
+Graphics test fixtures are platform-specific due to differences in:
+- Font rendering libraries (FreeType, HarfBuzz)
+- Standard library implementations
+- ARM toolchain behavior
+
+Test fixtures are named with the format: `test_name~platform-os.pbi`
+- `~spalding-linux.pbi` - Generated on Linux (CI environment)
+- `~spalding-darwin.pbi` - Generated on macOS (local development)
+
+## Local Development
+
+### macOS Developers
+
+**Option 1: Use Docker (Recommended)**
+
+Run tests in Docker to match the CI environment exactly:
+
+```bash
+# Run all tests
+./tests/run-tests-docker.sh
+
+# Run specific tests
+./tests/run-tests-docker.sh -M "test_kickstart"
+
+# Use specific board
+TEST_BOARD=snowy_bb2 ./tests/run-tests-docker.sh
+```
+
+This ensures your test results match CI exactly.
+
+**Option 2: Generate macOS Fixtures**
+
+If you prefer to run tests natively on macOS:
+
+```bash
+# Configure and build
+./waf configure --board=snowy_bb2
+./waf test
+
+# This will generate macOS-specific fixtures (~spalding-darwin.pbi)
+# which will be used instead of the Linux fixtures
+```
+
+Note: macOS-generated fixtures will differ from Linux fixtures. This is expected
+and doesn't indicate a problem with your changes. Use Docker to verify against CI.
+
+### Linux Developers
+
+Run tests normally - your environment matches CI:
+
+```bash
+./waf configure --board=snowy_bb2
+./waf test
+```
+
+## Updating Fixtures
+
+When you intentionally change rendering behavior:
+
+1. **Run tests in Docker** to generate new Linux fixtures:
+   ```bash
+   ./tests/run-tests-docker.sh
+   ```
+
+2. **Copy the generated fixtures** from the failed test directory:
+   ```bash
+   cp build/test/tests/failed/*-expected.pbi tests/fixtures/graphics/
+   ```
+
+3. **Update filenames** to include the `-linux` suffix if needed:
+   ```bash
+   # Rename from ~spalding.pbi to ~spalding-linux.pbi
+   ```
+
+4. **Commit and push** the updated fixtures
+
+## CI Environment
+
+- Container: `ghcr.io/coredevices/pebbleos-docker:v3`
+- OS: Ubuntu 24.04 (Linux)
+- Board: snowy_bb2
+- Compiler: arm-none-eabi-gcc 14.2.Rel1
+
+## Troubleshooting
+
+### Tests pass locally but fail on CI
+
+Run tests in Docker to reproduce CI results:
+```bash
+./tests/run-tests-docker.sh
+```
+
+### Tests fail locally but pass on CI
+
+Generate macOS-specific fixtures or use Docker for local development.
+
+### Fixture naming confusion
+
+The test framework automatically selects the correct fixture based on your OS:
+- On Linux: Uses `~spalding-linux.pbi`
+- On macOS: Uses `~spalding-darwin.pbi`
+- Falls back to `~spalding.pbi` if OS-specific doesn't exist

--- a/tests/fakes/fake_HCIAPI.c
+++ b/tests/fakes/fake_HCIAPI.c
@@ -10,6 +10,13 @@
 #include "util/list.h"
 
 #include <stdlib.h>
+#include <string.h>
+
+// BD_ADDR_t is typically a pointer to uint8_t or uint8_t array
+// This helper converts BTDeviceAddress to the expected format
+static const uint8_t *BTDeviceAddressToBDADDR(BTDeviceAddress addr) {
+  return addr.octets;
+}
 
 typedef struct {
   ListNode node;
@@ -63,10 +70,9 @@ int HCI_LE_Add_Device_To_White_List(unsigned int BluetoothStackID,
     return -1;
   }
 
-  const WhitelistEntry model = {
-    .Address_Type = Address_Type,
-    .Address = Address,
-  };
+  WhitelistEntry model;
+  model.Address_Type = Address_Type;
+  memcpy(model.Address, Address, sizeof(BD_ADDR_t));
 
   {
     WhitelistEntry *e = prv_find_whitelist_entry(&model);
@@ -78,10 +84,8 @@ int HCI_LE_Add_Device_To_White_List(unsigned int BluetoothStackID,
   }
 
   WhitelistEntry *e = (WhitelistEntry *) malloc(sizeof(WhitelistEntry));
-  *e = (const WhitelistEntry) {
-    .Address_Type = Address_Type,
-    .Address = Address,
-  };
+  e->Address_Type = Address_Type;
+  memcpy(e->Address, Address, sizeof(BD_ADDR_t));
   s_head = (WhitelistEntry *) list_prepend(&s_head->node, &e->node);
   return 0;
 }
@@ -90,10 +94,9 @@ int HCI_LE_Remove_Device_From_White_List(unsigned int BluetoothStackID,
                                          Byte_t Address_Type,
                                          BD_ADDR_t Address,
                                          Byte_t *StatusResult) {
-  const WhitelistEntry model = {
-    .Address_Type = Address_Type,
-    .Address = Address,
-  };
+  WhitelistEntry model;
+  model.Address_Type = Address_Type;
+  memcpy(model.Address, Address, sizeof(BD_ADDR_t));
   WhitelistEntry *e = prv_find_whitelist_entry(&model);
   if (e) {
     list_remove(&e->node, (ListNode **) &s_head, NULL);
@@ -107,10 +110,9 @@ int HCI_LE_Remove_Device_From_White_List(unsigned int BluetoothStackID,
 }
 
 bool fake_HCIAPI_whitelist_contains(const BTDeviceInternal *device) {
-  const WhitelistEntry model = {
-    .Address_Type = device->is_random_address ? 0x01 : 0x00,
-    .Address = BTDeviceAddressToBDADDR(device->address),
-  };
+  WhitelistEntry model;
+  model.Address_Type = device->is_random_address ? 0x01 : 0x00;
+  memcpy(model.Address, device->address.octets, sizeof(BD_ADDR_t));
   return (prv_find_whitelist_entry(&model) != NULL);
 }
 

--- a/tests/fakes/fake_HCIAPI.c
+++ b/tests/fakes/fake_HCIAPI.c
@@ -14,7 +14,7 @@
 
 // BD_ADDR_t is typically a pointer to uint8_t or uint8_t array
 // This helper converts BTDeviceAddress to the expected format
-static const uint8_t *BTDeviceAddressToBDADDR(BTDeviceAddress addr) {
+static const uint8_t *prv_addr_to_bdaddr(BTDeviceAddress addr) {
   return addr.octets;
 }
 

--- a/tests/fw/graphics/util.h
+++ b/tests/fw/graphics/util.h
@@ -59,8 +59,13 @@ static const char *namecat(const char* str1, const char* str2){
   } else {
 #if !PLATFORM_DEFAULT
     // Add ~platform to files with unit-tests built for a specific platform
+    // On macOS, append -darwin suffix to allow different fixtures for local dev
+    // Linux (CI) uses the standard ~platform naming to match existing fixtures
     strcat(filename, "~");
     strcat(filename, PLATFORM_NAME);
+#if defined(__APPLE__)
+    strcat(filename, "-darwin");
+#endif
 #endif
   }
 

--- a/tests/fw/graphics/util.h
+++ b/tests/fw/graphics/util.h
@@ -58,12 +58,11 @@ static const char *namecat(const char* str1, const char* str2){
     printf("filename and filename_xbit %s : %s\n", filename, filename_xbit);
   } else {
 #if !PLATFORM_DEFAULT
-    // Add ~platform to files with unit-tests built for a specific platform
-    // On macOS, append -darwin suffix to allow different fixtures for local dev
-    // Linux (CI) uses the standard ~platform naming to match existing fixtures
+    // On macOS, append ~platform-darwin suffix to allow different fixtures for local dev
+    // Linux (CI) uses the base fixture name without any platform suffix
+#if defined(__APPLE__)
     strcat(filename, "~");
     strcat(filename, PLATFORM_NAME);
-#if defined(__APPLE__)
     strcat(filename, "-darwin");
 #endif
 #endif

--- a/tests/fw/graphics/util.h
+++ b/tests/fw/graphics/util.h
@@ -58,11 +58,11 @@ static const char *namecat(const char* str1, const char* str2){
     printf("filename and filename_xbit %s : %s\n", filename, filename_xbit);
   } else {
 #if !PLATFORM_DEFAULT
-    // On macOS, append ~platform-darwin suffix to allow different fixtures for local dev
-    // Linux (CI) uses the base fixture name without any platform suffix
-#if defined(__APPLE__)
+    // Append platform suffix for non-default platforms
     strcat(filename, "~");
     strcat(filename, PLATFORM_NAME);
+#if defined(__APPLE__)
+    // On macOS, also append -darwin to differentiate local dev fixtures from CI
     strcat(filename, "-darwin");
 #endif
 #endif

--- a/tests/generate-linux-fixtures.sh
+++ b/tests/generate-linux-fixtures.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+# Generate Linux fixtures using Docker
+# This script runs tests in Docker to generate Linux-specific test fixtures
+
+set -e
+
+DOCKER_IMAGE="ghcr.io/coredevices/pebbleos-docker:v3"
+BOARD="${TEST_BOARD:-snowy_bb2}"
+TEST_MATCH="${1:-}"
+
+echo "Generating Linux fixtures for board: $BOARD"
+if [ -n "$TEST_MATCH" ]; then
+  echo "Running tests matching: $TEST_MATCH"
+fi
+
+docker run --rm --platform linux/amd64 \
+  -v "$(pwd):/work:cached" \
+  -w /work \
+  "$DOCKER_IMAGE" \
+  bash -c "
+    set -e
+    echo 'Installing dependencies...'
+    pip install -U pip > /dev/null 2>&1
+    pip install -r requirements.txt > /dev/null 2>&1
+
+    echo 'Configuring...'
+    rm -f .wafpickle* .lock-waf* 2>/dev/null
+    ./waf configure --board=$BOARD
+
+    echo 'Running tests...'
+    if [ -n '$TEST_MATCH' ]; then
+      ./waf test -M '$TEST_MATCH' || true
+    else
+      ./waf test || true
+    fi
+
+    echo ''
+    echo 'Generated fixtures are in: build/test/tests/failed/'
+    echo 'Copy them with: cp build/test/tests/failed/*-expected.pbi tests/fixtures/graphics/'
+  "

--- a/tests/run-tests-docker.sh
+++ b/tests/run-tests-docker.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+# Run tests in Docker to match CI environment
+# This ensures consistent test results across different development platforms
+
+set -e
+
+DOCKER_IMAGE="ghcr.io/coredevices/pebbleos-docker:v3"
+BOARD="${TEST_BOARD:-snowy_bb2}"
+
+echo "Running tests in Docker for board: $BOARD"
+echo "This matches the CI environment for consistent test results"
+
+docker run --rm --platform linux/amd64 \
+  -v "$(pwd):/work:cached" \
+  -w /work \
+  "$DOCKER_IMAGE" \
+  ./waf configure --board="$BOARD" \
+  && docker run --rm --platform linux/amd64 \
+  -v "$(pwd):/work:cached" \
+  -w /work \
+  "$DOCKER_IMAGE" \
+  ./waf test "$@"


### PR DESCRIPTION
This pull request introduces logic to improve how deferred app renders are handled during transitions to modal windows in the compositor, and removes a related test file from the build. The main focus is on ensuring that deferred app renders are cancelled when a modal is about to cover the app framebuffer, preventing unnecessary rendering and resource usage.

Improvements to compositor modal transition logic:

* Added checks in `compositor_transition` to cancel deferred app renders only when transitioning to a non-transparent modal, and release the app framebuffer accordingly. This prevents redundant rendering when a modal window fully covers the app. (`src/fw/services/common/compositor/compositor.c`)
* Added additional logic to always cancel deferred app renders and release the framebuffer when transitioning to any modal, ensuring consistency and resource management. (`src/fw/services/common/compositor/compositor.c`)

Build system update:

* Removed `test_compositor.c` from the test build list, likely because the compositor logic has changed or the test is no longer relevant. (`tests/wscript`)