### PR TITLE
fw/services/battery: add optional 80% charge limit to extend battery lifespan

### DIFF
--- a/include/pbl/services/battery/battery_charge_limit.h
+++ b/include/pbl/services/battery/battery_charge_limit.h
@@ -1,0 +1,15 @@
+/* SPDX-FileCopyrightText: 2025 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include "pbl/services/battery/battery_state.h"
+
+// The battery charge limit service optionally stops charging at 80% and resumes at 77%
+// to reduce battery degradation from sustained high charge levels.
+
+void battery_charge_limit_init(void);
+
+void battery_charge_limit_evaluate(PreciseBatteryChargeState state);
+
+bool battery_charge_limit_is_active(void);

--- a/include/pbl/services/battery/battery_charge_limit.h
+++ b/include/pbl/services/battery/battery_charge_limit.h
@@ -1,0 +1,16 @@
+/* SPDX-FileCopyrightText: 2026 Shashvat Prabhu */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include "pbl/services/battery/battery_state.h"
+
+// The battery charge limit service optionally stops charging at 80% to reduce battery
+// degradation from sustained high charge levels. Charging resumes if the level drops back
+// below 80%.
+
+void battery_charge_limit_init(void);
+
+void battery_charge_limit_evaluate(PreciseBatteryChargeState state);
+
+bool battery_charge_limit_is_active(void);

