### PR TITLE
fw/applib: fix PBL_PLATFORM_SWITCH_DEFAULT aplite check

### DIFF
--- a/src/fw/applib/platform.h
+++ b/src/fw/applib/platform.h
@@ -64,7 +64,7 @@ typedef enum PlatformType {
   ((PLAT) == PlatformTypeDiorite) ? (DIORITE) : \
   ((PLAT) == PlatformTypeChalk) ? (CHALK) : \
   ((PLAT) == PlatformTypeBasalt) ? (BASALT) : \
-  ((PLAT) == PlatformTypeBasalt) ? (APLITE) : \
+  ((PLAT) == PlatformTypeAplite) ? (APLITE) : \
   ((PLAT) == PlatformTypeGabbro) ? (GABBRO) : \
   (DEFAULT) \
 )


### PR DESCRIPTION
The APLITE case in PBL_PLATFORM_SWITCH_DEFAULT incorrectly compared against PlatformTypeBasalt instead of PlatformTypeAplite, meaning PlatformTypeAplite would never match and fall through to the DEFAULT case.