### PR TITLE
fw/apps/prf: include aging field in finished QR even if not run

### DIFF
--- a/src/fw/apps/prf/mfg_qr_results.c
+++ b/src/fw/apps/prf/mfg_qr_results.c
@@ -58,13 +58,6 @@ static void prv_append_result(char *buf, size_t bufsz, MfgTestId test) {
     return;
   }
 
-  // Aging only appears when it has actually been reported (i.e. in the
-  // finished bucket); skip the entry in any mode where it wasn't run so
-  // the semi-finished QR doesn't pick up a misleading AGE:N.
-  if (test == MfgTestId_Aging && !r->ran) {
-    return;
-  }
-
   size_t pos = strlen(buf);
   if (pos > 0 && pos < bufsz - 1) {
     buf[pos++] = ';';


### PR DESCRIPTION
## Summary
- Always include the aging test field (`AGE:N/P/F`) in the finished results QR code, even when the aging test has not been run
- Previously, aging was skipped in the QR when not run, making the field absent from the finished results

## Test plan
- [ ] Build PRF firmware and verify QR code includes `AGE:N` when aging test has not been run
- [ ] Run aging test and verify QR code shows `AGE:P` or `AGE:F` as appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)