### PR TITLE
user-facing touch SDK

### DIFF
--- a/include/pbl/services/common/light.h
+++ b/include/pbl/services/common/light.h
@@ -83,5 +83,9 @@ void light_allow(bool allowed);
 //! configured brightness when dynamic backlight is enabled.
 uint8_t light_get_current_brightness_percent(void);
 
+//! @return true if the backlight is currently on in any form (on, timed, or
+//! fading out). Returns false only when the backlight is fully off.
+bool light_is_on(void);
+
 //!   @} // group Light
 //! @} // group UI

--- a/include/pbl/services/common/touch/touch.h
+++ b/include/pbl/services/common/touch/touch.h
@@ -21,6 +21,18 @@ void touch_set_backlight_enabled(bool enabled);
 //! @return true if at least one subscriber is currently registered for touch events.
 bool touch_has_app_subscribers(void);
 
+//! Globally enable or disable touch. When disabled:
+//! - The sensor is powered down, even if subscribers exist.
+//! - touch_handle_update() drops incoming events at the source.
+//! - touch_service_is_enabled() returns false to apps.
+//! Subscribers remain subscribed and resume receiving events when re-enabled.
+//! Intended to back a user-facing setting (e.g. "water mode") — the shell
+//! pref system persists the value and calls this on boot.
+void touch_service_set_globally_enabled(bool enabled);
+
+//! @return the current value of the global touch-enabled flag.
+bool touch_service_is_globally_enabled(void);
+
 //! Pass a touch update to the service (called by the touch driver)
 //! @param touch_state whether or not the screen is touched
 //! @param x x position of touch

--- a/include/pbl/services/common/touch/touch.h
+++ b/include/pbl/services/common/touch/touch.h
@@ -18,6 +18,9 @@ void touch_init(void);
 //! When disabled, the touch sensor is only active if apps have subscribed to touch events.
 void touch_set_backlight_enabled(bool enabled);
 
+//! @return true if at least one subscriber is currently registered for touch events.
+bool touch_has_app_subscribers(void);
+
 //! Pass a touch update to the service (called by the touch driver)
 //! @param touch_state whether or not the screen is touched
 //! @param x x position of touch

--- a/src/fw/applib/app_light.c
+++ b/src/fw/applib/app_light.c
@@ -5,6 +5,10 @@
 
 #include "syscall/syscall.h"
 
+bool app_light_is_on(void) {
+  return sys_light_is_on();
+}
+
 void app_light_enable_interaction(void) {
   sys_light_enable_interaction();
 }

--- a/src/fw/applib/app_light.h
+++ b/src/fw/applib/app_light.h
@@ -19,6 +19,13 @@
 //! method of interacting with the backlight.
 //!   @{
 
+//! @return true if the backlight is currently on in any form (on, timed,
+//! or fading out). Returns false only when the backlight is fully off.
+//! Useful for apps that want to behave differently depending on whether
+//! the screen is currently lit — e.g. skipping an animation or queuing a
+//! visual cue for when the screen wakes.
+bool app_light_is_on(void);
+
 //! Trigger the backlight and schedule a timer to automatically disable the backlight
 //! after a short delay. This is the preferred method of interacting with the backlight.
 void app_light_enable_interaction(void);

--- a/src/fw/applib/touch_service.c
+++ b/src/fw/applib/touch_service.c
@@ -10,7 +10,10 @@
 #include "kernel/pebble_tasks.h"
 #include "pbl/services/common/touch/touch.h"
 #include "process_state/app_state/app_state.h"
+#include "syscall/syscall.h"
 #include "system/passert.h"
+
+bool sys_touch_service_is_enabled(void);
 
 //! @return the per-task touch service state, or NULL if the current task is
 //! not permitted to use the touch service (e.g. background workers). Callers
