### PR TITLE
fw/asterix: reduce DA7212 line gain to 0dB

### DIFF
--- a/src/fw/drivers/nrf5/audio/audio.c
+++ b/src/fw/drivers/nrf5/audio/audio.c
@@ -127,7 +127,7 @@ static void prv_codec_prepare(AudioDevice *dev) {
   // amp + mix enable, softmix off (softmix slow-ramps each routing change).
   prv_codec_write(dev, DA7212_MIXOUT_R_CTRL, 0x90);
 
-  prv_codec_write(dev, DA7212_LINE_GAIN, 0x3a);
+  prv_codec_write(dev, DA7212_LINE_GAIN, 0x30);
   prv_codec_write(dev, DA7212_LINE_CTRL, 0x80);
 
   prv_codec_write(dev, DA7212_SYSTEM_MODES_OUTPUT, 0x89);


### PR DESCRIPTION
The speaker service was configuring DA7212_LINE_GAIN to 0x3a (~+10dB), while the manufacturing speaker test uses 0x30 (0dB). Running the line amp that hot overdrives the watch speaker: the board noticeably warms up during playback

Drop the line gain to 0x30 to match the mfg test's 0dB setting.