### PR TITLE
fw: fix build errors when test apps are enabled

### DIFF
--- a/src/fw/apps/core/panic_window.c
+++ b/src/fw/apps/core/panic_window.c
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 
+#if !CAPABILITY_HAS_HARDWARE_PANIC_SCREEN
 static const uint8_t sad_watch[] = {
   0x04, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x20, 0x00, 0xff, 0xff, 0xff, 0xff, /* bytes 0 - 16 */
   0xff, 0x0f, 0xf8, 0xff, 0xff, 0x57, 0xf5, 0xff, 0xff, 0xa7, 0xf2, 0xff, 0xff, 0x57, 0xf5, 0xff, /* bytes 16 - 32 */
@@ -31,12 +32,14 @@ static const uint8_t sad_watch[] = {
   0xff, 0xa9, 0xca, 0xff, 0xff, 0x57, 0xf5, 0xff, 0xff, 0xa7, 0xf2, 0xff, 0xff, 0x57, 0xf5, 0xff, /* bytes 112 - 128 */
   0xff, 0x0f, 0xf8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 };
+#endif
 
 typedef struct PanicWindowAppData {
   Window window;
   Layer layer;
 } PanicWindowAppData;
 
+#if !CAPABILITY_HAS_HARDWARE_PANIC_SCREEN
 static void prv_update_proc(Layer* layer, GContext* ctx) {
   graphics_context_set_compositing_mode(ctx, GCompOpAssignInverted);
 
@@ -55,6 +58,7 @@ static void prv_update_proc(Layer* layer, GContext* ctx) {
   graphics_draw_text(ctx, text_buffer, error_code_face,
       text_dest_rect, GTextOverflowModeWordWrap, GTextAlignmentCenter, NULL);
 }
+#endif
 
 static void prv_panic_reset_callback(void* data) {
   RebootReason reason = {

--- a/src/fw/apps/demo/event_service.c
+++ b/src/fw/apps/demo/event_service.c
@@ -20,14 +20,14 @@ typedef struct {
   Window window;
   TextLayer count_layer;
   TextLayer connected_layer;
-  char count_str[10];
+  char count_str[12];
   int count;
 } EventServiceAppData;
 
 static void handle_tap(AccelAxisType axis, int32_t sign) {
   EventServiceAppData *data = app_state_get_user_data();
   ++data->count;
-  snprintf(data->count_str, 10, "%d", data->count);
+  snprintf(data->count_str, sizeof(data->count_str), "%d", data->count);
   text_layer_set_text(&data->count_layer, data->count_str);
 }
 

--- a/src/fw/apps/demo/menu.c
+++ b/src/fw/apps/demo/menu.c
@@ -41,7 +41,7 @@ typedef struct {
 
   Window detail_window;
   TextLayer detail_text;
-  char detail_text_buffer[50];
+  char detail_text_buffer[64];
 } AppData;
 
 static uint16_t get_num_sections_callback(struct MenuLayer *menu_layer, AppData *data) {
@@ -124,7 +124,7 @@ static void detail_window_load(Window *window) {
 }
 
 static void push_detail_window(AppData *data, MenuIndex *index, bool is_long_click) {
-  sniprintf(data->detail_text_buffer, 50, "SELECTION:\n\nSection %i, Row %i\nLong click: %c", index->section, index->row, is_long_click ? 'Y' : 'N');
+  sniprintf(data->detail_text_buffer, sizeof(data->detail_text_buffer), "SELECTION:\n\nSection %i, Row %i\nLong click: %c", index->section, index->row, is_long_click ? 'Y' : 'N');
 
   Window *detail_window = &data->detail_window;
   window_init(detail_window, WINDOW_NAME("Demo Menu Detail"));

--- a/src/fw/apps/demo/movable_line.c
+++ b/src/fw/apps/demo/movable_line.c
@@ -185,7 +185,7 @@ static void canvas_update_proc(Layer *layer, GContext* ctx) {
                   data->pixel_bit == PIXEL_BIT_LSB,
                   data->selection == ATTRIBUTE_PIXEL_BIT);
 
-  char text[6];
+  char text[10];
   snprintf(text, sizeof(text), "x=%"PRId16, data->intersection.x);
   draw_ui_element(ctx, GRect(30, 120, 40, 20), text,
                   data->selection == ATTRIBUTE_X,

--- a/src/fw/apps/demo/temperature_demo.c
+++ b/src/fw/apps/demo/temperature_demo.c
@@ -87,7 +87,7 @@ static void cur_temp_update_text(TemperatureDemoAppData *data) {
 // -------------------------------------------------------------------------------
 static void handle_second_tick(struct tm* tick_time, TimeUnits units_changed) {
   int32_t reading = temperature_read();
-  memcpy(s_temp_readings, s_temp_readings + 1, (READ_HISTORY_ENTRIES - 1) * sizeof(int32_t));
+  memmove(s_temp_readings, s_temp_readings + 1, (READ_HISTORY_ENTRIES - 1) * sizeof(int32_t));
   s_temp_readings[READ_HISTORY_ENTRIES - 1] = reading;
   cur_temp_update_text(s_data);
 }

--- a/src/fw/apps/demo/timeline_pins_demo.c
+++ b/src/fw/apps/demo/timeline_pins_demo.c
@@ -295,8 +295,8 @@ void timeline_pins_demo_add_pins(TimelinePinsDemoSet pin_set) {
       prv_add_weather_pin(1 * 24 * 60 * 60);
       prv_add_weather_pin(2 * 24 * 60 * 60);
       prv_add_weather_pin(3 * 24 * 60 * 60);
-      // Fallthrough
     }
+    // fallthrough
     case TimelinePinsDemo_OneDayAway:
       prv_add_weather_pin(-2 * 24 * 60 * 60);
       prv_add_weather_pin(2 * 24 * 60 * 60);


### PR DESCRIPTION
Fix several -Werror warnings that prevented building with --test_apps:

- timeline_pins_demo: move fallthrough comment outside braces so GCC recognizes it
- event_service: increase snprintf buffer size for int range
- menu: increase snprintf buffer size for format string output
- movable_line: increase snprintf buffer size for int16_t range
- temperature_demo: use memmove instead of memcpy for overlapping buffers
- panic_window: guard unused code with CAPABILITY_HAS_HARDWARE_PANIC_SCREEN