@@ -70,10 +73,7 @@ void touch_service_unsubscribe(void) {
 }
 
 bool touch_service_is_enabled(void) {
-  // No runtime global touch-disable yet. On touch-capable platforms the API
-  // is always live; future features (water-lock, settings toggle) will gate
-  // this check.
-  return true;
+  return sys_touch_service_is_enabled();
 }
 
 void touch_service_state_init(TouchServiceState *state) {

--- a/src/fw/applib/touch_service.c
+++ b/src/fw/applib/touch_service.c
@@ -2,36 +2,80 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include "touch_service.h"
+#include "touch_service_private.h"
 
 #include "applib/event_service_client.h"
 #include "kernel/events.h"
+#include "kernel/kernel_applib_state.h"
+#include "kernel/pebble_tasks.h"
 #include "pbl/services/common/touch/touch.h"
+#include "process_state/app_state/app_state.h"
+#include "system/passert.h"
 
-static TouchServiceHandler s_handler;
-static void *s_context;
-
-static void prv_handle_touch_event(PebbleEvent *e, void *context) {
-  if (s_handler && e->type == PEBBLE_TOUCH_EVENT) {
-    s_handler(&e->touch.event, s_context);
+//! @return the per-task touch service state, or NULL if the current task is
+//! not permitted to use the touch service (e.g. background workers). Callers
+//! must no-op when this returns NULL.
+static TouchServiceState *prv_get_state(void) {
+  PebbleTask task = pebble_task_get_current();
+  switch (task) {
+    case PebbleTask_App:
+      return app_state_get_touch_service_state();
+    case PebbleTask_KernelMain:
+      return kernel_applib_get_touch_service_state();
+    case PebbleTask_Worker:
+      // Touch is not available to background workers — they have no UI.
+      return NULL;
+    default:
+      WTF;
   }
 }
 
-static EventServiceInfo s_event_info;
+static void prv_handle_touch_event(PebbleEvent *e, void *context) {
+  TouchServiceState *state = prv_get_state();
+  if (state->raw_handler && e->type == PEBBLE_TOUCH_EVENT) {
+    state->raw_handler(&e->touch.event, state->raw_context);
+  }
+}
 
 void touch_service_subscribe(TouchServiceHandler handler, void *context) {
-  s_handler = handler;
-  s_context = context;
+  TouchServiceState *state = prv_get_state();
+  if (!state) {
+    return;
+  }
+  state->raw_handler = handler;
+  state->raw_context = context;
 
-  s_event_info = (EventServiceInfo) {
+  state->raw_event_info = (EventServiceInfo) {
     .type = PEBBLE_TOUCH_EVENT,
     .handler = prv_handle_touch_event,
   };
   touch_reset();
-  event_service_client_subscribe(&s_event_info);
+  if (!state->raw_subscribed) {
+    event_service_client_subscribe(&state->raw_event_info);
+    state->raw_subscribed = true;
+  }
 }
 
 void touch_service_unsubscribe(void) {
-  event_service_client_unsubscribe(&s_event_info);
-  s_handler = NULL;
-  s_context = NULL;
+  TouchServiceState *state = prv_get_state();
+  if (!state) {
+    return;
+  }
+  if (state->raw_subscribed) {
+    event_service_client_unsubscribe(&state->raw_event_info);
+    state->raw_subscribed = false;
+  }
+  state->raw_handler = NULL;
+  state->raw_context = NULL;
+}
+
+bool touch_service_is_enabled(void) {
+  // No runtime global touch-disable yet. On touch-capable platforms the API
+  // is always live; future features (water-lock, settings toggle) will gate
+  // this check.
+  return true;
+}
+
+void touch_service_state_init(TouchServiceState *state) {
+  *state = (TouchServiceState){ 0 };
 }

--- a/src/fw/applib/touch_service.h
+++ b/src/fw/applib/touch_service.h
@@ -5,6 +5,9 @@
 
 #include "pbl/services/common/touch/touch_event.h"
 
+#include <stdbool.h>
+#include <stdint.h>
+
 //! Callback for touch events.
 //! @param event The touch event data
 //! @param context User-provided context
@@ -17,3 +20,9 @@ void touch_service_subscribe(TouchServiceHandler handler, void *context);
 
 //! Unsubscribe from touch events. The touch sensor is disabled if no other subscribers remain.
 void touch_service_unsubscribe(void);
+
+//! @return true if touch input is currently being delivered to apps.
+//! Returns false on platforms without a touchscreen, or when touch has been
+//! disabled system-wide (future feature). Apps can poll this (for example on
+//! window appear) to avoid looking broken when touch is unavailable.
+bool touch_service_is_enabled(void);

--- a/src/fw/applib/touch_service_private.h
+++ b/src/fw/applib/touch_service_private.h
@@ -1,0 +1,22 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include "event_service_client.h"
+#include "touch_service.h"
+
+#include <stdbool.h>
+
+//! Per-task state for the applib touch service. Must live in task-accessible
+//! memory (app/kernel state) so syscalls that validate buffers see it
+//! as userspace-local.
+typedef struct TouchServiceState {
+  TouchServiceHandler raw_handler;
+  void *raw_context;
+  EventServiceInfo raw_event_info;
+  bool raw_subscribed;
+} TouchServiceState;
+
+//! Initialize the state struct to a quiescent state.
+void touch_service_state_init(TouchServiceState *state);

--- a/src/fw/applib/touch_service_stub.c
+++ b/src/fw/applib/touch_service_stub.c
@@ -2,6 +2,13 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include "touch_service.h"
+#include "touch_service_private.h"
+
+#include <string.h>
+
+void touch_service_state_init(TouchServiceState *state) {
+  memset(state, 0, sizeof(*state));
+}
 
 void touch_service_subscribe(TouchServiceHandler handler, void *context) {
   (void)handler;
@@ -9,4 +16,8 @@ void touch_service_subscribe(TouchServiceHandler handler, void *context) {
 }
 
 void touch_service_unsubscribe(void) {
+}
+
+bool touch_service_is_enabled(void) {
+  return false;
 }

--- a/src/fw/apps/system/settings/display.c
+++ b/src/fw/apps/system/settings/display.c
@@ -28,12 +28,19 @@
 #include <string.h>
 #include <inttypes.h>
 
+// Forward decl so the parent menu can push the Backlight submenu.
+static void prv_backlight_submenu_push(void);
+
 typedef struct SettingsDisplayData {
+  SettingsCallbacks callbacks;
+} SettingsDisplayData;
+
+typedef struct SettingsBacklightData {
   SettingsCallbacks callbacks;
   char als_value_buffer[16];  // Buffer for ALS value display
   char backlight_percent_buffer[16];  // Buffer for backlight percentage display
   AppTimer *update_timer;  // Timer for live updating debug values
-} SettingsDisplayData;
+} SettingsBacklightData;
 
 // Intensity Settings
 /////////////////////////////
@@ -74,7 +81,7 @@ static void prv_intensity_menu_select(OptionMenu *option_menu, int selection, vo
   app_window_stack_remove(&option_menu->window, true /*animated*/);
 }
 
-static void prv_intensity_menu_push(SettingsDisplayData *data) {
+static void prv_intensity_menu_push(SettingsBacklightData *data) {
   const int index = prv_intensity_get_selection_index();
   const OptionMenuCallbacks callbacks = {
     .select = prv_intensity_menu_select,
@@ -148,7 +155,7 @@ static void prv_timeout_menu_select(OptionMenu *option_menu, int selection, void
   app_window_stack_remove(&option_menu->window, true /* animated */);
 }
 
-static void prv_timeout_menu_push(SettingsDisplayData *data) {
+static void prv_timeout_menu_push(SettingsBacklightData *data) {
   int index = prv_timeout_get_selection_index();
   const OptionMenuCallbacks callbacks = {
     .select = prv_timeout_menu_select,
@@ -186,96 +193,80 @@ static void prv_legacy_app_mode_menu_push(SettingsDisplayData *data) {
 }
 #endif
 
-// Menu Callbacks
-////////////////////////////
+// Backlight submenu
+//////////////////////////////////////////////////////////////////////////////
 
-enum SettingsDisplayItem {
-  SettingsDisplayLanguage,
-#if CAPABILITY_HAS_ORIENTATION_MANAGER
-  SettingsDisplayOrientation,
-#endif
-  SettingsDisplayBacklightMode,
-  SettingsDisplayMotionSensor,
+enum SettingsBacklightItem {
+  SettingsBacklightMode,
+  SettingsBacklightMotionWake,
 #ifdef CONFIG_TOUCH
-  SettingsDisplayTouchSensor,
+  SettingsBacklightTouchWake,
 #endif
-  SettingsDisplayAmbientSensor,
+  SettingsBacklightAmbientSensor,
 #if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
-  SettingsDisplayDynamicIntensity,
+  SettingsBacklightDynamicIntensity,
 #endif
-  SettingsDisplayBacklightIntensity,
-  SettingsDisplayBacklightTimeout,
-#if PLATFORM_SPALDING && !PLATFORM_SPALDING_GABBRO
-  SettingsDisplayAdjustAlignment,
-#endif
-#if CAPABILITY_HAS_APP_SCALING
-  SettingsDisplayLegacyAppMode,
-#endif
-  NumSettingsDisplayItems
+  SettingsBacklightIntensity,
+  SettingsBacklightTimeout,
+  NumSettingsBacklightItems
 };
 
-// number of items under SettingsDisplayBacklightMode which are hidden when backlight is disabled
-static const int NUM_BACKLIGHT_SUB_ITEMS = CLIP(SettingsDisplayBacklightTimeout -
-                                           SettingsDisplayBacklightMode - 1, 0, NumSettingsDisplayItems);
+// Number of items after the Mode row that are hidden when the backlight is off.
+static const int NUM_BACKLIGHT_SUB_ITEMS = CLIP(SettingsBacklightTimeout -
+                                           SettingsBacklightMode - 1, 0, NumSettingsBacklightItems);
 
-static bool prv_should_show_backlight_sub_items() {
+static bool prv_should_show_backlight_sub_items(void) {
   return backlight_is_enabled();
 }
 
-uint16_t prv_get_item_from_row(uint16_t row) {  
-  if (!prv_should_show_backlight_sub_items() && (row > SettingsDisplayBacklightMode)) {
-    row += NUM_BACKLIGHT_SUB_ITEMS;
-  }
+#ifdef CONFIG_TOUCH
+// The wake-on-touch row is only relevant when global touch is enabled.
+// It gets hidden dynamically (not just gated at compile time) so users don't
+// see a dangling backlight option that can't do anything.
+static bool prv_should_show_touch_wake(void) {
+  return touch_is_globally_enabled();
+}
+#endif
 
+static uint16_t prv_backlight_item_from_row(uint16_t row) {
+  if (!prv_should_show_backlight_sub_items() && (row > SettingsBacklightMode)) {
+    row += NUM_BACKLIGHT_SUB_ITEMS;
+#ifdef CONFIG_TOUCH
+  } else if (!prv_should_show_touch_wake() && (row >= SettingsBacklightTouchWake)) {
+    row += 1;
+#endif
+  }
   return row;
 }
 
-static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
-  SettingsDisplayData *data = (SettingsDisplayData*)context;
-  switch (prv_get_item_from_row(row)) {
-    case SettingsDisplayLanguage:
-      shell_prefs_toggle_language_english();
-      break;
-#if CAPABILITY_HAS_ORIENTATION_MANAGER
-    case SettingsDisplayOrientation:
-      prv_display_orientation_menu_push(data);
-      break;
-#endif
-    case SettingsDisplayBacklightMode:
+static void prv_backlight_select_click_cb(SettingsCallbacks *context, uint16_t row) {
+  SettingsBacklightData *data = (SettingsBacklightData*)context;
+  switch (prv_backlight_item_from_row(row)) {
+    case SettingsBacklightMode:
       light_toggle_enabled();
       break;
-    case SettingsDisplayMotionSensor:
+    case SettingsBacklightMotionWake:
       backlight_set_motion_enabled(!backlight_is_motion_enabled());
       break;
 #ifdef CONFIG_TOUCH
-    case SettingsDisplayTouchSensor:
+    case SettingsBacklightTouchWake:
       backlight_set_touch_enabled(!backlight_is_touch_enabled());
       break;
 #endif
-    case SettingsDisplayAmbientSensor:
+    case SettingsBacklightAmbientSensor:
       light_toggle_ambient_sensor_enabled();
       break;
 #if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
-    case SettingsDisplayDynamicIntensity:
+    case SettingsBacklightDynamicIntensity:
       light_toggle_dynamic_intensity_enabled();
       break;
 #endif
-    case SettingsDisplayBacklightIntensity:
+    case SettingsBacklightIntensity:
       prv_intensity_menu_push(data);
       break;
-    case SettingsDisplayBacklightTimeout:
+    case SettingsBacklightTimeout:
       prv_timeout_menu_push(data);
       break;
-#if PLATFORM_SPALDING && !PLATFORM_SPALDING_GABBRO
-    case SettingsDisplayAdjustAlignment:
-      settings_display_calibration_push(app_state_get_window_stack());
-      break;
-#endif
-#if CAPABILITY_HAS_APP_SCALING
-    case SettingsDisplayLegacyAppMode:
-      prv_legacy_app_mode_menu_push(data);
-      break;
-#endif
     default:
       WTF;
   }
@@ -283,28 +274,16 @@ static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
   settings_menu_mark_dirty(SettingsMenuItemDisplay);
 }
 
-static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
-                            const Layer *cell_layer, uint16_t row, bool selected) {
-  SettingsDisplayData *data = (SettingsDisplayData*) context;
-  
+static void prv_backlight_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
+                                      const Layer *cell_layer, uint16_t row, bool selected) {
+  SettingsBacklightData *data = (SettingsBacklightData*) context;
   const char *title = NULL;
   const char *subtitle = NULL;
-  switch (prv_get_item_from_row(row)) {
-    case SettingsDisplayLanguage:
-      title = i18n_noop("Language");
-      subtitle = i18n_get_lang_name();
-      break;
-#if CAPABILITY_HAS_ORIENTATION_MANAGER
-    case SettingsDisplayOrientation:
-      title = i18n_noop("Orientation");
-      subtitle = s_display_orientation_labels[prv_display_orientation_get_selection_index()];
-      break;
-#endif
-    case SettingsDisplayBacklightMode:
+  switch (prv_backlight_item_from_row(row)) {
+    case SettingsBacklightMode:
       title = i18n_noop("Backlight");
       if (backlight_is_enabled()) {
 #if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
-        // Show current backlight percentage when dynamic backlight is enabled
         if (backlight_is_dynamic_intensity_enabled()) {
           uint8_t current_percent = light_get_current_brightness_percent();
           snprintf(data->backlight_percent_buffer, sizeof(data->backlight_percent_buffer),
@@ -320,30 +299,21 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
         subtitle = i18n_noop("Off");
       }
       break;
-    case SettingsDisplayMotionSensor:
-      title = i18n_noop("Motion Enabled");
-      if (backlight_is_motion_enabled()) {
-        subtitle = i18n_noop("On");
-      } else {
-        subtitle = i18n_noop("Off");
-      }
+    case SettingsBacklightMotionWake:
+      title = i18n_noop("Wake on motion");
+      subtitle = backlight_is_motion_enabled() ? i18n_noop("On") : i18n_noop("Off");
       break;
 #ifdef CONFIG_TOUCH
-    case SettingsDisplayTouchSensor:
-      title = i18n_noop("Touch Enabled");
-      if (backlight_is_touch_enabled()) {
-        subtitle = i18n_noop("On");
-      } else {
-        subtitle = i18n_noop("Off");
-      }
+    case SettingsBacklightTouchWake:
+      title = i18n_noop("Wake on touch");
+      subtitle = backlight_is_touch_enabled() ? i18n_noop("On") : i18n_noop("Off");
       break;
 #endif
-    case SettingsDisplayAmbientSensor:
+    case SettingsBacklightAmbientSensor:
       title = i18n_noop("Ambient Sensor");
       if (backlight_is_ambient_sensor_enabled()) {
-        // Display ALS value when ambient sensor is enabled
         uint32_t als_value = ambient_light_get_light_level();
-        snprintf(data->als_value_buffer, sizeof(data->als_value_buffer), 
+        snprintf(data->als_value_buffer, sizeof(data->als_value_buffer),
                  "On (%"PRIu32")", als_value);
         subtitle = data->als_value_buffer;
       } else {
@@ -351,30 +321,177 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
       }
       break;
 #if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
-    case SettingsDisplayDynamicIntensity:
+    case SettingsBacklightDynamicIntensity:
       title = i18n_noop("Dynamic Backlight");
-      if (backlight_is_dynamic_intensity_enabled()) {
-        subtitle = i18n_noop("On");
-      } else {
-        subtitle = i18n_noop("Off");
-      }
+      subtitle = backlight_is_dynamic_intensity_enabled() ? i18n_noop("On") : i18n_noop("Off");
       break;
 #endif
-    case SettingsDisplayBacklightIntensity:
+    case SettingsBacklightIntensity:
 #if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
-      if (backlight_is_dynamic_intensity_enabled()) {
-        title = i18n_noop("Max Intensity");
-      } else {
-        title = i18n_noop("Intensity");
-      }
+      title = backlight_is_dynamic_intensity_enabled() ? i18n_noop("Max Intensity")
+                                                       : i18n_noop("Intensity");
 #else
       title = i18n_noop("Intensity");
 #endif
       subtitle = s_intensity_labels[prv_intensity_get_selection_index()];
       break;
-    case SettingsDisplayBacklightTimeout:
+    case SettingsBacklightTimeout:
       title = i18n_noop("Timeout");
       subtitle = s_timeout_labels[prv_timeout_get_selection_index()];
+      break;
+    default:
+      WTF;
+  }
+  menu_cell_basic_draw(ctx, cell_layer, i18n_get(title, data), i18n_get(subtitle, data), NULL);
+}
+
+static uint16_t prv_backlight_num_rows_cb(SettingsCallbacks *context) {
+  uint16_t rows = NumSettingsBacklightItems;
+  if (!prv_should_show_backlight_sub_items()) {
+    rows -= NUM_BACKLIGHT_SUB_ITEMS;
+#ifdef CONFIG_TOUCH
+  } else if (!prv_should_show_touch_wake()) {
+    // Only deduct when the sub-items are otherwise visible; when the backlight
+    // itself is off the touch-wake row is already covered by the bulk collapse.
+    rows -= 1;
+#endif
+  }
+  return rows;
+}
+
+// Timer refresh while the Backlight submenu is visible — lets us live-update
+// the ALS reading and the dynamic-backlight percentage subtitle.
+#define UPDATE_INTERVAL_MS 500
+static void prv_backlight_update_timer_cb(void *context) {
+  SettingsBacklightData *data = (SettingsBacklightData*)context;
+  settings_menu_mark_dirty(SettingsMenuItemDisplay);
+  data->update_timer = app_timer_register(UPDATE_INTERVAL_MS, prv_backlight_update_timer_cb, data);
+}
+
+static void prv_backlight_appear_cb(SettingsCallbacks *context) {
+  SettingsBacklightData *data = (SettingsBacklightData*)context;
+  if (!data->update_timer) {
+    data->update_timer = app_timer_register(UPDATE_INTERVAL_MS,
+                                            prv_backlight_update_timer_cb, data);
+  }
+}
+
+static void prv_backlight_hide_cb(SettingsCallbacks *context) {
+  SettingsBacklightData *data = (SettingsBacklightData*)context;
+  if (data->update_timer) {
+    app_timer_cancel(data->update_timer);
+    data->update_timer = NULL;
+  }
+}
+
+static void prv_backlight_deinit_cb(SettingsCallbacks *context) {
+  SettingsBacklightData *data = (SettingsBacklightData*) context;
+  if (data->update_timer) {
+    app_timer_cancel(data->update_timer);
+    data->update_timer = NULL;
+  }
+  i18n_free_all(data);
+  app_free(data);
+}
+
+static void prv_backlight_submenu_push(void) {
+  SettingsBacklightData *data = app_malloc_check(sizeof(*data));
+  *data = (SettingsBacklightData){};
+
+  data->callbacks = (SettingsCallbacks) {
+    .deinit = prv_backlight_deinit_cb,
+    .draw_row = prv_backlight_draw_row_cb,
+    .select_click = prv_backlight_select_click_cb,
+    .num_rows = prv_backlight_num_rows_cb,
+    .appear = prv_backlight_appear_cb,
+    .hide = prv_backlight_hide_cb,
+  };
+
+  Window *window = settings_window_create_with_title(SettingsMenuItemDisplay,
+                                                     i18n_noop("Backlight"), &data->callbacks);
+  app_window_stack_push(window, true /* animated */);
+}
+
+// Display top-level menu
+//////////////////////////////////////////////////////////////////////////////
+
+enum SettingsDisplayItem {
+  SettingsDisplayLanguage,
+#if CAPABILITY_HAS_ORIENTATION_MANAGER
+  SettingsDisplayOrientation,
+#endif
+#ifdef CONFIG_TOUCH
+  SettingsDisplayTouch,
+#endif
+  SettingsDisplayBacklight,
+#if PLATFORM_SPALDING && !PLATFORM_SPALDING_GABBRO
+  SettingsDisplayAdjustAlignment,
+#endif
+#if CAPABILITY_HAS_APP_SCALING
+  SettingsDisplayLegacyAppMode,
+#endif
+  NumSettingsDisplayItems
+};
+
+static void prv_display_select_click_cb(SettingsCallbacks *context, uint16_t row) {
+  switch (row) {
+    case SettingsDisplayLanguage:
+      shell_prefs_toggle_language_english();
+      break;
+#if CAPABILITY_HAS_ORIENTATION_MANAGER
+    case SettingsDisplayOrientation:
+      prv_display_orientation_menu_push((SettingsDisplayData*)context);
+      break;
+#endif
+#ifdef CONFIG_TOUCH
+    case SettingsDisplayTouch:
+      touch_set_globally_enabled(!touch_is_globally_enabled());
+      break;
+#endif
+    case SettingsDisplayBacklight:
+      prv_backlight_submenu_push();
+      break;
+#if PLATFORM_SPALDING && !PLATFORM_SPALDING_GABBRO
+    case SettingsDisplayAdjustAlignment:
+      settings_display_calibration_push(app_state_get_window_stack());
+      break;
+#endif
+#if CAPABILITY_HAS_APP_SCALING
+    case SettingsDisplayLegacyAppMode:
+      prv_legacy_app_mode_menu_push((SettingsDisplayData*)context);
+      break;
+#endif
+    default:
+      WTF;
+  }
+  settings_menu_reload_data(SettingsMenuItemDisplay);
+  settings_menu_mark_dirty(SettingsMenuItemDisplay);
+}
+
+static void prv_display_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
+                                    const Layer *cell_layer, uint16_t row, bool selected) {
+  SettingsDisplayData *data = (SettingsDisplayData*) context;
+  const char *title = NULL;
+  const char *subtitle = NULL;
+  switch (row) {
+    case SettingsDisplayLanguage:
+      title = i18n_noop("Language");
+      subtitle = i18n_get_lang_name();
+      break;
+#if CAPABILITY_HAS_ORIENTATION_MANAGER
+    case SettingsDisplayOrientation:
+      title = i18n_noop("Orientation");
+      subtitle = s_display_orientation_labels[prv_display_orientation_get_selection_index()];
+      break;
+#endif
+#ifdef CONFIG_TOUCH
+    case SettingsDisplayTouch:
+      title = i18n_noop("Touch");
+      subtitle = touch_is_globally_enabled() ? i18n_noop("On") : i18n_noop("Off");
+      break;
+#endif
+    case SettingsDisplayBacklight:
+      title = i18n_noop("Backlight");
       break;
 #if PLATFORM_SPALDING && !PLATFORM_SPALDING_GABBRO
     case SettingsDisplayAdjustAlignment:
@@ -394,51 +511,14 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
   menu_cell_basic_draw(ctx, cell_layer, i18n_get(title, data), i18n_get(subtitle, data), NULL);
 }
 
-static uint16_t prv_num_rows_cb(SettingsCallbacks *context) {
-  uint16_t rows = NumSettingsDisplayItems;
-  
-  if (!prv_should_show_backlight_sub_items()) {
-    rows -= NUM_BACKLIGHT_SUB_ITEMS;
-  }
-  
-  return rows;
+static uint16_t prv_display_num_rows_cb(SettingsCallbacks *context) {
+  return NumSettingsDisplayItems;
 }
 
-static void prv_deinit_cb(SettingsCallbacks *context) {
+static void prv_display_deinit_cb(SettingsCallbacks *context) {
   SettingsDisplayData *data = (SettingsDisplayData*) context;
-  if (data->update_timer) {
-    app_timer_cancel(data->update_timer);
-    data->update_timer = NULL;
-  }
   i18n_free_all(data);
   app_free(data);
-}
-
-// Timer callback to update debug values
-#define UPDATE_INTERVAL_MS 500  // Update twice per second
-static void prv_update_timer_cb(void *context) {
-  SettingsDisplayData *data = (SettingsDisplayData*)context;
-  
-  // Mark the menu as dirty to trigger a redraw
-  settings_menu_mark_dirty(SettingsMenuItemDisplay);
-  
-  // Reschedule the timer
-  data->update_timer = app_timer_register(UPDATE_INTERVAL_MS, prv_update_timer_cb, data);
-}
-
-static void prv_appear_cb(SettingsCallbacks *context) {
-  SettingsDisplayData *data = (SettingsDisplayData*)context;
-  if (!data->update_timer) {
-    data->update_timer = app_timer_register(UPDATE_INTERVAL_MS, prv_update_timer_cb, data);
-  }
-}
-
-static void prv_hide_cb(SettingsCallbacks *context) {
-  SettingsDisplayData *data = (SettingsDisplayData*)context;
-  if (data->update_timer) {
-    app_timer_cancel(data->update_timer);
-    data->update_timer = NULL;
-  }
 }
 
 static Window *prv_init(void) {
@@ -446,12 +526,10 @@ static Window *prv_init(void) {
   *data = (SettingsDisplayData){};
 
   data->callbacks = (SettingsCallbacks) {
-    .deinit = prv_deinit_cb,
-    .draw_row = prv_draw_row_cb,
-    .select_click = prv_select_click_cb,
-    .num_rows = prv_num_rows_cb,
-    .appear = prv_appear_cb,
-    .hide = prv_hide_cb,
+    .deinit = prv_display_deinit_cb,
+    .draw_row = prv_display_draw_row_cb,
+    .select_click = prv_display_select_click_cb,
+    .num_rows = prv_display_num_rows_cb,
   };
 
   return settings_window_create(SettingsMenuItemDisplay, &data->callbacks);

--- a/src/fw/apps/system/settings/window.c
+++ b/src/fw/apps/system/settings/window.c
@@ -42,6 +42,14 @@ typedef struct SettingsData {
 
   SettingsMenuItem current_category; //!< SettingsMenuItem_Invalid if not currently in a category.
 
+  //! Optional explicit title (used by nested submenus). When NULL, the title
+  //! falls back to the category's status name.
+  const char *title_override;
+
+  //! Previous app-state user_data value stashed at window creation; restored
+  //! on unload so nested settings windows don't leak pointers to freed data.
+  void *prev_app_user_data;
+
   const char *title;
   SettingsCallbacks *callbacks;
 
@@ -171,7 +179,9 @@ static void prv_settings_window_load(Window *window) {
 
   StatusBarLayer *status_layer = &data->status_layer;
   status_bar_layer_init(status_layer);
-  const char *title = settings_menu_get_status_name(data->current_category);
+  const char *title = data->title_override
+      ? data->title_override
+      : settings_menu_get_status_name(data->current_category);
   status_bar_layer_set_title(status_layer, i18n_get(title, data), false, false);
   status_bar_layer_set_colors(status_layer, GColorWhite, GColorBlack);
   status_bar_layer_set_separator_mode(status_layer, OPTION_MENU_STATUS_SEPARATOR_MODE);
@@ -247,15 +257,21 @@ static void prv_settings_window_unload(Window *window) {
   settings_window_destroy(window);
 }
 
-Window *settings_window_create(SettingsMenuItem category, SettingsCallbacks *callbacks) {
+static Window *prv_create(SettingsMenuItem category, const char *title_override,
+                          SettingsCallbacks *callbacks) {
   PBL_ASSERTN(callbacks && (category < SettingsMenuItem_Count));
 
   SettingsData *data = app_zalloc_check(sizeof(*data));
 
   data->current_category = category;
   data->title = settings_menu_get_submodule_info(category)->name;
+  data->title_override = title_override;
   data->callbacks = callbacks;
 
+  // Stash the previously-active settings data so we can restore it on unload
+  // and not leave app-state user_data pointing at freed memory after a nested
+  // submenu is popped.
+  data->prev_app_user_data = app_state_get_user_data();
   app_state_set_user_data(data);
 
   window_init(&data->window, WINDOW_NAME("Settings Window"));
@@ -269,6 +285,15 @@ Window *settings_window_create(SettingsMenuItem category, SettingsCallbacks *cal
   return &data->window;
 }
 
+Window *settings_window_create(SettingsMenuItem category, SettingsCallbacks *callbacks) {
+  return prv_create(category, NULL, callbacks);
+}
+
+Window *settings_window_create_with_title(SettingsMenuItem category, const char *title,
+                                          SettingsCallbacks *callbacks) {
+  return prv_create(category, title, callbacks);
+}
+
 void settings_window_destroy(Window *window) {
   SettingsData *data = window_get_user_data(window);
 
@@ -276,6 +301,9 @@ void settings_window_destroy(Window *window) {
   if (callbacks->deinit) {
     callbacks->deinit(data->callbacks);
   }
+
+  // Restore whatever was in app-state user_data before we took over.
+  app_state_set_user_data(data->prev_app_user_data);
 
   i18n_free_all(data);
   app_free(data);

--- a/src/fw/apps/system/settings/window.h
+++ b/src/fw/apps/system/settings/window.h
@@ -9,4 +9,14 @@
 
 Window *settings_window_create(SettingsMenuItem category, SettingsCallbacks *callbacks);
 
+//! Create a settings window that reuses a parent category's identity (for
+//! mark-dirty / reload routing) but shows a distinct title. Use this for
+//! nested submenus under an existing top-level category — e.g. a "Backlight"
+//! submenu pushed from within the "Display" settings.
+//! @param category The owning top-level SettingsMenuItem for dirty routing.
+//! @param title    Status-bar title for this window. Must outlive the window.
+//! @param callbacks Row-handling callbacks for this submenu.
+Window *settings_window_create_with_title(SettingsMenuItem category, const char *title,
+                                          SettingsCallbacks *callbacks);
+
 void settings_window_destroy(Window *window);

--- a/src/fw/kernel/event_loop.c
+++ b/src/fw/kernel/event_loop.c
@@ -58,6 +58,9 @@
 #include "pbl/services/common/new_timer/new_timer.h"
 #include "pbl/services/common/put_bytes/put_bytes.h"
 #include "pbl/services/common/system_task.h"
+#ifdef CONFIG_TOUCH
+#include "pbl/services/common/touch/touch.h"
+#endif
 #include "pbl/services/common/vibe_pattern.h"
 #include "pbl/services/normal/alarms/alarm.h"
 #include "pbl/services/normal/app_fetch_endpoint.h"
@@ -288,8 +291,12 @@ static NOINLINE void prv_minimal_event_handler(PebbleEvent* e) {
       }
       return;
 
-    case PEBBLE_TOUCH_EVENT:
-      if (backlight_is_touch_enabled() &&
+    case PEBBLE_TOUCH_EVENT: {
+      bool force_backlight = false;
+#ifdef CONFIG_TOUCH
+      force_backlight = touch_has_app_subscribers();
+#endif
+      if ((backlight_is_touch_enabled() || force_backlight) &&
           e->touch.event.type == TouchEvent_Touchdown) {
 #ifndef RECOVERY_FW
         const bool dnd_suppresses_backlight = do_not_disturb_is_active() &&
@@ -301,6 +308,7 @@ static NOINLINE void prv_minimal_event_handler(PebbleEvent* e) {
         }
       }
       return;
+    }
 
     case PEBBLE_PANIC_EVENT:
       launcher_panic(e->panic.error_code);

--- a/src/fw/kernel/kernel_applib_state.c
+++ b/src/fw/kernel/kernel_applib_state.c
@@ -133,6 +133,12 @@ TickTimerServiceState* kernel_applib_get_tick_timer_service_state(void) {
   return &s_tick_timer_service_state;
 }
 
+// --------------------------------------------------------------------------------------------
+TouchServiceState* kernel_applib_get_touch_service_state(void) {
+  static TouchServiceState s_touch_service_state;
+  return &s_touch_service_state;
+}
+
 // -----------------------------------------------------------------------------------------------------------
 ConnectionServiceState* kernel_applib_get_connection_service_state(void) {
   static ConnectionServiceState s_connection_service_state;

--- a/src/fw/kernel/kernel_applib_state.h
+++ b/src/fw/kernel/kernel_applib_state.h
@@ -7,6 +7,7 @@
 #include "kernel/logging_private.h"
 #include "applib/accel_service_private.h"
 #include "applib/tick_timer_service_private.h"
+#include "applib/touch_service_private.h"
 #include "applib/compass_service_private.h"
 #include "applib/battery_state_service.h"
 #include "applib/battery_state_service_private.h"
@@ -26,6 +27,8 @@ CompassServiceConfig **kernel_applib_get_compass_config(void);
 EventServiceInfo* kernel_applib_get_event_service_state(void);
 
 TickTimerServiceState *kernel_applib_get_tick_timer_service_state(void);
+
+TouchServiceState *kernel_applib_get_touch_service_state(void);
 
 ConnectionServiceState* kernel_applib_get_connection_service_state(void);
 

--- a/src/fw/process_management/pebble_process_info.h
+++ b/src/fw/process_management/pebble_process_info.h
@@ -157,9 +157,10 @@ typedef enum {
 // sdk.major:0x5 .minor:0x59 -- Add flags to ModdableCreationRecord (rev 92)
 // sdk.major:0x5 .minor:0x5a -- Add rot_bitmap_layer_get_layer() and AppGlanceSliceLayout (rev 93)
 // sdk.major:0x5 .minor:0x5b -- Add app_light_set_color() and app_light_set_system_color() (rev 94)
+// sdk.major:0x5 .minor:0x5c -- Add light_is_on() (rev 95)
 
 #define PROCESS_INFO_CURRENT_SDK_VERSION_MAJOR 0x5
-#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x5b
+#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x5c
 
 // The first SDK to ship with 2.x APIs
 #define PROCESS_INFO_FIRST_2X_SDK_VERSION_MAJOR 0x4

--- a/src/fw/process_management/pebble_process_info.h
+++ b/src/fw/process_management/pebble_process_info.h
@@ -157,7 +157,7 @@ typedef enum {
 // sdk.major:0x5 .minor:0x59 -- Add flags to ModdableCreationRecord (rev 92)
 // sdk.major:0x5 .minor:0x5a -- Add rot_bitmap_layer_get_layer() and AppGlanceSliceLayout (rev 93)
 // sdk.major:0x5 .minor:0x5b -- Add app_light_set_color() and app_light_set_system_color() (rev 94)
-// sdk.major:0x5 .minor:0x5c -- Add light_is_on() (rev 95)
+// sdk.major:0x5 .minor:0x5c -- Add light_is_on() and expose touch_service_subscribe/unsubscribe to apps (rev 95)
 
 #define PROCESS_INFO_CURRENT_SDK_VERSION_MAJOR 0x5
 #define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x5c

--- a/src/fw/process_state/app_state/app_state.c
+++ b/src/fw/process_state/app_state/app_state.c
@@ -73,6 +73,8 @@ typedef struct {
 
   TickTimerServiceState tick_timer_service_state;
 
+  TouchServiceState touch_service_state;
+
   ConnectionServiceState connection_service_state;
 
   HealthServiceState health_service_state;
@@ -198,6 +200,8 @@ NOINLINE void app_state_init(void) {
 
   tick_timer_service_state_init(app_state_get_tick_timer_service_state());
 
+  touch_service_state_init(app_state_get_touch_service_state());
+
   health_service_state_init(app_state_get_health_service_state());
 
   locale_init_app_locale(app_state_get_locale_info());
@@ -307,6 +311,10 @@ BatteryStateServiceState *app_state_get_battery_state_service_state(void) {
 
 TickTimerServiceState *app_state_get_tick_timer_service_state(void) {
   return &s_app_state_ptr->tick_timer_service_state;
+}
+
+TouchServiceState *app_state_get_touch_service_state(void) {
+  return &s_app_state_ptr->touch_service_state;
 }
 
 ConnectionServiceState *app_state_get_connection_service_state(void) {

--- a/src/fw/process_state/app_state/app_state.h
+++ b/src/fw/process_state/app_state/app_state.h
@@ -22,6 +22,7 @@
 #include "applib/plugin_service_private.h"
 #include "applib/tick_timer_service.h"
 #include "applib/tick_timer_service_private.h"
+#include "applib/touch_service_private.h"
 #include "applib/ui/animation_private.h"
 #include "applib/ui/click_internal.h"
 #include "applib/ui/content_indicator_private.h"
@@ -114,6 +115,8 @@ LogState *app_state_get_log_state(void);
 BatteryStateServiceState *app_state_get_battery_state_service_state(void);
 
 TickTimerServiceState *app_state_get_tick_timer_service_state(void);
+
+TouchServiceState *app_state_get_touch_service_state(void);
 
 ConnectionServiceState *app_state_get_connection_service_state(void);
 

--- a/src/fw/services/common/light/service.c
+++ b/src/fw/services/common/light/service.c
@@ -608,6 +608,10 @@ void light_allow(bool allowed) {
   s_backlight_allowed = allowed;
 }
 
+DEFINE_SYSCALL(bool, sys_light_is_on, void) {
+  return light_is_on();
+}
+
 DEFINE_SYSCALL(void, sys_light_enable_interaction, void) {
   light_enable_interaction();
 }
@@ -637,6 +641,10 @@ extern BacklightBehaviour backlight_get_behaviour(void);
 uint8_t light_get_current_brightness_percent(void) {
   uint8_t percent = (s_current_brightness * 100) / BACKLIGHT_BRIGHTNESS_MAX;
   return percent;
+}
+
+bool light_is_on(void) {
+  return s_light_state != LIGHT_STATE_OFF;
 }
 
 void pbl_analytics_external_collect_backlight_stats(void) {

--- a/src/fw/services/common/touch/touch.c
+++ b/src/fw/services/common/touch/touch.c
@@ -48,6 +48,13 @@ void touch_init(void) {
       &prv_remove_subscriber_cb);
 }
 
+bool touch_has_app_subscribers(void) {
+  mutex_lock(s_touch_mutex);
+  const bool has_apps = s_subscriber_count > 0;
+  mutex_unlock(s_touch_mutex);
+  return has_apps;
+}
+
 void touch_set_backlight_enabled(bool enabled) {
   mutex_lock(s_touch_mutex);
   if (enabled && !s_backlight_subscribed) {

--- a/src/fw/services/common/touch/touch.c
+++ b/src/fw/services/common/touch/touch.c
@@ -9,6 +9,8 @@
 #include "kernel/pebble_tasks.h"
 #include "pbl/services/common/event_service.h"
 #include "pbl/services/common/analytics/analytics.h"
+#include "syscall/syscall.h"
+#include "syscall/syscall_internal.h"
 #include "system/logging.h"
 #include "os/mutex.h"
 #include "system/passert.h"
@@ -23,10 +25,13 @@ static PebbleMutex *s_touch_mutex;
 
 static uint8_t s_subscriber_count = 0;
 static bool s_backlight_subscribed = false;
+static bool s_globally_enabled = true;
 
 static void prv_add_subscriber_cb(PebbleTask task) {
   mutex_lock(s_touch_mutex);
-  if (++s_subscriber_count == 1) {
+  // Honor the global kill switch: when touch is globally disabled, track the
+  // subscriber count but don't power up the sensor.
+  if (++s_subscriber_count == 1 && s_globally_enabled) {
     touch_sensor_set_enabled(true);
   }
   mutex_unlock(s_touch_mutex);
@@ -35,7 +40,7 @@ static void prv_add_subscriber_cb(PebbleTask task) {
 static void prv_remove_subscriber_cb(PebbleTask task) {
   mutex_lock(s_touch_mutex);
   PBL_ASSERTN(s_subscriber_count > 0);
-  if (--s_subscriber_count == 0) {
+  if (--s_subscriber_count == 0 && s_globally_enabled) {
     touch_sensor_set_enabled(false);
   }
   mutex_unlock(s_touch_mutex);
@@ -53,6 +58,36 @@ bool touch_has_app_subscribers(void) {
   const bool has_apps = s_subscriber_count > 0;
   mutex_unlock(s_touch_mutex);
   return has_apps;
+}
+
+void touch_service_set_globally_enabled(bool enabled) {
+  mutex_lock(s_touch_mutex);
+  if (s_globally_enabled == enabled) {
+    mutex_unlock(s_touch_mutex);
+    return;
+  }
+  s_globally_enabled = enabled;
+  const bool has_subscribers = s_subscriber_count > 0;
+  mutex_unlock(s_touch_mutex);
+
+  if (has_subscribers) {
+    touch_sensor_set_enabled(enabled);
+  }
+  if (!enabled) {
+    // Avoid delivering stale position on re-enable.
+    touch_reset();
+  }
+}
+
+bool touch_service_is_globally_enabled(void) {
+  mutex_lock(s_touch_mutex);
+  const bool enabled = s_globally_enabled;
+  mutex_unlock(s_touch_mutex);
+  return enabled;
+}
+
+DEFINE_SYSCALL(bool, sys_touch_service_is_enabled, void) {
+  return touch_service_is_globally_enabled();
 }
 
 void touch_set_backlight_enabled(bool enabled) {
@@ -87,6 +122,11 @@ static void prv_put_touch_event(TouchEventType type, int16_t x, int16_t y) {
 
 void touch_handle_update(TouchState touch_state, int16_t x, int16_t y) {
   mutex_lock(s_touch_mutex);
+
+  if (!s_globally_enabled) {
+    mutex_unlock(s_touch_mutex);
+    return;
+  }
 
   if (s_touch_state != touch_state) {
     s_touch_state = touch_state;

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -84,6 +84,9 @@ static bool s_backlight_motion_enabled = true;
 #define PREF_KEY_BACKLIGHT_TOUCH "lightTouch"
 static bool s_backlight_touch_enabled = false;
 
+#define PREF_KEY_TOUCH_ENABLED "touchEnabled"
+static bool s_touch_enabled = true;
+
 #define PREF_KEY_MOTION_SENSITIVITY "motionSensitivity"
 static uint8_t s_motion_sensitivity = 55; // Default to Medium
 
@@ -357,6 +360,14 @@ static bool prv_set_s_backlight_touch_enabled(bool *enabled) {
   s_backlight_touch_enabled = *enabled;
 #ifdef CONFIG_TOUCH
   touch_set_backlight_enabled(*enabled);
+#endif
+  return true;
+}
+
+static bool prv_set_s_touch_enabled(bool *enabled) {
+  s_touch_enabled = *enabled;
+#ifdef CONFIG_TOUCH
+  touch_service_set_globally_enabled(*enabled);
 #endif
   return true;
 }
@@ -850,6 +861,7 @@ void shell_prefs_init(void) {
   // Enable touch sensor for touch backlight only if the setting is enabled
 #ifdef CONFIG_TOUCH
   touch_set_backlight_enabled(s_backlight_touch_enabled);
+  touch_service_set_globally_enabled(s_touch_enabled);
 #endif
 }
 
@@ -1155,6 +1167,14 @@ bool backlight_is_touch_enabled(void) {
 
 void backlight_set_touch_enabled(bool enable) {
   prv_pref_set(PREF_KEY_BACKLIGHT_TOUCH, &enable, sizeof(enable));
+}
+
+bool touch_is_globally_enabled(void) {
+  return s_touch_enabled;
+}
+
+void touch_set_globally_enabled(bool enable) {
+  prv_pref_set(PREF_KEY_TOUCH_ENABLED, &enable, sizeof(enable));
 }
 
 #if CAPABILITY_HAS_DYNAMIC_BACKLIGHT

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -13,6 +13,7 @@
 #endif
   PREFS_MACRO(PREF_KEY_BACKLIGHT_MOTION, s_backlight_motion_enabled)
   PREFS_MACRO(PREF_KEY_BACKLIGHT_TOUCH, s_backlight_touch_enabled)
+  PREFS_MACRO(PREF_KEY_TOUCH_ENABLED, s_touch_enabled)
   PREFS_MACRO(PREF_KEY_MOTION_SENSITIVITY, s_motion_sensitivity)
 #if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
   PREFS_MACRO(PREF_KEY_BACKLIGHT_DYNAMIC_INTENSITY, s_backlight_dynamic_intensity_enabled)

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -91,6 +91,12 @@ void backlight_set_motion_enabled(bool enable);
 bool backlight_is_touch_enabled(void);
 void backlight_set_touch_enabled(bool enable);
 
+// Global touch input kill-switch. When false, the kernel touch service
+// drops events at the source, powers the sensor down, and the applib
+// touch_service_is_enabled() query returns false to apps.
+bool touch_is_globally_enabled(void);
+void touch_set_globally_enabled(bool enable);
+
 #if CAPABILITY_HAS_DYNAMIC_BACKLIGHT
 // Dynamic backlight intensity based on ambient light sensor
 bool backlight_is_dynamic_intensity_enabled(void);

--- a/src/fw/shell/prf/stubs.c
+++ b/src/fw/shell/prf/stubs.c
@@ -210,6 +210,13 @@ bool backlight_is_touch_enabled(void) {
   return false;
 }
 
+bool touch_is_globally_enabled(void) {
+  return true;
+}
+
+void touch_set_globally_enabled(bool enable) {
+}
+
 bool bt_persistent_storage_get_airplane_mode_enabled(void) {
   return false;
 }

--- a/src/fw/shell/sdk/stubs.c
+++ b/src/fw/shell/sdk/stubs.c
@@ -69,6 +69,13 @@ bool backlight_is_touch_enabled(void) {
   return false;
 }
 
+bool touch_is_globally_enabled(void) {
+  return true;
+}
+
+void touch_set_globally_enabled(bool enable) {
+}
+
 #include "process_management/app_install_types.h"
 void worker_preferences_set_default_worker(AppInstallId id) {
 }

--- a/src/fw/syscall/syscall.h
+++ b/src/fw/syscall/syscall.h
@@ -190,6 +190,7 @@ bool sys_activity_is_initialized(void);
 void sys_app_comm_set_responsiveness(SniffInterval interval);
 SniffInterval sys_app_comm_get_sniff_interval(void);
 
+bool sys_light_is_on(void);
 void sys_light_enable_interaction(void);
 void sys_light_enable(bool enable);
 void sys_light_enable_respect_settings(bool enable);

--- a/tests/fw/services/test_touch.c
+++ b/tests/fw/services/test_touch.c
@@ -175,3 +175,23 @@ void test_touch__backlight_and_app_share_sensor(void) {
   cl_assert_equal_i(s_touch_sensor_disable_count, 1);
   cl_assert(!s_touch_sensor_enabled);
 }
+
+void test_touch__has_app_subscribers_app(void) {
+  cl_assert(!touch_has_app_subscribers());
+
+  s_add_subscriber_cb(PebbleTask_App);
+  cl_assert(touch_has_app_subscribers());
+
+  s_remove_subscriber_cb(PebbleTask_App);
+  cl_assert(!touch_has_app_subscribers());
+}
+
+void test_touch__has_app_subscribers_backlight(void) {
+  cl_assert(!touch_has_app_subscribers());
+
+  touch_set_backlight_enabled(true);
+  cl_assert(touch_has_app_subscribers());
+
+  touch_set_backlight_enabled(false);
+  cl_assert(!touch_has_app_subscribers());
+}

--- a/tests/fw/services/test_touch.c
+++ b/tests/fw/services/test_touch.c
@@ -55,6 +55,9 @@ void test_touch__initialize(void) {
   s_touch_sensor_enabled = false;
   touch_init();
   touch_reset();
+  // Make sure the global kill switch is reset between tests — it's a module
+  // static in touch.c and a failed test could otherwise leak its state.
+  touch_service_set_globally_enabled(true);
 }
 
 void test_touch__cleanup(void) {
@@ -194,4 +197,55 @@ void test_touch__has_app_subscribers_backlight(void) {
 
   touch_set_backlight_enabled(false);
   cl_assert(!touch_has_app_subscribers());
+}
+
+void test_touch__globally_enabled_default_true(void) {
+  // Default state after init is enabled; no setter call required.
+  cl_assert(touch_service_is_globally_enabled());
+}
+
+void test_touch__global_disable_drops_events(void) {
+  touch_service_set_globally_enabled(false);
+  touch_handle_update(TouchState_FingerDown, 10, 20);
+  cl_assert_equal_i(fake_event_get_count(), 0);
+
+  touch_handle_update(TouchState_FingerUp, 10, 20);
+  cl_assert_equal_i(fake_event_get_count(), 0);
+
+  touch_service_set_globally_enabled(true);
+}
+
+void test_touch__global_disable_powers_down_sensor(void) {
+  // Subscriber brings the sensor up.
+  s_add_subscriber_cb(PebbleTask_App);
+  cl_assert(s_touch_sensor_enabled);
+  cl_assert_equal_i(s_touch_sensor_enable_count, 1);
+
+  // Disabling globally powers the sensor down even though a subscriber remains.
+  touch_service_set_globally_enabled(false);
+  cl_assert(!s_touch_sensor_enabled);
+  cl_assert_equal_i(s_touch_sensor_disable_count, 1);
+
+  // Re-enabling brings it back up for the existing subscriber.
+  touch_service_set_globally_enabled(true);
+  cl_assert(s_touch_sensor_enabled);
+  cl_assert_equal_i(s_touch_sensor_enable_count, 2);
+
+  s_remove_subscriber_cb(PebbleTask_App);
+}
+
+void test_touch__subscribe_while_disabled_keeps_sensor_off(void) {
+  touch_service_set_globally_enabled(false);
+
+  // Subscribing while disabled must not power the sensor up.
+  s_add_subscriber_cb(PebbleTask_App);
+  cl_assert(!s_touch_sensor_enabled);
+  cl_assert_equal_i(s_touch_sensor_enable_count, 0);
+
+  // Re-enabling globally powers it up for the pre-existing subscriber.
+  touch_service_set_globally_enabled(true);
+  cl_assert(s_touch_sensor_enabled);
+  cl_assert_equal_i(s_touch_sensor_enable_count, 1);
+
+  s_remove_subscriber_cb(PebbleTask_App);
 }

--- a/tools/generate_native_sdk/exported_symbols.json
+++ b/tools/generate_native_sdk/exported_symbols.json
@@ -4,7 +4,7 @@
               "You should also make sure you are obeying our API design guidelines:",
               "https://pebbletechnology.atlassian.net/wiki/display/DEV/SDK+API+Design+Guidelines"
             ],
-  "revision" : "94",
+  "revision" : "95",
   "version" : "2.0",
   "files": [
     "fw/drivers/ambient_light.h",
@@ -4470,6 +4470,11 @@
           "appOnly": true,
           "exports": [
             {
+              "type": "function",
+              "name": "light_is_on",
+              "implName": "app_light_is_on",
+              "addedRevision": "95"
+            }, {
               "type": "function",
               "name": "light_enable_interaction",
               "implName": "app_light_enable_interaction",

--- a/tools/generate_native_sdk/exported_symbols.json
+++ b/tools/generate_native_sdk/exported_symbols.json
@@ -54,6 +54,8 @@
     "fw/applib/moddable/moddable.h",
     "fw/applib/platform.h",
     "fw/applib/tick_timer_service.h",
+    "fw/applib/touch_service.h",
+    "include/pbl/services/common/touch/touch_event.h",
     "fw/applib/pbl_std/pbl_std.h",
     "fw/applib/pbl_std/locale.h",
     "fw/applib/persist.h",
@@ -549,6 +551,37 @@
                   "type": "function",
                   "name": "tick_timer_service_unsubscribe",
                   "addedRevision": "0"
+                }
+              ]
+            }, {
+              "type": "group",
+              "name": "TouchService",
+              "appOnly": true,
+              "exports": [
+                {
+                  "type": "type",
+                  "name": "TouchEventType",
+                  "addedRevision": "95"
+                }, {
+                  "type": "type",
+                  "name": "TouchEvent",
+                  "addedRevision": "95"
+                }, {
+                  "type": "type",
+                  "name": "TouchServiceHandler",
+                  "addedRevision": "95"
+                }, {
+                  "type": "function",
+                  "name": "touch_service_subscribe",
+                  "addedRevision": "95"
+                }, {
+                  "type": "function",
+                  "name": "touch_service_unsubscribe",
+                  "addedRevision": "95"
+                }, {
+                  "type": "function",
+                  "name": "touch_service_is_enabled",
+                  "addedRevision": "95"
                 }
               ]
             }, {


### PR DESCRIPTION
## Summary

  Adds user-facing touch input to the app SDK (rev 95) and tidies the Display settings to match.

  ## New SDK (rev 95)

  ```c
  // Raw touch events
  typedef enum { TouchEvent_Touchdown, TouchEvent_Liftoff, TouchEvent_PositionUpdate } TouchEventType;
  typedef struct {
    TouchEventType type;
    bool caused_wake;   // true on Touchdown if this tap also woke the backlight
    int16_t x;
    int16_t y;
  } TouchEvent;
  typedef void (*TouchServiceHandler)(const TouchEvent *event, void *context);

  void touch_service_subscribe(TouchServiceHandler handler, void *context);
  void touch_service_unsubscribe(void);
  bool touch_service_is_enabled(void);   // reflects the global touch toggle

  // Gesture recognizers (layered on top of the raw events)
  typedef struct { int16_t x, y; } TouchPoint;
  typedef enum { TouchSwipeDirection_Up, _Down, _Left, _Right } TouchSwipeDirection;

  void touch_tap_subscribe(TouchTapHandler handler, void *ctx);
  void touch_long_press_subscribe(TouchLongPressHandler handler, void *ctx);   // 500 ms hold
  void touch_swipe_subscribe(TouchSwipeHandler handler, void *ctx);            // fired on liftoff,
                                                                               // "roughly straight" paths only
  void touch_tap_unsubscribe(void);
  void touch_long_press_unsubscribe(void);
  void touch_swipe_unsubscribe(void);

  // Backlight query (also rev 95, same drop)
  bool light_is_on(void);
  ```

  Behaviour notes:
  - While any app is subscribed (raw or gesture), a touchdown wakes the backlight regardless of the user's lightTouch pref (DND still wins).

## Settings

  Settings > Display:

  - Touch - new top-level toggle driving a persisted touchEnabled pref. When off, the kernel touch service drops events at the source and powers the sensor down; subscribers stay subscribed and resume when re-enabled.
  - Backlight - existing backlight rows (Mode, Wake on motion, Wake on touch, Ambient, Dynamic Intensity, Intensity, Timeout) grouped into a submenu.