### PR TITLE
fw/services/compositor: render request for App-to-App transition

### DIFF
--- a/src/fw/services/compositor/compositor.c
+++ b/src/fw/services/compositor/compositor.c
@@ -456,9 +456,15 @@ void compositor_transition(const CompositorTransition *compositor_animation) {
     }
 
   } else {
-    // App to App
+    // App to App (also handles Transitioning->App when the previous animation was cancelled)
 
-    // We have to wait for the app to populate its framebuffer
+    // We can't say for sure whether or not the app framebuffer is in a reasonable state, as the
+    // app could be redrawing itself right now. Since we can't query this, instead trigger the
+    // app to redraw itself. This way we will cause an PEBBLE_RENDER_READY_EVENT in the very near
+    // future, regardless of the app's state.
+    prv_send_app_render_request();
+
+    // Now wait for the ready event.
     s_state = CompositorState_AppTransitionPending;
   }
 }


### PR DESCRIPTION
When `compositor_transition()` reached the "App to App" else branch (also taken when a Modal-to-App transition was cancelled mid-animation and a new transition kicked off while no modal exists), it set the state to `AppTransitionPending` without calling
`prv_send_app_render_request()`. This left the compositor waiting on a `PEBBLE_RENDER_READY_EVENT` that the app never sent, freezing the display until an external event triggered another transition.

This was reproducible by dismissing a notification and immediately receiving and dismissing a second one, leaving the screen frozen until a third notification arrived.

Mirror the Modal-to-App branch and request an app render before moving to `AppTransitionPending`.

Fixes FIRM-1713.