### PR TITLE
nix: Fix development environment for nix-darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
               # hashes obtained from location ${url}.sha256asc
               sha256 =
                 {
-                  aarch64-darwin = "2d9e717dd4f7751d18936ae1365d25916534105ebcb7583039eff1092b824505";
+                  aarch64-darwin = "c7c78ffab9bebfce91d99d3c24da6bf4b81c01e16cf551eb2ff9f25b9e0a3818";
                   aarch64-linux = "87330bab085dd8749d4ed0ad633674b9dc48b237b61069e3b481abd364d0a684";
                   x86_64-linux = "62a63b981fe391a9cbad7ef51b17e49aeaa3e7b0d029b36ca1e9c3b2a9b78823";
                 }

--- a/tools/tool_check.py
+++ b/tools/tool_check.py
@@ -1,8 +1,10 @@
 # SPDX-FileCopyrightText: 2024 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import re
 import sh
+import shutil
 import subprocess
 import sys
 from packaging import version
@@ -29,19 +31,24 @@ def tool_check():
         check_requirement(req, pip_installed_dict)
 
     if sys.platform.startswith("darwin"):
-        Logs.pprint("CYAN", "Checking %s" % REQUIREMENTS_BREW)
+        if not shutil.which("brew") and os.environ.get("IN_NIX_SHELL"):
+            Logs.pprint("CYAN", "Skipping %s (in nix shell)" % REQUIREMENTS_BREW)
+        elif not shutil.which("brew"):
+            Logs.pprint("RED", "brew not found! Install Homebrew or use nix develop.")
+        else:
+            Logs.pprint("CYAN", "Checking %s" % REQUIREMENTS_BREW)
 
-        with open(REQUIREMENTS_BREW) as file:
-            brew_req_text = file.read()
-            brew_req_list = text_to_req_list(brew_req_text)
+            with open(REQUIREMENTS_BREW) as file:
+                brew_req_text = file.read()
+                brew_req_list = text_to_req_list(brew_req_text)
 
-        brew_installed_text = subprocess.check_output(["brew", "list"])
-        brew_installed_dict = installed_list_to_dict(
-            text_to_req_list(brew_installed_text.decode("utf8"))
-        )
+            brew_installed_text = subprocess.check_output(["brew", "list"])
+            brew_installed_dict = installed_list_to_dict(
+                text_to_req_list(brew_installed_text.decode("utf8"))
+            )
 
-        for req in brew_req_list:
-            check_requirement(req, brew_installed_dict)
+            for req in brew_req_list:
+                check_requirement(req, brew_installed_dict)
 
 
 def installed_list_to_dict(list):


### PR DESCRIPTION
I switched my system completely to nix-darwin, thus I do not have brew anymore
also the nix dev shell had a stale hash for the ARM toolchain on Apple Silicon

- Update `aarch64-darwin` toolchain sha256 hash in `flake.nix`
- Skip `requirements-brew.txt` check when `brew` is not available on macOS, printing a message instead of crashing