### PR TITLE
fw/shell/normal/prefs: enable stationary mode by default

### DIFF
--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -107,11 +107,7 @@ static bool s_display_orientation_left = false;
 static uint32_t s_backlight_ambient_threshold = 0; // default set from board config in shell_prefs_init()
 
 #define PREF_KEY_STATIONARY "stationaryMode"
-#if RELEASE && !PLATFORM_SPALDING
-static bool s_stationary_mode_enabled = false;
-#else
 static bool s_stationary_mode_enabled = true;
-#endif
 
 #define PREF_KEY_DEFAULT_WORKER "workerId"
 static Uuid s_default_worker = UUID_INVALID_INIT;


### PR DESCRIPTION
## Summary

Stationary mode is the mechanism that drops the system to `RunLevel_Stationary` after 30 minutes of no motion (when not on charger), which disables the HRM, backlight, BT, and vibes until the user touches the watch or an alarm fires.

With the release default set to `false` on every non-Spalding platform, this safety net was effectively dormant in the field — users would have to find Settings → Display → Stationary Mode to opt in. On an Obelix left off-wrist at night the HRM kept firing its green LEDs every 10 minutes (which is what Shannon reported in FIRM-1523).

Flip the default to `true` everywhere, matching what Spalding and debug builds already do.

Users who previously opted out retain their saved preference — the load loop in `shell_prefs_init()` at `src/fw/shell/normal/prefs.c:843` only overwrites the static default when a value is persisted (`settings_file_get_len == entry->value_len`), so a missing key is the only case that falls through to the initializer.

Fixes [FIRM-1523](https://linear.app/core-dev/issue/FIRM-1523/disable-hrm-if-the-watch-is-in-standby-or-charging-mode).

## What this changes for users

On a fresh install (or for any user who has never toggled the setting):

- After 30 minutes of the watch being still and not on charger, the watch drops to `RunLevel_Stationary`.
- HRM, BT, backlight, and vibes go off. Notifications will not arrive until the watch is moved / a button is pressed / an alarm fires, at which point `stationary_wake_up()` takes the runlevel back to `Normal` and BT reconnects.
- For users who have already explicitly enabled or disabled Stationary Mode in Settings, nothing changes.

## Test plan

- [x] Builds cleanly (release) for `qemu_emery`
- [x] `gitlint` passes; commit has `Signed-off-by`
- [ ] On a fresh Obelix install: after 30 min motionless off-charger, verify transition to stationary and HRM LEDs off
- [ ] Verify that picking up the watch wakes it back to normal and BT reconnects
- [ ] Verify that an existing user with `stationaryMode=false` persisted in prefs still stays disabled after the upgrade
- [ ] Sanity-check on Spalding (Time Round) — behavior should be unchanged (was already default-on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)