### PR TITLE
activity: stop HRM sampling early when watch is flat or off-wrist

### DIFF
--- a/src/fw/services/normal/activity/activity.c
+++ b/src/fw/services/normal/activity/activity.c
@@ -83,7 +83,11 @@ static void prv_heart_rate_subscription_update(uint32_t now_ts) {
   const uint32_t last_toggled_ts = s_activity_state.hr.toggled_sampling_at_ts;
 
   // Check if the watch is face up or face down (flat = likely off wrist)
-  const uint8_t z_axis = s_activity_state.last_orientation >> 4;
+  // Use the real-time orientation from the algorithm when available, otherwise fall back to the
+  // cached value from the last minute handler call.
+  uint8_t orientation = s_activity_state.last_orientation;
+  activity_algorithm_get_orientation(&orientation);
+  const uint8_t z_axis = orientation >> 4;
   const bool watch_is_flat = z_axis == 0 || z_axis == 8;
 
   bool should_toggle = false;

--- a/src/fw/services/normal/activity/activity.c
+++ b/src/fw/services/normal/activity/activity.c
@@ -82,19 +82,28 @@ static void prv_heart_rate_subscription_update(uint32_t now_ts) {
 
   const uint32_t last_toggled_ts = s_activity_state.hr.toggled_sampling_at_ts;
 
+  // Check if the watch is face up or face down (flat = likely off wrist)
+  const uint8_t z_axis = s_activity_state.last_orientation >> 4;
+  const bool watch_is_flat = z_axis == 0 || z_axis == 8;
+
   bool should_toggle = false;
   if (s_activity_state.hr.currently_sampling) {
     // If we are currently sampling, turn off when:
     // - We reach the end of our maximum time on, ACTIVITY_DEFAULT_HR_ON_TIME_SEC
     // - We get ACTIVITY_MIN_NUM_GOOD_SAMPLES_SHORT_CIRCUIT good quality samples
     // - We get ACTIVITY_MIN_NUM_EXCELLENT_SAMPLES_SHORT_CIRCUIT excellent quality samples
+    // - The watch is flat (likely off wrist, no point wasting battery)
     const uint32_t turn_off_at = last_toggled_ts + ACTIVITY_DEFAULT_HR_ON_TIME_SEC;
     const bool good_samples_req_met =
         (s_activity_state.hr.num_good_quality_samples >= ACTIVITY_MIN_NUM_GOOD_SAMPLES_SHORT_CIRCUIT);
     const bool excellent_samples_req_met =
         (s_activity_state.hr.num_excellent_samples >= ACTIVITY_MIN_NUM_EXCELLENT_SAMPLES_SHORT_CIRCUIT);
-    if ((turn_off_at <= now_ts) || good_samples_req_met || excellent_samples_req_met) {
+    if ((turn_off_at <= now_ts) || good_samples_req_met || excellent_samples_req_met ||
+        watch_is_flat) {
       should_toggle = true;
+      if (watch_is_flat) {
+        PBL_LOG_INFO("Stopping HRM sampling: watch is flat(ish)");
+      }
     }
   } else {
     // If we are not currently sampling, turn on after ACTIVITY_DEFAULT_HR_PERIOD_SEC
@@ -105,11 +114,6 @@ static void prv_heart_rate_subscription_update(uint32_t now_ts) {
   }
 
   if (should_toggle) {
-    // Check to see if the watch is face up or face down. If it is assume the watch is off wrist
-    // The z-axis is encoded in the 4 most significant bits of the orientation
-    const uint8_t z_axis = s_activity_state.last_orientation >> 4;
-    const bool watch_is_flat = z_axis == 0 || z_axis == 8;
-
     const bool should_be_sampling = !s_activity_state.hr.currently_sampling && !watch_is_flat;
     if (!s_activity_state.hr.currently_sampling && watch_is_flat) {
       PBL_LOG_INFO("Not subscribing to HRM: watch is flat(ish)");
@@ -146,9 +150,9 @@ T_STATIC void prv_hrm_subscription_cb(PebbleHRMEvent *hrm_event, void *context) 
                        (int8_t) hrm_event->bpm.quality);
 
     // Perform a basic validity check so we only proceed with reasonable data
-    // TODO: Use quality to filter out some readings,
-    // TODO PBL-40784: Use HRMQuality_OffWrist as a special case to slow down the HRM subscription
+    // TODO: Use quality to filter out some readings
     bool valid_hr_reading = true;
+
     if (hrm_event->bpm.bpm < ACTIVITY_DEFAULT_MIN_HR ||
         hrm_event->bpm.bpm > ACTIVITY_DEFAULT_MAX_HR) {
       valid_hr_reading = false;

--- a/src/fw/services/normal/activity/activity_algorithm.h
+++ b/src/fw/services/normal/activity/activity_algorithm.h
@@ -169,6 +169,12 @@ void activity_algorithm_minute_handler(time_t utc_sec, AlgMinuteRecord *record_o
 //! @return true if success
 bool activity_algorithm_get_steps(uint16_t *steps);
 
+//! Return the current orientation estimate based on accumulated accel data since the last
+//! minute handler call.
+//! @param[out] orientation the orientation value is returned here
+//! @return true if success
+bool activity_algorithm_get_orientation(uint8_t *orientation);
+
 //! Tells the activity algorithm whether or not it should automatically track activities
 //! @param enable true to start tracking, false to stop tracking
 void activity_algorithm_enable_activity_tracking(bool enable);

--- a/src/fw/services/normal/activity/kraepelin/activity_algorithm_kraepelin.c
+++ b/src/fw/services/normal/activity/kraepelin/activity_algorithm_kraepelin.c
@@ -1011,6 +1011,17 @@ bool activity_algorithm_get_steps(uint16_t *steps) {
 
 
 // ------------------------------------------------------------------------------------
+bool activity_algorithm_get_orientation(uint8_t *orientation) {
+  if (!prv_lock()) {
+    return false;
+  }
+  kalg_get_orientation(s_alg_state->k_state, orientation);
+  prv_unlock();
+  return true;
+}
+
+
+// ------------------------------------------------------------------------------------
 bool activity_algorithm_get_step_rate(uint16_t *steps, uint32_t *elapsed_ms, time_t *end_sec) {
   if (!prv_lock()) {
     return false;

--- a/src/fw/services/normal/activity/kraepelin/kraepelin_algorithm.c
+++ b/src/fw/services/normal/activity/kraepelin/kraepelin_algorithm.c
@@ -1359,6 +1359,18 @@ void kalg_minute_stats(KAlgState *state, uint16_t *vmc, uint8_t *orientation, bo
 
 
 // ------------------------------------------------------------------------------------
+void kalg_get_orientation(KAlgState *state, uint8_t *orientation) {
+  PBL_ASSERTN(state != NULL);
+  uint8_t theta = prv_get_angle_encoding(state->summary_mean[0], state->summary_mean[1],
+                                         KALG_NUM_ANGLES);
+  int16_t xy_vm = prv_isqrt(state->summary_mean[0] * state->summary_mean[0]
+                            + state->summary_mean[1] * state->summary_mean[1]);
+  uint8_t phi_i = prv_get_angle_encoding(state->summary_mean[2], xy_vm, KALG_NUM_ANGLES);
+  *orientation = KALG_NUM_ANGLES * phi_i + theta;
+}
+
+
+// ------------------------------------------------------------------------------------
 uint32_t kalg_analyze_finish_epoch(KAlgState *state) {
   PBL_ASSERTN(state != NULL);
   uint32_t new_steps = 0;

--- a/src/fw/services/normal/activity/kraepelin/kraepelin_algorithm.h
+++ b/src/fw/services/normal/activity/kraepelin/kraepelin_algorithm.h
@@ -112,6 +112,12 @@ uint32_t kalg_analyze_samples(KAlgState *state, AccelRawData *samples, uint32_t 
 // @param[out] still true if no movement above noise threshold was detected
 void kalg_minute_stats(KAlgState *state, uint16_t *vmc, uint8_t *orientation, bool *still);
 
+// Return the current orientation estimate based on accumulated accel data since the last
+// minute stats reset. Unlike kalg_minute_stats, this does not reset the accumulators.
+// @param[in] state the state structure passed into kalg_init
+// @param[out] orientation the orientation value is returned here
+void kalg_get_orientation(KAlgState *state, uint8_t *orientation);
+
 // Used by unit tests - run the partial epoch that hasn't been processed yet by
 // kalg_analyze_samples()
 // @param[in] state the state structure passed into kalg_init

--- a/tests/fw/services/activity/test_activity.c
+++ b/tests/fw/services/activity/test_activity.c
@@ -660,6 +660,11 @@ void activity_algorithm_minute_handler(time_t utc_sec, AlgMinuteRecord *record_o
   record_out->data.base.orientation = s_test_alg_state.orientation;
 }
 
+bool activity_algorithm_get_orientation(uint8_t *orientation) {
+  *orientation = s_test_alg_state.orientation;
+  return true;
+}
+
 bool activity_algorithm_dump_minute_data_to_log(void) {
   return false;
 }

--- a/tests/fw/services/activity/test_activity.c
+++ b/tests/fw/services/activity/test_activity.c
@@ -2387,6 +2387,29 @@ void test_activity__hrm_sampling_period(void) {
 
 
 // ---------------------------------------------------------------------------------------
+// Test that HRM sampling stops mid-window when the watch goes flat
+void test_activity__hrm_stops_when_flat(void) {
+  activity_start_tracking(false /*test_mode*/);
+  fake_system_task_callbacks_invoke_pending();
+  s_test_alg_state.orientation = 0x11; // Not flat
+
+  // Advance to the first sampling window
+  prv_advance_time_hr(ACTIVITY_DEFAULT_HR_PERIOD_SEC, 100 /*bpm*/, HRMQuality_Good,
+                      false /*force_continuous*/);
+  cl_assert_equal_i(s_hrm_manager_update_interval, 1);
+
+  // Simulate a few seconds of sampling, then watch goes flat mid-window
+  prv_advance_time_hr(5, 100 /*bpm*/, HRMQuality_Acceptable, false /*force_continuous*/);
+  cl_assert_equal_i(s_hrm_manager_update_interval, 1); // Still sampling
+
+  s_test_alg_state.orientation = 0x00; // Watch goes flat
+  prv_advance_time_hr(1, 100 /*bpm*/, HRMQuality_Acceptable, false /*force_continuous*/);
+  // Should have stopped sampling because watch is flat
+  cl_assert(s_hrm_manager_update_interval > SECONDS_PER_HOUR);
+}
+
+
+// ---------------------------------------------------------------------------------------
 // Test that average heart rate is reported correctly
 void test_activity__hrm_median(void) {
   int32_t median, total_weight;


### PR DESCRIPTION
Previously, the flat-on-table check only ran at the toggle boundary (every ~10 minutes), so if the watch was placed flat during an active 60-second sampling window, the green HRM LED would keep shining until the window expired. Similarly, when the GH3X2X sensor reported HRMQuality_OffWrist, sampling continued for the full window.

Move the flat check earlier so it is also evaluated during active sampling, and track off-wrist events from the sensor to stop sampling immediately when either condition is detected. This saves battery and avoids a bright green LED at night when the watch is on a table.

Fixes FIRM-1523