### PR TITLE
fw/services/activity: serialize early_deinit with KernelBG deinit

### DIFF
--- a/src/fw/services/activity/activity.c
+++ b/src/fw/services/activity/activity.c
@@ -885,9 +885,14 @@ cleanup:
 }
 
 static void prv_handle_activity_enabled_change(void) {
-  if (activity_tracking_on() && !prv_activity_allowed_to_be_enabled()) {
+  // Hold the activity mutex across the started/allowed check and prv_stop_tracking_early so we
+  // can't race with prv_set_enable_cb on KernelBG, which can call activity_algorithm_deinit() and
+  // free s_alg_state out from under an in-flight activity_algorithm_early_deinit().
+  mutex_lock_recursive(s_activity_state.mutex);
+  if (s_activity_state.started && !prv_activity_allowed_to_be_enabled()) {
     prv_stop_tracking_early();
   }
+  mutex_unlock_recursive(s_activity_state.mutex);
 
   system_task_add_callback(prv_set_enable_cb, NULL);
 }


### PR DESCRIPTION
prv_handle_activity_enabled_change() called prv_stop_tracking_early() without holding s_activity_state.mutex, racing with prv_set_enable_cb on KernelBG which can run prv_stop_tracking_cb -> activity_algorithm_ deinit() and free s_alg_state. The cached s_alg_state pointer in the inlined prv_lock/prv_unlock then read s_alg_state->mutex out of the freed heap slot (filled with the 0xa5a5a5a5 clear pattern), and the subsequent mutex_unlock_recursive(0xa5a5a5a5) faulted.

Take the activity mutex across the started/allowed check and the prv_stop_tracking_early() call so it serializes with prv_set_enable_cb, which already holds the same mutex while invoking the deinit path.

Fixes FIRM-1735