### PR TITLE
fw/comm/ppogatt: reset disconnect counter on destroy

### DIFF
--- a/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
+++ b/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
@@ -1373,6 +1373,7 @@ void ppogatt_destroy(void) {
     }
   }
   bt_unlock();
+  ppogatt_reset_disconnect_counter();
 }
 
 // -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The global s_disconnect_counter was not reset when ppogatt_destroy() was called during a BLE disconnection. This meant the counter persisted across BLE connections, and after enough disconnect cycles, the PPoGATT client would enter a permanent "stalled" state with no automatic recovery path, requiring the user to manually toggle Bluetooth.

Reset the counter in ppogatt_destroy(), since tearing down all clients means we are starting from a clean slate and each new BLE connection should get a full set of recovery attempts.

Fixes FIRM-1419