### PR TITLE
fw/comm/ble/ppogatt: fix infinite disconnect/reconnect loop

### DIFF
--- a/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
+++ b/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
@@ -1393,17 +1393,25 @@ unlock:
 // -------------------------------------------------------------------------------------------------
 
 void ppogatt_destroy(void) {
+  bool self_initiated_disconnect = false;
   bt_lock();
   {
     PPoGATTClient *client = s_ppogatt_head;
     while (client) {
       PPoGATTClient *next = (PPoGATTClient *) client->node.next;
+      self_initiated_disconnect = self_initiated_disconnect || client->disconnect_requested;
       prv_delete_client(client, true /* is_disconnected */, DeleteReason_DestroyCalled);
       client = next;
     }
   }
   bt_unlock();
-  ppogatt_reset_disconnect_counter();
+
+  // Only reset the disconnect counter if this was an external disconnect (e.g. RF interference,
+  // phone out of range). If we initiated the disconnect ourselves due to max resets, keep the
+  // counter so the stall protection can kick in after repeated failures.
+  if (!self_initiated_disconnect) {
+    ppogatt_reset_disconnect_counter();
+  }
 }
 
 // -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
ppogatt_destroy() was unconditionally resetting s_disconnect_counter on every BLE disconnect. This meant the stall protection (which should kick in after PPOGATT_DISCONNECT_COUNT_MAX consecutive failed resets) never triggered, causing an infinite disconnect/reconnect loop when the phone doesn't respond to ResetRequest.

Only reset the counter when the disconnect was external (e.g. RF interference, phone out of range). When we initiated the disconnect ourselves due to max resets (disconnect_requested), preserve the counter so the stall state can be reached after repeated failures.

This partially reverts 5b55ae808 ("fw/comm/ppogatt: reset disconnect counter on destroy"), which fixed the opposite problem (FIRM-1419: premature stalling after legitimate disconnects). The new approach handles both cases by checking disconnect_requested to distinguish self-initiated from external disconnects.

Fixes FIRM-1665