### PR TITLE
sdk: allow semver in package metadata

### DIFF
--- a/sdk/waftools/pebble_sdk.py
+++ b/sdk/waftools/pebble_sdk.py
@@ -118,8 +118,8 @@ def _write_appinfo_json_file(task):
 
 def _validate_version(ctx, original_version):
     """
-    Validates the format of the version field in an app's project info, and strips off a
-    zero-valued patch version number, if it exists, to be compatible with the Pebble FW
+    Validates the format of the version field in an app's project info
+    to be compatible with the Pebble FW.
     :param ctx: the ConfigureContext object
     :param version: the version provided in project info (package.json/appinfo.json)
     :return: a MAJOR.MINOR version that is acceptable for Pebble FW
@@ -127,9 +127,9 @@ def _validate_version(ctx, original_version):
     version = original_version.split(".")
     if len(version) > 3:
         ctx.fatal(
-            "App versions must be of the format MAJOR or MAJOR.MINOR or MAJOR.MINOR.0. An "
-            "invalid version of {} was specified for the app. Try {}.{}.0 instead".format(
-                original_version, version[0], version[1]
+            "App versions must be of the format MAJOR or MAJOR.MINOR or MAJOR.MINOR.PATCH. "
+            "An invalid version of {} was specified for the app. Try {}.{}.{} instead".format(
+                original_version, version[0], version[1], version[2]
             )
         )
     elif not (0 <= int(version[0]) <= 255):
@@ -142,13 +142,12 @@ def _validate_version(ctx, original_version):
             "An invalid or out of range value of {} was specified for the minor version of "
             "the app. The valid range is 0-255.".format(version[1])
         )
-    elif len(version) > 2 and not (int(version[2]) == 0):
-        ctx.fatal(
-            "The patch version of an app must be 0, but {} was specified ({}). Try {}.{}.0 "
-            "instead.".format(version[2], original_version, version[0], version[1])
-        )
+    # note: version[2] does not reach the Pebble FW (it is stripped off by generate_appinfo)
+    # so has no upper limit. Just make sure it's an int.
+    if len(version) == 3:
+        int(version[2])
 
-    return version[0] + "." + version[1]
+    return ".".join(version[:3])
 
 
 def options(opt):

--- a/src/fw/process_management/pebble_process_info.h
+++ b/src/fw/process_management/pebble_process_info.h
@@ -203,7 +203,7 @@ typedef struct __attribute__((__packed__)) {
   char header[8];                   //!< Sentinal value, should always be 'PBLAPP'
   Version struct_version;           //!< version of this structure's format
   Version sdk_version;              //!< version of the SDK used to build this process
-  Version process_version;          //!< version of the process
+  Version process_version;          //!< version of the process. Note this omits any semver "patch" version.
   uint16_t load_size;               //!< size of the binary in flash, including this metadata but not the reloc table
   uint32_t offset;                  //!< The entry point of this executable
   uint32_t crc;                     //!< CRC of the data only, ie, not including this struct or the reloc table at the end

--- a/tools/generate_appinfo.py
+++ b/tools/generate_appinfo.py
@@ -50,10 +50,10 @@ def generate_appinfo_c(app_info, output_filename, platform_name=None):
             version_label_major = version_label_list[0]
         if len(version_label_list) >= 2:
             version_label_minor = version_label_list[1]
-        if len(version_label_list) > 2:
-            raise Exception(
-                'appinfo.json versionLabel format for app revision must be "Major" or "Major.Minor"'
-            )
+        # Note app versions are encouraged to contain a third semver patch
+        # version number which is discarded here, causing the C-side
+        # PebbleProcessInfo.process_version to mismatch the version presented
+        # in the .pbw and appstore.
 
         # validate versionLabel range [0-255] and int-characters
         try:


### PR DESCRIPTION
This is to finish implementing the semver support started by Eric in February, which is currently incomplete/bugged; see https://github.com/coredevices/pebble-tool/issues/52

TLDR is: the Pebble firmware only supports MAJ.MIN version numbers in `PebbleProcessInfo.process_version`, which is completely unused AFAICT. The appstore/cloudpebble have changed to support/require the MAJ.MIN.PATCH format, and this was partially enabled by adding a hack to pebble-tool which temporarily zeroes the last digit during a build. That didn't account for the truncated version number being left in the final `.pbw`, causing much confusion and preventing semver appstore uploads via the dev dashboard.

All of the tools which process the version number here in the SDK actually already correctly strip off any digits beyond MAJ.MIN before they reach PebbleProcessInfo, but they raise superficial exceptions to prevent providing MAJ.MIN.PATCH.

This PR avoids stripping it off before it reaches generate_appinfo, removes the superficial exceptions, and adds comments explaining that it is deliberate for `PebbleProcessInfo.process_version` to potentially not match the pbw/appstore. This will enable pebble-tool to correctly build semver packages which can be uploaded to the dev dashboard.


Note: these superficial exceptions imply it was originally intended for any version in the pbw or appstore to be accurately reflected in `PebbleProcessInfo.process_version`. If you actually want to keep that original design, you'd want to revert the changes that allowed semver in the store/cloudpebble/pebble-tool/anywhere else, or make a (potentially) breaking change to add the extra version to PebbleProcessInfo