### PR TITLE
Add logs to Memfault coredumps via compact logs [FIRM-1569]

### DIFF
--- a/src/fw/popups/bluetooth_pairing_ui.c
+++ b/src/fw/popups/bluetooth_pairing_ui.c
@@ -609,7 +609,7 @@ void bluetooth_pairing_ui_handle_event(PebbleBluetoothPairEvent *event) {
         prv_handle_pairing_complete(event->success);
       } else {
         PBL_LOG_ERR("Got complete event for unknown process %p vs %p",
-                event->ctx, s_data_ptr ? s_data_ptr->ctx : NULL);
+                (void *)event->ctx, s_data_ptr ? (void *)s_data_ptr->ctx : NULL);
       }
       break;
 

--- a/src/fw/system/logging.h
+++ b/src/fw/system/logging.h
@@ -60,6 +60,29 @@ int pbl_log_get_bin_format(char* buffer, int buffer_len, const uint8_t log_level
   #include <logging/log_hashing.h>
 #endif
 
+#if MEMFAULT && defined(PBL_LOGS_HASHED) && __has_include("memfault/core/log.h")
+  #include "memfault/core/log.h"
+
+  #define PBL_TO_MFLT_LOG_LEVEL(level) \
+    ((level) <= LOG_LEVEL_ERROR ? kMemfaultPlatformLogLevel_Error : \
+     (level) <= LOG_LEVEL_WARNING ? kMemfaultPlatformLogLevel_Warning : \
+     (level) <= LOG_LEVEL_INFO ? kMemfaultPlatformLogLevel_Info : \
+     kMemfaultPlatformLogLevel_Debug)
+
+  // Memfault compact_log_helpers.h uses (arg)+0 in _Generic which triggers
+  // -Wpointer-arith when log arguments include function pointers. Suppress
+  // this warning around the SDK macro expansion.
+  #define PBL_MFLT_LOG_SAVE(level, fmt, ...) \
+    do { \
+      _Pragma("GCC diagnostic push") \
+      _Pragma("GCC diagnostic ignored \"-Wpointer-arith\"") \
+      MEMFAULT_COMPACT_LOG_SAVE(PBL_TO_MFLT_LOG_LEVEL(level), fmt, ## __VA_ARGS__); \
+      _Pragma("GCC diagnostic pop") \
+    } while (0)
+#else
+  #define PBL_MFLT_LOG_SAVE(level, fmt, ...) ((void)0)
+#endif
+
 #define LOG_COLOR_BLACK          "BLACK"        // Not so useful in general
 #define LOG_COLOR_RED            "RED"
 #define LOG_COLOR_GREEN          "GREEN"
@@ -156,6 +179,7 @@ int pbl_log_get_bin_format(char* buffer, int buffer_len, const uint8_t log_level
         if (PBL_SHOULD_LOG(level)) { \
           if (domain) { \
             NEW_LOG_HASH(pbl_log_hashed_async, level, color, fmt, ## __VA_ARGS__); \
+            PBL_MFLT_LOG_SAVE(level, fmt, ## __VA_ARGS__); \
           } \
         } \
       } while (0)

--- a/src/fw/wscript
+++ b/src/fw/wscript
@@ -393,6 +393,11 @@ def _link_firmware(bld, sources):
 
     ldscript = _generate_memory_layout(bld)
 
+    ldscripts = [ldscript, 'fw_common.ld']
+    if bld.env.memfault:
+        ldscripts.append(bld.srcnode.find_node(
+            'third_party/memfault/port/memfault_compact_log.ld'))
+
     if bld.env.NO_LINK:
         # Only build the object files
         bld.objects(source=sources,
@@ -407,7 +412,7 @@ def _link_firmware(bld, sources):
                     lib=['gcc'],
                     target=elf_node,
                     includes='fonts',
-                    ldscript=[ldscript, 'fw_common.ld'],
+                    ldscript=ldscripts,
                     linkflags=fw_linkflags)
 
         x.env.append_value('LINKFLAGS', fw_linkflags)

--- a/third_party/memfault/port/include/memfault_platform_config.h
+++ b/third_party/memfault/port/include/memfault_platform_config.h
@@ -13,7 +13,7 @@
 #define MEMFAULT_FREERTOS_PORT_HEAP_STATS_ENABLE 1
 #define MEMFAULT_COREDUMP_HEAP_STATS_LOCK_ENABLE 0
 #define MEMFAULT_METRICS_HEARTBEAT_INTERVAL_SECS (60 * 60)
-#define MEMFAULT_COMPACT_LOG_ENABLE 0
+#define MEMFAULT_COMPACT_LOG_ENABLE 1
 
 #define MEMFAULT_COLLECT_MPU_STATE 1
 
@@ -29,7 +29,7 @@
 // from the PebbleOS coredump instead.
 #define MEMFAULT_COREDUMP_COMPUTE_THREAD_STACK_USAGE 0
 
-// Todo, we will hook more deeply into the Pebble logging system
+// PBL_LOG emits compact log entries via MEMFAULT_COMPACT_LOG_SAVE (see logging.h)
 #define MEMFAULT_PLATFORM_HAS_LOG_CONFIG 0
 
 // base64-encoded chunks can overflow the maximum serial output length, so use a

--- a/third_party/memfault/port/memfault_compact_log.ld
+++ b/third_party/memfault/port/memfault_compact_log.ld
@@ -1,0 +1,17 @@
+/*
+  Memfault compact log format strings section.
+  Read more at https://mflt.io/compact-logs
+
+  This section is not loaded to memory - it only exists in the ELF for
+  post-processing by the Memfault cloud to decode compact log entries.
+*/
+
+SECTIONS
+{
+  log_fmt 0xF0000000 (INFO) :
+  {
+      __start_log_fmt = ABSOLUTE(.);
+      KEEP(*(*.log_fmt_hdr))
+      KEEP(*(log_fmt))
+  }
+}

--- a/third_party/memfault/port/src/memfault_pebble_coredump.c
+++ b/third_party/memfault/port/src/memfault_pebble_coredump.c
@@ -23,6 +23,7 @@
 #include "memfault/panics/coredump.h"
 #include "memfault/panics/coredump_impl.h"
 #include "memfault/panics/platform/coredump.h"
+#include "memfault/core/log_impl.h"
 
 #include "drivers/flash.h"
 #include "flash_region/flash_region.h"
@@ -47,7 +48,8 @@
 // Total budget for cached memory data (stack + TCB per thread + kernel state).
 // Each thread needs: stack (768) + TCB (96) + 2x cached block header (12 bytes each) = 888.
 // Plus kernel state: ~540 bytes. For 20 threads: 20*888 + 540 ~+ 18.3KB.
-#define STACK_DATA_BUFFER_SIZE (MAX_THREADS * (STACK_BYTES_PER_THREAD + TCB_SIZE + 24) + 1024)
+#define STACK_DATA_BUFFER_SIZE \
+  (MAX_THREADS * (STACK_BYTES_PER_THREAD + TCB_SIZE + 24) + 1024 + 2200)
 
 // SRAM base address (same across all platforms we support)
 #define SRAM_BASE_ADDR 0x20000000
@@ -359,7 +361,7 @@ void memfault_pebble_coredump_reconstruct(void) {
   // data is read from our buffer.
 
   #define CACHED_BLOCK_OVERHEAD sizeof(sMfltCachedBlock)
-  #define MAX_REGIONS (MAX_THREADS * 2 + 2)
+  #define MAX_REGIONS (MAX_THREADS * 2 + 2 + MEMFAULT_LOG_NUM_RAM_REGIONS)
 
   // Dynamically allocate the staging buffer for cached memory blocks.
   // This is freed after memfault_coredump_save() serializes it all to storage.
@@ -490,6 +492,22 @@ void memfault_pebble_coredump_reconstruct(void) {
       }
 
       ADD_CACHED_REGION(top_of_stack, to_read);
+    }
+  }
+
+  // Include Memfault log buffer regions so crash-time logs appear in the
+  // coredump. The log buffer and logger state are static variables at fixed
+  // linker-determined addresses. Even though current RAM is re-initialized
+  // after reboot, ADD_CACHED_REGION reads the crash-time contents from the
+  // SPI flash RAM dump (via prv_read_ram_from_coredump), not from current RAM.
+  sMemfaultLogRegions log_regions = { 0 };
+  if (memfault_log_get_regions(&log_regions)) {
+    for (size_t i = 0; i < MEMFAULT_LOG_NUM_RAM_REGIONS; i++) {
+      if (log_regions.region[i].region_size > 0) {
+        ADD_CACHED_REGION(
+          (uint32_t)(uintptr_t)log_regions.region[i].region_start,
+          log_regions.region[i].region_size);
+      }
     }
   }
 

--- a/third_party/memfault/port/src/memfault_platform_port.c
+++ b/third_party/memfault/port/src/memfault_platform_port.c
@@ -26,7 +26,7 @@ MEMFAULT_PUT_IN_SECTION(".noinit.mflt_reboot_info")
 static uint8_t s_reboot_tracking[MEMFAULT_REBOOT_TRACKING_REGION_SIZE];
 
 // Memfault logging storage
-static uint8_t s_log_buf_storage[512];
+static uint8_t s_log_buf_storage[2048];
 
 // Use Memfault logging level to filter messages
 static eMemfaultPlatformLogLevel s_min_log_level = MEMFAULT_RAM_LOGGER_DEFAULT_MIN_LOG_LEVEL;
@@ -160,6 +160,10 @@ int memfault_platform_boot(void) {
     memfault_events_storage_boot(s_event_storage, sizeof(s_event_storage));
   memfault_trace_event_boot(evt_storage);
 
+  // Initialize log buffer early so reconstruction can find the log region
+  // addresses via memfault_log_get_regions().
+  memfault_log_boot(s_log_buf_storage, MEMFAULT_ARRAY_SIZE(s_log_buf_storage));
+
   // Reconstruct a Memfault coredump from the PebbleOS flash coredump if one
   // exists. This must happen before collect_reset_info() so that the reboot
   // event includes coredump_saved=true, allowing the Memfault cloud to
@@ -172,8 +176,6 @@ int memfault_platform_boot(void) {
     .unexpected_reboot_count = memfault_reboot_tracking_get_crash_count(),
   };
   memfault_metrics_boot(evt_storage, &boot_info);
-
-  memfault_log_boot(s_log_buf_storage, MEMFAULT_ARRAY_SIZE(s_log_buf_storage));
 
   memfault_metrics_battery_boot();
 

--- a/third_party/memfault/wscript
+++ b/third_party/memfault/wscript
@@ -27,6 +27,11 @@ def configure(conf):
     MEMFAULT = conf.env.memfault
     conf.env.append_value("DEFINES", [f"MEMFAULT={MEMFAULT}"])
 
+    # Memfault compact logs require GNU ##__VA_ARGS__ comma-elision, which
+    # is only available in -std=gnu* modes. pebble_arm_gcc.py checks this
+    # flag and uses -std=gnu11 instead of -std=c11.
+    conf.env.memfault_needs_gnu_extensions = bool(MEMFAULT)
+
     if conf.options.memfault_force:
         conf.env.append_value("DEFINES", "MEMFAULT_FORCE")
 

--- a/waftools/pebble_arm_gcc.py
+++ b/waftools/pebble_arm_gcc.py
@@ -150,10 +150,17 @@ def configure(conf):
     conf.load("gcc")
     conf.load("asm")
 
+    # Memfault compact logs require GNU ##__VA_ARGS__ comma-elision;
+    # use -std=gnu11 when Memfault is enabled, otherwise -std=c11.
+    c_std = (
+        "-std=gnu11"
+        if getattr(conf.env, "memfault_needs_gnu_extensions", False)
+        else "-std=c11"
+    )
     conf.env.append_value(
         "CFLAGS",
         [
-            "-std=c11",
+            c_std,
         ],
     )
 


### PR DESCRIPTION
- Enable Memfault compact log system alongside existing PebbleOS log hashing, so each PBL_LOG call emits both a hashed log entry (for serial/flash) and a ~5-10 byte CBOR compact log entry into a 2KB RAM circular buffer

- On crash, the NMI handler captures all RAM (including the log buffer) to SPI flash; after reboot, coredump reconstruction includes the log buffer regions so the Memfault cloud can decode and display pre-crash logs

- Add log_fmt linker section at 0xF0000000 to hold compact log format strings in the ELF (non-loaded, like .log_strings)

- Switch firmware C standard from c11 to gnu11 to support the ##__VA_ARGS__ comma-elision required by Memfault's compact log macros