### PR TITLE
Add system dark mode

### DIFF
--- a/src/fw/applib/ui/date_selection_window.c
+++ b/src/fw/applib/ui/date_selection_window.c
@@ -138,7 +138,7 @@ static void prv_handle_dec(unsigned index, void *context) {
 // ---------------------------------------------------------------------------
 
 static void prv_text_layer_init(Layer *window_layer, TextLayer *text_layer, const GFont font) {
-  text_layer_init_with_parameters(text_layer, &GRectZero, NULL, font, GColorBlack, GColorClear,
+  text_layer_init_with_parameters(text_layer, &GRectZero, NULL, font, system_theme_get_fg_color(), GColorClear,
                                   GTextAlignmentCenter, GTextOverflowModeTrailingEllipsis);
   layer_add_child(window_layer, &text_layer->layer);
   layer_set_hidden(&text_layer->layer, true);
@@ -220,9 +220,6 @@ void date_selection_window_init(DateSelectionWindowData *window, const char *lab
 
   // Status bar setup
   status_bar_layer_init(&window->status_layer);
-  status_bar_layer_set_colors(&window->status_layer,
-                              PBL_IF_COLOR_ELSE(GColorWhite, GColorBlack),
-                              PBL_IF_COLOR_ELSE(GColorBlack, GColorWhite));
   status_bar_layer_set_separator_mode(&window->status_layer,
                                       PBL_IF_COLOR_ELSE(OPTION_MENU_STATUS_SEPARATOR_MODE,
                                                         StatusBarLayerSeparatorModeNone));

--- a/src/fw/applib/ui/menu_layer.c
+++ b/src/fw/applib/ui/menu_layer.c
@@ -17,6 +17,7 @@
 #include "applib/legacy2/ui/menu_layer_legacy2.h"
 #include "kernel/pbl_malloc.h"
 #include "process_management/process_manager.h"
+#include "shell/prefs.h"
 #include "shell/system_theme.h"
 #include "system/logging.h"
 #include "system/passert.h"
@@ -695,8 +696,9 @@ void menu_layer_init(MenuLayer *menu_layer, const GRect *frame) {
   scroll_layer_set_shadow_hidden(scroll_layer, true);
   scroll_layer_set_context(scroll_layer, menu_layer);
 
-  menu_layer_set_normal_colors(menu_layer, GColorWhite, GColorBlack);
-  menu_layer_set_highlight_colors(menu_layer, GColorBlack, GColorWhite);
+  menu_layer_set_normal_colors(menu_layer, system_theme_get_bg_color(), system_theme_get_fg_color());
+  GColor highlight_bg = shell_prefs_get_theme_highlight_color();
+  menu_layer_set_highlight_colors(menu_layer, highlight_bg, gcolor_legible_over(highlight_bg));
 
   InverterLayer *inverter = &menu_layer->inverter;
   inverter_layer_init(inverter, &GRectZero);
@@ -1419,7 +1421,7 @@ void menu_layer_set_scroll_vibe_on_blocked(MenuLayer *menu_layer, bool scroll_vi
   if (!menu_layer) {
     return;
   }
-  
+
   if (scroll_vibe_on_blocked) {
     menu_layer->scroll_vibe_on_wrap_around = false;
   }

--- a/src/fw/applib/ui/menu_layer.c
+++ b/src/fw/applib/ui/menu_layer.c
@@ -17,6 +17,7 @@
 #include "applib/legacy2/ui/menu_layer_legacy2.h"
 #include "kernel/pbl_malloc.h"
 #include "process_management/process_manager.h"
+#include "shell/prefs.h"
 #include "shell/system_theme.h"
 #include <pbl/logging/logging.h>
 #include "system/passert.h"
@@ -787,8 +788,9 @@ void menu_layer_init(MenuLayer *menu_layer, const GRect *frame) {
   scroll_layer_set_shadow_hidden(scroll_layer, true);
   scroll_layer_set_context(scroll_layer, menu_layer);
 
-  menu_layer_set_normal_colors(menu_layer, GColorWhite, GColorBlack);
-  menu_layer_set_highlight_colors(menu_layer, GColorBlack, GColorWhite);
+  menu_layer_set_normal_colors(menu_layer, system_theme_get_bg_color(), system_theme_get_fg_color());
+  GColor highlight_bg = shell_prefs_get_theme_highlight_color();
+  menu_layer_set_highlight_colors(menu_layer, highlight_bg, gcolor_legible_over(highlight_bg));
 
   InverterLayer *inverter = &menu_layer->inverter;
   inverter_layer_init(inverter, &GRectZero);
@@ -1531,7 +1533,7 @@ void menu_layer_set_scroll_vibe_on_blocked(MenuLayer *menu_layer, bool scroll_vi
   if (!menu_layer) {
     return;
   }
-  
+
   if (scroll_vibe_on_blocked) {
     menu_layer->scroll_vibe_on_wrap_around = false;
   }

--- a/src/fw/applib/ui/number_window.c
+++ b/src/fw/applib/ui/number_window.c
@@ -8,6 +8,7 @@
 #include "applib/applib_malloc.auto.h"
 #include "kernel/ui/kernel_ui.h"
 #include "kernel/ui/system_icons.h"
+#include "shell/system_theme.h"
 #include "util/size.h"
 
 #include <stdio.h>
@@ -94,7 +95,7 @@ void prv_update_proc(Layer *layer, GContext* ctx) {
   _Static_assert(offsetof(NumberWindow, window) == 0, "");
   NumberWindow *nw = (NumberWindow*) layer;
 
-  graphics_context_set_text_color(ctx, GColorBlack);
+  graphics_context_set_text_color(ctx, system_theme_get_fg_color());
 
   GRect frame = prv_get_text_frame(layer);
   frame.size.h = 54;

--- a/src/fw/applib/ui/number_window.c
+++ b/src/fw/applib/ui/number_window.c
@@ -9,6 +9,7 @@
 #include "kernel/ui/kernel_ui.h"
 #include "kernel/ui/system_icons.h"
 #include "pbl/util/size.h"
+#include "shell/system_theme.h"
 
 #include <stdio.h>
 #include <limits.h>
@@ -94,7 +95,7 @@ void prv_update_proc(Layer *layer, GContext* ctx) {
   _Static_assert(offsetof(NumberWindow, window) == 0, "");
   NumberWindow *nw = (NumberWindow*) layer;
 
-  graphics_context_set_text_color(ctx, GColorBlack);
+  graphics_context_set_text_color(ctx, system_theme_get_fg_color());
 
   GRect frame = prv_get_text_frame(layer);
   frame.size.h = 54;

--- a/src/fw/applib/ui/progress_layer.c
+++ b/src/fw/applib/ui/progress_layer.c
@@ -7,6 +7,7 @@
 #include "applib/graphics/gtypes.h"
 #include "applib/graphics/graphics.h"
 #include "applib/ui/layer.h"
+#include "shell/system_theme.h"
 #include "util/math.h"
 
 #include <string.h>
@@ -49,8 +50,8 @@ void progress_layer_init(ProgressLayer* progress_layer, const GRect *frame) {
 
   layer_init(&progress_layer->layer, frame);
   progress_layer->layer.update_proc = (LayerUpdateProc) progress_layer_update_proc;
-  progress_layer->foreground_color = GColorBlack;
-  progress_layer->background_color = GColorWhite;
+  progress_layer->foreground_color = system_theme_get_fg_color();
+  progress_layer->background_color = system_theme_get_bg_color();
   progress_layer->corner_radius = 1;
 }
 

--- a/src/fw/applib/ui/progress_layer.c
+++ b/src/fw/applib/ui/progress_layer.c
@@ -8,6 +8,7 @@
 #include "applib/graphics/graphics.h"
 #include "applib/ui/layer.h"
 #include "pbl/util/math.h"
+#include "shell/system_theme.h"
 
 #include <string.h>
 
@@ -49,8 +50,8 @@ void progress_layer_init(ProgressLayer* progress_layer, const GRect *frame) {
 
   layer_init(&progress_layer->layer, frame);
   progress_layer->layer.update_proc = (LayerUpdateProc) progress_layer_update_proc;
-  progress_layer->foreground_color = GColorBlack;
-  progress_layer->background_color = GColorWhite;
+  progress_layer->foreground_color = system_theme_get_fg_color();
+  progress_layer->background_color = system_theme_get_bg_color();
   progress_layer->corner_radius = 1;
 }
 

--- a/src/fw/applib/ui/status_bar_layer.c
+++ b/src/fw/applib/ui/status_bar_layer.c
@@ -15,6 +15,7 @@
 #include "kernel/ui/kernel_ui.h"
 #include "process_state/app_state/app_state.h"
 #include "pbl/services/clock.h"
+#include "shell/system_theme.h"
 #include "syscall/syscall.h"
 #include "syscall/syscall_internal.h"
 #include "system/passert.h"
@@ -104,8 +105,8 @@ void status_bar_layer_init(StatusBarLayer *status_bar_layer) {
   event_service_client_subscribe(&(status_bar_layer->tick_event));
 
   status_bar_layer->config = (StatusBarLayerConfig){
-    .foreground_color = GColorWhite,
-    .background_color = GColorBlack,
+    .foreground_color = system_theme_get_fg_color(),
+    .background_color = system_theme_get_bg_color(),
     .separator.mode = StatusBarLayerSeparatorModeNone,
   };
 

--- a/src/fw/applib/ui/status_bar_layer.c
+++ b/src/fw/applib/ui/status_bar_layer.c
@@ -15,6 +15,7 @@
 #include "kernel/ui/kernel_ui.h"
 #include "process_state/app_state/app_state.h"
 #include "pbl/services/clock.h"
+#include "shell/system_theme.h"
 #include "syscall/syscall.h"
 #include "syscall/syscall_internal.h"
 #include "system/passert.h"
@@ -137,8 +138,8 @@ void status_bar_layer_init(StatusBarLayer *status_bar_layer) {
   event_service_client_subscribe(&(status_bar_layer->tick_event));
 
   status_bar_layer->config = (StatusBarLayerConfig){
-    .foreground_color = GColorWhite,
-    .background_color = GColorBlack,
+    .foreground_color = system_theme_get_fg_color(),
+    .background_color = system_theme_get_bg_color(),
     .separator.mode = StatusBarLayerSeparatorModeNone,
   };
 

--- a/src/fw/applib/ui/time_range_selection_window.c
+++ b/src/fw/applib/ui/time_range_selection_window.c
@@ -100,7 +100,7 @@ static void prv_text_layer_init(Window *window, TextLayer *text_layer, GRect *re
                                 const char *i18n_str) {
   const GFont subtitle_font = system_theme_get_font_for_default_size(TextStyleFont_Subtitle);
   text_layer_init_with_parameters(text_layer, rect, i18n_get(i18n_str, window),
-                                  subtitle_font, GColorBlack, GColorClear, GTextAlignmentCenter,
+                                  subtitle_font, system_theme_get_fg_color(), GColorClear, GTextAlignmentCenter,
                                   GTextOverflowModeTrailingEllipsis);
   layer_add_child(&window->layer, &text_layer->layer);
 }

--- a/src/fw/applib/ui/time_selection_window.c
+++ b/src/fw/applib/ui/time_selection_window.c
@@ -216,7 +216,7 @@ void time_selection_window_configure(TimeSelectionWindowData *time_selection_win
 }
 
 static void prv_text_layer_init(Layer *window_layer, TextLayer *text_layer, const GFont font) {
-  text_layer_init_with_parameters(text_layer, &GRectZero, NULL, font, GColorBlack, GColorClear,
+  text_layer_init_with_parameters(text_layer, &GRectZero, NULL, font, system_theme_get_fg_color(), GColorClear,
                                   GTextAlignmentCenter, GTextOverflowModeTrailingEllipsis);
   layer_add_child(window_layer, &text_layer->layer);
   layer_set_hidden(&text_layer->layer, true);
@@ -272,9 +272,6 @@ void time_selection_window_init(TimeSelectionWindowData *time_selection_window,
 
   // Status setup
   status_bar_layer_init(&time_selection_window->status_layer);
-  status_bar_layer_set_colors(&time_selection_window->status_layer,
-                              PBL_IF_COLOR_ELSE(GColorWhite, GColorBlack),
-                              PBL_IF_COLOR_ELSE(GColorBlack, GColorWhite));
   status_bar_layer_set_separator_mode(&time_selection_window->status_layer,
                                       PBL_IF_COLOR_ELSE(OPTION_MENU_STATUS_SEPARATOR_MODE,
                                                         StatusBarLayerSeparatorModeNone));

--- a/src/fw/applib/ui/window.c
+++ b/src/fw/applib/ui/window.c
@@ -18,6 +18,7 @@
 #include "kernel/ui/modals/modal_manager.h"
 #include "process_management/process_manager.h"
 #include "process_state/app_state/app_state.h"
+#include "shell/system_theme.h"
 #include "system/logging.h"
 #include "system/passert.h"
 #include "syscall/syscall.h"
@@ -89,8 +90,8 @@ void prv_render_legacy2_system_status_bar(GContext *ctx, Window *window) {
     grect_clip(&ctx->draw_state.clip_box, &window->layer.frame);
 
     StatusBarLayerConfig config = {
-        .foreground_color = GColorWhite,
-        .background_color = GColorBlack,
+        .foreground_color = system_theme_get_fg_color(),
+        .background_color = system_theme_get_bg_color(),
         .mode = StatusBarLayerModeClock,
     };
     GRect frame = window->layer.frame;
@@ -185,7 +186,7 @@ void window_init(Window *window, const char* debug_name) {
   window->is_fullscreen = fullscreen;
   window->layer.window = window;
   window->layer.update_proc = window_do_layer_update_proc;
-  window->background_color = GColorWhite;
+  window->background_color = system_theme_get_bg_color();
   window->in_click_config_provider = false;
   window->is_waiting_for_click_config = false;
   window->parent_window_stack = NULL;

--- a/src/fw/applib/ui/window.c
+++ b/src/fw/applib/ui/window.c
@@ -20,6 +20,7 @@
 #include "process_management/process_manager.h"
 #include "process_state/app_state/app_state.h"
 #include <pbl/logging/logging.h>
+#include "shell/system_theme.h"
 #include "system/passert.h"
 #include "syscall/syscall.h"
 
@@ -90,8 +91,8 @@ void prv_render_legacy2_system_status_bar(GContext *ctx, Window *window) {
     grect_clip(&ctx->draw_state.clip_box, &window->layer.frame);
 
     StatusBarLayerConfig config = {
-        .foreground_color = GColorWhite,
-        .background_color = GColorBlack,
+        .foreground_color = system_theme_get_fg_color(),
+        .background_color = system_theme_get_bg_color(),
         .mode = StatusBarLayerModeClock,
     };
     GRect frame = window->layer.frame;
@@ -186,7 +187,7 @@ void window_init(Window *window, const char* debug_name) {
   window->is_fullscreen = fullscreen;
   window->layer.window = window;
   window->layer.update_proc = window_do_layer_update_proc;
-  window->background_color = GColorWhite;
+  window->background_color = system_theme_get_bg_color();
   window->in_click_config_provider = false;
   window->is_waiting_for_click_config = false;
   window->parent_window_stack = NULL;

--- a/src/fw/apps/system/alarms/alarms.c
+++ b/src/fw/apps/system/alarms/alarms.c
@@ -353,7 +353,7 @@ static void prv_push_alarms_app_opened_dialog(AlarmsAppData *data) {
   const char *header = i18n_get("Smart Alarm", data);
   ExpandableDialog *expandable_dialog = expandable_dialog_create_with_params(
       header, RESOURCE_ID_SMART_ALARM_TINY, first_use_text,
-      GColorBlack, GColorWhite, NULL, RESOURCE_ID_ACTION_BAR_ICON_CHECK,
+      system_theme_get_fg_color(), system_theme_get_bg_color(), NULL, RESOURCE_ID_ACTION_BAR_ICON_CHECK,
       prv_alarms_app_opened_click_handler);
 
   expandable_dialog_set_action_bar_background_color(expandable_dialog, ALARMS_APP_HIGHLIGHT_COLOR);
@@ -403,8 +403,6 @@ static void prv_handle_init(void) {
   layer_add_child(&data->window.layer, menu_layer_get_layer(&data->menu_layer));
 
   status_bar_layer_init(&data->status_layer);
-  status_bar_layer_set_colors(&data->status_layer, PBL_IF_COLOR_ELSE(GColorWhite, GColorBlack),
-                              PBL_IF_COLOR_ELSE(GColorBlack, GColorWhite));
   status_bar_layer_set_separator_mode(&data->status_layer, StatusBarLayerSeparatorModeNone);
   layer_add_child(&data->window.layer, status_bar_layer_get_layer(&data->status_layer));
 

--- a/src/fw/apps/system/alarms/alarms.c
+++ b/src/fw/apps/system/alarms/alarms.c
@@ -360,7 +360,7 @@ static void prv_push_alarms_app_opened_dialog(AlarmsAppData *data) {
   const char *header = i18n_get("Smart Alarm", data);
   ExpandableDialog *expandable_dialog = expandable_dialog_create_with_params(
       header, RESOURCE_ID_SMART_ALARM_TINY, first_use_text,
-      GColorBlack, GColorWhite, NULL, RESOURCE_ID_ACTION_BAR_ICON_CHECK,
+      system_theme_get_fg_color(), system_theme_get_bg_color(), NULL, RESOURCE_ID_ACTION_BAR_ICON_CHECK,
       prv_alarms_app_opened_click_handler);
 
   expandable_dialog_set_action_bar_background_color(expandable_dialog, ALARMS_APP_HIGHLIGHT_COLOR);
@@ -410,8 +410,6 @@ static void prv_handle_init(void) {
   layer_add_child(&data->window.layer, menu_layer_get_layer(&data->menu_layer));
 
   status_bar_layer_init(&data->status_layer);
-  status_bar_layer_set_colors(&data->status_layer, PBL_IF_COLOR_ELSE(GColorWhite, GColorBlack),
-                              PBL_IF_COLOR_ELSE(GColorBlack, GColorWhite));
   status_bar_layer_set_separator_mode(&data->status_layer, StatusBarLayerSeparatorModeNone);
   layer_add_child(&data->window.layer, status_bar_layer_get_layer(&data->status_layer));
 

--- a/src/fw/apps/system/health/health.c
+++ b/src/fw/apps/system/health/health.c
@@ -16,6 +16,7 @@
 #include "pbl/services/activity/activity_private.h"
 #include "pbl/services/timeline/timeline.h"
 #include "resource/resource_ids.auto.h"
+#include "shell/system_theme.h"
 #include "system/logging.h"
 
 // Health app versions
@@ -84,8 +85,8 @@ static void prv_show_insights_onboarding_dialog(void) {
       "Insights Onboarding",
       RESOURCE_ID_HEALTH_ICON_MOON,
       text,
-      GColorBlack,
-      GColorWhite,
+      system_theme_get_fg_color(),
+      system_theme_get_bg_color(),
       NULL,
       RESOURCE_ID_ACTION_BAR_ICON_CHECK,
       expandable_dialog_close_cb);

--- a/src/fw/apps/system/health/health.c
+++ b/src/fw/apps/system/health/health.c
@@ -17,6 +17,7 @@
 #include "pbl/services/timeline/timeline.h"
 #include "resource/resource_ids.auto.h"
 #include <pbl/logging/logging.h>
+#include "shell/system_theme.h"
 
 // Health app versions
 // 0: Invalid (app was never opened)
@@ -84,8 +85,8 @@ static void prv_show_insights_onboarding_dialog(void) {
       "Insights Onboarding",
       RESOURCE_ID_HEALTH_ICON_MOON,
       text,
-      GColorBlack,
-      GColorWhite,
+      system_theme_get_fg_color(),
+      system_theme_get_bg_color(),
       NULL,
       RESOURCE_ID_ACTION_BAR_ICON_CHECK,
       expandable_dialog_close_cb);

--- a/src/fw/apps/system/health/hr_detail_card.c
+++ b/src/fw/apps/system/health/hr_detail_card.c
@@ -9,6 +9,7 @@
 #include "pbl/services/i18n/i18n.h"
 #include "pbl/services/activity/activity.h"
 #include "pbl/services/activity/health_util.h"
+#include "shell/system_theme.h"
 
 #include <stdio.h>
 
@@ -89,7 +90,7 @@ Window *health_hr_detail_card_create(HealthData *health_data) {
     .num_headings = card_data->num_headings,
     .headings = card_data->headings,
     .weekly_max = max_progress,
-    .bg_color = GColorWhite,
+    .bg_color = system_theme_get_bg_color(),
     .num_zones = card_data->num_zones,
     .zones = card_data->zones,
     .data = card_data,

--- a/src/fw/apps/system/health/hr_summary_card.c
+++ b/src/fw/apps/system/health/hr_summary_card.c
@@ -24,6 +24,8 @@
 #define HEALTH_X_OFFSET ((DISP_COLS - LEGACY_2X_DISP_COLS) / 2)
 #define HEALTH_Y_OFFSET ((DISP_ROWS - LEGACY_2X_DISP_ROWS) / 2)
 
+#include "shell/system_theme.h"
+
 typedef struct HealthHrSummaryCardData {
   HealthData *health_data;
   HealthProgressBar progress_bar;
@@ -44,8 +46,8 @@ typedef struct HealthHrSummaryCardData {
 #define PROGRESS_BACKGROUND_COLOR (PBL_IF_COLOR_ELSE(GColorDarkCandyAppleRed, GColorBlack))
 #define PROGRESS_OUTLINE_COLOR (PBL_IF_COLOR_ELSE(GColorClear, GColorBlack))
 
-#define TEXT_COLOR (PBL_IF_COLOR_ELSE(GColorBulgarianRose, GColorBlack))
-#define CARD_BACKGROUND_COLOR (PBL_IF_COLOR_ELSE(GColorWhite, GColorWhite))
+#define TEXT_COLOR (PBL_IF_COLOR_ELSE(GColorBulgarianRose, system_theme_get_fg_color()))
+#define CARD_BACKGROUND_COLOR (system_theme_get_bg_color())
 
 
 static void prv_pulsing_heart_timer_cb(void *context) {
@@ -192,6 +194,19 @@ static void prv_hr_detail_card_unload_callback(Window *window) {
 // API Functions
 //
 
+static bool prv_recolor_pulsing_heart_cb(GDrawCommand *command, uint32_t index, void *context) {
+  GColor stroke = gdraw_command_get_stroke_color(command);
+  GColor fill = gdraw_command_get_fill_color(command);
+
+  if (gcolor_equal(stroke, GColorBlack)) {
+    gdraw_command_set_stroke_color(command, GColorWhite);
+  }
+  if (gcolor_equal(fill, GColorWhite)) {
+    gdraw_command_set_fill_color(command, GColorClear);
+  }
+  return true;
+}
+
 Layer *health_hr_summary_card_create(HealthData *health_data) {
   // create base layer
   Layer *base_layer = layer_create_with_data(GRectZero, sizeof(HealthHrSummaryCardData));
@@ -218,6 +233,17 @@ Layer *health_hr_summary_card_create(HealthData *health_data) {
 #endif
     .timestamp_font = fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD),
   };
+
+  if (system_theme_is_dark_mode() && data->pulsing_heart) {
+    const uint32_t num_frames = gdraw_command_sequence_get_num_frames(data->pulsing_heart);
+    for (uint32_t i = 0; i < num_frames; i++) {
+      GDrawCommandFrame *f = gdraw_command_sequence_get_frame_by_index(data->pulsing_heart, i);
+      if (f) {
+        gdraw_command_list_iterate(gdraw_command_frame_get_command_list(f),
+                                   prv_recolor_pulsing_heart_cb, NULL);
+      }
+    }
+  }
 
   data->pulsing_heart_timer = app_timer_register(0, prv_pulsing_heart_timer_cb, base_layer);
 

--- a/src/fw/apps/system/launcher/default/app_glance_structured.c
+++ b/src/fw/apps/system/launcher/default/app_glance_structured.c
@@ -13,6 +13,7 @@
 #include "resource/resource_ids.auto.h"
 #include "pbl/services/timeline/attribute.h"
 #include "shell/prefs.h"
+#include "shell/system_theme.h"
 #include "system/passert.h"
 #include "util/attributes.h"
 #include "util/string.h"
@@ -87,16 +88,9 @@ static void prv_structured_glance_icon_bitmap_processor_post_func(
 
 GColor launcher_app_glance_structured_get_highlight_color(
     LauncherAppGlanceStructured *structured_glance) {
-#if PBL_COLOR
-  if (structured_glance->glance.is_highlighted) {
-    GColor highlight_bg = shell_prefs_get_theme_highlight_color();
-    return gcolor_legible_over(highlight_bg);
-  } else {
-    return GColorBlack;
-  }
-#else
-  return structured_glance->glance.is_highlighted ? GColorWhite : GColorBlack;
-#endif
+  return structured_glance->glance.is_highlighted ?
+      gcolor_legible_over(shell_prefs_get_theme_highlight_color()) :
+      system_theme_get_fg_color();
 }
 
 static GColor prv_get_icon_tint_color(LauncherAppGlanceStructured *structured_glance) {
@@ -362,7 +356,7 @@ static GTextNode *prv_create_structured_glance_title_subtitle_node(
   GTextNode *title_node = prv_structured_glance_create_title_text_node(structured_glance);
   // We require a valid title node
   PBL_ASSERTN(title_node);
-  
+
   // Push the margin a bit closer
 #if PBL_DISPLAY_HEIGHT >= 200 && PBL_RECT
   title_node->margin.h = -3;

--- a/src/fw/apps/system/launcher/default/app_glance_structured.c
+++ b/src/fw/apps/system/launcher/default/app_glance_structured.c
@@ -13,6 +13,7 @@
 #include "resource/resource_ids.auto.h"
 #include "pbl/services/timeline/attribute.h"
 #include "shell/prefs.h"
+#include "shell/system_theme.h"
 #include "system/passert.h"
 #include "pbl/util/attributes.h"
 #include "pbl/util/string.h"
@@ -87,16 +88,9 @@ static void prv_structured_glance_icon_bitmap_processor_post_func(
 
 GColor launcher_app_glance_structured_get_highlight_color(
     LauncherAppGlanceStructured *structured_glance) {
-#if PBL_COLOR
-  if (structured_glance->glance.is_highlighted) {
-    GColor highlight_bg = shell_prefs_get_theme_highlight_color();
-    return gcolor_legible_over(highlight_bg);
-  } else {
-    return GColorBlack;
-  }
-#else
-  return structured_glance->glance.is_highlighted ? GColorWhite : GColorBlack;
-#endif
+  return structured_glance->glance.is_highlighted ?
+      gcolor_legible_over(shell_prefs_get_theme_highlight_color()) :
+      system_theme_get_fg_color();
 }
 
 static GColor prv_get_icon_tint_color(LauncherAppGlanceStructured *structured_glance) {
@@ -362,7 +356,7 @@ static GTextNode *prv_create_structured_glance_title_subtitle_node(
   GTextNode *title_node = prv_structured_glance_create_title_text_node(structured_glance);
   // We require a valid title node
   PBL_ASSERTN(title_node);
-  
+
   // Push the margin a bit closer
 #if PBL_DISPLAY_HEIGHT >= 200 && PBL_RECT
   title_node->margin.h = -3;

--- a/src/fw/apps/system/music.c
+++ b/src/fw/apps/system/music.c
@@ -690,7 +690,9 @@ static void prv_no_music_window_click_config(void *context) {
 static MusicNoMusicWindow *prv_create_no_music_window(void) {
   MusicNoMusicWindow *window = app_malloc_check(sizeof(MusicNoMusicWindow));
   window_init(&window->window, WINDOW_NAME("NoMusicWindow"));
-  window_set_background_color(&window->window, PBL_IF_COLOR_ELSE(GColorLightGray, GColorWhite));
+  window_set_background_color(&window->window, PBL_IF_COLOR_ELSE(
+    system_theme_is_dark_mode() ? GColorDarkGray : GColorLightGray,
+    GColorWhite));
   window_set_window_handlers(&window->window, &(WindowHandlers) {
       .unload = prv_unload_no_music_window
   });
@@ -713,7 +715,7 @@ static MusicNoMusicWindow *prv_create_no_music_window(void) {
                                   &NO_MUSIC_TEXT_RECT,
                                   i18n_get("START PLAYBACK\nON YOUR PHONE", window),
                                   fonts_get_system_font(config->no_music_font_key),
-                                  GColorBlack, GColorClear, GTextAlignmentCenter,
+                                  system_theme_get_fg_color(), GColorClear, GTextAlignmentCenter,
                                   GTextOverflowModeTrailingEllipsis);
   layer_add_child(&window->window.layer, &window->bitmap_layer.layer);
   layer_add_child(&window->window.layer, &window->text_layer.layer);
@@ -834,7 +836,7 @@ static void prv_configure_music_text_layer(
     TextLayer *text_layer, char* text_buffer, const GRect *rect, int16_t y_offset,
     GTextAlignment align, GFont font) {
   text_layer_init_with_parameters(text_layer, rect, text_buffer, font,
-                                  GColorBlack, GColorClear, align, GTextOverflowModeFill);
+                                  system_theme_get_fg_color(), GColorClear, align, GTextOverflowModeFill);
   layer_set_bounds(&text_layer->layer, &GRect(0, -y_offset,
                                               rect->size.w, rect->size.h + y_offset));
 }
@@ -842,7 +844,9 @@ static void prv_configure_music_text_layer(
 static void prv_init_ui(Window *window) {
   MusicAppData *data = window_get_user_data(window);
 
-  window_set_background_color(window, PBL_IF_COLOR_ELSE(GColorLightGray, GColorWhite));
+  window_set_background_color(window, PBL_IF_COLOR_ELSE(
+    system_theme_is_dark_mode() ? GColorDarkGray : GColorLightGray,
+    GColorWhite));
 
   const GSize WINDOW_SIZE = window->layer.bounds.size;
 
@@ -896,7 +900,7 @@ static void prv_init_ui(Window *window) {
 
   progress_layer_init(&data->track_pos_bar, &track_rect);
   progress_layer_set_background_color(&data->track_pos_bar,
-                                      PBL_IF_COLOR_ELSE(GColorBlack, GColorWhite));
+                                      PBL_IF_COLOR_ELSE(system_theme_get_bg_color(), GColorWhite));
   progress_layer_set_foreground_color(&data->track_pos_bar,
                                       PBL_IF_COLOR_ELSE(GColorRed, GColorBlack));
   progress_layer_set_corner_radius(&data->track_pos_bar, config->track_corner_radius);
@@ -915,7 +919,7 @@ static void prv_init_ui(Window *window) {
                                                           WINDOW_SIZE.w);
   status_layer_frame.size.w = STATUS_BAR_LAYER_WIDTH;
   layer_set_frame(&status_layer->layer, &status_layer_frame);
-  status_bar_layer_set_colors(&data->status_layer, GColorClear, GColorBlack);
+  status_bar_layer_set_colors(&data->status_layer, GColorClear, system_theme_get_fg_color());
   layer_add_child(&data->window.layer, &status_layer->layer);
 
   music_get_pos(&data->track_pos, &data->track_length);

--- a/src/fw/apps/system/music.c
+++ b/src/fw/apps/system/music.c
@@ -822,7 +822,9 @@ static void prv_no_music_window_click_config(void *context) {
 static MusicNoMusicWindow *prv_create_no_music_window(void) {
   MusicNoMusicWindow *window = app_malloc_check(sizeof(MusicNoMusicWindow));
   window_init(&window->window, WINDOW_NAME("NoMusicWindow"));
-  window_set_background_color(&window->window, PBL_IF_COLOR_ELSE(GColorLightGray, GColorWhite));
+  window_set_background_color(&window->window, PBL_IF_COLOR_ELSE(
+    system_theme_is_dark_mode() ? GColorDarkGray : GColorLightGray,
+    GColorWhite));
   window_set_window_handlers(&window->window, &(WindowHandlers) {
       .unload = prv_unload_no_music_window
   });
@@ -845,7 +847,7 @@ static MusicNoMusicWindow *prv_create_no_music_window(void) {
                                   &NO_MUSIC_TEXT_RECT,
                                   i18n_get("START PLAYBACK\nON YOUR PHONE", window),
                                   fonts_get_system_font(config->no_music_font_key),
-                                  GColorBlack, GColorClear, GTextAlignmentCenter,
+                                  system_theme_get_fg_color(), GColorClear, GTextAlignmentCenter,
                                   GTextOverflowModeTrailingEllipsis);
   layer_add_child(&window->window.layer, &window->bitmap_layer.layer);
   layer_add_child(&window->window.layer, &window->text_layer.layer);
@@ -985,7 +987,7 @@ static void prv_configure_music_text_layer(
     TextLayer *text_layer, char* text_buffer, const GRect *rect, int16_t y_offset,
     GTextAlignment align, GFont font) {
   text_layer_init_with_parameters(text_layer, rect, text_buffer, font,
-                                  GColorBlack, GColorClear, align, GTextOverflowModeFill);
+                                  system_theme_get_fg_color(), GColorClear, align, GTextOverflowModeFill);
   layer_set_bounds(&text_layer->layer, &GRect(0, -y_offset,
                                               rect->size.w, rect->size.h + y_offset));
 }
@@ -1418,7 +1420,9 @@ static void prv_apply_art_appearance(MusicAppData *data) {
 static void prv_init_ui(Window *window) {
   MusicAppData *data = window_get_user_data(window);
 
-  window_set_background_color(window, PBL_IF_COLOR_ELSE(GColorLightGray, GColorWhite));
+  window_set_background_color(window, PBL_IF_COLOR_ELSE(
+    system_theme_is_dark_mode() ? GColorDarkGray : GColorLightGray,
+    GColorWhite));
 
   const GSize WINDOW_SIZE = window->layer.bounds.size;
 
@@ -1501,7 +1505,7 @@ static void prv_init_ui(Window *window) {
 
   progress_layer_init(&data->track_pos_bar, &track_rect);
   progress_layer_set_background_color(&data->track_pos_bar,
-                                      PBL_IF_COLOR_ELSE(GColorBlack, GColorWhite));
+                                      PBL_IF_COLOR_ELSE(system_theme_get_bg_color(), GColorWhite));
   progress_layer_set_foreground_color(&data->track_pos_bar,
                                       PBL_IF_COLOR_ELSE(GColorRed, GColorBlack));
   progress_layer_set_corner_radius(&data->track_pos_bar, config->track_corner_radius);
@@ -1520,7 +1524,7 @@ static void prv_init_ui(Window *window) {
                                                           WINDOW_SIZE.w);
   status_layer_frame.size.w = STATUS_BAR_LAYER_WIDTH;
   layer_set_frame(&status_layer->layer, &status_layer_frame);
-  status_bar_layer_set_colors(&data->status_layer, GColorClear, GColorBlack);
+  status_bar_layer_set_colors(&data->status_layer, GColorClear, system_theme_get_fg_color());
   layer_add_child(&data->window.layer, &status_layer->layer);
 
   music_get_pos(&data->track_pos, &data->track_length);

--- a/src/fw/apps/system/notifications.c
+++ b/src/fw/apps/system/notifications.c
@@ -711,10 +711,10 @@ static void prv_window_load(Window *window) {
       .select_click = prv_select_callback,
   });
 
-  menu_layer_set_normal_colors(menu_layer, GColorWhite, GColorBlack);
+  menu_layer_set_normal_colors(menu_layer, system_theme_get_bg_color(), system_theme_get_fg_color());
   menu_layer_set_highlight_colors(menu_layer,
-                                  PBL_IF_COLOR_ELSE(DEFAULT_NOTIFICATION_COLOR, GColorBlack),
-                                  GColorWhite);
+                                  PBL_IF_COLOR_ELSE(DEFAULT_NOTIFICATION_COLOR, system_theme_get_fg_color()),
+                                  system_theme_get_bg_color());
 
   menu_layer_set_click_config_onto_window(menu_layer, window);
   menu_layer_set_scroll_wrap_around(menu_layer, shell_prefs_get_menu_scroll_wrap_around_enable());
@@ -730,14 +730,14 @@ static void prv_window_load(Window *window) {
                                   &GRect(horizontal_margin, window->layer.bounds.size.h / 2 - 15,
                                          window->layer.bounds.size.w - horizontal_margin,
                                          window->layer.bounds.size.h / 2),
-                                  i18n_get("No notifications", data), font, GColorBlack,
-                                  GColorWhite, GTextAlignmentCenter,
+                                  i18n_get("No notifications", data), font, system_theme_get_fg_color(),
+                                  system_theme_get_bg_color(), GTextAlignmentCenter,
                                   GTextOverflowModeTrailingEllipsis);
   layer_add_child(&window->layer, text_layer_get_layer(text_layer));
 
 #if PBL_ROUND
   GColor bg_color = GColorClear;
-  GColor fg_color = GColorBlack;
+  GColor fg_color = system_theme_get_fg_color();
 
   StatusBarLayer *status_bar = &data->status_bar_layer;
   status_bar_layer_init(status_bar);

--- a/src/fw/apps/system/notifications.c
+++ b/src/fw/apps/system/notifications.c
@@ -714,10 +714,10 @@ static void prv_window_load(Window *window) {
       .select_click = prv_select_callback,
   });
 
-  menu_layer_set_normal_colors(menu_layer, GColorWhite, GColorBlack);
+  menu_layer_set_normal_colors(menu_layer, system_theme_get_bg_color(), system_theme_get_fg_color());
   menu_layer_set_highlight_colors(menu_layer,
-                                  PBL_IF_COLOR_ELSE(DEFAULT_NOTIFICATION_COLOR, GColorBlack),
-                                  GColorWhite);
+                                  PBL_IF_COLOR_ELSE(DEFAULT_NOTIFICATION_COLOR, system_theme_get_fg_color()),
+                                  system_theme_get_bg_color());
 
   menu_layer_set_click_config_onto_window(menu_layer, window);
   menu_layer_set_scroll_wrap_around(menu_layer, shell_prefs_get_menu_scroll_wrap_around_enable());
@@ -733,14 +733,14 @@ static void prv_window_load(Window *window) {
                                   &GRect(horizontal_margin, window->layer.bounds.size.h / 2 - 15,
                                          window->layer.bounds.size.w - horizontal_margin,
                                          window->layer.bounds.size.h / 2),
-                                  i18n_get("No notifications", data), font, GColorBlack,
-                                  GColorWhite, GTextAlignmentCenter,
+                                  i18n_get("No notifications", data), font, system_theme_get_fg_color(),
+                                  system_theme_get_bg_color(), GTextAlignmentCenter,
                                   GTextOverflowModeTrailingEllipsis);
   layer_add_child(&window->layer, text_layer_get_layer(text_layer));
 
 #if PBL_ROUND
   GColor bg_color = GColorClear;
-  GColor fg_color = GColorBlack;
+  GColor fg_color = system_theme_get_fg_color();
 
   StatusBarLayer *status_bar = &data->status_bar_layer;
   status_bar_layer_init(status_bar);

--- a/src/fw/apps/system/settings/activity_tracker.c
+++ b/src/fw/apps/system/settings/activity_tracker.c
@@ -240,9 +240,6 @@ static Window *prv_init(void) {
   option_menu_init(&data->option_menu);
   // Not using option_menu_configure because prv_reload_menu_data already sets
   // icons_enabled and chosen row index
-  option_menu_set_status_colors(&data->option_menu, GColorWhite, GColorBlack);
-  GColor highlight_bg = shell_prefs_get_theme_highlight_color();
-  option_menu_set_highlight_colors(&data->option_menu, highlight_bg, gcolor_legible_over(highlight_bg));
   option_menu_set_title(&data->option_menu, i18n_get("Background App", data));
   option_menu_set_content_type(&data->option_menu, OptionMenuContentType_SingleLine);
   option_menu_set_callbacks(&data->option_menu, &option_menu_callbacks, data);

--- a/src/fw/apps/system/settings/display.c
+++ b/src/fw/apps/system/settings/display.c
@@ -456,6 +456,9 @@ enum SettingsDisplayItem {
 #if CAPABILITY_HAS_APP_SCALING
   SettingsDisplayLegacyAppMode,
 #endif
+#if !CAPABILITY_HAS_THEMING
+  SettingsDisplayDarkMode,
+#endif
   NumSettingsDisplayItems
 };
 
@@ -485,6 +488,11 @@ static void prv_display_select_click_cb(SettingsCallbacks *context, uint16_t row
 #if CAPABILITY_HAS_APP_SCALING
     case SettingsDisplayLegacyAppMode:
       prv_legacy_app_mode_menu_push((SettingsDisplayData*)context);
+      break;
+#endif
+#if !CAPABILITY_HAS_THEMING
+    case SettingsDisplayDarkMode:
+      shell_prefs_set_dark_mode((shell_prefs_get_dark_mode() + 1) % DarkModeCount);
       break;
 #endif
     default:
@@ -530,6 +538,20 @@ static void prv_display_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
       subtitle = (shell_prefs_get_legacy_app_render_mode() >= LegacyAppRenderMode_ScalingNearest) ?
                  i18n_noop("Scaled") : i18n_noop("Centered");
       break;
+#endif
+#if !CAPABILITY_HAS_THEMING
+    case SettingsDisplayDarkMode: {
+      title = i18n_noop("Dark Mode");
+      static const char * const s_dark_mode_labels[] = {
+        [DarkModeOff] = i18n_noop("Off"),
+        [DarkModeOn] = i18n_noop("On"),
+        #if CAPABILITY_HAS_AMBIENT_LIGHT_SENSOR
+        [DarkModeAuto] = i18n_noop("Auto"),
+        #endif
+      };
+      subtitle = s_dark_mode_labels[shell_prefs_get_dark_mode()];
+      break;
+    }
 #endif
     default:
       WTF;

--- a/src/fw/apps/system/settings/display.c
+++ b/src/fw/apps/system/settings/display.c
@@ -27,11 +27,17 @@
 #include <string.h>
 #include <inttypes.h>
 
+#include "applib/ui/time_range_selection_window.h"
+#include "pbl/services/clock.h"
+
 // Forward decl so the parent menu can push the Backlight submenu.
 static void prv_backlight_submenu_push(void);
 
 typedef struct SettingsDisplayData {
   SettingsCallbacks callbacks;
+#if !CAPABILITY_HAS_THEMING
+  TimeRangeSelectionWindowData schedule_window;
+#endif
 } SettingsDisplayData;
 
 typedef struct SettingsBacklightData {
@@ -559,6 +565,10 @@ enum SettingsDisplayItem {
 #ifdef CONFIG_APP_SCALING
   SettingsDisplayLegacyAppMode,
 #endif
+#if !CAPABILITY_HAS_THEMING
+  SettingsDisplayDarkMode,
+  SettingsDisplayDarkModeSchedule,
+#endif
   NumSettingsDisplayItems
 };
 
@@ -575,8 +585,82 @@ static bool prv_display_item_is_visible(uint16_t item) {
     return touch_is_globally_enabled();
   }
 #endif
+#if !CAPABILITY_HAS_THEMING
+  if (item == SettingsDisplayDarkModeSchedule) {
+    return shell_prefs_get_dark_mode() == DarkModeScheduled;
+  }
+#endif
   return true;
 }
+
+#if !CAPABILITY_HAS_THEMING
+static const char * const s_dark_mode_labels[] = {
+  [DarkModeOff] = i18n_noop("Off"),
+  [DarkModeOn] = i18n_noop("On"),
+  [DarkModeAmbient] = i18n_noop("Ambient"),
+  [DarkModeScheduled] = i18n_noop("Schedule"),
+};
+
+static void prv_dark_mode_schedule_window_push(SettingsDisplayData *data);
+
+static void prv_dark_mode_menu_select(OptionMenu *option_menu, int selection, void *context) {
+  SettingsDisplayData *data = settings_option_menu_get_context(context);
+  const DarkMode mode = (DarkMode)selection;
+  shell_prefs_set_dark_mode(mode);
+  if (mode == DarkModeScheduled) {
+    app_window_stack_remove(&option_menu->window, false /* animated */);
+    prv_dark_mode_schedule_window_push(data);
+  } else {
+    app_window_stack_remove(&option_menu->window, true /* animated */);
+  }
+  settings_menu_reload_data(SettingsMenuItemDisplay);
+  settings_menu_mark_dirty(SettingsMenuItemDisplay);
+}
+
+static void prv_dark_mode_menu_push(SettingsDisplayData *data) {
+  const int index = (int)shell_prefs_get_dark_mode();
+  const OptionMenuCallbacks callbacks = {
+    .select = prv_dark_mode_menu_select,
+  };
+  const char *title = PBL_IF_RECT_ELSE(i18n_noop("DARK MODE"), i18n_noop("Dark Mode"));
+  settings_option_menu_push(
+      title, OptionMenuContentType_SingleLine, index, &callbacks,
+      ARRAY_LENGTH(s_dark_mode_labels), true /* icons_enabled */,
+      (const char **)s_dark_mode_labels, data);
+}
+
+static void prv_complete_dark_mode_schedule(TimeRangeSelectionWindowData *schedule_window, void *data) {
+  DarkModeSchedule schedule = {
+    .from_hour = schedule_window->from.hour,
+    .from_minute = schedule_window->from.minute,
+    .to_hour = schedule_window->to.hour,
+    .to_minute = schedule_window->to.minute,
+  };
+  if (schedule.from_hour == schedule.to_hour && schedule.from_minute == schedule.to_minute) {
+    if ((schedule.to_minute = (schedule.to_minute + 1) % 60) == 0) {
+      schedule.to_hour = (schedule.to_hour + 1) % 24;
+    }
+  }
+  shell_prefs_set_dark_mode_schedule(&schedule);
+  settings_menu_reload_data(SettingsMenuItemDisplay);
+  settings_menu_mark_dirty(SettingsMenuItemDisplay);
+  const bool animated = true;
+  app_window_stack_remove(&schedule_window->window, animated);
+}
+
+static void prv_dark_mode_schedule_window_push(SettingsDisplayData *data) {
+  DarkModeSchedule schedule;
+  shell_prefs_get_dark_mode_schedule(&schedule);
+  TimeRangeSelectionWindowData *schedule_window = &data->schedule_window;
+  time_range_selection_window_init(schedule_window, PBL_IF_COLOR_ELSE(GColorCobaltBlue, GColorBlack),
+                                   prv_complete_dark_mode_schedule, data);
+  schedule_window->from.hour = schedule.from_hour;
+  schedule_window->from.minute = schedule.from_minute;
+  schedule_window->to.hour = schedule.to_hour;
+  schedule_window->to.minute = schedule.to_minute;
+  app_window_stack_push(&schedule_window->window, true);
+}
+#endif
 
 static uint16_t prv_display_item_from_row(uint16_t row) {
   uint16_t visible_row = 0;
@@ -623,6 +707,14 @@ static void prv_display_select_click_cb(SettingsCallbacks *context, uint16_t row
       prv_legacy_app_mode_menu_push((SettingsDisplayData*)context);
       break;
 #endif
+#if !CAPABILITY_HAS_THEMING
+    case SettingsDisplayDarkMode:
+      prv_dark_mode_menu_push((SettingsDisplayData *)context);
+      break;
+    case SettingsDisplayDarkModeSchedule:
+      prv_dark_mode_schedule_window_push((SettingsDisplayData *)context);
+      break;
+#endif
     default:
       WTF;
   }
@@ -635,6 +727,7 @@ static void prv_display_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
   SettingsDisplayData *data = (SettingsDisplayData*) context;
   const char *title = NULL;
   const char *subtitle = NULL;
+  char time_buf[32];
   switch (prv_display_item_from_row(row)) {
     case SettingsDisplayBacklight:
       title = i18n_noop("Backlight");
@@ -670,6 +763,23 @@ static void prv_display_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
       subtitle = s_legacy_app_mode_labels[shell_prefs_get_legacy_app_render_mode()];
       break;
 #endif
+#if !CAPABILITY_HAS_THEMING
+    case SettingsDisplayDarkMode:
+      title = i18n_noop("Dark Mode");
+      subtitle = s_dark_mode_labels[shell_prefs_get_dark_mode()];
+      break;
+    case SettingsDisplayDarkModeSchedule: {
+      title = i18n_noop("Schedule Time");
+      DarkModeSchedule schedule;
+      shell_prefs_get_dark_mode_schedule(&schedule);
+      clock_format_time(time_buf, sizeof(time_buf), schedule.from_hour, schedule.from_minute, true);
+      strcat(time_buf, " - ");
+      const size_t len = strlen(time_buf);
+      clock_format_time(time_buf + len, sizeof(time_buf) - len, schedule.to_hour, schedule.to_minute, true);
+      subtitle = time_buf;
+      break;
+    }
+#endif
     default:
       WTF;
   }
@@ -688,6 +798,9 @@ static uint16_t prv_display_num_rows_cb(SettingsCallbacks *context) {
 
 static void prv_display_deinit_cb(SettingsCallbacks *context) {
   SettingsDisplayData *data = (SettingsDisplayData*) context;
+#if !CAPABILITY_HAS_THEMING
+  time_range_selection_window_deinit(&data->schedule_window);
+#endif
   i18n_free_all(data);
   app_free(data);
 }

--- a/src/fw/apps/system/settings/option_menu.c
+++ b/src/fw/apps/system/settings/option_menu.c
@@ -42,7 +42,7 @@ OptionMenu *settings_option_menu_create(
     .title = i18n_get(i18n_title_key, option_menu),
     .content_type = content_type,
     .choice = choice,
-    .status_colors = { GColorWhite, GColorBlack },
+    .status_colors = { system_theme_get_bg_color(), system_theme_get_fg_color() },
     .highlight_colors = { highlight_bg, gcolor_legible_over(highlight_bg) },
     .icons_enabled = icons_enabled,
   };

--- a/src/fw/apps/system/settings/quick_launch_app_menu.c
+++ b/src/fw/apps/system/settings/quick_launch_app_menu.c
@@ -158,7 +158,7 @@ void quick_launch_app_menu_window_push(ButtonId button, bool is_tap) {
   const OptionMenuConfig config = {
     .title = i18n_get(i18n_noop("Quick Launch"), data),
     .choice = (install_id == INSTALL_ID_INVALID) ? 0 : (app_index + NUM_CUSTOM_CELLS),
-    .status_colors = { GColorWhite, GColorBlack, },
+    .status_colors = { system_theme_get_bg_color(), system_theme_get_fg_color() },
     .highlight_colors = { highlight_bg, gcolor_legible_over(highlight_bg) },
     .icons_enabled = true,
   };

--- a/src/fw/apps/system/settings/quick_launch_app_menu.c
+++ b/src/fw/apps/system/settings/quick_launch_app_menu.c
@@ -156,7 +156,7 @@ void quick_launch_app_menu_window_push(ButtonId button, bool is_tap) {
   const OptionMenuConfig config = {
     .title = i18n_get(i18n_noop("Quick Launch"), data),
     .choice = (install_id == INSTALL_ID_INVALID) ? 0 : (app_index + NUM_CUSTOM_CELLS),
-    .status_colors = { GColorWhite, GColorBlack, },
+    .status_colors = { system_theme_get_bg_color(), system_theme_get_fg_color() },
     .highlight_colors = { highlight_bg, gcolor_legible_over(highlight_bg) },
     .icons_enabled = true,
   };

--- a/src/fw/apps/system/settings/quick_launch_setup_menu.c
+++ b/src/fw/apps/system/settings/quick_launch_setup_menu.c
@@ -56,8 +56,8 @@ static void prv_push_first_use_dialog(void) {
   const char *text = i18n_get("Open favorite apps quickly with a long button press from your "
                               "watchface.", i18n_owner);
   ExpandableDialog *expandable_dialog = expandable_dialog_create_with_params(
-      WINDOW_NAME("Quick Launch First Use"), RESOURCE_ID_SUNNY_DAY_TINY, text, GColorBlack,
-      GColorWhite, NULL, RESOURCE_ID_ACTION_BAR_ICON_CHECK, prv_handle_quick_launch_confirm);
+      WINDOW_NAME("Quick Launch First Use"), RESOURCE_ID_SUNNY_DAY_TINY, text, system_theme_get_fg_color(),
+      system_theme_get_bg_color(), NULL, RESOURCE_ID_ACTION_BAR_ICON_CHECK, prv_handle_quick_launch_confirm);
   expandable_dialog_set_header(expandable_dialog, header);
 #if PBL_ROUND
   expandable_dialog_set_header_font(expandable_dialog,

--- a/src/fw/apps/system/settings/settings.c
+++ b/src/fw/apps/system/settings/settings.c
@@ -13,6 +13,7 @@
 #include "pbl/services/i18n/i18n.h"
 #include "system/passert.h"
 #include "shell/prefs.h"
+#include "shell/system_theme.h"
 #include "util/size.h"
 
 #define SETTINGS_CATEGORY_MENU_CELL_UNFOCUSED_ROUND_VERTICAL_PADDING 14
@@ -135,19 +136,21 @@ static void prv_window_load(Window *window) {
     .select_click = prv_select_callback,
     .get_separator_height = prv_get_separator_height_callback
   });
-  GColor highlight_bg = shell_prefs_get_theme_highlight_color();
-  menu_layer_set_normal_colors(menu_layer,
-                               PBL_IF_COLOR_ELSE(GColorBlack, GColorWhite),
-                               PBL_IF_COLOR_ELSE(GColorWhite, GColorBlack));
-  menu_layer_set_highlight_colors(menu_layer,
-                                  highlight_bg,
-                                  gcolor_legible_over(highlight_bg));
   menu_layer_set_click_config_onto_window(menu_layer, &data->window);
   menu_layer_set_scroll_wrap_around(menu_layer, shell_prefs_get_menu_scroll_wrap_around_enable());
   menu_layer_set_scroll_vibe_on_wrap(menu_layer, shell_prefs_get_menu_scroll_vibe_behavior() == MenuScrollVibeOnWrapAround);
   menu_layer_set_scroll_vibe_on_blocked(menu_layer, shell_prefs_get_menu_scroll_vibe_behavior() == MenuScrollVibeOnLocked);
 
   layer_add_child(&data->window.layer, menu_layer_get_layer(menu_layer));
+}
+
+static void prv_window_appear(Window *window) {
+  SettingsAppData *data = window_get_user_data(window);
+  // Refresh background and menu colors in case dark mode changed while away
+  window_set_background_color(window, system_theme_get_bg_color());
+  menu_layer_set_normal_colors(&data->menu_layer, system_theme_get_bg_color(),
+                               system_theme_get_fg_color());
+  layer_mark_dirty(menu_layer_get_layer(&data->menu_layer));
 }
 
 static void prv_window_unload(Window *window) {
@@ -174,9 +177,10 @@ static void handle_init(void) {
   window_set_user_data(window, data);
   window_set_window_handlers(window, &(WindowHandlers){
     .load = prv_window_load,
+    .appear = prv_window_appear,
     .unload = prv_window_unload,
   });
-  window_set_background_color(window, PBL_IF_COLOR_ELSE(GColorBlack, GColorWhite));
+  window_set_background_color(window, system_theme_get_bg_color());
   app_window_stack_push(window, true);
 }
 

--- a/src/fw/apps/system/settings/settings.c
+++ b/src/fw/apps/system/settings/settings.c
@@ -13,6 +13,7 @@
 #include "pbl/services/i18n/i18n.h"
 #include "system/passert.h"
 #include "shell/prefs.h"
+#include "shell/system_theme.h"
 #include "pbl/util/size.h"
 
 #define SETTINGS_CATEGORY_MENU_CELL_UNFOCUSED_ROUND_VERTICAL_PADDING 14
@@ -141,19 +142,21 @@ static void prv_window_load(Window *window) {
     .select_click = prv_select_callback,
     .get_separator_height = prv_get_separator_height_callback
   });
-  GColor highlight_bg = shell_prefs_get_theme_highlight_color();
-  menu_layer_set_normal_colors(menu_layer,
-                               PBL_IF_COLOR_ELSE(GColorBlack, GColorWhite),
-                               PBL_IF_COLOR_ELSE(GColorWhite, GColorBlack));
-  menu_layer_set_highlight_colors(menu_layer,
-                                  highlight_bg,
-                                  gcolor_legible_over(highlight_bg));
   menu_layer_set_click_config_onto_window(menu_layer, &data->window);
   menu_layer_set_scroll_wrap_around(menu_layer, shell_prefs_get_menu_scroll_wrap_around_enable());
   menu_layer_set_scroll_vibe_on_wrap(menu_layer, shell_prefs_get_menu_scroll_vibe_behavior() == MenuScrollVibeOnWrapAround);
   menu_layer_set_scroll_vibe_on_blocked(menu_layer, shell_prefs_get_menu_scroll_vibe_behavior() == MenuScrollVibeOnLocked);
 
   layer_add_child(&data->window.layer, menu_layer_get_layer(menu_layer));
+}
+
+static void prv_window_appear(Window *window) {
+  SettingsAppData *data = window_get_user_data(window);
+  // Refresh background and menu colors in case dark mode changed while away
+  window_set_background_color(window, system_theme_get_bg_color());
+  menu_layer_set_normal_colors(&data->menu_layer, system_theme_get_bg_color(),
+                               system_theme_get_fg_color());
+  layer_mark_dirty(menu_layer_get_layer(&data->menu_layer));
 }
 
 static void prv_window_unload(Window *window) {
@@ -180,9 +183,10 @@ static void handle_init(void) {
   window_set_user_data(window, data);
   window_set_window_handlers(window, &(WindowHandlers){
     .load = prv_window_load,
+    .appear = prv_window_appear,
     .unload = prv_window_unload,
   });
-  window_set_background_color(window, PBL_IF_COLOR_ELSE(GColorBlack, GColorWhite));
+  window_set_background_color(window, system_theme_get_bg_color());
   app_window_stack_push(window, true);
 }
 

--- a/src/fw/apps/system/settings/system.c
+++ b/src/fw/apps/system/settings/system.c
@@ -176,7 +176,6 @@ static void prv_init_status_bar(StatusBarLayer *status_layer, Window *window, co
   status_bar_layer_init(status_layer);
   status_bar_layer_set_title(status_layer, text, false, false);
   status_bar_layer_set_separator_mode(status_layer, OPTION_MENU_STATUS_SEPARATOR_MODE);
-  status_bar_layer_set_colors(status_layer, GColorWhite, GColorBlack);
   layer_add_child(&window->layer, status_bar_layer_get_layer(status_layer));
 }
 
@@ -881,7 +880,9 @@ static void prv_draw_fcc_cell_round(
   const uint8_t fcc_number_subtitle_height = fonts_get_font_height(fcc_number_subtitle_font);
   const GTextOverflowMode text_overflow_mode = GTextOverflowModeFill;
 
-  graphics_context_set_text_color(ctx, cell_is_highlighted ? GColorWhite : GColorBlack);
+  graphics_context_set_text_color(ctx, cell_is_highlighted ?
+    system_theme_get_bg_color() :
+    system_theme_get_fg_color());
 
   // Calculate the container of the FCC cell content and center it within the cell
   const int16_t title_and_icon_width = 50;
@@ -1324,7 +1325,7 @@ static void prv_kcc_window_load(Window *window) {
                                 - title_text_internal_padding;
   text_layer_init_with_parameters(&data->title_text, &title_text_frame,
                                   title, title_text_font,
-                                  GColorBlack, GColorClear, GTextAlignmentCenter,
+                                  system_theme_get_fg_color(), GColorClear, GTextAlignmentCenter,
                                   GTextOverflowModeTrailingEllipsis);
   layer_add_child(window_layer, text_layer_get_layer(&data->title_text));
 
@@ -1332,7 +1333,7 @@ static void prv_kcc_window_load(Window *window) {
   info_text_frame.origin.y = title_text_frame.origin.y + title_text_size.h + vertical_spacing;
   text_layer_init_with_parameters(&data->info_text, &info_text_frame,
                                   prv_get_korea_kcc_id(), info_text_font,
-                                  GColorBlack, GColorClear, GTextAlignmentCenter,
+                                  system_theme_get_fg_color(), GColorClear, GTextAlignmentCenter,
                                   GTextOverflowModeTrailingEllipsis);
   layer_add_child(window_layer, text_layer_get_layer(&data->info_text));
 }

--- a/src/fw/apps/system/settings/system.c
+++ b/src/fw/apps/system/settings/system.c
@@ -170,7 +170,6 @@ static void prv_init_status_bar(StatusBarLayer *status_layer, Window *window, co
   status_bar_layer_init(status_layer);
   status_bar_layer_set_title(status_layer, text, false, false);
   status_bar_layer_set_separator_mode(status_layer, OPTION_MENU_STATUS_SEPARATOR_MODE);
-  status_bar_layer_set_colors(status_layer, GColorWhite, GColorBlack);
   layer_add_child(&window->layer, status_bar_layer_get_layer(status_layer));
 }
 
@@ -778,7 +777,9 @@ static void prv_draw_fcc_cell_round(
   const uint8_t fcc_number_subtitle_height = fonts_get_font_height(fcc_number_subtitle_font);
   const GTextOverflowMode text_overflow_mode = GTextOverflowModeFill;
 
-  graphics_context_set_text_color(ctx, cell_is_highlighted ? GColorWhite : GColorBlack);
+  graphics_context_set_text_color(ctx, cell_is_highlighted ?
+    system_theme_get_bg_color() :
+    system_theme_get_fg_color());
 
   // Calculate the container of the FCC cell content and center it within the cell
   const int16_t title_and_icon_width = 50;
@@ -1221,7 +1222,7 @@ static void prv_kcc_window_load(Window *window) {
                                 - title_text_internal_padding;
   text_layer_init_with_parameters(&data->title_text, &title_text_frame,
                                   title, title_text_font,
-                                  GColorBlack, GColorClear, GTextAlignmentCenter,
+                                  system_theme_get_fg_color(), GColorClear, GTextAlignmentCenter,
                                   GTextOverflowModeTrailingEllipsis);
   layer_add_child(window_layer, text_layer_get_layer(&data->title_text));
 
@@ -1229,7 +1230,7 @@ static void prv_kcc_window_load(Window *window) {
   info_text_frame.origin.y = title_text_frame.origin.y + title_text_size.h + vertical_spacing;
   text_layer_init_with_parameters(&data->info_text, &info_text_frame,
                                   prv_get_korea_kcc_id(), info_text_font,
-                                  GColorBlack, GColorClear, GTextAlignmentCenter,
+                                  system_theme_get_fg_color(), GColorClear, GTextAlignmentCenter,
                                   GTextOverflowModeTrailingEllipsis);
   layer_add_child(window_layer, text_layer_get_layer(&data->info_text));
 }

--- a/src/fw/apps/system/settings/themes.c
+++ b/src/fw/apps/system/settings/themes.c
@@ -117,7 +117,7 @@ static OptionMenu *prv_push_color_menu(void) {
     PBL_LOG_WRN("Invalid menu color, using default");
     selected = 0;
   }
-  OptionMenu * const option_menu = settings_option_menu_create(
+  OptionMenu * const option_menu = settings_option_menu_push(
       title, OptionMenuContentType_SingleLine, selected, &callbacks,
       ARRAY_LENGTH(s_color_definitions), true /* icons_enabled */, color_names, NULL);
 
@@ -133,12 +133,52 @@ static OptionMenu *prv_push_color_menu(void) {
 
   return option_menu;
 }
+
+static const char * const s_dark_mode_labels[] = {
+  i18n_noop("Off"), i18n_noop("On"), i18n_noop("Auto"),
+};
+
+static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
+  if (row == 0) shell_prefs_set_dark_mode((shell_prefs_get_dark_mode() + 1) % DarkModeCount);
+  else prv_push_color_menu();
+  settings_menu_reload_data(SettingsMenuItemThemes);
+  settings_menu_mark_dirty(SettingsMenuItemThemes);
+}
+
+static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
+                             const Layer *cell_layer, uint16_t row, bool selected) {
+  const char *title, *subtitle;
+  if (row == 0) {
+    title = i18n_noop("Dark Mode");
+    subtitle = s_dark_mode_labels[shell_prefs_get_dark_mode()];
+  } else {
+    int idx = prv_color_to_index(shell_prefs_get_theme_highlight_color(),
+                                  DEFAULT_THEME_HIGHLIGHT_COLOR);
+    title = i18n_noop("Accent Color");
+    subtitle = s_color_definitions[idx < 0 ? 0 : idx].name;
+  }
+  menu_cell_basic_draw(ctx, cell_layer, i18n_get(title, context),
+                       i18n_get(subtitle, context), NULL);
+}
+
+static uint16_t prv_num_rows_cb(SettingsCallbacks *context) { return 2; }
+static void prv_deinit_cb(SettingsCallbacks *context) {
+  i18n_free_all(context);
+  app_free(context);
+}
+
 #endif // CAPABILITY_HAS_THEMING
 
 static Window *prv_create_color_menu(void) {
 #if CAPABILITY_HAS_THEMING
-  OptionMenu *option_menu = prv_push_color_menu();
-  return option_menu ? &option_menu->window : NULL;
+  SettingsCallbacks *callbacks = app_malloc_check(sizeof(*callbacks));
+  *callbacks = (SettingsCallbacks){
+    .deinit = prv_deinit_cb,
+    .draw_row = prv_draw_row_cb,
+    .select_click = prv_select_click_cb,
+    .num_rows = prv_num_rows_cb,
+  };
+  return settings_window_create(SettingsMenuItemThemes, callbacks);
 #else
   WTF;
   return NULL;

--- a/src/fw/apps/system/settings/themes.c
+++ b/src/fw/apps/system/settings/themes.c
@@ -15,11 +15,18 @@
 #include "pbl/services/i18n/i18n.h"
 #include "shell/prefs.h"
 #include "system/passert.h"
+#include "applib/ui/time_range_selection_window.h"
+#include "pbl/services/clock.h"
 #include "pbl/util/size.h"
 
 #ifdef CONFIG_THEMING
 
 #define DEFAULT_THEME_HIGHLIGHT_COLOR GColorVividCerulean
+
+typedef struct SettingsThemesData {
+  SettingsCallbacks callbacks;
+  TimeRangeSelectionWindowData schedule_window;
+} SettingsThemesData;
 
 typedef struct ColorDefinition {
   const char *name;
@@ -117,7 +124,7 @@ static OptionMenu *prv_push_color_menu(void) {
     PBL_LOG_WRN("Invalid menu color, using default");
     selected = 0;
   }
-  OptionMenu * const option_menu = settings_option_menu_create(
+  OptionMenu * const option_menu = settings_option_menu_push(
       title, OptionMenuContentType_SingleLine, selected, &callbacks,
       ARRAY_LENGTH(s_color_definitions), true /* icons_enabled */, color_names, NULL);
 
@@ -133,12 +140,139 @@ static OptionMenu *prv_push_color_menu(void) {
 
   return option_menu;
 }
+
+static const char * const s_dark_mode_labels[] = {
+  [DarkModeOff] = i18n_noop("Off"),
+  [DarkModeOn] = i18n_noop("On"),
+  [DarkModeAmbient] = i18n_noop("Ambient"),
+  [DarkModeScheduled] = i18n_noop("Schedule"),
+};
+
+static void prv_dark_mode_schedule_window_push(SettingsThemesData *data);
+
+static void prv_dark_mode_menu_select(OptionMenu *option_menu, int selection, void *context) {
+  SettingsThemesData *data = settings_option_menu_get_context(context);
+  const DarkMode mode = (DarkMode)selection;
+  shell_prefs_set_dark_mode(mode);
+  if (mode == DarkModeScheduled) {
+    app_window_stack_remove(&option_menu->window, false /* animated */);
+    prv_dark_mode_schedule_window_push(data);
+  } else {
+    app_window_stack_remove(&option_menu->window, true /* animated */);
+  }
+  settings_menu_reload_data(SettingsMenuItemThemes);
+  settings_menu_mark_dirty(SettingsMenuItemThemes);
+}
+
+static void prv_push_dark_mode_menu(SettingsThemesData *data) {
+  const int index = (int)shell_prefs_get_dark_mode();
+  const OptionMenuCallbacks callbacks = {
+    .select = prv_dark_mode_menu_select,
+  };
+  const char *title = PBL_IF_RECT_ELSE(i18n_noop("DARK MODE"), i18n_noop("Dark Mode"));
+  settings_option_menu_push(
+      title, OptionMenuContentType_SingleLine, index, &callbacks,
+      ARRAY_LENGTH(s_dark_mode_labels), true /* icons_enabled */,
+      (const char **)s_dark_mode_labels, data);
+}
+
+static void prv_complete_dark_mode_schedule(TimeRangeSelectionWindowData *schedule_window, void *data) {
+  DarkModeSchedule schedule = {
+    .from_hour = schedule_window->from.hour,
+    .from_minute = schedule_window->from.minute,
+    .to_hour = schedule_window->to.hour,
+    .to_minute = schedule_window->to.minute,
+  };
+  if (schedule.from_hour == schedule.to_hour && schedule.from_minute == schedule.to_minute) {
+    if ((schedule.to_minute = (schedule.to_minute + 1) % 60) == 0) {
+      schedule.to_hour = (schedule.to_hour + 1) % 24;
+    }
+  }
+  shell_prefs_set_dark_mode_schedule(&schedule);
+  settings_menu_reload_data(SettingsMenuItemThemes);
+  settings_menu_mark_dirty(SettingsMenuItemThemes);
+  const bool animated = true;
+  app_window_stack_remove(&schedule_window->window, animated);
+}
+
+static void prv_dark_mode_schedule_window_push(SettingsThemesData *data) {
+  DarkModeSchedule schedule;
+  shell_prefs_get_dark_mode_schedule(&schedule);
+  TimeRangeSelectionWindowData *schedule_window = &data->schedule_window;
+  time_range_selection_window_init(schedule_window, shell_prefs_get_theme_highlight_color(),
+                                   prv_complete_dark_mode_schedule, data);
+  schedule_window->from.hour = schedule.from_hour;
+  schedule_window->from.minute = schedule.from_minute;
+  schedule_window->to.hour = schedule.to_hour;
+  schedule_window->to.minute = schedule.to_minute;
+  app_window_stack_push(&schedule_window->window, true);
+}
+
+static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
+  SettingsThemesData *data = (SettingsThemesData *)context;
+  const bool has_schedule = (shell_prefs_get_dark_mode() == DarkModeScheduled);
+  if (row == 0) {
+    prv_push_dark_mode_menu(data);
+  } else if (has_schedule && row == 1) {
+    prv_dark_mode_schedule_window_push(data);
+  } else {
+    prv_push_color_menu();
+  }
+}
+
+static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
+                             const Layer *cell_layer, uint16_t row, bool selected) {
+  const char *title = NULL;
+  const char *subtitle = NULL;
+  char time_buf[32];
+  const bool has_schedule = (shell_prefs_get_dark_mode() == DarkModeScheduled);
+  if (row == 0) {
+    title = i18n_noop("Dark Mode");
+    subtitle = s_dark_mode_labels[shell_prefs_get_dark_mode()];
+  } else if (has_schedule && row == 1) {
+    title = i18n_noop("Schedule Time");
+    DarkModeSchedule schedule;
+    shell_prefs_get_dark_mode_schedule(&schedule);
+    clock_format_time(time_buf, sizeof(time_buf), schedule.from_hour, schedule.from_minute, true);
+    strcat(time_buf, " - ");
+    const size_t len = strlen(time_buf);
+    clock_format_time(time_buf + len, sizeof(time_buf) - len, schedule.to_hour, schedule.to_minute, true);
+    subtitle = time_buf;
+  } else {
+    int idx = prv_color_to_index(shell_prefs_get_theme_highlight_color(),
+                                  DEFAULT_THEME_HIGHLIGHT_COLOR);
+    title = i18n_noop("Accent Color");
+    subtitle = s_color_definitions[idx < 0 ? 0 : idx].name;
+  }
+  menu_cell_basic_draw(ctx, cell_layer, i18n_get(title, context),
+                       i18n_get(subtitle, context), NULL);
+}
+
+static uint16_t prv_num_rows_cb(SettingsCallbacks *context) {
+  return (shell_prefs_get_dark_mode() == DarkModeScheduled) ? 3 : 2;
+}
+
+static void prv_deinit_cb(SettingsCallbacks *context) {
+  SettingsThemesData *data = (SettingsThemesData *)context;
+  time_range_selection_window_deinit(&data->schedule_window);
+  i18n_free_all(context);
+  app_free(context);
+}
+
 #endif // CONFIG_THEMING
 
 static Window *prv_create_color_menu(void) {
 #ifdef CONFIG_THEMING
-  OptionMenu *option_menu = prv_push_color_menu();
-  return option_menu ? &option_menu->window : NULL;
+  SettingsThemesData *data = app_malloc_check(sizeof(*data));
+  *data = (SettingsThemesData){
+    .callbacks = {
+      .deinit = prv_deinit_cb,
+      .draw_row = prv_draw_row_cb,
+      .select_click = prv_select_click_cb,
+      .num_rows = prv_num_rows_cb,
+    },
+  };
+  return settings_window_create(SettingsMenuItemThemes, &data->callbacks);
 #else
   WTF;
   return NULL;

--- a/src/fw/apps/system/settings/window.c
+++ b/src/fw/apps/system/settings/window.c
@@ -29,6 +29,7 @@
 #include "pbl/services/i18n/i18n.h"
 #include "pbl/services/system_task.h"
 #include "system/bootbits.h"
+#include "shell/system_theme.h"
 #include "system/passert.h"
 #include "shell/prefs.h"
 
@@ -62,10 +63,18 @@ typedef struct SettingsData {
 // Pref change handler
 ///////////////////////
 
+static void prv_refresh_theme_colors(SettingsData *data) {
+  const GColor bg = system_theme_get_bg_color();
+  const GColor fg = system_theme_get_fg_color();
+  window_set_background_color(&data->window, bg);
+  status_bar_layer_set_colors(&data->status_layer, bg, fg);
+  menu_layer_set_normal_colors(&data->menu_layer, bg, fg);
+  layer_mark_dirty(menu_layer_get_layer(&data->menu_layer));
+}
+
 static void prv_pref_change_handler(PebbleEvent *event, void *context) {
   SettingsData *data = context;
-  // Refresh the menu when any pref changes
-  layer_mark_dirty(menu_layer_get_layer(&data->menu_layer));
+  prv_refresh_theme_colors(data);
 }
 
 // Filter category helpers
@@ -85,8 +94,8 @@ static void prv_set_sub_menu_colors(GContext *ctx, const Layer *cell_layer, bool
     graphics_context_set_fill_color(ctx, highlight_bg);
     graphics_context_set_text_color(ctx, gcolor_legible_over(highlight_bg));
   } else {
-    graphics_context_set_fill_color(ctx, GColorWhite);
-    graphics_context_set_text_color(ctx, GColorBlack);
+    graphics_context_set_fill_color(ctx, system_theme_get_bg_color());
+    graphics_context_set_text_color(ctx, system_theme_get_fg_color());
   }
   graphics_fill_rect(ctx, &cell_layer->bounds);
 }
@@ -183,7 +192,7 @@ static void prv_settings_window_load(Window *window) {
       ? data->title_override
       : settings_menu_get_status_name(data->current_category);
   status_bar_layer_set_title(status_layer, i18n_get(title, data), false, false);
-  status_bar_layer_set_colors(status_layer, GColorWhite, GColorBlack);
+  status_bar_layer_set_colors(status_layer, system_theme_get_bg_color(), system_theme_get_fg_color());
   status_bar_layer_set_separator_mode(status_layer, OPTION_MENU_STATUS_SEPARATOR_MODE);
   layer_add_child(&data->window.layer, status_bar_layer_get_layer(status_layer));
 
@@ -203,9 +212,6 @@ static void prv_settings_window_load(Window *window) {
     .selection_changed = prv_selection_changed_callback,
     .selection_will_change = prv_selection_will_change_callback,
   });
-  menu_layer_set_normal_colors(menu_layer, GColorWhite, GColorBlack);
-  GColor highlight_bg = shell_prefs_get_theme_highlight_color();
-  menu_layer_set_highlight_colors(menu_layer, highlight_bg, gcolor_legible_over(highlight_bg));
   menu_layer_set_click_config_onto_window(menu_layer, &data->window);
   menu_layer_set_scroll_wrap_around(menu_layer, shell_prefs_get_menu_scroll_wrap_around_enable());
   menu_layer_set_scroll_vibe_on_wrap(menu_layer, shell_prefs_get_menu_scroll_vibe_behavior() == MenuScrollVibeOnWrapAround);
@@ -234,6 +240,8 @@ static void prv_settings_window_load(Window *window) {
 
 static void prv_settings_window_appear(Window *window) {
   SettingsData *data = window_get_user_data(window);
+  // Refresh colors in case the theme changed while this window was hidden
+  prv_refresh_theme_colors(data);
   SettingsCallbacks *callbacks = prv_get_current_callbacks(data);
   if (callbacks->appear) {
     callbacks->appear(data->callbacks);
@@ -312,7 +320,7 @@ void settings_window_destroy(Window *window) {
 void settings_menu_mark_dirty(SettingsMenuItem category) {
   SettingsData *data = app_state_get_user_data();
   if (data->current_category == category) {
-    layer_mark_dirty(menu_layer_get_layer(&data->menu_layer));
+    prv_refresh_theme_colors(data);
   }
 }
 

--- a/src/fw/apps/system/timeline/layer.c
+++ b/src/fw/apps/system/timeline/layer.c
@@ -613,7 +613,7 @@ static void prv_update_proc(struct Layer *layer, GContext* ctx) {
   TimelineLayer *timeline_layer = (TimelineLayer *)layer;
   const GRect *bounds = &layer->bounds;
 
-  graphics_context_set_fill_color(ctx, GColorWhite);
+  graphics_context_set_fill_color(ctx, system_theme_get_bg_color());
   graphics_fill_rect(ctx, &(GRect) { .size = bounds->size });
 
   AnimationProgress progress;
@@ -621,7 +621,7 @@ static void prv_update_proc(struct Layer *layer, GContext* ctx) {
       animation_get_progress(timeline_layer->animation, &progress)) {
     const GPoint offset = { PEEK_ANIMATIONS_SPEED_LINES_OFFSET_X,
                             interpolate_int64_linear(progress, 0, -DISP_ROWS) };
-    graphics_context_set_fill_color(ctx, GColorBlack);
+    graphics_context_set_fill_color(ctx, system_theme_get_fg_color());
     peek_animations_draw_timeline_speed_lines(ctx, offset);
   }
 
@@ -934,6 +934,7 @@ void timeline_layer_init(TimelineLayer *layer, const GRect *frame_ref,
   };
   peek_layer_set_icon(&layer->day_separator, &timeline_res);
   peek_layer_set_background_color(&layer->day_separator, GColorClear);
+  peek_layer_set_text_color(&layer->day_separator, system_theme_get_fg_color());
   peek_layer_set_dot_diameter(&layer->day_separator, style->day_sep_dot_diameter);
   layer_set_hidden((Layer *)&layer->day_separator, true);
   layer_add_child((Layer *)layer, (Layer *)&layer->day_separator);

--- a/src/fw/apps/system/timeline/peek_layer.c
+++ b/src/fw/apps/system/timeline/peek_layer.c
@@ -46,7 +46,7 @@ static void prv_update_proc(Layer *layer, GContext *ctx) {
   }
 
   if (peek_layer->show_dot) {
-    graphics_context_set_fill_color(ctx, GColorBlack);
+    graphics_context_set_fill_color(ctx, system_theme_get_fg_color());
     GRect dot_rect = { .size = { peek_layer->dot_diameter, peek_layer->dot_diameter } };
     grect_align(&dot_rect, &peek_layer->layer.bounds, GAlignCenter, false /* clip */);
     graphics_fill_radial(ctx, dot_rect, GOvalScaleModeFitCircle, peek_layer->dot_diameter, 0,
@@ -166,6 +166,12 @@ void peek_layer_set_frame(PeekLayer *peek_layer, const GRect *frame) {
 
 void peek_layer_set_background_color(PeekLayer *peek_layer, GColor color) {
   peek_layer->bg_color = color;
+}
+
+void peek_layer_set_text_color(PeekLayer *peek_layer, GColor color) {
+  text_layer_set_text_color(&peek_layer->number.text_layer, color);
+  text_layer_set_text_color(&peek_layer->title.text_layer, color);
+  text_layer_set_text_color(&peek_layer->subtitle.text_layer, color);
 }
 
 static bool prv_is_dot_size(GSize size) {

--- a/src/fw/apps/system/timeline/peek_layer.h
+++ b/src/fw/apps/system/timeline/peek_layer.h
@@ -99,6 +99,9 @@ ImmutableAnimation *peek_layer_create_play_section_animation(PeekLayer *peek_lay
 //! Set the background color of the peek layer.
 void peek_layer_set_background_color(PeekLayer *peek_layer, GColor color);
 
+//! Set the text color of all peek layer text fields.
+void peek_layer_set_text_color(PeekLayer *peek_layer, GColor color);
+
 //! Sets the text of the peek layer text fields. The text is copied over.
 //! See the individual text field setters for more information about each field.
 void peek_layer_set_fields(PeekLayer *peek_layer, const char *number, const char *title,

--- a/src/fw/apps/system/weather/clock_face.c
+++ b/src/fw/apps/system/weather/clock_face.c
@@ -642,7 +642,7 @@ static void prv_canvas_draw(Layer *layer, GContext *ctx) {
   // Transparent window bg on round (step 3) — the degenerate no-state frame must paint
   // the white itself, since this proc is what guarantees full coverage.
   if (!s_cf) {
-    graphics_context_set_fill_color(ctx, GColorWhite);
+    graphics_context_set_fill_color(ctx, system_theme_get_bg_color());
     graphics_fill_rect(ctx, layer_get_bounds(layer), 0, GCornerNone);
     return;
   }
@@ -664,8 +664,8 @@ static void prv_canvas_draw(Layer *layer, GContext *ctx) {
   int W = bounds.size.w;
   int H = bounds.size.h;
 
-  // White background — matches other screens
-  graphics_context_set_fill_color(ctx, GColorWhite);
+  // Background — matches other screens
+  graphics_context_set_fill_color(ctx, system_theme_get_bg_color());
   graphics_fill_rect(ctx, bounds, 0, GCornerNone);
 
   // Clock face centre — full screen, no bar offset
@@ -747,12 +747,15 @@ static void prv_canvas_draw(Layer *layer, GContext *ctx) {
 
       graphics_context_set_compositing_mode(ctx, GCompOpAssign);
       if (show_temp_side) {
-        graphics_context_set_fill_color(ctx, GColorWhite);
+        const GColor circle_bg = system_theme_is_dark_mode() ? GColorDarkGray : GColorWhite;
+        graphics_context_set_fill_color(ctx, circle_bg);
         graphics_fill_circle(ctx, GPoint(ix, iy), rr);
-        // Colour: soft grey outline. BW: strokes cannot dither (LightGray
-        // maps to White and vanishes) — solid black is the only visible ring.
-        graphics_context_set_stroke_color(ctx,
-                                          PBL_IF_BW_ELSE(GColorBlack, GColorLightGray));
+        // Colour: soft grey outline in light mode; match dark gray fill in dark mode.
+        // BW: strokes cannot dither (LightGray maps to White and vanishes) — solid black is the only visible ring.
+        const GColor stroke_color = system_theme_is_dark_mode()
+            ? GColorDarkGray
+            : PBL_IF_BW_ELSE(GColorBlack, GColorLightGray);
+        graphics_context_set_stroke_color(ctx, stroke_color);
         graphics_context_set_stroke_width(ctx, 1);
         graphics_draw_circle(ctx, GPoint(ix, iy), rr);
       } else {
@@ -785,7 +788,7 @@ static void prv_canvas_draw(Layer *layer, GContext *ctx) {
           GSize nsz = graphics_text_layout_get_content_size(
               nbuf, tfont, GRect(0, 0, 40, 18),
               GTextOverflowModeFill, GTextAlignmentCenter);
-          graphics_context_set_text_color(ctx, GColorBlack);
+          graphics_context_set_text_color(ctx, system_theme_get_fg_color());
           graphics_draw_text(ctx, nbuf, tfont,
               GRect(ix - nsz.w / 2, iy - 11, nsz.w, 18),
               GTextOverflowModeFill, GTextAlignmentCenter, NULL);
@@ -862,9 +865,9 @@ static void prv_canvas_draw(Layer *layer, GContext *ctx) {
       const int font_top_pad = -4;
       int ty_s = stg_cy - nsz.h / 2 + font_top_pad;
       // Clear staging area so no icon pixels bleed into the capture.
-      graphics_context_set_fill_color(ctx, GColorWhite);
+      graphics_context_set_fill_color(ctx, system_theme_get_bg_color());
       graphics_fill_rect(ctx, GRect(stg_x, stg_y, stg_w, stg_h), 0, GCornerNone);
-      graphics_context_set_text_color(ctx, GColorBlack);
+      graphics_context_set_text_color(ctx, system_theme_get_fg_color());
       // Number: centred horizontally at stg_cx
       graphics_draw_text(ctx, stg_buf, centre_font,
           GRect(stg_x + left_pad, stg_y + ty_s, nsz.w + 2, nsz.h),
@@ -968,7 +971,7 @@ static void prv_canvas_draw(Layer *layer, GContext *ctx) {
             weather_fb_row_set(ri.data, ax, GColorBlackARGB8);
 #else
             uint8_t pixel = srow[sx];
-            if (pixel == 0xFF) continue;   // GColor8 white
+            if (pixel == system_theme_get_bg_color().argb) continue;
             weather_fb_row_set(ri.data, ax, pixel);
 #endif
           }
@@ -1237,7 +1240,7 @@ static void prv_window_load(Window *window) {
   // window with the bg colour every frame unless transparent, and prv_canvas_draw always
   // paints every pixel (its own white fill / the squash resample). See forecast_list's
   // matching change. The !s_cf early-return keeps a white guard.
-  window_set_background_color(window, PBL_IF_ROUND_ELSE(GColorClear, GColorWhite));
+  window_set_background_color(window, PBL_IF_ROUND_ELSE(GColorClear, system_theme_get_bg_color()));
   GRect bounds = layer_get_bounds(window_get_root_layer(window));
   s_cf->canvas = layer_create(bounds);
   layer_set_update_proc(s_cf->canvas, prv_canvas_draw);

--- a/src/fw/apps/system/weather/expanded_view.c
+++ b/src/fw/apps/system/weather/expanded_view.c
@@ -232,7 +232,10 @@ static void prv_set_from_forecast(const WeatherLocationForecast *f,
   if (raw) {
     s_ev->icon = gdraw_command_image_clone(raw);   // writable copy so we can scale it
     gdraw_command_image_destroy(raw);
-    if (s_ev->icon) gdraw_command_image_scale(s_ev->icon, GSize(EV_ICON_SIZE, EV_ICON_SIZE));
+    if (s_ev->icon) {
+      gdraw_command_image_scale(s_ev->icon, GSize(EV_ICON_SIZE, EV_ICON_SIZE));
+      weather_recolor_pdc_image_for_dark_mode(s_ev->icon);
+    }
   }
 }
 
@@ -307,7 +310,7 @@ static void prv_draw_gauge(GContext *ctx, int cx, int cy, int r, const char *lab
     int v = value < 0 ? 0 : (value > max_val ? max_val : value);
     int32_t filled = weather_scale_i32(EV_GAUGE_ARC_SPAN, v, max_val);
     if (filled > 0) {
-      graphics_context_set_fill_color(ctx, PBL_IF_COLOR_ELSE(fill, GColorBlack));
+      graphics_context_set_fill_color(ctx, PBL_IF_COLOR_ELSE(fill, system_theme_get_fg_color()));
       graphics_fill_radial(ctx, ring, GOvalScaleModeFitCircle, EV_GAUGE_RING_W,
                            EV_GAUGE_ARC_START, EV_GAUGE_ARC_START + filled);
     }
@@ -315,7 +318,7 @@ static void prv_draw_gauge(GContext *ctx, int cx, int cy, int r, const char *lab
   char vbuf[12];
   if (unknown) snprintf(vbuf, sizeof(vbuf), "--");
   else         snprintf(vbuf, sizeof(vbuf), "%d%s", value, unit);
-  graphics_context_set_text_color(ctx, GColorBlack);
+  graphics_context_set_text_color(ctx, system_theme_get_fg_color());
   graphics_draw_text(ctx, vbuf, fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD),
                      GRect(cx - r + 2, cy - 12, 2 * r - 4, 24),
                      GTextOverflowModeTrailingEllipsis, GTextAlignmentCenter, NULL);
@@ -368,7 +371,7 @@ static void prv_draw_precip_pill(GContext *ctx, int W, int tdx, int precip) {
 void expanded_view_draw_glance_content(GContext *ctx, int W, int tdx, const char *status,
                                        const char *sunset, const char *temp, int uv, int precip,
                                        int wind) {
-  graphics_context_set_text_color(ctx, GColorBlack);
+  graphics_context_set_text_color(ctx, system_theme_get_fg_color());
   // Status bar (top) — the time or "Last updated ..."; NULL while the card draws the swap itself.
   if (status) {
     graphics_draw_text(ctx, status, fonts_get_system_font(EV_STATUS_FONT),
@@ -448,7 +451,7 @@ void expanded_view_draw_glance_content(GContext *ctx, int W, int tdx, const char
     if (precip >= 0) snprintf(rain_part, sizeof(rain_part), "RAIN %d%%", precip);
     else             snprintf(rain_part, sizeof(rain_part), "RAIN --");
     snprintf(meters, sizeof(meters), "%s   %s", uv_part, rain_part);
-    graphics_context_set_text_color(ctx, GColorBlack);
+    graphics_context_set_text_color(ctx, system_theme_get_fg_color());
     graphics_draw_text(ctx, meters, fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD),
                        GRect(tdx, EV_METERS_Y, W, 22),
                        GTextOverflowModeTrailingEllipsis, GTextAlignmentCenter, NULL);
@@ -466,7 +469,7 @@ static void prv_canvas_draw(Layer *layer, GContext *ctx) {
   GRect b = layer_get_bounds(layer);
   const int W = b.size.w;
 
-  graphics_context_set_fill_color(ctx, GColorWhite);
+  graphics_context_set_fill_color(ctx, system_theme_get_bg_color());
   graphics_fill_rect(ctx, b, 0, GCornerNone);
 
   // Icon stays fixed (the hero fly placed it); everything else slides in from the left + bounces.
@@ -487,7 +490,7 @@ static void prv_canvas_draw(Layer *layer, GContext *ctx) {
     prv_build_time(time_str, sizeof(time_str));
     const int sx = (int)interpolate_moook_soft(s_ev->swap_p, 0, W, 3);
     GFont f = fonts_get_system_font(EV_STATUS_FONT);
-    graphics_context_set_text_color(ctx, GColorBlack);
+    graphics_context_set_text_color(ctx, system_theme_get_fg_color());
     graphics_draw_text(ctx, s_ev->updated_str, f, GRect(sx, EV_STATUS_Y, W, 20),
                        GTextOverflowModeTrailingEllipsis, GTextAlignmentCenter, NULL);
     graphics_draw_text(ctx, time_str, f, GRect(sx - W, EV_STATUS_Y, W, 20),
@@ -509,7 +512,7 @@ static void prv_canvas_draw(Layer *layer, GContext *ctx) {
   // half-circle reads as a rendering glitch, not an affordance.
   if (!EV_SMALL_RECT) {
     const int select_protrusion = 5;
-    graphics_context_set_fill_color(ctx, GColorBlack);
+    graphics_context_set_fill_color(ctx, system_theme_get_fg_color());
     graphics_fill_oval(ctx, GRect(W - select_protrusion, (b.size.h - 26) / 2, 26, 26),
                        GOvalScaleModeFitCircle);
   }
@@ -524,7 +527,7 @@ static void prv_canvas_draw(Layer *layer, GContext *ctx) {
     const int arrow_band = 18;
     const GRect down_frame = GRect(0, b.size.h - arrow_band, W, arrow_band);
     content_indicator_draw_arrow(ctx, &down_frame, ContentIndicatorDirectionDown,
-                                 GColorBlack, GColorWhite, GAlignCenter);
+                                 system_theme_get_fg_color(), system_theme_get_bg_color(), GAlignCenter);
   }
 #endif
 }
@@ -719,7 +722,7 @@ static void prv_window_appear(Window *window) {
 
 static void prv_window_load(Window *window) {
   if (!s_ev) return;
-  window_set_background_color(window, GColorWhite);
+  window_set_background_color(window, system_theme_get_bg_color());
   GRect bounds = layer_get_bounds(window_get_root_layer(window));
   GRect frame = bounds;
   // Globe-BACK entrance (BOTH shapes): start the whole card off-screen to the left so its first

--- a/src/fw/apps/system/weather/forecast_list.c
+++ b/src/fw/apps/system/weather/forecast_list.c
@@ -246,7 +246,8 @@ static uint32_t prv_official_weather_pdc_res_small(WeatherType t) {
 static WeatherType prv_header_type(void);
 #endif
 static void prv_load_icons(void) {
-#ifdef CONFIG_TOUCH
+  if (!s_list) return;
+#if defined(CONFIG_TOUCH) && !PBL_ROUND
   s_list->today_header_dirty = true;   // today's date/condition changed → recompute layout
 #endif
 #if defined(CONFIG_TOUCH)
@@ -261,6 +262,7 @@ static void prv_load_icons(void) {
         prv_official_weather_pdc_res(s_list->days[i].current_weather_type));
     s_list->pdc_icons[i] = raw ? gdraw_command_image_clone(raw) : NULL;
     if (raw) gdraw_command_image_destroy(raw);
+    weather_recolor_pdc_image_for_dark_mode(s_list->pdc_icons[i]);
   }
   // Larger today icon for the summary header: official SMALL (50px) PDC scaled down.
   if (s_list->today_pdc) {
@@ -275,6 +277,7 @@ static void prv_load_icons(void) {
       gdraw_command_image_destroy(traw);
       if (s_list->today_pdc) {
         gdraw_command_image_scale(s_list->today_pdc, GSize(R5_TODAY_ICON, R5_TODAY_ICON));
+        weather_recolor_pdc_image_for_dark_mode(s_list->today_pdc);
       }
     }
   }
@@ -655,6 +658,7 @@ static void prv_start_up_to_card(void) {
       weather_type_icon_large_resource(prv_header_type()));
   GDrawCommandImage *pdc = raw ? gdraw_command_image_clone(raw) : NULL;
   if (raw) gdraw_command_image_destroy(raw);
+  weather_recolor_pdc_image_for_dark_mode(pdc);
   if (!pdc) { prv_start_squash(SQUASH_DOWN_EXIT); return; }
   const int W = layer_get_bounds(s_list->canvas).size.w;
   s_list->fly_pdc   = pdc;
@@ -1043,6 +1047,7 @@ static void prv_start_report_stage3(void) {
       gdraw_command_image_create_with_resource(RESOURCE_ID_WEATHER_REPORT_PAPER);
   s_list->fly_pdc = raw ? gdraw_command_image_clone(raw) : NULL;   // flash PDC is read-only
   if (raw) gdraw_command_image_destroy(raw);
+  weather_recolor_pdc_image_for_dark_mode(s_list->fly_pdc);
   // Frozen fan start-ray (Timeline picks a random ray per unfold; RTC seconds vary plenty).
   s_list->report_angle = (int32_t)(rtc_get_time() % TRIG_MAX_ANGLE);
   if (!s_list->fly_pdc) {   // resource missing: skip straight to the handoff
@@ -1109,10 +1114,10 @@ static void prv_start_report_stage4(void) {
 static void prv_draw_report_ball(GContext *ctx) {
   const GRect mb = layer_get_bounds(s_list->canvas);
   const int cx = s_list->fx_ball_x, cy = R5_SCREEN_CY;
-  graphics_context_set_fill_color(ctx, GColorBlack);
+  graphics_context_set_fill_color(ctx, system_theme_get_fg_color());
   graphics_fill_circle(ctx, GPoint(cx, cy), R5_REPORT_BALL_R);
   const int32_t a = -(int32_t)(mb.size.w + R5_REPORT_BALL_R + 1 - cx) * (TRIG_MAX_ANGLE / 82);
-  graphics_context_set_fill_color(ctx, GColorWhite);
+  graphics_context_set_fill_color(ctx, system_theme_get_bg_color());
   graphics_fill_circle(ctx, GPoint(cx + (int)((int32_t)sin_lookup(a) * 7 / TRIG_MAX_RATIO),
                                    cy - (int)((int32_t)cos_lookup(a) * 7 / TRIG_MAX_RATIO)), 3);
 }
@@ -1140,7 +1145,7 @@ static void prv_draw_unfolding_paper(GContext *ctx) {
   const GRect mb = layer_get_bounds(s_list->canvas);
   const GPoint origin = GPoint((mb.size.w - nsz.w) / 2, R5_SCREEN_CY - nsz.h / 2);
   if (4 * up < ANIMATION_NORMALIZED_MAX) {   // dot phase: keep the ball UNDER the fat stroke
-    graphics_context_set_fill_color(ctx, GColorBlack);
+    graphics_context_set_fill_color(ctx, system_theme_get_fg_color());
     graphics_fill_circle(ctx, GPoint(mb.size.w / 2, R5_SCREEN_CY), R5_REPORT_BALL_R);
   }
   const GRect to   = GRect(0, 0, nsz.w, nsz.h);
@@ -1183,7 +1188,7 @@ static void prv_draw_report_caption(GContext *ctx, int dx, bool settled) {
     dy = (int)(6 * ((int64_t)q * q / ANIMATION_NORMALIZED_MAX) / ANIMATION_NORMALIZED_MAX);
   }
   const GRect mb = layer_get_bounds(s_list->canvas);
-  graphics_context_set_text_color(ctx, GColorBlack);
+  graphics_context_set_text_color(ctx, system_theme_get_fg_color());
   graphics_draw_text(ctx, "WEATHER REPORT", fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD),
                      GRect(dx, R5_SCREEN_CY + 46 + dy, mb.size.w, 24),
                      GTextOverflowModeTrailingEllipsis, GTextAlignmentCenter, NULL);
@@ -1451,7 +1456,7 @@ static void prv_draw_stat_row(GContext *ctx, const WeatherLocationForecast *fan,
                               const int *col_x, int y) {
   GFont vfont = s_list->day_font;   // GOTHIC_14_BOLD, cached at load
   const int cw = R5_COL_STEP_ICON;
-  graphics_context_set_text_color(ctx, GColorBlack);
+  graphics_context_set_text_color(ctx, system_theme_get_fg_color());
   for (int i = 0; i < n; i++) {
     const int v = fan[i].today_precip_mm;
     char buf[16];
@@ -1481,7 +1486,7 @@ static void prv_draw_bottom_stats(GContext *ctx, const WeatherLocationForecast *
     // black circle, horizontally centred, the same 30px above the bottom edge as Timeline. On emery
     // (>=200px height -> s_style_large) its centre lands at y = future_top_margin(7) + fat_pin(131) +
     // future_dot_offset(16) + thin_pin(88)/2 = 198 on the 228px screen.
-    graphics_context_set_fill_color(ctx, GColorBlack);
+    graphics_context_set_fill_color(ctx, system_theme_get_fg_color());
     graphics_fill_circle(ctx, GPoint(W / 2, R5_DOT_REST_Y + slide), 6);
   }
 }
@@ -1538,7 +1543,7 @@ static void prv_draw_sun_body(GContext *ctx, GPoint c, int scale_pct, GColor out
     {(int16_t)a,  (int16_t)-d}, {(int16_t)d,  (int16_t)-a},
   };
   GPath path = { .num_points = 8, .points = pts, .offset = c };
-  graphics_context_set_fill_color(ctx, GColorWhite);
+  graphics_context_set_fill_color(ctx, system_theme_get_bg_color());
   gpath_draw_filled(ctx, &path);
   graphics_context_set_stroke_color(ctx, outline_col);
   graphics_context_set_stroke_width(ctx, 3);     // the PDC body's own stroke width
@@ -1607,7 +1612,7 @@ static int prv_sun_proj(int32_t r10, int32_t trig, int c) {
 }
 
 static void prv_draw_animated_sun(GContext *ctx, GPoint c, int32_t phase, int scale_pct) {
-  const GColor sun_color = GColorBlack;
+  const GColor sun_color = system_theme_get_fg_color();
   graphics_context_set_antialiased(ctx, true);
   // The PDC's own octagon, fill + stroked outline (see prv_draw_sun_body).
   prv_draw_sun_body(ctx, c, scale_pct, sun_color);
@@ -1796,7 +1801,7 @@ static void prv_draw_flake(GContext *ctx, GPoint c, int r) {
 
 static void prv_draw_animated_precip(GContext *ctx, GPoint pdc_offset, int32_t phase,
                                      const PrecipStyle *st) {
-  const GColor main_col = GColorBlack;   // one ink for all precip — flakes included
+  const GColor main_col = system_theme_get_fg_color();   // one ink for all precip — flakes included
   const GColor pale_col = main_col;      // (white flakes vanished on the white page)
   // phase is the sun-angle accumulator -> back to a tick count (sun-speed independent).
   const int tick = phase / R5_SUN_ANGLE_STEP;
@@ -1930,7 +1935,7 @@ static void prv_draw_series_links(GContext *ctx, const int *colx, const int *y,
 static void prv_draw_ring_dot(GContext *ctx, GPoint p, GColor ring) {
   graphics_context_set_fill_color(ctx, ring);
   graphics_fill_circle(ctx, p, 4);
-  graphics_context_set_fill_color(ctx, GColorWhite);
+  graphics_context_set_fill_color(ctx, system_theme_get_bg_color());
   graphics_fill_circle(ctx, p, 2);
 }
 
@@ -1957,7 +1962,7 @@ static void prv_canvas_draw_round_5day(Layer *layer, GContext *ctx) {
   GRect bounds = layer_get_bounds(layer);
   const int W = bounds.size.w;
 
-  graphics_context_set_fill_color(ctx, GColorWhite);
+  graphics_context_set_fill_color(ctx, system_theme_get_bg_color());
   graphics_fill_rect(ctx, bounds, 0, GCornerNone);
 
   // DOWN/UP header transition offsets (BOTH boards). hs = px the today header is translated
@@ -1988,7 +1993,7 @@ static void prv_canvas_draw_round_5day(Layer *layer, GContext *ctx) {
     const int sb_fh = fonts_get_font_height(sb_font);
     const int sb_ty = (STATUS_BAR_LAYER_HEIGHT - 2 * STATUS_BAR_LAYER_SEPARATOR_Y_OFFSET - sb_fh)
                       - hs;
-    graphics_context_set_text_color(ctx, GColorBlack);
+    graphics_context_set_text_color(ctx, system_theme_get_fg_color());
     if (s_list->clock_loc_show || s_list->clock_swap_active) {
       // First entry: the active location holds the slot, then swaps out exactly like
       // the sunset card's status bar — location exits right, time trails from the left.
@@ -2140,7 +2145,7 @@ static void prv_canvas_draw_round_5day(Layer *layer, GContext *ctx) {
     // colour animation drops down + dither-fades out into the page. Second half: from that
     // blank frame, the static icon rises up into position + fades in. The dither erases to
     // the page white so only the bitmap fades — no box.
-    const GColor icon_bg = GColorWhite;
+    const GColor icon_bg = system_theme_get_bg_color();
     const int half = R5_FADE_MAX / 2;
     if (fade > half) {
       // Outgoing colour animation: drop down + fade out into the banner.
@@ -2171,7 +2176,7 @@ static void prv_canvas_draw_round_5day(Layer *layer, GContext *ctx) {
   }
   // Large temp, sized + vertically aligned to balance the 40px today icon.
 #if PBL_ROUND
-  graphics_context_set_text_color(ctx, GColorBlack);
+  graphics_context_set_text_color(ctx, system_theme_get_fg_color());
   graphics_draw_text(ctx, tnow, fonts_get_system_font(FONT_KEY_LECO_36_BOLD_NUMBERS),
       GRect(112, 22 - hs, 120, 44),   // -hs: ride the header scroll off the top
       GTextOverflowModeTrailingEllipsis, GTextAlignmentCenter, NULL);
@@ -2179,7 +2184,7 @@ static void prv_canvas_draw_round_5day(Layer *layer, GContext *ctx) {
   // Emery: FLAT BLACK LECO on the white page — the Timeline sloth-screen grammar: black
   // type directly on the field, white reserved for fills inside the black-inked artwork.
   // Right margin equals the icon's left margin (R5_TODAY_X).
-  graphics_context_set_text_color(ctx, GColorBlack);
+  graphics_context_set_text_color(ctx, system_theme_get_fg_color());
   graphics_draw_text(ctx, tnow, fonts_get_system_font(FONT_KEY_LECO_36_BOLD_NUMBERS),
       GRect(W - R5_TODAY_X - 120, R5_TODAY_Y - 2 - hs, 120, 44),   // -2: LECO parks low
       GTextOverflowModeTrailingEllipsis, GTextAlignmentRight, NULL);
@@ -2191,7 +2196,7 @@ static void prv_canvas_draw_round_5day(Layer *layer, GContext *ctx) {
   // Title-case (e.g. "Partly Cloudy") — Pebble reserves ALL CAPS for terse labels/units.
   // Condition matches the date: same font/size/weight, same baseline (date is on
   // the left under the icon, condition on the right under the temp).
-  graphics_context_set_text_color(ctx, GColorBlack);   // black on the page
+  graphics_context_set_text_color(ctx, system_theme_get_fg_color());   // foreground on the page
   // Condition: right-anchored at x=230 (mirrors the left date, aligned to the fan's
   // 30/230 columns), growing LEFT as it lengthens down to x=110 (just clear of the
   // date). Length-dependent: measure the phrase + step the font down one size if even
@@ -2201,7 +2206,7 @@ static void prv_canvas_draw_round_5day(Layer *layer, GContext *ctx) {
   graphics_draw_text(ctx, cond, cond_font,
       GRect(cond_l, R5_DAYDATE_Y - hs, cond_r - cond_l, 16),
       GTextOverflowModeTrailingEllipsis, GTextAlignmentRight, NULL);
-  graphics_context_set_text_color(ctx, GColorBlack);   // black on the page
+  graphics_context_set_text_color(ctx, system_theme_get_fg_color());   // foreground on the page
   // Date: left box, left-aligned (the today icon above is centred over this string).
   graphics_draw_text(ctx, daydate, day_font,   // day_font IS GOTHIC_14_BOLD — no re-lookup
       GRect(PBL_IF_ROUND_ELSE(30, R5_TODAY_X), R5_DAYDATE_Y - hs,
@@ -2220,7 +2225,7 @@ static void prv_canvas_draw_round_5day(Layer *layer, GContext *ctx) {
     const int cx = col_icon[i];
 
     const char *weekday = s_list->weekday_cache[i];   // built in the date-cache block above
-    graphics_context_set_text_color(ctx, GColorBlack);
+    graphics_context_set_text_color(ctx, system_theme_get_fg_color());
     const int bow = R5_BOW_DY(i, n, ss);   // slight follow-the-glass curve (round only)
     if (!R5_DAYNAME_SCROLL_HIDE || ss * 4 < R5_SECTION_TRAVEL) {
       graphics_draw_text(ctx, weekday, day_font,
@@ -2361,8 +2366,8 @@ static void prv_canvas_draw_round_5day(Layer *layer, GContext *ctx) {
     for (int i = 0; i < n; i++) {
       if (okh[i]) prv_draw_ring_dot(ctx, GPoint(col_high[i], yh[i]), GColorOrange);
     }
-    // Numerals: both bold black — high ABOVE its dot, low BELOW its dot.
-    graphics_context_set_text_color(ctx, GColorBlack);
+    // Numerals: both bold — high ABOVE its dot, low BELOW its dot.
+    graphics_context_set_text_color(ctx, system_theme_get_fg_color());
     for (int i = 0; i < n; i++) {
       if (okh[i]) prv_draw_temp_centered(ctx, th[i], day_font, col_high[i], yh[i] - 4 - 16);
       if (okl[i]) prv_draw_temp_centered(ctx, tl[i], day_font, col_low[i], yl[i] + 4);
@@ -2419,20 +2424,20 @@ static void prv_canvas_draw_round_5day(Layer *layer, GContext *ctx) {
     if (okh[i]) {
       graphics_context_set_fill_color(ctx, GColorOrange);
       graphics_fill_circle(ctx, GPoint(col_high[i], y_hi[i]), R5_DOT_R);
-      graphics_context_set_fill_color(ctx, GColorWhite);
+      graphics_context_set_fill_color(ctx, system_theme_get_bg_color());
       graphics_fill_circle(ctx, GPoint(col_high[i], y_hi[i]), R5_DOT_INNER);
     }
     if (okl[i]) {
       graphics_context_set_fill_color(ctx, GColorVividCerulean);
       graphics_fill_circle(ctx, GPoint(col_low[i], y_lo[i]), R5_DOT_R);
-      graphics_context_set_fill_color(ctx, GColorWhite);
+      graphics_context_set_fill_color(ctx, system_theme_get_bg_color());
       graphics_fill_circle(ctx, GPoint(col_low[i], y_lo[i]), R5_DOT_INNER);
     }
   }
   // Temperature labels: high ABOVE its warm dot, low BELOW its cool dot.
   for (int i = 0; i < n; i++) {
     char hs[16], ls[16];
-    graphics_context_set_text_color(ctx, GColorBlack);  // black numerals; dots/lines stay coloured
+    graphics_context_set_text_color(ctx, system_theme_get_fg_color());  // numerals; dots/lines stay coloured
     if (okh[i]) {
       snprintf(hs, sizeof(hs), "%d\xC2\xB0", fan[i].today_high);
       graphics_draw_text(ctx, hs, small_font,
@@ -2456,7 +2461,7 @@ static void prv_canvas_draw(Layer *layer, GContext *ctx) {
   // The window bg is transparent on round (step 3) — this proc is what guarantees full
   // coverage, so the degenerate no-state frame must paint the white itself.
   if (!s_list) {
-    graphics_context_set_fill_color(ctx, GColorWhite);
+    graphics_context_set_fill_color(ctx, system_theme_get_bg_color());
     graphics_fill_rect(ctx, layer_get_bounds(layer), 0, GCornerNone);
     return;
   }
@@ -2465,9 +2470,9 @@ static void prv_canvas_draw(Layer *layer, GContext *ctx) {
 #endif
 #ifdef CONFIG_TOUCH
   if (s_list->report_fx == 4) {
-    // Stage 4 — the paper's bow: white card, the paper squash-stretching off the left
+    // Stage 4 — the paper's bow: card, the paper squash-stretching off the left
     // (its own points deform — Timeline smiley exit), the caption sliding out with it.
-    graphics_context_set_fill_color(ctx, GColorWhite);
+    graphics_context_set_fill_color(ctx, system_theme_get_bg_color());
     graphics_fill_rect(ctx, layer_get_bounds(layer), 0, GCornerNone);
     prv_draw_exiting_paper(ctx);
     const int dx = (int)prv_moook_full(s_list->report_p, 0,
@@ -2482,9 +2487,9 @@ static void prv_canvas_draw(Layer *layer, GContext *ctx) {
     // prv_render_squash_in below overwrites every pixel from it — re-rendering the scene
     // here would be pure per-frame waste. Skip it.
   } else if (s_list->report_fx >= 2 && !PBL_IF_ROUND_ELSE(0, s_list->squash_mode)) {
-    // Report scene, content cleared off-left: a pure-white title-card backdrop (matches the
+    // Report scene, content cleared off-left: a title-card backdrop (matches the
     // squash memset and the report window bg — seamless at both cuts).
-    graphics_context_set_fill_color(ctx, GColorWhite);
+    graphics_context_set_fill_color(ctx, system_theme_get_bg_color());
     graphics_fill_rect(ctx, layer_get_bounds(layer), 0, GCornerNone);
   } else
   prv_canvas_draw_round_5day(layer, ctx);
@@ -2497,7 +2502,7 @@ static void prv_canvas_draw(Layer *layer, GContext *ctx) {
       !s_list->report_fx) {
     const int protrusion = 5;
     GRect mb = layer_get_bounds(layer);
-    graphics_context_set_fill_color(ctx, GColorBlack);
+    graphics_context_set_fill_color(ctx, system_theme_get_fg_color());
     graphics_fill_oval(ctx, GRect(mb.size.w - protrusion, (mb.size.h - 26) / 2, 26, 26),
                        GOvalScaleModeFitCircle);
   }
@@ -2518,11 +2523,11 @@ static void prv_canvas_draw(Layer *layer, GContext *ctx) {
     const int arrow_band = 18;
     const GRect up_frame = GRect(0, 0, ab.size.w, arrow_band);
     content_indicator_draw_arrow(ctx, &up_frame, ContentIndicatorDirectionUp,
-                                 GColorBlack, GColorWhite, GAlignCenter);
+                                 system_theme_get_fg_color(), system_theme_get_bg_color(), GAlignCenter);
     if (s_list->header_shown) {
       const GRect down_frame = GRect(0, ab.size.h - arrow_band, ab.size.w, arrow_band);
       content_indicator_draw_arrow(ctx, &down_frame, ContentIndicatorDirectionDown,
-                                   GColorBlack, GColorWhite, GAlignCenter);
+                                   system_theme_get_fg_color(), system_theme_get_bg_color(), GAlignCenter);
     }
   }
 #endif
@@ -2533,7 +2538,7 @@ static void prv_canvas_draw(Layer *layer, GContext *ctx) {
     // (stage 1) / orbital-shakes (stage 2) crisply while the frame jelly-stretches off the top.
     // Shared: it is the subject of the transition on both shapes.
     GRect mb = layer_get_bounds(layer);
-    graphics_context_set_fill_color(ctx, GColorBlack);
+    graphics_context_set_fill_color(ctx, system_theme_get_fg_color());
     graphics_fill_circle(ctx, GPoint(mb.size.w / 2 + s_list->fx_shake_dx,
                                      s_list->fx_dot_y + s_list->fx_shake_dy), 6);
   }
@@ -2576,11 +2581,11 @@ static void prv_canvas_draw(Layer *layer, GContext *ctx) {
   int off = s_list->scroll_offset_px;
 
   // Background
-  graphics_context_set_fill_color(ctx, GColorWhite);
+  graphics_context_set_fill_color(ctx, system_theme_get_bg_color());
   graphics_fill_rect(ctx, bounds, 0, GCornerNone);
 
   // Hoist context state changes outside the row loop.
-  graphics_context_set_stroke_color(ctx, PBL_IF_COLOR_ELSE(GColorLightGray, GColorBlack));
+  graphics_context_set_stroke_color(ctx, PBL_IF_COLOR_ELSE(GColorLightGray, system_theme_get_fg_color()));
   graphics_context_set_compositing_mode(ctx, GCompOpSet);
 
   int rh = s_list->row_height;
@@ -2624,7 +2629,7 @@ static void prv_canvas_draw(Layer *layer, GContext *ctx) {
     // Day label
     char weekday_label[16];
     prv_fill_weekday_label(i, f->label, weekday_label, sizeof(weekday_label));
-    graphics_context_set_text_color(ctx, GColorBlack);
+    graphics_context_set_text_color(ctx, system_theme_get_fg_color());
     graphics_draw_text(ctx, weekday_label, s_list->day_font,
         GRect(day_label_x, ty, DAY_LABEL_W, 20),
         GTextOverflowModeTrailingEllipsis, GTextAlignmentLeft, NULL);
@@ -2665,12 +2670,11 @@ static void prv_canvas_draw(Layer *layer, GContext *ctx) {
                        0, GCornerNone);
   }
 
-  // Location bar drawn last (covers any row that scrolled under it). Solid black
-  // on the BW boards — the dithered blue rendered the white text unreadable.
-  graphics_context_set_fill_color(ctx, PBL_IF_COLOR_ELSE(GColorVividCerulean, GColorBlack));
+  // Location bar drawn last (covers any row that scrolled under it).
+  graphics_context_set_fill_color(ctx, PBL_IF_COLOR_ELSE(GColorVividCerulean, system_theme_get_fg_color()));
   graphics_fill_rect(ctx, GRect(0, LOCATION_BAR_Y, W, LOCATION_BAR_H),
                      0, GCornerNone);
-  graphics_context_set_text_color(ctx, GColorWhite);
+  graphics_context_set_text_color(ctx, system_theme_get_bg_color());
   GFont bar_font = fonts_get_system_font(FONT_KEY_GOTHIC_14_BOLD);
   const int bar_inset = ROUND_BAR_INSET;
   // Location name: left-aligned
@@ -2963,8 +2967,8 @@ void forecast_list_start_select_exit(void (*done_cb)(void *ctx), void *ctx) {
 #if PBL_ROUND
   // The slide moves the CANVAS FRAME, exposing window pixels nobody paints now that the
   // window bg is transparent (step 3) — the vacated strip would smear stale frames. Restore
-  // the white bg for just this rare 115ms fallback; prv_select_exit_stopped re-clears it.
-  window_set_background_color(s_list->window, GColorWhite);
+  // the bg for just this rare 115ms fallback; prv_select_exit_stopped re-clears it.
+  window_set_background_color(s_list->window, system_theme_get_bg_color());
 #endif
   s_select_exit_anim = prv_start_anim(interpolate_moook_duration() / 2,  // 115ms (Timeline)
                                       AnimationCurveLinear,               // moook is the shaping
@@ -3343,6 +3347,7 @@ static void prv_window_appear(Window *window) {
           weather_type_icon_large_resource(prv_header_type()));
       GDrawCommandImage *pdc = raw ? gdraw_command_image_clone(raw) : NULL;
       if (raw) gdraw_command_image_destroy(raw);
+      weather_recolor_pdc_image_for_dark_mode(pdc);
       if (pdc) {
         const int W = layer_get_bounds(s_list->canvas).size.w;
         s_list->fly_pdc  = pdc;
@@ -3517,7 +3522,7 @@ static void prv_forecast_list_push(const WeatherLocationForecast *days, size_t n
   // on the 260px glass), and every branch of prv_canvas_draw already paints every pixel
   // (scene white-fill first / report white card / squash resample full-coverage), so the
   // window fill was pure duplicate work. The !s_list early-return keeps a white guard.
-  window_set_background_color(s_list->window, PBL_IF_ROUND_ELSE(GColorClear, GColorWhite));
+  window_set_background_color(s_list->window, PBL_IF_ROUND_ELSE(GColorClear, system_theme_get_bg_color()));
   window_set_window_handlers(s_list->window, (WindowHandlers){
     .load   = prv_window_load,
     .appear = prv_window_appear,

--- a/src/fw/apps/system/weather/globe_view.c
+++ b/src/fw/apps/system/weather/globe_view.c
@@ -2270,7 +2270,7 @@ static void show_intro_canvas(GlobeView *view) {
     if (!view) return;
 
     if (view->window) {
-        window_set_background_color(view->window, GColorWhite);
+        window_set_background_color(view->window, system_theme_get_bg_color());
     }
     if (view->canvas_layer) layer_set_hidden(view->canvas_layer, false);
     if (view->space_layer) layer_set_hidden(view->space_layer, true);
@@ -3102,7 +3102,7 @@ static void draw_transition_state(GContext *ctx, GlobeView *view, GPoint origin,
                   frame_size.w + (GLOBE_CRADLE_WIPE_MARGIN * 2),
                   wipe_h + (GLOBE_CRADLE_WIPE_MARGIN * 2));
 
-        graphics_context_set_fill_color(ctx, GColorWhite);
+        graphics_context_set_fill_color(ctx, system_theme_get_bg_color());
         graphics_fill_rect(ctx, wipe_rect,
                            0, GCornerNone);
         if (view->reveal_direction > 0) {
@@ -3151,7 +3151,7 @@ static void draw_intro_title(GContext *ctx, GRect bounds, int globe_y,
     (void)frame_size;
 
     const int header_height = GLOBE_SMALL_RECT ? 24 : 38;
-    graphics_context_set_text_color(ctx, GColorBlack);
+    graphics_context_set_text_color(ctx, system_theme_get_fg_color());
     graphics_draw_text(ctx, "CITY SELECT",
                        fonts_get_system_font(GLOBE_SMALL_RECT ? FONT_KEY_GOTHIC_18_BOLD
                                                               : FONT_KEY_GOTHIC_28_BOLD),
@@ -3159,7 +3159,7 @@ static void draw_intro_title(GContext *ctx, GRect bounds, int globe_y,
                        GTextOverflowModeTrailingEllipsis,
                        GTextAlignmentCenter,
                        NULL);
-    graphics_context_set_fill_color(ctx, GColorBlack);
+    graphics_context_set_fill_color(ctx, system_theme_get_fg_color());
     graphics_fill_rect(ctx,
                        GRect(0, header_height - 2, bounds.size.w, 2),
                        0, GCornerNone);
@@ -3172,7 +3172,7 @@ static void draw_intro_title(GContext *ctx, GRect bounds, int globe_y,
     int title_y = (planet_top - GLOBE_INTRO_TITLE_HEIGHT) / 2;
     if (title_y < 0) title_y = 0;
 
-    graphics_context_set_text_color(ctx, GColorBlack);
+    graphics_context_set_text_color(ctx, system_theme_get_fg_color());
     graphics_draw_text(ctx, title,
                        font,
                        GRect(0, title_y - 4,
@@ -3182,11 +3182,11 @@ static void draw_intro_title(GContext *ctx, GRect bounds, int globe_y,
                        GTextAlignmentCenter,
                        NULL);
     // Divider under the title (round port of the rect city-select redesign): the same
-    // 2px black rule, FULL WIDTH — the round framebuffer clips each row to the glass,
+    // 2px rule, FULL WIDTH — the round framebuffer clips each row to the glass,
     // so drawing edge to edge lands it bezel-to-bezel. Rides title_y like the title.
     {
       const int rule_y = title_y + GLOBE_INTRO_TITLE_HEIGHT - 2;
-      graphics_context_set_fill_color(ctx, GColorBlack);
+      graphics_context_set_fill_color(ctx, system_theme_get_fg_color());
       graphics_fill_rect(ctx, GRect(0, rule_y, bounds.size.w, 2), 0, GCornerNone);
     }
 #endif
@@ -3240,15 +3240,15 @@ static void draw_saved_locations_label(GContext *ctx, GlobeView *view,
 
     // BW: the dithered blue read as noise under white text — the selected bar
     // goes solid black instead.
-    const GColor sel_fill = PBL_IF_COLOR_ELSE(GColorVividCerulean, GColorBlack);
-    graphics_context_set_fill_color(ctx, selected ? sel_fill : GColorWhite);
+    const GColor sel_fill = PBL_IF_COLOR_ELSE(GColorVividCerulean, system_theme_get_fg_color());
+    graphics_context_set_fill_color(ctx, selected ? sel_fill : system_theme_get_bg_color());
     graphics_fill_rect(ctx, GRect(0, y, bounds.size.w, bar_h), 0, GCornerNone);
-    graphics_context_set_fill_color(ctx, GColorBlack);
+    graphics_context_set_fill_color(ctx, system_theme_get_fg_color());
     graphics_fill_rect(ctx, GRect(0, y, bounds.size.w, 2),
                        0, GCornerNone);
 
-    GColor label_color = selected ? GColorWhite : GColorBlack;
-    GColor bg_color = selected ? sel_fill : GColorWhite;
+    GColor label_color = selected ? GColorWhite : system_theme_get_fg_color();
+    GColor bg_color = selected ? sel_fill : system_theme_get_bg_color();
     draw_saved_locations_pin(ctx,
                              GPoint(side_inset,
                                     y + (bar_h - GLOBE_SAVED_COG_SIZE) / 2),
@@ -3299,13 +3299,13 @@ static void draw_saved_locations_label(GContext *ctx, GlobeView *view,
         graphics_fill_rect(ctx, GRect(0, y, bounds.size.w, fill_h),
                            0, GCornerNone);
     }
-    // Divider above the row, ALWAYS drawn (rect redesign parity): 2px black rule replacing
+    // Divider above the row, ALWAYS drawn (rect redesign parity): 2px rule replacing
     // the old selection-only 1px grey line, FULL WIDTH (the glass mask clips it edge to edge).
-    graphics_context_set_fill_color(ctx, GColorBlack);
+    graphics_context_set_fill_color(ctx, system_theme_get_fg_color());
     graphics_fill_rect(ctx, GRect(0, y, bounds.size.w, 2), 0, GCornerNone);
 
-    GColor label_color = selected ? GColorWhite : GColorBlack;
-    GColor bg_color = selected ? GColorVividCerulean : GColorWhite;
+    GColor label_color = selected ? GColorWhite : system_theme_get_fg_color();
+    GColor bg_color = selected ? GColorVividCerulean : system_theme_get_bg_color();
     draw_saved_locations_pin(ctx,
                              GPoint(pin_x, y + (GLOBE_SAVED_LABEL_HEIGHT -
                                                 GLOBE_SAVED_COG_SIZE) / 2),
@@ -3659,7 +3659,7 @@ GlobeView *globe_view_create(void) {
 
     // Configure window
     window_set_user_data(view->window, view);
-    window_set_background_color(view->window, GColorWhite);
+    window_set_background_color(view->window, system_theme_get_bg_color());
     window_set_click_config_provider_with_context(view->window, window_click_provider, view);
     window_set_window_handlers(view->window, (WindowHandlers) {
         .appear = window_appear_handler,

--- a/src/fw/apps/system/weather/layout.c
+++ b/src/fw/apps/system/weather/layout.c
@@ -27,6 +27,7 @@
 #include "pbl/services/timeline/timeline_resources.h"
 #include "pbl/services/weather/weather_service.h"
 #include "pbl/services/weather/weather_types.h"
+#include "shell/system_theme.h"
 #include "system/logging.h"
 #include "system/passert.h"
 #include "util/size.h"
@@ -318,8 +319,8 @@ static void prv_content_indicator_setup_direction(ContentIndicator *content_indi
                                                   ContentIndicatorDirection direction) {
   content_indicator_configure_direction(content_indicator, direction, &(ContentIndicatorConfig) {
     .layer = indicator_layer,
-    .colors.foreground = GColorBlack,
-    .colors.background = GColorWhite,
+    .colors.foreground = system_theme_get_fg_color(),
+    .colors.background = system_theme_get_bg_color(),
   });
 }
 

--- a/src/fw/apps/system/weather/pebble_compat.h
+++ b/src/fw/apps/system/weather/pebble_compat.h
@@ -72,6 +72,7 @@
 #include "util/time/time.h"
 #include "pbl/util/uuid.h"
 #include "pbl/logging/logging.h"
+#include "shell/system_theme.h"
 
 // --- Window-stack call-site shims: the SDK names map 1:1 to the app-window
 //     variants firmware apps must use. ---

--- a/src/fw/apps/system/weather/saved_locations.c
+++ b/src/fw/apps/system/weather/saved_locations.c
@@ -191,7 +191,7 @@ static void prv_draw_glance_row(GContext *ctx, const Layer *cell_layer,
   const bool highlighted = menu_cell_layer_is_highlighted(cell_layer);
   GFont font = fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD);
   graphics_context_set_text_color(ctx,
-                                  highlighted ? GColorWhite : GColorBlack);
+                                  highlighted ? GColorWhite : system_theme_get_fg_color());
 
   char temp_text[12];
   snprintf(temp_text, sizeof(temp_text), "%d°", (int)glance->temp);
@@ -495,7 +495,7 @@ void saved_locations_push(const SavedLocationsConfig *config) {
     return;
   }
   window_set_user_data(view->window, view);
-  window_set_background_color(view->window, GColorWhite);
+  window_set_background_color(view->window, system_theme_get_bg_color());
   window_set_window_handlers(view->window, (WindowHandlers) {
 #ifdef CONFIG_TOUCH
     .appear = prv_window_appear,
@@ -529,10 +529,10 @@ void saved_locations_push(const SavedLocationsConfig *config) {
     .draw_row = prv_draw_row,
     .select_click = prv_select_click,
   });
-  menu_layer_set_normal_colors(view->menu_layer, GColorWhite, GColorBlack);
+  menu_layer_set_normal_colors(view->menu_layer, system_theme_get_bg_color(), system_theme_get_fg_color());
   menu_layer_set_highlight_colors(view->menu_layer,
-                                  PBL_IF_COLOR_ELSE(GColorVividCerulean, GColorBlack),
-                                  GColorWhite);
+                                  PBL_IF_COLOR_ELSE(GColorVividCerulean, system_theme_get_fg_color()),
+                                  system_theme_get_bg_color());
   menu_layer_set_click_config_onto_window(view->menu_layer, view->window);
   layer_add_child(root, menu_layer_get_layer(view->menu_layer));
 

--- a/src/fw/apps/system/weather/weather_app_layout.c
+++ b/src/fw/apps/system/weather/weather_app_layout.c
@@ -297,7 +297,7 @@ static void prv_draw_weather_background(const GRect *circle_bounding_box, GConte
   // erases background chrome (the section rule) behind the icon art's
   // transparent edges while an icon crosses it — icons always read as in
   // front of the rule.
-  graphics_context_set_fill_color(context, GColorWhite);
+  graphics_context_set_fill_color(context, system_theme_get_bg_color());
   graphics_fill_circle(context, center, (uint16_t)(box.size.w / 2 + 4));
   if (!gcolor_equal(background_color, GColorClear)) {
     graphics_context_set_fill_color(context, background_color);
@@ -375,7 +375,7 @@ static int prv_round_rail(int ink_top_y) {
 // would clear at its top row and clip at its bottom (the circle narrows down).
 static void prv_draw_uv_bar_frame(GContext *ctx, GPoint gc, int by, int h,
                                   int r_out, int r_in) {
-  graphics_context_set_fill_color(ctx, GColorBlack);
+  graphics_context_set_fill_color(ctx, system_theme_get_fg_color());
   for (int y = by; y < by + h; y++) {
     const int dy = y - gc.y;
     const int ho = (int)weather_isqrt(
@@ -527,8 +527,8 @@ static void prv_build_forecast_desc(const WeatherLocationForecast *f,
 
 // Little radiant sun for the UV bar: core disc + 8 rays.
 static void prv_draw_sun_glyph(GContext *ctx, GPoint c) {
-  graphics_context_set_fill_color(ctx, GColorBlack);
-  graphics_context_set_stroke_color(ctx, GColorBlack);
+  graphics_context_set_fill_color(ctx, system_theme_get_fg_color());
+  graphics_context_set_stroke_color(ctx, system_theme_get_fg_color());
   graphics_context_set_stroke_width(ctx, 1);
   graphics_fill_circle(ctx, c, 3);
   for (int i = 0; i < 8; i++) {
@@ -618,12 +618,12 @@ void weather_app_layout_draw_uv_bar(GContext *ctx, GPoint gc, int by,
   const int num_w   = c ? WX_UVC_NUM_W   : 46;
   const char *hdr_font = WX_UV_HDR_FONT;   // both sizes use the report's label font
 
-  graphics_context_set_stroke_color(ctx, GColorBlack);
+  graphics_context_set_stroke_color(ctx, system_theme_get_fg_color());
   graphics_context_set_stroke_width(ctx, 1);
   prv_draw_uv_bar_frame(ctx, gc, by, h, r_out, r_in);
   prv_draw_sun_glyph(ctx, GPoint(gc.x + sun_dx,
                                  by + (c ? WX_UVC_SUN_DY : WEATHER_APP_LAYOUT_ROUND_UV_SUN_DY)));
-  graphics_context_set_text_color(ctx, GColorBlack);
+  graphics_context_set_text_color(ctx, system_theme_get_fg_color());
   graphics_draw_text(ctx, label, fonts_get_system_font(hdr_font),
                      GRect(gc.x + hdr_dx, by + hdr_dy, c ? 96 : 70, 20),
                      GTextOverflowModeFill, GTextAlignmentLeft, NULL);
@@ -645,7 +645,7 @@ void weather_app_layout_draw_uv_bar(GContext *ctx, GPoint gc, int by,
     graphics_draw_line(ctx, GPoint(px + 3, py - 3), GPoint(px + 3, py + 3));
     graphics_context_set_stroke_width(ctx, 1);
   }
-  graphics_context_set_fill_color(ctx, GColorBlack);
+  graphics_context_set_fill_color(ctx, system_theme_get_fg_color());
   // The VALUE stays LECO_36 in both sizes — the compact bar shrinks its squares and pulls the
   // value box in, never the digit itself.
   graphics_draw_text(ctx, uv_text, fonts_get_system_font(WX_UV_NUM_FONT),
@@ -865,7 +865,7 @@ static void prv_draw_top_rows(const WeatherAppLayout *layout, GPoint *off, int c
   // LECO_36 +11, G18_BOLD/G18 +7, G14_BOLD +5. Label ink 42..55 then leaves a
   // 14px gap to the temp's ink at 70 -- emery's exact label->temp air. The rail is solved from the ink, not the
   // box, so the curve follows what the eye actually sees.
-  graphics_context_set_text_color(ctx, GColorBlack);
+  graphics_context_set_text_color(ctx, system_theme_get_fg_color());
 
   char caps[24];
   prv_upcase_into(caps, sizeof(caps), t->label);
@@ -950,7 +950,7 @@ static void prv_draw_top_rows(const WeatherAppLayout *layout, GPoint *off, int c
   // Label→temp air: 17px ink gap minus the user's −3 trim = 14 (gap param 3);
   // the rows below stay reference-tight (9/4) and ride with the temp.
   prv_draw_text(line, cw, ctx, caps, layout->location_font,
-                GColorBlack, GTextAlignmentLeft);
+                system_theme_get_fg_color(), GTextAlignmentLeft);
   line.y += fonts_get_font_height(fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD));
   line.y += label_temp_gap;
   // Even ink gaps down the temp / hi-lo / condition stack (matching
@@ -961,15 +961,15 @@ static void prv_draw_top_rows(const WeatherAppLayout *layout, GPoint *off, int c
   // condition riding at 93. (The temp trim moves everything below it; only the hi/lo trim
   // moves the condition relative to the hi/lo.)
   line.y += prv_draw_text(line, cw, ctx, t->temp, layout->temperature_font,
-                          GColorBlack, GTextAlignmentLeft) - 1;
+                          system_theme_get_fg_color(), GTextAlignmentLeft) - 1;
   line.y += prv_draw_text(line, cw, ctx, t->highlow, layout->high_low_phrase_font,
-                          GColorBlack, GTextAlignmentLeft) - 1;
+                          system_theme_get_fg_color(), GTextAlignmentLeft) - 1;
   if (!WEATHER_APP_LAYOUT_RECT_SMALL && t->phrase && t->phrase[0]) {
     // Width-limited so a long phrase ellipsizes before the disc (disc's left
     // edge sits ~x116 in content coords). The small rects skip the phrase row
     // (the header icon carries the condition) to keep the description on-page.
     line.y += prv_draw_text(line, 112, ctx, t->phrase, layout->metrics_value_font,
-                            GColorBlack, GTextAlignmentLeft) - 2;
+                            system_theme_get_fg_color(), GTextAlignmentLeft) - 2;
   }
   // Forecast description ("High UV. Winds SW at 12mph. Precipitation 20%."):
   // warning, wind, precip. Measured and CENTERED in the band between the
@@ -985,7 +985,7 @@ static void prv_draw_top_rows(const WeatherAppLayout *layout, GPoint *off, int c
     const int band_bot = off->y + band_bot_anchor;  // the box's nominal top (keeps desc placement)
     int desc_y = band_top + (band_bot - band_top - dsz.h) / 2;
     if (desc_y < band_top) desc_y = band_top;
-    graphics_context_set_text_color(ctx, GColorBlack);
+    graphics_context_set_text_color(ctx, system_theme_get_fg_color());
     graphics_draw_text(ctx, t->desc, layout->metrics_font,
                        GRect(off->x, desc_y, cw, dsz.h + 2),
                        GTextOverflowModeTrailingEllipsis, GTextAlignmentLeft, NULL);
@@ -1016,7 +1016,7 @@ static void prv_draw_top_rows(const WeatherAppLayout *layout, GPoint *off, int c
       uvv = uvv * 10 + (*c - '0');
     }
     const int by = box_top;
-    graphics_context_set_stroke_color(ctx, GColorBlack);
+    graphics_context_set_stroke_color(ctx, system_theme_get_fg_color());
     graphics_context_set_stroke_width(ctx, 1);
     graphics_draw_rect(ctx, GRect(off->x, by, cw, 40));
     graphics_draw_rect(ctx, GRect(off->x + 1, by + 1, cw - 2, 38));
@@ -1050,7 +1050,7 @@ static void prv_draw_top_rows(const WeatherAppLayout *layout, GPoint *off, int c
       graphics_draw_line(ctx, GPoint(px + 3, py - 3), GPoint(px + 3, py + 3));
       graphics_context_set_stroke_width(ctx, 1);
     }
-    graphics_context_set_fill_color(ctx, GColorBlack);
+    graphics_context_set_fill_color(ctx, system_theme_get_fg_color());
     graphics_draw_text(ctx, t->uv, layout->temperature_font,
                        GRect(off->x + cw - 52, by - 5, 46, 44),
                        GTextOverflowModeFill, GTextAlignmentRight, NULL);
@@ -1114,7 +1114,7 @@ static void prv_draw_bottom_rows(const WeatherAppLayout *layout, GPoint *off, in
   off->x += WEATHER_APP_LAYOUT_BOTTOM_TEXT_X_SHIFT;
   char rcaps[24];
   prv_upcase_into(rcaps, sizeof(rcaps), label);
-  graphics_context_set_text_color(ctx, GColorBlack);
+  graphics_context_set_text_color(ctx, system_theme_get_fg_color());
   const int r_icon_left = layout->tomorrow_icon_rest_frame.origin.x;
   const int r_w = r_icon_left - 4 - off->x;
   graphics_draw_text(ctx, rcaps, layout->tomorrow_font,
@@ -1138,7 +1138,7 @@ static void prv_draw_bottom_rows(const WeatherAppLayout *layout, GPoint *off, in
                                                   : layout->tomorrow_font;
   char caps[24];
   prv_upcase_into(caps, sizeof(caps), label);
-  graphics_context_set_text_color(ctx, GColorBlack);
+  graphics_context_set_text_color(ctx, system_theme_get_fg_color());
   const GSize lsz = graphics_text_layout_get_content_size(
       caps, foot_font, GRect(0, 0, 200, 20), GTextOverflowModeFill,
       GTextAlignmentLeft);
@@ -1455,8 +1455,8 @@ static void prv_render_layout(Layer *layer, GContext *context) {
     int in_dy  = prv_interpolate_text_moook(p, dir_down ? full_h : -full_h, 0);
 
     // ---- TOP HALF (region 0 → separator_y) ----
-    // Fill white first so it acts as a clip: any text drawn outside is invisible.
-    graphics_context_set_fill_color(context, GColorWhite);
+    // Fill background first so it acts as a clip: any text drawn outside is invisible.
+    graphics_context_set_fill_color(context, system_theme_get_bg_color());
     graphics_fill_rect(context, GRect(0, 0, bounds.size.w, separator_y), 0, GCornerNone);
     GPoint top_out = GPoint(content_x_offset, 0 + out_dy);
     prv_draw_snapshot_top(layout, &top_out, content_width, context);
@@ -1464,7 +1464,7 @@ static void prv_render_layout(Layer *layer, GContext *context) {
     prv_draw_top_half_text(layout, &top_in, content_width, context);
 
     // ---- BOTTOM HALF (region separator_y → full_h) ----
-    graphics_context_set_fill_color(context, GColorWhite);
+    graphics_context_set_fill_color(context, system_theme_get_bg_color());
     graphics_fill_rect(context, GRect(0, separator_y, bounds.size.w, full_h - separator_y),
                        0, GCornerNone);
     {
@@ -1518,7 +1518,7 @@ static void prv_render_layout(Layer *layer, GContext *context) {
   // #AAA the hardware offers). 2x2 dots (the darker tone alone carries the
   // "bigger/heavier" read — the taller 3px version was reverted),
   // pitch 4 keeps the reference's ~1:1 dot:gap rhythm.
-  graphics_context_set_fill_color(context, PBL_IF_COLOR_ELSE(GColorDarkGray, GColorBlack));
+  graphics_context_set_fill_color(context, PBL_IF_COLOR_ELSE(GColorDarkGray, system_theme_get_fg_color()));
   // Round sits the rule 3px higher than the region split (and the UV widget moved with it).
   // The split itself is deliberately NOT moved: separator_y also anchors the bottom-half fill
   // and the footer's content offset, so shifting it would carry the TOMORROW block up too.
@@ -1541,14 +1541,16 @@ static void prv_render_layout(Layer *layer, GContext *context) {
   // stepping onto the final day swaps the chevron out for the fin.
   if (layout->next_forecast) {
     const int chin_x = -layout->content_layer_origin.x;   // content coords -> screen 0
-    graphics_context_set_fill_color(context, GColorLightGray);
+    graphics_context_set_fill_color(context, PBL_IF_COLOR_ELSE(
+        system_theme_is_dark_mode() ? GColorDarkGray : GColorLightGray,
+        system_theme_get_bg_color()));
     graphics_fill_rect(context,
                        GRect(chin_x, WEATHER_APP_LAYOUT_ROUND_CHIN_Y, PBL_DISPLAY_WIDTH,
                              PBL_DISPLAY_HEIGHT - WEATHER_APP_LAYOUT_ROUND_CHIN_Y),
                        0, GCornerNone);
     // Solid chevron, built a scanline at a time so it stays a crisp odd-width
     // triangle at any size (13,11,9,...,1) rather than an antialiased path.
-    graphics_context_set_fill_color(context, GColorBlack);
+    graphics_context_set_fill_color(context, system_theme_get_fg_color());
     const int cx = PBL_DISPLAY_WIDTH / 2 + chin_x;
     for (int i = 0; i < WEATHER_APP_LAYOUT_ROUND_CHEV_H; i++) {
       const int half = WEATHER_APP_LAYOUT_ROUND_CHEV_W / 2 - i;
@@ -2049,6 +2051,7 @@ void weather_app_layout_init(WeatherAppLayout *layout, const GRect *frame) {
   if (fin_raw) {
     gdraw_command_image_destroy(fin_raw);  // munmaps the read-only flash mapping
   }
+  weather_recolor_pdc_image_for_dark_mode(layout->fin_pdc);
 #if WEATHER_APP_LAYOUT_USE_PDC_WEATHER_ICONS
   layout->weather_icon_pdc_sequence = NULL;
   layout->current_weather_escape_layer = NULL;
@@ -2193,6 +2196,7 @@ void weather_app_layout_init(WeatherAppLayout *layout, const GRect *frame) {
                                      WEATHER_APP_LAYOUT_ROUND_PDC_ART));
     }
   }
+  weather_recolor_pdc_sequence_for_dark_mode(layout->weather_icon_pdc_sequence);
   layout->current_weather_escape_layer =
       layer_create_with_data(GRect(0, 0, 1, 1), sizeof(WeatherAppLayout *));
   if (layout->current_weather_escape_layer) {

--- a/src/fw/apps/system/weather/weather_math.c
+++ b/src/fw/apps/system/weather/weather_math.c
@@ -54,7 +54,7 @@ static void prv_squash_resample(GBitmap *fb, const uint8_t *scratch,
                                 AnimationProgress m, int mode) {
   GRect b = gbitmap_get_bounds(fb);
   const int W = b.size.w, H = b.size.h;
-  const uint8_t white = GColorWhite.argb;
+  const uint8_t bg_color = system_theme_get_bg_color().argb;
   if (mode == WEATHER_SQUASH_LEFT_EXIT) {
     // Horizontal jelly (the vertical grammar rotated 90°). RIGHT_IN (mode 7) was
     // trimmed with its last caller (the report's old squash-in entrance).
@@ -79,7 +79,7 @@ static void prv_squash_resample(GBitmap *fb, const uint8_t *scratch,
       uint8_t *dst = ri.data;                       // absolute-x
       const uint8_t *src = scratch + (uint32_t)y * W;
       for (int x = (int)ri.min_x; x <= (int)ri.max_x; x++) {
-        if (x < vis0 || x >= vis1) { weather_fb_row_set(dst, x, white); continue; }
+        if (x < vis0 || x >= vis1) { weather_fb_row_set(dst, x, bg_color); continue; }
         int sx = (int)((((int32_t)(x - left_edge)) * sx_step) >> 16);
         if (sx < 0) sx = 0; else if (sx >= W) sx = W - 1;
         weather_fb_row_set(dst, x, src[sx]);
@@ -129,10 +129,10 @@ static void prv_squash_resample(GBitmap *fb, const uint8_t *scratch,
       const uint8_t *src = scratch + (uint32_t)sy * W;
       for (int x = lo; x <= hi; x++) {
         weather_fb_row_set(ri.data, x,
-                           (x >= (int)sri.min_x && x <= (int)sri.max_x) ? src[x] : white);
+                           (x >= (int)sri.min_x && x <= (int)sri.max_x) ? src[x] : bg_color);
       }
     } else {
-      for (int x = lo; x <= hi; x++) weather_fb_row_set(ri.data, x, white);
+      for (int x = lo; x <= hi; x++) weather_fb_row_set(ri.data, x, bg_color);
     }
   }
 }
@@ -257,6 +257,7 @@ void weather_capture_framebuffer_rect(GBitmap *fb, GBitmap *dst,
   int sy = src_rect.origin.y;
   int w = src_rect.size.w;
   int h = src_rect.size.h;
+  const uint8_t bg_argb = system_theme_get_bg_color().argb;
 
   for (int row = 0; row < h; row++) {
     GBitmapDataRowInfo ri = gbitmap_get_data_row_info(fb, (uint16_t)(sy + row));
@@ -265,9 +266,9 @@ void weather_capture_framebuffer_rect(GBitmap *fb, GBitmap *dst,
     // The destination is 1-bit on the BW boards (8-bit blanks are refused
     // there), so both sides are packed. dst_x is a byte offset and stays 0
     // for the 1-bit callers.
-    memset(dst_row, 0xFF, dbpr);
+    memset(dst_row, bg_argb, dbpr);
 #else
-    memset(dst_row, 0xFF, (size_t)w);
+    memset(dst_row, bg_argb, (size_t)w);
 #endif
 
     int xs = sx > (int)ri.min_x ? sx : (int)ri.min_x;
@@ -277,12 +278,12 @@ void weather_capture_framebuffer_rect(GBitmap *fb, GBitmap *dst,
       for (int x = xs; x <= xe; x++) {
         bitset8_update(dst_row, (unsigned)(x - sx),
                        bitset8_get(ri.data, (unsigned)x));
-        weather_fb_row_set(ri.data, x, GColorWhiteARGB8);
+        weather_fb_row_set(ri.data, x, bg_argb);
       }
 #else
       size_t n = (size_t)(xe - xs + 1);
       memcpy(dst_row + (xs - sx), ri.data + xs, n);
-      memset(ri.data + xs, 0xFF, n);
+      memset(ri.data + xs, bg_argb, n);
 #endif
     }
   }
@@ -336,7 +337,7 @@ void weather_draw_lava_ring(GContext *ctx, GPoint center, int outer_r,
   int sy1 = center.y - (int)((int32_t)cos_lookup(phase) * outer_r / TRIG_MAX_RATIO);
   int sx2 = center.x + (int)((int32_t)sin_lookup(neg) * outer_r / TRIG_MAX_RATIO);
   int sy2 = center.y - (int)((int32_t)cos_lookup(neg) * outer_r / TRIG_MAX_RATIO);
-  graphics_context_set_fill_color(ctx, GColorWhite);
+  graphics_context_set_fill_color(ctx, system_theme_get_bg_color());
   graphics_fill_circle(ctx, GPoint(sx1, sy1), 2);
   graphics_fill_circle(ctx, GPoint(sx2, sy2), 2);
 
@@ -350,5 +351,43 @@ void weather_draw_lava_ring(GContext *ctx, GPoint center, int outer_r,
     int bx = center.x + (int)((int32_t)sin_lookup(b_ang[b]) * outer_r / TRIG_MAX_RATIO);
     int by = center.y - (int)((int32_t)cos_lookup(b_ang[b]) * outer_r / TRIG_MAX_RATIO);
     graphics_fill_circle(ctx, GPoint(bx, by), 1);
+  }
+}
+
+static bool prv_recolor_pdc_command_cb(GDrawCommand *command, uint32_t index, void *context) {
+  (void)index;
+  (void)context;
+  GColor stroke = gdraw_command_get_stroke_color(command);
+  if (gcolor_equal(stroke, GColorBlack)) {
+    gdraw_command_set_stroke_color(command, GColorWhite);
+  } else if (gcolor_equal(stroke, GColorWhite)) {
+    gdraw_command_set_stroke_color(command, GColorBlack);
+  }
+  GColor fill = gdraw_command_get_fill_color(command);
+  if (gcolor_equal(fill, GColorWhite)) {
+    gdraw_command_set_fill_color(command, GColorBlack);
+  } else if (gcolor_equal(fill, GColorBlack)) {
+    gdraw_command_set_fill_color(command, GColorWhite);
+  }
+  return true;
+}
+
+void weather_recolor_pdc_image_for_dark_mode(GDrawCommandImage *image) {
+  if (!image || !system_theme_is_dark_mode()) return;
+  GDrawCommandList *list = gdraw_command_image_get_command_list(image);
+  if (list) {
+    gdraw_command_list_iterate(list, prv_recolor_pdc_command_cb, NULL);
+  }
+}
+
+void weather_recolor_pdc_sequence_for_dark_mode(GDrawCommandSequence *sequence) {
+  if (!sequence || !system_theme_is_dark_mode()) return;
+  const uint32_t nframes = gdraw_command_sequence_get_num_frames(sequence);
+  for (uint32_t i = 0; i < nframes; i++) {
+    GDrawCommandFrame *f = gdraw_command_sequence_get_frame_by_index(sequence, i);
+    if (f) {
+      gdraw_command_list_iterate(gdraw_command_frame_get_command_list(f),
+                                 prv_recolor_pdc_command_cb, NULL);
+    }
   }
 }

--- a/src/fw/apps/system/weather/weather_math.h
+++ b/src/fw/apps/system/weather/weather_math.h
@@ -91,3 +91,7 @@ void weather_render_squash(GContext *ctx, uint8_t *scratch, AnimationProgress m,
 // smoothness step 2); rect keeps calling weather_render_squash unchanged.
 void weather_render_squash_cached(GContext *ctx, const uint8_t *scratch,
                                   AnimationProgress m, int mode);
+
+//! Invert PDC icon black/white colors when system is in dark mode.
+void weather_recolor_pdc_image_for_dark_mode(GDrawCommandImage *image);
+void weather_recolor_pdc_sequence_for_dark_mode(GDrawCommandSequence *sequence);

--- a/src/fw/apps/system/weather/weather_report.c
+++ b/src/fw/apps/system/weather/weather_report.c
@@ -334,7 +334,7 @@ void weather_report_push(const WeatherLocationForecast *days, size_t num_days, i
     s_report = NULL;
     return;
   }
-  window_set_background_color(s_report->window, GColorWhite);
+  window_set_background_color(s_report->window, system_theme_get_bg_color());
   window_set_window_handlers(s_report->window, (WindowHandlers){
     .load   = prv_window_load,
     .appear = prv_window_appear,
@@ -629,7 +629,7 @@ void weather_report_push(const WeatherLocationForecast *days, size_t num_days, i
     s_report = NULL;
     return;
   }
-  window_set_background_color(s_report->window, GColorWhite);
+  window_set_background_color(s_report->window, system_theme_get_bg_color());
   window_set_window_handlers(s_report->window, (WindowHandlers){
     .load   = prv_window_load,
     .appear = prv_window_appear,

--- a/src/fw/apps/system/workout/selection.c
+++ b/src/fw/apps/system/workout/selection.c
@@ -176,7 +176,7 @@ WorkoutSelectionWindow *workout_selection_push(SelectWorkoutCallback select_work
     .draw_row = prv_draw_row_callback,
     .select_click = prv_select_callback,
   });
-  menu_layer_set_normal_colors(menu_layer, GColorWhite, GColorBlack);
+  menu_layer_set_normal_colors(menu_layer, system_theme_get_bg_color(), system_theme_get_fg_color());
   menu_layer_set_highlight_colors(menu_layer,
                                   PBL_IF_COLOR_ELSE(GColorYellow, GColorBlack),
                                   PBL_IF_COLOR_ELSE(GColorBlack, GColorWhite));

--- a/src/fw/popups/notifications/notification_window.c
+++ b/src/fw/popups/notifications/notification_window.c
@@ -51,6 +51,7 @@
 #include "pbl/services/timeline/timeline_resources.h"
 #include "system/logging.h"
 #include "system/passert.h"
+#include "shell/system_theme.h"
 #include "util/math.h"
 #include "util/trig.h"
 
@@ -1167,7 +1168,7 @@ static void prv_layout_did_appear_handler(SwapLayer *swap_layer, LayoutLayer *la
 static void prv_update_colors_handler(SwapLayer *swap_layer, GColor bg_color,
                                       bool status_bar_filled, void *context) {
   NotificationWindowData *data = context;
-  GColor status_color = (status_bar_filled) ? bg_color : GColorWhite;
+  GColor status_color = (status_bar_filled) ? bg_color : system_theme_get_bg_color();
   // Status bar is clear on round, because the banner is rendered under it
   status_bar_layer_set_colors(&data->status_layer, PBL_IF_ROUND_ELSE(GColorClear, status_color),
                               gcolor_legible_over(status_color));

--- a/src/fw/popups/notifications/notification_window.c
+++ b/src/fw/popups/notifications/notification_window.c
@@ -57,6 +57,7 @@
 #include "system/passert.h"
 #include "pbl/util/math.h"
 #include "pbl/util/trig.h"
+#include "shell/system_theme.h"
 
 #include <inttypes.h>
 #include <stdio.h>
@@ -1225,7 +1226,7 @@ static void prv_layout_did_appear_handler(SwapLayer *swap_layer, LayoutLayer *la
 static void prv_update_colors_handler(SwapLayer *swap_layer, GColor bg_color,
                                       bool status_bar_filled, void *context) {
   NotificationWindowData *data = context;
-  GColor status_color = (status_bar_filled) ? bg_color : GColorWhite;
+  GColor status_color = (status_bar_filled) ? bg_color : system_theme_get_bg_color();
   // Status bar is clear on round, because the banner is rendered under it
   status_bar_layer_set_colors(&data->status_layer, PBL_IF_ROUND_ELSE(GColorClear, status_color),
                               gcolor_legible_over(status_color));

--- a/src/fw/popups/timeline/peek.c
+++ b/src/fw/popups/timeline/peek.c
@@ -47,7 +47,7 @@ static void prv_draw_background(GContext *ctx, const GRect *frame_orig,
   // Fill all the way to the bottom of the screen
   frame.size.h = DISP_ROWS - frame.origin.y;
 #endif
-  const GColor background_color = GColorWhite;
+  const GColor background_color = system_theme_get_bg_color();
   graphics_context_set_fill_color(ctx, background_color);
   graphics_fill_rect(ctx, &frame);
 
@@ -59,7 +59,7 @@ static void prv_draw_background(GContext *ctx, const GRect *frame_orig,
 
   // Draw the top border and concurrent event indicators
   frame = *frame_orig;
-  const GColor border_color = GColorBlack;
+  const GColor border_color = system_theme_is_dark_mode() ? GColorDarkGray : GColorBlack;
   for (unsigned int i = 0; i <= num_concurrent; i++) {
     const bool has_content = (i < num_concurrent);
     for (unsigned int type = 0; type < (has_content ? 2 : 1); type++) {
@@ -421,7 +421,7 @@ static void prv_push_timeline_peek(void *unused) {
 void timeline_peek_init(void) {
   TimelinePeek *peek = &s_peek;
   *peek = (TimelinePeek) {
-#if CAPABILITY_HAS_TIMELINE_PEEK && !SHELL_SDK && !TARGET_QEMU
+#if CAPABILITY_HAS_TIMELINE_PEEK && !SHELL_SDK
     .enabled = timeline_peek_prefs_get_enabled(),
 #endif
   };
@@ -458,7 +458,7 @@ static bool prv_can_animate(void) {
 
 void timeline_peek_set_visible(bool visible, bool animated) {
   TimelinePeek *peek = &s_peek;
-#if !SHELL_SDK && !TARGET_QEMU
+#if !SHELL_SDK
   if (!peek->exists) {
     visible = false;
   }

--- a/src/fw/popups/timeline/peek.c
+++ b/src/fw/popups/timeline/peek.c
@@ -47,7 +47,7 @@ static void prv_draw_background(GContext *ctx, const GRect *frame_orig,
   // Fill all the way to the bottom of the screen
   frame.size.h = DISP_ROWS - frame.origin.y;
 #endif
-  const GColor background_color = GColorWhite;
+  const GColor background_color = system_theme_get_bg_color();
   graphics_context_set_fill_color(ctx, background_color);
   graphics_fill_rect(ctx, &frame);
 
@@ -59,7 +59,7 @@ static void prv_draw_background(GContext *ctx, const GRect *frame_orig,
 
   // Draw the top border and concurrent event indicators
   frame = *frame_orig;
-  const GColor border_color = GColorBlack;
+  const GColor border_color = system_theme_is_dark_mode() ? GColorDarkGray : GColorBlack;
   for (unsigned int i = 0; i <= num_concurrent; i++) {
     const bool has_content = (i < num_concurrent);
     for (unsigned int type = 0; type < (has_content ? 2 : 1); type++) {

--- a/src/fw/services/timeline/notification_layout.c
+++ b/src/fw/services/timeline/notification_layout.c
@@ -483,7 +483,7 @@ static NOINLINE void prv_card_render_internal(NotificationLayout *layout, GConte
     .text_flow = PBL_IF_ROUND_ELSE(true, false),
     .paging = PBL_IF_ROUND_ELSE(true, false),
   };
-  graphics_context_set_text_color(ctx, GColorBlack);
+  graphics_context_set_text_color(ctx, system_theme_get_fg_color());
   (text_visible ? graphics_text_node_draw :
                   graphics_text_node_get_size)(layout->view_node, ctx, &box, &config,
                                                &layout->view_size);

--- a/src/fw/services/timeline/notification_layout.c
+++ b/src/fw/services/timeline/notification_layout.c
@@ -626,7 +626,7 @@ static NOINLINE void prv_card_render_internal(NotificationLayout *layout, GConte
     .text_flow = PBL_IF_ROUND_ELSE(true, false),
     .paging = PBL_IF_ROUND_ELSE(true, false),
   };
-  graphics_context_set_text_color(ctx, GColorBlack);
+  graphics_context_set_text_color(ctx, system_theme_get_fg_color());
   (text_visible ? graphics_text_node_draw :
                   graphics_text_node_get_size)(layout->view_node, ctx, &box, &config,
                                                &layout->view_size);

--- a/src/fw/services/timeline/swap_layer.c
+++ b/src/fw/services/timeline/swap_layer.c
@@ -14,6 +14,7 @@
 #include "pbl/services/timeline/layout_layer.h"
 #include "pbl/services/timeline/notification_layout.h"
 #include "pbl/services/notifications/alerts_preferences_private.h"
+#include "shell/system_theme.h"
 #include "kernel/ui/kernel_ui.h"
 #include "process_state/app_state/app_state.h"
 #include "system/logging.h"
@@ -243,7 +244,7 @@ static void prv_arrow_layer_update_proc(Layer *layer, GContext* ctx) {
   const GRect *layer_bounds = &layer->bounds;
 
 #if PBL_RECT
-  graphics_context_set_fill_color(ctx, GColorWhite);
+  graphics_context_set_fill_color(ctx, system_theme_get_bg_color());
   graphics_fill_rect(ctx, layer_bounds);
 #endif
 
@@ -261,7 +262,11 @@ static void prv_arrow_layer_update_proc(Layer *layer, GContext* ctx) {
 #if UNITTEST
   const GCompOp compositing_mode = GCompOpSet;
 #else
-  const GCompOp compositing_mode = PBL_IF_COLOR_ELSE(GCompOpSet, GCompOpAssign);
+  // Arrow color is inverted in dark mode
+  const GCompOp compositing_mode = PBL_IF_COLOR_ELSE(
+    system_theme_is_dark_mode() ? GCompOpTint : GCompOpSet,
+    GCompOpAssign
+  );
 #endif
   graphics_context_set_compositing_mode(ctx, compositing_mode);
 

--- a/src/fw/services/timeline/swap_layer.c
+++ b/src/fw/services/timeline/swap_layer.c
@@ -14,6 +14,7 @@
 #include "pbl/services/timeline/layout_layer.h"
 #include "pbl/services/timeline/notification_layout.h"
 #include "pbl/services/notifications/alerts_preferences_private.h"
+#include "shell/system_theme.h"
 #include "kernel/ui/kernel_ui.h"
 #include "process_state/app_state/app_state.h"
 #include <pbl/logging/logging.h>
@@ -249,7 +250,7 @@ static void prv_arrow_layer_update_proc(Layer *layer, GContext* ctx) {
   const GRect *layer_bounds = &layer->bounds;
 
 #if PBL_RECT
-  graphics_context_set_fill_color(ctx, GColorWhite);
+  graphics_context_set_fill_color(ctx, system_theme_get_bg_color());
   graphics_fill_rect(ctx, layer_bounds);
 #endif
 
@@ -267,7 +268,11 @@ static void prv_arrow_layer_update_proc(Layer *layer, GContext* ctx) {
 #if UNITTEST
   const GCompOp compositing_mode = GCompOpSet;
 #else
-  const GCompOp compositing_mode = PBL_IF_COLOR_ELSE(GCompOpSet, GCompOpAssign);
+  // Arrow color is inverted in dark mode
+  const GCompOp compositing_mode = PBL_IF_COLOR_ELSE(
+    system_theme_is_dark_mode() ? GCompOpTint : GCompOpSet,
+    GCompOpAssign
+  );
 #endif
   graphics_context_set_compositing_mode(ctx, compositing_mode);
 

--- a/src/fw/services/timeline/timeline_layout.c
+++ b/src/fw/services/timeline/timeline_layout.c
@@ -659,7 +659,8 @@ static void prv_render_view(TimelineLayout *layout, GContext *ctx, bool render, 
   GRect box;
   (is_card ? prv_get_card_view_bounds : prv_get_pin_view_bounds)(layout, &box);
   graphics_context_set_text_color(
-      ctx, (is_card ? layout_get_colors((LayoutLayer *)layout)->primary_color : GColorBlack));
+      ctx, (is_card ? layout_get_colors((LayoutLayer *)layout)->primary_color :
+                     system_theme_get_fg_color()));
   static const GRect page_frame_on_screen =
      { { 0, STATUS_BAR_LAYER_HEIGHT }, { DISP_COLS, DISP_ROWS - STATUS_BAR_LAYER_HEIGHT } };
   const GTextNodeDrawConfig config = {

--- a/src/fw/services/timeline/timeline_layout.c
+++ b/src/fw/services/timeline/timeline_layout.c
@@ -667,7 +667,8 @@ static void prv_render_view(TimelineLayout *layout, GContext *ctx, bool render, 
   GRect box;
   (is_card ? prv_get_card_view_bounds : prv_get_pin_view_bounds)(layout, &box);
   graphics_context_set_text_color(
-      ctx, (is_card ? layout_get_colors((LayoutLayer *)layout)->primary_color : GColorBlack));
+      ctx, (is_card ? layout_get_colors((LayoutLayer *)layout)->primary_color :
+                     system_theme_get_fg_color()));
   static const GRect page_frame_on_screen =
      { { 0, STATUS_BAR_LAYER_HEIGHT }, { DISP_COLS, DISP_ROWS - STATUS_BAR_LAYER_HEIGHT } };
   const GTextNodeDrawConfig config = {

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -101,7 +101,7 @@ static uint32_t s_dynamic_backlight_min_threshold = 0; // default set from board
 #if CAPABILITY_HAS_ORIENTATION_MANAGER
 #define PREF_KEY_DISPLAY_ORIENTATION_LEFT_HANDED "displayOrientationLeftHanded"
 static bool s_display_orientation_left = false;
-#endif 
+#endif
 
 #define PREF_KEY_BACKLIGHT_AMBIENT_THRESHOLD "lightAmbientThreshold"
 static uint32_t s_backlight_ambient_threshold = 0; // default set from board config in shell_prefs_init()
@@ -249,11 +249,13 @@ static GColor s_theme_highlight_color = GColorVividCerulean;
 #define PREF_KEY_MENU_SCROLL_VIBE_BEHAVIOR "menuScrollVibeBehavior"
 #define PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS "musicShowVolumeControls"
 #define PREF_KEY_MUSIC_SHOW_PROGRESS_BAR "musicShowProgressBar"
+#define PREF_KEY_DARK_MODE "darkMode"
 
 static bool s_menu_scroll_wrap_around = false;
 static MenuScrollVibeBehavior s_menu_scroll_vibe_behavior = MenuScrollNoVibe;
 static bool s_music_show_volume_controls = true;
 static bool s_music_show_progress_bar = true;
+static uint8_t s_dark_mode = DarkModeOff;
 
 // ============================================================================================
 // Handlers for each pref that validate the new setting and store the new value in our globals.
@@ -391,13 +393,13 @@ static bool prv_set_s_motion_sensitivity(uint8_t *sensitivity) {
     return false;
   }
   s_motion_sensitivity = *sensitivity;
-  
+
   // Update accelerometer sensitivity in accel_manager
   // This applies the setting to the hardware
   #if CAPABILITY_HAS_ACCEL_SENSITIVITY
   accel_manager_update_sensitivity(*sensitivity);
   #endif
-  
+
   return true;
 }
 
@@ -745,7 +747,16 @@ static bool prv_set_s_music_show_progress_bar(bool *enabled) {
   s_music_show_progress_bar = *enabled;
   return true;
 }
-  
+
+static bool prv_set_s_dark_mode(uint8_t *mode) {
+  if (*mode >= DarkModeCount) {
+    s_dark_mode = DarkModeOn;
+    return false;
+  }
+  s_dark_mode = *mode;
+  return true;
+}
+
 // ------------------------------------------------------------------------------------
 // Table of all prefs
 typedef bool (*PrefSetHandler)(const void *value, size_t val_len);
@@ -830,10 +841,10 @@ void shell_prefs_init(void) {
   }
 
   settings_file_close(&file);
-  
+
   // Update the ambient light driver with the loaded threshold value
   ambient_light_set_dark_threshold(s_backlight_ambient_threshold);
-  
+
   // Initialize prefs sync (must be after prefs are loaded)
   prefs_sync_init();
 
@@ -1853,4 +1864,13 @@ bool shell_prefs_get_music_show_progress_bar(void) {
 
 void shell_prefs_set_music_show_progress_bar(bool enable) {
   prv_pref_set(PREF_KEY_MUSIC_SHOW_PROGRESS_BAR, &enable, sizeof(enable));
+}
+
+DarkMode shell_prefs_get_dark_mode(void) {
+  return (DarkMode)s_dark_mode;
+}
+
+void shell_prefs_set_dark_mode(DarkMode mode) {
+  uint8_t val = (uint8_t)mode;
+  prv_pref_set(PREF_KEY_DARK_MODE, &val, sizeof(val));
 }

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -162,7 +162,7 @@ static const BacklightPresetSettings s_backlight_preset_settings[] = {
 #ifdef CONFIG_ORIENTATION_MANAGER
 #define PREF_KEY_DISPLAY_ORIENTATION_LEFT_HANDED "displayOrientationLeftHanded"
 static bool s_display_orientation_left = false;
-#endif 
+#endif
 
 #define PREF_KEY_BACKLIGHT_AMBIENT_THRESHOLD "lightAmbientThreshold"
 static uint32_t s_backlight_ambient_threshold = 0; // default set from board config in shell_prefs_init()
@@ -320,12 +320,21 @@ static GColor s_theme_highlight_color = GColorVividCerulean;
 #define PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS "musicShowVolumeControls"
 #define PREF_KEY_MUSIC_SHOW_PROGRESS_BAR "musicShowProgressBar"
 #define PREF_KEY_MUSIC_SHOW_ALBUM_ART "musicShowAlbumArt"
+#define PREF_KEY_DARK_MODE "darkMode"
+#define PREF_KEY_DARK_MODE_SCHEDULE "darkModeSchedule"
 
 static bool s_menu_scroll_wrap_around = false;
 static MenuScrollVibeBehavior s_menu_scroll_vibe_behavior = MenuScrollNoVibe;
 static bool s_music_show_volume_controls = true;
 static bool s_music_show_progress_bar = true;
 static bool s_music_show_album_art = false;
+static uint8_t s_dark_mode = DarkModeOff;
+static DarkModeSchedule s_dark_mode_schedule = {
+  .from_hour = 19,
+  .from_minute = 0,
+  .to_hour = 7,
+  .to_minute = 0,
+};
 
 // ============================================================================================
 // Handlers for each pref that validate the new setting and store the new value in our globals.
@@ -510,13 +519,13 @@ static bool prv_set_s_motion_sensitivity(uint8_t *sensitivity) {
     return false;
   }
   s_motion_sensitivity = *sensitivity;
-  
+
   // Update accelerometer sensitivity in accel_manager
   // This applies the setting to the hardware
   #ifdef CONFIG_ACCEL_SENSITIVITY
   accel_manager_update_sensitivity(*sensitivity);
   #endif
-  
+
   return true;
 }
 
@@ -891,6 +900,24 @@ static bool prv_set_s_music_show_album_art(bool *enabled) {
   return true;
 }
   
+static bool prv_set_s_dark_mode(uint8_t *mode) {
+  if (*mode >= DarkModeCount) {
+    s_dark_mode = DarkModeOn;
+    return false;
+  }
+  s_dark_mode = *mode;
+  return true;
+}
+
+static bool prv_set_s_dark_mode_schedule(DarkModeSchedule *schedule) {
+  if (schedule->from_hour >= 24 || schedule->from_minute >= 60 ||
+      schedule->to_hour >= 24 || schedule->to_minute >= 60) {
+    return false;
+  }
+  s_dark_mode_schedule = *schedule;
+  return true;
+}
+
 // ------------------------------------------------------------------------------------
 // Table of all prefs
 typedef bool (*PrefSetHandler)(const void *value, size_t val_len);
@@ -1065,7 +1092,7 @@ void shell_prefs_init(void) {
 
   // Update the ambient light driver with the loaded threshold value
   ambient_light_set_dark_threshold(s_backlight_ambient_threshold);
-  
+
   // Initialize prefs sync (must be after prefs are loaded)
   prefs_sync_init();
 
@@ -2183,4 +2210,25 @@ bool shell_prefs_get_music_show_album_art(void) {
 
 void shell_prefs_set_music_show_album_art(bool enable) {
   prv_pref_set(PREF_KEY_MUSIC_SHOW_ALBUM_ART, &enable, sizeof(enable));
+}
+
+DarkMode shell_prefs_get_dark_mode(void) {
+  return (DarkMode)s_dark_mode;
+}
+
+void shell_prefs_set_dark_mode(DarkMode mode) {
+  uint8_t val = (uint8_t)mode;
+  prv_pref_set(PREF_KEY_DARK_MODE, &val, sizeof(val));
+}
+
+void shell_prefs_get_dark_mode_schedule(DarkModeSchedule *schedule_out) {
+  if (schedule_out) {
+    *schedule_out = s_dark_mode_schedule;
+  }
+}
+
+void shell_prefs_set_dark_mode_schedule(const DarkModeSchedule *schedule) {
+  if (schedule) {
+    prv_pref_set(PREF_KEY_DARK_MODE_SCHEDULE, schedule, sizeof(*schedule));
+  }
 }

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -70,3 +70,4 @@
   PREFS_MACRO(PREF_KEY_MENU_SCROLL_VIBE_BEHAVIOR, s_menu_scroll_vibe_behavior)
   PREFS_MACRO(PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS, s_music_show_volume_controls)
   PREFS_MACRO(PREF_KEY_MUSIC_SHOW_PROGRESS_BAR, s_music_show_progress_bar)
+  PREFS_MACRO(PREF_KEY_DARK_MODE, s_dark_mode)

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -73,3 +73,5 @@
   PREFS_MACRO(PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS, s_music_show_volume_controls)
   PREFS_MACRO(PREF_KEY_MUSIC_SHOW_PROGRESS_BAR, s_music_show_progress_bar)
   PREFS_MACRO(PREF_KEY_MUSIC_SHOW_ALBUM_ART, s_music_show_album_art)
+  PREFS_MACRO(PREF_KEY_DARK_MODE, s_dark_mode)
+  PREFS_MACRO(PREF_KEY_DARK_MODE_SCHEDULE, s_dark_mode_schedule)

--- a/src/fw/shell/normal/shell.c
+++ b/src/fw/shell/normal/shell.c
@@ -9,14 +9,15 @@
 #include "process_management/app_install_types.h"
 #include "process_management/app_manager.h"
 #include "pbl/services/compositor/compositor_transitions.h"
+#include "shell/prefs.h"
 
-#define WATCHFACE_SHUTTER_COLOR GColorWhite
 #define HEALTH_SHUTTER_COLOR PBL_IF_COLOR_ELSE(GColorBlack, GColorWhite)
 #define ACTION_SHUTTER_COLOR PBL_IF_COLOR_ELSE(GColorLightGray, GColorWhite)
 
 static const CompositorTransition *prv_get_watchface_compositor_animation(
     CompositorTransitionDirection direction) {
-  return PBL_IF_RECT_ELSE(compositor_shutter_transition_get(direction, WATCHFACE_SHUTTER_COLOR),
+  return PBL_IF_RECT_ELSE(compositor_shutter_transition_get(direction,
+                                                            shell_prefs_get_theme_highlight_color()),
                           compositor_port_hole_transition_app_get(direction));
 }
 

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -209,3 +209,15 @@ void shell_prefs_set_music_show_volume_controls(bool enable);
 
 bool shell_prefs_get_music_show_progress_bar(void);
 void shell_prefs_set_music_show_progress_bar(bool enable);
+
+typedef enum DarkMode {
+  DarkModeOff = 0,
+  DarkModeOn = 1,
+#if CAPABILITY_HAS_AMBIENT_LIGHT_SENSOR
+  DarkModeAuto = 2,  // Follows the ambient light sensor; dark mode when ambient light is low
+#endif
+  DarkModeCount
+} DarkMode;
+
+DarkMode shell_prefs_get_dark_mode(void);
+void shell_prefs_set_dark_mode(DarkMode mode);

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -276,3 +276,24 @@ void shell_prefs_set_music_show_progress_bar(bool enable);
 
 bool shell_prefs_get_music_show_album_art(void);
 void shell_prefs_set_music_show_album_art(bool enable);
+
+typedef struct DarkModeSchedule {
+  uint8_t from_hour;
+  uint8_t from_minute;
+  uint8_t to_hour;
+  uint8_t to_minute;
+} DarkModeSchedule;
+
+typedef enum DarkMode {
+  DarkModeOff = 0,
+  DarkModeOn = 1,
+  DarkModeAmbient = 2,  // Follows the ambient light sensor; dark mode when ambient light is low
+  DarkModeScheduled = 3, // Follows the configured start/end time schedule
+  DarkModeCount
+} DarkMode;
+
+DarkMode shell_prefs_get_dark_mode(void);
+void shell_prefs_set_dark_mode(DarkMode mode);
+
+void shell_prefs_get_dark_mode_schedule(DarkModeSchedule *schedule_out);
+void shell_prefs_set_dark_mode_schedule(const DarkModeSchedule *schedule);

--- a/src/fw/shell/prf/stubs.c
+++ b/src/fw/shell/prf/stubs.c
@@ -252,6 +252,17 @@ void shell_prefs_set_language_english(bool english) {
 void shell_prefs_toggle_language_english(void) {
 }
 
+GColor shell_prefs_get_theme_highlight_color(void) {
+  return PBL_IF_COLOR_ELSE(GColorVividCerulean, GColorBlack);
+}
+
+DarkMode shell_prefs_get_dark_mode(void) {
+  return DarkModeOff;
+}
+
+void shell_prefs_set_dark_mode(DarkMode mode) {
+}
+
 FontInfo *fonts_get_system_emoji_font_for_size(unsigned int font_height) {
   return NULL;
 }

--- a/src/fw/shell/prf/stubs.c
+++ b/src/fw/shell/prf/stubs.c
@@ -275,6 +275,26 @@ uint32_t shell_prefs_get_language_resource_id(void) {
 void shell_prefs_set_language(ShellLanguage language) {
 }
 
+GColor shell_prefs_get_theme_highlight_color(void) {
+  return PBL_IF_COLOR_ELSE(GColorVividCerulean, GColorBlack);
+}
+
+DarkMode shell_prefs_get_dark_mode(void) {
+  return DarkModeOff;
+}
+
+void shell_prefs_set_dark_mode(DarkMode mode) {
+}
+
+void shell_prefs_get_dark_mode_schedule(DarkModeSchedule *schedule_out) {
+  if (schedule_out) {
+    *schedule_out = (DarkModeSchedule){ .from_hour = 19, .from_minute = 0, .to_hour = 7, .to_minute = 0 };
+  }
+}
+
+void shell_prefs_set_dark_mode_schedule(const DarkModeSchedule *schedule) {
+}
+
 FontInfo *fonts_get_system_emoji_font_for_size(unsigned int font_height) {
   return NULL;
 }

--- a/src/fw/shell/sdk/prefs.c
+++ b/src/fw/shell/sdk/prefs.c
@@ -294,6 +294,14 @@ void shell_prefs_set_theme_highlight_color(GColor color) {
   // Not used in SDK shell
 }
 
+DarkMode shell_prefs_get_dark_mode(void) {
+  return DarkModeOff;
+}
+
+void shell_prefs_set_dark_mode(DarkMode mode) {
+  // Not used in SDK shell
+}
+
 #if CAPABILITY_HAS_APP_SCALING
 LegacyAppRenderMode shell_prefs_get_legacy_app_render_mode(void) {
   return (LegacyAppRenderMode)s_legacy_app_render_mode;

--- a/src/fw/shell/sdk/prefs.c
+++ b/src/fw/shell/sdk/prefs.c
@@ -294,6 +294,24 @@ void shell_prefs_set_theme_highlight_color(GColor color) {
   // Not used in SDK shell
 }
 
+DarkMode shell_prefs_get_dark_mode(void) {
+  return DarkModeOff;
+}
+
+void shell_prefs_set_dark_mode(DarkMode mode) {
+  // Not used in SDK shell
+}
+
+void shell_prefs_get_dark_mode_schedule(DarkModeSchedule *schedule_out) {
+  if (schedule_out) {
+    *schedule_out = (DarkModeSchedule){ .from_hour = 19, .from_minute = 0, .to_hour = 7, .to_minute = 0 };
+  }
+}
+
+void shell_prefs_set_dark_mode_schedule(const DarkModeSchedule *schedule) {
+  // Not used in SDK shell
+}
+
 #ifdef CONFIG_APP_SCALING
 LegacyAppRenderMode shell_prefs_get_legacy_app_render_mode(void) {
   return (LegacyAppRenderMode)s_legacy_app_render_mode;

--- a/src/fw/shell/system_theme.c
+++ b/src/fw/shell/system_theme.c
@@ -5,12 +5,18 @@
 
 #include "applib/fonts/fonts.h"
 #include "apps/system/settings/notifications_private.h"
+#include "process_management/pebble_process_md.h"
 #include "process_management/process_manager.h"
 #include "pbl/services/analytics/analytics.h"
 #include "shell/prefs.h"
+#include "syscall/syscall.h"
 #include "syscall/syscall_internal.h"
 #include "system/passert.h"
 #include "util/size.h"
+
+#if CAPABILITIES_HAS_AMBIENT_LIGHT
+#include "drivers/ambient_light.h"
+#endif
 
 #include <string.h>
 
@@ -168,6 +174,48 @@ GFont system_theme_get_font_for_size(PreferredContentSize size, TextStyleFont fo
 GFont system_theme_get_font_for_default_size(TextStyleFont font) {
   return fonts_get_system_font(system_theme_get_font_key_for_size(PreferredContentSizeDefault,
                                                                   font));
+}
+
+//! Returns true if the current (system) app context should render in dark mode.
+static bool prv_is_system_app(void) {
+  const PebbleTask task = pebble_task_get_current();
+  if (task != PebbleTask_App && task != PebbleTask_Worker) {
+    // Kernel / other tasks are always treated as system
+    return true;
+  }
+  const ProcessAppSDKType sdk_type =
+      process_metadata_get_app_sdk_type(sys_process_manager_get_current_process_md());
+  return sdk_type == ProcessAppSDKType_System;
+}
+
+bool system_theme_is_dark_mode(void) {
+  // Dark mode is only supported on color platforms, so treat all non-color platforms as light mode
+  if (PBL_IF_COLOR_ELSE(false, true)) {
+    return false;
+  }
+  if (!prv_is_system_app()) {
+    return false;
+  }
+  switch (shell_prefs_get_dark_mode()) {
+    case DarkModeOff:
+      return false;
+    case DarkModeOn:
+      return true;
+  #if CAPABILITY_HAS_AMBIENT_LIGHT_SENSOR
+    case DarkModeAuto:
+      return !ambient_light_is_light();
+  #endif
+    default:
+      return false;
+  }
+}
+
+GColor system_theme_get_bg_color(void) {
+  return system_theme_is_dark_mode() ? GColorBlack : GColorWhite;
+}
+
+GColor system_theme_get_fg_color(void) {
+  return system_theme_is_dark_mode() ? GColorWhite : GColorBlack;
 }
 
 static const PreferredContentSize s_platform_default_content_sizes[] = {

--- a/src/fw/shell/system_theme.c
+++ b/src/fw/shell/system_theme.c
@@ -5,12 +5,16 @@
 
 #include "applib/fonts/fonts.h"
 #include "apps/system/settings/notifications_private.h"
+#include "process_management/pebble_process_md.h"
 #include "process_management/process_manager.h"
 #include "pbl/services/analytics/analytics.h"
 #include "shell/prefs.h"
+#include "syscall/syscall.h"
 #include "syscall/syscall_internal.h"
 #include "system/passert.h"
 #include "pbl/util/size.h"
+#include <pbl/drivers/rtc.h>
+#include <pbl/drivers/ambient_light.h>
 
 #include <string.h>
 
@@ -168,6 +172,63 @@ GFont system_theme_get_font_for_size(PreferredContentSize size, TextStyleFont fo
 GFont system_theme_get_font_for_default_size(TextStyleFont font) {
   return fonts_get_system_font(system_theme_get_font_key_for_size(PreferredContentSizeDefault,
                                                                   font));
+}
+
+//! Returns true if the current (system) app context should render in dark mode.
+static bool prv_is_system_app(void) {
+  const PebbleTask task = pebble_task_get_current();
+  if (task != PebbleTask_App && task != PebbleTask_Worker) {
+    // Kernel / other tasks are always treated as system
+    return true;
+  }
+  const ProcessAppSDKType sdk_type =
+      process_metadata_get_app_sdk_type(sys_process_manager_get_current_process_md());
+  return sdk_type == ProcessAppSDKType_System;
+}
+
+bool system_theme_is_dark_mode(void) {
+  // Dark mode is only supported on color platforms, so treat all non-color platforms as light mode
+  if (PBL_IF_COLOR_ELSE(false, true)) {
+    return false;
+  }
+  if (!prv_is_system_app()) {
+    return false;
+  }
+  switch (shell_prefs_get_dark_mode()) {
+    case DarkModeOff:
+      return false;
+    case DarkModeOn:
+      return true;
+    case DarkModeAmbient:
+      return !ambient_light_is_light();
+    case DarkModeScheduled: {
+      DarkModeSchedule schedule;
+      shell_prefs_get_dark_mode_schedule(&schedule);
+      struct tm time_now;
+      rtc_get_time_tm(&time_now);
+      const int now_min = time_now.tm_hour * 60 + time_now.tm_min;
+      const int start_min = schedule.from_hour * 60 + schedule.from_minute;
+      const int end_min = schedule.to_hour * 60 + schedule.to_minute;
+      if (start_min == end_min) {
+        return false;
+      }
+      if (start_min < end_min) {
+        return (now_min >= start_min && now_min < end_min);
+      } else {
+        return (now_min >= start_min || now_min < end_min);
+      }
+    }
+    default:
+      return false;
+  }
+}
+
+GColor system_theme_get_bg_color(void) {
+  return system_theme_is_dark_mode() ? GColorBlack : GColorWhite;
+}
+
+GColor system_theme_get_fg_color(void) {
+  return system_theme_is_dark_mode() ? GColorWhite : GColorBlack;
 }
 
 static const PreferredContentSize s_platform_default_content_sizes[] = {

--- a/src/fw/shell/system_theme.h
+++ b/src/fw/shell/system_theme.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "applib/fonts/fonts.h"
+#include "applib/graphics/gtypes.h"
 #include "applib/platform.h"
 #include "applib/preferred_content_size.h"
 
@@ -96,3 +97,14 @@ PreferredContentSize system_theme_get_default_content_size_for_runtime_platform(
 //! platform
 PreferredContentSize system_theme_convert_host_content_size_to_runtime_platform(
     PreferredContentSize size);
+
+//! @return true if the current app context should render in dark mode (system apps only).
+bool system_theme_is_dark_mode(void);
+
+//! @return The background color appropriate for the current theme (black in dark mode on color
+//!         displays, white otherwise).
+GColor system_theme_get_bg_color(void);
+
+//! @return The foreground color appropriate for the current theme (white in dark mode on color
+//!         displays, black otherwise).
+GColor system_theme_get_fg_color(void);

--- a/tests/fw/services/timeline/test_timeline_layouts.c
+++ b/tests/fw/services/timeline/test_timeline_layouts.c
@@ -79,6 +79,7 @@ void clock_get_since_time(char *buffer, int buf_size, time_t timestamp) {
 #include "stubs_property_animation.h"
 #include "stubs_serial.h"
 #include "stubs_shell_prefs.h"
+#include "stubs_system_theme.h"
 #include "stubs_sleep.h"
 #include "stubs_syscalls.h"
 #include "stubs_task_watchdog.h"

--- a/tests/fw/ui/test_jumboji.c
+++ b/tests/fw/ui/test_jumboji.c
@@ -26,6 +26,7 @@
 #include "stubs_pin_db.h"
 #include "stubs_resources.h"
 #include "stubs_shell_prefs.h"
+#include "stubs_system_theme.h"
 #include "stubs_text_node.h"
 #include "stubs_timeline_item.h"
 #include "stubs_timeline_resources.h"

--- a/tests/fw/ui/test_jumboji.c
+++ b/tests/fw/ui/test_jumboji.c
@@ -27,6 +27,7 @@
 #include "stubs_pin_db.h"
 #include "stubs_resources.h"
 #include "stubs_shell_prefs.h"
+#include "stubs_system_theme.h"
 #include "stubs_text_node.h"
 #include "stubs_timeline_item.h"
 #include "stubs_timeline_resources.h"

--- a/tests/fw/ui/test_menu_layer.c
+++ b/tests/fw/ui/test_menu_layer.c
@@ -17,8 +17,10 @@
 #include "stubs_passert.h"
 #include "stubs_pbl_malloc.h"
 #include "stubs_pebble_tasks.h"
-#include "stubs_ui_window.h"
 #include "stubs_process_manager.h"
+#include "stubs_shell_prefs.h"
+#include "stubs_system_theme.h"
+#include "stubs_ui_window.h"
 #include "stubs_unobstructed_area.h"
 #include "stubs_vibes.h"
 

--- a/tests/fw/ui/test_menu_layer.c
+++ b/tests/fw/ui/test_menu_layer.c
@@ -29,8 +29,10 @@
 #include "stubs_passert.h"
 #include "stubs_pbl_malloc.h"
 #include "stubs_pebble_tasks.h"
-#include "stubs_ui_window.h"
 #include "stubs_process_manager.h"
+#include "stubs_shell_prefs.h"
+#include "stubs_system_theme.h"
+#include "stubs_ui_window.h"
 #include "stubs_unobstructed_area.h"
 #include "stubs_vibes.h"
 

--- a/tests/fw/ui/test_status_bar_layer.c
+++ b/tests/fw/ui/test_status_bar_layer.c
@@ -28,6 +28,7 @@
 #include "stubs_process_manager.h"
 #include "stubs_resources.h"
 #include "stubs_syscalls.h"
+#include "stubs_system_theme.h"
 #include "stubs_ui_window.h"
 #include "stubs_unobstructed_area.h"
 #include "stubs_window_stack.h"

--- a/tests/fw/ui/test_window_stack.c
+++ b/tests/fw/ui/test_window_stack.c
@@ -40,6 +40,7 @@
 #include "stubs_queue.h"
 #include "stubs_resources.h"
 #include "stubs_syscalls.h"
+#include "stubs_system_theme.h"
 #include "stubs_unobstructed_area.h"
 
 // Fakes

--- a/tests/fw/ui/test_window_stack.c
+++ b/tests/fw/ui/test_window_stack.c
@@ -39,6 +39,7 @@
 #include "stubs_queue.h"
 #include "stubs_resources.h"
 #include "stubs_syscalls.h"
+#include "stubs_system_theme.h"
 #include "stubs_unobstructed_area.h"
 
 // Fakes

--- a/tests/stubs/stubs_ambient_light.h
+++ b/tests/stubs/stubs_ambient_light.h
@@ -3,18 +3,20 @@
 
 #pragma once
 
-void ambient_light_init(void) {
+#include "util/attributes.h"
+
+void WEAK ambient_light_init(void) {
 }
-uint32_t ambient_light_get_light_level(void) {
+uint32_t WEAK ambient_light_get_light_level(void) {
 	return 0;
 }
-void command_als_read(void) {
+void WEAK command_als_read(void) {
 }
-uint32_t ambient_light_get_dark_threshold(void) {
+uint32_t WEAK ambient_light_get_dark_threshold(void) {
 	return 0;
 }
-void ambient_light_set_dark_threshold(uint32_t new_threshold) {
+void WEAK ambient_light_set_dark_threshold(uint32_t new_threshold) {
 }
-bool ambient_light_is_light(void) {
+bool WEAK ambient_light_is_light(void) {
 	return false;
 }

--- a/tests/stubs/stubs_ambient_light.h
+++ b/tests/stubs/stubs_ambient_light.h
@@ -3,7 +3,9 @@
 
 #pragma once
 
-void ambient_light_init(void) {
+#include "util/attributes.h"
+
+void WEAK ambient_light_init(void) {
 }
 void ambient_light_prime(void) {
 }
@@ -13,17 +15,17 @@ void ambient_light_suspend(void) {
 }
 void ambient_light_resume(void) {
 }
-uint32_t ambient_light_get_light_level(void) {
+uint32_t WEAK ambient_light_get_light_level(void) {
 	return 0;
 }
-void command_als_read(void) {
+void WEAK command_als_read(void) {
 }
-uint32_t ambient_light_get_dark_threshold(void) {
+uint32_t WEAK ambient_light_get_dark_threshold(void) {
 	return 0;
 }
-void ambient_light_set_dark_threshold(uint32_t new_threshold) {
+void WEAK ambient_light_set_dark_threshold(uint32_t new_threshold) {
 }
-bool ambient_light_is_light(void) {
+bool WEAK ambient_light_is_light(void) {
 	return false;
 }
 uint32_t ambient_light_level_to_lux(uint32_t light_level) {

--- a/tests/stubs/stubs_pebble_process_md.h
+++ b/tests/stubs/stubs_pebble_process_md.h
@@ -4,15 +4,16 @@
 #pragma once
 
 #include "process_management/pebble_process_md.h"
+#include "util/attributes.h"
 
-Version process_metadata_get_sdk_version(const PebbleProcessMd *md) {
+Version WEAK process_metadata_get_sdk_version(const PebbleProcessMd *md) {
   return (Version) { PROCESS_INFO_CURRENT_SDK_VERSION_MAJOR, PROCESS_INFO_CURRENT_SDK_VERSION_MINOR };
 }
 
-ProcessAppSDKType process_metadata_get_app_sdk_type(const PebbleProcessMd *md) {
+ProcessAppSDKType WEAK process_metadata_get_app_sdk_type(const PebbleProcessMd *md) {
   return 0;
 }
 
-int process_metadata_get_code_bank_num(const PebbleProcessMd *md) {
+int WEAK process_metadata_get_code_bank_num(const PebbleProcessMd *md) {
   return 0;
 }

--- a/tests/stubs/stubs_shell_prefs.h
+++ b/tests/stubs/stubs_shell_prefs.h
@@ -74,6 +74,14 @@ void WEAK shell_prefs_set_menu_scroll_wrap_around_enable(bool enable) {
   s_menu_scroll_enable = enable;
 }
 
+GColor WEAK shell_prefs_get_theme_highlight_color(void) {
+  return PBL_IF_COLOR_ELSE(GColorVividCerulean, GColorBlack);
+}
+
+DarkMode WEAK shell_prefs_get_dark_mode(void) {
+  return DarkModeOff;
+}
+
 static MenuScrollVibeBehavior s_menu_scroll_vibe_behavior = MenuScrollNoVibe;
 
 MenuScrollVibeBehavior WEAK shell_prefs_get_menu_scroll_vibe_behavior(void) {

--- a/tests/stubs/stubs_shell_prefs.h
+++ b/tests/stubs/stubs_shell_prefs.h
@@ -74,6 +74,23 @@ void WEAK shell_prefs_set_menu_scroll_wrap_around_enable(bool enable) {
   s_menu_scroll_enable = enable;
 }
 
+GColor WEAK shell_prefs_get_theme_highlight_color(void) {
+  return PBL_IF_COLOR_ELSE(GColorVividCerulean, GColorBlack);
+}
+
+DarkMode WEAK shell_prefs_get_dark_mode(void) {
+  return DarkModeOff;
+}
+
+void WEAK shell_prefs_get_dark_mode_schedule(DarkModeSchedule *schedule_out) {
+  if (schedule_out) {
+    *schedule_out = (DarkModeSchedule){ .from_hour = 19, .from_minute = 0, .to_hour = 7, .to_minute = 0 };
+  }
+}
+
+void WEAK shell_prefs_set_dark_mode_schedule(const DarkModeSchedule *schedule) {
+}
+
 static MenuScrollVibeBehavior s_menu_scroll_vibe_behavior = MenuScrollNoVibe;
 
 MenuScrollVibeBehavior WEAK shell_prefs_get_menu_scroll_vibe_behavior(void) {

--- a/tests/stubs/stubs_system_theme.h
+++ b/tests/stubs/stubs_system_theme.h
@@ -6,6 +6,9 @@
 #include "shell/system_theme.h"
 #include "util/attributes.h"
 
+#include "stubs_ambient_light.h"
+#include "stubs_pebble_process_md.h"
+
 #include <stdlib.h>
 
 const char *WEAK system_theme_get_font_key(TextStyleFont font) {
@@ -28,4 +31,16 @@ PreferredContentSize WEAK system_theme_get_default_content_size_for_runtime_plat
 PreferredContentSize WEAK system_theme_convert_host_content_size_to_runtime_platform(
     PreferredContentSize size) {
   return size;
+}
+
+GColor WEAK system_theme_get_bg_color(void) {
+  return GColorWhite;
+}
+
+GColor WEAK system_theme_get_fg_color(void) {
+  return GColorBlack;
+}
+
+bool WEAK system_theme_is_dark_mode(void) {
+  return false;
 }

--- a/tests/stubs/stubs_system_theme.h
+++ b/tests/stubs/stubs_system_theme.h
@@ -6,6 +6,9 @@
 #include "shell/system_theme.h"
 #include "pbl/util/attributes.h"
 
+#include "stubs_ambient_light.h"
+#include "stubs_pebble_process_md.h"
+
 #include <stdlib.h>
 
 const char *WEAK system_theme_get_font_key(TextStyleFont font) {
@@ -28,4 +31,16 @@ PreferredContentSize WEAK system_theme_get_default_content_size_for_runtime_plat
 PreferredContentSize WEAK system_theme_convert_host_content_size_to_runtime_platform(
     PreferredContentSize size) {
   return size;
+}
+
+GColor WEAK system_theme_get_bg_color(void) {
+  return GColorWhite;
+}
+
+GColor WEAK system_theme_get_fg_color(void) {
+  return GColorBlack;
+}
+
+bool WEAK system_theme_is_dark_mode(void) {
+  return false;
 }


### PR DESCRIPTION
Hey pebble friends! I recently started using my pebble again in preparation for my new PT2 arriving soon. I noticed that using the watch at nighttime was _really_ bright and noticed how nice the settings menu w/ black background was. Since PebbleOS is now open source, I decided to try adding in a dark mode. So far is looking really good and will hopefully be a nice feature for people.

Not sure if there are any contribution guidelines I need to keep in mind, but happy to help get this through however you all might think is best. I used claude for portions of the logic, but wrote a significant portion on my own as well. This PR does cover a lot of files, but commits should roughly line up with separate potions of code changes. Happy to split things up if it is too much in one PR though.

Technical Details:
- There are 3 new helper functions added to `src/fw/shell/system_theme.c`
  - `system_theme_is_dark_mode()`
  - `system_theme_get_fg_color()`
  - `system_theme_get_bg_color()`
- The Settings -> Display/Theme page (dependent on theme support, falls back to display) has new options for `Dark Mode: Off / On / Auto`.
  - Dark mode is turned off by default
  - "Auto" mode uses the ambient light sensor to determine if dark mode should be enabled
  - The settings page order was changed slightly after the screenshot was taken
- Most of the changes in this PR are changing colors from hardcoded values to the above functions for fg/bg colors.

These changes should be scoped to pebbleos with a check that I _think_ should prevent the default values going to 3rd party apps. If it seems like there is community interest, it should be pretty simple to roll out to application developers later on.

Below are screenshots of many parts of the ui that have been touched. I did a pretty thorough check through all pages and I _think_ it is in a pretty decent spot. The colors are washed in a few from QEMU + backlight dimming.

I still have a little bit of testing on a few more places, but pretty close to ready for merging once approved. Haven't looked too deeply at round/new/etc hardware, but I think a lot of the spots should be decent. Thanks all, love that pebble is back and so happy to be able to contribute! :grin: :rock:

<img width="288" height="336" alt="Screenshot from 2026-04-19 00-17-05" src="https://github.com/user-attachments/assets/63b44037-da97-4241-9061-9a0d4fd07514" /><br/>
<img width="288" height="336" alt="Screenshot from 2026-04-19 00-17-23" src="https://github.com/user-attachments/assets/f0c46d57-e6cd-4b7e-b5f6-3050016af8b7" /><br/>
<img width="288" height="336" alt="Screenshot from 2026-04-19 00-17-34" src="https://github.com/user-attachments/assets/de05c457-09e5-48b6-b902-6439af2e652d" /><br/>
<img width="288" height="336" alt="Screenshot from 2026-04-19 00-17-45" src="https://github.com/user-attachments/assets/9e8c9309-0a24-486a-8167-0531db92b356" /><br/>
<img width="288" height="336" alt="Screenshot from 2026-04-19 00-18-05" src="https://github.com/user-attachments/assets/5fdfa1e7-23b0-4cdc-94ce-77ad6a275e82" /><br/>
<img width="288" height="336" alt="Screenshot from 2026-04-19 00-18-20" src="https://github.com/user-attachments/assets/23804315-24dd-4eba-9f50-1b645c36886f" /><br/>
<img width="288" height="336" alt="Screenshot from 2026-04-19 00-18-46" src="https://github.com/user-attachments/assets/7fa20229-f5ac-4983-b3a5-6389699d60b2" /><br/>
<img width="288" height="336" alt="Screenshot from 2026-04-19 01-22-03" src="https://github.com/user-attachments/assets/dd8d0bf2-0ad7-4d6d-b3b5-374449b6d310" /><br/>
<img width="288" height="336" alt="Screenshot from 2026-04-19 01-22-21" src="https://github.com/user-attachments/assets/2b0449ab-a2c2-438b-8dcb-fa31c827d551" /><br/>