### PR TITLE
sdk: expose PERSIST_STORAGE_MAX_SIZE to apps

### DIFF
--- a/src/fw/applib/persist.h
+++ b/src/fw/applib/persist.h
@@ -35,7 +35,8 @@
 //! retrieve values from the phone, it provides you with a much faster way to restore state.
 //! In addition, it draws less power from the battery.
 //!
-//! Note that the size of all persisted values cannot exceed 1MB per app.
+//! Note that the size of all persisted values per app cannot exceed
+//! \ref PERSIST_STORAGE_MAX_SIZE.
 //!   @{
 
 //! The maximum size of a persist value in bytes
@@ -43,6 +44,11 @@
 
 //! The maximum size of a persist string in bytes including the NULL terminator
 #define PERSIST_STRING_MAX_LENGTH PERSIST_DATA_MAX_LENGTH
+
+//! The maximum total size in bytes of all persisted values for a single app.
+//! Apps targeting older SDKs where this define is not present should assume a
+//! 4 KB limit.
+#define PERSIST_STORAGE_MAX_SIZE (1 * 1024 * 1024)
 
 struct PersistStore;
 

--- a/src/fw/process_management/pebble_process_info.h
+++ b/src/fw/process_management/pebble_process_info.h
@@ -161,9 +161,10 @@ typedef enum {
 // sdk.major:0x5 .minor:0x5d -- Add app_light_set_color_rgb888() for 8-bit-per-channel backlight tint (rev 96)
 // sdk.major:0x5 .minor:0x5e -- Add Speaker API (rev 97)
 // sdk.major:0x5 .minor:0x5f -- speaker_play_tone() now plays the exact frequency (rev 98)
+// sdk.major:0x5 .minor:0x60 -- Expose PERSIST_STORAGE_MAX_SIZE to apps (rev 99)
 
 #define PROCESS_INFO_CURRENT_SDK_VERSION_MAJOR 0x5
-#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x5f
+#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x60
 
 // The first SDK to ship with 2.x APIs
 #define PROCESS_INFO_FIRST_2X_SDK_VERSION_MAJOR 0x4

--- a/src/fw/services/persist/service.c
+++ b/src/fw/services/persist/service.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "applib/persist.h"
 #include "kernel/pbl_malloc.h"
 #include "os/mutex.h"
 #include "process_management/app_install_manager.h"
@@ -19,7 +20,6 @@
 #include "util/list.h"
 #include "util/units.h"
 
-#define PERSIST_STORAGE_MAX_SPACE MiBYTES(1)
 #define PERSIST_STORAGE_INITIAL_ALLOC KiBYTES(4)
 
 typedef struct PersistStore {
@@ -126,7 +126,7 @@ SettingsFile * persist_service_lock_and_get_store(const Uuid *uuid) {
     char filename[PERSIST_FILE_NAME_MAX_LENGTH];
     PBL_ASSERTN(PASSED(prv_get_file_name(filename, sizeof(filename), uuid)));
     PBL_ASSERTN(PASSED(settings_file_open_growable(&store->file, filename,
-                                                   PERSIST_STORAGE_MAX_SPACE,
+                                                   PERSIST_STORAGE_MAX_SIZE,
                                                    PERSIST_STORAGE_INITIAL_ALLOC)));
     store->file_open = true;
   }

--- a/tools/build_sdk.py
+++ b/tools/build_sdk.py
@@ -76,6 +76,29 @@ def _patch_process_info_version(dest_path, frozen_revision):
         f.write(text)
 
 
+# Defines whose value depends on the target firmware. Frozen platforms predate
+# the firmware change and must use the legacy value. Each entry maps a define
+# name to its legacy value.
+_FROZEN_DEFINE_OVERRIDES = {
+    "PERSIST_STORAGE_MAX_SIZE": "4096",
+}
+
+
+def _patch_frozen_define_overrides(header_path):
+    """Rewrite firmware-capability-dependent defines in a generated SDK header
+    to their legacy values for frozen platforms."""
+    with open(header_path) as f:
+        text = f.read()
+    for name, legacy_value in _FROZEN_DEFINE_OVERRIDES.items():
+        text = re.sub(
+            r"(#define\s+{}\s+).*".format(re.escape(name)),
+            r"\g<1>{}".format(legacy_value),
+            text,
+        )
+    with open(header_path, "w") as f:
+        f.write(text)
+
+
 def build_sdk_for_platform(platform_name, output_dir, internal_sdk_build):
     if platform_name not in pebble_platforms:
         raise SystemExit(
@@ -145,6 +168,10 @@ def build_sdk_for_platform(platform_name, output_dir, internal_sdk_build):
     )
 
     if is_frozen:
+        for header in ("pebble.h", "pebble_worker.h"):
+            header_path = path.join(sdk_include_dir, header)
+            if path.isfile(header_path):
+                _patch_frozen_define_overrides(header_path)
         print("    Skipped libpebble.a (frozen SDK, use pre-built library)")
 
     print("    Output: {}".format(platform_dir))

--- a/tools/generate_native_sdk/exported_symbols.json
+++ b/tools/generate_native_sdk/exported_symbols.json
@@ -4,7 +4,7 @@
               "You should also make sure you are obeying our API design guidelines:",
               "https://pebbletechnology.atlassian.net/wiki/display/DEV/SDK+API+Design+Guidelines"
             ],
-  "revision" : "98",
+  "revision" : "99",
   "version" : "2.0",
   "files": [
     "fw/drivers/ambient_light.h",
@@ -1687,6 +1687,10 @@
             }, {
               "type": "define",
               "name": "PERSIST_STRING_MAX_LENGTH"
+            }, {
+              "type": "define",
+              "name": "PERSIST_STORAGE_MAX_SIZE",
+              "addedRevision": "99"
             }, {
               "type": "type",
               "name": "StatusCode"


### PR DESCRIPTION
Apps had no way to know the per-app persist storage cap at compile time; the existing limit lived only in firmware as an internal define. Expose it as PERSIST_STORAGE_MAX_SIZE in applib/persist.h so apps can size buffers and allocations against it. The persist service now uses the same public define as its single source of truth.

Frozen-platform SDKs (aplite, basalt, chalk, diorite) ship pre-1 MiB firmware, so build_sdk.py rewrites the value to 4096 in their generated pebble.h / pebble_worker.h. Apps targeting older SDKs that don't define PERSIST_STORAGE_MAX_SIZE at all should fall back to 4096 themselves.