### PR TITLE
fw/apps/system: Add music settings for volume controls and progress bar

### DIFF
--- a/src/fw/apps/system/music.c
+++ b/src/fw/apps/system/music.c
@@ -18,6 +18,7 @@
 #include "services/common/i18n/i18n.h"
 #include "services/normal/music.h"
 #include "services/normal/vibes/vibe_score.h"
+#include "shell/prefs.h"
 #include "shell/system_theme.h"
 #include "process_management/app_manager.h"
 #include "process_state/app_state/app_state.h"
@@ -485,11 +486,15 @@ static void prv_update_ui_state_skipping(MusicAppData *data, bool animated) {
                                      &data->icon_skip_forward, animated);
   action_bar_layer_set_icon_animated(&data->action_bar, BUTTON_BACKWARD,
                                      &data->icon_skip_backward, animated);
+  const bool show_volume_controls = shell_prefs_get_music_show_volume_controls();
   if (music_get_playback_state() == MusicPlayStatePaused) {
     action_bar_layer_set_icon_animated(&data->action_bar, BUTTON_ID_SELECT, &data->icon_play,
                                        animated);
-  } else {
+  } else if (show_volume_controls) {
     action_bar_layer_set_icon_animated(&data->action_bar, BUTTON_ID_SELECT, &data->icon_ellipsis,
+                                       animated);
+  } else {
+    action_bar_layer_set_icon_animated(&data->action_bar, BUTTON_ID_SELECT, &data->icon_pause,
                                        animated);
   }
 }
