### PR TITLE
fw/services/common/accel_manager: add debug toggle for shake INFO logs

### DIFF
--- a/src/fw/apps/system/settings/system.c
+++ b/src/fw/apps/system/settings/system.c
@@ -69,6 +69,7 @@ enum {
 #if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
   DebuggingItemDynamicBacklightMinThreshold,
 #endif
+  DebuggingItemAccelShakeLogInfo,
   DebuggingItem_Count,
 };
 
@@ -588,6 +589,7 @@ static const char* s_debugging_titles[DebuggingItem_Count] = {
 #if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
   [DebuggingItemDynamicBacklightMinThreshold] = i18n_noop("Dyn BL Min Threshold"),
 #endif
+  [DebuggingItemAccelShakeLogInfo] = i18n_noop("Shake Log Info"),
 };
 
 static void prv_debugging_draw_row_callback(GContext* ctx, const Layer *cell_layer,
@@ -629,6 +631,10 @@ static void prv_debugging_draw_row_callback(GContext* ctx, const Layer *cell_lay
     subtitle_text = data->dyn_bl_min_threshold_buffer;
   }
 #endif
+  else if (cell_index->row == DebuggingItemAccelShakeLogInfo) {
+    subtitle_text = shell_prefs_get_accel_shake_log_info_enabled() ?
+                        i18n_get("Enabled", data) : i18n_get("Disabled", data);
+  }
   menu_cell_basic_draw(ctx, cell_layer, title, subtitle_text, NULL);
 }
 
@@ -673,6 +679,10 @@ static void prv_debugging_select_callback(MenuLayer *menu_layer,
       prv_dyn_bl_min_threshold_menu_push(data);
       break;
 #endif
+    case DebuggingItemAccelShakeLogInfo:
+      shell_prefs_set_accel_shake_log_info_enabled(
+          !shell_prefs_get_accel_shake_log_info_enabled());
+      break;
     default:
       WTF;
   }

--- a/src/fw/services/common/accel_manager/service.c
+++ b/src/fw/services/common/accel_manager/service.c
@@ -722,6 +722,17 @@ void accel_cb_shake_detected(IMUCoordinateAxis axis, int32_t direction) {
     return;
   }
 
+#if !defined(RECOVERY_FW)
+  extern bool shell_prefs_get_accel_shake_log_info_enabled(void);
+  if (shell_prefs_get_accel_shake_log_info_enabled()) {
+    PBL_LOG_INFO("Shake detected; axis=%d, direction=%" PRId32, axis, direction);
+  } else {
+    PBL_LOG_DBG("Shake detected; axis=%d, direction=%" PRId32, axis, direction);
+  }
+#else
+  PBL_LOG_DBG("Shake detected; axis=%d, direction=%" PRId32, axis, direction);
+#endif
+
   PebbleEvent e = {
     .type = PEBBLE_ACCEL_SHAKE_EVENT,
     .accel_tap = {

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -218,11 +218,13 @@ static uint16_t s_timeline_peek_before_time_m =
 
 #define PREF_KEY_POWER_MODE "powerMode"
 #define PREF_KEY_COREDUMP_ON_REQUEST "coredumpOnRequest"
+#define PREF_KEY_ACCEL_SHAKE_LOG_INFO "accelShakeLogInfo"
 #if CAPABILITY_HAS_APP_SCALING
 #define PREF_KEY_LEGACY_APP_RENDER_MODE "legacyAppRenderMode"
 #endif
 static uint8_t s_power_mode = PowerMode_HighPerformance;
 static bool s_coredump_on_request_enabled = false;
+static bool s_accel_shake_log_info_enabled = false;
 #if CAPABILITY_HAS_APP_SCALING
 static uint8_t s_legacy_app_render_mode = 1; // Default to scaled mode
 #endif
@@ -614,6 +616,11 @@ static bool prv_set_s_power_mode(uint8_t *mode) {
 
 static bool prv_set_s_coredump_on_request_enabled(bool *enabled) {
   s_coredump_on_request_enabled = *enabled;
+  return true;
+}
+
+static bool prv_set_s_accel_shake_log_info_enabled(bool *enabled) {
+  s_accel_shake_log_info_enabled = *enabled;
   return true;
 }
 
@@ -1683,6 +1690,14 @@ bool shell_prefs_can_coredump_on_request(void) {
 
 void shell_prefs_set_coredump_on_request(bool enabled) {
   prv_pref_set(PREF_KEY_COREDUMP_ON_REQUEST, &enabled, sizeof(enabled));
+}
+
+bool shell_prefs_get_accel_shake_log_info_enabled(void) {
+  return s_accel_shake_log_info_enabled;
+}
+
+void shell_prefs_set_accel_shake_log_info_enabled(bool enabled) {
+  prv_pref_set(PREF_KEY_ACCEL_SHAKE_LOG_INFO, &enabled, sizeof(enabled));
 }
 
 #if CAPABILITY_HAS_APP_SCALING

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -51,6 +51,7 @@
 #endif
   PREFS_MACRO(PREF_KEY_POWER_MODE, s_power_mode)
   PREFS_MACRO(PREF_KEY_COREDUMP_ON_REQUEST, s_coredump_on_request_enabled)
+  PREFS_MACRO(PREF_KEY_ACCEL_SHAKE_LOG_INFO, s_accel_shake_log_info_enabled)
 #if CAPABILITY_HAS_APP_SCALING
   PREFS_MACRO(PREF_KEY_LEGACY_APP_RENDER_MODE, s_legacy_app_render_mode)
 #endif

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -139,6 +139,10 @@ void shell_prefs_set_power_mode(PowerMode mode);
 bool shell_prefs_can_coredump_on_request(void);
 void shell_prefs_set_coredump_on_request(bool enabled);
 
+// When enabled, accel shake detection logs are emitted at INFO level instead of DEBUG.
+bool shell_prefs_get_accel_shake_log_info_enabled(void);
+void shell_prefs_set_accel_shake_log_info_enabled(bool enabled);
+
 #if CAPABILITY_HAS_APP_SCALING
 // Legacy app rendering mode - whether to use bezel or scaling for legacy apps
 typedef enum LegacyAppRenderMode {

--- a/tests/fw/services/test_accel_manager.c
+++ b/tests/fw/services/test_accel_manager.c
@@ -46,6 +46,9 @@ int32_t sys_vibe_get_vibe_strength(void) {
 }
 void accel_set_shake_sensitivity_high(bool sensitivity_high) {}
 void accel_set_shake_sensitivity_percent(uint8_t percent) {}
+bool shell_prefs_get_accel_shake_log_info_enabled(void) {
+  return false;
+}
 QueueHandle_t pebble_task_get_to_queue(PebbleTask task) {
   return NULL;
 }


### PR DESCRIPTION
Add a "Shake Log Info" entry under Settings → System → Debugging that, when enabled, promotes accel shake detection logs from DEBUG to INFO so they are visible without a debug-level log filter. Defaults to disabled.

Fixes FIRM-1626