### PR TITLE
fw/services: remove health disabled warning when starting apps

### DIFF
--- a/src/fw/popups/health_tracking_ui.c
+++ b/src/fw/popups/health_tracking_ui.c
@@ -73,23 +73,6 @@ void health_tracking_ui_show_message(uint32_t res_id, const char *text, bool sho
 }
 
 // ---------------------------------------------------------------------------
-void health_tracking_ui_app_show_disabled(void) {
-  // Show at most once per app launch
-  AppInstallId app_id = app_manager_get_current_app_id();
-  if (app_id == s_last_app_id) {
-    return;
-  }
-  s_last_app_id = app_id;
-
-  /// Health disabled dialog
-  static const char *msg =
-      i18n_noop("This app requires Pebble Health to work. Enable Health in the Pebble"
-                " mobile app to continue.");
-
-  health_tracking_ui_show_message(RESOURCE_ID_GENERIC_WARNING_TINY, msg, false);
-}
-
-// ---------------------------------------------------------------------------
 void health_tracking_ui_feature_show_disabled(void) {
   /// Feature requires health dialog
   static const char *msg =

--- a/src/fw/popups/health_tracking_ui.h
+++ b/src/fw/popups/health_tracking_ui.h
@@ -9,10 +9,6 @@
 void health_tracking_ui_show_message(uint32_t res_id, const char *text, bool show_action_bar);
 
 //! Show the modal that tells the user that health tracking is disabled
-//! and a given app will not work as expected
-void health_tracking_ui_app_show_disabled(void);
-
-//! Show the modal that tells the user that health tracking is disabled
 //! and a given feature will not work as expected
 void health_tracking_ui_feature_show_disabled(void);
 

--- a/src/fw/services/normal/activity/activity_metrics.c
+++ b/src/fw/services/normal/activity/activity_metrics.c
@@ -7,7 +7,6 @@
 #include "kernel/pbl_malloc.h"
 #include "os/mutex.h"
 #include "os/tick.h"
-#include "popups/health_tracking_ui.h"
 #include "services/normal/protobuf_log/protobuf_log.h"
 #include "syscall/syscall.h"
 #include "syscall/syscall_internal.h"
@@ -705,10 +704,6 @@ bool activity_get_metric(ActivityMetric metric, uint32_t history_len, int32_t *h
 
   mutex_lock_recursive(state->mutex);
   {
-    if (!activity_prefs_tracking_is_enabled() && pebble_task_get_current() == PebbleTask_App) {
-      health_tracking_ui_app_show_disabled();
-    }
-
     // Update derived metrics
     prv_update_real_time_derived_metrics();
 

--- a/tests/fw/services/activity/test_activity.c
+++ b/tests/fw/services/activity/test_activity.c
@@ -87,7 +87,6 @@ const int s_exp_full_day_resting_kcalories = 1455;
 
 // Stub for health tracking disabled UI
 void health_tracking_ui_feature_show_disabled(void) { }
-void health_tracking_ui_app_show_disabled(void) { }
 
 // These are declared as T_STATIC in activity.c
 void prv_hrm_subscription_cb(PebbleHRMEvent *hrm_event, void *context);


### PR DESCRIPTION
It's really annoying if you disable health - pops up literally every time I go back 
to my watchface, even though I haven't configured the face to use any health data.