### PR TITLE
fw/memfault: right-size coredump storage allocation [FIRM-1537]

### DIFF
--- a/third_party/memfault/port/src/memfault_pebble_coredump.c
+++ b/third_party/memfault/port/src/memfault_pebble_coredump.c
@@ -512,9 +512,6 @@ void memfault_pebble_coredump_reconstruct(void) {
   reboot_reason_get(&reason);
   eMemfaultRebootReason mflt_reason = prv_pbl_to_mflt_reason(reason.code);
 
-  // Allocate the coredump storage buffer before saving
-  memfault_coredump_storage_alloc();
-
   // Save the Memfault coredump to RAM-backed storage
   sMemfaultCoredumpSaveInfo save_info = {
     .regs = &s_core_regs,
@@ -523,6 +520,17 @@ void memfault_pebble_coredump_reconstruct(void) {
     .regions = regions,
     .num_regions = num_regions,
   };
+
+  // Compute the exact serialized size and allocate only what's needed,
+  // rather than a fixed 32KB buffer that may fail on low-memory devices.
+  size_t save_size = memfault_coredump_get_save_size(&save_info);
+  if (save_size == 0) {
+    MEMFAULT_LOG_ERROR("Failed to compute coredump save size");
+    kernel_free(stack_data);
+    kernel_free(regions);
+    return;
+  }
+  memfault_coredump_storage_alloc(save_size);
 
   bool saved = memfault_coredump_save(&save_info);
 

--- a/third_party/memfault/port/src/memfault_pebble_coredump.h
+++ b/third_party/memfault/port/src/memfault_pebble_coredump.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <stddef.h>
+
 //! Reconstruct a Memfault coredump from the PebbleOS flash-based coredump.
 //!
 //! This should be called during boot after the flash driver is initialized.
@@ -24,7 +26,10 @@ void memfault_pebble_coredump_mark_exported(void);
 
 //! Allocate the RAM-backed coredump storage buffer.
 //!
+//! @param size The number of bytes to allocate. Use
+//!   memfault_coredump_get_save_size() to compute the exact size needed.
+//!
 //! Called before memfault_coredump_save(). The buffer is freed when
 //! memfault_platform_coredump_storage_clear() is called after all chunks
 //! have been read by the packetizer.
-void memfault_coredump_storage_alloc(void);
+void memfault_coredump_storage_alloc(size_t size);

--- a/third_party/memfault/port/src/memfault_platform_coredump_storage.c
+++ b/third_party/memfault/port/src/memfault_platform_coredump_storage.c
@@ -21,21 +21,26 @@
 #include "memfault_pebble_coredump.h"
 
 #include "kernel/pbl_malloc.h"
+#include "util/math.h"
 
-#define COREDUMP_STORAGE_SIZE MEMFAULT_PLATFORM_COREDUMP_STORAGE_RAM_SIZE
 #define COREDUMP_SECTOR_SIZE 4096
 
 // Dynamically allocated coredump storage buffer.
 static uint8_t *s_coredump_storage;
 static size_t s_coredump_storage_size;
 
-void memfault_coredump_storage_alloc(void) {
+void memfault_coredump_storage_alloc(size_t size) {
   if (s_coredump_storage != NULL) {
     return;  // Already allocated
   }
-  s_coredump_storage = kernel_zalloc(COREDUMP_STORAGE_SIZE);
+  // Round up to sector size for the SDK's erase operation
+  size = ROUND_TO_MOD_CEIL(size, COREDUMP_SECTOR_SIZE);
+  s_coredump_storage = kernel_zalloc(size);
   if (s_coredump_storage != NULL) {
-    s_coredump_storage_size = COREDUMP_STORAGE_SIZE;
+    s_coredump_storage_size = size;
+  } else {
+    MEMFAULT_LOG_ERROR("Failed to allocate %u bytes for coredump storage",
+                       (unsigned)size);
   }
 }
 


### PR DESCRIPTION
Instead of always allocating a fixed 32KB buffer for the RAM-backed coredump storage, compute the exact serialized size using memfault_coredump_get_save_size() and allocate only what's needed.