### PR TITLE
shell/battery_ui_fsm: skip first warning when next one is imminent

### DIFF
--- a/src/fw/shell/normal/battery_ui_fsm.c
+++ b/src/fw/shell/normal/battery_ui_fsm.c
@@ -103,6 +103,13 @@ static const uint8_t s_warning_points[] = { 12, 6 };
 static const uint8_t s_warning_points[] = { 18, 12 };
 #endif
 
+// Minimum hours of headroom above the next warning threshold required to show
+// the current warning. If battery crosses a warning point already close to the
+// next one (e.g. a fast drop or a level-estimate correction), skip the earlier
+// warning so the user does not see contradictory daypart messaging like
+// "Powered 'til tomorrow" followed shortly by "Powered 'til tonight".
+#define BATTERY_WARNING_MIN_HOURS_HEADROOM 3
+
 // State functions
 
 static void prv_display_warning(void *data) {
@@ -114,6 +121,14 @@ static void prv_display_warning(void *data) {
          battery_curve_get_percent_remaining(s_warning_points[s_warning_points_index + 1]))) {
     s_warning_points_index++;
     new_warning = true;
+  }
+
+  if (new_warning && s_warning_points_index < num_points) {
+    const uint32_t hours_remaining = battery_curve_get_hours_remaining(percent);
+    const uint32_t next_point_hours = s_warning_points[s_warning_points_index + 1];
+    if (hours_remaining < next_point_hours + BATTERY_WARNING_MIN_HOURS_HEADROOM) {
+      new_warning = false;
+    }
   }
 
   if (new_warning) {

--- a/tests/fw/shell/normal/test_battery_ui_fsm.c
+++ b/tests/fw/shell/normal/test_battery_ui_fsm.c
@@ -262,10 +262,34 @@ void test_battery_ui_fsm__warning(void) {
   cl_assert(s_modal_onscreen && s_modal_percent == battery_curve_get_percent_remaining(12));
 }
 
+void test_battery_ui_fsm__skip_first_warning_when_next_is_close(void) {
+  // If the first warning would fire at a battery level already within
+  // BATTERY_WARNING_MIN_HOURS_HEADROOM (3h) of the next threshold, the
+  // gray warning is skipped so the user doesn't get contradictory daypart
+  // messages (e.g. "Powered 'til tomorrow" followed by "Powered 'til tonight").
+  PreciseBatteryChargeState nop = prv_make_state(50, false, false);
+  // 14h remaining is within 3h of the 12h red threshold -> gray should be skipped.
+  PreciseBatteryChargeState warning_14h =
+      prv_make_state(battery_curve_get_percent_remaining(14), false, false);
+  PreciseBatteryChargeState warning_12h =
+      prv_make_state(battery_curve_get_percent_remaining(12), false, false);
+
+  prv_change_state(warning_14h);
+  cl_assert(!s_modal_onscreen);
+  cl_assert_equal_i(s_vibe_count, 0);
+
+  // Dropping below the red threshold should fire red normally.
+  prv_change_state(warning_12h);
+  cl_assert(s_modal_onscreen);
+  cl_assert_equal_i(s_modal_percent, battery_curve_get_percent_remaining(12));
+  cl_assert_equal_i(s_vibe_count, 1);
+}
+
 void test_battery_ui_fsm__honor_dnd(void) {
   PreciseBatteryChargeState nop = prv_make_state(50, false, false),
                             charging = prv_make_state(50, true, true),
-                            warning = prv_make_state(15, false, false);
+                            warning = prv_make_state(
+                                battery_curve_get_percent_remaining(18), false, false);
   s_dnd_on = true;
   prv_change_state(charging);
   cl_assert(s_modal_onscreen && s_modal_charging);


### PR DESCRIPTION
If the battery crosses a warning threshold already close to the next one (e.g. from a fast drop or a fuel-gauge correction), we can show a gray "Powered 'til tomorrow" and then immediately a red "Powered 'til tonight" — individually correct, but contradictory to the user because the daypart message is computed from different reference times.

Require a minimum of 3h of headroom above the next warning threshold before firing the current warning. If the headroom isn't there, skip the earlier warning and let the next one fire normally with an accurate daypart message.

Fixes FIRM-1703