### PR TITLE
fw/apps/system/music: fix divide-by-zero in track progress

### DIFF
--- a/src/fw/apps/system/music.c
+++ b/src/fw/apps/system/music.c
@@ -768,7 +768,10 @@ static void prv_update_track_progress(MusicAppData *data) {
   if (!music_is_progress_reporting_supported()) {
     progress_layer_set_progress(&data->track_pos_bar, 0);
   } else {
-    unsigned int percent = MIN((data->track_pos * 100) / data->track_length, 100);
+    unsigned int percent = 0;
+    if (data->track_length > 0) {
+      percent = MIN((data->track_pos * 100) / data->track_length, 100);
+    }
     progress_layer_set_progress(&data->track_pos_bar, percent);
     prv_copy_time_period(data->position_buffer, sizeof(data->position_buffer),
                          data->track_pos / 1000);


### PR DESCRIPTION
Guard against track_length being zero before computing the progress percentage. A TOCTOU race exists between music_get_pos() (which copies track_length into local app data) and music_is_progress_reporting_supported() (which re-reads track_length from the music service). If track_length transitions from 0 to non-zero between those two calls, the else branch is taken with a local track_length of 0, causing an integer divide-by-zero UsageFault that crashes the system.

Fixes FIRM-1507