### PR TITLE
fw/drivers/ambient: reduce W1160 ALS poll timeout to 200ms

### DIFF
--- a/src/fw/drivers/ambient/ambient_light_w1160.c
+++ b/src/fw/drivers/ambient/ambient_light_w1160.c
@@ -71,7 +71,7 @@
 #define W1160_ADC2LUX_COEF          (3U)
 
 #define W1160_ALS_POLL_DELAY_MS     (5)    /* ms between data-ready polls */
-#define W1160_ALS_POLL_TIMEOUT_MS   (1000) /* max wait for ALS data-ready */
+#define W1160_ALS_POLL_TIMEOUT_MS   (200)  /* max wait for ALS data-ready */
 
 static bool s_initialized;
 static uint32_t s_sensor_light_dark_threshold;


### PR DESCRIPTION
The ALS data-ready polling timeout of 1000ms, combined with the 5-sample multi-read in the light service, created a worst-case blocking time of ~5s on KernelMain. This exceeded the task watchdog threshold (5s warn / 6.5s coredump), causing watchdog resets when the W1160 sensor was slow to respond.

Reduce the timeout to 200ms so the worst case is ~1s, well within the watchdog window.

Fixes FIRM-1495