### PR TITLE
fw/applib/tick_timer_service: fix spurious handler calls on timer skew

### DIFF
--- a/src/fw/applib/tick_timer_service.c
+++ b/src/fw/applib/tick_timer_service.c
@@ -44,7 +44,9 @@ static void do_handle(PebbleEvent *e, void *context) {
   struct tm currtime;
   sys_localtime_r(&e->clock_tick.tick_time, &currtime);
 
-  if (!state->first_tick) {
+  bool is_first = state->first_tick;
+
+  if (!is_first) {
     if (state->last_time.tm_sec != currtime.tm_sec) {
       units_changed |= SECOND_UNIT;
     }
@@ -67,7 +69,13 @@ static void do_handle(PebbleEvent *e, void *context) {
   state->last_time = currtime;
   state->first_tick = false;
 
-  if ((state->tick_units & units_changed) || (units_changed == 0)) {
+  if (is_first) {
+    // Always fire on first tick after subscribe so apps get initial state
+    state->handler(&currtime, units_changed);
+  } else if ((state->tick_units & units_changed) != 0) {
+    // Only fire when a subscribed unit actually changed — avoids spurious
+    // handler calls when the underlying timer double-fires within the same
+    // second (e.g. due to FreeRTOS timer skew or RTC adjustment)
     state->handler(&currtime, units_changed);
   }
 }


### PR DESCRIPTION
## Summary

- Fix spurious tick handler calls caused by FreeRTOS timer double-fires
- The `(units_changed == 0)` condition in `do_handle()` was intended for the first tick after subscribe, but also fires on any subsequent tick where no time component changed (e.g. timer skew, RTC adjustment)
- For `MINUTE_UNIT` subscribers (watchfaces), this causes visible bugs: animations firing multiple times per minute instead of once
- Fix separates the first-tick path from the normal path: first tick always fires, subsequent ticks only fire when a subscribed unit actually changed

Related: FIRM-1377 — the `regular_timer.c` fix in PR #838 addressed missed minute callbacks, but didn't fix spurious extra calls at the `tick_timer_service` layer.

## Test plan

- [x] Verified no handler in the codebase checks `units_changed == 0` (all 24+ callers ignore the parameter)
- [ ] Test MINUTE_UNIT watchface — should animate exactly once per minute, not on timer double-fires
- [ ] Test SECOND_UNIT app (e.g. music timer) — should still fire every second
- [ ] Test first-tick behavior — handler should fire immediately on `tick_timer_service_subscribe()`