### PR TITLE
fw/vibes: add logging for notification vibe lifecycle

### DIFF
--- a/src/fw/popups/notifications/notification_window.c
+++ b/src/fw/popups/notifications/notification_window.c
@@ -1108,6 +1108,8 @@ static void prv_window_unload(Window *window) {
     return;
   }
 
+  PBL_LOG_INFO("Notification vibe: window_unload, cancelling vibes (pending_vibe=%d)",
+               data->pending_vibe);
   vibes_cancel();
   data->pending_vibe = false;
   prv_cleanup_timers(data);
@@ -1405,6 +1407,7 @@ static void prv_handle_notification_acted_upon(Uuid *id) {
 }
 
 static void prv_do_notification_vibe(NotificationWindowData *data, Uuid *id) {
+  PBL_LOG_INFO("Notification vibe: do_vibe called");
   TimelineItem *item = prv_get_current_notification(data);
   // Check if the current notification is the one we want to vibe for - if not then reload to make
   // sure it is, before reading the attributes.

--- a/src/fw/services/common/vibe_pattern.c
+++ b/src/fw/services/common/vibe_pattern.c
@@ -265,6 +265,7 @@ static void prv_timer_callback(void* data) {
   } else {
     // I'm done with the active pattern
     // make sure it's off
+    PBL_LOG_INFO("vibe_pattern: pattern complete");
     prv_vibes_set_vibe_strength(VIBE_STRENGTH_OFF);
     s_pattern_in_progress = false;
   }
@@ -292,7 +293,6 @@ bool prv_vibe_pattern_enqueue_step_raw(uint32_t duration_ms, int32_t strength) {
   mutex_lock(s_vibe_pattern_mutex);
 
   if (s_pattern_in_progress) {
-    PBL_LOG_DBG("Pattern is in progress");
     mutex_unlock(s_vibe_pattern_mutex);
     return false;
   }
@@ -346,6 +346,7 @@ DEFINE_SYSCALL(void, sys_vibe_pattern_trigger_start, void) {
 
 DEFINE_SYSCALL(void, sys_vibe_pattern_clear, void) {
   mutex_lock(s_vibe_pattern_mutex);
+  PBL_LOG_INFO("vibe_pattern: clear (was_in_progress=%d)", s_pattern_in_progress);
   new_timer_stop(s_pattern_timer);
   while (s_vibe_queue_head) {
     VibePatternStep *removed_node = s_vibe_queue_head;

--- a/src/fw/services/normal/vibes/vibe_score.c
+++ b/src/fw/services/normal/vibes/vibe_score.c
@@ -7,6 +7,7 @@
 #include "syscall/syscall.h"
 
 #include "system/passert.h"
+#include "system/logging.h"
 #include "drivers/vibe.h"
 #include "applib/applib_malloc.auto.h"
 #include "util/net.h"
@@ -198,8 +199,10 @@ void vibe_score_do_vibe(VibeScore *score) {
   VibeNoteIndex *pattern_list = prv_vibe_score_get_pattern_list(pattern_attribute);
   unsigned int pattern_length = prv_vibe_score_get_pattern_length(pattern_attribute);
 
+  unsigned int total_duration_ms = 0;
   for (unsigned int i = 0; i < pattern_length; i++) {
     VibeNote *note = &note_list[pattern_list[i]];
+    total_duration_ms += note->vibe_duration_ms + note->brake_duration_ms;
     if (note->vibe_duration_ms > 0) {
       sys_vibe_pattern_enqueue_step_raw(note->vibe_duration_ms, note->strength);
     }
@@ -207,6 +210,9 @@ void vibe_score_do_vibe(VibeScore *score) {
       sys_vibe_pattern_enqueue_step_raw(note->brake_duration_ms, vibe_get_braking_strength());
     }
   }
+  unsigned int repeat_delay = vibe_score_get_repeat_delay_ms(score);
+  PBL_LOG_INFO("vibe_score: do_vibe, %u notes, %ums total, repeat_delay=%ums",
+               pattern_length, total_duration_ms, repeat_delay);
   sys_vibe_pattern_trigger_start();
 }
 


### PR DESCRIPTION
Add INFO-level logs across the notification vibe path to help debug FIRM-1538 (notification vibe looping until dismissed). Logs trace:
- When notification vibes are triggered, deferred, or cancelled
- Vibe score details (note count, duration, repeat delay)
- Pattern engine start, step transitions, completion, and clear