### PR TITLE
activity: disable HRM activity tracking by default

### DIFF
--- a/include/pbl/services/normal/activity/activity.h
+++ b/include/pbl/services/normal/activity/activity.h
@@ -95,7 +95,7 @@ typedef struct PACKED ActivityHRMSettings {
 #define ACTIVITY_HRM_DEFAULT_PREFERENCES { \
   .enabled = true, \
   .measurement_interval = HRMonitoringInterval_10Min, \
-  .activity_tracking_enabled = true, \
+  .activity_tracking_enabled = false, \
 }
 
 // We consider values outside of this range to be invalid


### PR DESCRIPTION
## Summary
- Flip `activity_tracking_enabled` in `ACTIVITY_HRM_DEFAULT_PREFERENCES` from `true` to `false` so the HRM is off during detected activities (walk/run) until the user opts in from Settings > Health.

## Test plan
- [ ] Fresh install: verify Settings > Health > HR Activity Tracking shows as "Off"
- [ ] Start a walk/run and confirm HRM is not engaged
- [ ] Toggle the setting on and confirm HRM engages during activity as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)