### PR TITLE
fw/services/common/battery: fix false critical shutdown after charger removal

### DIFF
--- a/src/fw/services/common/battery/battery_monitor.c
+++ b/src/fw/services/common/battery/battery_monitor.c
@@ -178,7 +178,11 @@ void battery_monitor_handle_state_change_event(PreciseBatteryChargeState state) 
   const uint32_t LOW_POWER_PERCENT = ratio32_from_percent(BOARD_CONFIG_POWER.low_power_threshold);
 
   bool low_power = !state.is_charging && (state.charge_percent <= LOW_POWER_PERCENT);
-  s_low_on_first_run = s_low_on_first_run || (low_power && s_first_run);
+  if (low_power && s_first_run && !state.is_plugged) {
+    s_low_on_first_run = true;
+  } else if (!low_power) {
+    s_low_on_first_run = false;
+  }
 #else
   const uint32_t PRF_LOW_POWER_THRESHOLD_PERCENT = ratio32_from_percent(5);
 


### PR DESCRIPTION
## Summary

- Fix `s_low_on_first_run` one-way latch in battery monitor that caused false critical shutdowns after charger removal (even at 100% battery)
- Only set the flag when booting unplugged with a low battery (the intended case)
- Clear the flag when battery recovers above the low power threshold

Fixes FIRM-1511

## Test plan

- [x] `test_battery_monitor` tests pass (including `low_first_run` and `transitions`)
- [ ] Boot watch on charger, charge to 100%, unplug → verify no critical shutdown
- [ ] Boot watch unplugged with low battery → verify still enters critical mode and shuts down

🤖 Generated with [Claude Code](https://claude.com/claude-code)