### PR TITLE
fw/debug: fix reboot reason log format string

### DIFF
--- a/src/fw/debug/debug_reboot_reason.c
+++ b/src/fw/debug/debug_reboot_reason.c
@@ -132,8 +132,8 @@ void debug_reboot_reason_print(McuRebootReason mcu_reboot_reason) {
   }
   // Generic reason string
   if (reason_string) {
-    pbl_log(LOG_LEVEL_WARNING, __FILE__, __LINE__, restarted_safely_string,
-            rebooted_due_to, reason.extra.value);
+    pbl_log(LOG_LEVEL_WARNING, __FILE__, __LINE__, reason_string,
+            restarted_safely_string, rebooted_due_to, reason.extra.value);
   }
 
   if (is_unread_coredump_available()) {


### PR DESCRIPTION
## Summary

- Fix the generic reboot reason `pbl_log` call that was using `restarted_safely_string` (e.g. `"Safely"`) as the format string instead of `reason_string`, causing only `"Safely"` to appear in logs with no actual reboot reason.

## Test plan

- [ ] Boot a device and verify the reboot reason log line shows the full reason (e.g. `Safely rebooted due to LowBattery`) instead of just `Safely`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)