### PR TITLE
Memfault coredump fix

### DIFF
--- a/src/fw/services/normal/filesystem/pfs.c
+++ b/src/fw/services/normal/filesystem/pfs.c
@@ -1414,7 +1414,17 @@ status_t pfs_close(int fd) {
 
   File *f = &PFS_FD(fd).file;
   if (f->is_tmp) {
-    // TODO: For safety, could disallow this op if user has orig file hdl open
+    // If the original file is still open, force-evict it before removing.
+    // This prevents pfs_remove() from CROAKing on the in-use original fd.
+    // Callers should close the original before the temp, but if they don't,
+    // we handle it gracefully here rather than crashing.
+    int orig_fd;
+    if (get_avail_fd(f->name, &orig_fd, false) == FDBusy) {
+      PBL_LOG_ERR("Original file %s still open when closing temp, force-evicting",
+                  f->name);
+      PFS_FD(orig_fd).fd_status = FD_STATUS_UNREFERENCED;
+      PFS_FD(orig_fd).time_closed = time_closed_counter++;
+    }
     pfs_remove(f->name);
     // Note: if we reboot before updating the tmp state flag to done, the tmp &
     // original file will be deleted. This is an extremely small window, but

--- a/src/fw/services/normal/filesystem/pfs.c
+++ b/src/fw/services/normal/filesystem/pfs.c
@@ -1414,8 +1414,7 @@ status_t pfs_close(int fd) {
 
   File *f = &PFS_FD(fd).file;
   if (f->is_tmp) {
-    // Note: file_found_in_cache() now prevents opening a non-temp file while a
-    // temp file with the same name is in use, so pfs_remove() here is safe.
+    // TODO: For safety, could disallow this op if user has orig file hdl open
     pfs_remove(f->name);
     // Note: if we reboot before updating the tmp state flag to done, the tmp &
     // original file will be deleted. This is an extremely small window, but
@@ -1716,17 +1715,6 @@ static NOINLINE bool file_found_in_cache(const char *name, uint8_t op_flags, int
   } else if (res == FDBusy) {
     res = E_BUSY; // the file is already open
     goto cleanup;
-  }
-
-  // When opening a non-temp file, check if a temp file with the same name is in use.
-  // If so, block the open to prevent crashes when the temp file is later closed
-  // (pfs_close for temp files calls pfs_remove on the original filename).
-  if (!is_tmp) {
-    int tmp_fd;
-    if (get_avail_fd(name, &tmp_fd, true) == FDBusy) {
-      res = E_BUSY;
-      goto cleanup;
-    }
   }
 
   File *file = &PFS_FD(fd).file;


### PR DESCRIPTION
DLS compaction (`prv_realloc_storage`) needs both the original and temp file open simultaneously to copy data. The E_BUSY check that was supposed to prevent the croak prevented Memfault coredumps instead lol