### PR TITLE
applib/light: add light_set_color_rgb888() for full 8-bit-per-channel tint

### DIFF
--- a/include/pbl/services/common/light.h
+++ b/include/pbl/services/common/light.h
@@ -46,10 +46,10 @@ void light_enable_interaction(void);
 //! Reset the state if an app overrode the usual state machine using light_enable()
 void light_reset_user_controlled(void);
 
-//! @copydoc app_light_set_color
-//! Argb is a GColor8-packed byte (2 bits per channel, alpha ignored).
-//! No-op on platforms without a color backlight.
-void light_set_color(uint8_t argb);
+//! @copydoc app_light_set_color_rgb888
+//! rgb is a packed 0x00RRGGBB value (8 bits per channel). No-op on
+//! platforms without a color backlight.
+void light_set_color_rgb888(uint32_t rgb);
 
 //! @copydoc app_light_set_system_color
 //! No-op on platforms without a color backlight.

--- a/src/fw/applib/app_light.c
+++ b/src/fw/applib/app_light.c
@@ -17,8 +17,24 @@ void app_light_enable(bool enable) {
   sys_light_enable(enable);
 }
 
+//! Expand a GColor8 argb byte (2 bits per channel) to a packed 0x00RRGGBB
+//! value by bit-replicating each 2-bit component into 8 bits.
+static uint32_t prv_argb_to_rgb888(uint8_t argb) {
+  const uint8_t r2 = (argb >> 4) & 0x3;
+  const uint8_t g2 = (argb >> 2) & 0x3;
+  const uint8_t b2 = argb & 0x3;
+  const uint8_t r = (uint8_t)((r2 << 6) | (r2 << 4) | (r2 << 2) | r2);
+  const uint8_t g = (uint8_t)((g2 << 6) | (g2 << 4) | (g2 << 2) | g2);
+  const uint8_t b = (uint8_t)((b2 << 6) | (b2 << 4) | (b2 << 2) | b2);
+  return ((uint32_t)r << 16) | ((uint32_t)g << 8) | b;
+}
+
 void app_light_set_color(GColor color) {
-  sys_light_set_color(color.argb);
+  sys_light_set_color_rgb888(prv_argb_to_rgb888(color.argb));
+}
+
+void app_light_set_color_rgb888(uint32_t rgb) {
+  sys_light_set_color_rgb888(rgb);
 }
 
 void app_light_set_system_color(void) {

--- a/src/fw/applib/app_light.h
+++ b/src/fw/applib/app_light.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "applib/graphics/gtypes.h"
 
@@ -40,8 +41,18 @@ void app_light_enable(bool enable);
 //! app is foregrounded and is automatically reset to the user's default
 //! (white) when the app exits or is preempted by a system notification.
 //! On platforms without a color backlight this is a no-op.
+//! @note GColor carries only 2 bits per channel (64 distinct tints). Use
+//! app_light_set_color_rgb888() if you need the full 8-bit-per-channel range
+//! that the LED hardware supports.
 //! @param color The color to tint the backlight to.
 void app_light_set_color(GColor color);
+
+//! Tint the backlight LED to a packed 24-bit RGB value (0x00RRGGBB).
+//! Same persistence semantics as app_light_set_color(): the override lasts
+//! while the app is foregrounded and is reset on app exit or system preempt.
+//! No-op on platforms without a color backlight.
+//! @param rgb Packed 0x00RRGGBB value; 8 bits per channel. High byte ignored.
+void app_light_set_color_rgb888(uint32_t rgb);
 
 //! Restore the backlight to the user's default color. Rarely needed — the
 //! system resets automatically on app exit. No-op on platforms without a

--- a/src/fw/process_management/pebble_process_info.h
+++ b/src/fw/process_management/pebble_process_info.h
@@ -158,9 +158,10 @@ typedef enum {
 // sdk.major:0x5 .minor:0x5a -- Add rot_bitmap_layer_get_layer() and AppGlanceSliceLayout (rev 93)
 // sdk.major:0x5 .minor:0x5b -- Add app_light_set_color() and app_light_set_system_color() (rev 94)
 // sdk.major:0x5 .minor:0x5c -- Add light_is_on() and expose touch_service_subscribe/unsubscribe to apps (rev 95)
+// sdk.major:0x5 .minor:0x5d -- Add app_light_set_color_rgb888() for 8-bit-per-channel backlight tint (rev 96)
 
 #define PROCESS_INFO_CURRENT_SDK_VERSION_MAJOR 0x5
-#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x5c
+#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x5d
 
 // The first SDK to ship with 2.x APIs
 #define PROCESS_INFO_FIRST_2X_SDK_VERSION_MAJOR 0x4

--- a/src/fw/services/common/light/service.c
+++ b/src/fw/services/common/light/service.c
@@ -231,18 +231,6 @@ static void prv_update_intensity_analytics(uint8_t new_intensity_pct) {
 }
 
 #if CAPABILITY_HAS_COLOR_BACKLIGHT
-//! Expand a GColor8 argb byte (2 bits per channel) into a packed RGB888
-//! uint32 by bit-replicating each 2-bit component across 8 bits.
-static uint32_t prv_argb_to_rgb888(uint8_t argb) {
-  const uint8_t r2 = (argb >> 4) & 0x3;
-  const uint8_t g2 = (argb >> 2) & 0x3;
-  const uint8_t b2 = argb & 0x3;
-  const uint8_t r = (uint8_t)((r2 << 6) | (r2 << 4) | (r2 << 2) | r2);
-  const uint8_t g = (uint8_t)((g2 << 6) | (g2 << 4) | (g2 << 2) | g2);
-  const uint8_t b = (uint8_t)((b2 << 6) | (b2 << 4) | (b2 << 2) | b2);
-  return ((uint32_t)r << 16) | ((uint32_t)g << 8) | b;
-}
-
 //! LED color to drive when no app has set an override. Backed by the
 //! user's stored backlight-color preference, defaulting to LED_WARM_WHITE.
 static uint32_t prv_default_rgb_color(void) {
@@ -498,17 +486,17 @@ void light_reset_user_controlled(void) {
   mutex_unlock(s_mutex);
 }
 
-void light_set_color(uint8_t argb) {
+void light_set_color_rgb888(uint32_t rgb) {
 #if CAPABILITY_HAS_COLOR_BACKLIGHT
   mutex_lock(s_mutex);
-  s_app_rgb_override = prv_argb_to_rgb888(argb);
+  s_app_rgb_override = rgb & 0x00FFFFFF;
   s_app_rgb_override_valid = true;
   if (s_light_state != LIGHT_STATE_OFF) {
     prv_apply_rgb_color();
   }
   mutex_unlock(s_mutex);
 #else
-  (void)argb;
+  (void)rgb;
 #endif
 }
 
@@ -628,8 +616,8 @@ DEFINE_SYSCALL(void, sys_light_reset_to_timed_mode, void) {
   prv_light_reset_to_timed_mode();
 }
 
-DEFINE_SYSCALL(void, sys_light_set_color, uint8_t argb) {
-  light_set_color(argb);
+DEFINE_SYSCALL(void, sys_light_set_color_rgb888, uint32_t rgb) {
+  light_set_color_rgb888(rgb);
 }
 
 DEFINE_SYSCALL(void, sys_light_set_system_color, void) {

--- a/src/fw/syscall/syscall.h
+++ b/src/fw/syscall/syscall.h
@@ -195,7 +195,7 @@ void sys_light_enable_interaction(void);
 void sys_light_enable(bool enable);
 void sys_light_enable_respect_settings(bool enable);
 void sys_light_reset_to_timed_mode(void);
-void sys_light_set_color(uint8_t argb);
+void sys_light_set_color_rgb888(uint32_t rgb);
 void sys_light_set_system_color(void);
 
 bool sys_mobile_app_is_connected_debounced(void);

--- a/tools/generate_native_sdk/exported_symbols.json
+++ b/tools/generate_native_sdk/exported_symbols.json
@@ -4,7 +4,7 @@
               "You should also make sure you are obeying our API design guidelines:",
               "https://pebbletechnology.atlassian.net/wiki/display/DEV/SDK+API+Design+Guidelines"
             ],
-  "revision" : "95",
+  "revision" : "96",
   "version" : "2.0",
   "files": [
     "fw/drivers/ambient_light.h",
@@ -4522,6 +4522,11 @@
               "name": "light_set_color",
               "implName": "app_light_set_color",
               "addedRevision": "94"
+            }, {
+              "type": "function",
+              "name": "light_set_color_rgb888",
+              "implName": "app_light_set_color_rgb888",
+              "addedRevision": "96"
             }, {
               "type": "function",
               "name": "light_set_system_color",


### PR DESCRIPTION
I was not realizing people would want full RGB control until I started writing the docs ._.