### PR TITLE
fw/asterix: add DA7212 audio driver for speaker playback + raise PMIC discharge limit during audio

### DIFF
--- a/platform/platform_capabilities.py
+++ b/platform/platform_capabilities.py
@@ -134,6 +134,7 @@ board_capability_dicts = [
             "HAS_FLASH_OTP",
             "HAS_ACCEL_SENSITIVITY",
             "HAS_ORIENTATION_MANAGER",
+            "HAS_SPEAKER",
         },
     },
     {

--- a/src/fw/board/board_nrf5.h
+++ b/src/fw/board/board_nrf5.h
@@ -304,6 +304,7 @@ typedef const struct HRMDevice HRMDevice;
 typedef const struct MicDevice MicDevice;
 typedef const struct QSPIPort QSPIPort;
 typedef const struct QSPIFlash QSPIFlash;
+typedef const struct AudioDevice AudioDevice;
 
 void board_early_init(void);
 void board_init(void);

--- a/src/fw/board/boards/board_asterix.c
+++ b/src/fw/board/boards/board_asterix.c
@@ -4,12 +4,14 @@
 #include <nrfx_i2s.h>
 
 #include "board/board.h"
+#include "drivers/audio.h"
 #include "drivers/flash/qspi_flash_definitions.h"
 #include "drivers/gpio.h"
 #include "drivers/i2c.h"
 #include "drivers/i2c/definitions.h"
 #include "drivers/mic.h"
 #include "drivers/mic/nrf5/pdm_definitions.h"
+#include "drivers/nrf5/audio/audio_definitions.h"
 #include "drivers/i2c/nrf5.h"
 #include "drivers/uart/nrf5.h"
 #include "drivers/pmic/npm1300.h"
@@ -199,6 +201,33 @@ static MicDevice s_mic_device = {
   .channels = 1,
 };
 MicDevice * const MIC = &s_mic_device;
+
+/* Speaker / audio output (DA7212 codec over I2S) */
+static AudioDeviceState s_audio_state_storage;
+static void prv_audio_power_up(void) {
+  NPM1300_OPS.dischg_limit_ma_set(NPM1300_DISCHG_LIMIT_MA_MAX);
+}
+static void prv_audio_power_down(void) {
+  NPM1300_OPS.dischg_limit_ma_set(NPM1300_CONFIG.dischg_limit_ma);
+}
+static const BoardPowerOps s_audio_power_ops = {
+  .power_up = prv_audio_power_up,
+  .power_down = prv_audio_power_down,
+};
+static const AudioDevice s_audio_device = {
+  .state = &s_audio_state_storage,
+  .i2s_instance = NRFX_I2S_INSTANCE(0),
+  .sck_pin = NRF_GPIO_PIN_MAP(0, 12),   // P0.12 - I2S SCK  -> DA7212 BCLK
+  .lrck_pin = NRF_GPIO_PIN_MAP(0, 7),   // P0.07 - I2S LRCK -> DA7212 WCLK
+  .mck_pin = NRF_GPIO_PIN_MAP(1, 9),    // P1.09 - I2S MCK  -> DA7212 MCLK
+  .sdout_pin = NRF_GPIO_PIN_MAP(0, 13), // P0.13 - I2S SDOUT -> DA7212 DATA_IN
+  .sdin_pin = NRF_I2S_PIN_NOT_CONNECTED, // codec DATA_OUT unused for playback
+  .irq_priority = 5,
+  .codec = &I2C_SLAVE_DA7212,
+  .power_ops = &s_audio_power_ops,
+  .samplerate = 16000,
+};
+AudioDevice * const AUDIO = (AudioDevice *)&s_audio_device;
 
 /* sensor SPI bus */
 

--- a/src/fw/board/boards/board_asterix.h
+++ b/src/fw/board/boards/board_asterix.h
@@ -143,6 +143,7 @@ extern QSPIPort * const QSPI;
 extern QSPIFlash * const QSPI_FLASH;
 
 extern MicDevice * const MIC;
+extern AudioDevice * const AUDIO;
 
 extern I2CSlavePort * const I2C_NPM1300;
 extern I2CSlavePort * const I2C_DRV2604;

--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -5,6 +5,7 @@
 #include "board/display.h"
 #include "board/splash.h"
 #include "drivers/led_controller.h"
+#include "drivers/pmic/npm1300.h"
 #include "drivers/sf32lb52/debounced_button_definitions.h"
 #include "drivers/hrm/gh3x2x.h"
 #include "system/passert.h"
@@ -619,6 +620,19 @@ const MicDevice* MIC = &mic_device;
 IRQ_MAP(PDM1, pdm1_data_handler, MIC);
 IRQ_MAP(DMAC1_CH5, pdm1_l_dma_handler, MIC);
 
+static void prv_audio_power_up(void) {
+  NPM1300_OPS.dischg_limit_ma_set(NPM1300_DISCHG_LIMIT_MA_MAX);
+}
+
+static void prv_audio_power_down(void) {
+  NPM1300_OPS.dischg_limit_ma_set(NPM1300_CONFIG.dischg_limit_ma);
+}
+
+static const BoardPowerOps prv_audio_power_ops = {
+    .power_up = prv_audio_power_up,
+    .power_down = prv_audio_power_down,
+};
+
 static AudioDeviceState audio_state;
 static const AudioDevice audio_device = {
     .state = &audio_state,
@@ -635,6 +649,7 @@ static const AudioDevice audio_device = {
         .gpio_pin = 0,
         .active_high =true,
     },
+    .power_ops = &prv_audio_power_ops,
 };
 const AudioDevice* AUDIO = &audio_device;
 IRQ_MAP(DMAC1_CH4, audec_dac0_dma_irq_handler, AUDIO);

--- a/src/fw/drivers/audio.h
+++ b/src/fw/drivers/audio.h
@@ -1,8 +1,20 @@
 /* SPDX-FileCopyrightText: 2025 Core Devices LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#pragma once
+
+#include <stdint.h>
+
 typedef const struct AudioDevice AudioDevice;
 typedef void (*AudioTransCB)(uint32_t *free_size);
+
+//! Optional board-level power hooks. Either callback may be NULL.
+//! power_up runs before the consumer enables (e.g. raise PMIC discharge limit);
+//! power_down runs after the consumer disables (e.g. restore the limit).
+typedef struct BoardPowerOps {
+  void (*power_up)(void);
+  void (*power_down)(void);
+} BoardPowerOps;
 
 extern void audio_init(AudioDevice* audio_device);
 extern void audio_start(AudioDevice* audio_device, AudioTransCB cb);

--- a/src/fw/drivers/nrf5/audio/audio.c
+++ b/src/fw/drivers/nrf5/audio/audio.c
@@ -1,0 +1,447 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "audio_definitions.h"
+
+#include "board/board.h"
+#include "drivers/audio.h"
+#include "drivers/clocksource.h"
+#include "drivers/i2c.h"
+#include "kernel/pbl_malloc.h"
+#include "kernel/util/sleep.h"
+#include "pbl/services/common/system_task.h"
+#include "system/logging.h"
+#include "system/passert.h"
+#include "util/circular_buffer.h"
+#include "util/math.h"
+
+#include "nrfx_i2s.h"
+
+// ---------------------------------------------------------------------------
+// DA7212 codec registers used by the driver.
+// ---------------------------------------------------------------------------
+#define DA7212_PLL_STATUS            0x03
+#define DA7212_CIF_CTRL              0x1D
+#define DA7212_DIG_ROUTING_DAI       0x21
+#define DA7212_SR                    0x22
+#define DA7212_REFERENCES            0x23
+#define DA7212_PLL_FRAC_TOP          0x24
+#define DA7212_PLL_FRAC_BOT          0x25
+#define DA7212_PLL_INTEGER           0x26
+#define DA7212_PLL_CTRL              0x27
+#define DA7212_DAI_CLK_MODE          0x28
+#define DA7212_DAI_CTRL              0x29
+#define DA7212_DIG_ROUTING_DAC       0x2A
+#define DA7212_DAC_FILTERS5          0x40
+#define DA7212_DAC_R_GAIN            0x46
+#define DA7212_LINE_GAIN             0x4A
+#define DA7212_MIXOUT_R_SELECT       0x4C
+#define DA7212_SYSTEM_MODES_OUTPUT   0x51
+#define DA7212_DAC_R_CTRL            0x6A
+#define DA7212_LINE_CTRL             0x6D
+#define DA7212_MIXOUT_R_CTRL         0x6F
+#define DA7212_LDO_CTRL              0x90
+#define DA7212_GAIN_RAMP_CTRL        0x92
+#define DA7212_SYSTEM_ACTIVE         0xFD
+
+// DAC_R_GAIN value corresponding to 0 dB per DA7212 datasheet.
+#define DA7212_DAC_R_GAIN_0DB        0x6f
+
+#define I2S_BUF_SAMPLES_STEREO       (NRF5_AUDIO_I2S_BUF_SAMPLES_MONO * 2)
+#define I2S_BUF_SIZE_BYTES           (I2S_BUF_SAMPLES_STEREO * sizeof(int16_t))
+// nrfx_i2s buffer_size is counted in 32-bit words.
+#define I2S_BUF_SIZE_WORDS           (I2S_BUF_SIZE_BYTES / sizeof(uint32_t))
+
+static void prv_i2s_data_handler(nrfx_i2s_buffers_t const *p_released, uint32_t status);
+
+// ---------------------------------------------------------------------------
+// DA7212 helpers.
+// ---------------------------------------------------------------------------
+
+static void prv_codec_write(AudioDevice *dev, uint8_t reg, uint8_t value) {
+  uint8_t data[2] = { reg, value };
+  i2c_use(dev->codec);
+  bool ok = i2c_write_block(dev->codec, sizeof(data), data);
+  i2c_release(dev->codec);
+  PBL_ASSERTN(ok);
+}
+
+static uint8_t prv_codec_read(AudioDevice *dev, uint8_t reg) {
+  uint8_t value = 0;
+  i2c_use(dev->codec);
+  bool ok = i2c_read_register(dev->codec, reg, &value);
+  i2c_release(dev->codec);
+  PBL_ASSERTN(ok);
+  return value;
+}
+
+// Bring the DA7212 out of standby, lock its PLL and configure the DAC/LINE
+// path — but leave the DAI (BCLK/WCLK) disabled. The caller starts the nRF
+// I2S peripheral in slave mode in between, then calls prv_codec_start_dai()
+// below to have the codec begin driving BCLK/WCLK into the nRF.
+//
+// We run the codec as I2S master because the nRF's 32 MHz clock tree can't
+// divide down to exactly 16 kHz LRCK, while the DA7212 PLL can synthesize
+// exactly 12.288 MHz system clock from our 4 MHz MCK and emit a true 16 kHz
+// WCLK when SR=0x05. Register values are taken from
+// src/fw/apps/prf/mfg_mic_asterix.c (PLL setup) and
+// src/fw/apps/prf/mfg_speaker_asterix.c (codec-master DAI mode).
+static void prv_codec_prepare(AudioDevice *dev) {
+  prv_codec_write(dev, DA7212_CIF_CTRL, 0x80);
+  psleep(10);
+
+  prv_codec_write(dev, DA7212_SYSTEM_ACTIVE, 0x01);
+  prv_codec_write(dev, DA7212_REFERENCES, 0x08);
+  psleep(30);
+
+  prv_codec_write(dev, DA7212_LDO_CTRL, 0x80);
+
+  // PLL: MCLK=4MHz (input divider 2), target system clock 12.288MHz for
+  // SR=16kHz. VCO = 98.304MHz => integer=49, frac=1245 (0x4dd).
+  prv_codec_write(dev, DA7212_PLL_FRAC_TOP, 0x04);
+  prv_codec_write(dev, DA7212_PLL_FRAC_BOT, 0xdd);
+  prv_codec_write(dev, DA7212_PLL_INTEGER, 0x31);
+  prv_codec_write(dev, DA7212_PLL_CTRL, 0xC0);
+
+  // DA7212 rev 3.6 13.29 workaround for 2-5MHz MCLK range.
+  prv_codec_write(dev, 0xF0, 0x8B);
+  prv_codec_write(dev, 0xF2, 0x03);
+  prv_codec_write(dev, 0xF0, 0x00);
+  psleep(40);
+
+  PBL_ASSERT(prv_codec_read(dev, DA7212_PLL_STATUS) == 0x07,
+             "DA7212 PLL not locked");
+
+  // Gain ramp off: the mfg test uses a multi-second ramp for smooth
+  // mic-capture playback, but for the speaker service we want audio as soon
+  // as the stream opens.
+  prv_codec_write(dev, DA7212_GAIN_RAMP_CTRL, 0x00);
+  prv_codec_write(dev, DA7212_SR, 0x05);
+
+  prv_codec_write(dev, DA7212_DIG_ROUTING_DAI, 0x32);
+  prv_codec_write(dev, DA7212_DIG_ROUTING_DAC, 0xba);
+
+  prv_codec_write(dev, DA7212_DAC_R_GAIN, DA7212_DAC_R_GAIN_0DB);
+  prv_codec_write(dev, DA7212_DAC_R_CTRL, 0x80);
+  prv_codec_write(dev, DA7212_MIXOUT_R_SELECT, 0x08);
+  // amp + mix enable, softmix off (softmix slow-ramps each routing change).
+  prv_codec_write(dev, DA7212_MIXOUT_R_CTRL, 0x90);
+
+  prv_codec_write(dev, DA7212_LINE_GAIN, 0x3a);
+  prv_codec_write(dev, DA7212_LINE_CTRL, 0x80);
+
+  prv_codec_write(dev, DA7212_SYSTEM_MODES_OUTPUT, 0x89);
+
+  // Clear soft mute now that the path is up (DAI still disabled).
+  prv_codec_write(dev, DA7212_DAC_FILTERS5, 0x00);
+}
+
+// Enable the DA7212 DAI as I2S master. This is the point at which BCLK/WCLK
+// begin toggling on P0.12 / P0.07; the nRF I2S must already be armed in slave
+// mode when this runs.
+static void prv_codec_start_dai(AudioDevice *dev) {
+  // DAI_CTRL: enable, 16-bit samples. Codec is still in slave-clock mode at
+  // this point, so its DAI output pins remain high-Z.
+  prv_codec_write(dev, DA7212_DAI_CTRL, 0x80);
+  // DAI_CLK_MODE: master + BCLKS_PER_WCLK=001 (64 BCLK per WCLK frame). The
+  // codec now drives BCLK and WCLK; nRF I2S slave picks them up.
+  prv_codec_write(dev, DA7212_DAI_CLK_MODE, 0x81);
+}
+
+static void prv_codec_stop(AudioDevice *dev) {
+  prv_codec_write(dev, DA7212_DAC_FILTERS5, 0x80);
+  prv_codec_write(dev, DA7212_SYSTEM_ACTIVE, 0x00);
+}
+
+// ---------------------------------------------------------------------------
+// Buffer management.
+// ---------------------------------------------------------------------------
+
+static bool prv_allocate_buffers(AudioDeviceState *state) {
+  state->circ_buffer_storage = kernel_malloc(NRF5_AUDIO_CIRC_BUF_SIZE_BYTES);
+  if (!state->circ_buffer_storage) {
+    PBL_LOG_ERR("Failed to allocate audio circular buffer");
+    return false;
+  }
+
+  for (int i = 0; i < NRF5_AUDIO_I2S_BUF_COUNT; i++) {
+    state->i2s_bufs[i] = kernel_malloc(I2S_BUF_SIZE_BYTES);
+    if (!state->i2s_bufs[i]) {
+      PBL_LOG_ERR("Failed to allocate I2S buffer %d", i);
+      for (int j = 0; j < i; j++) {
+        kernel_free(state->i2s_bufs[j]);
+        state->i2s_bufs[j] = NULL;
+      }
+      kernel_free(state->circ_buffer_storage);
+      state->circ_buffer_storage = NULL;
+      return false;
+    }
+    memset(state->i2s_bufs[i], 0, I2S_BUF_SIZE_BYTES);
+  }
+
+  circular_buffer_init(&state->circ_buffer, state->circ_buffer_storage,
+                       NRF5_AUDIO_CIRC_BUF_SIZE_BYTES);
+  return true;
+}
+
+static void prv_free_buffers(AudioDeviceState *state) {
+  for (int i = 0; i < NRF5_AUDIO_I2S_BUF_COUNT; i++) {
+    if (state->i2s_bufs[i]) {
+      kernel_free(state->i2s_bufs[i]);
+      state->i2s_bufs[i] = NULL;
+    }
+  }
+  if (state->circ_buffer_storage) {
+    kernel_free(state->circ_buffer_storage);
+    state->circ_buffer_storage = NULL;
+  }
+}
+
+// Fill a stereo I2S buffer by draining mono samples from the circular buffer
+// and duplicating each to both channels. Any shortfall is padded with silence.
+// Runs in the nrfx_i2s ISR.
+static void prv_fill_i2s_buffer(AudioDeviceState *state, int16_t *out) {
+  const uint32_t n_mono = NRF5_AUDIO_I2S_BUF_SAMPLES_MONO;
+  const uint32_t mono_bytes = n_mono * sizeof(int16_t);
+
+  uint16_t available = circular_buffer_get_read_space_remaining(&state->circ_buffer);
+  uint16_t to_copy = (available > mono_bytes) ? mono_bytes : available;
+  uint32_t samples_copied = 0;
+
+  if (to_copy > 0) {
+    uint16_t copied = circular_buffer_copy(&state->circ_buffer, out, to_copy);
+    circular_buffer_consume(&state->circ_buffer, copied);
+    samples_copied = copied / sizeof(int16_t);
+  }
+
+  // Zero the unfilled tail of the mono portion.
+  for (uint32_t i = samples_copied; i < n_mono; i++) {
+    out[i] = 0;
+  }
+
+  // Expand mono -> stereo in place, iterating back-to-front so reads from
+  // out[i] happen before writes at the paired stereo slots overwrite them.
+  for (int32_t i = (int32_t)n_mono - 1; i >= 0; i--) {
+    int16_t s = out[i];
+    out[2 * i] = s;
+    out[2 * i + 1] = s;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// trans_cb dispatch (runs on the system task).
+// ---------------------------------------------------------------------------
+
+static void prv_audio_trans_bg(void *data) {
+  AudioDeviceState *state = (AudioDeviceState *)data;
+  state->callback_pending = false;
+  if (state->is_running && state->trans_cb) {
+    uint32_t free_size = circular_buffer_get_write_space_remaining(&state->circ_buffer);
+    state->trans_cb(&free_size);
+  }
+}
+
+static void prv_maybe_request_refill_from_isr(AudioDeviceState *state) {
+  if (!state->trans_cb || state->callback_pending || !state->is_running) {
+    return;
+  }
+  uint16_t free_size = circular_buffer_get_write_space_remaining(&state->circ_buffer);
+  if (free_size < NRF5_AUDIO_REFILL_THRESHOLD_BYTES) {
+    return;
+  }
+
+  state->callback_pending = true;
+  bool should_context_switch = false;
+  if (!system_task_add_callback_from_isr(prv_audio_trans_bg, state,
+                                         &should_context_switch)) {
+    state->callback_pending = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// nrfx_i2s data handler.
+// ---------------------------------------------------------------------------
+
+// nrfx_i2s_data_handler_t takes no user data, so we stash the currently active
+// device here while it's running.
+static AudioDevice *s_active_device;
+
+static void prv_i2s_data_handler(nrfx_i2s_buffers_t const *p_released, uint32_t status) {
+  AudioDevice *dev = s_active_device;
+  if (!dev) {
+    return;
+  }
+  AudioDeviceState *state = dev->state;
+
+  if (status & NRFX_I2S_STATUS_NEXT_BUFFERS_NEEDED) {
+    int16_t *fill_buf = state->i2s_bufs[state->buf_idx];
+    prv_fill_i2s_buffer(state, fill_buf);
+
+    nrfx_i2s_buffers_t next = {
+        .p_tx_buffer = (uint32_t *)fill_buf,
+        .p_rx_buffer = NULL,
+        .buffer_size = I2S_BUF_SIZE_WORDS,
+    };
+    (void)nrfx_i2s_next_buffers_set(&dev->i2s_instance, &next);
+    state->buf_idx = (state->buf_idx + 1) % NRF5_AUDIO_I2S_BUF_COUNT;
+
+    prv_maybe_request_refill_from_isr(state);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API.
+// ---------------------------------------------------------------------------
+
+void audio_init(AudioDevice *audio_device) {
+  PBL_ASSERTN(audio_device);
+  AudioDeviceState *state = audio_device->state;
+
+  memset(state, 0, sizeof(*state));
+}
+
+void audio_start(AudioDevice *audio_device, AudioTransCB cb) {
+  PBL_ASSERTN(audio_device);
+  AudioDeviceState *state = audio_device->state;
+
+  if (state->is_running) {
+    PBL_LOG_WRN("Audio already running");
+    return;
+  }
+
+  if (!prv_allocate_buffers(state)) {
+    return;
+  }
+
+  state->trans_cb = cb;
+  state->callback_pending = false;
+  state->buf_idx = 0;
+
+  s_active_device = audio_device;
+
+  if (audio_device->power_ops && audio_device->power_ops->power_up) {
+    audio_device->power_ops->power_up();
+  }
+
+  // The DA7212 PLL references our MCK, which must be stable before we try to
+  // lock it. HFXO is also needed by the I2S peripheral for MCK generation.
+  clocksource_hfxo_request();
+
+  nrfx_i2s_config_t cfg = NRFX_I2S_DEFAULT_CONFIG(
+      audio_device->sck_pin, audio_device->lrck_pin, audio_device->mck_pin,
+      audio_device->sdout_pin, audio_device->sdin_pin);
+  cfg.irq_priority = audio_device->irq_priority;
+  cfg.channels = NRF_I2S_CHANNELS_STEREO;
+  cfg.sample_width = NRF_I2S_SWIDTH_16BIT;
+  cfg.format = NRF_I2S_FORMAT_I2S;
+  cfg.alignment = NRF_I2S_ALIGN_LEFT;
+  // nRF is the I2S slave: SCK/LRCK come from the DA7212 (codec is master).
+  // MCK is still generated by nRF at 4 MHz and fed into the codec PLL; the
+  // codec divides it down to exactly 16 kHz WCLK internally, avoiding the
+  // ~2% mismatch we'd get from nRF-as-master with any available MDIV/ratio.
+  cfg.mode = NRF_I2S_MODE_SLAVE;
+  cfg.mck_setup = NRF_I2S_MCK_32MDIV8;
+  // Ratio is unused for LRCK in slave mode; pick a value that nrfx accepts
+  // for 16-bit stereo (validate_config only enforces this in master mode).
+  cfg.ratio = NRF_I2S_RATIO_256X;
+
+  nrfx_err_t err = nrfx_i2s_init(&audio_device->i2s_instance, &cfg,
+                                 prv_i2s_data_handler);
+  PBL_ASSERT(err == NRFX_SUCCESS, "nrfx_i2s_init failed: %d", err);
+
+  // Prime the first buffer with silence; real samples arrive via audio_write.
+  memset(state->i2s_bufs[0], 0, I2S_BUF_SIZE_BYTES);
+  nrfx_i2s_buffers_t initial = {
+      .p_tx_buffer = (uint32_t *)state->i2s_bufs[0],
+      .p_rx_buffer = NULL,
+      .buffer_size = I2S_BUF_SIZE_WORDS,
+  };
+  state->buf_idx = 1;
+
+  state->is_running = true;
+
+  // Arm the nRF I2S in slave mode. This also starts MCK toggling on the mck
+  // pin — required before the codec PLL can lock. The peripheral will sit
+  // idle until the codec starts driving BCLK/WCLK in phase 2.
+  err = nrfx_i2s_start(&audio_device->i2s_instance, &initial, 0);
+  PBL_ASSERT(err == NRFX_SUCCESS, "nrfx_i2s_start failed: %d", err);
+
+  // Codec phase 1: PLL lock against the now-running MCK + full path config.
+  // DAI output stays disabled so P0.12/P0.07 remain high-Z (nRF has them
+  // configured as inputs in slave mode).
+  prv_codec_prepare(audio_device);
+
+  // Codec phase 2: enable the DAI as master. Clocks start toggling now and
+  // the nRF begins consuming the silence buffer.
+  prv_codec_start_dai(audio_device);
+
+  PBL_LOG_INFO("Audio started");
+}
+
+uint32_t audio_write(AudioDevice *audio_device, void *write_buf, uint32_t size) {
+  PBL_ASSERTN(audio_device);
+  AudioDeviceState *state = audio_device->state;
+
+  if (!state->is_running || !state->circ_buffer_storage) {
+    return 0;
+  }
+
+  uint16_t free_size = circular_buffer_get_write_space_remaining(&state->circ_buffer);
+  uint16_t to_write = (size > free_size) ? free_size : (uint16_t)size;
+  if (to_write > 0) {
+    (void)circular_buffer_write(&state->circ_buffer, write_buf, to_write);
+  }
+  return circular_buffer_get_write_space_remaining(&state->circ_buffer);
+}
+
+void audio_set_volume(AudioDevice *audio_device, int volume) {
+  PBL_ASSERTN(audio_device);
+  AudioDeviceState *state = audio_device->state;
+  if (!state->is_running) {
+    return;
+  }
+
+  if (volume <= 0) {
+    prv_codec_write(audio_device, DA7212_DAC_FILTERS5, 0x80);
+    return;
+  }
+  if (volume > 100) {
+    volume = 100;
+  }
+
+  // Map 1..100 onto the DAC_R_GAIN range 0x01..0x7F.
+  uint8_t gain = (uint8_t)((volume * 0x7F) / 100);
+  if (gain == 0) {
+    gain = 1;
+  }
+  prv_codec_write(audio_device, DA7212_DAC_R_GAIN, gain);
+  prv_codec_write(audio_device, DA7212_DAC_FILTERS5, 0x00);
+}
+
+void audio_stop(AudioDevice *audio_device) {
+  PBL_ASSERTN(audio_device);
+  AudioDeviceState *state = audio_device->state;
+
+  if (!state->is_running) {
+    return;
+  }
+
+  state->is_running = false;
+
+  prv_codec_stop(audio_device);
+
+  nrfx_i2s_stop(&audio_device->i2s_instance);
+  nrfx_i2s_uninit(&audio_device->i2s_instance);
+
+  clocksource_hfxo_release();
+
+  if (audio_device->power_ops && audio_device->power_ops->power_down) {
+    audio_device->power_ops->power_down();
+  }
+
+  state->trans_cb = NULL;
+  s_active_device = NULL;
+  prv_free_buffers(state);
+
+  PBL_LOG_INFO("Audio stopped");
+}

--- a/src/fw/drivers/nrf5/audio/audio_definitions.h
+++ b/src/fw/drivers/nrf5/audio/audio_definitions.h
@@ -1,0 +1,55 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include "board/board.h"
+#include "drivers/audio.h"
+#include "util/circular_buffer.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "nrfx_i2s.h"
+
+// Number of mono samples per I2S half-buffer. The stereo buffer holds 2x this
+// many 16-bit samples. With SAMPLE_RATE=16000, 512 mono samples = 32ms.
+#define NRF5_AUDIO_I2S_BUF_SAMPLES_MONO   512
+#define NRF5_AUDIO_I2S_BUF_COUNT          2
+
+// Mono bytes held in the circular buffer (caller <-> DMA). 4096 bytes = 2048
+// mono samples = 128ms at 16kHz.
+#define NRF5_AUDIO_CIRC_BUF_SIZE_BYTES    4096
+
+// Request a refill from the caller whenever this much mono-data space is free.
+#define NRF5_AUDIO_REFILL_THRESHOLD_BYTES 1024
+
+typedef struct AudioDeviceState {
+  AudioTransCB trans_cb;
+  bool is_running;
+  bool callback_pending;
+  uint8_t buf_idx;
+
+  int16_t *i2s_bufs[NRF5_AUDIO_I2S_BUF_COUNT];
+
+  uint8_t *circ_buffer_storage;
+  CircularBuffer circ_buffer;
+} AudioDeviceState;
+
+typedef const struct AudioDevice {
+  AudioDeviceState *state;
+
+  nrfx_i2s_t i2s_instance;
+  uint32_t sck_pin;
+  uint32_t lrck_pin;
+  uint32_t mck_pin;
+  uint32_t sdout_pin;
+  uint32_t sdin_pin;
+  uint8_t irq_priority;
+
+  I2CSlavePort *codec;
+
+  const BoardPowerOps *power_ops;
+
+  uint32_t samplerate;
+} AudioDevice;

--- a/src/fw/drivers/sf32lb52/audio/audio.c
+++ b/src/fw/drivers/sf32lb52/audio/audio.c
@@ -17,6 +17,10 @@ void audio_init(AudioDevice* audio_device) {
 }
 
 void audio_start(AudioDevice* audio_device, AudioTransCB cb) {
+    if (audio_device->power_ops && audio_device->power_ops->power_up) {
+        audio_device->power_ops->power_up();
+    }
+
     gpio_output_set(&audio_device->pa_ctrl, true);
     delay_us(PA_POWER_DELAY_TIME);
     gpio_output_set(&audio_device->pa_ctrl, false);
@@ -36,4 +40,8 @@ void audio_set_volume(AudioDevice* audio_device, int volume) {
 void audio_stop(AudioDevice* audio_device) {
     audec_stop(audio_device);
     gpio_output_set(&audio_device->pa_ctrl, false);
+
+    if (audio_device->power_ops && audio_device->power_ops->power_down) {
+        audio_device->power_ops->power_down();
+    }
 }

--- a/src/fw/drivers/sf32lb52/audio/audio_definitions.h
+++ b/src/fw/drivers/sf32lb52/audio/audio_definitions.h
@@ -51,6 +51,7 @@ typedef const struct AudioDevice {
   uint32_t audec_dma_request;
   IRQn_Type audec_dma_irq;
   OutputConfig pa_ctrl;
+  const BoardPowerOps *power_ops;
   uint8_t data_format;
   uint8_t data_mode;
   uint32_t samplerate;

--- a/src/fw/drivers/wscript_build
+++ b/src/fw/drivers/wscript_build
@@ -69,6 +69,7 @@ elif bld.is_snowy_compatible() or bld.is_snowy_emery() or bld.is_spalding_gabbro
 
 elif bld.is_asterix():
     bld.env.DRIVERS.extend([
+        'driver_audio',
         'driver_backlight',
         'driver_button',
         'driver_mcu',
@@ -134,6 +135,21 @@ elif bld.is_obelix():
             'pbl_includes',
             'driver_gpio',
             'hal_sifli',
+        ],
+    )
+elif bld.is_asterix():
+    bld.objects(
+        name='driver_audio',
+        source=[
+            'nrf5/audio/audio.c',
+        ],
+        use=[
+            'fw_includes',
+            'pbl_includes',
+            'driver_i2c',
+            'driver_nrf5_hfxo',
+            'freertos',
+            'hal_nordic',
         ],
     )
 


### PR DESCRIPTION
nRF5 I2S driver implementing drivers/audio.h for P2D. Codec runs as I2S master (nRF as slave) so the DA7212 PLL can synthesize an exact 16 kHz WCLK from our 4 MHz MCK
nRF-as-master can't divide 32 MHz to exactly 16 kHz.

also adds callbacks to the audio driver to raise pmic limit at start + reset pmic limit at end