### PR TITLE
fw/applib/moddable: add instrumentation flag support

### DIFF
--- a/src/fw/applib/app_logging.h
+++ b/src/fw/applib/app_logging.h
@@ -76,6 +76,10 @@ typedef enum {
 //!   @}
 //! @}
 
+// @internal
+// Returns true if app logging over Bluetooth is enabled (someone is listening)
+bool app_log_is_bt_enabled(void);
+
 typedef enum AppLoggingMode {
   AppLoggingDisabled = 0,
   AppLoggingEnabled = 1,

--- a/src/fw/applib/moddable/moddable.c
+++ b/src/fw/applib/moddable/moddable.c
@@ -7,6 +7,8 @@
 #include "applib/app_logging.h"
 #include "applib/moddable/moddable.h"
 
+#include <stddef.h>
+
 #if CAPABILITY_HAS_MODDABLE_XS && !defined(RECOVERY_FW)
 #include "xsmc.h"
 #include "xsHost.h"
@@ -32,17 +34,25 @@ void moddable_cleanup(void)
 	task_free(state);
 }
 
+// Minimum recordSize for the original struct (without flags field)
+#define kModdableCreationRecordMinSize offsetof(ModdableCreationRecord, flags)
+
 DEFINE_SYSCALL(void, moddable_createMachine, ModdableCreationRecord *cr)
 {
 	xsMachine *the;
+	uint32_t flags = 0;
 
 	if (NULL == cr)
 		the = modCloneMachine(NULL, NULL);
 	else {
-		if (cr->recordSize < sizeof(ModdableCreationRecord)) {
+		if (cr->recordSize < kModdableCreationRecordMinSize) {
 			PBL_LOG_ERR("invalid recordSize");
 			return;
 		}
+
+		// Read flags if the record is large enough to include them
+		if (cr->recordSize >= sizeof(ModdableCreationRecord))
+			flags = cr->flags;
 
 		uint32_t stack = cr->stack, slot = cr->slot, chunk = cr->chunk;
 		if (!stack && !slot && !chunk)
@@ -80,9 +90,14 @@ DEFINE_SYSCALL(void, moddable_createMachine, ModdableCreationRecord *cr)
 		return;
 	}
 
+	// Don't log instrumentation if nobody is listening to APP_LOG over BT
+	if (!app_log_is_bt_enabled())
+		flags &= ~kModdableCreationFlagLogInstrumentation;
+
 	ModdablePebbleAppState state = task_zalloc_check(sizeof(ModdablePebbleAppStateRecord));
 	state->the = the;
 	state->eventedTimer = EVENTED_TIMER_INVALID_ID;
+	state->creationFlags = flags;
 	app_state_set_rocky_memory_api_context((void *)state);
 
 	evented_timer_register(2, false, startMachine, the);

--- a/src/fw/applib/moddable/moddable.h
+++ b/src/fw/applib/moddable/moddable.h
@@ -4,12 +4,15 @@
 
 #include <stdint.h>
 
+#define kModdableCreationFlagLogInstrumentation  (1 << 0)
+
 typedef struct {
 	uint32_t		recordSize;
 
 	uint32_t		stack;		// bytes
 	uint32_t		slot;			// bytes
 	uint32_t		chunk;		// bytes
+	uint32_t		flags;
 } ModdableCreationRecord;
 
 void moddable_createMachine(ModdableCreationRecord *creation);

--- a/src/fw/debug/app_logging.c
+++ b/src/fw/debug/app_logging.c
@@ -17,6 +17,10 @@ static const uint16_t APP_LOGGING_ENDPOINT = 2006;
 
 static AppLoggingMode s_app_logging_mode = AppLoggingDisabled;
 
+bool app_log_is_bt_enabled(void) {
+  return s_app_logging_mode == AppLoggingEnabled;
+}
+
 static const uint32_t MIN_STACK_FOR_SEND_DATA = 400;
 
 DEFINE_SYSCALL(void, sys_app_log, size_t length, void *log_buffer) {

--- a/src/fw/process_management/pebble_process_info.h
+++ b/src/fw/process_management/pebble_process_info.h
@@ -154,9 +154,10 @@ typedef enum {
 // sdk.major:0x5 .minor:0x56 -- Add PlatformType enum and defines (rev 89)
 // sdk.major:0x5 .minor:0x57 -- Add moddable_createMachine (rev 90)
 // sdk.major:0x5 .minor:0x58 -- Add size 60 LECO font (rev 91)
+// sdk.major:0x5 .minor:0x59 -- Add flags to ModdableCreationRecord (rev 92)
 
 #define PROCESS_INFO_CURRENT_SDK_VERSION_MAJOR 0x5
-#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x58
+#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x59
 
 // The first SDK to ship with 2.x APIs
 #define PROCESS_INFO_FIRST_2X_SDK_VERSION_MAJOR 0x4

--- a/tools/generate_native_sdk/exported_symbols.json
+++ b/tools/generate_native_sdk/exported_symbols.json
@@ -4,7 +4,7 @@
               "You should also make sure you are obeying our API design guidelines:",
               "https://pebbletechnology.atlassian.net/wiki/display/DEV/SDK+API+Design+Guidelines"
             ],
-  "revision" : "91",
+  "revision" : "92",
   "version" : "2.0",
   "files": [
     "fw/drivers/ambient_light.h",
@@ -1493,6 +1493,10 @@
               "type": "function",
               "name": "app_event_loop",
               "addedRevision": "0"
+            }, {
+              "type": "define",
+              "name": "kModdableCreationFlagLogInstrumentation",
+              "addedRevision": "92"
             }, {
               "type": "type",
               "name": "ModdableCreationRecord",


### PR DESCRIPTION
Add a flags field to ModdableCreationRecord with forward-compatible versioning based on recordSize.