### PR TITLE
fw/drivers/imu/mmc5603nj: fix racy refcount assert in mag_release

### DIFF
--- a/src/fw/apps/prf/mfg_test_aging.c
+++ b/src/fw/apps/prf/mfg_test_aging.c
@@ -385,13 +385,11 @@ static void prv_handle_second_tick(struct tm *tick_time, TimeUnits units_changed
       BatteryChargeState cs = battery_get_charge_state();
 
       if (!cs.is_plugged) {
-        prv_cleanup_component(data);
         prv_enter_fail(data, "Unplugged during\ncharge+cycle");
         break;
       }
 
       if (bc.t_mc < TEMP_MIN_MC || bc.t_mc > TEMP_MAX_MC) {
-        prv_cleanup_component(data);
         prv_enter_fail(data, "Temperature out\nof range");
         break;
       }
@@ -406,23 +404,21 @@ static void prv_handle_second_tick(struct tm *tick_time, TimeUnits units_changed
           // there by continuous top-off, which is gentler on the cell.
           battery_set_charge_enable(false);
         } else if (data->phase_elapsed_sec >= CHARGE_TIMEOUT_SEC) {
-          prv_cleanup_component(data);
           prv_enter_fail(data, "Charge timeout\n(90min)");
           break;
         }
       } else if (cs.charge_percent < CHARGE_HOLD_MIN_PERCENT) {
-        prv_cleanup_component(data);
         prv_enter_fail(data, "Battery dropped\nafter charge");
         break;
       }
 
       // Phase done?
       if (data->phase_elapsed_sec >= CHARGE_AND_CYCLE_DURATION_SEC) {
-        prv_cleanup_component(data);
         if (!data->charge_complete) {
           prv_enter_fail(data, "Charge incomplete\nat phase end");
           break;
         }
+        prv_cleanup_component(data);
         battery_set_charge_enable(true);
         data->state = AgingStateWaitUnplug;
         break;

--- a/src/fw/drivers/imu/mmc5603nj/mmc5603nj.c
+++ b/src/fw/drivers/imu/mmc5603nj/mmc5603nj.c
@@ -75,8 +75,9 @@ void mag_start_sampling(void) {
 }
 
 void mag_release(void) {
-  PBL_ASSERTN(s_initialized && s_use_refcount != 0);
+  PBL_ASSERTN(s_initialized);
   mutex_lock(s_mag_mutex);
+  PBL_ASSERTN(s_use_refcount != 0);
   --s_use_refcount;
   if (s_use_refcount == 0) {
     if (!prv_mmc5603nj_set_sample_rate_hz(0)) {


### PR DESCRIPTION
The assert checking s_use_refcount != 0 was done before acquiring the mutex, creating a race condition where another thread could modify the refcount between the check and the lock. Move the refcount assert inside the critical section while keeping the s_initialized check outside (it is set once at init and never cleared).