### PR TITLE
flake.nix: use Apple clang on Darwin for Moddable build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,6 @@
             ];
             buildInputs = with pkgs; [
               emscripten
-              gcc
               gcc-arm-embedded-14_2r1
               gettext
               git
@@ -54,6 +53,7 @@
               python313
             ] ++ lib.optionals stdenv.isLinux [
               clang_multi
+              gcc
               # Required for Moddable build
               dash
               glib


### PR DESCRIPTION
Nix's gcc does not see the macOS SDK frameworks, so Moddable's serial2xsbug build fails with "CoreFoundation/CoreFoundation.h: No such file or directory". Scope the gcc buildInput to Linux only so that on Darwin `cc` resolves to Apple's clang (from Command Line Tools), which picks up the SDK and framework paths automatically. I didnt notice before because the tools were still cached for me. 