### PR TITLE
fw/drivers/display/sf32lb: add update-timeout watchdog

### DIFF
--- a/src/fw/console/prompt_commands.c
+++ b/src/fw/console/prompt_commands.c
@@ -1129,6 +1129,18 @@ void command_audit_delay_us(void) {
   __enable_irq();
 }
 
+#if !defined(RELEASE) && (PLATFORM_OBELIX || PLATFORM_GETAFIX)
+#include "drivers/display/sf32lb/display_jdi.h"
+
+// Arms the JDI display driver to drop the next LCDC transfer-complete callback,
+// simulating the silent-DMA failure mode (e.g. ICB overflow). The display
+// update watchdog should fire ~200ms later and recover.
+void command_display_drop_complete(void) {
+  display_jdi_test_drop_next_complete();
+  prompt_send_response("display: armed drop of next LCDC complete; watch for watchdog log");
+}
+#endif
+
 #if !MICRO_FAMILY_SF32LB52
 // Simply parks the chip permanently in stop mode in whatever state it's currently in. This can be
 // pretty handy when trying to profile power of the chip under certains states

--- a/src/fw/console/prompt_commands.h
+++ b/src/fw/console/prompt_commands.h
@@ -293,6 +293,10 @@ extern void command_console_disable_rx(const char *seconds_str);
 extern void command_force_deepwfi(const char *arg);
 #endif
 
