### PR TITLE
fw/drivers/sf32lb52/audio: don't assert on oversized audec_write [FIRM-1711]

### DIFF
--- a/src/fw/drivers/sf32lb52/audio/audec.c
+++ b/src/fw/drivers/sf32lb52/audio/audec.c
@@ -359,8 +359,10 @@ uint32_t audec_write(AudioDevice* audio_device, void *writeBuf, uint32_t size) {
     AudioDeviceState* state = audio_device->state;
     if (state->circ_buffer_storage) {
         uint32_t free_size = circular_buffer_get_write_space_remaining(&state->circ_buffer);
-        PBL_ASSERT(size<=free_size, "circ buf over");
-        circular_buffer_write(&state->circ_buffer, writeBuf, size);
+        uint16_t to_write = (size > free_size) ? (uint16_t)free_size : (uint16_t)size;
+        if (to_write > 0) {
+            circular_buffer_write(&state->circ_buffer, writeBuf, to_write);
+        }
         return circular_buffer_get_write_space_remaining(&state->circ_buffer);
     }
 


### PR DESCRIPTION
audec_write() asserted when a caller passed more bytes than the circular buffer had free. That path is reachable from user apps via the speaker stream, so a misbehaving app could panic the watch.
Clamp the write to the available space and return the remaining free bytes, matching the audio_write contract used by the nrf5 and qemu drivers.