### PR TITLE
fw/drivers/vibe: fix vibration strength having no effect on AW86225

### DIFF
--- a/src/fw/drivers/vibe/vibe_aw86225.c
+++ b/src/fw/drivers/vibe/vibe_aw86225.c
@@ -167,7 +167,7 @@ void vibe_init(void) {
   ret &= prv_write_register(AW862XX_REG_CONTCFG3, AW862XX_CONTCFG3_DRV_WIDTH);
   ret &= prv_write_register(AW862XX_REG_CONTCFG7, AW862XX_CONTCFG7_FULL_SCALE);
   
-  prv_modify_reg(AW862XX_REG_CONTCFG6, AW862XX_CONTCFG6_TRACK_MASK, AW862XX_CONTCFG6_TRACK_EN);
+  prv_write_register(AW862XX_REG_CONTCFG6, AW862XX_CONTCFG6_TRACK_EN | AW862XX_CONTCFG7_FULL_SCALE);
   prv_modify_reg(AW862XX_REG_PLAYCFG3, AW862XX_BIT_PLAYCFG3_BRK_EN_MASK, AW862XX_BIT_PLAYCFG3_BRK_ENABLE);
   prv_modify_reg(AW862XX_REG_PLAYCFG3, AW862XX_BIT_PLAYCFG3_PLAY_MODE_MASK, AW862XX_BIT_PLAYCFG3_PLAY_MODE_CONT);
   prv_modify_reg(AW862XX_REG_SYSCTRL1, AW862XX_SYSCTRL1_VBAT_MODE_MASK, AW862XX_SYSCTRL1_VBAT_MODE_EN);
@@ -187,7 +187,12 @@ void vibe_set_strength(int8_t strength) {
     return;
   }
 
-  uint32_t scale = strength * AW862XX_CONTCFG7_FULL_SCALE / 100UL;
+  // Blend linear and quadratic curves to spread out the perceptual range
+  // while keeping low settings still usable.
+  uint32_t linear = (uint32_t)strength * AW862XX_CONTCFG7_FULL_SCALE / 100UL;
+  uint32_t quadratic = (uint32_t)strength * strength * AW862XX_CONTCFG7_FULL_SCALE / 10000UL;
+  uint32_t scale = (linear + quadratic) / 2;
+  prv_modify_reg(AW862XX_REG_CONTCFG6, ~AW862XX_CONTCFG7_FULL_SCALE, (uint8_t)scale);
   prv_write_register(AW862XX_REG_CONTCFG7, (uint8_t)scale);
 }
 
@@ -203,8 +208,10 @@ void vibe_ctl(bool on) {
       vibe_init();
       vibe_set_strength(s_target_strength);
     }
-    prv_write_register(AW862XX_REG_CONTCFG8, 0xFF);
-    prv_write_register(AW862XX_REG_CONTCFG9, 0xFF);
+    // Scale drive durations with strength so lower settings produce shorter pulses
+    uint8_t duration = 0x80 + (uint8_t)(s_target_strength * (0xFF - 0x80) / 100);
+    prv_write_register(AW862XX_REG_CONTCFG8, duration);
+    prv_write_register(AW862XX_REG_CONTCFG9, duration);
     prv_aw862xx_play_go(true);
   } else {
     prv_aw862xx_play_go(false);


### PR DESCRIPTION
vibe_set_strength() only wrote to CONTCFG7 (phase 2 amplitude), while phase 1 amplitude in CONTCFG6[6:0] was left at the chip's power-on default. Since vibe_ctl() sets both phase durations to max, the motor spent all its time in phase 1 at a fixed amplitude, making the strength setting imperceptible.

Fix by:
- Writing the scaled amplitude to both CONTCFG6[6:0] and CONTCFG7
- Initializing CONTCFG6 with full-scale drv1_lvl during vibe_init()
- Applying a blended linear/quadratic curve for wider perceptual spread
- Scaling drive durations (CONTCFG8/CONTCFG9) with strength

Fixes FIRM-1023