### PR TITLE
fw/comm_session: coalesce receiver callbacks to prevent BT deadlock

### DIFF
--- a/src/fw/services/common/comm_session/default_kernel_receiver.c
+++ b/src/fw/services/common/comm_session/default_kernel_receiver.c
@@ -9,6 +9,7 @@
 #include "services/common/system_task.h"
 #include "system/logging.h"
 #include "system/passert.h"
+#include "util/slist.h"
 
 #include <inttypes.h>
 
@@ -36,6 +37,7 @@ const PebbleTask g_default_kernel_receiver_opt_main = PebbleTask_KernelMain;
 //       sent by PebbleKit apps, but get handled by the system.
 
 typedef struct {
+  SingleListNode node;
   CommSession *session;
   const PebbleProtocolEndpoint *endpoint;
   size_t total_payload_size;
@@ -44,6 +46,17 @@ typedef struct {
   bool should_use_kernel_main;
   uint8_t payload[];
 } DefaultReceiverImpl;
+
+//! Pending receiver lists: completed messages are appended here instead of each
+//! getting their own system_task/launcher_task callback. A single callback is
+//! scheduled per list and drains all entries when it fires. This prevents the
+//! system task queue from overflowing when many Pebble Protocol messages arrive
+//! in rapid succession (e.g. after BT reconnect).
+static SingleListNode *s_pending_bg_head;
+static bool s_bg_callback_pending;
+
+static SingleListNode *s_pending_main_head;
+static bool s_main_callback_pending;
 
 static Receiver *prv_default_kernel_receiver_prepare(
     CommSession *session, const PebbleProtocolEndpoint *endpoint,
@@ -88,14 +101,40 @@ static void prv_wipe_receiver_data(DefaultReceiverImpl *receiver) {
   *receiver = (DefaultReceiverImpl) { };
 }
 
-static void prv_default_kernel_receiver_cb(void *data) {
-  DefaultReceiverImpl *impl = (DefaultReceiverImpl *)data;
-  PBL_ASSERTN(impl && impl->handler_scheduled && impl->session);
+static void prv_append_to_pending_list(DefaultReceiverImpl *impl,
+                                       SingleListNode **head) {
+  slist_init(&impl->node);
+  if (*head) {
+    slist_append(*head, &impl->node);
+  } else {
+    *head = &impl->node;
+  }
+}
 
-  impl->endpoint->handler(impl->session, impl->payload, impl->total_payload_size);
+static void prv_drain_pending_list(SingleListNode **head,
+                                   bool *callback_pending) {
+  // Snapshot and detach the list so new items that arrive while we are
+  // processing do not extend the current batch indefinitely.
+  SingleListNode *list = *head;
+  *head = NULL;
+  *callback_pending = false;
 
-  prv_wipe_receiver_data(impl);
-  kernel_free(impl);
+  while (list) {
+    DefaultReceiverImpl *impl = (DefaultReceiverImpl *)list;
+    list = slist_get_next(list);
+    PBL_ASSERTN(impl->handler_scheduled && impl->session);
+    impl->endpoint->handler(impl->session, impl->payload, impl->total_payload_size);
+    prv_wipe_receiver_data(impl);
+    kernel_free(impl);
+  }
+}
+
+static void prv_default_kernel_receiver_bg_cb(void *data) {
+  prv_drain_pending_list(&s_pending_bg_head, &s_bg_callback_pending);
+}
+
+static void prv_default_kernel_receiver_main_cb(void *data) {
+  prv_drain_pending_list(&s_pending_main_head, &s_main_callback_pending);
 }
 
 static void prv_default_kernel_receiver_finish(Receiver *receiver) {
@@ -107,15 +146,22 @@ static void prv_default_kernel_receiver_finish(Receiver *receiver) {
             impl->endpoint->handler);
   }
 
-  // Note: At the moment we unconditionally spawn a new callback upon
-  // completion of each individual payload. If we are getting a flood of
-  // events, this may generate too many CBs and overflow the queue. We could keep a list
-  // of pending receiver events and only schedule the CB if there isn't one
-  // already pending
+  // Coalesce callbacks: append to the pending list and only schedule a new
+  // system_task / launcher_task callback if one isn't already in flight.
+  // This avoids overflowing the system task queue when many Pebble Protocol
+  // messages arrive in rapid succession (e.g. after BT reconnect).
   if (impl->should_use_kernel_main) {
-    launcher_task_add_callback(prv_default_kernel_receiver_cb, receiver);
+    prv_append_to_pending_list(impl, &s_pending_main_head);
+    if (!s_main_callback_pending) {
+      s_main_callback_pending = true;
+      launcher_task_add_callback(prv_default_kernel_receiver_main_cb, NULL);
+    }
   } else {
-    system_task_add_callback(prv_default_kernel_receiver_cb, receiver);
+    prv_append_to_pending_list(impl, &s_pending_bg_head);
+    if (!s_bg_callback_pending) {
+      s_bg_callback_pending = true;
+      system_task_add_callback(prv_default_kernel_receiver_bg_cb, NULL);
+    }
   }
 }
 

--- a/src/libutil/includes/util/slist.h
+++ b/src/libutil/includes/util/slist.h
@@ -1,0 +1,94 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+#include <stdbool.h>
+#include <stdint.h>
+#include "order.h"
+
+typedef struct SingleListNode {
+  struct SingleListNode *next;
+} SingleListNode;
+
+typedef bool (*SingleListFilterCallback)(SingleListNode *found_node, void *data);
+
+//! - If a callback returns true, the iteration continues
+//! - If a callback returns false, the ieration stops.
+typedef bool (*SingleListForEachCallback)(SingleListNode *node, void *context);
+
+#define SINGLE_LIST_NODE_NULL { .next = NULL }
+
+//! Initializes the node.
+void slist_init(SingleListNode *node);
+
+//! Inserts new_node after node in the list.
+//! Always returns new_node.
+SingleListNode* slist_insert_after(SingleListNode *node, SingleListNode *new_node);
+
+//! Prepends new_node to the head of the list.
+//! @param head The current head of the list, can be NULL.
+//! Always returns the new head of the list.
+SingleListNode* slist_prepend(SingleListNode *head, SingleListNode *new_node);
+
+//! Appends new_node to the tail of the list that head is part of.
+//! @param head Any node in the list, can be NULL (will result in a list containing only new_node).
+//! Always returns the tail of the list.
+SingleListNode* slist_append(SingleListNode *head, SingleListNode *new_node);
+
+//! Removes the head of the list and returns the new head.
+SingleListNode* slist_pop_head(SingleListNode *head);
+
+//! Removes the node from the list.
+//! @param node the SingleListNode to remove.
+//! @param[in,out] *head will be updated if the removed node happens to be the head.
+//! @note head must not be NULL.
+void slist_remove(SingleListNode *node, SingleListNode **head);
+
+//! Gets the next node.
+SingleListNode* slist_get_next(SingleListNode *node);
+
+//! Gets the last node in the list.
+SingleListNode* slist_get_tail(SingleListNode *node);
+
+//! @return true if the passed in node is the tail of a list.
+bool slist_is_tail(const SingleListNode *node);
+
+//! Counts the number of nodes from head to tail.
+uint32_t slist_count(SingleListNode *head);
+
+//! @param[in] head The head of the list to search.
+//! @param[in] node The node to search for.
+//! @returns True if the list contains node.
+bool slist_contains(const SingleListNode *head, const SingleListNode *node);
+
+//! Gets the first node that conforms to the given filter callback.
+//! @param head The list node from which to start the search.
+//! @param filter_callback A function returning true if the node matches the filter criteria.
+//! @param data Optional callback data.
+SingleListNode* slist_find(SingleListNode *head, SingleListFilterCallback filter_callback,
+                           void *data);
+
+//! Adds a node to a list ordered by given comparator.
+//! @param[in] head The head of the list that we want to add to.
+//! @param[in] new_node The node being added.
+//! @param[in] comparator The comparison function to use.
+//! @param[in] ascending True to maintain the list ordered ascending from head to tail.
+//! @returns The (new) head of the list.
+//! @note This function will not sort existing nodes in the list.
+SingleListNode* slist_sorted_add(SingleListNode *head, SingleListNode *new_node,
+                                 Comparator comparator, bool ascending);
+
+//! Concatenate two lists.
+//! @param list_a list onto which to concatenate list_b.
+//! @param list_b list to concatenate onto list_a.
+//! @return head of the new list.
+SingleListNode* slist_concatenate(SingleListNode *list_a, SingleListNode *list_b);
+
+//! Iterates over each node and passes it into callback given.
+//! @param[in] head The head of the list that we want to iterate over.
+//! @param[in] each_cb The callback function to pass each node into.
+//! @param[in] context Optional callback data.
+void slist_foreach(SingleListNode *head, SingleListForEachCallback each_cb, void *context);
+
+//! Dump a list to PBL_LOG.
+void slist_debug_dump(SingleListNode *head);

--- a/src/libutil/slist.c
+++ b/src/libutil/slist.c
@@ -1,0 +1,207 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "util/slist.h"
+#include "util/assert.h"
+#include "util/logging.h"
+
+#include <stddef.h>
+#include <stdio.h>
+
+void slist_init(SingleListNode *node) {
+  node->next = NULL;
+}
+
+SingleListNode* slist_insert_after(SingleListNode *node, SingleListNode *new_node) {
+  if (node == NULL) {
+    return new_node;
+  }
+  new_node->next = node->next;
+  node->next = new_node;
+
+  return new_node;
+}
+
+SingleListNode* slist_prepend(SingleListNode *head, SingleListNode *new_node) {
+  if (new_node == NULL) {
+    return head;
+  }
+  new_node->next = head;
+  return new_node;
+}
+
+SingleListNode* slist_append(SingleListNode *head, SingleListNode *new_node) {
+  return slist_insert_after(slist_get_tail(head), new_node);
+}
+
+SingleListNode* slist_pop_head(SingleListNode *head) {
+  if (head == NULL) {
+    return NULL;
+  }
+  SingleListNode *new_head = head->next;
+  head->next = NULL;
+  return new_head;
+}
+
+void slist_remove(SingleListNode *node, SingleListNode **head) {
+  if (node == NULL || head == NULL || *head == NULL) {
+    return;
+  }
+
+  if (*head == node) {
+    *head = node->next;
+    node->next = NULL;
+    return;
+  }
+
+  SingleListNode *prev = *head;
+  while (prev->next != NULL && prev->next != node) {
+    prev = prev->next;
+  }
+
+  if (prev->next == node) {
+    prev->next = node->next;
+    node->next = NULL;
+  }
+}
+
+SingleListNode* slist_get_next(SingleListNode *node) {
+  if (node == NULL) {
+    return NULL;
+  }
+  return node->next;
+}
+
+SingleListNode* slist_get_tail(SingleListNode *node) {
+  if (node == NULL) {
+    return NULL;
+  }
+  while (node->next != NULL) {
+    node = node->next;
+  }
+  return node;
+}
+
+bool slist_is_tail(const SingleListNode *node) {
+  if (!node) {
+    return false;
+  }
+  return !node->next;
+}
+
+uint32_t slist_count(SingleListNode *head) {
+  if (head == NULL) {
+    return 0;
+  }
+  uint32_t count = 1;
+  while ((head = head->next) != NULL) {
+    ++count;
+  }
+  return count;
+}
+
+bool slist_contains(const SingleListNode *head, const SingleListNode *node) {
+  if (head == NULL || node == NULL) {
+    return false;
+  }
+  while (head) {
+    if (head == node) {
+      return true;
+    }
+    head = head->next;
+  }
+  return false;
+}
+
+SingleListNode* slist_find(SingleListNode *head, SingleListFilterCallback filter_callback,
+                           void *data) {
+  if (head == NULL) {
+    return NULL;
+  }
+  SingleListNode *cursor = head;
+  do {
+    if (filter_callback(cursor, data)) {
+      return cursor;
+    }
+  } while ((cursor = cursor->next));
+  return NULL;
+}
+
+SingleListNode* slist_sorted_add(SingleListNode *head, SingleListNode *new_node,
+                                 Comparator comparator, bool ascending) {
+  if (head == NULL) {
+    return new_node;
+  }
+  if (new_node == NULL) {
+    return head;
+  }
+
+  SingleListNode *prev = NULL;
+  SingleListNode *cursor = head;
+  for (;;) {
+    int order = comparator(cursor, new_node);
+    if (!ascending) {
+      order = -order;
+    }
+
+    if (order < 0) {
+      // Insert before cursor
+      new_node->next = cursor;
+      if (prev == NULL) {
+        return new_node;
+      } else {
+        prev->next = new_node;
+        return head;
+      }
+    }
+    if (cursor->next == NULL) {
+      // Append after the last node
+      cursor->next = new_node;
+      new_node->next = NULL;
+      return head;
+    }
+    prev = cursor;
+    cursor = cursor->next;
+  }
+}
+
+SingleListNode* slist_concatenate(SingleListNode *restrict list_a,
+                                  SingleListNode *restrict list_b) {
+  if (list_a == NULL) {
+    return list_b;
+  }
+  if (list_b == NULL) {
+    return list_a;
+  }
+
+  SingleListNode *tail_a = slist_get_tail(list_a);
+  tail_a->next = list_b;
+
+  return list_a;
+}
+
+void slist_foreach(SingleListNode *head, SingleListForEachCallback each_cb, void *context) {
+  if (!each_cb) {
+    return;
+  }
+
+  SingleListNode *iter = head;
+  while (iter) {
+    // Save off a pointer so the client can destroy the node in the callback
+    SingleListNode *next = iter->next;
+    if (!each_cb(iter, context)) {
+      return;
+    }
+    iter = next;
+  }
+}
+
+void slist_debug_dump(SingleListNode *head) {
+  SingleListNode *iter = head;
+  char buffer[20];
+  while (iter) {
+    snprintf(buffer, sizeof(buffer), "node %p (%p)", iter, iter->next);
+    UTIL_LOG(buffer);
+    iter = iter->next;
+  }
+}

--- a/tests/fw/services/comm_session/test_default_kernel_receiver.c
+++ b/tests/fw/services/comm_session/test_default_kernel_receiver.c
@@ -52,6 +52,13 @@ typedef struct {
 } ExpectedData;
 
 static ExpectedData s_expected_data;
+static bool s_skip_data_assert;
+
+//! Record of data received by handlers, for verifying batched delivery order.
+#define MAX_RECORDED_CALLS 16
+static uint8_t s_recorded_data[MAX_RECORDED_CALLS];
+static size_t s_recorded_lens[MAX_RECORDED_CALLS];
+static int s_recorded_count;
 
 static void prv_set_expected_data(void *data, size_t len) {
   s_expected_data.buf = data;
@@ -59,6 +66,9 @@ static void prv_set_expected_data(void *data, size_t len) {
 }
 
 static void prv_assert_data_matches_expected(const void *data, size_t len) {
+  if (s_skip_data_assert) {
+    return;
+  }
   cl_assert_equal_i(len, s_expected_data.len);
   cl_assert(memcmp(s_expected_data.buf, data, len) == 0);
 }
@@ -72,6 +82,11 @@ static void prv_assert_no_handler_calls(void) {
 static void prv_endpoint_handler_a(
     CommSession *session, const uint8_t *data, size_t length) {
   s_handler_call_count[HandlerA]++;
+  if (s_recorded_count < MAX_RECORDED_CALLS) {
+    s_recorded_data[s_recorded_count] = data[0];
+    s_recorded_lens[s_recorded_count] = length;
+    s_recorded_count++;
+  }
   prv_assert_data_matches_expected(data, length);
 }
 
@@ -108,6 +123,8 @@ static const PebbleProtocolEndpoint s_endpoints[NumHandlers] = {
 void test_default_kernel_receiver__cleanup(void) {
   memset(s_handler_call_count, 0x0, sizeof(s_handler_call_count));
   s_kernel_main_schedule_count = 0;
+  s_skip_data_assert = false;
+  s_recorded_count = 0;
 }
 
 
@@ -185,7 +202,8 @@ void test_default_kernel_receiver__prepare_write_finish_multiple_sessions(void) 
 
 //! It's possible the same session can receiver multiple messages before any
 //! are processed on kernel BG. Make sure they do not interfere with one
-//! another
+//! another. With coalesced callbacks, a single system_task callback drains
+//! all pending messages in order.
 void test_default_kernel_receiver__same_session_batched(void) {
   const int batch_num = 10;
   char data = 'a';
@@ -204,12 +222,17 @@ void test_default_kernel_receiver__same_session_batched(void) {
 
   prv_assert_no_handler_calls();
 
-  char expected_data = 'a';
+  // All 10 messages are coalesced into a single system_task callback.
+  // Skip per-handler expected_data assertion; verify order via recording.
+  s_skip_data_assert = true;
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(s_handler_call_count[HandlerA], batch_num);
+
+  // Verify that handlers were called in the correct order with correct data
+  cl_assert_equal_i(s_recorded_count, batch_num);
   for (int i = 0; i < batch_num; i++) {
-    prv_set_expected_data(&expected_data, 1);
-    fake_system_task_callbacks_invoke(1);
-    cl_assert_equal_i(s_handler_call_count[HandlerA], i + 1);
-    expected_data += 1;
+    cl_assert_equal_i(s_recorded_data[i], 'a' + i);
+    cl_assert_equal_i(s_recorded_lens[i], 1);
   }
 
   cl_assert_equal_i(fake_pbl_malloc_num_net_allocs(), 0);

--- a/tests/libutil/test_slist.c
+++ b/tests/libutil/test_slist.c
@@ -1,0 +1,376 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "util/slist.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "clar.h"
+#include "stubs_passert.h"
+
+// Stubs
+///////////////////////////////////////////////////////////
+int g_pbl_log_level = 0;
+void pbl_log(int level, const char* src_filename, int src_line_number, const char* fmt, ...) { }
+
+// Tests
+///////////////////////////////////////////////////////////
+
+void test_slist__initialize(void) {
+}
+
+void test_slist__cleanup(void) {
+}
+
+void test_slist__insert_after(void) {
+  SingleListNode *tail = NULL;
+  SingleListNode a = SINGLE_LIST_NODE_NULL, b = SINGLE_LIST_NODE_NULL;
+  tail = slist_insert_after(tail, &a);
+  cl_assert(tail == &a);
+  tail = slist_insert_after(&a, &b);
+  cl_assert(tail == &b);
+  cl_assert(a.next == &b);
+  cl_assert(b.next == NULL);
+}
+
+void test_slist__insert_after_middle(void) {
+  SingleListNode a = SINGLE_LIST_NODE_NULL;
+  SingleListNode b = SINGLE_LIST_NODE_NULL;
+  SingleListNode c = SINGLE_LIST_NODE_NULL;
+  a.next = &c;
+  slist_insert_after(&a, &b);
+  cl_assert(a.next == &b);
+  cl_assert(b.next == &c);
+  cl_assert(c.next == NULL);
+}
+
+void test_slist__prepend(void) {
+  SingleListNode a = SINGLE_LIST_NODE_NULL;
+  SingleListNode b = SINGLE_LIST_NODE_NULL;
+  SingleListNode c = SINGLE_LIST_NODE_NULL;
+  SingleListNode *head;
+  head = slist_prepend(&c, &b);
+  cl_assert(head == &b);
+  cl_assert(b.next == &c);
+  head = slist_prepend(&b, &a);
+  cl_assert(head == &a);
+  cl_assert(a.next == &b);
+  cl_assert(b.next == &c);
+  cl_assert(c.next == NULL);
+}
+
+void test_slist__prepend_null(void) {
+  SingleListNode a = SINGLE_LIST_NODE_NULL;
+  SingleListNode *head = slist_prepend(NULL, &a);
+  cl_assert(head == &a);
+  cl_assert(a.next == NULL);
+}
+
+void test_slist__append(void) {
+  SingleListNode a = SINGLE_LIST_NODE_NULL;
+  SingleListNode b = SINGLE_LIST_NODE_NULL;
+  SingleListNode c = SINGLE_LIST_NODE_NULL;
+  SingleListNode *tail;
+  tail = slist_append(&a, &b);
+  cl_assert(tail == &b);
+  tail = slist_append(&a, &c);
+  cl_assert(tail == &c);
+  cl_assert(a.next == &b);
+  cl_assert(b.next == &c);
+  cl_assert(c.next == NULL);
+}
+
+void test_slist__append_null(void) {
+  SingleListNode a = SINGLE_LIST_NODE_NULL;
+  SingleListNode *tail = slist_append(NULL, &a);
+  cl_assert(tail == &a);
+}
+
+void test_slist__pop_head(void) {
+  SingleListNode a = SINGLE_LIST_NODE_NULL, b = SINGLE_LIST_NODE_NULL;
+  a.next = &b;
+  SingleListNode *new_head = slist_pop_head(&a);
+  cl_assert(new_head == &b);
+  cl_assert(a.next == NULL);
+  cl_assert(b.next == NULL);
+}
+
+void test_slist__pop_head_single(void) {
+  SingleListNode a = SINGLE_LIST_NODE_NULL;
+  SingleListNode *new_head = slist_pop_head(&a);
+  cl_assert(new_head == NULL);
+}
+
+void test_slist__pop_head_null(void) {
+  cl_assert(slist_pop_head(NULL) == NULL);
+}
+
+void test_slist__remove_head(void) {
+  SingleListNode a = SINGLE_LIST_NODE_NULL;
+  SingleListNode b = SINGLE_LIST_NODE_NULL;
+  SingleListNode c = SINGLE_LIST_NODE_NULL;
+  a.next = &b;
+  b.next = &c;
+  SingleListNode *head = &a;
+  slist_remove(&a, &head);
+  cl_assert(head == &b);
+  cl_assert(a.next == NULL);
+  cl_assert(b.next == &c);
+}
+
+void test_slist__remove_middle(void) {
+  SingleListNode a = SINGLE_LIST_NODE_NULL;
+  SingleListNode b = SINGLE_LIST_NODE_NULL;
+  SingleListNode c = SINGLE_LIST_NODE_NULL;
+  a.next = &b;
+  b.next = &c;
+  SingleListNode *head = &a;
+  slist_remove(&b, &head);
+  cl_assert(head == &a);
+  cl_assert(a.next == &c);
+  cl_assert(b.next == NULL);
+  cl_assert(c.next == NULL);
+}
+
+void test_slist__remove_tail(void) {
+  SingleListNode a = SINGLE_LIST_NODE_NULL;
+  SingleListNode b = SINGLE_LIST_NODE_NULL;
+  SingleListNode c = SINGLE_LIST_NODE_NULL;
+  a.next = &b;
+  b.next = &c;
+  SingleListNode *head = &a;
+  slist_remove(&c, &head);
+  cl_assert(head == &a);
+  cl_assert(a.next == &b);
+  cl_assert(b.next == NULL);
+  cl_assert(c.next == NULL);
+}
+
+void test_slist__remove_only(void) {
+  SingleListNode a = SINGLE_LIST_NODE_NULL;
+  SingleListNode *head = &a;
+  slist_remove(&a, &head);
+  cl_assert(head == NULL);
+  cl_assert(a.next == NULL);
+}
+
+void test_slist__remove_not_found(void) {
+  SingleListNode a = SINGLE_LIST_NODE_NULL;
+  SingleListNode b = SINGLE_LIST_NODE_NULL;
+  SingleListNode orphan = SINGLE_LIST_NODE_NULL;
+  a.next = &b;
+  SingleListNode *head = &a;
+  slist_remove(&orphan, &head);
+  // List should be unchanged
+  cl_assert(head == &a);
+  cl_assert(a.next == &b);
+  cl_assert(b.next == NULL);
+}
+
+void test_slist__get_next(void) {
+  SingleListNode a = SINGLE_LIST_NODE_NULL, b = SINGLE_LIST_NODE_NULL;
+  a.next = &b;
+  cl_assert(slist_get_next(&a) == &b);
+  cl_assert(slist_get_next(&b) == NULL);
+  cl_assert(slist_get_next(NULL) == NULL);
+}
+
+void test_slist__get_tail(void) {
+  SingleListNode a = SINGLE_LIST_NODE_NULL;
+  SingleListNode b = SINGLE_LIST_NODE_NULL;
+  SingleListNode c = SINGLE_LIST_NODE_NULL;
+  a.next = &b;
+  b.next = &c;
+  cl_assert(slist_get_tail(&a) == &c);
+  cl_assert(slist_get_tail(&b) == &c);
+  cl_assert(slist_get_tail(&c) == &c);
+  cl_assert(slist_get_tail(NULL) == NULL);
+}
+
+void test_slist__is_tail(void) {
+  SingleListNode a = SINGLE_LIST_NODE_NULL, b = SINGLE_LIST_NODE_NULL;
+  a.next = &b;
+  cl_assert(!slist_is_tail(&a));
+  cl_assert(slist_is_tail(&b));
+  cl_assert(!slist_is_tail(NULL));
+}
+
+void test_slist__count(void) {
+  SingleListNode a = SINGLE_LIST_NODE_NULL;
+  SingleListNode b = SINGLE_LIST_NODE_NULL;
+  SingleListNode c = SINGLE_LIST_NODE_NULL;
+  a.next = &b;
+  b.next = &c;
+  cl_assert_equal_i(slist_count(&a), 3);
+  cl_assert_equal_i(slist_count(&b), 2);
+  cl_assert_equal_i(slist_count(&c), 1);
+  cl_assert_equal_i(slist_count(NULL), 0);
+}
+
+void test_slist__contains(void) {
+  SingleListNode a = SINGLE_LIST_NODE_NULL;
+  SingleListNode b = SINGLE_LIST_NODE_NULL;
+  SingleListNode c = SINGLE_LIST_NODE_NULL;
+  SingleListNode orphan = SINGLE_LIST_NODE_NULL;
+  a.next = &b;
+  b.next = &c;
+  cl_assert(slist_contains(&a, &a));
+  cl_assert(slist_contains(&a, &b));
+  cl_assert(slist_contains(&a, &c));
+  cl_assert(!slist_contains(&a, &orphan));
+  cl_assert(!slist_contains(NULL, &a));
+  cl_assert(!slist_contains(&a, NULL));
+}
+
+typedef struct SIntNode {
+  SingleListNode list_node;
+  int value;
+} SIntNode;
+
+static bool prv_filter_value(SingleListNode *node, void *data) {
+  SIntNode *int_node = (SIntNode *)node;
+  return int_node->value == (int)(intptr_t)data;
+}
+
+void test_slist__find(void) {
+  SIntNode a = { .value = 10 };
+  SIntNode b = { .value = 20 };
+  SIntNode c = { .value = 30 };
+  slist_init(&a.list_node);
+  slist_init(&b.list_node);
+  slist_init(&c.list_node);
+  a.list_node.next = &b.list_node;
+  b.list_node.next = &c.list_node;
+
+  cl_assert(slist_find(&a.list_node, prv_filter_value, (void *)(intptr_t)20) == &b.list_node);
+  cl_assert(slist_find(&a.list_node, prv_filter_value, (void *)(intptr_t)30) == &c.list_node);
+  cl_assert(slist_find(&a.list_node, prv_filter_value, (void *)(intptr_t)10) == &a.list_node);
+  cl_assert(slist_find(&a.list_node, prv_filter_value, (void *)(intptr_t)99) == NULL);
+  cl_assert(slist_find(NULL, prv_filter_value, (void *)(intptr_t)10) == NULL);
+}
+
+static int prv_sort_comparator(SIntNode *a, SIntNode *b) {
+  return b->value - a->value;
+}
+
+void test_slist__sort_ascending(void) {
+  SIntNode bar1 = { .value = 1 };
+  SIntNode bar2 = { .value = 2 };
+  SIntNode bar3 = { .value = 3 };
+  slist_init(&bar1.list_node);
+  slist_init(&bar2.list_node);
+  slist_init(&bar3.list_node);
+
+  SingleListNode *head = NULL;
+
+  head = slist_sorted_add(head, &bar2.list_node, (Comparator)prv_sort_comparator, true);
+  cl_assert(head == &bar2.list_node);
+
+  head = slist_sorted_add(head, &bar3.list_node, (Comparator)prv_sort_comparator, true);
+  cl_assert(head == &bar2.list_node);
+  cl_assert(slist_get_tail(head) == &bar3.list_node);
+
+  head = slist_sorted_add(head, &bar1.list_node, (Comparator)prv_sort_comparator, true);
+  cl_assert(head == &bar1.list_node);
+  cl_assert(slist_get_next(head) == &bar2.list_node);
+  cl_assert(slist_get_tail(head) == &bar3.list_node);
+}
+
+void test_slist__sort_descending(void) {
+  SIntNode bar1 = { .value = 1 };
+  SIntNode bar2 = { .value = 2 };
+  SIntNode bar3 = { .value = 3 };
+  slist_init(&bar1.list_node);
+  slist_init(&bar2.list_node);
+  slist_init(&bar3.list_node);
+
+  SingleListNode *head = NULL;
+
+  head = slist_sorted_add(head, &bar2.list_node, (Comparator)prv_sort_comparator, false);
+  cl_assert(head == &bar2.list_node);
+
+  head = slist_sorted_add(head, &bar3.list_node, (Comparator)prv_sort_comparator, false);
+  cl_assert(head == &bar3.list_node);
+  cl_assert(slist_get_tail(head) == &bar2.list_node);
+
+  head = slist_sorted_add(head, &bar1.list_node, (Comparator)prv_sort_comparator, false);
+  cl_assert(head == &bar3.list_node);
+  cl_assert(slist_get_next(head) == &bar2.list_node);
+  cl_assert(slist_get_tail(head) == &bar1.list_node);
+}
+
+void test_slist__concatenate(void) {
+  SingleListNode a = SINGLE_LIST_NODE_NULL;
+  SingleListNode b = SINGLE_LIST_NODE_NULL;
+  SingleListNode c = SINGLE_LIST_NODE_NULL;
+  SingleListNode d = SINGLE_LIST_NODE_NULL;
+  SingleListNode e = SINGLE_LIST_NODE_NULL;
+  a.next = &b;
+  b.next = &c;
+  d.next = &e;
+
+  SingleListNode *head = slist_concatenate(&a, &d);
+  cl_assert(head == &a);
+  cl_assert(c.next == &d);
+  cl_assert(d.next == &e);
+  cl_assert(e.next == NULL);
+  cl_assert_equal_i(slist_count(head), 5);
+}
+
+void test_slist__concatenate_null(void) {
+  SingleListNode a = SINGLE_LIST_NODE_NULL;
+  cl_assert(slist_concatenate(NULL, &a) == &a);
+  cl_assert(slist_concatenate(&a, NULL) == &a);
+  cl_assert(slist_concatenate(NULL, NULL) == NULL);
+}
+
+#define CTX_VALUE 0xdeadbeef
+#define INT_VALUE 17
+
+static bool prv_slist_set_val_each(SingleListNode *node, void *context) {
+  SIntNode *int_node = (SIntNode *)node;
+  int_node->value = INT_VALUE;
+  cl_assert_equal_i(CTX_VALUE, (uintptr_t)context);
+  return true;
+}
+
+void test_slist__each(void) {
+  SIntNode a = {}, b = {}, c = {};
+  SingleListNode *head;
+  head = slist_prepend((SingleListNode *)&c, (SingleListNode *)&b);
+  head = slist_prepend((SingleListNode *)&b, (SingleListNode *)&a);
+
+  cl_assert_equal_i(slist_count(head), 3);
+  slist_foreach(head, prv_slist_set_val_each, (void *)(uintptr_t)CTX_VALUE);
+
+  uint32_t num_nodes = 0;
+  SingleListNode *temp = head;
+  while (temp) {
+    SingleListNode *next = temp->next;
+    SIntNode *int_node = (SIntNode *)temp;
+    cl_assert_equal_i(int_node->value, INT_VALUE);
+    temp = next;
+    num_nodes++;
+  }
+
+  cl_assert_equal_i(num_nodes, 3);
+}
+
+static bool prv_stop_at_second(SingleListNode *node, void *context) {
+  int *count = (int *)context;
+  (*count)++;
+  return (*count < 2);
+}
+
+void test_slist__each_early_stop(void) {
+  SingleListNode a = SINGLE_LIST_NODE_NULL;
+  SingleListNode b = SINGLE_LIST_NODE_NULL;
+  SingleListNode c = SINGLE_LIST_NODE_NULL;
+  a.next = &b;
+  b.next = &c;
+  int count = 0;
+  slist_foreach(&a, prv_stop_at_second, &count);
+  cl_assert_equal_i(count, 2);
+}

--- a/tests/libutil/wscript
+++ b/tests/libutil/wscript
@@ -12,6 +12,10 @@ def build(ctx):
 
     clar(ctx,
          sources_ant_glob=None,
+         test_sources_ant_glob="test_slist.c")
+
+    clar(ctx,
+         sources_ant_glob=None,
          test_sources_ant_glob="test_math.c",
          test_libs=['m'])
 


### PR DESCRIPTION
A deadlock occurred between KernelMain (holding bt_lock, blocked on full system task queue) and KernelBG (sole queue consumer, blocked on bt_lock) during BT reconnect floods.

Implement the callback coalescing suggested by the existing TODO: instead of scheduling a new system_task_add_callback per completed Pebble Protocol message, maintain pending lists and batch-drain them in a single callback per task type. This reduces queue usage from N entries to at most 2, preventing the overflow that caused the deadlock.

Fixes FIRM-1405