### PR TITLE
src/fw/kernel: Add HRM struct version capability bit

### DIFF
--- a/include/pbl/services/comm_session/session_remote_version.h
+++ b/include/pbl/services/comm_session/session_remote_version.h
@@ -36,6 +36,8 @@ typedef struct PACKED {
       bool continue_fw_install_across_disconnect_support: 1;
       bool blob_db_version_support: 1;
       bool settings_sync_support: 1;  // Phone supports Settings BlobDB sync
+      bool hrm_activity_tracking_support: 1;  // Watch's ActivityHRMSettings struct includes
+                                              // measurement_interval and activity_tracking_enabled
     };
     uint64_t flags;
   };

--- a/src/fw/kernel/system_versions.c
+++ b/src/fw/kernel/system_versions.c
@@ -140,6 +140,7 @@ static void prv_send_watch_versions(CommSession *session) {
   versions_msg.capabilities.smooth_fw_install_progress_support = 1;
   versions_msg.capabilities.custom_vibe_pattern_support = 1;
   versions_msg.capabilities.blob_db_version_support = 1;
+  versions_msg.capabilities.hrm_activity_tracking_support = 1;
   bt_local_id_copy_address(&versions_msg.device_address);
 
   versions_msg.system_resources_version = resource_get_system_version();


### PR DESCRIPTION
Needed so that the mobile app can safely send the ActivityHRMSettings
 struct to the watch on different firmware versions.