### PR TITLE
Raise 4K storage

### DIFF
--- a/include/pbl/services/settings/settings_file.h
+++ b/include/pbl/services/settings/settings_file.h
@@ -41,6 +41,16 @@ typedef struct SettingsFile {
   //! fail.
   int max_used_space;
 
+  //! The current allocation budget for physical file size. For growable files,
+  //! this starts at a small initial value and grows toward max_used_space on
+  //! demand. For non-growable files, this equals max_used_space.
+  int alloc_used_space;
+
+  //! The floor for alloc_used_space. Compact will not shrink below this. For
+  //! growable files this is the initial_alloc_size requested at open time;
+  //! for non-growable files this equals max_used_space (no shrink).
+  int min_alloc_used_space;
+
   //! Amount of space in the settings_file that is currently dead, i.e.
   //! has been written to with some data, but that data is no longer valid.
   //! (overwritten records get added to this)
@@ -69,6 +79,8 @@ typedef struct SettingsFile {
 //! ignored. We could change this if the need arises.
 status_t settings_file_open(SettingsFile *file, const char *name,
                             int max_used_space);
+status_t settings_file_open_growable(SettingsFile *file, const char *name,
+                                     int max_used_space, int initial_alloc_size);
 void settings_file_close(SettingsFile *file);
 
 bool settings_file_exists(SettingsFile *file, const void *key, size_t key_len);

--- a/include/pbl/services/settings/settings_raw_iter.h
+++ b/include/pbl/services/settings/settings_raw_iter.h
@@ -112,10 +112,19 @@ int settings_raw_iter_get_resumed_record_pos(SettingsRawIter *iter);
 void settings_raw_iter_read_key(SettingsRawIter *iter, uint8_t *key);
 void settings_raw_iter_read_val(SettingsRawIter *iter, uint8_t *val, int val_len);
 
+//! Read key and value into a single contiguous buffer in one PFS call.
+//! key_val_out must be at least key_len + val_len bytes. Key occupies the first
+//! key_len bytes, val the next val_len bytes.
+void settings_raw_iter_read_key_val(SettingsRawIter *iter, uint8_t *key_val_out);
+
 //! Write (over top of) the header/key/val for the current record.
 void settings_raw_iter_write_header(SettingsRawIter *iter, SettingsRecordHeader *hdr);
 void settings_raw_iter_write_key(SettingsRawIter *iter, const uint8_t *key);
 void settings_raw_iter_write_val(SettingsRawIter *iter, const uint8_t *val);
+
+//! Write key and value from a single contiguous buffer in one PFS call.
+//! Layout matches settings_raw_iter_read_key_val.
+void settings_raw_iter_write_key_val(SettingsRawIter *iter, const uint8_t *key_val);
 
 //! Write a byte in place for the current record
 void settings_raw_iter_write_byte(SettingsRawIter *iter, int offset, uint8_t byte);

--- a/src/fw/applib/persist.h
+++ b/src/fw/applib/persist.h
@@ -35,7 +35,7 @@
 //! retrieve values from the phone, it provides you with a much faster way to restore state.
 //! In addition, it draws less power from the battery.
 //!
-//! Note that the size of all persisted values cannot exceed 4K per app.
+//! Note that the size of all persisted values cannot exceed 1MB per app.
 //!   @{
 
 //! The maximum size of a persist value in bytes

--- a/src/fw/services/persist/service.c
+++ b/src/fw/services/persist/service.c
@@ -20,6 +20,7 @@
 #include "util/units.h"
 
 #define PERSIST_STORAGE_MAX_SPACE KiBYTES(6)
+#define PERSIST_STORAGE_INITIAL_ALLOC KiBYTES(4)
 
 typedef struct PersistStore {
   ListNode  list_node;
@@ -124,7 +125,9 @@ SettingsFile * persist_service_lock_and_get_store(const Uuid *uuid) {
   if (!store->file_open) {
     char filename[PERSIST_FILE_NAME_MAX_LENGTH];
     PBL_ASSERTN(PASSED(prv_get_file_name(filename, sizeof(filename), uuid)));
-    PBL_ASSERTN(PASSED(settings_file_open(&store->file, filename, PERSIST_STORAGE_MAX_SPACE)));
+    PBL_ASSERTN(PASSED(settings_file_open_growable(&store->file, filename,
+                                                   PERSIST_STORAGE_MAX_SPACE,
+                                                   PERSIST_STORAGE_INITIAL_ALLOC)));
     store->file_open = true;
   }
   return &store->file;

--- a/src/fw/services/persist/service.c
+++ b/src/fw/services/persist/service.c
@@ -19,7 +19,7 @@
 #include "util/list.h"
 #include "util/units.h"
 
-#define PERSIST_STORAGE_MAX_SPACE KiBYTES(6)
+#define PERSIST_STORAGE_MAX_SPACE MiBYTES(1)
 #define PERSIST_STORAGE_INITIAL_ALLOC KiBYTES(4)
 
 typedef struct PersistStore {

--- a/src/fw/services/settings/settings_file.c
+++ b/src/fw/services/settings/settings_file.c
@@ -25,16 +25,17 @@ static bool file_hdr_is_uninitialized(SettingsFileHeader *file_hdr) {
       && (file_hdr->flags == 0xffff);
 }
 
-static status_t prv_open(SettingsFile *file, const char *name, uint8_t flags, int max_used_space) {
+static status_t prv_open(SettingsFile *file, const char *name, uint8_t flags,
+                          int max_used_space, int alloc_used_space,
+                          int min_alloc_used_space) {
   // Making the max_space_total at least a little bit larger than the
-  // max_used_space allows us to avoid thrashing. Without it, if
-  // max_space_total == max_used_space, then if the file is full, changing a
+  // alloc_used_space allows us to avoid thrashing. Without it, if
+  // max_space_total == alloc_used_space, then if the file is full, changing a
   // single value would force the whole file to be rewritten- every single
   // time! It's probably worth it to "waste" a bit of flash space to avoid
   // this pathalogical case.
-  int max_space_total = pfs_sector_optimal_size(max_used_space * 12 / 10, strlen(name));
+  int max_space_total = pfs_sector_optimal_size(alloc_used_space * 12 / 10, strlen(name));
 
-  // TODO: Dynamically sized files?
   int fd = pfs_open(name, flags, FILE_TYPE_STATIC, max_space_total);
   if (fd < 0) {
     PBL_LOG_ERR("Could not open settings file '%s', %d", name, fd);
@@ -50,6 +51,8 @@ static status_t prv_open(SettingsFile *file, const char *name, uint8_t flags, in
   *file = (SettingsFile) {
     .name = kernel_strdup_check(name),
     .max_used_space = max_used_space,
+    .alloc_used_space = alloc_used_space,
+    .min_alloc_used_space = min_alloc_used_space,
     .max_space_total = max_space_total,
   };
 
@@ -73,7 +76,15 @@ static status_t prv_open(SettingsFile *file, const char *name, uint8_t flags, in
     PBL_LOG_WRN("Unrecognized version %d for file %s, removing...",
             file_hdr.version, name);
     pfs_close_and_remove(fd);
-    return prv_open(file, name, flags, max_used_space);
+    return prv_open(file, name, flags, max_used_space, alloc_used_space, min_alloc_used_space);
+  }
+
+  // For growable files, adopt the actual file size before bootup_check so that
+  // any compaction during recovery uses the correct (grown) allocation size.
+  int actual_size = pfs_get_file_size(file->iter.fd);
+  if (alloc_used_space < max_used_space && actual_size > max_space_total) {
+    file->alloc_used_space = actual_size * 10 / 12;
+    file->max_space_total = actual_size;
   }
 
   status_t status = bootup_check(file);
@@ -81,24 +92,21 @@ static status_t prv_open(SettingsFile *file, const char *name, uint8_t flags, in
     PBL_LOG_ERR("Bootup check failed (%"PRId32"), not good. "
             "Attempting to recover by deleting %s...", status, name);
     pfs_close_and_remove(fd);
-    return prv_open(file, name, flags, max_used_space);
+    return prv_open(file, name, flags, max_used_space, alloc_used_space, min_alloc_used_space);
   }
 
   // There's a chance that the caller increased the desired size of the settings file since
   // the file was originally created (i.e. the file was created in an earlier version of the
   // firmware). If we detect that situation, let's re-write the file to the new larger requested
   // size.
-  int actual_size = pfs_get_file_size(file->iter.fd);
-  if (actual_size < max_space_total) {
+  if (alloc_used_space >= max_used_space && actual_size < max_space_total) {
     PBL_LOG_INFO("Re-writing settings file %s to increase its size from %d to %d.",
             name, actual_size, max_space_total);
-    // The settings_file_rewrite_filtered call creates a new file based on file->max_used_space
-    // and copies the contents of the existing file into it.
     status = settings_file_rewrite_filtered(file, NULL, NULL);
     if (status < 0) {
       PBL_LOG_ERR("Could not resize file %s (error %"PRId32"). Creating new one",
               name, status);
-      return prv_open(file, name, flags, max_used_space);
+      return prv_open(file, name, flags, max_used_space, alloc_used_space, min_alloc_used_space);
     }
   }
 
@@ -109,7 +117,16 @@ static status_t prv_open(SettingsFile *file, const char *name, uint8_t flags, in
 
 status_t settings_file_open(SettingsFile *file, const char *name,
                             int max_used_space) {
-  return prv_open(file, name, OP_FLAG_READ | OP_FLAG_WRITE, max_used_space);
+  return prv_open(file, name, OP_FLAG_READ | OP_FLAG_WRITE,
+                  max_used_space, max_used_space, max_used_space);
+}
+
+status_t settings_file_open_growable(SettingsFile *file, const char *name,
+                                     int max_used_space, int initial_alloc_size) {
+  // prv_grow doubles alloc_used_space; a zero seed would loop forever.
+  PBL_ASSERTN(initial_alloc_size > 0);
+  return prv_open(file, name, OP_FLAG_READ | OP_FLAG_WRITE,
+                  max_used_space, initial_alloc_size, initial_alloc_size);
 }
 
 void settings_file_close(SettingsFile *file) {
@@ -199,7 +216,8 @@ status_t settings_file_rewrite_filtered(
 
   SettingsFile new_file;
   status_t status = prv_open(&new_file, file->name, OP_FLAG_OVERWRITE | OP_FLAG_READ,
-                             file->max_used_space);
+                             file->max_used_space, file->alloc_used_space,
+                             file->min_alloc_used_space);
   if (status < 0) {
     PBL_LOG_ERR("Could not open temporary file to compact settings file. Error %"PRIi32".",
             status);
@@ -253,8 +271,11 @@ status_t settings_file_rewrite_filtered(
   // old file. After the close suceeds, we will end up reading the new
   // (compacted) file.
   char *name = kernel_strdup(new_file.name);
+  int alloc_used_space = new_file.alloc_used_space;
+  int min_alloc_used_space = new_file.min_alloc_used_space;
   settings_file_close(&new_file);
-  status = prv_open(file, name, OP_FLAG_READ | OP_FLAG_WRITE, file->max_used_space);
+  status = prv_open(file, name, OP_FLAG_READ | OP_FLAG_WRITE,
+                    file->max_used_space, alloc_used_space, min_alloc_used_space);
   kernel_free(name);
 
   // FIRM-1649: instrumentation. See note at the top of this function.
@@ -272,7 +293,29 @@ void settings_file_set_change_callback(SettingsFileChangeCallback callback) {
 }
 
 T_STATIC status_t settings_file_compact(SettingsFile *file) {
-  return settings_file_rewrite_filtered(file, NULL, NULL);
+  // For growable files, drop alloc_used_space toward the floor when live data
+  // is much smaller than the current allocation. Without this, a file that
+  // burst to e.g. 256 KiB and then idled would hold that flash forever even
+  // after the records were deleted, slowly bleeding free PFS space across
+  // device lifetime. Aim for the smallest doubling step that leaves ~2x
+  // headroom over used_space; the next grow cycle will re-expand if needed.
+  const int old_alloc = file->alloc_used_space;
+  if (file->alloc_used_space > file->min_alloc_used_space) {
+    int target = file->min_alloc_used_space;
+    while (target < file->used_space * 2 && target < file->alloc_used_space) {
+      target *= 2;
+    }
+    if (target < file->alloc_used_space) {
+      file->alloc_used_space = target;
+    }
+  }
+  status_t status = settings_file_rewrite_filtered(file, NULL, NULL);
+  if (status < 0) {
+    // rewrite_filtered fails before the swap if it fails at all; the on-disk
+    // file is still at old_alloc, so put the in-memory book-keeping back.
+    file->alloc_used_space = old_alloc;
+  }
+  return status;
 }
 
 static bool key_matches(SettingsRawIter *iter, const uint8_t *key, int key_len) {
@@ -420,6 +463,27 @@ status_t settings_file_set_byte(SettingsFile *file, const void *key,
   return S_SUCCESS;
 }
 
+static status_t prv_grow(SettingsFile *file, int needed_used_space) {
+  int new_alloc = file->alloc_used_space;
+  while (new_alloc < needed_used_space && new_alloc < file->max_used_space) {
+    new_alloc *= 2;
+  }
+  if (new_alloc > file->max_used_space) {
+    new_alloc = file->max_used_space;
+  }
+  if (new_alloc < needed_used_space) {
+    return E_OUT_OF_STORAGE;
+  }
+
+  int old_alloc = file->alloc_used_space;
+  file->alloc_used_space = new_alloc;
+  status_t status = settings_file_rewrite_filtered(file, NULL, NULL);
+  if (status < 0) {
+    file->alloc_used_space = old_alloc;
+  }
+  return status;
+}
+
 // Internal implementation that takes a timestamp parameter
 // Note that this operation is designed to be atomic from the perspective of
 // an outside observer. That is, either the new value will be completely
@@ -443,7 +507,14 @@ static status_t prv_settings_file_set_internal(SettingsFile *file, const void *k
     return E_OUT_OF_STORAGE;
   }
   if (file->used_space + file->dead_space + rec_size > file->max_space_total) {
-    status_t status = settings_file_compact(file);
+    bool needs_growth = (file->used_space + rec_size > file->max_space_total) &&
+                        (file->alloc_used_space < file->max_used_space);
+    status_t status;
+    if (needs_growth) {
+      status = prv_grow(file, file->used_space + rec_size);
+    } else {
+      status = settings_file_compact(file);
+    }
     if (status < 0) {
       return status;
     }
@@ -612,7 +683,8 @@ status_t settings_file_rewrite(SettingsFile *file,
   SettingsFile new_file;
   status_t status = prv_open(&new_file, file->name,
                              OP_FLAG_OVERWRITE | OP_FLAG_READ,
-                             file->max_used_space);
+                             file->max_used_space, file->alloc_used_space,
+                             file->min_alloc_used_space);
   if (status < 0) {
     return status;
   }
@@ -628,8 +700,11 @@ status_t settings_file_rewrite(SettingsFile *file,
   // old file. After the close suceeds, we will end up reading the new
   // (compacted) file.
   char *name = kernel_strdup(new_file.name);
+  int alloc_used_space = new_file.alloc_used_space;
+  int min_alloc_used_space = new_file.min_alloc_used_space;
   settings_file_close(&new_file);
-  status = prv_open(file, name, OP_FLAG_READ | OP_FLAG_WRITE, file->max_used_space);
+  status = prv_open(file, name, OP_FLAG_READ | OP_FLAG_WRITE,
+                    file->max_used_space, alloc_used_space, min_alloc_used_space);
   kernel_free(name);
 
   return status;

--- a/src/fw/services/settings/settings_file.c
+++ b/src/fw/services/settings/settings_file.c
@@ -5,6 +5,7 @@
 #include "pbl/services/settings/settings_raw_iter.h"
 
 #include "drivers/rtc.h"
+#include "drivers/task_watchdog.h"
 #include "kernel/pbl_malloc.h"
 #include "pbl/services/filesystem/pfs.h"
 #include "system/logging.h"
@@ -214,6 +215,10 @@ status_t settings_file_rewrite_filtered(
   PBL_LOG_INFO("FIRM-1649: settings_file_rewrite_filtered start file=%s",
                file->name);
 
+  // A 1 MiB grow can take many seconds of pure flash erase + write time. Pause
+  // the task watchdog rather than letting it trip and kick App Throttling.
+  task_watchdog_pause(60);
+
   SettingsFile new_file;
   status_t status = prv_open(&new_file, file->name, OP_FLAG_OVERWRITE | OP_FLAG_READ,
                              file->max_used_space, file->alloc_used_space,
@@ -221,10 +226,16 @@ status_t settings_file_rewrite_filtered(
   if (status < 0) {
     PBL_LOG_ERR("Could not open temporary file to compact settings file. Error %"PRIi32".",
             status);
+    task_watchdog_resume();
     return status;
   }
 
   settings_raw_iter_begin(&new_file.iter);
+
+  // One reusable buffer for key+val per record; sized for the worst case.
+  // Avoids two malloc/free pairs per record over what can be thousands of
+  // records on a large persist file.
+  uint8_t *kv_buf = kernel_malloc(SETTINGS_KEY_MAX_LEN + SETTINGS_VAL_MAX_LEN);
 
   for (settings_raw_iter_begin(&file->iter); !settings_raw_iter_end(&file->iter);
       settings_raw_iter_next(&file->iter)) {
@@ -249,22 +260,19 @@ status_t settings_file_rewrite_filtered(
       clear_flag(hdr, SETTINGS_FLAG_OVERWRITE_STARTED);
     }
 
-    // Get the old key and value
-    uint8_t *key = kernel_malloc(hdr->key_len);
-    settings_raw_iter_read_key(&file->iter, key);
-    uint8_t *val = kernel_malloc(hdr->val_len);
-    settings_raw_iter_read_val(&file->iter, val, hdr->val_len);
+    // Read key+val in a single PFS call; key occupies the first key_len bytes.
+    settings_raw_iter_read_key_val(&file->iter, kv_buf);
+    uint8_t *key = kv_buf;
+    uint8_t *val = kv_buf + hdr->key_len;
 
     // Include in re-written file if it passes the filter
     if (!filter_cb || filter_cb(key, hdr->key_len, val, hdr->val_len, context)) {
       settings_raw_iter_write_header(&new_file.iter, hdr);
-      settings_raw_iter_write_key(&new_file.iter, key);
-      settings_raw_iter_write_val(&new_file.iter, val);
+      settings_raw_iter_write_key_val(&new_file.iter, kv_buf);
       settings_raw_iter_next(&new_file.iter);
     }
-    kernel_free(key);
-    kernel_free(val);
   }
+  kernel_free(kv_buf);
   settings_file_close(file);
   // We have to close and reopen the new_file so that it's temp flag is cleared.
   // Before the close succeeds, if we reboot, we will just end up reading the
@@ -277,6 +285,8 @@ status_t settings_file_rewrite_filtered(
   status = prv_open(file, name, OP_FLAG_READ | OP_FLAG_WRITE,
                     file->max_used_space, alloc_used_space, min_alloc_used_space);
   kernel_free(name);
+
+  task_watchdog_resume();
 
   // FIRM-1649: instrumentation. See note at the top of this function.
   const uint32_t rewrite_elapsed_ms =

--- a/src/fw/services/settings/settings_raw_iter.c
+++ b/src/fw/services/settings/settings_raw_iter.c
@@ -186,6 +186,13 @@ void settings_raw_iter_read_val(SettingsRawIter *iter, uint8_t *val_out, int val
   sfs_read(iter, val_out, val_len);
 }
 
+void settings_raw_iter_read_key_val(SettingsRawIter *iter, uint8_t *key_val_out) {
+  const int kv_len = iter->hdr.key_len + iter->hdr.val_len;
+  if (kv_len == 0) return;
+  sfs_seek(iter, iter->hdr_pos + sizeof(SettingsRecordHeader), FSeekSet);
+  sfs_read(iter, key_val_out, kv_len);
+}
+
 void settings_raw_iter_write_header(SettingsRawIter *iter, SettingsRecordHeader *hdr) {
   PBL_ASSERTN(hdr->key_len <= SETTINGS_KEY_MAX_LEN);
   PBL_ASSERTN(hdr->val_len <= SETTINGS_VAL_MAX_LEN);
@@ -202,6 +209,13 @@ void settings_raw_iter_write_val(SettingsRawIter *iter, const uint8_t *val) {
   if (iter->hdr.val_len == 0) return;
   sfs_seek(iter, iter->hdr_pos + sizeof(SettingsRecordHeader) + iter->hdr.key_len, FSeekSet);
   sfs_write(iter, val, iter->hdr.val_len);
+}
+
+void settings_raw_iter_write_key_val(SettingsRawIter *iter, const uint8_t *key_val) {
+  const int kv_len = iter->hdr.key_len + iter->hdr.val_len;
+  if (kv_len == 0) return;
+  sfs_seek(iter, iter->hdr_pos + sizeof(SettingsRecordHeader), FSeekSet);
+  sfs_write(iter, key_val, kv_len);
 }
 void settings_raw_iter_write_byte(SettingsRawIter *iter, int offset, uint8_t byte) {
   sfs_seek(iter, iter->hdr_pos +

--- a/tests/fakes/fake_settings_file.c
+++ b/tests/fakes/fake_settings_file.c
@@ -103,6 +103,11 @@ status_t settings_file_open(SettingsFile *file, const char *name,
   }
 }
 
+status_t settings_file_open_growable(SettingsFile *file, const char *name,
+                                     int max_used_space, int initial_alloc_size) {
+  return settings_file_open(file, name, max_used_space);
+}
+
 void settings_file_close(SettingsFile *file) {
   cl_assert(s_settings_file.open);
   s_settings_file.open = false;

--- a/tests/fw/services/settings/test_settings_file.c
+++ b/tests/fw/services/settings/test_settings_file.c
@@ -611,6 +611,274 @@ void test_settings_file__reallocate_larger(void) {
   verify(&file, key, key_len, val, val_len);
 }
 
+// Test that a growable file automatically grows when writes exceed the initial allocation
+// but stay within the enforcement cap.
+void test_settings_file__growable_auto_growth(void) {
+  printf("\nTesting growable file auto-growth...\n");
+
+  // PFS allocates in 4096-byte pages, so the initial_alloc must span at least
+  // one page. Use an initial_alloc that results in one PFS page and a max_cap
+  // that allows multiple pages. Write enough large records to exceed one page.
+  const int initial_alloc = 2048;
+  const int max_cap = 32768;
+  SettingsFile file;
+  cl_must_pass(settings_file_open_growable(&file, "tg", max_cap, initial_alloc));
+
+  int initial_file_size = pfs_get_file_size(file.iter.fd);
+  printf("Initial file size: %d, max_space_total: %d\n",
+         initial_file_size, file.max_space_total);
+
+  // Write large records to fill and exceed the initial allocation.
+  // Each record: 8 (header) + 4 (key) + 128 (val) = 140 bytes.
+  // One PFS page holds ~4000 usable bytes, so ~28 records fills it.
+  uint8_t key[5];
+  int key_len = 4;
+  uint8_t val[128];
+  int val_len = sizeof(val);
+  memset(val, 0xAB, val_len);
+  // 8114 / 140 ≈ 57 records to fill the initial allocation. Write 65 to force growth.
+  int num_records = 65;
+  for (int i = 0; i < num_records; i++) {
+    snprintf((char *)key, sizeof(key), "k%03d", i);
+    val[0] = (uint8_t)i; // Make each value unique
+    cl_must_pass(settings_file_set(&file, key, key_len, val, val_len));
+  }
+
+  int grown_file_size = pfs_get_file_size(file.iter.fd);
+  printf("Grown file size: %d\n", grown_file_size);
+  cl_assert(grown_file_size > initial_file_size);
+
+  // Verify all data survived the growth
+  for (int i = 0; i < num_records; i++) {
+    snprintf((char *)key, sizeof(key), "k%03d", i);
+    val[0] = (uint8_t)i;
+    verify(&file, key, key_len, val, val_len);
+  }
+
+  settings_file_close(&file);
+}
+
+// Test that a growable file returns E_OUT_OF_STORAGE when the enforcement cap is hit.
+void test_settings_file__growable_enforces_cap(void) {
+  printf("\nTesting growable file cap enforcement...\n");
+
+  // Use a cap of 4096 (one PFS page worth) and initial_alloc of 2048.
+  // Write large records to hit the cap.
+  const int initial_alloc = 2048;
+  const int max_cap = 4096;
+  SettingsFile file;
+  cl_must_pass(settings_file_open_growable(&file, "tc", max_cap, initial_alloc));
+
+  uint8_t key[5];
+  int key_len = 4;
+  uint8_t val[128];
+  int val_len = sizeof(val);
+  memset(val, 0xCD, val_len);
+  // Each record = 8 + 4 + 128 = 140 bytes. max_cap of 4096 holds ~28 records.
+  int i;
+  for (i = 0; i < 100; i++) {
+    snprintf((char *)key, sizeof(key), "k%03d", i);
+    val[0] = (uint8_t)i;
+    status_t status = settings_file_set(&file, key, key_len, val, val_len);
+    if (status == E_OUT_OF_STORAGE) {
+      printf("Hit storage cap at record %d\n", i);
+      break;
+    }
+    cl_must_pass(status);
+  }
+
+  // We should have hit the cap before writing 100 records
+  cl_assert(i < 100);
+
+  // Verify the records that were written are still readable
+  for (int j = 0; j < i; j++) {
+    snprintf((char *)key, sizeof(key), "k%03d", j);
+    val[0] = (uint8_t)j;
+    verify(&file, key, key_len, val, val_len);
+  }
+
+  settings_file_close(&file);
+}
+
+// Test that closing and reopening a grown file preserves its size and data.
+void test_settings_file__growable_reopen(void) {
+  printf("\nTesting growable file reopen after growth...\n");
+
+  const int initial_alloc = 2048;
+  const int max_cap = 32768;
+  SettingsFile file;
+  cl_must_pass(settings_file_open_growable(&file, "tr", max_cap, initial_alloc));
+
+  // Write enough large records to force growth past the initial page
+  uint8_t key[5];
+  int key_len = 4;
+  uint8_t val[128];
+  int val_len = sizeof(val);
+  memset(val, 0xEF, val_len);
+  int num_records = 65;
+  for (int i = 0; i < num_records; i++) {
+    snprintf((char *)key, sizeof(key), "k%03d", i);
+    val[0] = (uint8_t)i;
+    cl_must_pass(settings_file_set(&file, key, key_len, val, val_len));
+  }
+
+  int grown_file_size = pfs_get_file_size(file.iter.fd);
+  printf("Grown file size: %d\n", grown_file_size);
+  settings_file_close(&file);
+
+  // Reopen with the same growable parameters
+  cl_must_pass(settings_file_open_growable(&file, "tr", max_cap, initial_alloc));
+
+  int reopened_file_size = pfs_get_file_size(file.iter.fd);
+  printf("Reopened file size: %d\n", reopened_file_size);
+  // The file should not have shrunk
+  cl_assert(reopened_file_size >= grown_file_size);
+
+  // Verify all data survived the close/reopen
+  for (int i = 0; i < num_records; i++) {
+    snprintf((char *)key, sizeof(key), "k%03d", i);
+    val[0] = (uint8_t)i;
+    verify(&file, key, key_len, val, val_len);
+  }
+
+  settings_file_close(&file);
+}
+
+// Compaction shrinks a grown growable file back toward the initial allocation when most
+// records have been deleted, so a brief storage burst doesn't permanently hold flash.
+void test_settings_file__growable_shrinks_on_compact(void) {
+  printf("\nTesting growable file shrink on compact...\n");
+
+  const int initial_alloc = 2048;
+  const int max_cap = 32768;
+  SettingsFile file;
+  cl_must_pass(settings_file_open_growable(&file, "tk", max_cap, initial_alloc));
+
+  uint8_t key[5];
+  int key_len = 4;
+  uint8_t val[128];
+  int val_len = sizeof(val);
+  memset(val, 0x77, val_len);
+
+  // Drive enough writes to push past several doublings.
+  const int num_records = 65;
+  for (int i = 0; i < num_records; i++) {
+    snprintf((char *)key, sizeof(key), "k%03d", i);
+    val[0] = (uint8_t)i;
+    cl_must_pass(settings_file_set(&file, key, key_len, val, val_len));
+  }
+
+  const int grown_file_size = pfs_get_file_size(file.iter.fd);
+  const int grown_alloc = file.alloc_used_space;
+  printf("Grown: file_size=%d alloc=%d\n", grown_file_size, grown_alloc);
+  cl_assert(grown_alloc > initial_alloc);
+
+  // Delete almost everything. Leave one record so we still exercise the rewrite path.
+  for (int i = 0; i < num_records - 1; i++) {
+    snprintf((char *)key, sizeof(key), "k%03d", i);
+    cl_must_pass(settings_file_delete(&file, key, key_len));
+  }
+
+  // Force compact. Should drop alloc to the smallest doubling that fits 2x used.
+  cl_must_pass(settings_file_compact(&file));
+
+  const int shrunk_file_size = pfs_get_file_size(file.iter.fd);
+  const int shrunk_alloc = file.alloc_used_space;
+  printf("Shrunk: file_size=%d alloc=%d\n", shrunk_file_size, shrunk_alloc);
+  cl_assert(shrunk_alloc < grown_alloc);
+  cl_assert(shrunk_file_size < grown_file_size);
+
+  // The remaining record must still be readable after the shrink-rewrite.
+  snprintf((char *)key, sizeof(key), "k%03d", num_records - 1);
+  val[0] = (uint8_t)(num_records - 1);
+  verify(&file, key, key_len, val, val_len);
+
+  settings_file_close(&file);
+}
+
+// A non-growable file (settings_file_open with the legacy API) must not shrink during
+// compaction. The pre-allocation guarantee is part of the contract.
+void test_settings_file__non_growable_does_not_shrink_on_compact(void) {
+  printf("\nTesting non-growable file does not shrink on compact...\n");
+
+  const int max_used = 8192;
+  SettingsFile file;
+  cl_must_pass(settings_file_open(&file, "tn", max_used));
+
+  const int initial_alloc = file.alloc_used_space;
+  const int initial_file_size = pfs_get_file_size(file.iter.fd);
+  printf("Initial: file_size=%d alloc=%d\n", initial_file_size, initial_alloc);
+
+  uint8_t key[5];
+  int key_len = 4;
+  uint8_t val[32];
+  int val_len = sizeof(val);
+  memset(val, 0x33, val_len);
+
+  // Write a few small records, then delete all of them.
+  for (int i = 0; i < 10; i++) {
+    snprintf((char *)key, sizeof(key), "k%03d", i);
+    cl_must_pass(settings_file_set(&file, key, key_len, val, val_len));
+  }
+  for (int i = 0; i < 10; i++) {
+    snprintf((char *)key, sizeof(key), "k%03d", i);
+    cl_must_pass(settings_file_delete(&file, key, key_len));
+  }
+  cl_must_pass(settings_file_compact(&file));
+
+  const int post_alloc = file.alloc_used_space;
+  const int post_file_size = pfs_get_file_size(file.iter.fd);
+  printf("After compact: file_size=%d alloc=%d\n", post_file_size, post_alloc);
+  cl_assert_equal_i(post_alloc, initial_alloc);
+  cl_assert_equal_i(post_file_size, initial_file_size);
+
+  settings_file_close(&file);
+}
+
+// Migration: a file written by a prior firmware via settings_file_open with a small
+// max_used_space must reopen as growable without losing data, and its physical allocation
+// must be adopted (not silently shrunk to the new initial_alloc_size).
+void test_settings_file__growable_migration_from_non_growable(void) {
+  printf("\nTesting migration from non-growable to growable...\n");
+
+  const int legacy_max = 6144;
+  uint8_t key[5];
+  int key_len = 4;
+  uint8_t val[64];
+  int val_len = sizeof(val);
+  memset(val, 0x5A, val_len);
+
+  SettingsFile file;
+  cl_must_pass(settings_file_open(&file, "tm", legacy_max));
+  int legacy_file_size = pfs_get_file_size(file.iter.fd);
+  printf("Legacy file size: %d\n", legacy_file_size);
+
+  const int num_records = 20;
+  for (int i = 0; i < num_records; i++) {
+    snprintf((char *)key, sizeof(key), "k%03d", i);
+    val[0] = (uint8_t)i;
+    cl_must_pass(settings_file_set(&file, key, key_len, val, val_len));
+  }
+  settings_file_close(&file);
+
+  const int new_initial_alloc = 4096;
+  const int new_max = 1024 * 1024;
+  cl_must_pass(settings_file_open_growable(&file, "tm", new_max, new_initial_alloc));
+
+  int reopened_file_size = pfs_get_file_size(file.iter.fd);
+  printf("Reopened (as growable) file size: %d\n", reopened_file_size);
+  // The pre-allocated legacy file must not be shrunk on reopen.
+  cl_assert(reopened_file_size >= legacy_file_size);
+
+  for (int i = 0; i < num_records; i++) {
+    snprintf((char *)key, sizeof(key), "k%03d", i);
+    val[0] = (uint8_t)i;
+    verify(&file, key, key_len, val, val_len);
+  }
+
+  settings_file_close(&file);
+}
+
 // Test that we can start searching beginning at the record we previously found in a recent
 // call into settings file. This makes sure we don't start searching at the beginning of a file
 // each API call.

--- a/tests/stubs/stubs_settings_file.h
+++ b/tests/stubs/stubs_settings_file.h
@@ -9,6 +9,11 @@ status_t settings_file_open(SettingsFile *file, const char *name, int max_used_s
   return S_SUCCESS;
 }
 
+status_t settings_file_open_growable(SettingsFile *file, const char *name,
+                                     int max_used_space, int initial_alloc_size) {
+  return settings_file_open(file, name, max_used_space);
+}
+
 status_t settings_file_get(SettingsFile *file, const void *key, size_t key_len,
                            void *val_out, size_t val_out_len) {
   return S_SUCCESS;

--- a/tests/stubs/stubs_task_watchdog.h
+++ b/tests/stubs/stubs_task_watchdog.h
@@ -18,3 +18,9 @@ void task_watchdog_feed(void) {
 
 void task_watchdog_bit_set(PebbleTask task) {
 }
+
+void task_watchdog_pause(unsigned int seconds) {
+}
+
+void task_watchdog_resume(void) {
+}


### PR DESCRIPTION
Took over the branch and folded in some review-driven follow-ups. Three commits now, in this order:

  1. **`fw/services/normal/settings: add growable settings files`** _(was `cf6e09f46`, expanded)_
  2. **`fw/services/normal/persist: raise per-app storage limit to 1 MiB`** _(unchanged content; reordered to land second)_
  3. **`fw/services/normal/settings: speed up file rewrite, pause watchdog`** _(new)_
  
  Reordered for bisectability (need growable files before raising the limits), made growable files shirnk on compact (before it would stay at what it grew to)
  Big grows hit the task watchdog, thats fixed with the third commit
  There are some files that currently allocate for the worst case (appglancedb ~100KB, notifstr ~30KB, weatherdh ~40KB, etc), we can switch those to growable in a later PR.

Fixes FIRM-1655