### PR TITLE
fw/apps/watch/low_power: use larger LECO on emery/gabbro

### DIFF
--- a/src/fw/apps/watch/low_power/face.c
+++ b/src/fw/apps/watch/low_power/face.c
@@ -65,7 +65,11 @@ static void init(void) {
   window_set_background_color(&s_low_power_data->low_power_window, GColorLightGray);
   app_window_stack_push(&s_low_power_data->low_power_window, true /* Animated */);
 
+#if PBL_DISPLAY_HEIGHT >= 200
+  const GFont text_font = fonts_get_system_font(FONT_KEY_LECO_60_NUMBERS_AM_PM);
+#else
   const GFont text_font = fonts_get_system_font(FONT_KEY_LECO_42_NUMBERS);
+#endif
   const GTextAlignment text_alignment = GTextAlignmentCenter;
   const unsigned int font_height = fonts_get_font_height(text_font);
   const GTextOverflowMode text_overflow_mode = GTextOverflowModeTrailingEllipsis;


### PR DESCRIPTION
## Summary

The low-power watchface hardcoded `FONT_KEY_LECO_42_NUMBERS` on every platform. On emery (200x228) and gabbro (260x260) there is plenty of room for the larger clock. Select `FONT_KEY_LECO_60_NUMBERS_AM_PM` via the same `PBL_DISPLAY_HEIGHT >= 200` guard already used in `src/fw/apps/system/workout/active.c`. Smaller displays keep `LECO_42_NUMBERS`.

Fixes [FIRM-1700](https://linear.app/core-dev/issue/FIRM-1700/low-power-watchface-needs-larger-leco-on-emerygabbro).

## Test plan

- [x] Builds cleanly for `qemu_emery` (200x228)
- [x] Builds cleanly for `qemu_gabbro` (260x260)
- [ ] On emery/gabbro: low-power watchface shows the larger LECO_60 clock, still vertically centered relative to the battery icon
- [ ] On smaller platforms (snowy, spalding, silk, asterix): unchanged, still LECO_42

🤖 Generated with [Claude Code](https://claude.com/claude-code)