--- a/src/fw/apps/system/settings/system.c
+++ b/src/fw/apps/system/settings/system.c
@@ -154,7 +154,6 @@ typedef enum {
   SystemMenuItemInformation,
   SystemMenuItemCertification,
   SystemMenuItemStationaryToggle,
-  SystemMenuItemChargeLimitToggle,
   SystemMenuItemDebugging,
   SystemMenuItemShutDown,
   SystemMenuItemFactoryReset,
@@ -165,7 +164,6 @@ static const char *s_item_titles[SystemMenuItem_Count] = {
   [SystemMenuItemInformation]   = i18n_noop("Information"),
   [SystemMenuItemCertification] = i18n_noop("Certification"),
   [SystemMenuItemStationaryToggle] = i18n_noop("Stand-By Mode"),
-  [SystemMenuItemChargeLimitToggle] = i18n_noop("Charge Limit (80%)"),
   [SystemMenuItemDebugging]     = i18n_noop("Debugging"),
   [SystemMenuItemShutDown]      = i18n_noop("Shut Down"),
   [SystemMenuItemFactoryReset]  = i18n_noop("Factory Reset"),
@@ -1406,10 +1404,6 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
     case SystemMenuItemStationaryToggle:
       subtitle = stationary_get_enabled() ? i18n_get("On", data) : i18n_get("Off", data);
       break;
-    case SystemMenuItemChargeLimitToggle:
-      subtitle = shell_prefs_get_charge_limit_enabled() ? i18n_get("On", data)
-                                                        : i18n_get("Off", data);
-      break;
     case SystemMenuItemShutDown:
     case SystemMenuItemInformation:
     case SystemMenuItemCertification:
@@ -1439,9 +1433,6 @@ static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
       break;
     case SystemMenuItemStationaryToggle:
       stationary_set_enabled(!stationary_get_enabled());
-      break;
-    case SystemMenuItemChargeLimitToggle:
-      shell_prefs_set_charge_limit_enabled(!shell_prefs_get_charge_limit_enabled());
       break;
     case SystemMenuItemShutDown:
       launcher_task_add_callback(prv_shutdown_cb, 0);

--- a/src/fw/apps/system/settings/system.c
+++ b/src/fw/apps/system/settings/system.c
@@ -154,6 +154,7 @@ typedef enum {
   SystemMenuItemInformation,
   SystemMenuItemCertification,
   SystemMenuItemStationaryToggle,
+  SystemMenuItemChargeLimitToggle,
   SystemMenuItemDebugging,
   SystemMenuItemShutDown,
   SystemMenuItemFactoryReset,
@@ -164,6 +165,7 @@ static const char *s_item_titles[SystemMenuItem_Count] = {
   [SystemMenuItemInformation]   = i18n_noop("Information"),
   [SystemMenuItemCertification] = i18n_noop("Certification"),
   [SystemMenuItemStationaryToggle] = i18n_noop("Stand-By Mode"),
+  [SystemMenuItemChargeLimitToggle] = i18n_noop("Charge Limit (80%)"),
   [SystemMenuItemDebugging]     = i18n_noop("Debugging"),
   [SystemMenuItemShutDown]      = i18n_noop("Shut Down"),
   [SystemMenuItemFactoryReset]  = i18n_noop("Factory Reset"),
@@ -1404,6 +1406,10 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
     case SystemMenuItemStationaryToggle:
       subtitle = stationary_get_enabled() ? i18n_get("On", data) : i18n_get("Off", data);
       break;
+    case SystemMenuItemChargeLimitToggle:
+      subtitle = shell_prefs_get_charge_limit_enabled() ? i18n_get("On", data)
+                                                        : i18n_get("Off", data);
+      break;
     case SystemMenuItemShutDown:
     case SystemMenuItemInformation:
     case SystemMenuItemCertification:
@@ -1433,6 +1439,9 @@ static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
       break;
     case SystemMenuItemStationaryToggle:
       stationary_set_enabled(!stationary_get_enabled());
+      break;
+    case SystemMenuItemChargeLimitToggle:
+      shell_prefs_set_charge_limit_enabled(!shell_prefs_get_charge_limit_enabled());
       break;
     case SystemMenuItemShutDown:
       launcher_task_add_callback(prv_shutdown_cb, 0);

--- a/src/fw/services/battery/battery_charge_limit.c
+++ b/src/fw/services/battery/battery_charge_limit.c
@@ -4,20 +4,16 @@
 #include "pbl/services/battery/battery_charge_limit.h"
 
 #include "drivers/battery.h"
-#include "drivers/rtc.h"
 #include "pbl/services/regular_timer.h"
 #include "shell/prefs.h"
 #include "system/logging.h"
 
 #define CHARGE_LIMIT_PCT 80
-#define CHARGE_RESUME_PCT 77
-#define MIN_TOGGLE_INTERVAL_S 60
 #define PERIODIC_CHECK_INTERVAL_S 60
 
 ////////////////////////
 // State
 T_STATIC bool s_limit_active;
-T_STATIC RtcTicks s_last_toggle_ticks;
 static RegularTimerInfo s_periodic_timer;
 
 static void prv_periodic_timer_cb(void *data) {
@@ -50,24 +46,13 @@ void battery_charge_limit_evaluate(PreciseBatteryChargeState state) {
     return;
   }
 
-  // Rate limit: don't toggle more than once per MIN_TOGGLE_INTERVAL_S
-  if (s_last_toggle_ticks != 0) {
-    RtcTicks now = rtc_get_ticks();
-    RtcTicks elapsed = (now - s_last_toggle_ticks) / RTC_TICKS_HZ;
-    if (elapsed < MIN_TOGGLE_INTERVAL_S) {
-      return;
-    }
-  }
-
   if (state.pct >= CHARGE_LIMIT_PCT && !s_limit_active) {
     battery_set_charge_enable(false);
     s_limit_active = true;
-    s_last_toggle_ticks = rtc_get_ticks();
     PBL_LOG_INFO("Charge limit: disabling charging at %d pct", state.pct);
-  } else if (state.pct <= CHARGE_RESUME_PCT && s_limit_active) {
+  } else if (state.pct < CHARGE_LIMIT_PCT && s_limit_active) {
     battery_set_charge_enable(true);
     s_limit_active = false;
-    s_last_toggle_ticks = rtc_get_ticks();
     PBL_LOG_INFO("Charge limit: resuming charging at %d pct", state.pct);
   }
 }

--- a/src/fw/services/battery/battery_charge_limit.c
+++ b/src/fw/services/battery/battery_charge_limit.c
@@ -1,0 +1,77 @@
+/* SPDX-FileCopyrightText: 2025 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "pbl/services/battery/battery_charge_limit.h"
+
+#include "drivers/battery.h"
+#include "drivers/rtc.h"
+#include "pbl/services/regular_timer.h"
+#include "shell/prefs.h"
+#include "system/logging.h"
+
+#define CHARGE_LIMIT_PCT 80
+#define CHARGE_RESUME_PCT 77
+#define MIN_TOGGLE_INTERVAL_S 60
+#define PERIODIC_CHECK_INTERVAL_S 60
+
+////////////////////////
+// State
+T_STATIC bool s_limit_active;
+T_STATIC RtcTicks s_last_toggle_ticks;
+static RegularTimerInfo s_periodic_timer;
+
+static void prv_periodic_timer_cb(void *data) {
+  BatteryChargeState charge = battery_get_charge_state();
+  PreciseBatteryChargeState state = {
+    .pct = charge.charge_percent,
+    .is_plugged = charge.is_plugged,
+    .is_charging = charge.is_charging,
+  };
+  battery_charge_limit_evaluate(state);
+}
+
+void battery_charge_limit_init(void) {
+  s_periodic_timer.cb = prv_periodic_timer_cb;
+  regular_timer_add_multisecond_callback(&s_periodic_timer, PERIODIC_CHECK_INTERVAL_S);
+}
+
+void battery_charge_limit_evaluate(PreciseBatteryChargeState state) {
+  if (!shell_prefs_get_charge_limit_enabled()) {
+    if (s_limit_active) {
+      battery_set_charge_enable(true);
+      s_limit_active = false;
+      PBL_LOG_INFO("Charge limit: disabled, re-enabling charging");
+    }
+    return;
+  }
+
+  if (!state.is_plugged) {
+    s_limit_active = false;
+    return;
+  }
+
+  // Rate limit: don't toggle more than once per MIN_TOGGLE_INTERVAL_S
+  if (s_last_toggle_ticks != 0) {
+    RtcTicks now = rtc_get_ticks();
+    RtcTicks elapsed = (now - s_last_toggle_ticks) / RTC_TICKS_HZ;
+    if (elapsed < MIN_TOGGLE_INTERVAL_S) {
+      return;
+    }
+  }
+
+  if (state.pct >= CHARGE_LIMIT_PCT && !s_limit_active) {
+    battery_set_charge_enable(false);
+    s_limit_active = true;
+    s_last_toggle_ticks = rtc_get_ticks();
+    PBL_LOG_INFO("Charge limit: disabling charging at %d pct", state.pct);
+  } else if (state.pct <= CHARGE_RESUME_PCT && s_limit_active) {
+    battery_set_charge_enable(true);
+    s_limit_active = false;
+    s_last_toggle_ticks = rtc_get_ticks();
+    PBL_LOG_INFO("Charge limit: resuming charging at %d pct", state.pct);
+  }
+}
+
+bool battery_charge_limit_is_active(void) {
+  return s_limit_active;
+}

--- a/src/fw/services/battery/battery_charge_limit.c
+++ b/src/fw/services/battery/battery_charge_limit.c
@@ -1,0 +1,62 @@
+/* SPDX-FileCopyrightText: 2026 Shashvat Prabhu */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "pbl/services/battery/battery_charge_limit.h"
+
+#include "drivers/battery.h"
+#include "pbl/services/regular_timer.h"
+#include "shell/prefs.h"
+#include "system/logging.h"
+
+#define CHARGE_LIMIT_PCT 80
+#define PERIODIC_CHECK_INTERVAL_S 60
+
+////////////////////////
+// State
+T_STATIC bool s_limit_active;
+static RegularTimerInfo s_periodic_timer;
+
+static void prv_periodic_timer_cb(void *data) {
+  BatteryChargeState charge = battery_get_charge_state();
+  PreciseBatteryChargeState state = {
+    .pct = charge.charge_percent,
+    .is_plugged = charge.is_plugged,
+    .is_charging = charge.is_charging,
+  };
+  battery_charge_limit_evaluate(state);
+}
+
+void battery_charge_limit_init(void) {
+  s_periodic_timer.cb = prv_periodic_timer_cb;
+  regular_timer_add_multisecond_callback(&s_periodic_timer, PERIODIC_CHECK_INTERVAL_S);
+}
+
+void battery_charge_limit_evaluate(PreciseBatteryChargeState state) {
+  if (!shell_prefs_get_charge_limit_enabled()) {
+    if (s_limit_active) {
+      battery_set_charge_enable(true);
+      s_limit_active = false;
+      PBL_LOG_INFO("Charge limit: disabled, re-enabling charging");
+    }
+    return;
+  }
+
+  if (!state.is_plugged) {
+    s_limit_active = false;
+    return;
+  }
+
+  if (state.pct >= CHARGE_LIMIT_PCT && !s_limit_active) {
+    battery_set_charge_enable(false);
+    s_limit_active = true;
+    PBL_LOG_INFO("Charge limit: disabling charging at %d pct", state.pct);
+  } else if (state.pct < CHARGE_LIMIT_PCT && s_limit_active) {
+    battery_set_charge_enable(true);
+    s_limit_active = false;
+    PBL_LOG_INFO("Charge limit: resuming charging at %d pct", state.pct);
+  }
+}
+
+bool battery_charge_limit_is_active(void) {
+  return s_limit_active;
+}

--- a/src/fw/services/battery/battery_monitor.c
+++ b/src/fw/services/battery/battery_monitor.c
@@ -4,6 +4,7 @@
 #include "pbl/services/battery/battery_monitor.h"
 
 #include "board/board.h"
+#include "pbl/services/battery/battery_charge_limit.h"
 #include "kernel/low_power.h"
 #include "kernel/util/standby.h"
 #include "pbl/services/firmware_update.h"
@@ -208,6 +209,8 @@ void battery_monitor_handle_state_change_event(PreciseBatteryChargeState state) 
 
   prv_log_battery_state(state);
 
+  battery_charge_limit_evaluate(state);
+
   s_first_run = false;
 }
 
@@ -219,6 +222,8 @@ void battery_monitor_init(void) {
 
   // Initialize driver interface
   battery_state_init();
+
+  battery_charge_limit_init();
 }
 
 bool battery_monitor_critical_lockout(void) {

--- a/src/fw/services/battery/wscript_build
+++ b/src/fw/services/battery/wscript_build
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 use = ['fw_includes', 'services_analytics']
-sources = ['battery_monitor.c']
+sources = ['battery_charge_limit.c', 'battery_monitor.c']
 
 if bld.is_asterix() or bld.is_obelix() or bld.is_getafix():
     use.append('nrf_fuel_gauge')

--- a/src/fw/services/blob_db/settings_blob_db.c
+++ b/src/fw/services/blob_db/settings_blob_db.c
@@ -107,6 +107,9 @@ static const char *s_syncable_settings[] = {
   "menuScrollWrapAround",
   "menuScrollVibeBehavior",
 
+  // Battery preferences
+  "chargeLimitEnabled",
+
   // Worker preferences
   "workerId",
 

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -109,6 +109,9 @@ static uint32_t s_backlight_ambient_threshold = 0; // default set from board con
 #define PREF_KEY_STATIONARY "stationaryMode"
 static bool s_stationary_mode_enabled = true;
 
+#define PREF_KEY_CHARGE_LIMIT_ENABLED "chargeLimitEnabled"
+static bool s_charge_limit_enabled = false;
+
 #define PREF_KEY_DEFAULT_WORKER "workerId"
 static Uuid s_default_worker = UUID_INVALID_INIT;
 
@@ -427,6 +430,11 @@ static bool prv_set_s_display_orientation_left(bool *left) {
 
 static bool prv_set_s_stationary_mode_enabled(bool *enabled) {
   s_stationary_mode_enabled = *enabled;
+  return true;
+}
+
+static bool prv_set_s_charge_limit_enabled(bool *enabled) {
+  s_charge_limit_enabled = *enabled;
   return true;
 }
 
@@ -1231,6 +1239,14 @@ bool shell_prefs_get_stationary_enabled(void) {
 
 void shell_prefs_set_stationary_enabled(bool enabled) {
   prv_pref_set(PREF_KEY_STATIONARY, &enabled, sizeof(enabled));
+}
+
+bool shell_prefs_get_charge_limit_enabled(void) {
+  return s_charge_limit_enabled;
+}
+
+void shell_prefs_set_charge_limit_enabled(bool enabled) {
+  prv_pref_set(PREF_KEY_CHARGE_LIMIT_ENABLED, &enabled, sizeof(enabled));
 }
 
 AppInstallId worker_preferences_get_default_worker(void) {

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -21,6 +21,7 @@
 #endif
   PREFS_MACRO(PREF_KEY_BACKLIGHT_AMBIENT_THRESHOLD, s_backlight_ambient_threshold)
   PREFS_MACRO(PREF_KEY_STATIONARY, s_stationary_mode_enabled)
+  PREFS_MACRO(PREF_KEY_CHARGE_LIMIT_ENABLED, s_charge_limit_enabled)
   PREFS_MACRO(PREF_KEY_DEFAULT_WORKER, s_default_worker)
   PREFS_MACRO(PREF_KEY_TEXT_STYLE, s_text_style)
   PREFS_MACRO(PREF_KEY_LANG_ENGLISH, s_language_english)

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -188,6 +188,9 @@ bool display_orientation_is_left(void);
 void display_orientation_set_left(bool left);
 #endif
 
+bool shell_prefs_get_charge_limit_enabled(void);
+void shell_prefs_set_charge_limit_enabled(bool enabled);
+
 GColor shell_prefs_get_theme_highlight_color(void);
 void shell_prefs_set_theme_highlight_color(GColor color);
 

--- a/src/fw/shell/prf/stubs.c
+++ b/src/fw/shell/prf/stubs.c
@@ -156,6 +156,13 @@ void app_storage_get_file_name(char *name, size_t buf_length, AppInstallId app_i
   *name = 0;
 }
 
+bool shell_prefs_get_charge_limit_enabled(void) {
+  return false;
+}
+
+void shell_prefs_set_charge_limit_enabled(bool enabled) {
+}
+
 bool shell_prefs_get_clock_24h_style(void) {
   return true;
 }

--- a/src/fw/shell/sdk/stubs.c
+++ b/src/fw/shell/sdk/stubs.c
@@ -101,6 +101,13 @@ bool shell_prefs_get_stationary_enabled(void) {
   return false;
 }
 
+bool shell_prefs_get_charge_limit_enabled(void) {
+  return false;
+}
+
+void shell_prefs_set_charge_limit_enabled(bool enabled) {
+}
+
 bool shell_prefs_get_language_english(void) {
   return true;
 }

--- a/tests/fw/test_battery_monitor.c
+++ b/tests/fw/test_battery_monitor.c
@@ -1,6 +1,7 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include "pbl/services/battery/battery_charge_limit.h"
 #include "pbl/services/battery/battery_monitor.h"
 #include "pbl/services/battery/battery_state.h"
 #include "pbl/services/battery/battery_curve.h"
@@ -55,6 +56,10 @@ bool firmware_update_is_in_progress(void) {
 }
 
 void battery_force_charge_enable(bool is_charging) { }
+
+void battery_charge_limit_init(void) { }
+
+void battery_charge_limit_evaluate(PreciseBatteryChargeState state) { }
 
 bool stop_mode_is_allowed(void) {
   return s_stop_mode_allowed;


### PR DESCRIPTION
This PR adds a software charge limit feature that stops charging at 80% and resumes at 77% (3% hysteresis) to reduce lithium battery degradation from sustained high charge levels. The feature is exposed as a user-facing toggle in System settings, off by default.

Changes:

-  Add `battery_charge_limit` module that calls `battery_set_charge_enable()` to disable/re-enable charging based on battery percentage thresholds; includes a 60s rate limit to prevent rapid charger cycling and a 60s periodic timer to cover gaps in fuel gauge event delivery when charging is disabled
-  Add `charge_limit_enabled` pref (persistent on/off setting via `SettingsFile`, default false) with getter/setter following the existing `stationary_mode_enabled` pattern
- Add "Charge Limit (80%)" toggle row in System settings menu, mirroring the existing "Stand-By Mode" toggle
- Hook `battery_charge_limit_evaluate()` into `battery_monitor_handle_state_change_event()` and `battery_charge_limit_init()` into `battery_monitor_init()`
- Register `battery_charge_limit.c` in `services/battery/wscript_build`
  
  Resolves #722