### PR TITLE
loghash: catch ValueError in log message formatting

### DIFF
--- a/python_libs/pebble-loghash/pebble/loghashing/newlogging.py
+++ b/python_libs/pebble-loghash/pebble/loghashing/newlogging.py
@@ -213,7 +213,7 @@ def parse_message(msg, log_dict):
     # Use "printf" to generate the reconstructed string. Make sure the arguments are correct
     try:
         output_msg = safe_output_msg % tuple(arg_list)
-    except (TypeError, UnicodeDecodeError) as e:
+    except (TypeError, ValueError, UnicodeDecodeError) as e:
         output_msg = msg + " ----> ERROR: " + str(e)
 
     # Add the formatted msg to the copy of our line dict


### PR DESCRIPTION
The printf-style string formatting can raise ValueError (e.g. for unsupported format characters) in addition to TypeError and UnicodeDecodeError. Handle it gracefully instead of crashing.