### PR TITLE
fw/services/common/light: recalc brightness when toggling dynamic int…

### DIFF
--- a/include/pbl/services/common/light.h
+++ b/include/pbl/services/common/light.h
@@ -52,6 +52,9 @@ void light_toggle_enabled(void);
 //! @internal
 void light_toggle_ambient_sensor_enabled(void);
 
+//! @internal
+void light_toggle_dynamic_intensity_enabled(void);
+
 //! Switches for temporary disabling backlight (ie: low power mode)
 void light_allow(bool allowed);
 

--- a/src/fw/apps/system/settings/display.c
+++ b/src/fw/apps/system/settings/display.c
@@ -249,7 +249,7 @@ static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
       break;
 #if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
     case SettingsDisplayDynamicIntensity:
-      backlight_set_dynamic_intensity_enabled(!backlight_is_dynamic_intensity_enabled());
+      light_toggle_dynamic_intensity_enabled();
       break;
 #endif
     case SettingsDisplayBacklightIntensity:

--- a/src/fw/services/common/light/service.c
+++ b/src/fw/services/common/light/service.c
@@ -486,6 +486,17 @@ void light_toggle_ambient_sensor_enabled(void) {
   mutex_unlock(s_mutex);
 }
 
+void light_toggle_dynamic_intensity_enabled(void) {
+#if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
+  mutex_lock(s_mutex);
+  backlight_set_dynamic_intensity_enabled(!backlight_is_dynamic_intensity_enabled());
+  if (prv_light_allowed()) {
+    prv_change_state(LIGHT_STATE_ON_TIMED);
+  }
+  mutex_unlock(s_mutex);
+#endif
+}
+
 void light_allow(bool allowed) {
   if (s_backlight_allowed && !allowed) {
     prv_change_state(LIGHT_STATE_OFF);


### PR DESCRIPTION
…ensity

Toggling Dynamic Backlight from the settings menu only wrote the preference, so the actual brightness kept whatever value had been computed on the previous activation until the next backlight event. Users saw the apparent intensity change even though the max intensity setting was unchanged.

Add light_toggle_dynamic_intensity_enabled() following the existing light_toggle_ambient_sensor_enabled() pattern: it flips the pref and kicks the state machine into ON_TIMED so prv_backlight_get_intensity() is re-evaluated immediately.

Fixes FIRM-1590