### PR TITLE
fw/settings: add HR monitoring interval setting

### DIFF
--- a/src/fw/apps/system/settings/health.c
+++ b/src/fw/apps/system/settings/health.c
@@ -5,10 +5,14 @@
 #include "option_menu.h"
 #include "window.h"
 
+#include "applib/ui/option_menu_window.h"
 #include "kernel/pbl_malloc.h"
+#include "process_state/app_state/app_state.h"
 #include "services/common/i18n/i18n.h"
+#include "services/normal/activity/activity.h"
 #include "shell/prefs.h"
 #include "system/passert.h"
+#include "util/size.h"
 
 #include <string.h>
 
@@ -21,10 +25,47 @@ static const char *s_units_distance_labels[] = {
     i18n_noop("Miles"),
 };
 
+#if CAPABILITY_HAS_BUILTIN_HRM
+static const char *s_hrm_interval_labels[] = {
+    i18n_noop("10 Minutes"),
+    i18n_noop("30 Minutes"),
+    i18n_noop("1 Hour"),
+    i18n_noop("Disabled"),
+};
+#endif
+
 enum SettingsHealthItem {
     SettingsHealthUnitDistance,
+#if CAPABILITY_HAS_BUILTIN_HRM
+    SettingsHealthHRMonitoringInterval,
+#endif
     NumSettingsHealthItems
 };
+
+#if CAPABILITY_HAS_BUILTIN_HRM
+// HRM Interval option menu
+/////////////////////////////
+
+static void prv_hrm_interval_menu_select(OptionMenu *option_menu, int selection, void *context) {
+    activity_prefs_set_hrm_measurement_interval((HRMonitoringInterval)selection);
+    app_window_stack_remove(&option_menu->window, true /*animated*/);
+}
+
+static void prv_hrm_interval_menu_push(SettingsHealthData *data) {
+    const int index = (int)activity_prefs_get_hrm_measurement_interval();
+    const OptionMenuCallbacks callbacks = {
+        .select = prv_hrm_interval_menu_select,
+    };
+    const char *title = i18n_noop("HR Monitoring");
+    settings_option_menu_push(
+        title, OptionMenuContentType_SingleLine, index, &callbacks,
+        ARRAY_LENGTH(s_hrm_interval_labels), true /* icons_enabled */,
+        s_hrm_interval_labels, data);
+}
+#endif
+
+// Menu Callbacks
+/////////////////////////////
 
 static void prv_deinit_cb(SettingsCallbacks *context) {
     SettingsHealthData *data = (SettingsHealthData*)context;
@@ -41,7 +82,7 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
     const char *subtitle = NULL;
 
     switch (row) {
-        case SettingsHealthUnitDistance:
+        case SettingsHealthUnitDistance: {
             title = i18n_noop("Distance Unit");
             UnitsDistance unit = shell_prefs_get_units_distance();
             if (unit >= UnitsDistanceCount) {
@@ -50,20 +91,39 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
                 subtitle = s_units_distance_labels[unit];
             }
             break;
+        }
+#if CAPABILITY_HAS_BUILTIN_HRM
+        case SettingsHealthHRMonitoringInterval: {
+            title = i18n_noop("HR Monitoring");
+            HRMonitoringInterval interval = activity_prefs_get_hrm_measurement_interval();
+            if (interval >= HRMonitoringIntervalCount) {
+                subtitle = i18n_noop("Unknown");
+            } else {
+                subtitle = s_hrm_interval_labels[interval];
+            }
+            break;
+        }
+#endif
         default:
             WTF;
     }
-    menu_cell_basic_draw(ctx, cell_layer, title, subtitle, NULL);
+    menu_cell_basic_draw(ctx, cell_layer, i18n_get(title, data), i18n_get(subtitle, data), NULL);
 }
 
 static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
     SettingsHealthData *data = (SettingsHealthData*)context;
     switch (row) {
-        case SettingsHealthUnitDistance:
+        case SettingsHealthUnitDistance: {
             UnitsDistance unit = shell_prefs_get_units_distance();
             unit = (unit + 1) % UnitsDistanceCount;
             shell_prefs_set_units_distance(unit);
             break;
+        }
+#if CAPABILITY_HAS_BUILTIN_HRM
+        case SettingsHealthHRMonitoringInterval:
+            prv_hrm_interval_menu_push(data);
+            break;
+#endif
         default:
             WTF;
     }

