### PR TITLE
fw/kernel: fix task_cpu_app_pct overflow when apps come and go

### DIFF
--- a/include/pbl/services/analytics/analytics.def
+++ b/include/pbl/services/analytics/analytics.def
@@ -93,6 +93,7 @@ PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(settings_motion_sensitivity)
 // Application
 PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(app_message_sent_count)
 PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(app_message_received_count)
+PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(app_tick_timer_second_subscribed)
 
 // Connectivity
 PBL_ANALYTICS_METRIC_DEFINE_TIMER(connectivity_connected_time_ms)

--- a/src/fw/applib/tick_timer_service.c
+++ b/src/fw/applib/tick_timer_service.c
@@ -7,6 +7,7 @@
 #include "event_service_client.h"
 #include "process_management/app_manager.h"
 
+#include "pbl/services/analytics/analytics.h"
 #include "pbl/services/clock.h"
 #include "pbl/services/event_service.h"
 #include "pbl/services/tick_timer.h"
@@ -90,6 +91,10 @@ void tick_timer_service_subscribe(TimeUnits tick_units, TickHandler handler) {
   state->tick_units = tick_units;
   state->first_tick = true;
   event_service_client_subscribe(&state->tick_service_info);
+  if (pebble_task_get_current() == PebbleTask_App) {
+    PBL_ANALYTICS_SET_UNSIGNED(app_tick_timer_second_subscribed,
+                               (tick_units & SECOND_UNIT) ? 1 : 0);
+  }
   // TODO: make an effort to get this closer to the "actual" second tick
 }
 
@@ -97,6 +102,9 @@ void tick_timer_service_unsubscribe(void) {
   TickTimerServiceState *state = prv_get_state(PebbleTask_Unknown);
   event_service_client_unsubscribe(&state->tick_service_info);
   state->handler = NULL;
+  if (pebble_task_get_current() == PebbleTask_App) {
+    PBL_ANALYTICS_SET_UNSIGNED(app_tick_timer_second_subscribed, 0);
+  }
 }
 
 

--- a/src/fw/kernel/pebble_tasks.c
+++ b/src/fw/kernel/pebble_tasks.c
@@ -18,12 +18,44 @@
 
 TaskHandle_t g_task_handles[NumPebbleTask] KERNEL_READONLY_DATA = { 0 };
 
+// Cycles consumed by tasks that have already been destroyed in each slot.
+// Captured at unregister time so the analytics heartbeat can keep accounting
+// for App/Worker activity across short-lived task instances.
+static uint32_t s_dead_task_cycles[NumPebbleTask];
+
 static void prv_task_register(PebbleTask task, TaskHandle_t task_handle) {
   g_task_handles[task] = task_handle;
 }
 
+static uint32_t prv_read_task_run_time(TaskHandle_t handle) {
+  UBaseType_t num_tasks = uxTaskGetNumberOfTasks();
+  TaskStatus_t *statuses = kernel_malloc(num_tasks * sizeof(TaskStatus_t));
+  if (!statuses) {
+    return 0;
+  }
+  UBaseType_t count = uxTaskGetSystemState(statuses, num_tasks, NULL);
+  uint32_t cycles = 0;
+  for (UBaseType_t i = 0; i < count; i++) {
+    if (statuses[i].xHandle == handle) {
+      cycles = statuses[i].ulRunTimeCounter;
+      break;
+    }
+  }
+  kernel_free(statuses);
+  return cycles;
+}
+
 void pebble_task_unregister(PebbleTask task) {
+  TaskHandle_t handle = g_task_handles[task];
+  if (handle == NULL) {
+    return;
+  }
+  uint32_t cycles = prv_read_task_run_time(handle);
+  // Clear the handle before crediting the cycles: the collector reads
+  // s_dead_task_cycles before walking the task list, so this ordering
+  // ensures cycles are never seen in both buckets simultaneously.
   g_task_handles[task] = NULL;
+  s_dead_task_cycles[task] += cycles;
 }
 
 const char* pebble_task_get_name(PebbleTask task) {
@@ -121,9 +153,19 @@ static const enum pbl_analytics_key s_task_cpu_pct_keys[NumPebbleTask] = {
 };
 
 void pbl_analytics_external_collect_task_cpu_stats(void) {
-  static uint32_t s_prev_task_run_time[NumPebbleTask];
+  static uint32_t s_prev_total_task_cycles[NumPebbleTask];
   static uint32_t s_prev_idle_run_time;
   static uint32_t s_prev_total_run_time;
+
+  // Snapshot dead-task cycles before walking the live task list. Combined with
+  // the (clear-handle, then update-accumulator) ordering in
+  // pebble_task_unregister(), this guarantees that cycles from a task dying
+  // mid-collection are never double-counted; in the worst case they show up
+  // one heartbeat late.
+  uint32_t dead_cycles[NumPebbleTask];
+  for (int task = 0; task < NumPebbleTask; task++) {
+    dead_cycles[task] = s_dead_task_cycles[task];
+  }
 
   UBaseType_t num_tasks = uxTaskGetNumberOfTasks();
   TaskStatus_t *statuses = kernel_malloc(num_tasks * sizeof(TaskStatus_t));
@@ -154,8 +196,9 @@ void pbl_analytics_external_collect_task_cpu_stats(void) {
   kernel_free(statuses);
 
   for (int task = 0; task < NumPebbleTask; task++) {
-    uint32_t delta = curr_task_run_time[task] - s_prev_task_run_time[task];
-    s_prev_task_run_time[task] = curr_task_run_time[task];
+    uint32_t total = dead_cycles[task] + curr_task_run_time[task];
+    uint32_t delta = total - s_prev_total_task_cycles[task];
+    s_prev_total_task_cycles[task] = total;
     uint32_t pct = delta_total ? (uint32_t)(((uint64_t)delta * 10000U) / delta_total) : 0;
     pbl_analytics_set_unsigned(s_task_cpu_pct_keys[task], pct);
   }


### PR DESCRIPTION
The App and Worker task slots are dynamic: tasks are created on launch and destroyed on exit, so their FreeRTOS ulRunTimeCounter does not persist across an app restart. Diffing the current counter against a stale previous value underflowed uint32 and pushed the reported percentage to ~4 billion cycles per delta_total, surfacing as spikes around 116k on the task_cpu_app_pct chart.

Capture each dying task's final ulRunTimeCounter into a per-slot sticky accumulator from pebble_task_unregister(), and report cumulative slot cycles (sticky + currently-alive counter) in the heartbeat. This keeps cycles attributed to the App/Worker slots even when several apps launch and exit within a single (~1 hour) heartbeat period.

The unregister clears the task handle before crediting the cycles, and the collector snapshots sticky cycles before walking the live task list. Together these orderings ensure cycles consumed by a task that dies mid-collection are never double-counted; in the worst case they are reported one heartbeat late.