### PR TITLE
fw/applib/animation: reduce render frame rate on sf32lb52

### DIFF
--- a/src/fw/applib/ui/animation.c
+++ b/src/fw/applib/ui/animation.c
@@ -1065,7 +1065,7 @@ void animation_private_state_init(AnimationState *state) {
     // To aid for debugging, let's start each task off at a different handle offset. Eventually they
     // will collide but it is not required that each task have globally unique handles
     .next_handle = pebble_task_get_current() * 100000000,
-    .last_delay_ms = ANIMATION_TARGET_FRAME_INTERVAL_MS,
+    .last_delay_ms = ANIMATION_FRAME_RENDER_INTERVAL_MS,
     .last_frame_time_ms = prv_get_ms_since_system_start()
   };
 
@@ -1136,10 +1136,10 @@ void animation_private_timer_callback(void *context) {
 
   // Frame rate control:
   const int32_t frame_interval_ms = serial_distance32(state->aux->last_frame_time_ms, now);
-  const int32_t error_ms = frame_interval_ms - ANIMATION_TARGET_FRAME_INTERVAL_MS;
+  const int32_t error_ms = frame_interval_ms - ANIMATION_FRAME_RENDER_INTERVAL_MS;
   const int32_t theoretic_delay_ms = state->aux->last_delay_ms - error_ms;
   const uint32_t delay_ms = CLIP(theoretic_delay_ms, (int32_t) 0,
-                                (int32_t) ANIMATION_TARGET_FRAME_INTERVAL_MS);
+                                (int32_t) ANIMATION_FRAME_RENDER_INTERVAL_MS);
 
   prv_reschedule_timer(state, delay_ms);
   state->aux->last_delay_ms = delay_ms;

--- a/src/fw/applib/ui/animation.h
+++ b/src/fw/applib/ui/animation.h
@@ -70,6 +70,20 @@ typedef struct ImmutableAnimation ImmutableAnimation;
 //! 1000ms / 30 Hz
 #define ANIMATION_TARGET_FRAME_INTERVAL_MS 33
 
+//! @internal
+//! Target interval between rendered frames for the frame rate control loop.
+//! This is separate from ANIMATION_TARGET_FRAME_INTERVAL_MS so that the render
+//! rate can be adjusted independently from animation duration calculations.
+//! Platforms with lower CPU frequencies can increase this to reduce rendering
+//! load and improve frame timing consistency.
+#ifndef ANIMATION_FRAME_RENDER_INTERVAL_MS
+#if defined(MICRO_FAMILY_SF32LB52)
+#define ANIMATION_FRAME_RENDER_INTERVAL_MS 50  // 20 Hz
+#else
+#define ANIMATION_FRAME_RENDER_INTERVAL_MS ANIMATION_TARGET_FRAME_INTERVAL_MS
+#endif
+#endif
+
 
 //! The type used to represent how far an animation has progressed. This is passed to the
 //! animation's update handler


### PR DESCRIPTION
Add a separate ANIMATION_FRAME_RENDER_INTERVAL_MS that controls how often frames are rendered, while keeping ANIMATION_TARGET_FRAME_INTERVAL_MS for animation duration calculations.

On SF32LB52 at 144 MHz, target 20 Hz instead of 30 Hz to give each frame more CPU time and reduce jitter.