--- a/src/fw/services/normal/activity/activity.c
+++ b/src/fw/services/normal/activity/activity.c
@@ -72,11 +72,40 @@ static bool prv_activity_allowed_to_be_enabled(void) {
 
 
 // ------------------------------------------------------------------------------------------------
+#if CAPABILITY_HAS_BUILTIN_HRM
+// Get the HRM measurement period in seconds based on the user's setting
+static uint32_t prv_get_hrm_period_sec(void) {
+  switch (activity_prefs_get_hrm_measurement_interval()) {
+    case HRMonitoringInterval_30Min:
+      return 30 * SECONDS_PER_MINUTE;
+    case HRMonitoringInterval_1Hour:
+      return SECONDS_PER_HOUR;
+    case HRMonitoringInterval_10Min:
+    default:
+      return 10 * SECONDS_PER_MINUTE;
+  }
+}
+#endif
+
+// ------------------------------------------------------------------------------------------------
 // If necessary, change the sampling period of our heart rate subscription
 // @param[in] now_ts number of seconds the system has been running (from time_get_uptime_seconds())
 static void prv_heart_rate_subscription_update(uint32_t now_ts) {
 #if CAPABILITY_HAS_BUILTIN_HRM
   if (!s_hrm_present) {
+    return;
+  }
+
+  // If measurement interval is disabled, ensure we're not sampling and skip
+  if (activity_prefs_get_hrm_measurement_interval() == HRMonitoringInterval_Disabled) {
+    if (s_activity_state.hr.currently_sampling) {
+      bool success = sys_hrm_manager_set_update_interval(s_activity_state.hr.hrm_session,
+                                                         ACTIVITY_HRM_SUBSCRIPTION_OFF_PERIOD_SEC,
+                                                         0 /*expire_sec*/);
+      PBL_ASSERTN(success);
+      s_activity_state.hr.currently_sampling = false;
+      s_activity_state.hr.toggled_sampling_at_ts = now_ts;
+    }
     return;
   }
 
@@ -97,8 +126,8 @@ static void prv_heart_rate_subscription_update(uint32_t now_ts) {
       should_toggle = true;
     }
   } else {
-    // If we are not currently sampling, turn on after ACTIVITY_DEFAULT_HR_PERIOD_SEC
-    const uint32_t turn_on_at = last_toggled_ts + ACTIVITY_DEFAULT_HR_PERIOD_SEC;
+    // If we are not currently sampling, turn on after the configured period
+    const uint32_t turn_on_at = last_toggled_ts + prv_get_hrm_period_sec();
     if (turn_on_at <= now_ts) {
       should_toggle = true;
     }

--- a/src/fw/services/normal/activity/activity.h
+++ b/src/fw/services/normal/activity/activity.h
@@ -50,9 +50,19 @@ typedef struct PACKED HeartRatePreferences {
   uint8_t zone3_threshold;
 } HeartRatePreferences;
 
+// HRM measurement interval options
+typedef enum {
+  HRMonitoringInterval_10Min = 0,
+  HRMonitoringInterval_30Min,
+  HRMonitoringInterval_1Hour,
+  HRMonitoringInterval_Disabled,
+  HRMonitoringIntervalCount,
+} HRMonitoringInterval;
+
 // Activity HRM Settings Struct, for storing to prefs
 typedef struct PACKED ActivityHRMSettings {
   bool enabled;
+  uint8_t measurement_interval; // HRMonitoringInterval value
 } ActivityHRMSettings;
 
 // Default values, taken from http://www.cdc.gov/nchs/fastats/body-measurements.htm
@@ -83,6 +93,7 @@ typedef struct PACKED ActivityHRMSettings {
 
 #define ACTIVITY_HRM_DEFAULT_PREFERENCES { \
   .enabled = true, \
+  .measurement_interval = HRMonitoringInterval_10Min, \
 }
 
 // We consider values outside of this range to be invalid
@@ -396,6 +407,16 @@ uint8_t activity_prefs_heart_get_zone3_threshold(void);
 
 //! Return true if the HRM is enabled, false if not
 bool activity_prefs_heart_rate_is_enabled(void);
+
+#if CAPABILITY_HAS_BUILTIN_HRM
+//! Get the HRM measurement interval setting
+//! @return the current HRMonitoringInterval value
+HRMonitoringInterval activity_prefs_get_hrm_measurement_interval(void);
+
+//! Set the HRM measurement interval
+//! @param interval the desired HRMonitoringInterval value
+void activity_prefs_set_hrm_measurement_interval(HRMonitoringInterval interval);
+#endif
 
 //! Get the current and (optionally) historical values for a given metric. The caller passes
 //! in a pointer to an array that will be filled in with the results (current value for today at

--- a/src/fw/services/normal/activity/activity_private.h
+++ b/src/fw/services/normal/activity/activity_private.h
@@ -51,11 +51,7 @@ typedef uint16_t ActivityScalarStore;
 // part of the next day's sleep
 #define ACTIVITY_LAST_SLEEP_MINUTE_OF_DAY  (21 * MINUTES_PER_HOUR)
 
-// Default HeartRate sampling period (Must take a sample every X seconds by default)
-#define ACTIVITY_DEFAULT_HR_PERIOD_SEC (10 * SECONDS_PER_MINUTE)
-
-// Default HeartRate sampling ON time (Stays on for X seconds every
-// ACTIVITY_DEFAULT_HR_PERIOD_SEC seconds)
+// Default HeartRate sampling ON time
 #define ACTIVITY_DEFAULT_HR_ON_TIME_SEC (60)
 
 // Turn off the HR device after we've received X good quality samples

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -1551,6 +1551,25 @@ bool activity_prefs_heart_rate_is_enabled(void) {
   return s_activity_hrm_preferences.enabled;
 }
 
+#if CAPABILITY_HAS_BUILTIN_HRM
+HRMonitoringInterval activity_prefs_get_hrm_measurement_interval(void) {
+  uint8_t interval = s_activity_hrm_preferences.measurement_interval;
+  if (interval >= HRMonitoringIntervalCount) {
+    return HRMonitoringInterval_10Min;
+  }
+  return (HRMonitoringInterval)interval;
+}
+
+void activity_prefs_set_hrm_measurement_interval(HRMonitoringInterval interval) {
+  if (s_activity_hrm_preferences.measurement_interval != (uint8_t)interval) {
+    s_activity_hrm_preferences.measurement_interval = (uint8_t)interval;
+    prv_pref_set(PREF_KEY_ACTIVITY_HRM_PREFERENCES, &s_activity_hrm_preferences,
+                 sizeof(s_activity_hrm_preferences));
+    hrm_manager_handle_prefs_changed();
+  }
+}
+#endif
+
 void alarm_prefs_set_alarms_app_opened(uint8_t version) {
   if (s_alarms_app_opened != version) {
     s_alarms_app_opened = version;

--- a/src/fw/shell/sdk/prefs.c
+++ b/src/fw/shell/sdk/prefs.c
@@ -243,6 +243,15 @@ bool activity_prefs_heart_rate_is_enabled(void) {
   return true;
 }
 
+#if CAPABILITY_HAS_BUILTIN_HRM
+HRMonitoringInterval activity_prefs_get_hrm_measurement_interval(void) {
+  return HRMonitoringInterval_10Min;
+}
+
+void activity_prefs_set_hrm_measurement_interval(HRMonitoringInterval interval) {
+}
+#endif
+
 ActivityInsightSettings *activity_prefs_get_sleep_reward_settings(void) {
   static ActivityInsightSettings s_settings = { 0 };
   return &s_settings;

--- a/tests/fw/services/activity/test_activity.c
+++ b/tests/fw/services/activity/test_activity.c
@@ -2338,7 +2338,7 @@ void test_activity__hrm_sampling_period(void) {
   fake_system_task_callbacks_invoke_pending();
   s_test_alg_state.orientation = 0x11; // Not flat
 
-  prv_advance_time_hr(ACTIVITY_DEFAULT_HR_PERIOD_SEC, 100 /*bpm*/, HRMQuality_Good, false /*force_continuous*/);
+  prv_advance_time_hr((10 * SECONDS_PER_MINUTE), 100 /*bpm*/, HRMQuality_Good, false /*force_continuous*/);
 
   // Should be 1 second sampling when we start up
   cl_assert_equal_i(s_hrm_manager_update_interval, 1);
@@ -2368,14 +2368,14 @@ void test_activity__hrm_sampling_period(void) {
 
   // Advance to our next sampling period, but the watch is flat so we shouldn't start sampling
   s_test_alg_state.orientation = 0x00; // Flat
-  prv_advance_time_hr(ACTIVITY_DEFAULT_HR_PERIOD_SEC, 100 /*bpm*/, HRMQuality_Good, false /*force_continuous*/);
+  prv_advance_time_hr((10 * SECONDS_PER_MINUTE), 100 /*bpm*/, HRMQuality_Good, false /*force_continuous*/);
   cl_assert(s_hrm_manager_update_interval > SECONDS_PER_HOUR);
 
   // Advance to our next sampling period, the watch is no longer flat so we should be sampling.
   // The period has already expired during the flat advance above, so just advance until
   // the next minute boundary triggers the subscription update and starts sampling.
   s_test_alg_state.orientation = 0x22; // Not flat
-  for (uint32_t i = 0; i < ACTIVITY_DEFAULT_HR_PERIOD_SEC; i++) {
+  for (uint32_t i = 0; i < (10 * SECONDS_PER_MINUTE); i++) {
     prv_advance_time_hr(1, 100 /*bpm*/, HRMQuality_Good, false /*force_continuous*/);
     if (s_hrm_manager_update_interval == 1) {
       break;


### PR DESCRIPTION
Add a configurable HRM measurement frequency to Health settings, allowing users to choose between 10min, 30min, 1h, or disabled. The setting is only shown on platforms with a built-in HRM (CAPABILITY_HAS_BUILTIN_HRM). When disabled, periodic HR sampling is stopped entirely.