### PR TITLE
kernel: fix event queue set sizing to include worker queue capacity

### DIFF
--- a/src/fw/kernel/events.c
+++ b/src/fw/kernel/events.c
@@ -108,7 +108,10 @@ void events_init(void) {
                  "You made the PebbleEvent bigger! It should be no more than 12");
 
 
-  s_system_event_queue_set = xQueueCreateSet(MAX_KERNEL_EVENTS + MAX_FROM_APP_EVENTS);
+  // Queue sets must be sized to hold the sum of member queue lengths, otherwise
+  // sends can fail while member queues still have room.
+  s_system_event_queue_set = xQueueCreateSet(MAX_KERNEL_EVENTS + MAX_FROM_APP_EVENTS +
+                                             MAX_FROM_WORKER_EVENTS);
 
   s_kernel_event_queue = xQueueCreate(MAX_KERNEL_EVENTS, sizeof(PebbleEvent));
   PBL_ASSERTN(s_kernel_event_queue != NULL);


### PR DESCRIPTION
### Motivation
- Prevent spurious `RebootReasonCode_EventQueueFull` reboots seen after launching the Timer by ensuring the FreeRTOS queue set is sized to hold all member queues.

### Description
- Include `MAX_FROM_WORKER_EVENTS` when creating `s_system_event_queue_set` in `events_init()` and add an inline comment about queue-set sizing; change made in `src/fw/kernel/events.c`.

### Testing
- Ran `./waf configure --board asterix` (failed in this environment due to missing `arm-none-eabi-gcc` toolchain) and attempted `gitlint --commits HEAD~1..HEAD` (failed because `gitlint` is not installed), so no firmware build or linter run was completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c23df1fb08832b8ef5162f97b0baaa)