### PR TITLE
fw/applib/voice: bump dictation confirmation font size

### DIFF
--- a/src/fw/applib/applib_malloc.json
+++ b/src/fw/applib/applib_malloc.json
@@ -242,7 +242,7 @@
         "_comment": "Generously padded because it's not feature complete yet (only 3.x)"
     }, {
         "name": "ExpandableDialog",
-        "size_3x_padding": 44,
+        "size_3x_padding": 36,
         "size_3x": 1280,
         "dependencies": ["Dialog", "TextLayer", "ScrollLayer", "ActionBarLayer", "Layer"],
         "_comment": "Generously padded because it's not feature complete yet (only 3.x)"

--- a/src/fw/applib/ui/dialogs/expandable_dialog.c
+++ b/src/fw/applib/ui/dialogs/expandable_dialog.c
@@ -188,7 +188,7 @@ static void prv_expandable_dialog_load(Window *window) {
   w = frame.size.w - right_margin_px - left_margin_px - action_bar_offset
       - right_aligned_box_reduction;
   h = INT16_MAX;  // height is clamped to content size
-  GFont font = fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD);
+  GFont font = expandable_dialog->body_font;
 
   TextLayer *text_layer = &dialog->text_layer;
   text_layer_init_with_parameters(text_layer, &GRect(x, y, w, h), dialog->buffer, font,
@@ -326,6 +326,7 @@ void expandable_dialog_init(ExpandableDialog *expandable_dialog, const char *dia
   PBL_ASSERTN(expandable_dialog);
   *expandable_dialog = (ExpandableDialog) {
     .header_font = fonts_get_system_font(FONT_KEY_GOTHIC_28_BOLD),
+    .body_font = fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD),
   };
 
   dialog_init(&expandable_dialog->dialog, dialog_name);
@@ -398,6 +399,10 @@ void expandable_dialog_set_header(ExpandableDialog *expandable_dialog, const cha
 
 void expandable_dialog_set_header_font(ExpandableDialog *expandable_dialog, GFont header_font) {
   expandable_dialog->header_font = header_font;
+}
+
+void expandable_dialog_set_body_font(ExpandableDialog *expandable_dialog, GFont body_font) {
+  expandable_dialog->body_font = body_font;
 }
 
 void expandable_dialog_set_select_action(ExpandableDialog *expandable_dialog,

--- a/src/fw/applib/ui/dialogs/expandable_dialog.h
+++ b/src/fw/applib/ui/dialogs/expandable_dialog.h
@@ -33,6 +33,7 @@ typedef struct ExpandableDialog {
   GBitmap *down_icon;
 
   GFont header_font;
+  GFont body_font;
   char header[DIALOG_MAX_HEADER_LEN + 1];
 
   TextLayer header_layer;
@@ -107,6 +108,11 @@ void expandable_dialog_set_header(ExpandableDialog *expandable_dialog, const cha
 //! @param expandable_dialog Pointer to the \ref ExpandableDialog on which to set the header
 //! @param header_font The font to use for the header text
 void expandable_dialog_set_header_font(ExpandableDialog *expandable_dialog, GFont header_font);
+
+//! Sets the body text font
+//! @param expandable_dialog Pointer to the \ref ExpandableDialog on which to set the body font
+//! @param body_font The font to use for the body text
+void expandable_dialog_set_body_font(ExpandableDialog *expandable_dialog, GFont body_font);
 
 //! Sets the icon and ClickHandler of the SELECT button on the action bar.
 //! @param expandable_dialog Pointer to the \ref ExpandableDialog for which to set

--- a/src/fw/applib/voice/transcription_dialog.c
+++ b/src/fw/applib/voice/transcription_dialog.c
@@ -14,6 +14,7 @@
 #include "applib/ui/scroll_layer.h"
 #include "kernel/ui/kernel_ui.h"
 #include "resource/resource_ids.auto.h"
+#include "shell/system_theme.h"
 #include "system/passert.h"
 
 #include <stdlib.h>
@@ -249,6 +250,8 @@ void transcription_dialog_init(TranscriptionDialog *transcription_dialog) {
   *transcription_dialog = (TranscriptionDialog){};
 
   expandable_dialog_init((ExpandableDialog *)transcription_dialog, "Transcription Dialog");
+  expandable_dialog_set_body_font((ExpandableDialog *)transcription_dialog,
+                                  system_theme_get_font(TextStyleFont_Body));
   expandable_dialog_set_select_action((ExpandableDialog *)transcription_dialog,
       RESOURCE_ID_ACTION_BAR_ICON_CHECK, prv_transcription_dialog_select_handler);
 


### PR DESCRIPTION
Use the system theme's body font for the transcription dialog so the text scales with the user's PreferredContentSize, matching the font used by notification body text. Previously the body text was hardcoded to GOTHIC_24_BOLD via expandable_dialog, which was too small on larger displays.

Adds a body_font field and setter to ExpandableDialog so the transcription dialog can override it without affecting other expandable dialogs.

Fixes FIRM-1622