### PR TITLE
fw/activity: add setting to toggle HR tracking during activities

### DIFF
--- a/src/fw/apps/system/settings/health.c
+++ b/src/fw/apps/system/settings/health.c
@@ -38,6 +38,7 @@ enum SettingsHealthItem {
     SettingsHealthUnitDistance,
 #if CAPABILITY_HAS_BUILTIN_HRM
     SettingsHealthHRMonitoringInterval,
+    SettingsHealthHRActivityTracking,
 #endif
     NumSettingsHealthItems
 };
@@ -103,6 +104,12 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
             }
             break;
         }
+        case SettingsHealthHRActivityTracking: {
+            title = i18n_noop("HR During Activity");
+            subtitle = activity_prefs_hrm_activity_tracking_is_enabled()
+                ? i18n_noop("On") : i18n_noop("Off");
+            break;
+        }
 #endif
         default:
             WTF;
@@ -122,6 +129,10 @@ static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
 #if CAPABILITY_HAS_BUILTIN_HRM
         case SettingsHealthHRMonitoringInterval:
             prv_hrm_interval_menu_push(data);
+            break;
+        case SettingsHealthHRActivityTracking:
+            activity_prefs_set_hrm_activity_tracking_enabled(
+                !activity_prefs_hrm_activity_tracking_is_enabled());
             break;
 #endif
         default:

--- a/src/fw/services/normal/activity/activity.h
+++ b/src/fw/services/normal/activity/activity.h
@@ -63,6 +63,7 @@ typedef enum {
 typedef struct PACKED ActivityHRMSettings {
   bool enabled;
   uint8_t measurement_interval; // HRMonitoringInterval value
+  bool activity_tracking_enabled; // HR tracking during detected activities (walk/run)
 } ActivityHRMSettings;
 
 // Default values, taken from http://www.cdc.gov/nchs/fastats/body-measurements.htm
@@ -94,6 +95,7 @@ typedef struct PACKED ActivityHRMSettings {
 #define ACTIVITY_HRM_DEFAULT_PREFERENCES { \
   .enabled = true, \
   .measurement_interval = HRMonitoringInterval_10Min, \
+  .activity_tracking_enabled = true, \
 }
 
 // We consider values outside of this range to be invalid
@@ -416,6 +418,12 @@ HRMonitoringInterval activity_prefs_get_hrm_measurement_interval(void);
 //! Set the HRM measurement interval
 //! @param interval the desired HRMonitoringInterval value
 void activity_prefs_set_hrm_measurement_interval(HRMonitoringInterval interval);
+
+//! Return true if HR tracking during detected activities (walk/run) is enabled
+bool activity_prefs_hrm_activity_tracking_is_enabled(void);
+
+//! Enable or disable HR tracking during detected activities (walk/run)
+void activity_prefs_set_hrm_activity_tracking_enabled(bool enabled);
 #endif
 
 //! Get the current and (optionally) historical values for a given metric. The caller passes

--- a/src/fw/services/normal/activity/kraepelin/kraepelin_algorithm.c
+++ b/src/fw/services/normal/activity/kraepelin/kraepelin_algorithm.c
@@ -33,6 +33,7 @@ Pebble App roject.
 #include "applib/accel_service.h"
 #include "util/trig.h"
 #include "services/common/hrm/hrm_manager_private.h"
+#include "services/normal/activity/activity.h"
 #include "system/logging.h"
 #include "system/passert.h"
 #include "util/math.h"
@@ -2018,7 +2019,8 @@ static void prv_step_activity_update(KAlgState *alg_state, KAlgStepActivityState
 #if CAPABILITY_HAS_BUILTIN_HRM
     // Make sure we have a couple active minutes in a row before enabling the HRM to save battery
     const unsigned min_duration_for_hrm = 3 * SECONDS_PER_MINUTE;
-    if (duration_secs >= min_duration_for_hrm && state->hrm_session == HRM_INVALID_SESSION_REF) {
+    if (duration_secs >= min_duration_for_hrm && state->hrm_session == HRM_INVALID_SESSION_REF &&
+        activity_prefs_hrm_activity_tracking_is_enabled()) {
       state->hrm_session = hrm_manager_subscribe_with_callback(INSTALL_ID_INVALID,
           1 /* update interval */, 0 /*expire_s*/, HRMFeature_BPM, prv_hrm_subscription_cb, NULL);
     }

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -1568,6 +1568,19 @@ void activity_prefs_set_hrm_measurement_interval(HRMonitoringInterval interval) 
     hrm_manager_handle_prefs_changed();
   }
 }
+
+bool activity_prefs_hrm_activity_tracking_is_enabled(void) {
+  return s_activity_hrm_preferences.activity_tracking_enabled;
+}
+
+void activity_prefs_set_hrm_activity_tracking_enabled(bool enabled) {
+  if (s_activity_hrm_preferences.activity_tracking_enabled != enabled) {
+    s_activity_hrm_preferences.activity_tracking_enabled = enabled;
+    prv_pref_set(PREF_KEY_ACTIVITY_HRM_PREFERENCES, &s_activity_hrm_preferences,
+                 sizeof(s_activity_hrm_preferences));
+    hrm_manager_handle_prefs_changed();
+  }
+}
 #endif
 
 void alarm_prefs_set_alarms_app_opened(uint8_t version) {

--- a/src/fw/shell/sdk/prefs.c
+++ b/src/fw/shell/sdk/prefs.c
@@ -250,6 +250,13 @@ HRMonitoringInterval activity_prefs_get_hrm_measurement_interval(void) {
 
 void activity_prefs_set_hrm_measurement_interval(HRMonitoringInterval interval) {
 }
+
+bool activity_prefs_hrm_activity_tracking_is_enabled(void) {
+  return true;
+}
+
+void activity_prefs_set_hrm_activity_tracking_enabled(bool enabled) {
+}
 #endif
 
 ActivityInsightSettings *activity_prefs_get_sleep_reward_settings(void) {


### PR DESCRIPTION
The Kraepelin activity detection algorithm subscribes to continuous HRM when a walk/run is detected (after 3 minutes of activity). Add a new "HR During Activity" toggle in Health settings to allow disabling this behavior, saving battery during walks/runs.