### PR TITLE
Add v70 direct analytics heartbeat pipeline

### DIFF
--- a/src/fw/services/common/analytics/analytics.h
+++ b/src/fw/services/common/analytics/analytics.h
@@ -9,11 +9,52 @@
 #include "null/analytics_impl.h"
 #endif
 
+#if defined(ANALYTICS_DIRECT_HEARTBEAT)
+#include "direct/heartbeat_v70.h"
+#endif
+
 static inline void analytics_init(void) {
   analytics_impl_init();
+#if defined(ANALYTICS_DIRECT_HEARTBEAT)
+  v70_heartbeat_init();
+#endif
 }
 
 void analytics_external_update(void);
+
+#if defined(ANALYTICS_DIRECT_HEARTBEAT)
+
+#define PBL_ANALYTICS_SET_SIGNED(key_name, signed_value) do { \
+    PBL_ANALYTICS_IMPL_SET_SIGNED(key_name, signed_value); \
+    v70_shadow_set_signed(V70_METRIC_##key_name, (signed_value)); \
+  } while (0)
+
+#define PBL_ANALYTICS_SET_UNSIGNED(key_name, unsigned_value) do { \
+    PBL_ANALYTICS_IMPL_SET_UNSIGNED(key_name, unsigned_value); \
+    v70_shadow_set_unsigned(V70_METRIC_##key_name, (unsigned_value)); \
+  } while (0)
+
+#define PBL_ANALYTICS_SET_STRING(key_name, value) do { \
+    PBL_ANALYTICS_IMPL_SET_STRING(key_name, value); \
+    v70_shadow_set_string(V70_METRIC_##key_name, (value)); \
+  } while (0)
+
+#define PBL_ANALYTICS_TIMER_START(key_name) do { \
+    PBL_ANALYTICS_IMPL_TIMER_START(key_name); \
+    v70_shadow_timer_start(V70_METRIC_##key_name); \
+  } while (0)
+
+#define PBL_ANALYTICS_TIMER_STOP(key_name) do { \
+    PBL_ANALYTICS_IMPL_TIMER_STOP(key_name); \
+    v70_shadow_timer_stop(V70_METRIC_##key_name); \
+  } while (0)
+
+#define PBL_ANALYTICS_ADD(key_name, amount) do { \
+    PBL_ANALYTICS_IMPL_ADD(key_name, amount); \
+    v70_shadow_add(V70_METRIC_##key_name, (amount)); \
+  } while (0)
+
+#else
 
 #define PBL_ANALYTICS_SET_SIGNED(key_name, signed_value) \
   PBL_ANALYTICS_IMPL_SET_SIGNED(key_name, signed_value)
@@ -28,3 +69,5 @@ void analytics_external_update(void);
 #define PBL_ANALYTICS_TIMER_STOP(key_name) PBL_ANALYTICS_IMPL_TIMER_STOP(key_name)
 
 #define PBL_ANALYTICS_ADD(key_name, amount) PBL_ANALYTICS_IMPL_ADD(key_name, amount)
+
+#endif

