### PR TITLE
fw/services/voice: handle duplicate VoiceEndpointSetupReceived

### DIFF
--- a/src/fw/services/normal/voice/voice.c
+++ b/src/fw/services/normal/voice/voice.c
@@ -541,7 +541,8 @@ void voice_handle_session_setup_result(VoiceEndpointResult result,
   bool has_error = true;
 
   if (s_state != SessionState_StartSession &&
-      s_state != SessionState_AudioEndpointSetupReceived) {
+      s_state != SessionState_AudioEndpointSetupReceived &&
+      s_state != SessionState_VoiceEndpointSetupReceived) {
     PBL_LOG_WRN("Session setup result received when not expected, state=%d",
             (int)s_state);
     prv_cancel_session();
@@ -549,6 +550,13 @@ void voice_handle_session_setup_result(VoiceEndpointResult result,
         VoiceEventTypeSessionSetup : VoiceEventTypeSessionResult;
     prv_send_event(event_type, VoiceStatusErrorGeneric, NULL);
     goto done;
+  }
+
+  // If we already received the voice endpoint setup, a duplicate is unexpected.
+  // Log a warning and ignore it rather than asserting in prv_handle_subsystem_started().
+  if (s_state == SessionState_VoiceEndpointSetupReceived) {
+    PBL_LOG_WRN("Duplicate voice endpoint setup result received, ignoring");
+    goto unlock;
   }
 
   if (session_type >= VoiceEndpointSessionTypeCount) {


### PR DESCRIPTION
gracefully

The guard in voice_handle_session_setup_result() did not account for the case where a duplicate voice endpoint setup result arrives while already in SessionState_VoiceEndpointSetupReceived. This caused prv_handle_subsystem_started() to hit PBL_ASSERTN, crashing the watch.

Add VoiceEndpointSetupReceived to the state guard and add an explicit duplicate check that logs a warning and returns early instead of asserting.

Fixes FIRM-1452