### PR TITLE
fw/services/common/light: log when motion backlight is rejected

### DIFF
--- a/src/fw/services/common/light.c
+++ b/src/fw/services/common/light.c
@@ -385,6 +385,9 @@ void light_enable_interaction(void) {
 
   if (prv_light_allowed()) {
     prv_change_state(LIGHT_STATE_ON_TIMED);
+  } else {
+    PBL_LOG_INFO("Backlight rejected: allowed=%d, brightness=%ld, is_light=%d",
+                 s_backlight_allowed, s_current_brightness, ambient_light_is_light());
   }
 
   mutex_unlock(s_mutex);


### PR DESCRIPTION
## Summary
- Add INFO-level log to `light_enable_interaction()` when `prv_light_allowed()` rejects a backlight activation
- Logs `s_backlight_allowed`, `s_current_brightness`, and `ambient_light_is_light()` state
- Helps diagnose FIRM-1525 (motion backlight not working in dark rooms)

## Context
Currently the entire backlight rejection path is completely silent — when a shake event fires but `prv_light_allowed()` blocks the backlight, nothing is logged. This makes it impossible to distinguish between "shake events aren't firing" and "shake events fire but ALS rejects them" from release logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)