+#if !defined(RELEASE) && (PLATFORM_OBELIX || PLATFORM_GETAFIX)
+extern void command_display_drop_complete(void);
+#endif
+
 #define KEEP_NON_ESSENTIAL_COMMANDS 1
 static const Command s_prompt_commands[] = {
   // PULSE entry point, needed for anything PULSE-related to work
@@ -643,6 +647,9 @@ static const Command s_prompt_commands[] = {
   { "console disable rx", command_console_disable_rx, 1 },
 #if MICRO_FAMILY_SF32LB52
   { "force deepwfi", command_force_deepwfi, 1 },
+#endif
+#if !defined(RELEASE) && (PLATFORM_OBELIX || PLATFORM_GETAFIX)
+  { "display drop_complete", command_display_drop_complete, 0 },
 #endif
 
 #if MEMFAULT

--- a/src/fw/drivers/display/sf32lb/display_jdi.c
+++ b/src/fw/drivers/display/sf32lb/display_jdi.c
@@ -12,6 +12,7 @@
 #include "kernel/util/delay.h"
 #include "kernel/util/stop.h"
 #include "os/mutex.h"
+#include "pbl/services/new_timer/new_timer.h"
 #include "system/logging.h"
 #include "system/passert.h"
 
@@ -26,6 +27,11 @@
 #define POWER_SEQ_DELAY_TIME_US  11000
 #define POWER_RESET_CYCLE_DELAY_TIME_US 500000
 
+// Watchdog timeout for a single LCDC DMA. A normal full-frame transfer takes
+// well under 20ms; 200ms gives plenty of slack for system load while still
+// recovering well before the user notices a freeze.
+#define DISPLAY_UPDATE_TIMEOUT_MS 200
+
 // Pointer to the compositor's framebuffer - we convert in-place to save 44KB RAM
 static uint8_t *s_framebuffer;
 static uint16_t s_update_y0;
@@ -34,6 +40,8 @@ static bool s_initialized;
 static bool s_updating;
 static UpdateCompleteCallback s_uccb;
 static SemaphoreHandle_t s_sem;
+static TimerID s_watchdog_timer = TIMER_INVALID_ID;
+static uint32_t s_watchdog_fires;
 
 #if DISPLAY_ORIENTATION_ROTATED_180
 static bool s_rotated_180 = true;
@@ -116,7 +124,21 @@ static void prv_display_update_start(void) {
   HAL_LCDC_SendLayerData_IT(&state->hlcdc);
 }
 
-static void prv_display_update_terminate(void *data) {
+// Atomically claim the right to finalize an in-flight update. Returns true to
+// the first of the IRQ-driven completion path and the watchdog timeout path
+// that gets here; the loser sees s_updating already cleared and bails. This is
+// what prevents a double-call of s_uccb() / stop_mode_enable() when an IRQ
+// completion races a watchdog fire.
+static bool prv_claim_finalize(void) {
+  bool claimed;
+  portENTER_CRITICAL();
+  claimed = s_updating;
+  s_updating = false;
+  portEXIT_CRITICAL();
+  return claimed;
+}
+
+static void prv_finish_update(void) {
   // Convert the updated region back from 332 to 222 format
   for (uint16_t y = s_update_y0; y <= s_update_y1; y++) {
     uint8_t *row = &s_framebuffer[y * PBL_DISPLAY_WIDTH];
@@ -142,9 +164,53 @@ static void prv_display_update_terminate(void *data) {
     }
   }
 
-  s_updating = false;
   s_uccb();
   stop_mode_enable(InhibitorDisplay);
+}
+
+// PEBBLE_CALLBACK_EVENT handler — runs on KernelMain, where the compositor's
+// update-complete handler expects to be called.
+static void prv_finalize_on_kernel_main(void *data) {
+  prv_finish_update();
+}
+
+static void prv_display_update_terminate(void *data) {
+  if (!prv_claim_finalize()) {
+    // Watchdog already finalized this update.
+    return;
+  }
+  new_timer_stop(s_watchdog_timer);
+  prv_finish_update();
+}
+
+// Runs on PebbleTask_NewTimers if the LCDC DMA fails to deliver a
+// transfer-complete callback within DISPLAY_UPDATE_TIMEOUT_MS. The known
+// trigger is the SiFli HAL's ICB-overflow path (bf0_hal_lcdc.c
+// HAL_LCDC_IRQHandler) which sets HAL_LCDC_ERROR_OVERFLOW without invoking
+// XferCpltCallback — without this watchdog, s_updating stays true forever and
+// the compositor silently stops rendering (compositor.c prv_should_render).
+static void prv_display_update_watchdog(void *data) {
+  if (!prv_claim_finalize()) {
+    // IRQ-driven completion got here first; nothing to do.
+    return;
+  }
+
+  DisplayJDIState *state = DISPLAY->state;
+  s_watchdog_fires++;
+  PBL_LOG_ERR(
+      "display_jdi: update timed out after %ums (ErrorCode=0x%lx, y=%u..%u, fires=%lu)",
+      (unsigned)DISPLAY_UPDATE_TIMEOUT_MS, (unsigned long)state->hlcdc.ErrorCode,
+      (unsigned)s_update_y0, (unsigned)s_update_y1, (unsigned long)s_watchdog_fires);
+
+  // Clear any latched HAL error so the next update isn't immediately rejected.
+  state->hlcdc.ErrorCode = 0;
+
+  // Compositor state is single-threaded on KernelMain; defer the rest there.
+  PebbleEvent e = {
+      .type = PEBBLE_CALLBACK_EVENT,
+      .callback = {.callback = prv_finalize_on_kernel_main},
+  };
+  event_put(&e);
 }
 
 void display_jdi_irq_handler(DisplayJDIDevice *disp) {
@@ -287,10 +353,20 @@ void display_update(NextRowCallback nrcb, UpdateCompleteCallback uccb) {
   // Adjust framebuffer pointer to start of buffer (row 0)
   s_framebuffer = s_framebuffer - (s_update_y0 * PBL_DISPLAY_WIDTH);
 
+  // Lazy-create the watchdog timer. display_init() can run via boot_splash_start
+  // (main.c) before new_timer_service_init(), so creating the timer in
+  // display_init() would silently fail. The compositor doesn't reach this path
+  // until well after new_timer_service_init() has run.
+  if (s_watchdog_timer == TIMER_INVALID_ID) {
+    s_watchdog_timer = new_timer_create();
+  }
+
   s_uccb = uccb;
   s_updating = true;
 
   stop_mode_disable(InhibitorDisplay);
+  new_timer_start(s_watchdog_timer, DISPLAY_UPDATE_TIMEOUT_MS, prv_display_update_watchdog, NULL,
+                  0);
   prv_display_update_start();
 }
 

--- a/src/fw/drivers/display/sf32lb/display_jdi.c
+++ b/src/fw/drivers/display/sf32lb/display_jdi.c
@@ -43,6 +43,10 @@ static SemaphoreHandle_t s_sem;
 static TimerID s_watchdog_timer = TIMER_INVALID_ID;
 static uint32_t s_watchdog_fires;
 
+#ifndef RELEASE
+static volatile bool s_test_drop_next_complete;
+#endif
+
 #if DISPLAY_ORIENTATION_ROTATED_180
 static bool s_rotated_180 = true;
 #else
@@ -220,6 +224,16 @@ void display_jdi_irq_handler(DisplayJDIDevice *disp) {
 
 void HAL_LCDC_SendLayerDataCpltCbk(LCDC_HandleTypeDef *lcdc) {
   portBASE_TYPE woken = pdFALSE;
+
+#ifndef RELEASE
+  if (s_test_drop_next_complete && s_updating) {
+    s_test_drop_next_complete = false;
+    // Simulate a lost completion event: DMA finished in hardware but the
+    // firmware never dispatches the terminate path. The watchdog should fire.
+    portEND_SWITCHING_ISR(woken);
+    return;
+  }
+#endif
 
   if (s_updating) {
     PebbleEvent e = {
@@ -405,3 +419,9 @@ uint32_t display_baud_rate_change(uint32_t new_frequency_hz) { return 0U; }
 void display_set_offset(GPoint offset) {}
 
 GPoint display_get_offset(void) { return GPointZero; }
+
+#ifndef RELEASE
+void display_jdi_test_drop_next_complete(void) {
+  s_test_drop_next_complete = true;
+}
+#endif

--- a/src/fw/drivers/display/sf32lb/display_jdi.h
+++ b/src/fw/drivers/display/sf32lb/display_jdi.h
@@ -50,3 +50,12 @@ typedef const struct DisplayJDIDevice {
 } DisplayJDIDevice;
 
 void display_jdi_irq_handler(DisplayJDIDevice *disp);
+
+#ifndef RELEASE
+//! Test hook: arm a one-shot drop of the next LCDC transfer-complete callback.
+//! When armed, the next time the DMA finishes the firmware will *not* dispatch
+//! the completion event, simulating the silent-DMA failure mode (e.g. ICB
+//! overflow). The display update watchdog should fire ~200ms later, log a
+//! timeout, and recover. Intended for verifying the watchdog on hardware.
+void display_jdi_test_drop_next_complete(void);
+#endif


### PR DESCRIPTION
The JDI display driver gates all compositor rendering on a single `s_updating` flag that is only ever cleared in the LCDC transfer-complete callback. If the LCDC fails to deliver that callback — e.g. on the SiFli HAL's ICB-overflow path which sets HAL_LCDC_ERROR_OVERFLOW without invoking XferCpltCallback — the flag stays true forever and the compositor silently stops rendering, even though the rest of the system keeps working.

Add a 200 ms NewTimer-based watchdog: armed in `display_update`, cancelled in `prv_display_update_terminate`, and on timeout it logs the latched HAL ErrorCode, clears it, and posts a PEBBLE_CALLBACK_EVENT so the finalize path runs on KernelMain (matching the IRQ-driven dispatch and keeping compositor state single-threaded). A test-and-clear of `s_updating` ensures only one of the IRQ and watchdog paths runs the recovery body when they race.

Fixes FIRM-1740