### PR TITLE
include DST in tm_gmtoff and preserve app/schedule compatibility

### DIFF
--- a/src/fw/applib/pbl_std/pbl_std.c
+++ b/src/fw/applib/pbl_std/pbl_std.c
@@ -4,6 +4,7 @@
 #include "applib/pbl_std/pbl_std.h"
 #include "applib/app_logging.h"
 #include "applib/applib_malloc.auto.h"
+#include "drivers/rtc.h"
 #include "process_state/app_state/app_state.h"
 #include "process_state/worker_state/worker_state.h"
 #include "syscall/syscall.h"
@@ -82,11 +83,55 @@ time_t pbl_override_time_legacy(time_t *tloc) {
   return (legacy_time);
 }
 
+static bool prv_tm_matches_local_time(const struct tm *requested, const struct tm *actual) {
+  return (requested->tm_sec == actual->tm_sec) &&
+         (requested->tm_min == actual->tm_min) &&
+         (requested->tm_hour == actual->tm_hour) &&
+         (requested->tm_mday == actual->tm_mday) &&
+         (requested->tm_mon == actual->tm_mon) &&
+         (requested->tm_year == actual->tm_year);
+}
+
+static void prv_fill_localtime_result(time_t t, struct tm *tb) {
+  sys_localtime_r(&t, tb);
+  sys_copy_timezone_abbr(tb->tm_zone, t);
+}
+
+static time_t prv_mktime_with_normalized_gmtoff(const struct tm *tb, int isdst) {
+  TimezoneInfo tz_info = { 0 };
+  rtc_get_timezone(&tz_info);
+
+  struct tm normalized = *tb;
+  normalized.tm_gmtoff = tz_info.tm_gmtoff;
+  normalized.tm_isdst = isdst;
+  return mktime(&normalized);
+}
+
 DEFINE_SYSCALL(time_t, pbl_override_mktime, struct tm *tb) {
   if (PRIVILEGE_WAS_ELEVATED) {
     syscall_assert_userspace_buffer(tb, sizeof(struct tm));
   }
-  return mktime(tb);
+
+  const int requested_isdst = tb->tm_isdst;
+  time_t t;
+  if (requested_isdst >= 0) {
+    t = prv_mktime_with_normalized_gmtoff(tb, requested_isdst);
+  } else {
+    struct tm actual;
+    t = prv_mktime_with_normalized_gmtoff(tb, 0);
+    time_t dst_t = prv_mktime_with_normalized_gmtoff(tb, 1);
+
+    prv_fill_localtime_result(t, &actual);
+    if (!prv_tm_matches_local_time(tb, &actual)) {
+      prv_fill_localtime_result(dst_t, &actual);
+      if (prv_tm_matches_local_time(tb, &actual)) {
+        t = dst_t;
+      }
+    }
+  }
+
+  prv_fill_localtime_result(t, tb);
+  return t;
 }
 
 uint16_t time_ms(time_t *tloc, uint16_t *out_ms) {
@@ -293,4 +338,3 @@ int pbl_snprintf(char * str, size_t n, const char * format, ...) {
 
   return ret;
 }
-

--- a/src/fw/services/common/clock.c
+++ b/src/fw/services/common/clock.c
@@ -632,8 +632,19 @@ time_t clock_to_timestamp(WeekDay day, int hour, int minute) {
 
   cal.tm_hour = hour;
   cal.tm_min = minute;
+  cal.tm_sec = 0;
+  cal.tm_gmtoff = time_get_gmtoffset();
+  cal.tm_isdst = 0;
 
-  return mktime(&cal);
+  t = mktime(&cal);
+  if (time_get_isdst(t)) {
+    t -= time_get_dstoffset();
+    if (!time_get_isdst(t)) {
+      t = time_get_dst_start();
+    }
+  }
+
+  return t;
 }
 
 void command_timezone_clear(void) {

--- a/src/fw/services/common/cron.c
+++ b/src/fw/services/common/cron.c
@@ -395,7 +395,7 @@ order field, this is guaranteed to put the result ahead of the local epoch.
   cron_tm.tm_mday += 1;
 
   // Decide the DSTny (Adjust for DST transitions)
-  cron_tm.tm_gmtoff = current_tm.tm_gmtoff; // We're using the current time's GMT offset
+  cron_tm.tm_gmtoff = time_get_gmtoffset();
   cron_tm.tm_isdst = 0; // We'll do the DST adjust ourselves
   time_t t = mktime(&cron_tm);
 

--- a/src/fw/util/time/time.c
+++ b/src/fw/util/time/time.c
@@ -114,10 +114,10 @@ struct tm *time_to_tm(const time_t * tim_p, struct tm *res, bool utc_mode) {
     res->tm_zone[TZ_LEN - 1] = '\0';
     local_time = utc_time;
   } else {
-    res->tm_gmtoff = time_get_gmtoffset();
     res->tm_isdst = time_get_isdst(utc_time);
+    res->tm_gmtoff = time_get_gmtoffset() + (res->tm_isdst ? s_dst_adjust : 0);
     time_get_timezone_abbr(res->tm_zone, utc_time);
-    local_time = utc_time + res->tm_gmtoff + (res->tm_isdst ? s_dst_adjust : 0);
+    local_time = utc_time + res->tm_gmtoff;
   }
 
   int32_t days = local_time / SECONDS_PER_DAY;


### PR DESCRIPTION
- Make localtime() expose tm_gmtoff as the effective wall-clock offset (including DST when active), matching expected semantics.
- Keep recurring clock/cron scheduling stable across DST boundaries by converting with the base timezone offset and applying DST transition correction separately.
- Preserve app-facing mktime compatibility by normalizing app-provided tm_gmtoff before conversion, including tm_isdst < 0 handling.