### PR TITLE
bluetooth-fw/nimble: fix infinite loop in NimBLE store delete

### DIFF
--- a/src/bluetooth-fw/nimble/nimble_store.c
+++ b/src/bluetooth-fw/nimble/nimble_store.c
@@ -231,19 +231,25 @@ static int prv_nimble_store_write_sec(const int obj_type,
 static int prv_nimble_store_delete_sec(int obj_type, const struct ble_store_key_sec *key_sec) {
   BTDeviceInternal device;
   BleStoreValueSec *s;
+  ListNode **sec_list = prv_find_sec_list_for_obj_type(obj_type);
 
   bt_lock();
   s = prv_nimble_store_find_sec(obj_type, key_sec);
-  bt_unlock();
-
   if (s == NULL) {
+    bt_unlock();
     return BLE_HS_ENOENT;
   }
 
-  // NOTE: deletion will wipe both PEER and OUR sec data, regardless of which
-  // object type was passed in this call as they are stored together. This is
-  // handled by bt_driver_handle_host_removed_bonding(), called internally by
-  // bt_persistent_storage_delete_ble_pairing_by_addr().
+  // Remove from in-memory list before calling into persistent storage,
+  // so that NimBLE's ble_store_util_delete_all() loop terminates correctly.
+  // Previously we relied on bt_driver_handle_host_removed_bonding() to remove
+  // the entry as a side-effect, but that reads the identity from SPRF which
+  // may already be erased by a prior iteration, causing an infinite loop.
+  list_remove((ListNode *)s, sec_list, NULL);
+  bt_unlock();
+
+  kernel_free(s);
+
   nimble_addr_to_pebble_device(&key_sec->peer_addr, &device);
   bt_persistent_storage_delete_ble_pairing_by_addr(&device);
 


### PR DESCRIPTION
## Summary
- Fix infinite loop in `prv_nimble_store_delete_sec()` triggered during BLE repeat pairing in PRF
- NimBLE's `ble_store_util_delete_all()` loops calling our store delete callback until `BLE_HS_ENOENT` is returned; we returned 0 (success) but relied on a side-effect chain through SPRF to remove the in-memory entry — after SPRF was erased on the first iteration, subsequent iterations failed to remove the entry, looping forever
- Fix by directly removing the entry from the in-memory list before calling into persistent storage

## Test plan
- [x] In PRF: pair phone A, disconnect, pair phone B, disconnect, remove pairing on phone A, reconnect phone A — verify pairing completes without watchdog trigger
- [x] Verify normal pairing flow still works in PRF
- [x] Verify pairing flow still works in main firmware

Fixes FIRM-1522

🤖 Generated with [Claude Code](https://claude.com/claude-code)