### PR TITLE
revert stub void-cast, suppress -Werror=unused-value instead

### DIFF
--- a/tools/generate_native_sdk/generate_app_header.py
+++ b/tools/generate_native_sdk/generate_app_header.py
@@ -114,9 +114,7 @@ def make_app_header(exports_tree, output_filename, header_type, inject_text):
                     elif e.stub_return == "void":
                         writeline(f, "#define %s(...) do {} while(0)" % e.name)
                     else:
-                        writeline(
-                            f, "#define %s(...) ((void)(%s))" % (e.name, e.stub_return)
-                        )
+                        writeline(f, "#define %s(...) (%s)" % (e.name, e.stub_return))
                     writeline(f)
             elif e.type == "function":
                 if skip:

--- a/waftools/pebble_sdk_gcc.py
+++ b/waftools/pebble_sdk_gcc.py
@@ -49,6 +49,7 @@ def configure(conf):
         "-Wno-error=expansion-to-defined",
         "-Wno-error=zero-length-bounds",
         "-Wno-error=cast-function-type",
+        "-Wno-error=unused-value",
     ]
 
     if (conf.env.SDK_VERSION_MAJOR == 5) and (conf.env.SDK_VERSION_MINOR > 19):


### PR DESCRIPTION
The original PR tried to fix a `-Werror=unused-value` failure in SDK app builds for frozen platforms (aplite/basalt/chalk). Stubbed functions expand to `(stub_return)`, so calling one as a statement - e.g. `stubbed_func();` - becomes `(0);`, which trips "statement with no effect."

The fix wrapped the macro in `(void)(...)`. That does silence the warning, but it also makes the macro **void-typed**, which breaks any app that uses the return value. Plenty of apps do that, since returning a sensible default is the whole point of stubbing on frozen platforms. For example TimeStyle:

  ```c
  // main.c:93 — quiet_time_is_active() is stubbed on aplite
  if (!quiet_time_is_active() && tick_time->tm_sec == 0) { ... }
  //    ^ error: invalid use of void expression
  ```

Apps were relying on stubs evaluating to a usable 0/false so cross-platform code compiles unchanged on frozen platforms. The cast-to-void fix silently broke that contract.
Sorry about that