### PR TITLE
Make Normal/PRF a configuration stage choice

### DIFF
--- a/.github/workflows/build-prf.yml
+++ b/.github/workflows/build-prf.yml
@@ -84,13 +84,13 @@ jobs:
             OPTS="--mfg --nohash"
           fi
 
-          ./waf configure --board ${{ matrix.board }} $OPTS
+          ./waf configure --board ${{ matrix.board }} --variant=prf $OPTS
 
       - name: Build
-        run: ./waf build_prf
+        run: ./waf build
 
       - name: Bundle
-        run: ./waf bundle_prf
+        run: ./waf bundle
 
       - name: Store
         uses: actions/upload-artifact@v4
@@ -99,12 +99,12 @@ jobs:
           path: |
             build/**/*.elf
             build/**/*.pbz
-            build/prf/src/fw/tintin_fw_loghash_dict.json
+            build/src/fw/tintin_fw_loghash_dict.json
 
       - name: Get Build ID
         id: build_id
         run: |
-          echo "BUILD_ID=$(arm-none-eabi-readelf -n build/prf/src/fw/tintin_fw.elf | sed -n -e 's/^.*Build ID: //p')" >> "$GITHUB_OUTPUT"
+          echo "BUILD_ID=$(arm-none-eabi-readelf -n build/src/fw/tintin_fw.elf | sed -n -e 's/^.*Build ID: //p')" >> "$GITHUB_OUTPUT"
 
       - name: Upload log hash dictionary
         uses: Noelware/s3-action@2.3.1
@@ -115,7 +115,7 @@ jobs:
           endpoint: ${{ vars.LOG_HASH_BUCKET_ENDPOINT }}
           bucket: ${{ vars.LOG_HASH_BUCKET_NAME }}
           files: |
-            build/prf/src/fw/tintin_fw_loghash_dict.json
+            build/src/fw/tintin_fw_loghash_dict.json
           path-format: ${{ steps.build_id.outputs.BUILD_ID }}-${{ github.sha }}-prf.json
 
   build-prf-status:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,27 +44,27 @@ jobs:
           pip install -r requirements.txt
 
       - name: Configure
-        run: ./waf configure --board ${{ matrix.board }} --release
+        run: ./waf configure --board ${{ matrix.board }} --variant=prf --release
 
       - name: Build PRF
-        run: ./waf build_prf
+        run: ./waf build
 
       - name: Bundle PRF
-        run: ./waf bundle_prf
+        run: ./waf bundle
 
       - name: Copy PRF artifacts
         run: |
           mkdir -p artifacts
