### PR TITLE
open settings files as growable

### DIFF
--- a/src/fw/services/blob_db/app_db.c
+++ b/src/fw/services/blob_db/app_db.c
@@ -40,9 +40,10 @@ struct AppDBInitData {
 
 static status_t prv_lock_mutex_and_open_file(void) {
   mutex_lock(s_app_db.mutex);
-  status_t rv = settings_file_open(&s_app_db.settings_file,
-                                   SETTINGS_FILE_NAME,
-                                   SETTINGS_FILE_SIZE);
+  status_t rv = settings_file_open_growable(&s_app_db.settings_file,
+                                            SETTINGS_FILE_NAME,
+                                            SETTINGS_FILE_SIZE,
+                                            KiBYTES(4));
   if (rv != S_SUCCESS) {
     mutex_unlock(s_app_db.mutex);
   }

--- a/src/fw/services/blob_db/app_glance_db.c
+++ b/src/fw/services/blob_db/app_glance_db.c
@@ -602,8 +602,9 @@ status_t app_glance_db_delete_glance(const Uuid *uuid) {
 
 static status_t prv_lock_mutex_and_open_file(void) {
   mutex_lock(s_app_glance_db.mutex);
-  const status_t rv = settings_file_open(&s_app_glance_db.settings_file, SETTINGS_FILE_NAME,
-                                         SETTINGS_FILE_SIZE);
+  const status_t rv = settings_file_open_growable(&s_app_glance_db.settings_file,
+                                                  SETTINGS_FILE_NAME, SETTINGS_FILE_SIZE,
+                                                  KiBYTES(4));
   if (rv != S_SUCCESS) {
     mutex_unlock(s_app_glance_db.mutex);
   }

--- a/src/fw/services/blob_db/contacts_db.c
+++ b/src/fw/services/blob_db/contacts_db.c
@@ -28,9 +28,10 @@ static struct {
 
 static status_t prv_lock_mutex_and_open_file(void) {
   mutex_lock(s_contacts_db.mutex);
-  status_t rv = settings_file_open(&s_contacts_db.settings_file,
-                                   SETTINGS_FILE_NAME,
-                                   SETTINGS_FILE_SIZE);
+  status_t rv = settings_file_open_growable(&s_contacts_db.settings_file,
+                                            SETTINGS_FILE_NAME,
+                                            SETTINGS_FILE_SIZE,
+                                            KiBYTES(4));
   if (rv != S_SUCCESS) {
     mutex_unlock(s_contacts_db.mutex);
   }

--- a/src/fw/services/blob_db/health_db.c
+++ b/src/fw/services/blob_db/health_db.c
@@ -91,7 +91,8 @@ _Static_assert(sizeof(HeartRateZoneData) % sizeof(uint32_t) == 0,
 static status_t prv_file_open_and_lock(SettingsFile *file) {
   mutex_lock(s_mutex);
 
-  status_t rv = settings_file_open(file, HEALTH_DB_FILE_NAME, HEALTH_DB_MAX_SIZE);
+  status_t rv = settings_file_open_growable(file, HEALTH_DB_FILE_NAME, HEALTH_DB_MAX_SIZE,
+                                            KiBYTES(8));
   if (rv != S_SUCCESS) {
     PBL_LOG_ERR("Failed to open settings file");
     mutex_unlock(s_mutex);

--- a/src/fw/services/blob_db/ios_notif_pref_db.c
+++ b/src/fw/services/blob_db/ios_notif_pref_db.c
@@ -35,7 +35,8 @@ static PebbleMutex *s_mutex;
 static status_t prv_file_open_and_lock(SettingsFile *file) {
   mutex_lock(s_mutex);
 
-  status_t rv = settings_file_open(file, iOS_NOTIF_PREF_DB_FILE_NAME, iOS_NOTIF_PREF_MAX_SIZE);
+  status_t rv = settings_file_open_growable(file, iOS_NOTIF_PREF_DB_FILE_NAME,
+                                            iOS_NOTIF_PREF_MAX_SIZE, KiBYTES(4));
   if (rv != S_SUCCESS) {
     mutex_unlock(s_mutex);
   }

--- a/src/fw/services/blob_db/timeline_item_storage.c
+++ b/src/fw/services/blob_db/timeline_item_storage.c
@@ -8,6 +8,7 @@
 #include "pbl/services/filesystem/pfs.h"
 #include "pbl/services/settings/settings_raw_iter.h"
 #include "system/logging.h"
+#include "util/units.h"
 
 #define MAX_CHILDREN_PER_PIN 3
 
@@ -264,7 +265,8 @@ void timeline_item_storage_init(TimelineItemStorage *storage,
     .max_item_age = max_age,
     .mutex = mutex_create(),
   };
-  status_t rv = settings_file_open(&storage->file, storage->name, storage->max_size);
+  status_t rv = settings_file_open_growable(&storage->file, storage->name,
+                                            storage->max_size, KiBYTES(8));
   if (FAILED(rv)) {
     PBL_LOG_ERR("Unable to create settings file %s, rv = %"PRId32 "!",
             filename, rv);

--- a/src/fw/services/blob_db/watch_app_prefs_db.c
+++ b/src/fw/services/blob_db/watch_app_prefs_db.c
@@ -32,9 +32,10 @@ T_STATIC const char *PREF_KEY_SEND_TEXT_APP = "sendTextApp";
 
 static status_t prv_lock_mutex_and_open_file(void) {
   mutex_lock_recursive(s_watch_app_prefs_db.mutex);
-  status_t rv = settings_file_open(&s_watch_app_prefs_db.settings_file,
-                                   SETTINGS_FILE_NAME,
-                                   SETTINGS_FILE_SIZE);
+  status_t rv = settings_file_open_growable(&s_watch_app_prefs_db.settings_file,
+                                            SETTINGS_FILE_NAME,
+                                            SETTINGS_FILE_SIZE,
+                                            KiBYTES(4));
   if (rv != S_SUCCESS) {
     mutex_unlock_recursive(s_watch_app_prefs_db.mutex);
   }

--- a/src/fw/services/blob_db/weather_db.c
+++ b/src/fw/services/blob_db/weather_db.c
@@ -32,9 +32,10 @@ typedef struct WeatherDBIteratorData {
 
 static status_t prv_lock_mutex_and_open_file(void) {
   mutex_lock(s_weather_db.mutex);
-  status_t rv = settings_file_open(&s_weather_db.settings_file,
-                                   SETTINGS_FILE_NAME,
-                                   SETTINGS_FILE_SIZE);
+  status_t rv = settings_file_open_growable(&s_weather_db.settings_file,
+                                            SETTINGS_FILE_NAME,
+                                            SETTINGS_FILE_SIZE,
+                                            KiBYTES(4));
   if (rv != S_SUCCESS) {
     mutex_unlock(s_weather_db.mutex);
   }


### PR DESCRIPTION
Convert eight blob_db settings files from fixed pre-allocation to growable, following on from #1197 which added `settings_file_open_growable()` and converted persist. Each file is sized for worst-case usage but typically runs nowhere near full, so dropping the initial allocation and letting it grow on demand reclaims a large chunk of PFS on most devices.

| File | Cap | Initial |
  |---|---|---|
  | `appglancedb` | 80 KiB | 4 KiB |
  | `weatherdb` | 30 KiB | 4 KiB |
  | `pindb` / `reminderdb` (timeline_item_storage) | ~53 KiB each | 8 KiB |
  | `appdb` | 20 KiB | 4 KiB |
  | `watch_app_prefs` | 20 KiB | 4 KiB |
  | `contactsdb` | 30 KiB | 4 KiB |
  | `iosnotifprefdb` | 10 KiB | 4 KiB |
  | `healthdb` | 12 KiB | 8 KiB |

  On existing devices, `prv_open` detects `actual_size > max_space_total` and adopts the existing physical file size, so first reopen after upgrade is a no-op — no rewrite, no shrink, no data loss. Files shrink lazily on the next compact triggered by normal write traffic (when `used_space + dead_space + rec_size` overflows `max_space_total`).

  That means the savings trickle in over time rather than landing on first boot. Roughly:

  - `pindb`/`reminderdb`/`healthdb` — soon, since these see frequent writes
  - `weatherdb`/`iosnotifprefdb` — hours to days, depending on phone activity
  - `appglancedb`/`appdb`/`watch_app_prefs`/`contactsdb` — could be a long time on a stable device with no installs / no contact resync / no glance updates