### PR TITLE
fw/apps/prf/mfg_als: force backlight off during test

### DIFF
--- a/src/fw/apps/prf/mfg_als.c
+++ b/src/fw/apps/prf/mfg_als.c
@@ -149,9 +149,6 @@ static void prv_select_click_handler(ClickRecognizerRef recognizer, void *contex
   AmbientLightAppData *data = app_state_get_user_data();
 
   if (data->test_state == ALSStateWaitForStart) {
-    // Turn off backlight before starting test
-    light_enable(false);
-
     // Start countdown
     data->test_state = ALSStateCountdown;
     data->state_start_time = rtc_get_ticks();
@@ -171,6 +168,10 @@ static void prv_config_provider(void *context) {
 
 static void prv_handle_init(void) {
   AmbientLightAppData *data = task_zalloc_check(sizeof(AmbientLightAppData));
+
+  // Force backlight off for the duration of the test to avoid interfering
+  // with ALS readings (e.g. when pressing CENTER to start sampling).
+  light_allow(false);
 
   data->window = window_create();
   window_set_fullscreen(data->window, true);
@@ -219,6 +220,8 @@ static void prv_handle_deinit(void) {
   text_layer_destroy(data->reading_text_layer);
   window_destroy(data->window);
   task_free(data);
+
+  light_allow(true);
 }
 
 static void prv_main(void) {

--- a/src/fw/apps/prf/mfg_button.c
+++ b/src/fw/apps/prf/mfg_button.c
@@ -54,7 +54,7 @@ static void prv_handle_second_tick(struct tm *tick_time, TimeUnits units_changed
   if (data->seconds_remaining == 0 || test_passed) {
     data->test_complete = true;
 
-    mfg_test_result_report(MfgTestId_Buttons, test_passed, data->buttons_pressed);
+    mfg_test_result_report(MfgTestId_Buttons, test_passed, 0);
 
     if (test_passed) {
       sniprintf(data->status_string, sizeof(data->status_string), "PASS!");

--- a/src/fw/apps/prf/mfg_qr_results.c
+++ b/src/fw/apps/prf/mfg_qr_results.c
@@ -71,7 +71,7 @@ static void prv_append_result(char *buf, size_t bufsz, MfgTestId test) {
 
   switch (test) {
   case MfgTestId_Buttons:
-    snprintf(entry, sizeof(entry), "BTN:%c,%X", rc, (unsigned)(r->value & 0xF));
+    snprintf(entry, sizeof(entry), "BTN:%c", rc);
     break;
   case MfgTestId_Display:
     snprintf(entry, sizeof(entry), "DSP:%c", rc);


### PR DESCRIPTION
Use light_allow(false) on app entry (and restore on exit) so the backlight cannot be turned on by button presses while the ALS test is running. Pressing CENTER to start the test would otherwise momentarily turn the backlight on and interfere with the ambient light readings.