### PR TITLE
fw/apps/system: add timeout other places

### DIFF
--- a/src/fw/apps/system/notifications.c
+++ b/src/fw/apps/system/notifications.c
@@ -28,6 +28,7 @@
 #include "pbl/services/blob_db/pin_db.h"
 #include "pbl/services/notifications/notification_storage.h"
 #include "pbl/services/timeline/notification_layout.h"
+#include "shell/normal/app_idle_timeout.h"
 #include "shell/prefs.h"
 #include "shell/system_theme.h"
 #include "system/passert.h"
@@ -799,7 +800,9 @@ static void prv_handle_deinit(void) {
 static void prv_s_main(void) {
   prv_handle_init();
 
+  app_idle_timeout_start();
   app_event_loop();
+  app_idle_timeout_stop();
 
   prv_handle_deinit();
 }

--- a/src/fw/apps/system/settings/settings.c
+++ b/src/fw/apps/system/settings/settings.c
@@ -11,6 +11,7 @@
 #include "kernel/pbl_malloc.h"
 #include "resource/resource_ids.auto.h"
 #include "pbl/services/i18n/i18n.h"
+#include "shell/normal/app_idle_timeout.h"
 #include "system/passert.h"
 #include "shell/prefs.h"
 #include "util/size.h"
@@ -186,7 +187,9 @@ static void handle_deinit(void) {
 
 static void s_main(void) {
   handle_init();
+  app_idle_timeout_start();
   app_event_loop();
+  app_idle_timeout_stop();
   handle_deinit();
 }
 

--- a/src/fw/apps/system/watchfaces.c
+++ b/src/fw/apps/system/watchfaces.c
@@ -14,6 +14,7 @@
 #include "kernel/pbl_malloc.h"
 #include "process_management/app_manager.h"
 #include "process_management/app_menu_data_source.h"
+#include "shell/normal/app_idle_timeout.h"
 #include "shell/normal/watchface.h"
 #include "process_state/app_state/app_state.h"
 #include "resource/resource_ids.auto.h"
@@ -193,7 +194,9 @@ static void handle_init(void) {
 static void s_main(void) {
   handle_init();
 
+  app_idle_timeout_start();
   app_event_loop();
+  app_idle_timeout_stop();
 }
 #else
 static void s_main(void) {}

--- a/src/fw/apps/system/weather/weather.c
+++ b/src/fw/apps/system/weather/weather.c
@@ -19,6 +19,7 @@
 #include "pbl/services/timeline/timeline.h"
 #include "pbl/services/weather/weather_service.h"
 #include "pbl/services/weather/weather_types.h"
+#include "shell/normal/app_idle_timeout.h"
 #include "util/array.h"
 #include "util/attributes.h"
 #include "util/list.h"
@@ -199,7 +200,9 @@ static void prv_deinit(void) {
 
 static void prv_main(void) {
   prv_init();
+  app_idle_timeout_start();
   app_event_loop();
+  app_idle_timeout_stop();
   prv_deinit();
 }
 


### PR DESCRIPTION
* Added the same main timeout of 30 seconds from main menu to other stock apps: Notifications, Settings, Watchfaces and Weather. Its enable by default.

If we need to make them optional, I can add a mobile settings side.