### PR TITLE
sdk: add persist_get_max_size() for runtime persist storage capacity

### DIFF
--- a/include/pbl/services/persist.h
+++ b/include/pbl/services/persist.h
@@ -28,6 +28,9 @@ typedef struct SettingsFile SettingsFile;
 //! Initialize the persist service.
 void persist_service_init(void);
 
+//! Get the per-app persistent storage capacity in bytes.
+size_t persist_service_get_max_size(void);
+
 //! Lock and get the persist store for the given app.
 SettingsFile *persist_service_lock_and_get_store(const Uuid *uuid);
 

--- a/src/fw/applib/persist.c
+++ b/src/fw/applib/persist.c
@@ -31,6 +31,10 @@ static void prv_unlock(SettingsFile **store) {
       = prv_lock_and_get_store()
 
 
+DEFINE_SYSCALL(size_t, persist_get_max_size, void) {
+  return persist_service_get_max_size();
+}
+
 DEFINE_SYSCALL(bool, persist_exists, const uint32_t key) {
   LOCK_AND_GET_STORE(store);
   return settings_file_exists(store, &key, sizeof(key));

--- a/src/fw/applib/persist.h
+++ b/src/fw/applib/persist.h
@@ -35,7 +35,8 @@
 //! retrieve values from the phone, it provides you with a much faster way to restore state.
 //! In addition, it draws less power from the battery.
 //!
-//! Note that the size of all persisted values cannot exceed 1MB per app.
+//! The total size of an app's persisted values is capped; call
+//! \ref persist_get_max_size to query the limit at runtime.
 //!   @{
 
 //! The maximum size of a persist value in bytes
@@ -45,6 +46,12 @@
 #define PERSIST_STRING_MAX_LENGTH PERSIST_DATA_MAX_LENGTH
 
 struct PersistStore;
+
+//! Gets the maximum total size in bytes of all persisted values for the
+//! current app on this firmware. Apps targeting older SDKs that don't have
+//! this function should assume a 4 KB limit.
+//! @return The per-app persistent storage capacity in bytes.
+size_t persist_get_max_size(void);
 
 //! Checks whether a value has been set for a given key in persistent storage.
 //! @param key The key of the field to check.

--- a/src/fw/process_management/pebble_process_info.h
+++ b/src/fw/process_management/pebble_process_info.h
@@ -161,9 +161,10 @@ typedef enum {
 // sdk.major:0x5 .minor:0x5d -- Add app_light_set_color_rgb888() for 8-bit-per-channel backlight tint (rev 96)
 // sdk.major:0x5 .minor:0x5e -- Add Speaker API (rev 97)
 // sdk.major:0x5 .minor:0x5f -- speaker_play_tone() now plays the exact frequency (rev 98)
+// sdk.major:0x5 .minor:0x60 -- Add persist_get_max_size() for runtime persist storage capacity (rev 99)
 
 #define PROCESS_INFO_CURRENT_SDK_VERSION_MAJOR 0x5
-#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x5f
+#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x60
 
 // The first SDK to ship with 2.x APIs
 #define PROCESS_INFO_FIRST_2X_SDK_VERSION_MAJOR 0x4

--- a/src/fw/services/persist/service.c
+++ b/src/fw/services/persist/service.c
@@ -86,6 +86,10 @@ static bool prv_bad_persist_file_filter(const char *filename) {
          strcmp(filename + APP_FILE_NAME_PREFIX_LENGTH, "persist") == 0;
 }
 
+size_t persist_service_get_max_size(void) {
+  return PERSIST_STORAGE_MAX_SPACE;
+}
+
 // Designed to be called once during reset
 void persist_service_init(void) {
   persist_map_init();

--- a/tools/generate_native_sdk/exported_symbols.json
+++ b/tools/generate_native_sdk/exported_symbols.json
@@ -4,7 +4,7 @@
               "You should also make sure you are obeying our API design guidelines:",
               "https://pebbletechnology.atlassian.net/wiki/display/DEV/SDK+API+Design+Guidelines"
             ],
-  "revision" : "98",
+  "revision" : "99",
   "version" : "2.0",
   "files": [
     "fw/drivers/ambient_light.h",
@@ -1697,6 +1697,11 @@
               "type": "function",
               "name": "persist_exists",
               "addedRevision": "0"
+            }, {
+              "type": "function",
+              "name": "persist_get_max_size",
+              "addedRevision": "99",
+              "stubReturn": "4096"
             }, {
               "type": "function",
               "name": "persist_get_size",


### PR DESCRIPTION
Apps had no way to know the per-app persist storage cap; the limit lived only in firmware as an internal define. Add persist_get_max_size() so apps can query the firmware's capacity at runtime — currently 1 MiB on modern firmware and 4 KiB on legacy frozen-platform SDKs.

Frozen platforms (aplite, basalt, chalk, diorite) ship pre-1 MiB firmware that has no syscall, so the SDK generator stubs the call to return 4096 directly via stubReturn. Apps targeting older SDKs that predate this function should fall back to 4096 themselves.