### PR TITLE
bluetooth/pairability: reset cached discoverable state on BT init [FIRM-1283]

### DIFF
--- a/src/fw/services/common/bluetooth/pairability.c
+++ b/src/fw/services/common/bluetooth/pairability.c
@@ -138,6 +138,9 @@ void bt_pairability_update_due_to_bonding_change(void) {
 }
 
 void bt_pairability_init(void) {
+  // Reset cached discoverable state: the advertising infrastructure was torn down
+  // before this init, so we must re-drive gap_le_slave_set_discoverable() if needed.
+  s_last_ble_discoverable_state = false;
   bt_pairability_update_due_to_bonding_change();
   prv_schedule_evaluation();
 }


### PR DESCRIPTION
When airplane mode is toggled off, bt_pairability_init() is called after the BLE advertising infrastructure has been fully torn down and rebuilt. However, the cached s_last_ble_discoverable_state was not being reset, causing evaluate_pairing_refcount() to skip calling gap_le_slave_set_discoverable(true) since it believed discovery advertising was already active. This left an unpaired watch invisible to phones attempting to pair.

Reset s_last_ble_discoverable_state to false in bt_pairability_init() so the next evaluation unconditionally re-drives discoverable advertising when needed.