### PR TITLE
voice: add raw audio streaming session type and API

### DIFF
--- a/src/fw/applib/voice/microphone_session.c
+++ b/src/fw/applib/voice/microphone_session.c
@@ -1,0 +1,168 @@
+/* SPDX-FileCopyrightText: 2024 Google LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "microphone_session.h"
+
+#include "applib/applib_malloc.auto.h"
+#include "applib/event_service_client.h"
+#include "kernel/events.h"
+#include "process_management/app_install_manager.h"
+#include "services/normal/voice/voice.h"
+#include "syscall/syscall.h"
+#include "system/logging.h"
+#include "system/passert.h"
+
+#if CAPABILITY_HAS_MICROPHONE
+
+struct MicrophoneSession {
+  MicrophoneSessionStatusCallback callback;
+  void *context;
+  VoiceSessionId session_id;
+  bool in_progress;
+  bool destroy_pending;
+  EventServiceInfo voice_event_sub;
+};
+
+// Translate VoiceStatus → MicrophoneSessionStatus for failure cases.
+static MicrophoneSessionStatus prv_status_from_voice_status(VoiceStatus voice_status) {
+  switch (voice_status) {
+    case VoiceStatusErrorConnectivity:
+      return MicrophoneSessionStatusFailureConnectivityError;
+    case VoiceStatusErrorDisabled:
+      return MicrophoneSessionStatusFailureDisabled;
+    default:
+      return MicrophoneSessionStatusFailureInternalError;
+  }
+}
+
+static void prv_finish_session(MicrophoneSession *session) {
+  session->in_progress = false;
+  session->session_id = VOICE_SESSION_ID_INVALID;
+  event_service_client_unsubscribe(&session->voice_event_sub);
+
+  if (session->destroy_pending) {
+    microphone_session_destroy(session);
+  }
+}
+
+static void prv_voice_event_handler(PebbleEvent *e, void *context) {
+  MicrophoneSession *session = context;
+  PBL_ASSERTN(session);
+
+  const PebbleVoiceServiceEvent *ve = &e->voice_service;
+
+  if (ve->type == VoiceEventTypeSessionSetup) {
+    if (ve->status == VoiceStatusSuccess) {
+      // Phone is ready; audio is now streaming.
+      session->callback(session, MicrophoneSessionStatusRecording, session->context);
+    } else {
+      MicrophoneSessionStatus status = prv_status_from_voice_status(ve->status);
+      prv_finish_session(session);
+      session->callback(session, status, session->context);
+    }
+    return;
+  }
+
+  if (ve->type == VoiceEventTypeSessionResult) {
+    MicrophoneSessionStatus status = (ve->status == VoiceStatusSuccess)
+        ? MicrophoneSessionStatusSuccess
+        : prv_status_from_voice_status(ve->status);
+    prv_finish_session(session);
+    session->callback(session, status, session->context);
+    return;
+  }
+  // VoiceEventTypeSilenceDetected / VoiceEventTypeSpeechDetected are ignored for raw audio.
+}
+
+#endif // CAPABILITY_HAS_MICROPHONE
+
+MicrophoneSession *microphone_session_create(MicrophoneSessionStatusCallback callback,
+                                             void *callback_context) {
+#if CAPABILITY_HAS_MICROPHONE
+  if (!callback) {
+    return NULL;
+  }
+
+  // Only allow app tasks to open raw audio sessions, and only when the phone supports the API.
+  bool from_app = (pebble_task_get_current() == PebbleTask_App) &&
+                  !app_install_id_from_system(sys_process_manager_get_current_process_id());
+  if (from_app && !sys_system_pp_has_capability(CommSessionVoiceApiSupport)) {
+    PBL_LOG_INFO("Phone not connected or does not support raw audio streaming");
+    return NULL;
+  }
+
+  MicrophoneSession *session = applib_type_malloc(MicrophoneSession);
+  if (!session) {
+    return NULL;
+  }
+
+  *session = (MicrophoneSession) {
+    .callback = callback,
+    .context = callback_context,
+    .session_id = VOICE_SESSION_ID_INVALID,
+    .voice_event_sub = (EventServiceInfo) {
+      .type = PEBBLE_VOICE_SERVICE_EVENT,
+      .handler = prv_voice_event_handler,
+      .context = session,
+    },
+  };
+
+  return session;
+#else
+  return NULL;
+#endif
+}
+
+void microphone_session_destroy(MicrophoneSession *session) {
+#if CAPABILITY_HAS_MICROPHONE
+  if (!session) {
+    return;
+  }
+
+  if (session->in_progress) {
+    // Can't destroy mid-stream; cancel and defer actual free until event fires.
+    session->destroy_pending = true;
+    sys_microphone_unsubscribe(session->session_id);
+    return;
+  }
+
+  event_service_client_unsubscribe(&session->voice_event_sub);
+  applib_free(session);
+#endif
+}
+
+MicrophoneSessionStatus microphone_session_start(MicrophoneSession *session) {
+#if CAPABILITY_HAS_MICROPHONE
+  if (!session || session->in_progress) {
+    return MicrophoneSessionStatusFailureInternalError;
+  }
+
+  event_service_client_subscribe(&session->voice_event_sub);
+
+  VoiceSessionId sid = sys_microphone_subscribe();
+  if (sid == VOICE_SESSION_ID_INVALID) {
+    event_service_client_unsubscribe(&session->voice_event_sub);
+    return MicrophoneSessionStatusFailureInternalError;
+  }
+
+  session->session_id = sid;
+  session->in_progress = true;
+  return MicrophoneSessionStatusRecording;
+#else
+  return MicrophoneSessionStatusFailureInternalError;
+#endif
+}
+
+MicrophoneSessionStatus microphone_session_stop(MicrophoneSession *session) {
+#if CAPABILITY_HAS_MICROPHONE
+  if (!session || !session->in_progress) {
+    return MicrophoneSessionStatusFailureInternalError;
+  }
+
+  sys_microphone_unsubscribe(session->session_id);
+  // prv_finish_session is called when VoiceEventTypeSessionResult arrives.
+  return MicrophoneSessionStatusSuccess;
+#else
+  return MicrophoneSessionStatusFailureInternalError;
+#endif
+}

--- a/src/fw/applib/voice/microphone_session.h
+++ b/src/fw/applib/voice/microphone_session.h
@@ -1,0 +1,76 @@
+/* SPDX-FileCopyrightText: 2024 Google LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+//! @file voice/microphone_session.h
+//! Raw microphone audio streaming API.
+//!
+//! A MicrophoneSession streams Speex-encoded audio from the watch microphone to the connected
+//! phone app without performing speech-to-text. The phone app receives the raw Speex frames via
+//! the audio endpoint protocol and is responsible for decoding and processing them.
+//!
+//! Usage:
+//!   1. Call microphone_session_create() to allocate a session.
+//!   2. Call microphone_session_start() to begin streaming; your callback fires when the phone
+//!      is ready (MicrophoneSessionStatusRecording) or if setup fails.
+//!   3. Call microphone_session_stop() when done; your callback fires with
+//!      MicrophoneSessionStatusSuccess when the stream has been flushed.
+//!   4. Call microphone_session_destroy() to free the session.
+//!
+//! Only one audio session (dictation or raw audio) may be active at a time.
+
+typedef struct MicrophoneSession MicrophoneSession;
+
+typedef enum {
+  //! Streaming started — the phone is receiving Speex frames.
+  MicrophoneSessionStatusRecording,
+
+  //! Streaming stopped cleanly after microphone_session_stop().
+  MicrophoneSessionStatusSuccess,
+
+  //! No BT or internet connection to the phone app.
+  MicrophoneSessionStatusFailureConnectivityError,
+
+  //! Raw audio streaming is disabled on this platform or by the phone app.
+  MicrophoneSessionStatusFailureDisabled,
+
+  //! An internal error prevented the session from starting or continuing.
+  MicrophoneSessionStatusFailureInternalError,
+} MicrophoneSessionStatus;
+
+//! Callback invoked when the session state changes.
+//! @param session  The session that generated the event.
+//! @param status   The new session status.
+//! @param context  The context pointer supplied to microphone_session_create().
+typedef void (*MicrophoneSessionStatusCallback)(MicrophoneSession *session,
+                                                MicrophoneSessionStatus status,
+                                                void *context);
+
+//! Allocate a microphone session.
+//! @param callback          Status callback — must not be NULL.
+//! @param callback_context  Opaque pointer forwarded to every callback invocation.
+//! @return Pointer to the new session, or NULL if the platform lacks a microphone, the phone
+//!         app does not support raw audio streaming, or an internal allocation failure occurred.
+MicrophoneSession *microphone_session_create(MicrophoneSessionStatusCallback callback,
+                                             void *callback_context);
+
+//! Free a microphone session. If a stream is in progress it is cancelled first.
+//! @param session  Session to destroy; a NULL pointer is silently ignored.
+void microphone_session_destroy(MicrophoneSession *session);
+
+//! Begin streaming audio to the phone app.
+//! Can only be called when no stream is already in progress.
+//! @param session  Session returned by microphone_session_create().
+//! @return MicrophoneSessionStatusRecording on success, or a failure status.
+MicrophoneSessionStatus microphone_session_start(MicrophoneSession *session);
+
+//! Stop an in-progress audio stream.
+//! The callback will fire with MicrophoneSessionStatusSuccess once the endpoint has been flushed.
+//! @param session  Session returned by microphone_session_create().
+//! @return MicrophoneSessionStatusSuccess, or MicrophoneSessionStatusFailureInternalError if no
+//!         stream was in progress.
+MicrophoneSessionStatus microphone_session_stop(MicrophoneSession *session);

--- a/src/fw/services/normal/voice/voice.c
+++ b/src/fw/services/normal/voice/voice.c
@@ -62,6 +62,7 @@ static uint32_t s_session_generation = 0;      // Monotonic session counter
 static uint32_t s_timeout_generation = 0;      // Generation tied to currently scheduled timeout
 static bool s_teardown_in_progress = false;    // Debounce concurrent teardown paths
 static bool s_delayed_speex_cleanup = false;   // Flag to defer Speex cleanup during cancellation
+static bool s_is_raw_audio = false;            // True when session is raw audio (no STT)
 
 static void prv_send_event(VoiceEventType event_type, VoiceStatus status,
                            PebbleVoiceServiceEventData *data);
@@ -177,6 +178,7 @@ static void prv_reset(void) {
   
   s_state = SessionState_Idle;
   s_session_id = AUDIO_ENDPOINT_SESSION_INVALID_ID;
+  s_is_raw_audio = false;
 
 }
 
@@ -469,9 +471,16 @@ void voice_stop_dictation(VoiceSessionId session_id) {
     return;
   }
 
-  s_state = SessionState_WaitForSessionResult;
-  prv_stop_recording();
-  prv_start_result_timeout();
+  if (s_is_raw_audio) {
+    // Raw audio: no transcription expected from phone — stop cleanly and reset immediately.
+    prv_stop_recording();
+    prv_send_event(VoiceEventTypeSessionResult, VoiceStatusSuccess, NULL);
+    prv_reset();
+  } else {
+    s_state = SessionState_WaitForSessionResult;
+    prv_stop_recording();
+    prv_start_result_timeout();
+  }
 
 unlock:
   mutex_unlock(s_lock);
@@ -763,6 +772,30 @@ DEFINE_SYSCALL(void, sys_voice_stop_dictation, VoiceSessionId session_id) {
 
 DEFINE_SYSCALL(void, sys_voice_cancel_dictation, VoiceSessionId session_id) {
   voice_cancel_dictation(session_id);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Raw audio session
+
+VoiceSessionId voice_start_raw_audio(void) {
+  s_is_raw_audio = true;
+  return voice_start_dictation(VoiceEndpointSessionTypeRawAudio);
+}
+
+void voice_stop_raw_audio(VoiceSessionId session_id) {
+  voice_stop_dictation(session_id);
+}
+
+void voice_cancel_raw_audio(VoiceSessionId session_id) {
+  voice_cancel_dictation(session_id);
+}
+
+DEFINE_SYSCALL(VoiceSessionId, sys_microphone_subscribe) {
+  return voice_start_raw_audio();
+}
+
+DEFINE_SYSCALL(void, sys_microphone_unsubscribe, VoiceSessionId session_id) {
+  voice_stop_raw_audio(session_id);
 }
 
 void voice_kill_app_session(PebbleTask task) {

--- a/src/fw/services/normal/voice/voice.h
+++ b/src/fw/services/normal/voice/voice.h
@@ -105,11 +105,29 @@ void voice_handle_nlp_result(VoiceEndpointResult result, AudioEndpointSessionId 
                              char *reminder, time_t timestamp);
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+// Raw audio session (mic → Speex → phone, no STT)
+
+//! Start a raw audio session. The voice service will stream Speex-encoded audio to the phone
+//! without running speech-to-text. Use VoiceEventTypeSessionSetup to detect when streaming begins
+//! and VoiceEventTypeSessionResult when it ends.
+//! @return session ID, or VOICE_SESSION_ID_INVALID if a session is already in progress
+VoiceSessionId voice_start_raw_audio(void);
+
+//! Stop an in-progress raw audio session and flush the audio endpoint.
+void voice_stop_raw_audio(VoiceSessionId session_id);
+
+//! Cancel a raw audio session at any stage without waiting for endpoint flush.
+void voice_cancel_raw_audio(VoiceSessionId session_id);
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 // Syscalls
 
 VoiceSessionId sys_voice_start_dictation(VoiceEndpointSessionType session_type);
 void sys_voice_stop_dictation(VoiceSessionId session_id);
 void sys_voice_cancel_dictation(VoiceSessionId session_id);
+
+VoiceSessionId sys_microphone_subscribe(void);
+void sys_microphone_unsubscribe(VoiceSessionId session_id);
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Process cleanup

--- a/src/fw/services/normal/voice_endpoint.h
+++ b/src/fw/services/normal/voice_endpoint.h
@@ -15,6 +15,7 @@ typedef enum {
   VoiceEndpointSessionTypeDictation = 0x01,
   VoiceEndpointSessionTypeCommand = 0x02,   // Not used yet
   VoiceEndpointSessionTypeNLP = 0x03,
+  VoiceEndpointSessionTypeRawAudio = 0x04,  // Raw Speex audio stream, no STT
 
   VoiceEndpointSessionTypeCount,
 } VoiceEndpointSessionType;


### PR DESCRIPTION
Introduce VoiceEndpointSessionTypeRawAudio (0x04) so a watchapp can stream Speex-encoded mic audio directly to the phone app without triggering speech-to-text.

Changes:
- voice_endpoint.h: add VoiceEndpointSessionTypeRawAudio = 0x04
- voice.c / voice.h: add voice_start/stop/cancel_raw_audio() and the two new syscalls sys_microphone_subscribe / sys_microphone_unsubscribe. voice_stop_dictation() skips WaitForSessionResult when in raw-audio mode (no transcription message expected from the phone).
- applib/voice/microphone_session.h: public app-facing API (microphone_session_create/destroy/start/stop).
- applib/voice/microphone_session.c: applib implementation — subscribes to PEBBLE_VOICE_SERVICE_EVENT, translates VoiceStatus events to MicrophoneSessionStatus, and calls the new syscalls.

The phone app must handle session_type=0x04 in the SessionSetupMsg and stream the raw Speex frames from the audio endpoint without running STT.

Co-authored-by: claude-opus-4-6

https://claude.ai/code/session_013FDDXhQSU1GH3xBDLLQXKu