-          cp build/prf/src/fw/tintin_fw.hex artifacts/prf_${{ matrix.board }}_${{github.ref_name}}.hex
-          cp build/prf/src/fw/tintin_fw.bin artifacts/prf_${{ matrix.board }}_${{github.ref_name}}.bin
-          cp build/prf/src/fw/tintin_fw.elf artifacts/prf_${{ matrix.board }}_${{github.ref_name}}.elf
-          cp build/prf/*.pbz artifacts
-          cp build/prf/src/fw/tintin_fw_loghash_dict.json artifacts/prf_${{ matrix.board }}_${{github.ref_name}}_loghash_dict.json
+          cp build/src/fw/tintin_fw.hex artifacts/prf_${{ matrix.board }}_${{github.ref_name}}.hex
+          cp build/src/fw/tintin_fw.bin artifacts/prf_${{ matrix.board }}_${{github.ref_name}}.bin
+          cp build/src/fw/tintin_fw.elf artifacts/prf_${{ matrix.board }}_${{github.ref_name}}.elf
+          cp build/*.pbz artifacts
+          cp build/src/fw/tintin_fw_loghash_dict.json artifacts/prf_${{ matrix.board }}_${{github.ref_name}}_loghash_dict.json
 
       - name: Get PRF Build ID
         id: prf_build_id
         run: |
-          echo "BUILD_ID=$(arm-none-eabi-readelf -n build/prf/src/fw/tintin_fw.elf | sed -n -e 's/^.*Build ID: //p')" >> "$GITHUB_OUTPUT"
+          echo "BUILD_ID=$(arm-none-eabi-readelf -n build/src/fw/tintin_fw.elf | sed -n -e 's/^.*Build ID: //p')" >> "$GITHUB_OUTPUT"
 
       - name: Upload PRF log hash dictionary
         uses: Noelware/s3-action@2.3.1
@@ -74,21 +74,21 @@ jobs:
           endpoint: ${{ vars.LOG_HASH_BUCKET_ENDPOINT }}
           bucket: ${{ vars.LOG_HASH_BUCKET_NAME }}
           files: |
-            build/prf/src/fw/tintin_fw_loghash_dict.json
+            build/src/fw/tintin_fw_loghash_dict.json
           path-format: ${{ steps.prf_build_id.outputs.BUILD_ID }}-${{ github.sha }}-prf.json
 
       - name: Configure PRF MFG
-        run: ./waf configure --board ${{ matrix.board }} --mfg --nohash --release
+        run: ./waf configure --board ${{ matrix.board }} --variant=prf --mfg --nohash --release
 
       - name: Build MFG PRF
-        run: ./waf build_prf
+        run: ./waf build
 
       - name: Copy MFG PRF artifacts
         run: |
           mkdir -p artifacts
-          cp build/prf/src/fw/tintin_fw.hex artifacts/prf_mfg_${{ matrix.board }}_${{github.ref_name}}.hex
-          cp build/prf/src/fw/tintin_fw.bin artifacts/prf_mfg_${{ matrix.board }}_${{github.ref_name}}.bin
-          cp build/prf/src/fw/tintin_fw.elf artifacts/prf_mfg_${{ matrix.board }}_${{github.ref_name}}.elf
+          cp build/src/fw/tintin_fw.hex artifacts/prf_mfg_${{ matrix.board }}_${{github.ref_name}}.hex
+          cp build/src/fw/tintin_fw.bin artifacts/prf_mfg_${{ matrix.board }}_${{github.ref_name}}.bin
+          cp build/src/fw/tintin_fw.elf artifacts/prf_mfg_${{ matrix.board }}_${{github.ref_name}}.elf
 
       - name: Store
         uses: actions/upload-artifact@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,9 +28,9 @@ PebbleOS is the operating system running on Pebble smartwatches.
   - `--release` enables release mode
   - `--mfg` enables manufacturing mode
   - `--qemu` enables QEMU mode
+  - `--variant=normal|prf` selects build variant (default: normal)
 
-- Build main firmware: `./waf build`
-- Build recovery firmware (PRF): `./waf build_prf`
+- Build firmware: `./waf build`
 - Run tests: `./waf test`
 
 ## Git rules

--- a/docs/development/prf.md
+++ b/docs/development/prf.md
@@ -5,10 +5,16 @@ It allows connecting from a phone to, for example, flash a new firmware image ev
 
 ## Building
 
-Once a project is configured, PRF image can be built by running:
+Configure the project with the `prf` variant:
 
 ```shell
-./waf build_prf
+./waf configure --board <board> --variant prf
+```
+
+Then build as usual:
+
+```shell
+./waf build
 ```
 
 ## Flashing
@@ -16,7 +22,7 @@ Once a project is configured, PRF image can be built by running:
 The PRF image can be flashed directly into the application area by running:
 
 ```shell
-./waf flash_prf
+./waf flash
 ```
 
 This is useful when developing PRF features because the watch will boot directly to PRF.
@@ -36,5 +42,5 @@ booting, or holding {kbd}`BACK` for 7-10s while in the main application.
 You can interact with PRF console by running:
 
 ```shell
-./waf console_prf
+./waf console
 ```

--- a/resources/wscript
+++ b/resources/wscript
@@ -18,7 +18,7 @@ def _set_prf_required_media_options(bld, resources_dict):
         In case the build variant is PRF, it will also set PRF-required
         options like '"builtin": true'.
     """
-    if bld.variant != 'prf':
+    if bld.env.VARIANT != 'prf':
         return
 
     for media_item_dict in resources_dict["media"]:
@@ -46,7 +46,7 @@ def _get_resources_dict(bld):
     common_platform_path = 'common/' + bld.get_platform_name() + '/resource_map.json'
 
     # handle prf or normal
-    is_recovery = (bld.variant == 'prf')
+    is_recovery = (bld.env.VARIANT == 'prf')
     specific_path = 'prf/base/resource_map.json' if is_recovery else 'normal/base/resource_map.json'
     specific_node = bld.path.find_node(specific_path)
     specific_dict = _get_map_dict(bld, specific_node)
@@ -130,7 +130,7 @@ def build(bld):
         resource_dependencies=resource_dependencies,
         resource_ball=resource_ball)
 
-    if bld.variant != 'prf':
+    if bld.env.VARIANT != 'prf':
         pbpack = fw_bld_node.make_node("system_resources.pbpack")
         bld(features='generate_pbpack',
             resource_ball=resource_ball,
@@ -160,7 +160,7 @@ def build(bld):
         font_key_table=fw_bld_node.make_node('src/fw/font_resource_table.auto.h'),
         resource_definition_files=resource_definition_sources)
 
-    if bld.variant == '':
+    if bld.env.VARIANT != 'prf':
         # Build timeline files
         bld(features='generate_timeline',
             name='generate_timeline',

--- a/src/fw/applib/wscript
+++ b/src/fw/applib/wscript
@@ -49,7 +49,7 @@ def build(bld):
     bld.recurse('vendor/tinflate')
     bld.recurse('vendor/uPNG')
 
-    if bld.variant == 'prf':
+    if bld.env.VARIANT == 'prf':
         excludes += ['ui/dialogs/bt_conn_dialog.c',
                      'ui/dialogs/expandable_dialog.c',
                      'ui/option_menu_window.c',

--- a/src/fw/drivers/hrm/wscript_build
+++ b/src/fw/drivers/hrm/wscript_build
@@ -6,7 +6,7 @@ use = ['fw_includes']
 
 if bld.env.CONFIG_HRM_GH3X2X:
     sources.append('gh3x2x.c')
-    if bld.variant != 'prf' or bld.env.IS_MFG:
+    if bld.env.VARIANT != 'prf' or bld.env.IS_MFG:
         bld.env.DEFINES.append('HRM_USE_GH3X2X')
         use.append('gh3x2x')
 elif bld.env.CONFIG_HRM_STUB:

--- a/src/fw/prj.conf
+++ b/src/fw/prj.conf
@@ -1,0 +1,2 @@
+# PebbleOS application-level Kconfig overrides
+# Values here are applied on top of the board defconfig.

--- a/src/fw/services/common/analytics/wscript_build
+++ b/src/fw/services/common/analytics/wscript_build
@@ -4,7 +4,7 @@
 use = ['fw_includes']
 sources = ['analytics.c']
 
-if bld.variant != 'prf':
+if bld.env.VARIANT != 'prf':
     sources.append('native.c')
     bld.env.DEFINES.append('ANALYTICS_NATIVE')
 

--- a/src/fw/services/common/bluetooth/wscript_build
+++ b/src/fw/services/common/bluetooth/wscript_build
@@ -15,7 +15,7 @@ sources = [
     'pp_ble_control.c',
 ]
 
-if bld.variant != 'prf':
+if bld.env.VARIANT != 'prf':
     sources.append('bluetooth_persistent_storage_normal.c')
     if bld.env.CONFIG_HRM:
         sources.append('ble_hrm.c')

--- a/src/fw/services/common/comm_session/wscript_build
+++ b/src/fw/services/common/comm_session/wscript_build
@@ -12,7 +12,7 @@ def generate_endpoints_table(task):
         definition.update(json.load(f_in))
 
     endpoints.extend(definition['prf_and_normal_fw'])
-    if bld.variant != 'prf':
+    if bld.env.VARIANT != 'prf':
         endpoints.extend(definition['normal_fw_only'])
     endpoints.sort()
 

--- a/src/fw/services/wscript_build
+++ b/src/fw/services/wscript_build
@@ -4,7 +4,7 @@
 bld.env.SERVICES = []
 bld.env.SERVICES_TEXT = []
 bld.recurse('common')
-if bld.variant == 'prf':
+if bld.env.VARIANT == 'prf':
     bld.recurse('prf')
 else:
     bld.recurse('normal')

--- a/src/fw/shell/wscript
+++ b/src/fw/shell/wscript
@@ -191,7 +191,7 @@ def generate_apps_table(task):
 
 
 def build(bld):
-    if bld.variant == 'prf':
+    if bld.env.VARIANT == 'prf':
         shell_name = 'prf'
     else:
         shell_name = bld.env.NORMAL_SHELL

--- a/src/fw/wscript
+++ b/src/fw/wscript
@@ -56,11 +56,6 @@ def get_tintin_fw_node(ctx, subdir=None):
 
 
 @conf
-def get_tintin_fw_node_prf(ctx):
-    return ctx.get_tintin_fw_node('prf')
-
-
-@conf
 def get_tintin_boot_node(ctx):
     return ctx.path.get_bld().make_node('src/boot/tintin_boot.bin')
 
@@ -123,7 +118,7 @@ def _generate_memory_layout(bld):
         flash_size = 1024 * 1024
         # Bootloader
         offset_size = 16 * 1024
-        if bld.is_silk() and bld.variant == 'prf':
+        if bld.is_silk() and bld.env.VARIANT == 'prf':
             # silk PRF is limited to 512k to save on SPI flash space
             fw_max_size = flash_size // 2
         else:
@@ -141,7 +136,7 @@ def _generate_memory_layout(bld):
         slot_size = 3072 * 1024
         resources_size = 2048 * 1024
         prf_size = 576 * 1024
-        if bld.variant == 'prf' and not (bld.env.IS_MFG or bld.env.PRF_AS_FIRMWARE):
+        if bld.env.VARIANT == 'prf' and not (bld.env.IS_MFG or bld.env.PRF_AS_FIRMWARE):
             offset_size = ptable_size + bootloader_size + 2 * slot_size + 2 * resources_size
             fw_max_size = prf_size
         else:
@@ -155,7 +150,7 @@ def _generate_memory_layout(bld):
         # Bootloader
         offset_size = 32 * 1024
         flash_size = 1024 * 1024
-        if bld.is_asterix() and bld.variant == 'prf' and not bld.env.IS_MFG:
+        if bld.is_asterix() and bld.env.VARIANT == 'prf' and not bld.env.IS_MFG:
             fw_max_size = flash_size // 2
         else:
             fw_max_size = flash_size
@@ -812,7 +807,7 @@ def build(bld):
     if bld.is_silk():
         bld.env.append_value('DEFINES', ['QSPI_DMA_DISABLE=1'])
 
-    if bld.variant == 'prf':
+    if bld.env.VARIANT == 'prf':
         _build_recovery(bld)
     else:
         _build_normal(bld)

--- a/third_party/memfault/wscript
+++ b/third_party/memfault/wscript
@@ -40,7 +40,7 @@ def build(bld):
     if not bld.env.memfault:
         return
 
-    if bld.variant == "prf":
+    if bld.env.VARIANT == "prf":
         bld.env.DEFINES = [d for d in bld.env.DEFINES if not d.startswith('MEMFAULT')]
         bld.env.append_value('DEFINES', 'MEMFAULT=0')
         bld.env.memfault = 0

--- a/waftools/kconfig.py
+++ b/waftools/kconfig.py
@@ -62,6 +62,10 @@ def configure(conf):
     kconf.warn_assign_undef = True
     kconf.load_config(defconfig)
 
+    prj_conf = os.path.join(srcdir, "src", "fw", "prj.conf")
+    if os.path.exists(prj_conf):
+        kconf.load_config(prj_conf, replace=False)
+
     # Check for assigned values overridden by unsatisfied dependencies
     # (same pattern as Zephyr's check_assigned_sym_values)
     for sym in kconf.unique_defined_syms:
@@ -107,7 +111,10 @@ def configure(conf):
         conf.env[key] = val
     conf.env.append_unique("CFLAGS", ["-include", autoconf_path])
     conf.env.append_unique("cfg_files", [config_path])
-    conf.msg("Kconfig", f"{len(kconfig)} symbols loaded from {board}")
+    msg = f"{len(kconfig)} symbols loaded from {board}"
+    if os.path.exists(prj_conf):
+        msg += " + prj.conf"
+    conf.msg("Kconfig", msg)
 
 
 class menuconfig(BuildContext):

--- a/waftools/kconfig.py
+++ b/waftools/kconfig.py
@@ -66,6 +66,11 @@ def configure(conf):
     if os.path.exists(prj_conf):
         kconf.load_config(prj_conf, replace=False)
 
+    variant = conf.options.variant
+    variant_conf = os.path.join(srcdir, "src", "fw", f"prj_{variant}.conf")
+    if os.path.exists(variant_conf):
+        kconf.load_config(variant_conf, replace=False)
+
     # Check for assigned values overridden by unsatisfied dependencies
     # (same pattern as Zephyr's check_assigned_sym_values)
     for sym in kconf.unique_defined_syms:
@@ -114,6 +119,8 @@ def configure(conf):
     msg = f"{len(kconfig)} symbols loaded from {board}"
     if os.path.exists(prj_conf):
         msg += " + prj.conf"
+    if os.path.exists(variant_conf):
+        msg += f" + prj_{variant}.conf"
     conf.msg("Kconfig", msg)
 
 

--- a/wscript
+++ b/wscript
@@ -188,6 +188,9 @@ def options(opt):
                    help='Enables malloc instrumentation')
     opt.add_option('--infinite_backlight', action='store_true',
                    help='Makes the backlight never time-out.')
+    opt.add_option('--variant', action='store', default='normal',
+                   choices=['normal', 'prf'],
+                   help='Build variant: normal (default) or prf (recovery firmware)')
     opt.add_option('--mfg', action='store_true', help='Enable specific MFG-only options in the PRF build')
     opt.add_option('--no-pulse-everywhere',
                    action='store_true',
@@ -450,6 +453,11 @@ def configure(conf):
     else:
         conf.fatal('No micro family specified for {}!'.format(conf.options.board))
 
+    conf.env.VARIANT = conf.options.variant
+    if conf.env.VARIANT == 'prf':
+        conf.env.append_value('DEFINES', ['RECOVERY_FW'])
+        conf.env.JS_ENGINE = 'none'
+
     if conf.options.mfg:
         # Note that for the most part PRF and MFG firmwares are the same, so for MFG PRF builds
         # both MANUFACTURING_FW and RECOVERY_FW will be defined.
@@ -505,10 +513,6 @@ def configure(conf):
     Logs.pprint('CYAN', 'Configuring arm_firmware environment')
     conf.setenv('', base_env)
     conf.load('pebble_arm_gcc', tooldir='waftools')
-
-    conf.setenv('arm_prf_mode', env=conf.env)
-    conf.env.append_value('DEFINES', ['RECOVERY_FW'])
-    conf.env.JS_ENGINE = 'none' #Disable JS engine for PRF builds to save space, as PRF doesn't support JS anyway
 
     Logs.pprint('CYAN', 'Configuring unit test environment')
     conf.setenv('local', unit_test_env)
@@ -670,14 +674,11 @@ def build(bld):
         bld.recurse('tools')
         return
 
-    if bld.variant == 'prf':
-        bld.set_env(bld.all_envs['arm_prf_mode'])
-
-    if bld.variant in ('', 'applib', 'prf'):
+    if bld.variant in ('', 'applib'):
         # Dependency for SDK
         bld.recurse('third_party/moddable')
 
-    if bld.variant == '':
+    if bld.variant == '' and bld.env.VARIANT != 'prf':
         # sdk generation
         bld.recurse('sdk')
 
@@ -694,7 +695,7 @@ def build(bld):
         return
 
     # Do not enable stationary mode in PRF or release firmware
-    if (bld.variant != 'prf' and not bld.env.QEMU and bld.env.NORMAL_SHELL != 'sdk'):
+    if (bld.env.VARIANT != 'prf' and not bld.env.QEMU and bld.env.NORMAL_SHELL != 'sdk'):
         bld.env.append_value('DEFINES', 'STATIONARY_MODE')
 
     if bld.variant == 'test':
@@ -706,7 +707,7 @@ def build(bld):
         bld.recurse('tools')
         return
 
-    if bld.variant == '':
+    if bld.variant == '' and bld.env.VARIANT != 'prf':
         bld.recurse('stored_apps')
 
     bld.recurse('third_party')
@@ -727,12 +728,6 @@ def build(bld):
         bld.add_post_fun(size_resources)
         if 'PBL_LOGS_HASHED' in bld.env.DEFINES:
             bld.add_post_fun(merge_loghash_dicts)
-
-
-class build_prf(BuildContext):
-    """executes the recovery firmware build"""
-    cmd = 'build_prf'
-    variant = 'prf'
 
 
 class build_applib(BuildContext):
@@ -786,7 +781,7 @@ class SizeResources(BuildContext):
 def size_resources(ctx):
     """prints size information of resources"""
 
-    if ctx.variant == 'prf':
+    if ctx.env.VARIANT == 'prf':
         return
 
     pbpack_path = ctx.path.get_bld().find_node('system_resources.pbpack')
@@ -818,12 +813,6 @@ def size_resources(ctx):
 def size(ctx):
     from waflib import Options
     Options.commands = ['size_fw', 'size_resources'] + Options.commands
-
-
-class size_prf(BuildContext):
-    """checks the size of PRF"""
-    cmd = 'size_prf'
-    variant = 'prf'
 
 
 class test(BuildContext):
@@ -931,48 +920,11 @@ def bundle(ctx):
 
     if ctx.env.QEMU:
         bundle_qemu(ctx)
+    elif ctx.env.VARIANT == 'prf':
+        _make_bundle(ctx, ctx.get_tintin_fw_node().path_from(ctx.path), fw_type='recovery')
     else:
         _make_bundle(ctx, ctx.get_tintin_fw_node().path_from(ctx.path),
                      resource_path=ctx.get_pbpack_node().path_from(ctx.path))
-
-
-class bundle_prf(BuildContext):
-    """bundles a recovery firmware"""
-    cmd = 'bundle_prf'
-    variant = 'prf'
-
-    def execute_build(ctx):
-        _make_bundle(ctx, ctx.get_tintin_fw_node().path_from(ctx.path), fw_type='recovery')
-
-
-def _bundle_resourceless_fw(ctx, fw_path, fw_type):
-    # We need to create a dummy pbpack and bundle it in. Some FW images don't use
-    # resources, but the firmware will refuse to upgrade to a firmware if a resource
-    # file isn't sent over, regardless of it's validity.
-    import tempfile
-
-    # We need to actually write some content in here or else the phone app won't think the
-    # resources are valid, and put_bytes will refuse to update to any firmware image if it doesn't
-    # come with a corresponding resource pack. No one will ever read these though so who cares
-    # what the content is.
-    with tempfile.NamedTemporaryFile(delete=False) as dummy_pbpack:
-        dummy_pbpack.write('DUMMY')
-        pbpack_path = dummy_pbpack.name
-
-    try:
-        _make_bundle(ctx, fw_path, fw_type=fw_type, resource_path=pbpack_path)
-    finally:
-        os.remove(pbpack_path)
-
-
-class bundle_recovery(BuildContext):
-    """bundles a recovery firmware as normal firmware"""
-    cmd = 'bundle_recovery'
-    variant = 'prf'
-
-    def execute_build(ctx):
-        _bundle_resourceless_fw(ctx, ctx.get_tintin_fw_node().path_from(ctx.path),
-                                fw_type='recovery')
 
 
 class BundleQEMUCommand(BuildContext):
@@ -1019,11 +971,6 @@ class QemuImageMicroCommand(BuildContext):
     fun = 'qemu_image_micro'
 
 
-class QemuImageMicroPrfCommand(BuildContext):
-    cmd = 'qemu_image_prf_micro'
-    fun = 'qemu_image_prf_micro'
-
-
 class QemuImageSpiCommand(BuildContext):
     cmd = 'qemu_image_spi'
     fun = 'qemu_image_spi'
@@ -1036,11 +983,6 @@ class MfgImageSpiCommand(BuildContext):
 
 def qemu_image_micro(ctx):
     fw_hex = ctx.get_tintin_fw_node().change_ext('.hex')
-    _create_qemu_image_micro(ctx, fw_hex.path_from(ctx.path))
-
-
-def qemu_image_prf_micro(ctx):
-    fw_hex = ctx.get_tintin_fw_node_prf().change_ext('.hex')
     _create_qemu_image_micro(ctx, fw_hex.path_from(ctx.path))
 
 
@@ -1124,7 +1066,7 @@ def mfg_image_spi(ctx):
     # Pad the first section before PRF storage
     mfg_spi_img_file.write("\xff" * prf_begin)
 
-    prf_path = ctx.get_tintin_fw_node_prf().path_from(ctx.path)
+    prf_path = ctx.options.file or ctx.get_tintin_fw_node().path_from(ctx.path)
     prf_image = insert_firmware_descr.insert_firmware_description_struct(prf_path)
     mfg_spi_img_file.write(prf_image)
 
@@ -1157,15 +1099,6 @@ def console(ctx):
         # opened. There may be a glitch on RTS when rts is set differently from
         # their default value.
         os.system("python ./tools/log_hashing/miniterm_co.py %s %d --rts 0" % (tty, baudrate))
-
-
-class ConsoleCommand(BuildContext):
-    cmd = 'console_prf'
-    fun = 'console_prf'
-
-def console_prf(ctx):
-    os.putenv("PBL_CONSOLE_DICT_PATH", "build/prf/src/fw/loghash_dict.json")
-    console(ctx)
 
 
 class BleConsoleCommand(BuildContext):
@@ -1203,28 +1136,11 @@ def ble_console(ctx):
     os.system("python ./tools/log_hashing/miniterm_co.py %s %d" % (tty, baudrate))
 
 
-class BleConsolePrfCommand(BuildContext):
-    cmd = 'ble_console_prf'
-    fun = 'ble_console_prf'
-
-
-def ble_console_prf(ctx):
-    os.putenv("PBL_CONSOLE_DICT_PATH", "build/prf/src/fw/loghash_dict.json")
-    ble_console(ctx)
-
-
 def qemu(ctx):
     # Make sure the micro-flash image is up to date. By default, we don't rebuild the
     # SPI flash image in case you want to continue with the stored apps, etc. you had before.
     from waflib import Options
     Options.commands = ['qemu_image_micro', 'qemu_launch'] + Options.commands
-
-
-def qemu_prf(ctx):
-    # Make sure the micro-flash image is up to date. By default, we don't rebuild the
-    # SPI flash image in case you want to continue with the stored apps, etc. you had before.
-    from waflib import Options
-    Options.commands = ['qemu_image_prf_micro', 'qemu_launch'] + Options.commands
 
 
 class QemuLaunchCommand(BuildContext):
@@ -1380,14 +1296,6 @@ def gdb(ctx, fw_elf=None, cfg_file='openocd.cfg', is_ble=False):
         run_arm_gdb(ctx, fw_elf, cmd_str='--init-command=".gdbinit"')
 
 
-class gdb_prf(BuildContext):
-    """same as `gdb`, but loading the PRF elf instead"""
-    cmd = 'gdb_prf'
-
-    def execute_build(ctx):
-        gdb(ctx, ctx.get_tintin_fw_node_prf().change_ext('.elf'))
-
-
 def openocd(ctx):
     """ Starts openocd and leaves it running. It will reset the board to
         increase the chances of attaching succesfully. """
@@ -1506,7 +1414,7 @@ def image_recovery(ctx):
         return
 
     tool_name = _get_pulse_flash_tool(ctx)
-    recovery_bin_path = ctx.options.file or ctx.get_tintin_fw_node_prf().path_from(ctx.path)
+    recovery_bin_path = ctx.options.file or ctx.get_tintin_fw_node().path_from(ctx.path)
     waflib.Logs.pprint('CYAN', 'Writing recovery bin "%s" to tty %s' % (recovery_bin_path, tty))
 
     ret = os.system("python ./tools/%s.py -t %s -p firmware %s" % (tool_name, tty, recovery_bin_path))
@@ -1526,20 +1434,20 @@ def _check_firmware_image_size(ctx, path):
     firmware_size = os.path.getsize(path)
     # Determine flash and bootloader size so we can calculate the max firmware size
     if ctx.env.MICRO_FAMILY == 'STM32F4':
-        if ctx.env.BOARD.startswith('silk') and ctx.variant == 'prf':
+        if ctx.env.BOARD.startswith('silk') and ctx.env.VARIANT == 'prf':
             # silk PRF is limited to 512k to save on SPI flash space
             max_firmware_size = 512 * BYTES_PER_K
         else:
             # 1024k of flash and 16k bootloader
             max_firmware_size = (1024 - 16) * BYTES_PER_K
     elif ctx.env.MICRO_FAMILY == 'NRF52':
-        if ctx.variant == 'prf' and not ctx.env.IS_MFG:
+        if ctx.env.VARIANT == 'prf' and not ctx.env.IS_MFG:
             max_firmware_size = 512 * BYTES_PER_K
         else:
             # 1024k of flash and 32k bootloader
             max_firmware_size = (1024 - 32) * BYTES_PER_K
     elif ctx.env.MICRO_FAMILY == 'SF32LB52':
-        if ctx.variant == 'prf' and not ctx.env.IS_MFG:
+        if ctx.env.VARIANT == 'prf' and not ctx.env.IS_MFG:
             max_firmware_size = 576 * BYTES_PER_K
         else:
             # 3072k of flash
@@ -1569,16 +1477,6 @@ class FlashCommand(BuildContext):
 
 def flash(ctx):
     flash_everything(ctx, ctx.get_tintin_fw_node())
-
-
-class FlashPrfCommand(BuildContext):
-    """flashes recovery firmware as normal firmware"""
-    cmd = 'flash_prf'
-    fun = 'flash_prf'
-
-
-def flash_prf(ctx):
-    flash_fw(ctx, ctx.get_tintin_fw_node_prf())
 
 
 class FlashFirmware(BuildContext):


### PR DESCRIPTION
Making PRF a variant was just a poor decision; it shares little with the normal firmware. This is an intermediate step so we can start having a separate Kconfig choice when building PRF. In the future, PRF should be a completely separate application that just pulls whatever it needs.