### PR TITLE
fw/services/common/firmware_update: request HP mode during updates

### DIFF
--- a/src/fw/services/common/firmware_update.c
+++ b/src/fw/services/common/firmware_update.c
@@ -12,6 +12,9 @@
 #include "process_management/app_manager.h"
 #include "services/common/battery/battery_monitor.h"
 #include "services/common/system_task.h"
+#ifndef RECOVERY_FW
+#include "services/normal/powermode_service.h"
+#endif
 #include "services/runlevel.h"
 #include "system/bootbits.h"
 #include "system/logging.h"
@@ -183,6 +186,9 @@ static FirmwareUpdateStatus prv_firmware_update_start(PebbleSystemMessageEvent *
       .restart = true,
     });
     put_bytes_expect_init(FIRMWARE_TIMEOUT_MS);
+#ifndef RECOVERY_FW
+    powermode_service_request_hp();
+#endif
     result = FirmwareUpdateRunning;
   }
 
@@ -211,6 +217,9 @@ static void prv_firmware_update_finish(bool failed) {
   }
 
   s_update_status = failed ? FirmwareUpdateFailed : FirmwareUpdateStopped;
+#ifndef RECOVERY_FW
+  powermode_service_release_hp();
+#endif
 
   xSemaphoreGive(s_firmware_update_semaphore);
 }


### PR DESCRIPTION
When a firmware update is triggered from a watchface, the system may be in low power mode. Request high-performance CPU mode for the duration of the update to ensure it completes as fast as possible.

Fixes FIRM-1652