### PR TITLE
fw/board/obelix: raise low-power threshold from 2% to 4%

### DIFF
--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -563,7 +563,7 @@ const BoardConfigPower BOARD_CONFIG_POWER = {
     .peripheral = hwp_gpio1,
     .gpio_pin = 26,
   },
-  .low_power_threshold = 2U,
+  .low_power_threshold = 4U,
   .battery_capacity_hours = 370U,
 };
 


### PR DESCRIPTION
## Summary

Engage low-power (clock-only) mode on obelix at 4% battery instead of 2% so the watch has more headroom before the cell reaches a critical level. Users were observing the watch dropping from "low power engaged" to dead in under 12 hours, leaving no useful runway in the clock-only mode.

Only `obelix` is changed. Other boards keep their existing thresholds.

Fixes [FIRM-1751](https://linear.app/core-dev/issue/FIRM-1751/low-power-clock-only-mode-only-lasted-less-than-12-hours).

## Test plan
- [ ] Build obelix
- [ ] Confirm low-power UI engages at 4% on a real obelix watch
- [ ] Sanity-check clock-only mode runtime after the bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)