### PR TITLE
tests: fix build and runtime failures on Apple Silicon

### DIFF
--- a/tests/vendor/duma/duma_config.h
+++ b/tests/vendor/duma/duma_config.h
@@ -186,7 +186,11 @@
 /*
  * Number of bytes per virtual-memory page, as returned by Page_Size().
  */
+#if defined(__APPLE__) && defined(__aarch64__)
+#define DUMA_PAGE_SIZE 16384
+#else
 #define DUMA_PAGE_SIZE 4096
+#endif
 
 /*
  * Minimum required alignment by CPU.

--- a/wscript
+++ b/wscript
@@ -525,6 +525,13 @@ def configure(conf):
                         '-fdata-sections',
                         '-ffunction-sections' ]
 
+    # Apple's ARM64 linker uses chained fixups which require pointer-aligned
+    # relocations. Packed structs with pointer members fail to link because the
+    # packed layout can place pointers at non-aligned offsets. Disable chained
+    # fixups to use classic relocations instead.
+    if sys.platform == 'darwin':
+        conf.env.append_value('LINKFLAGS', '-Wl,-no_fixup_chains')
+
     conf.env.append_value('DEFINES', 'CLAR_FIXTURE_PATH="' +
                                      conf.path.make_node('tests/fixtures/').abspath() + '"')
 


### PR DESCRIPTION
Apple's ARM64 linker uses chained fixups which require pointer-aligned relocations. Packed structs with pointer members fail to link because the packed layout can place pointers at non-aligned offsets. Disable chained fixups with -Wl,-no_fixup_chains on macOS.

Also fix DUMA page size: Apple Silicon uses 16KB pages, not 4KB.