### PR TITLE
fw/kernel/event_loop: accept double tap in single-tap wake mode

### DIFF
--- a/src/fw/kernel/event_loop.c
+++ b/src/fw/kernel/event_loop.c
@@ -327,7 +327,8 @@ static NOINLINE void prv_minimal_event_handler(PebbleEvent* e) {
       bool wake_on_gesture = false;
       switch (backlight_get_touch_wake()) {
         case BacklightTouchWake_Tap:
-          wake_on_gesture = (e->gesture.event.type == GestureEvent_Tap);
+          wake_on_gesture = (e->gesture.event.type == GestureEvent_Tap ||
+                             e->gesture.event.type == GestureEvent_DoubleTap);
           break;
         case BacklightTouchWake_DoubleTap:
           wake_on_gesture = (e->gesture.event.type == GestureEvent_DoubleTap);


### PR DESCRIPTION
## Summary
- When Wake on Touch is set to single tap, also accept double-tap as a wake gesture, so users picking the most permissive setting get both gestures.
- Double-tap-only mode is unchanged.

## Test plan
- [ ] Set Wake on Touch to Tap; verify both single-tap and double-tap wake the backlight.
- [ ] Set Wake on Touch to Double Tap; verify only double-tap wakes the backlight.
- [ ] Set Wake on Touch to Off; verify neither gesture wakes the backlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)