### PR TITLE
fw/drivers/mic/sf32lb52: fully unwind mic_start failure path [FIRM-1646]

### DIFF
--- a/src/fw/drivers/mic/sf32lb52/pdm.c
+++ b/src/fw/drivers/mic/sf32lb52/pdm.c
@@ -322,6 +322,15 @@ bool mic_start(const MicDevice *this, MicDataHandlerCB data_handler, void *conte
 
   // Start PDM capture
   if (!prv_start_pdm_capture(this)) {
+    HAL_NVIC_DisableIRQ(this->pdm_dma_irq);
+    HAL_NVIC_DisableIRQ(this->pdm_irq);
+    HAL_PDM_DMAStop(hpdm);
+    HAL_PDM_DeInit(hpdm);
+    HAL_RCC_DisableModule(RCC_MOD_PDM1);
+
+    kernel_free(hpdm->pRxBuffPtr);
+    hpdm->pRxBuffPtr = NULL;
+
     stop_mode_enable(InhibitorMic);
     state->is_running = false;  // Reset on failure
 #if PDM_POWER_NPM1300_LDO2


### PR DESCRIPTION
If prv_start_pdm_capture() fails, mic_start() previously left the PDM peripheral initialized, its clock gated on, both NVIC lines unmasked, and the DMA RX buffer leaked. A subsequent mic_stop() is a no-op since is_running was already cleared, so the stale state persisted until reboot and every later mic_start() hit the same failure. On the voice path this surfaced as "Dictation is not available" sticking around after a single mic_start() failure.

Mirror mic_stop()'s teardown on the failure branch: mask both IRQs, stop DMA, deinit the PDM, disable the RCC module, and free pRxBuffPtr before running the existing cleanup. Next mic_start() then starts from a clean peripheral state and the voice service's retry can succeed.