--- a/src/fw/services/common/analytics/direct/heartbeat_v70.c
+++ b/src/fw/services/common/analytics/direct/heartbeat_v70.c
@@ -89,6 +89,10 @@ _Static_assert(sizeof(V70BlobHeader) == 3,
 
 // ---------------------------------------------------------------------------
 // Shadow store
+//
+// Two categories of metrics:
+//   "accumulator" — counters (ADD) and timers: reset to zero after each send
+//   "snapshot"    — SET values: persist across sends until next SET call
 // ---------------------------------------------------------------------------
 
 static int64_t  s_shadow[V70_METRIC_COUNT];
@@ -96,21 +100,27 @@ static RtcTicks s_timer_start[V70_METRIC_COUNT];
 static char     s_watchface_name[32];
 static char     s_watchface_uuid[39];
 
+// Track which metrics were set via SET (not ADD/TIMER) so we preserve them
+static bool s_is_snapshot[V70_METRIC_COUNT];
+
 void v70_shadow_set_unsigned(V70MetricId id, uint64_t value) {
   if (id < V70_METRIC_COUNT) {
     s_shadow[id] = (int64_t)value;
+    s_is_snapshot[id] = true;
   }
 }
 
 void v70_shadow_set_signed(V70MetricId id, int64_t value) {
   if (id < V70_METRIC_COUNT) {
     s_shadow[id] = value;
+    s_is_snapshot[id] = true;
   }
 }
 
 void v70_shadow_add(V70MetricId id, int64_t amount) {
   if (id < V70_METRIC_COUNT) {
     s_shadow[id] += amount;
+    // ADD metrics are accumulators — not marked as snapshot
   }
 }
 
@@ -140,14 +150,46 @@ void v70_shadow_set_string(V70MetricId id, const char *value) {
 }
 
 // ---------------------------------------------------------------------------
+// Connectivity refcount — tracks overlapping system sessions
+// ---------------------------------------------------------------------------
+
+static int s_connectivity_refcount;
+
+void v70_connectivity_connected(void) {
+  if (s_connectivity_refcount++ == 0) {
+    v70_shadow_timer_start(V70_METRIC_connectivity_connected_time_ms);
+  }
+}
+
+void v70_connectivity_disconnected(void) {
+  if (s_connectivity_refcount > 0 && --s_connectivity_refcount == 0) {
+    v70_shadow_timer_stop(V70_METRIC_connectivity_connected_time_ms);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // DLS session & timing
 // ---------------------------------------------------------------------------
 
 static DataLoggingSession *s_dls_session;
+static bool s_dls_initialized;
 static RtcTicks s_last_send_ticks;
 static uint8_t s_last_battery_pct;
 
 void v70_heartbeat_init(void) {
+  // Don't create DLS session here — DLS may not be initialized yet at boot.
+  // Defer to first v70_heartbeat_send() call.
+  s_last_send_ticks = rtc_get_ticks();
+  s_last_battery_pct = battery_get_charge_state().charge_percent;
+}
+
+static void prv_ensure_dls_session(void) {
+  if (s_dls_initialized) {
+    return;
+  }
+  if (!dls_initialized()) {
+    return;
+  }
   s_dls_session = dls_create(
       DlsSystemTagAnalyticsDeviceHeartbeat,
       DATA_LOGGING_BYTE_ARRAY,
@@ -156,8 +198,7 @@ void v70_heartbeat_init(void) {
       false,  // don't resume
       NULL    // system UUID
   );
-  s_last_send_ticks = rtc_get_ticks();
-  s_last_battery_pct = battery_get_charge_state().charge_percent;
+  s_dls_initialized = true;
 }
 
 // ---------------------------------------------------------------------------
@@ -193,19 +234,21 @@ static void prv_collect_old_metrics(V70DeviceHeartbeat *hb) {
 #define SHADOW_I16(metric) ((int16_t)s_shadow[V70_METRIC_##metric])
 
 void v70_heartbeat_send(void) {
+  // Lazily create DLS session on first send (fix #1: DLS not ready at boot)
+  prv_ensure_dls_session();
   if (!s_dls_session) {
     return;
   }
 
-  // Stop any running timers to capture their elapsed time
-  // (they'll be restarted by the next PBL_ANALYTICS_TIMER_START call)
+  // Snapshot running timers: capture elapsed time without stopping them
   for (int i = 0; i < V70_METRIC_COUNT; i++) {
     if (s_timer_start[i] != 0) {
-      RtcTicks elapsed = rtc_get_ticks() - s_timer_start[i];
+      RtcTicks now = rtc_get_ticks();
+      RtcTicks elapsed = now - s_timer_start[i];
       uint32_t elapsed_ms = (uint32_t)((elapsed * 1000) / RTC_TICKS_HZ);
       s_shadow[i] += elapsed_ms;
       // Restart the timer for the next period
-      s_timer_start[i] = rtc_get_ticks();
+      s_timer_start[i] = now;
     }
   }
 
@@ -273,7 +316,7 @@ void v70_heartbeat_send(void) {
   hb->app_message_received_count = SHADOW_U32(app_message_received_count);
   hb->utc_offset_s              = SHADOW_I32(utc_offset_s);
 
-  // Strings
+  // Strings (these persist — not cleared after send)
   memcpy(hb->watchface_name, s_watchface_name, sizeof(hb->watchface_name));
   memcpy(hb->watchface_uuid, s_watchface_uuid, sizeof(hb->watchface_uuid));
 
@@ -283,9 +326,13 @@ void v70_heartbeat_send(void) {
   // Send via data logging
   dls_log(s_dls_session, buf, 1);
 
-  // Reset shadow store for next period
-  memset(s_shadow, 0, sizeof(s_shadow));
-  memset(s_watchface_name, 0, sizeof(s_watchface_name));
-  memset(s_watchface_uuid, 0, sizeof(s_watchface_uuid));
+  // Reset only accumulator metrics (ADD and TIMER), preserve snapshot (SET) values
+  // Fix #2: snapshot metrics like utc_offset_s, watchface strings persist
+  for (int i = 0; i < V70_METRIC_COUNT; i++) {
+    if (!s_is_snapshot[i]) {
+      s_shadow[i] = 0;
+    }
+  }
+  // Note: s_watchface_name/uuid are NOT cleared — they persist until next SET_STRING
   // Note: s_timer_start is NOT reset — running timers continue accumulating
 }

--- a/src/fw/services/common/analytics/direct/heartbeat_v70.c
+++ b/src/fw/services/common/analytics/direct/heartbeat_v70.c
@@ -1,0 +1,291 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "heartbeat_v70.h"
+
+#include <string.h>
+
+#include "drivers/rtc.h"
+#include "services/common/battery/battery_state.h"
+#include "services/normal/data_logging/data_logging_service.h"
+#include "services/normal/vibes/vibe_intensity.h"
+#include "shell/prefs.h"
+
+// ---------------------------------------------------------------------------
+// v70 packed struct — must match eng-dash blob-parser.ts exactly
+// ---------------------------------------------------------------------------
+
+#define V70_BLOB_VERSION 70
+#define V70_FORMAT_DEVICE_HEARTBEAT 0x00
+
+typedef struct __attribute__((packed)) {
+  uint8_t  format_type;            // 0x00
+  uint16_t version;                // 70
+} V70BlobHeader;
+
+typedef struct __attribute__((packed)) {
+  uint32_t timestamp;              // unix epoch UTC
+  uint32_t duration_ms;
+  uint8_t  battery_soc_pct;
+  int32_t  battery_soc_pct_drop;
+  uint16_t battery_voltage;
+  int16_t  battery_voltage_delta;
+  uint32_t battery_charge_time_ms;
+  uint32_t battery_plugged_time_ms;
+  uint32_t cpu_running_pct;        // scaled x100
+  uint32_t cpu_sleep0_pct;         // scaled x100
+  uint32_t cpu_sleep1_pct;         // scaled x100
+  uint32_t cpu_sleep2_pct;         // scaled x100
+  uint32_t backlight_on_time_ms;
+  uint8_t  backlight_avg_intensity_pct;
+  uint32_t vibrator_on_time_ms;
+  uint8_t  vibrator_avg_strength_pct;
+  uint32_t hrm_on_time_ms;
+  uint32_t accel_sample_count;
+  uint32_t accel_shake_count;
+  uint32_t accel_double_tap_count;
+  uint32_t accel_peek_count;
+  uint32_t button_pressed_count;
+  uint32_t notification_received_count;
+  uint32_t notification_received_dnd_count;
+  uint32_t phone_call_incoming_count;
+  uint32_t phone_call_time_ms;
+  uint32_t memory_pct_max;
+  uint32_t stack_free_kernel_main_bytes;
+  uint32_t stack_free_kernel_background_bytes;
+  uint32_t stack_free_newtimers_bytes;
+  uint32_t pfs_space_free_kb;
+  uint32_t flash_spi_write_bytes;
+  uint32_t flash_spi_erase_bytes;
+  uint32_t low_power_time_ms;
+  uint32_t stationary_time_ms;
+  uint32_t watchface_time_ms;
+  uint32_t connectivity_connected_time_ms;
+  uint32_t ble_adv_short_intvl_time_ms;
+  uint32_t ble_adv_long_intvl_time_ms;
+  uint32_t ble_conn_itvl_min_time_ms;
+  uint32_t ble_conn_itvl_mid_time_ms;
+  uint32_t ble_conn_itvl_max_time_ms;
+  uint32_t settings_health_tracking_enabled;
+  uint32_t settings_health_hrm_enabled;
+  uint32_t settings_health_hrm_measurement_interval;
+  uint32_t settings_health_hrm_activity_tracking_enabled;
+  uint32_t app_message_sent_count;
+  uint32_t app_message_received_count;
+  int32_t  utc_offset_s;
+  uint8_t  setting_backlight;
+  uint8_t  setting_backlight_intensity_pct;
+  uint8_t  setting_backlight_timeout_sec;
+  uint8_t  setting_shake_to_light;
+  uint8_t  setting_vibration_strength;
+  char     watchface_name[32];
+  char     watchface_uuid[39];
+} V70DeviceHeartbeat;
+
+_Static_assert(sizeof(V70DeviceHeartbeat) == 259,
+               "V70 body size must be exactly 259 bytes");
+_Static_assert(sizeof(V70BlobHeader) == 3,
+               "V70 header size must be exactly 3 bytes");
+
+// ---------------------------------------------------------------------------
+// Shadow store
+// ---------------------------------------------------------------------------
+
+static int64_t  s_shadow[V70_METRIC_COUNT];
+static RtcTicks s_timer_start[V70_METRIC_COUNT];
+static char     s_watchface_name[32];
+static char     s_watchface_uuid[39];
+
+void v70_shadow_set_unsigned(V70MetricId id, uint64_t value) {
+  if (id < V70_METRIC_COUNT) {
+    s_shadow[id] = (int64_t)value;
+  }
+}
+
+void v70_shadow_set_signed(V70MetricId id, int64_t value) {
+  if (id < V70_METRIC_COUNT) {
+    s_shadow[id] = value;
+  }
+}
+
+void v70_shadow_add(V70MetricId id, int64_t amount) {
+  if (id < V70_METRIC_COUNT) {
+    s_shadow[id] += amount;
+  }
+}
+
+void v70_shadow_timer_start(V70MetricId id) {
+  if (id < V70_METRIC_COUNT) {
+    s_timer_start[id] = rtc_get_ticks();
+  }
+}
+
+void v70_shadow_timer_stop(V70MetricId id) {
+  if (id < V70_METRIC_COUNT && s_timer_start[id] != 0) {
+    RtcTicks elapsed = rtc_get_ticks() - s_timer_start[id];
+    uint32_t elapsed_ms = (uint32_t)((elapsed * 1000) / RTC_TICKS_HZ);
+    s_shadow[id] += elapsed_ms;
+    s_timer_start[id] = 0;
+  }
+}
+
+void v70_shadow_set_string(V70MetricId id, const char *value) {
+  if (id == V70_METRIC_watchface_name) {
+    strncpy(s_watchface_name, value ? value : "", sizeof(s_watchface_name) - 1);
+    s_watchface_name[sizeof(s_watchface_name) - 1] = '\0';
+  } else if (id == V70_METRIC_watchface_uuid) {
+    strncpy(s_watchface_uuid, value ? value : "", sizeof(s_watchface_uuid) - 1);
+    s_watchface_uuid[sizeof(s_watchface_uuid) - 1] = '\0';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DLS session & timing
+// ---------------------------------------------------------------------------
+
+static DataLoggingSession *s_dls_session;
+static RtcTicks s_last_send_ticks;
+static uint8_t s_last_battery_pct;
+
+void v70_heartbeat_init(void) {
+  s_dls_session = dls_create(
+      DlsSystemTagAnalyticsDeviceHeartbeat,
+      DATA_LOGGING_BYTE_ARRAY,
+      sizeof(V70BlobHeader) + sizeof(V70DeviceHeartbeat),
+      true,   // buffered
+      false,  // don't resume
+      NULL    // system UUID
+  );
+  s_last_send_ticks = rtc_get_ticks();
+  s_last_battery_pct = battery_get_charge_state().charge_percent;
+}
+
+// ---------------------------------------------------------------------------
+// Collect the 8 "old" metrics from subsystem getters
+// ---------------------------------------------------------------------------
+
+static void prv_collect_old_metrics(V70DeviceHeartbeat *hb) {
+  // Battery SOC
+  BatteryChargeState batt = battery_get_charge_state();
+  hb->battery_soc_pct = batt.charge_percent;
+  hb->battery_soc_pct_drop = (int32_t)s_last_battery_pct - (int32_t)batt.charge_percent;
+  s_last_battery_pct = batt.charge_percent;
+
+  // Backlight settings
+  hb->setting_backlight = (uint8_t)backlight_get_timeout_ms() > 0 ?
+      (backlight_is_motion_enabled() ? 2 : 1) : 0;
+  hb->setting_backlight_intensity_pct = backlight_get_intensity_percent();
+  hb->setting_backlight_timeout_sec = (uint8_t)(backlight_get_timeout_ms() / 1000);
+  hb->setting_shake_to_light = backlight_is_motion_enabled() ? 1 : 0;
+
+  // Vibration strength
+  hb->setting_vibration_strength = (uint8_t)vibe_intensity_get();
+}
+
+// ---------------------------------------------------------------------------
+// Assemble and send the v70 heartbeat
+// ---------------------------------------------------------------------------
+
+// Convenience: read a shadow value as uint32, clamped
+#define SHADOW_U32(metric) ((uint32_t)s_shadow[V70_METRIC_##metric])
+#define SHADOW_I32(metric) ((int32_t)s_shadow[V70_METRIC_##metric])
+#define SHADOW_U16(metric) ((uint16_t)s_shadow[V70_METRIC_##metric])
+#define SHADOW_I16(metric) ((int16_t)s_shadow[V70_METRIC_##metric])
+
+void v70_heartbeat_send(void) {
+  if (!s_dls_session) {
+    return;
+  }
+
+  // Stop any running timers to capture their elapsed time
+  // (they'll be restarted by the next PBL_ANALYTICS_TIMER_START call)
+  for (int i = 0; i < V70_METRIC_COUNT; i++) {
+    if (s_timer_start[i] != 0) {
+      RtcTicks elapsed = rtc_get_ticks() - s_timer_start[i];
+      uint32_t elapsed_ms = (uint32_t)((elapsed * 1000) / RTC_TICKS_HZ);
+      s_shadow[i] += elapsed_ms;
+      // Restart the timer for the next period
+      s_timer_start[i] = rtc_get_ticks();
+    }
+  }
+
+  // Build the blob
+  uint8_t buf[sizeof(V70BlobHeader) + sizeof(V70DeviceHeartbeat)];
+  V70BlobHeader *header = (V70BlobHeader *)buf;
+  V70DeviceHeartbeat *hb = (V70DeviceHeartbeat *)(buf + sizeof(V70BlobHeader));
+
+  memset(buf, 0, sizeof(buf));
+
+  // Header
+  header->format_type = V70_FORMAT_DEVICE_HEARTBEAT;
+  header->version = V70_BLOB_VERSION;
+
+  // Timestamp and duration
+  hb->timestamp = (uint32_t)rtc_get_time();
+  RtcTicks now = rtc_get_ticks();
+  hb->duration_ms = (uint32_t)(((now - s_last_send_ticks) * 1000) / RTC_TICKS_HZ);
+  s_last_send_ticks = now;
+
+  // Shadowed Memfault metrics
+  hb->battery_voltage           = SHADOW_U16(battery_voltage);
+  hb->battery_voltage_delta     = SHADOW_I16(battery_voltage_delta);
+  hb->battery_charge_time_ms    = SHADOW_U32(battery_charge_time_ms);
+  hb->battery_plugged_time_ms   = SHADOW_U32(battery_plugged_time_ms);
+  hb->cpu_running_pct           = SHADOW_U32(cpu_running_pct);
+  hb->cpu_sleep0_pct            = SHADOW_U32(cpu_sleep0_pct);
+  hb->cpu_sleep1_pct            = SHADOW_U32(cpu_sleep1_pct);
+  hb->cpu_sleep2_pct            = SHADOW_U32(cpu_sleep2_pct);
+  hb->backlight_on_time_ms      = SHADOW_U32(backlight_on_time_ms);
+  hb->backlight_avg_intensity_pct = (uint8_t)s_shadow[V70_METRIC_backlight_avg_intensity_pct];
+  hb->vibrator_on_time_ms       = SHADOW_U32(vibrator_on_time_ms);
+  hb->vibrator_avg_strength_pct = (uint8_t)s_shadow[V70_METRIC_vibrator_avg_strength_pct];
+  hb->hrm_on_time_ms            = SHADOW_U32(hrm_on_time_ms);
+  hb->accel_sample_count        = SHADOW_U32(accel_sample_count);
+  hb->accel_shake_count         = SHADOW_U32(accel_shake_count);
+  hb->accel_double_tap_count    = SHADOW_U32(accel_double_tap_count);
+  hb->accel_peek_count          = SHADOW_U32(accel_peek_count);
+  hb->button_pressed_count      = SHADOW_U32(button_pressed_count);
+  hb->notification_received_count     = SHADOW_U32(notification_received_count);
+  hb->notification_received_dnd_count = SHADOW_U32(notification_received_dnd_count);
+  hb->phone_call_incoming_count = SHADOW_U32(phone_call_incoming_count);
+  hb->phone_call_time_ms        = SHADOW_U32(phone_call_time_ms);
+  hb->memory_pct_max            = SHADOW_U32(memory_pct_max);
+  hb->stack_free_kernel_main_bytes       = SHADOW_U32(stack_free_kernel_main_bytes);
+  hb->stack_free_kernel_background_bytes = SHADOW_U32(stack_free_kernel_background_bytes);
+  hb->stack_free_newtimers_bytes         = SHADOW_U32(stack_free_newtimers_bytes);
+  hb->pfs_space_free_kb         = SHADOW_U32(pfs_space_free_kb);
+  hb->flash_spi_write_bytes     = SHADOW_U32(flash_spi_write_bytes);
+  hb->flash_spi_erase_bytes     = SHADOW_U32(flash_spi_erase_bytes);
+  hb->low_power_time_ms         = SHADOW_U32(low_power_time_ms);
+  hb->stationary_time_ms        = SHADOW_U32(stationary_time_ms);
+  hb->watchface_time_ms         = SHADOW_U32(watchface_time_ms);
+  hb->connectivity_connected_time_ms = SHADOW_U32(connectivity_connected_time_ms);
+  hb->ble_adv_short_intvl_time_ms = SHADOW_U32(ble_adv_short_intvl_time_ms);
+  hb->ble_adv_long_intvl_time_ms  = SHADOW_U32(ble_adv_long_intvl_time_ms);
+  hb->ble_conn_itvl_min_time_ms   = SHADOW_U32(ble_conn_itvl_min_time_ms);
+  hb->ble_conn_itvl_mid_time_ms   = SHADOW_U32(ble_conn_itvl_mid_time_ms);
+  hb->ble_conn_itvl_max_time_ms   = SHADOW_U32(ble_conn_itvl_max_time_ms);
+  hb->settings_health_tracking_enabled            = SHADOW_U32(settings_health_tracking_enabled);
+  hb->settings_health_hrm_enabled                 = SHADOW_U32(settings_health_hrm_enabled);
+  hb->settings_health_hrm_measurement_interval    = SHADOW_U32(settings_health_hrm_measurement_interval);
+  hb->settings_health_hrm_activity_tracking_enabled = SHADOW_U32(settings_health_hrm_activity_tracking_enabled);
+  hb->app_message_sent_count    = SHADOW_U32(app_message_sent_count);
+  hb->app_message_received_count = SHADOW_U32(app_message_received_count);
+  hb->utc_offset_s              = SHADOW_I32(utc_offset_s);
+
+  // Strings
+  memcpy(hb->watchface_name, s_watchface_name, sizeof(hb->watchface_name));
+  memcpy(hb->watchface_uuid, s_watchface_uuid, sizeof(hb->watchface_uuid));
+
+  // The 8 "old" metrics read directly from subsystems
+  prv_collect_old_metrics(hb);
+
+  // Send via data logging
+  dls_log(s_dls_session, buf, 1);
+
+  // Reset shadow store for next period
+  memset(s_shadow, 0, sizeof(s_shadow));
+  memset(s_watchface_name, 0, sizeof(s_watchface_name));
+  memset(s_watchface_uuid, 0, sizeof(s_watchface_uuid));
+  // Note: s_timer_start is NOT reset — running timers continue accumulating
+}

--- a/src/fw/services/common/analytics/direct/heartbeat_v70.h
+++ b/src/fw/services/common/analytics/direct/heartbeat_v70.h
@@ -70,6 +70,10 @@ void v70_shadow_timer_start(V70MetricId id);
 void v70_shadow_timer_stop(V70MetricId id);
 void v70_shadow_set_string(V70MetricId id, const char *value);
 
+// Connectivity refcount — handles overlapping system sessions
+void v70_connectivity_connected(void);
+void v70_connectivity_disconnected(void);
+
 // Lifecycle
 void v70_heartbeat_init(void);
 void v70_heartbeat_send(void);

--- a/src/fw/services/common/analytics/direct/heartbeat_v70.h
+++ b/src/fw/services/common/analytics/direct/heartbeat_v70.h
@@ -1,0 +1,75 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include <stdint.h>
+
+// v70 metric IDs for the shadow store.
+// Names match the Memfault key names so PBL_ANALYTICS_* macros can use
+// token pasting: V70_METRIC_##key_name
+typedef enum {
+  // Memfault-shadowed metrics (accumulated via PBL_ANALYTICS_* macros)
+  V70_METRIC_battery_voltage = 0,
+  V70_METRIC_battery_voltage_delta,
+  V70_METRIC_battery_charge_time_ms,
+  V70_METRIC_battery_plugged_time_ms,
+  V70_METRIC_cpu_running_pct,
+  V70_METRIC_cpu_sleep0_pct,
+  V70_METRIC_cpu_sleep1_pct,
+  V70_METRIC_cpu_sleep2_pct,
+  V70_METRIC_backlight_on_time_ms,
+  V70_METRIC_backlight_avg_intensity_pct,
+  V70_METRIC_vibrator_on_time_ms,
+  V70_METRIC_vibrator_avg_strength_pct,
+  V70_METRIC_hrm_on_time_ms,
+  V70_METRIC_accel_sample_count,
+  V70_METRIC_accel_shake_count,
+  V70_METRIC_accel_double_tap_count,
+  V70_METRIC_accel_peek_count,
+  V70_METRIC_button_pressed_count,
+  V70_METRIC_notification_received_count,
+  V70_METRIC_notification_received_dnd_count,
+  V70_METRIC_phone_call_incoming_count,
+  V70_METRIC_phone_call_time_ms,
+  V70_METRIC_memory_pct_max,
+  V70_METRIC_stack_free_kernel_main_bytes,
+  V70_METRIC_stack_free_kernel_background_bytes,
+  V70_METRIC_stack_free_newtimers_bytes,
+  V70_METRIC_pfs_space_free_kb,
+  V70_METRIC_flash_spi_write_bytes,
+  V70_METRIC_flash_spi_erase_bytes,
+  V70_METRIC_low_power_time_ms,
+  V70_METRIC_stationary_time_ms,
+  V70_METRIC_watchface_time_ms,
+  V70_METRIC_connectivity_connected_time_ms,
+  V70_METRIC_ble_adv_short_intvl_time_ms,
+  V70_METRIC_ble_adv_long_intvl_time_ms,
+  V70_METRIC_ble_conn_itvl_min_time_ms,
+  V70_METRIC_ble_conn_itvl_mid_time_ms,
+  V70_METRIC_ble_conn_itvl_max_time_ms,
+  V70_METRIC_settings_health_tracking_enabled,
+  V70_METRIC_settings_health_hrm_enabled,
+  V70_METRIC_settings_health_hrm_measurement_interval,
+  V70_METRIC_settings_health_hrm_activity_tracking_enabled,
+  V70_METRIC_app_message_sent_count,
+  V70_METRIC_app_message_received_count,
+  V70_METRIC_utc_offset_s,
+  V70_METRIC_COUNT, // = 45
+
+  // String metrics — handled specially, not in the int64 array
+  V70_METRIC_watchface_name = V70_METRIC_COUNT,
+  V70_METRIC_watchface_uuid,
+} V70MetricId;
+
+// Shadow store API
+void v70_shadow_set_unsigned(V70MetricId id, uint64_t value);
+void v70_shadow_set_signed(V70MetricId id, int64_t value);
+void v70_shadow_add(V70MetricId id, int64_t amount);
+void v70_shadow_timer_start(V70MetricId id);
+void v70_shadow_timer_stop(V70MetricId id);
+void v70_shadow_set_string(V70MetricId id, const char *value);
+
+// Lifecycle
+void v70_heartbeat_init(void);
+void v70_heartbeat_send(void);

--- a/src/fw/services/common/analytics/wscript
+++ b/src/fw/services/common/analytics/wscript
@@ -2,7 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 def configure(conf):
-    pass
+    # Enable v70 direct heartbeat when Memfault is enabled
+    memfault_val = getattr(conf.env, 'memfault', 0)
+    conf.env.analytics_direct_heartbeat = bool(int(memfault_val)) if memfault_val else False
+    if conf.env.analytics_direct_heartbeat:
+        conf.msg('v70 direct heartbeat', 'enabled')
 
 
 def build(bld):
@@ -18,6 +22,7 @@ def build(bld):
         if not bld.env.memfault:
             bld.fatal('analytics_direct_heartbeat requires memfault to be enabled')
         sources.append('direct/heartbeat_v70.c')
+        use.append('fw_includes')
         bld.env.DEFINES.append('ANALYTICS_DIRECT_HEARTBEAT')
 
     bld.stlib(

--- a/src/fw/services/common/analytics/wscript
+++ b/src/fw/services/common/analytics/wscript
@@ -15,6 +15,8 @@ def build(bld):
         bld.env.DEFINES.append('ANALYTICS_IMPL_MEMFAULT')
 
     if getattr(bld.env, 'analytics_direct_heartbeat', False):
+        if not bld.env.memfault:
+            bld.fatal('analytics_direct_heartbeat requires memfault to be enabled')
         sources.append('direct/heartbeat_v70.c')
         bld.env.DEFINES.append('ANALYTICS_DIRECT_HEARTBEAT')
 

--- a/src/fw/services/common/analytics/wscript
+++ b/src/fw/services/common/analytics/wscript
@@ -14,6 +14,10 @@ def build(bld):
         sources.append('memfault/analytics_impl.c')
         bld.env.DEFINES.append('ANALYTICS_IMPL_MEMFAULT')
 
+    if getattr(bld.env, 'analytics_direct_heartbeat', False):
+        sources.append('direct/heartbeat_v70.c')
+        bld.env.DEFINES.append('ANALYTICS_DIRECT_HEARTBEAT')
+
     bld.stlib(
         source=sources,
         target='services_common_analytics',

--- a/src/fw/services/common/comm_session/session_analytics.c
+++ b/src/fw/services/common/comm_session/session_analytics.c
@@ -34,7 +34,7 @@ void comm_session_analytics_open_session(CommSession *session) {
     memfault_chunk_collect_after_delay();
 #endif
 #if defined(ANALYTICS_DIRECT_HEARTBEAT)
-    v70_shadow_timer_start(V70_METRIC_connectivity_connected_time_ms);
+    v70_connectivity_connected();
 #endif
   }
   session->open_ticks = rtc_get_ticks();
@@ -48,7 +48,7 @@ void comm_session_analytics_close_session(CommSession *session, CommSessionClose
       kMemfaultMetricsConnectivityState_ConnectionLost);
 #endif
 #if defined(ANALYTICS_DIRECT_HEARTBEAT)
-    v70_shadow_timer_stop(V70_METRIC_connectivity_connected_time_ms);
+    v70_connectivity_disconnected();
 #endif
   }
 

--- a/src/fw/services/common/comm_session/session_analytics.c
+++ b/src/fw/services/common/comm_session/session_analytics.c
@@ -11,6 +11,9 @@
 #endif
 #include "services/common/comm_session/session_internal.h"
 #include "services/common/analytics/analytics.h"
+#if defined(ANALYTICS_DIRECT_HEARTBEAT)
+#include "services/common/analytics/direct/heartbeat_v70.h"
+#endif
 #include "services/common/ping.h"
 #include "util/time/time.h"
 
@@ -30,6 +33,9 @@ void comm_session_analytics_open_session(CommSession *session) {
     // to complete the datalogging Report handshake.
     memfault_chunk_collect_after_delay();
 #endif
+#if defined(ANALYTICS_DIRECT_HEARTBEAT)
+    v70_shadow_timer_start(V70_METRIC_connectivity_connected_time_ms);
+#endif
   }
   session->open_ticks = rtc_get_ticks();
 }
@@ -40,6 +46,9 @@ void comm_session_analytics_close_session(CommSession *session, CommSessionClose
 #if MEMFAULT
     memfault_metrics_connectivity_connected_state_change(
       kMemfaultMetricsConnectivityState_ConnectionLost);
+#endif
+#if defined(ANALYTICS_DIRECT_HEARTBEAT)
+    v70_shadow_timer_stop(V70_METRIC_connectivity_connected_time_ms);
 #endif
   }
 

--- a/third_party/memfault/port/src/memfault_platform_metrics.c
+++ b/third_party/memfault/port/src/memfault_platform_metrics.c
@@ -7,6 +7,9 @@
 #include "services/common/battery/battery_state.h"
 #include "util/heap.h"
 #include "services/common/analytics/analytics.h"
+#if defined(ANALYTICS_DIRECT_HEARTBEAT)
+#include "services/common/analytics/direct/heartbeat_v70.h"
+#endif
 #include "shell/normal/watchface.h"
 #include "process_management/app_install_manager.h"
 
@@ -23,4 +26,7 @@ int memfault_platform_get_stateofcharge(sMfltPlatformBatterySoc *soc) {
 
 void memfault_metrics_heartbeat_collect_data(void) {
   analytics_external_update();
+#if defined(ANALYTICS_DIRECT_HEARTBEAT)
+  v70_heartbeat_send();
+#endif
 }


### PR DESCRIPTION
## Summary
- Adds a direct-to-server analytics pipeline that runs in parallel with Memfault
- Assembles a 262-byte v70 device heartbeat blob (55 metrics: 47 Memfault-shadowed + 8 restored old metrics) and sends via DLS tag 78
- `PBL_ANALYTICS_*` macros are wrapped to dual-write into a shadow store — zero changes to existing call sites
- Gated behind `ANALYTICS_DIRECT_HEARTBEAT` build flag, auto-enabled when Memfault is on
- Companion eng-dash endpoint already merged: receives these blobs and writes to BigQuery `heartbeats_v2`

## Files
- **NEW** `direct/heartbeat_v70.h` — packed struct, V70MetricId enum, shadow store API
- **NEW** `direct/heartbeat_v70.c` — shadow store, v70 assembly, DLS logging, connectivity refcount
- **EDIT** `analytics.h` — macro wrapping for dual-write (Memfault + shadow)
- **EDIT** `memfault_platform_metrics.c` — fires `v70_heartbeat_send()` after `analytics_external_update()`
- **EDIT** `session_analytics.c` — BLE connectivity refcount for overlapping sessions
- **EDIT** `wscript` — build flag and configure logic

## Test plan
- [x] Compiles cleanly for `asterix` board with `--memfault=1` (1819/1819 tasks)
- [x] `_Static_assert(sizeof(V70DeviceHeartbeat) == 259)` validates struct matches eng-dash parser
- [x] Codex review: 4 issues found and fixed (DLS boot ordering, snapshot metric persistence, overlapping BLE sessions, build flag guard)
- [ ] Flash to Asterix dev board and verify DLS tag 78 data arrives on phone
- [ ] End-to-end: phone POSTs blob to eng-dash `/api/analytics/ingest`, verify BigQuery row

🤖 Generated with [Claude Code](https://claude.com/claude-code)