### PR TITLE
fw/services: expose quiet time motion backlight in Settings BlobDB

### DIFF
--- a/src/fw/services/normal/blob_db/settings_blob_db.c
+++ b/src/fw/services/normal/blob_db/settings_blob_db.c
@@ -128,6 +128,7 @@ static const char *s_syncable_notif_prefs[] = {
   "notifDesignStyle",
   "notifVibeDelay",
   "notifBacklight",
+  "dndMotionBacklight",
 };
 
 static const size_t s_num_syncable_notif_prefs = ARRAY_LENGTH(s_syncable_notif_prefs);

--- a/src/fw/services/normal/notifications/alerts_preferences.c
+++ b/src/fw/services/normal/notifications/alerts_preferences.c
@@ -563,6 +563,7 @@ void alerts_preferences_handle_blob_db_event(PebbleBlobDBEvent *event) {
   RELOAD_IF_MATCH(PREF_KEY_NOTIF_DESIGN_STYLE, s_notification_alternative_design);
   RELOAD_IF_MATCH(PREF_KEY_NOTIF_VIBE_DELAY, s_notification_vibe_delay);
   RELOAD_IF_MATCH(PREF_KEY_NOTIF_BACKLIGHT, s_notification_backlight);
+  RELOAD_IF_MATCH(PREF_KEY_DND_MOTION_BACKLIGHT, s_dnd_motion_backlight);
 
 #undef RELOAD_IF_MATCH
 


### PR DESCRIPTION
Add "dndMotionBacklight" to the syncable notification preferences whitelist and handle it in the BlobDB event handler so the setting can be synced from the phone app.

Fixes FIRM-1591