### PR TITLE
docs: update action bar width for platforms

### DIFF
--- a/src/fw/applib/ui/action_bar_layer.h
+++ b/src/fw/applib/ui/action_bar_layer.h
@@ -44,7 +44,8 @@
 //! list, for example "jump to next track" in a Music app.
 //!
 //! <h3>Geometry</h3>
-//! * The action bar is 30 pixels wide. Use the \ref ACTION_BAR_WIDTH define.
+//! * The action bar's width varies per platform. 30px on most displays, 34px on Emery and
+//! Gabbro, and 40px on Chalk. Use the \ref ACTION_BAR_WIDTH define.
 //! * Icons should not be wider than 28 pixels, or taller than 18 pixels.
 //! It is recommended to use a size of around 15 x 15 pixels for the "visual core" of the icon,
 //! and extending or contracting where needed.


### PR DESCRIPTION
The action bar width is no longer always 30px. Learned from experience 😅 . 

Would be awesome to get this updated in the docs.

See the current values in the SDK.:

https://github.com/coredevices/PebbleOS/blob/d7ef6199a70462cc0154103b965006c60d8eddf1/src/fw/applib/ui/action_bar_layer.h#L88-L95