### PR TITLE
sdk: cast stubbed function returns to void

### DIFF
--- a/tools/generate_native_sdk/generate_app_header.py
+++ b/tools/generate_native_sdk/generate_app_header.py
@@ -114,7 +114,9 @@ def make_app_header(exports_tree, output_filename, header_type, inject_text):
                     elif e.stub_return == "void":
                         writeline(f, "#define %s(...) do {} while(0)" % e.name)
                     else:
-                        writeline(f, "#define %s(...) (%s)" % (e.name, e.stub_return))
+                        writeline(
+                            f, "#define %s(...) ((void)(%s))" % (e.name, e.stub_return)
+                        )
                     writeline(f)
             elif e.type == "function":
                 if skip:


### PR DESCRIPTION
Stubbed function macros for frozen platforms previously expanded to `(stub_return)`, which triggers -Werror=unused-value ("statement with no effect") when an app calls the stub without using its return value.

Wrap the expansion in `(void)(...)` so the macro is safe in statement context. Apps that assign from a stubbed function will now fail to compile, which surfaces the unavailable API rather than silently returning 0.