### PR TITLE
GH3x2x: Initialize the reset and INT pin status when system bootup

### DIFF
--- a/src/fw/drivers/hrm/gh3x2x/gh3x2x.c
+++ b/src/fw/drivers/hrm/gh3x2x/gh3x2x.c
@@ -442,10 +442,10 @@ void hrm_init(HRMDevice *dev) {
     PBL_LOG_ERR("GH3X2X failed to initialize");
     return;
   }
-#else
+#endif
+
   gh3026_reset_pin_ctrl(0);
   gpio_input_init_pull_up_down(&dev->int_input, GPIO_PuPd_DOWN);
-#endif
 
   dev->state->is_wear = false;
   dev->state->initialized = true;


### PR DESCRIPTION
Initialize the reset and INT pin status when system bootup

GH3x2x would cause unstable current leakage if reset pin is high, force it to low to make sure GH3x2x at low power status when initialization.