@@ -537,7 +542,9 @@ static void prv_action_bar_revert(void *context) {
 }
 
 static void reset_action_bar_revert_timer(MusicAppData *data) {
-  app_timer_reschedule(data->action_bar_revert_timer, ACTION_BAR_TIMEOUT_MS);
+  if (data->action_bar_revert_timer) {
+    app_timer_reschedule(data->action_bar_revert_timer, ACTION_BAR_TIMEOUT_MS);
+  }
 }
 
 static void prv_skip_click_handler(ClickRecognizerRef recognizer, void *context) {
@@ -564,6 +571,11 @@ static void prv_volume_click_handler(ClickRecognizerRef recognizer, void *contex
 }
 
 static void prv_ellipsis_click_handler(ClickRecognizerRef recognizer, void *context) {
+  if (!shell_prefs_get_music_show_volume_controls()) {
+    music_command_send(MusicCommandTogglePlayPause);
+    return;
+  }
+
   MusicAppData *data = context;
   data->action_bar_revert_timer = app_timer_register(ACTION_BAR_TIMEOUT_MS, prv_action_bar_revert,
                                                      data);
@@ -609,6 +621,10 @@ static void prv_volume_long_click_end_handler(ClickRecognizerRef recognizer, voi
 }
 
 static void prv_play_pause_long_click_start_handler(ClickRecognizerRef recognizer, void *context) {
+  if (!shell_prefs_get_music_show_volume_controls()) {
+    return;
+  }
+
   prv_toggle_playing();
   prv_set_action_bar_state(context, ActionBarStateLongPress);
   prv_do_haptic_feedback_vibe(context);
@@ -621,17 +637,22 @@ static void prv_play_pause_long_click_end_handler(ClickRecognizerRef recognizer,
 static void prv_skipping_click_config_provider(void *context) {
   window_single_click_subscribe(BUTTON_ID_UP, prv_skip_click_handler);
   window_single_click_subscribe(BUTTON_ID_DOWN, prv_skip_click_handler);
+  const bool show_volume_controls = shell_prefs_get_music_show_volume_controls();
   if (music_get_playback_state() == MusicPlayStatePaused) {
     window_single_click_subscribe(BUTTON_ID_SELECT, prv_play_pause_click_handler);
-  } else {
+  } else if (show_volume_controls) {
     window_single_click_subscribe(BUTTON_ID_SELECT, prv_ellipsis_click_handler);
+  } else {
+    window_single_click_subscribe(BUTTON_ID_SELECT, prv_play_pause_click_handler);
   }
-  window_long_click_subscribe(BUTTON_ID_UP, 0, prv_volume_long_click_start_handler,
-                              prv_volume_long_click_end_handler);
-  window_long_click_subscribe(BUTTON_ID_DOWN, 0, prv_volume_long_click_start_handler,
-                              prv_volume_long_click_end_handler);
-  window_long_click_subscribe(BUTTON_ID_SELECT, 0, prv_play_pause_long_click_start_handler,
-                              prv_play_pause_long_click_end_handler);
+  if (show_volume_controls) {
+    window_long_click_subscribe(BUTTON_ID_UP, 0, prv_volume_long_click_start_handler,
+                                prv_volume_long_click_end_handler);
+    window_long_click_subscribe(BUTTON_ID_DOWN, 0, prv_volume_long_click_start_handler,
+                                prv_volume_long_click_end_handler);
+    window_long_click_subscribe(BUTTON_ID_SELECT, 0, prv_play_pause_long_click_start_handler,
+                                prv_play_pause_long_click_end_handler);
+  }
 }
 
 static void prv_volume_click_config_provider(void *context) {
@@ -643,8 +664,8 @@ static void prv_volume_click_config_provider(void *context) {
 }
 
 static void prv_update_layout(MusicAppData *data) {
-  // Hide track position bar if progress reporting not supported
-  bool hide_layer = !music_is_progress_reporting_supported();
+  const bool show_progress_bar = shell_prefs_get_music_show_progress_bar();
+  bool hide_layer = !show_progress_bar || !music_is_progress_reporting_supported();
   layer_set_hidden(&data->track_pos_bar.layer, hide_layer);
   layer_set_hidden(&data->position_text_layer.layer, hide_layer);
   layer_set_hidden(&data->length_text_layer.layer, hide_layer);
@@ -717,7 +738,9 @@ static void prv_pop_no_music_window(MusicAppData *data) {
 }
 
 static void prv_update_now_playing(MusicAppData *data) {
-  layer_set_hidden((Layer *)&data->track_pos_bar, !music_is_progress_reporting_supported());
+  const bool show_progress_bar = shell_prefs_get_music_show_progress_bar();
+  layer_set_hidden((Layer *)&data->track_pos_bar,
+                   !show_progress_bar || !music_is_progress_reporting_supported());
 
   char artist_buffer[MUSIC_BUFFER_LENGTH];
   char title_buffer[MUSIC_BUFFER_LENGTH];
@@ -761,6 +784,9 @@ static void prv_update_track_progress(MusicAppData *data) {
   if (data->pause_track_pos_updates) {
     return;
   }
+  if (!shell_prefs_get_music_show_progress_bar()) {
+    return;
+  }
   if (!music_is_progress_reporting_supported()) {
     progress_layer_set_progress(&data->track_pos_bar, 0);
   } else {
@@ -789,7 +815,8 @@ static void prv_handle_tick_time(struct tm *time, TimeUnits units_changed) {
 }
 
 static void prv_set_pos_update_timer(MusicAppData* data, MusicPlayState playstate) {
-  if (!music_is_progress_reporting_supported()) {
+  if (!music_is_progress_reporting_supported() || !shell_prefs_get_music_show_progress_bar()) {
+    tick_timer_service_unsubscribe();
     return;
   }
   switch (playstate) {

--- a/src/fw/services/normal/blob_db/settings_blob_db.c
+++ b/src/fw/services/normal/blob_db/settings_blob_db.c
@@ -105,6 +105,10 @@ static const char *s_syncable_settings[] = {
 
   // Worker preferences
   "workerId",
+
+  // Music preferences
+  "musicShowVolumeControls",
+  "musicShowProgressBar",
 };
 
 static const size_t s_num_syncable_settings = ARRAY_LENGTH(s_syncable_settings);

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -235,9 +235,13 @@ static GColor s_theme_highlight_color = GColorVividCerulean;
 
 #define PREF_KEY_MENU_SCROLL_WRAP_AROUND "menuScrollWrapAround"
 #define PREF_KEY_MENU_SCROLL_VIBE_BEHAVIOR "menuScrollVibeBehavior"
+#define PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS "musicShowVolumeControls"
+#define PREF_KEY_MUSIC_SHOW_PROGRESS_BAR "musicShowProgressBar"
 
 static bool s_menu_scroll_wrap_around = false;
 static MenuScrollVibeBehavior s_menu_scroll_vibe_behavior = MenuScrollNoVibe;
+static bool s_music_show_volume_controls = true;
+static bool s_music_show_progress_bar = true;
 
 // ============================================================================================
 // Handlers for each pref that validate the new setting and store the new value in our globals.
@@ -675,6 +679,16 @@ static bool prv_set_s_menu_scroll_vibe_behavior(MenuScrollVibeBehavior *new_beha
     return false;
   }
   s_menu_scroll_vibe_behavior = *new_behavior;
+  return true;
+}
+
+static bool prv_set_s_music_show_volume_controls(bool *enabled) {
+  s_music_show_volume_controls = *enabled;
+  return true;
+}
+
+static bool prv_set_s_music_show_progress_bar(bool *enabled) {
+  s_music_show_progress_bar = *enabled;
   return true;
 }
   
@@ -1732,4 +1746,20 @@ void analytics_external_collect_settings(void) {
   PBL_ANALYTICS_SET_UNSIGNED(settings_health_hrm_activity_tracking_enabled,
                              activity_prefs_hrm_activity_tracking_is_enabled());
 #endif
+}
+
+bool shell_prefs_get_music_show_volume_controls(void) {
+  return s_music_show_volume_controls;
+}
+
+void shell_prefs_set_music_show_volume_controls(bool enable) {
+  prv_pref_set(PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS, &enable, sizeof(enable));
+}
+
+bool shell_prefs_get_music_show_progress_bar(void) {
+  return s_music_show_progress_bar;
+}
+
+void shell_prefs_set_music_show_progress_bar(bool enable) {
+  prv_pref_set(PREF_KEY_MUSIC_SHOW_PROGRESS_BAR, &enable, sizeof(enable));
 }

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -61,4 +61,5 @@
 
   PREFS_MACRO(PREF_KEY_MENU_SCROLL_WRAP_AROUND, s_menu_scroll_wrap_around)
   PREFS_MACRO(PREF_KEY_MENU_SCROLL_VIBE_BEHAVIOR, s_menu_scroll_vibe_behavior)
-  
+  PREFS_MACRO(PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS, s_music_show_volume_controls)
+  PREFS_MACRO(PREF_KEY_MUSIC_SHOW_PROGRESS_BAR, s_music_show_progress_bar)

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -172,3 +172,9 @@ typedef enum MenuScrollVibeBehavior {
 
 MenuScrollVibeBehavior shell_prefs_get_menu_scroll_vibe_behavior(void);
 void shell_prefs_set_menu_scroll_vibe_behavior(MenuScrollVibeBehavior behavior);
+
+bool shell_prefs_get_music_show_volume_controls(void);
+void shell_prefs_set_music_show_volume_controls(bool enable);
+
+bool shell_prefs_get_music_show_progress_bar(void);
+void shell_prefs_set_music_show_progress_bar(bool enable);


### PR DESCRIPTION
Add "Show Volume Controls" and "Show Progress Bar" options with the mobile app watch settings.

When "Show Volume Controls" is hidden:
UP/DOWN buttons perform next/previous track.
The SELECT button long-press is disabled to prevent entering volume mode.

When "Show Progress Bar" is hidden:
The progress bar and time labels are hidden.
The app unsubscribes from the tick timer to save power.

core app PR: https://github.com/coredevices/mobileapp/pull/148

refactor of previous work: https://github.com/coredevices/PebbleOS/pull/525