### PR TITLE
fw/applib: redraw watchface immediately on 24h format change

### DIFF
--- a/src/fw/applib/tick_timer_service.c
+++ b/src/fw/applib/tick_timer_service.c
@@ -7,6 +7,7 @@
 #include "event_service_client.h"
 #include "process_management/app_manager.h"
 
+#include "pbl/services/common/clock.h"
 #include "pbl/services/common/event_service.h"
 #include "pbl/services/common/tick_timer.h"
 #include "kernel/events.h"
@@ -65,7 +66,11 @@ static void do_handle(PebbleEvent *e, void *context) {
     }
   }
 
-  if (((state->tick_units & units_changed) != 0) || state->first_tick) {
+  bool is_24h = clock_is_24h_style();
+  bool format_changed = (is_24h != state->last_is_24h);
+  state->last_is_24h = is_24h;
+
+  if (((state->tick_units & units_changed) != 0) || state->first_tick || format_changed) {
     state->handler(&currtime, units_changed);
   }
 

--- a/src/fw/applib/tick_timer_service_private.h
+++ b/src/fw/applib/tick_timer_service_private.h
@@ -11,6 +11,7 @@ typedef struct __attribute__((packed)) TickTimerServiceState {
   TimeUnits tick_units;
   struct tm last_time;
   bool first_tick;
+  bool last_is_24h;
 
   EventServiceInfo tick_service_info;
 } TickTimerServiceState;

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -261,7 +261,17 @@ static bool s_music_show_progress_bar = true;
 // programmatically via the PREFS_MACRO macro defined below:
 //   static bool prv_set_<static_var_name>(<static_var_type> new_value)
 static bool prv_set_s_clock_24h(bool *new_value) {
-  s_clock_24h = *new_value;
+  if (s_clock_24h != *new_value) {
+    s_clock_24h = *new_value;
+    // Fire a tick event so watchfaces re-render with the new time format
+    PebbleEvent e = {
+      .type = PEBBLE_TICK_EVENT,
+      .clock_tick.tick_time = rtc_get_time(),
+    };
+    event_put(&e);
+  } else {
+    s_clock_24h = *new_value;
+  }
   return true;
 }
 


### PR DESCRIPTION
## Summary
- When the 24h clock format setting changes, watchfaces now re-render immediately instead of waiting up to 60s for the next minute tick
- `prv_set_s_clock_24h` fires a `PEBBLE_TICK_EVENT` when the value actually changes
- `tick_timer_service` tracks the 24h format state and forces the tick handler to fire when it detects a change, regardless of what time units changed

## Root cause
`prv_set_s_clock_24h()` in `prefs.c` only updated the static variable without notifying anyone. Watchfaces like TicToc (BW) call `clock_is_24h_style()` in their MINUTE_UNIT tick handler, so they wouldn't pick up the change until the next minute boundary — up to 60 seconds later.

## Test plan
- [x] Change 24h format via phone app Settings — watchface should update within 1 second
- [x] Change via on-watch Settings > Time > 24h toggle — same immediate update
- [x] Verify watchfaces subscribing to MINUTE_UNIT still get the update
- [x] Verify no extra redraws when setting doesn't actually change

Fixes https://linear.app/core-dev/issue/FIRM-1624

🤖 Generated with [Claude Code](https://claude.com/claude-code)