### PR TITLE
fw/applib/tick_timer_service: only fire if first tick or units changed

### DIFF
--- a/src/fw/applib/tick_timer_service.c
+++ b/src/fw/applib/tick_timer_service.c
@@ -64,12 +64,13 @@ static void do_handle(PebbleEvent *e, void *context) {
       units_changed |= YEAR_UNIT;
     }
   }
-  state->last_time = currtime;
-  state->first_tick = false;
 
-  if ((state->tick_units & units_changed) || (units_changed == 0)) {
+  if (((state->tick_units & units_changed) != 0) || state->first_tick) {
     state->handler(&currtime, units_changed);
   }
+
+  state->last_time = currtime;
+  state->first_tick = false;
 }
 
 void tick_timer_service_init(void) {


### PR DESCRIPTION
Skip spurious calls if no units change (possible to due RTC vs RTOS timer skew).