### PR TITLE
text_resources: pre-load glyph bitmaps during layout to prevent stack overflow

### DIFF
--- a/src/fw/applib/graphics/text_resources.c
+++ b/src/fw/applib/graphics/text_resources.c
@@ -622,7 +622,9 @@ static const GlyphData *prv_get_glyph(FontCache *font_cache, Codepoint codepoint
 
 int8_t text_resources_get_glyph_horiz_advance(FontCache *font_cache, const Codepoint codepoint,
                                               FontInfo *font_info) {
-  const GlyphData *g = prv_get_glyph(font_cache, codepoint, font_info, false /* need_bitmap */);
+  // Pre-load the bitmap so the subsequent render_glyph() call finds it cached in glyph_buffer,
+  // avoiding deep flash I/O calls from within the render call chain (prevents app stack overflow).
+  const GlyphData *g = prv_get_glyph(font_cache, codepoint, font_info, true /* need_bitmap */);
   if (!g) {
     return 0;
   }


### PR DESCRIPTION
During text rendering, walk_line() calls get_horiz_advance() immediately before render_glyph() for each character. Previously, get_horiz_advance() only loaded glyph metadata (need_bitmap=false), so render_glyph() had to load the bitmap from flash via a deep call chain (pfs_read -> flash_read -> qspi_flash_read_blocking). On the app task's tight 2 KB stack, this 38+ frame deep chain overflows when rendering non-Latin text (e.g. Cyrillic) through action menus.

By passing need_bitmap=true in get_horiz_advance(), the bitmap is loaded into glyph_buffer during the advance call. The immediately following render_glyph() then finds it cached, avoiding the deep flash I/O path entirely.

Fixes FIRM-1363 and confirmed using the provided language pack in that ticket