### PR TITLE
Handle unsupported watchfaces for Quick View

### DIFF
--- a/src/fw/applib/unobstructed_area_service.c
+++ b/src/fw/applib/unobstructed_area_service.c
@@ -160,12 +160,17 @@ void unobstructed_area_service_unsubscribe(UnobstructedAreaState *state) {
 
 void unobstructed_area_service_get_area(UnobstructedAreaState *state, GRect *area_out) {
   if (state && area_out) {
+    state->has_requested_area = true;
     *area_out = state->area;
   }
 }
 
 bool unobstructed_area_service_is_subscribed(UnobstructedAreaState *state) {
   return state ? state->is_subscribed : false;
+}
+
+bool unobstructed_area_service_has_requested_area(UnobstructedAreaState *state) {
+  return state ? state->has_requested_area : false;
 }
 
 void app_unobstructed_area_service_subscribe(UnobstructedAreaHandlers handlers, void *context) {

--- a/src/fw/applib/unobstructed_area_service.c
+++ b/src/fw/applib/unobstructed_area_service.c
@@ -148,17 +148,24 @@ void unobstructed_area_service_subscribe(UnobstructedAreaState *state,
   PBL_ASSERTN(state && handlers);
   state->handlers = *handlers;
   state->context = context;
+  state->is_subscribed = true;
 }
 
 void unobstructed_area_service_unsubscribe(UnobstructedAreaState *state) {
   PBL_ASSERTN(state);
   state->handlers = (UnobstructedAreaHandlers) {};
+  state->context = NULL;
+  state->is_subscribed = false;
 }
 
 void unobstructed_area_service_get_area(UnobstructedAreaState *state, GRect *area_out) {
   if (state && area_out) {
     *area_out = state->area;
   }
+}
+
+bool unobstructed_area_service_is_subscribed(UnobstructedAreaState *state) {
+  return state ? state->is_subscribed : false;
 }
 
 void app_unobstructed_area_service_subscribe(UnobstructedAreaHandlers handlers, void *context) {

--- a/src/fw/applib/unobstructed_area_service_private.h
+++ b/src/fw/applib/unobstructed_area_service_private.h
@@ -35,6 +35,11 @@ void unobstructed_area_service_deinit(UnobstructedAreaState *state);
 void unobstructed_area_service_get_area(UnobstructedAreaState *state, GRect *area);
 
 //! @internal
+//! Returns whether the app subscribed to unobstructed area changes.
+//! @param state Unobstructed area state belonging to the consuming task
+bool unobstructed_area_service_is_subscribed(UnobstructedAreaState *state);
+
+//! @internal
 //! Subscribe to be notified when the app's unobstructed area changes.
 //! @param state Unobstructed area state belonging to the consuming task
 //! @param handlers The handlers that should be called when the unobstructed area changes.

--- a/src/fw/applib/unobstructed_area_service_private.h
+++ b/src/fw/applib/unobstructed_area_service_private.h
@@ -14,6 +14,7 @@ typedef struct UnobstructedAreaState {
   GRect area;
   void *context;
   bool is_subscribed;
+  bool has_requested_area;
   bool is_changing;
 } UnobstructedAreaState;
 
@@ -38,6 +39,11 @@ void unobstructed_area_service_get_area(UnobstructedAreaState *state, GRect *are
 //! Returns whether the app subscribed to unobstructed area changes.
 //! @param state Unobstructed area state belonging to the consuming task
 bool unobstructed_area_service_is_subscribed(UnobstructedAreaState *state);
+
+//! @internal
+//! Returns whether the app has queried the unobstructed area.
+//! @param state Unobstructed area state belonging to the consuming task
+bool unobstructed_area_service_has_requested_area(UnobstructedAreaState *state);
 
 //! @internal
 //! Subscribe to be notified when the app's unobstructed area changes.

--- a/src/fw/apps/system/settings/timeline.c
+++ b/src/fw/apps/system/settings/timeline.c
@@ -85,7 +85,7 @@ static uint16_t s_before_time_values[PeekBeforeTimingMenuIndexCount] = {
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
 static const char *s_unsupported_faces_strings[UnsupportedFacesMenuIndexCount] = {
   /// Shows up in the Timeline settings as an "Unsupported Faces" submenu option.
-  i18n_noop("Nothing"),
+  i18n_noop("Overlay"),
   /// Shows up in the Timeline settings as an "Unsupported Faces" submenu option.
   i18n_noop("Shift up"),
   /// Shows up in the Timeline settings as an "Unsupported Faces" submenu option.

--- a/src/fw/apps/system/settings/timeline.c
+++ b/src/fw/apps/system/settings/timeline.c
@@ -34,6 +34,9 @@ typedef struct SettingsTimelinePeekData {
 
 typedef enum TimelinePeekMenuIndex {
   TimelinePeekMenuIndex_Toggle,
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
+  TimelinePeekMenuIndex_SquishFaces,
+#endif
   TimelinePeekMenuIndex_Timing,
 
   TimelinePeekMenuIndexCount,
@@ -133,6 +136,15 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
       subtitle = s_before_time_strings[
           prv_before_time_min_to_index(timeline_peek_prefs_get_before_time())];
       break;
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
+    case TimelinePeekMenuIndex_SquishFaces:
+      /// Shows up in the Timeline settings as the title for squishing unsupported watchfaces.
+      title = i18n_noop("Squish Faces");
+      /// Shows up in the Timeline settings as the status under the "Squish Faces" toggle.
+      subtitle = timeline_peek_prefs_get_watchface_fit_enabled() ? i18n_noop("On")
+                                                                 : i18n_noop("Off");
+      break;
+#endif
     case TimelinePeekMenuIndexCount:
       break;
   }
@@ -150,6 +162,12 @@ static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
     case TimelinePeekMenuIndex_Timing:
       prv_push_before_time_menu(data);
       goto done;
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
+    case TimelinePeekMenuIndex_SquishFaces:
+      timeline_peek_prefs_set_watchface_fit_enabled(
+          !timeline_peek_prefs_get_watchface_fit_enabled());
+      goto done;
+#endif
     case TimelinePeekMenuIndexCount:
       break;
   }

--- a/src/fw/apps/system/settings/timeline.c
+++ b/src/fw/apps/system/settings/timeline.c
@@ -35,7 +35,7 @@ typedef struct SettingsTimelinePeekData {
 typedef enum TimelinePeekMenuIndex {
   TimelinePeekMenuIndex_Toggle,
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
-  TimelinePeekMenuIndex_SquishFaces,
+  TimelinePeekMenuIndex_UnsupportedFaces,
 #endif
   TimelinePeekMenuIndex_Timing,
 
@@ -55,6 +55,16 @@ typedef enum PeekBeforeTimingMenuIndex {
   PeekBeforeTimingMenuIndexDefault = PeekBeforeTimingMenuIndex_10Min,
 } PeekBeforeTimingMenuIndex;
 
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
+typedef enum UnsupportedFacesMenuIndex {
+  UnsupportedFacesMenuIndex_Nothing,
+  UnsupportedFacesMenuIndex_ShiftUp,
+  UnsupportedFacesMenuIndex_SquishUp,
+
+  UnsupportedFacesMenuIndexCount,
+} UnsupportedFacesMenuIndex;
+#endif
+
 static const char *s_before_time_strings[PeekBeforeTimingMenuIndexCount] = {
   /// Shows up in the Timeline settings as a "Timing" subtitle and submenu option.
   i18n_noop("Start Time"),
@@ -71,6 +81,24 @@ static const char *s_before_time_strings[PeekBeforeTimingMenuIndexCount] = {
 static uint16_t s_before_time_values[PeekBeforeTimingMenuIndexCount] = {
   0, 5, 10, 15, 30,
 };
+
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
+static const char *s_unsupported_faces_strings[UnsupportedFacesMenuIndexCount] = {
+  /// Shows up in the Timeline settings as an "Unsupported Faces" submenu option.
+  i18n_noop("Nothing"),
+  /// Shows up in the Timeline settings as an "Unsupported Faces" submenu option.
+  i18n_noop("Shift up"),
+  /// Shows up in the Timeline settings as an "Unsupported Faces" submenu option.
+  i18n_noop("Squish up"),
+};
+
+static const TimelinePeekUnsupportedFaceMode
+    s_unsupported_faces_values[UnsupportedFacesMenuIndexCount] = {
+  TimelinePeekUnsupportedFaceMode_None,
+  TimelinePeekUnsupportedFaceMode_ShiftUp,
+  TimelinePeekUnsupportedFaceMode_SquishUp,
+};
+#endif
 
 static PeekBeforeTimingMenuIndex prv_before_time_min_to_index(unsigned int before_time_m) {
   if (before_time_m == 0) {
@@ -103,6 +131,38 @@ static void prv_push_before_time_menu(SettingsTimelinePeekData *data) {
       title, OptionMenuContentType_SingleLine, selected, &callbacks,
       ARRAY_LENGTH(s_before_time_strings), true /* icons_enabled */, s_before_time_strings, data);
 }
+
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
+static UnsupportedFacesMenuIndex prv_unsupported_face_mode_to_index(
+    TimelinePeekUnsupportedFaceMode mode) {
+  for (unsigned int i = 0; i < ARRAY_LENGTH(s_unsupported_faces_values); i++) {
+    if (s_unsupported_faces_values[i] == mode) {
+      return i;
+    }
+  }
+  return UnsupportedFacesMenuIndex_Nothing;
+}
+
+static void prv_unsupported_faces_menu_select(OptionMenu *option_menu, int selection,
+                                              void *context) {
+  timeline_peek_prefs_set_unsupported_face_mode(s_unsupported_faces_values[selection]);
+  app_window_stack_remove(&option_menu->window, true /* animated */);
+}
+
+static void prv_push_unsupported_faces_menu(SettingsTimelinePeekData *data) {
+  /// Shows up in the Timeline settings as the title for unsupported watchface behavior.
+  const char *title = i18n_noop("Unsupported Faces");
+  const int selected = prv_unsupported_face_mode_to_index(
+      timeline_peek_prefs_get_unsupported_face_mode());
+  const OptionMenuCallbacks callbacks = {
+    .select = prv_unsupported_faces_menu_select,
+  };
+  settings_option_menu_push(
+      title, OptionMenuContentType_SingleLine, selected, &callbacks,
+      ARRAY_LENGTH(s_unsupported_faces_strings), true /* icons_enabled */,
+      s_unsupported_faces_strings, data);
+}
+#endif
 
 static void prv_deinit_cb(SettingsCallbacks *context) {
   i18n_free_all(context);
@@ -137,12 +197,11 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
           prv_before_time_min_to_index(timeline_peek_prefs_get_before_time())];
       break;
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
-    case TimelinePeekMenuIndex_SquishFaces:
-      /// Shows up in the Timeline settings as the title for squishing unsupported watchfaces.
-      title = i18n_noop("Squish Faces");
-      /// Shows up in the Timeline settings as the status under the "Squish Faces" toggle.
-      subtitle = timeline_peek_prefs_get_watchface_fit_enabled() ? i18n_noop("On")
-                                                                 : i18n_noop("Off");
+    case TimelinePeekMenuIndex_UnsupportedFaces:
+      /// Shows up in the Timeline settings for watchfaces that do not support Quick View.
+      title = i18n_noop("Unsupported Faces");
+      subtitle = s_unsupported_faces_strings[prv_unsupported_face_mode_to_index(
+          timeline_peek_prefs_get_unsupported_face_mode())];
       break;
 #endif
     case TimelinePeekMenuIndexCount:
@@ -163,9 +222,8 @@ static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
       prv_push_before_time_menu(data);
       goto done;
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
-    case TimelinePeekMenuIndex_SquishFaces:
-      timeline_peek_prefs_set_watchface_fit_enabled(
-          !timeline_peek_prefs_get_watchface_fit_enabled());
+    case TimelinePeekMenuIndex_UnsupportedFaces:
+      prv_push_unsupported_faces_menu(data);
       goto done;
 #endif
     case TimelinePeekMenuIndexCount:

--- a/src/fw/services/blob_db/settings_blob_db.c
+++ b/src/fw/services/blob_db/settings_blob_db.c
@@ -91,6 +91,7 @@ static const char *s_syncable_settings[] = {
   // Timeline preferences
   "timelineQuickViewEnabled",
   "timelineQuickViewBeforeTimeMin",
+  "timelineQuickViewWatchfaceFit",
   "timelineSettingsOpened",
 
   // Activity preferences

--- a/src/fw/services/compositor/compositor.c
+++ b/src/fw/services/compositor/compositor.c
@@ -517,7 +517,8 @@ static bool prv_should_fit_watchface_for_timeline_peek(void) {
   }
 
   UnobstructedAreaState *unobstructed_state = app_state_get_unobstructed_area_state();
-  if (unobstructed_area_service_is_subscribed(unobstructed_state)) {
+  if (unobstructed_area_service_is_subscribed(unobstructed_state) ||
+      unobstructed_area_service_has_requested_area(unobstructed_state)) {
     return false;
   }
 

--- a/src/fw/services/compositor/compositor.c
+++ b/src/fw/services/compositor/compositor.c
@@ -569,29 +569,58 @@ void compositor_scaled_app_fb_copy_offset(const GRect update_rect, bool copy_rel
   const int16_t disp_height = dst_bitmap.bounds.size.h;
   // Check if we should use scaling mode for legacy apps
   const LegacyAppRenderMode render_mode = shell_prefs_get_legacy_app_render_mode();
-  if (squish_watchface_for_peek || (render_mode >= LegacyAppRenderMode_ScalingNearest)) {
+  const bool should_scale_app =
+      (render_mode >= LegacyAppRenderMode_ScalingNearest) || squish_watchface_for_peek ||
+      (shift_watchface_for_peek && prv_app_framebuffer_matches_display());
+  if (should_scale_app) {
     const bool bilinear = (render_mode == LegacyAppRenderMode_ScalingBilinear);
+    const bool shift_scaled_watchface_for_peek =
+        shift_watchface_for_peek && !squish_watchface_for_peek;
     const GRect scale_to = squish_watchface_for_peek
         ? GRect(0, 0, disp_width, timeline_peek_get_origin_y())
         : GRect(0, 0, disp_width, disp_height);
+
+    if (shift_scaled_watchface_for_peek) {
+      int16_t first_row = CLIP(update_rect.origin.y, 0, DISP_ROWS - 1);
+      int16_t last_row = CLIP(update_rect.origin.y + update_rect.size.h, first_row, DISP_ROWS);
+      for (int16_t y = first_row; y < last_row; y++) {
+        GBitmapDataRowInfo dst_row_info = gbitmap_get_data_row_info(&dst_bitmap, y);
+        const int16_t start_x = MAX(update_rect.origin.x, dst_row_info.min_x);
+        const int16_t end_x = MIN(update_rect.origin.x + update_rect.size.w,
+                                  dst_row_info.max_x + 1);
+        memset(&dst_row_info.data[start_x], GColorBlack.argb, end_x - start_x);
+      }
+    }
 
     // Calculate scaling factors using fixed-point arithmetic (16.16 format)
     // This gives us sub-pixel precision for better scaling
     const uint32_t scale_x = ((uint32_t)app_width << 16) / scale_to.size.w;
     const uint32_t scale_y = ((uint32_t)app_height << 16) / scale_to.size.h;
+    const int16_t app_shift_y = timeline_peek_get_origin_y() - scale_to.size.h;
 
     for (int16_t dst_y = 0; dst_y < update_rect.size.h; dst_y++) {
       const int16_t dst_y_offset = dst_y + update_rect.origin.y + offset_y;
       if (dst_y_offset < 0 || dst_y_offset >= disp_height) continue;
-      if (squish_watchface_for_peek &&
-          (dst_y_offset < scale_to.origin.y ||
-           dst_y_offset >= scale_to.origin.y + scale_to.size.h)) {
+      if ((squish_watchface_for_peek &&
+           (dst_y_offset < scale_to.origin.y ||
+            dst_y_offset >= scale_to.origin.y + scale_to.size.h)) ||
+          (shift_scaled_watchface_for_peek &&
+           (dst_y_offset >= timeline_peek_get_origin_y()))) {
         continue;
       }
 
-      const uint16_t dst_y_coord = squish_watchface_for_peek
-          ? (dst_y_offset - scale_to.origin.y)
-          : copy_relative_to_origin ? CLIP(dst_y_offset, 0, disp_height - 1) : dst_y;
+      uint16_t dst_y_coord;
+      if (squish_watchface_for_peek) {
+        dst_y_coord = dst_y_offset - scale_to.origin.y;
+      } else if (shift_scaled_watchface_for_peek) {
+        const int16_t shifted_y = dst_y_offset - app_shift_y;
+        if (shifted_y < 0 || shifted_y >= scale_to.size.h) {
+          continue;
+        }
+        dst_y_coord = shifted_y;
+      } else {
+        dst_y_coord = copy_relative_to_origin ? CLIP(dst_y_offset, 0, disp_height - 1) : dst_y;
+      }
       const uint32_t src_y_fixed = (uint32_t)dst_y_coord * scale_y;
       const int16_t src_y = src_y_fixed >> 16;
 

--- a/src/fw/services/compositor/compositor.c
+++ b/src/fw/services/compositor/compositor.c
@@ -509,21 +509,24 @@ uint16_t prv_scale_coordinate(const uint32_t scale_factor, uint16_t val) {
 }
 
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED && !RECOVERY_FW
-static bool prv_should_fit_watchface_for_timeline_peek(void) {
+static TimelinePeekUnsupportedFaceMode prv_get_unsupported_face_mode_for_timeline_peek(void) {
+  const TimelinePeekUnsupportedFaceMode mode =
+      timeline_peek_prefs_get_unsupported_face_mode();
   const PebbleProcessMd *app_md = app_manager_get_current_app_md();
-  if (!timeline_peek_prefs_get_watchface_fit_enabled() || !app_md ||
+  if (mode == TimelinePeekUnsupportedFaceMode_None || !app_md ||
       app_md->process_type != ProcessTypeWatchface) {
-    return false;
+    return TimelinePeekUnsupportedFaceMode_None;
   }
 
   UnobstructedAreaState *unobstructed_state = app_state_get_unobstructed_area_state();
   if (unobstructed_area_service_is_subscribed(unobstructed_state) ||
       unobstructed_area_service_has_requested_area(unobstructed_state)) {
-    return false;
+    return TimelinePeekUnsupportedFaceMode_None;
   }
 
   const int16_t obstruction_y = timeline_peek_get_origin_y();
-  return (obstruction_y > 0) && (obstruction_y < DISP_ROWS);
+  return ((obstruction_y > 0) && (obstruction_y < DISP_ROWS)) ?
+      mode : TimelinePeekUnsupportedFaceMode_None;
 }
 #endif
 
@@ -537,12 +540,19 @@ void compositor_scaled_app_fb_copy_offset(const GRect update_rect, bool copy_rel
   GBitmap dst_bitmap = compositor_get_framebuffer_as_bitmap();
 
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED && !RECOVERY_FW
-  const bool fit_watchface_for_peek = prv_should_fit_watchface_for_timeline_peek();
+  const TimelinePeekUnsupportedFaceMode unsupported_face_mode =
+      prv_get_unsupported_face_mode_for_timeline_peek();
+  const bool squish_watchface_for_peek =
+      (unsupported_face_mode == TimelinePeekUnsupportedFaceMode_SquishUp);
+  const bool shift_watchface_for_peek =
+      (unsupported_face_mode == TimelinePeekUnsupportedFaceMode_ShiftUp);
 #else
-  const bool fit_watchface_for_peek = false;
+  const bool squish_watchface_for_peek = false;
+  const bool shift_watchface_for_peek = false;
 #endif
 
-  if (prv_app_framebuffer_matches_display() && !fit_watchface_for_peek) {
+  if (prv_app_framebuffer_matches_display() && !squish_watchface_for_peek &&
+      !shift_watchface_for_peek) {
     GBitmap sub_bitmap;
     gbitmap_init_as_sub_bitmap(&sub_bitmap, &src_bitmap, update_rect);
     bitblt_bitmap_into_bitmap(&dst_bitmap, &sub_bitmap, update_rect.origin, GCompOpAssign,
@@ -559,9 +569,9 @@ void compositor_scaled_app_fb_copy_offset(const GRect update_rect, bool copy_rel
   const int16_t disp_height = dst_bitmap.bounds.size.h;
   // Check if we should use scaling mode for legacy apps
   const LegacyAppRenderMode render_mode = shell_prefs_get_legacy_app_render_mode();
-  if (fit_watchface_for_peek || (render_mode >= LegacyAppRenderMode_ScalingNearest)) {
+  if (squish_watchface_for_peek || (render_mode >= LegacyAppRenderMode_ScalingNearest)) {
     const bool bilinear = (render_mode == LegacyAppRenderMode_ScalingBilinear);
-    const GRect scale_to = fit_watchface_for_peek
+    const GRect scale_to = squish_watchface_for_peek
         ? GRect(0, 0, disp_width, timeline_peek_get_origin_y())
         : GRect(0, 0, disp_width, disp_height);
 
@@ -573,13 +583,13 @@ void compositor_scaled_app_fb_copy_offset(const GRect update_rect, bool copy_rel
     for (int16_t dst_y = 0; dst_y < update_rect.size.h; dst_y++) {
       const int16_t dst_y_offset = dst_y + update_rect.origin.y + offset_y;
       if (dst_y_offset < 0 || dst_y_offset >= disp_height) continue;
-      if (fit_watchface_for_peek &&
+      if (squish_watchface_for_peek &&
           (dst_y_offset < scale_to.origin.y ||
            dst_y_offset >= scale_to.origin.y + scale_to.size.h)) {
         continue;
       }
 
-      const uint16_t dst_y_coord = fit_watchface_for_peek
+      const uint16_t dst_y_coord = squish_watchface_for_peek
           ? (dst_y_offset - scale_to.origin.y)
           : copy_relative_to_origin ? CLIP(dst_y_offset, 0, disp_height - 1) : dst_y;
       const uint32_t src_y_fixed = (uint32_t)dst_y_coord * scale_y;
@@ -609,13 +619,13 @@ void compositor_scaled_app_fb_copy_offset(const GRect update_rect, bool copy_rel
         if (dst_x_offset < dst_row_info.min_x || dst_x_offset > dst_row_info.max_x) {
           continue;
         }
-        if (fit_watchface_for_peek &&
+        if (squish_watchface_for_peek &&
             (dst_x_offset < scale_to.origin.x ||
              dst_x_offset >= scale_to.origin.x + scale_to.size.w)) {
           continue;
         }
 
-        const uint16_t dst_x_coord = fit_watchface_for_peek
+        const uint16_t dst_x_coord = squish_watchface_for_peek
             ? (dst_x_offset - scale_to.origin.x)
             : copy_relative_to_origin ? CLIP(dst_x_offset, 0, disp_width - 1) : dst_x;
         const uint32_t src_x_fixed = (uint32_t)dst_x_coord * scale_x;
@@ -669,6 +679,36 @@ void compositor_scaled_app_fb_copy_offset(const GRect update_rect, bool copy_rel
           dst_line[dst_x_offset] = result;
         }
       }
+    }
+  } else if (shift_watchface_for_peek) {
+    const int16_t app_offset_x = (disp_width - app_width) / 2;
+    const int16_t app_offset_y = timeline_peek_get_origin_y() - app_height;
+    const GRect shifted_region = GRect(app_offset_x, app_offset_y, app_width, app_height);
+    const GRect unobstructed_region = GRect(0, 0, disp_width, timeline_peek_get_origin_y());
+
+    int16_t first_row = CLIP(update_rect.origin.y, 0, DISP_ROWS - 1);
+    int16_t last_row = CLIP(update_rect.origin.y + update_rect.size.h, first_row, DISP_ROWS);
+    for (int16_t y = first_row; y < last_row; y++) {
+      GBitmapDataRowInfo dst_row_info = gbitmap_get_data_row_info(&dst_bitmap, y);
+      const int16_t start_x = MAX(update_rect.origin.x, dst_row_info.min_x);
+      const int16_t end_x = MIN(update_rect.origin.x + update_rect.size.w, dst_row_info.max_x + 1);
+      memset(&dst_row_info.data[start_x], GColorBlack.argb, end_x - start_x);
+    }
+
+    GRect clipped_update_region = update_rect;
+    grect_clip(&clipped_update_region, &unobstructed_region);
+    grect_clip(&clipped_update_region, &shifted_region);
+    if (clipped_update_region.size.w > 0 && clipped_update_region.size.h > 0) {
+      GBitmap sub_bitmap;
+      const GRect src_rect = GRect(
+        clipped_update_region.origin.x - app_offset_x,
+        clipped_update_region.origin.y - app_offset_y + offset_y,
+        clipped_update_region.size.w,
+        clipped_update_region.size.h
+      );
+      gbitmap_init_as_sub_bitmap(&sub_bitmap, &src_bitmap, src_rect);
+      bitblt_bitmap_into_bitmap(&dst_bitmap, &sub_bitmap, clipped_update_region.origin,
+                                GCompOpAssign, GColorWhite);
     }
   } else
 #endif

--- a/src/fw/services/compositor/compositor.c
+++ b/src/fw/services/compositor/compositor.c
@@ -508,18 +508,44 @@ uint16_t prv_scale_coordinate(const uint32_t scale_factor, uint16_t val) {
   return val_fixed >> 16;  // Get integer part
 }
 
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED && !RECOVERY_FW
+static bool prv_should_fit_watchface_for_timeline_peek(void) {
+  const PebbleProcessMd *app_md = app_manager_get_current_app_md();
+  if (!timeline_peek_prefs_get_watchface_fit_enabled() || !app_md ||
+      app_md->process_type != ProcessTypeWatchface) {
+    return false;
+  }
+
+  UnobstructedAreaState *unobstructed_state = app_state_get_unobstructed_area_state();
+  if (unobstructed_area_service_is_subscribed(unobstructed_state)) {
+    return false;
+  }
+
+  const int16_t obstruction_y = timeline_peek_get_origin_y();
+  return (obstruction_y > 0) && (obstruction_y < DISP_ROWS);
+}
+#endif
+
 void compositor_scaled_app_fb_copy(const GRect update_rect, bool copy_relative_to_origin) {
   compositor_scaled_app_fb_copy_offset(update_rect, copy_relative_to_origin, 0 /* offset_y */);
 }
 
-void compositor_scaled_app_fb_copy_offset(const GRect update_rect, bool copy_relative_to_origin, int16_t offset_y) {
+void compositor_scaled_app_fb_copy_offset(const GRect update_rect, bool copy_relative_to_origin,
+                                          int16_t offset_y) {
   GBitmap src_bitmap = compositor_get_app_framebuffer_as_bitmap();
   GBitmap dst_bitmap = compositor_get_framebuffer_as_bitmap();
 
-  if (prv_app_framebuffer_matches_display()) {
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED && !RECOVERY_FW
+  const bool fit_watchface_for_peek = prv_should_fit_watchface_for_timeline_peek();
+#else
+  const bool fit_watchface_for_peek = false;
+#endif
+
+  if (prv_app_framebuffer_matches_display() && !fit_watchface_for_peek) {
     GBitmap sub_bitmap;
     gbitmap_init_as_sub_bitmap(&sub_bitmap, &src_bitmap, update_rect);
-    bitblt_bitmap_into_bitmap(&dst_bitmap, &sub_bitmap, update_rect.origin, GCompOpAssign, GColorWhite);
+    bitblt_bitmap_into_bitmap(&dst_bitmap, &sub_bitmap, update_rect.origin, GCompOpAssign,
+                              GColorWhite);
     return;
   }
 
@@ -532,20 +558,29 @@ void compositor_scaled_app_fb_copy_offset(const GRect update_rect, bool copy_rel
   const int16_t disp_height = dst_bitmap.bounds.size.h;
   // Check if we should use scaling mode for legacy apps
   const LegacyAppRenderMode render_mode = shell_prefs_get_legacy_app_render_mode();
-  if (render_mode >= LegacyAppRenderMode_ScalingNearest) {
+  if (fit_watchface_for_peek || (render_mode >= LegacyAppRenderMode_ScalingNearest)) {
     const bool bilinear = (render_mode == LegacyAppRenderMode_ScalingBilinear);
+    const GRect scale_to = fit_watchface_for_peek
+        ? GRect(0, 0, disp_width, timeline_peek_get_origin_y())
+        : GRect(0, 0, disp_width, disp_height);
 
     // Calculate scaling factors using fixed-point arithmetic (16.16 format)
     // This gives us sub-pixel precision for better scaling
-    const uint32_t scale_x = ((uint32_t)app_width << 16) / disp_width;
-    const uint32_t scale_y = ((uint32_t)app_height << 16) / disp_height;
+    const uint32_t scale_x = ((uint32_t)app_width << 16) / scale_to.size.w;
+    const uint32_t scale_y = ((uint32_t)app_height << 16) / scale_to.size.h;
 
     for (int16_t dst_y = 0; dst_y < update_rect.size.h; dst_y++) {
       const int16_t dst_y_offset = dst_y + update_rect.origin.y + offset_y;
       if (dst_y_offset < 0 || dst_y_offset >= disp_height) continue;
+      if (fit_watchface_for_peek &&
+          (dst_y_offset < scale_to.origin.y ||
+           dst_y_offset >= scale_to.origin.y + scale_to.size.h)) {
+        continue;
+      }
 
-      const uint16_t dst_y_coord = copy_relative_to_origin ?
-          CLIP(dst_y_offset, 0, disp_height - 1) : dst_y;
+      const uint16_t dst_y_coord = fit_watchface_for_peek
+          ? (dst_y_offset - scale_to.origin.y)
+          : copy_relative_to_origin ? CLIP(dst_y_offset, 0, disp_height - 1) : dst_y;
       const uint32_t src_y_fixed = (uint32_t)dst_y_coord * scale_y;
       const int16_t src_y = src_y_fixed >> 16;
 
@@ -573,9 +608,15 @@ void compositor_scaled_app_fb_copy_offset(const GRect update_rect, bool copy_rel
         if (dst_x_offset < dst_row_info.min_x || dst_x_offset > dst_row_info.max_x) {
           continue;
         }
+        if (fit_watchface_for_peek &&
+            (dst_x_offset < scale_to.origin.x ||
+             dst_x_offset >= scale_to.origin.x + scale_to.size.w)) {
+          continue;
+        }
 
-        const uint16_t dst_x_coord = copy_relative_to_origin ?
-            CLIP(dst_x_offset, 0, disp_width - 1) : dst_x;
+        const uint16_t dst_x_coord = fit_watchface_for_peek
+            ? (dst_x_offset - scale_to.origin.x)
+            : copy_relative_to_origin ? CLIP(dst_x_offset, 0, disp_width - 1) : dst_x;
         const uint32_t src_x_fixed = (uint32_t)dst_x_coord * scale_x;
         const int16_t src_x = src_x_fixed >> 16;
 

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -221,6 +221,11 @@ static bool s_timeline_peek_enabled = true;
 static uint16_t s_timeline_peek_before_time_m =
     (TIMELINE_PEEK_DEFAULT_SHOW_BEFORE_TIME_S / SECONDS_PER_MINUTE);
 
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
+#define PREF_KEY_TIMELINE_PEEK_WATCHFACE_FIT "timelineQuickViewWatchfaceFit"
+static bool s_timeline_peek_watchface_fit_enabled = true;
+#endif
+
 #define PREF_KEY_POWER_MODE "powerMode"
 #define PREF_KEY_COREDUMP_ON_REQUEST "coredumpOnRequest"
 #define PREF_KEY_ACCEL_SHAKE_LOG_INFO "accelShakeLogInfo"
@@ -636,6 +641,13 @@ static bool prv_set_s_timeline_peek_before_time_m(uint16_t *before_time_m) {
   timeline_peek_set_show_before_time(*before_time_m * SECONDS_PER_MINUTE);
   return true;
 }
+
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
+static bool prv_set_s_timeline_peek_watchface_fit_enabled(bool *enabled) {
+  s_timeline_peek_watchface_fit_enabled = *enabled;
+  return true;
+}
+#endif
 
 static bool prv_set_s_power_mode(uint8_t *mode) {
   if (*mode >= PowerModeCount) {
@@ -1724,6 +1736,16 @@ void timeline_peek_prefs_set_before_time(uint16_t before_time_m) {
 uint16_t timeline_peek_prefs_get_before_time(void) {
   return s_timeline_peek_before_time_m;
 }
+
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
+void timeline_peek_prefs_set_watchface_fit_enabled(bool enabled) {
+  prv_pref_set(PREF_KEY_TIMELINE_PEEK_WATCHFACE_FIT, &enabled, sizeof(enabled));
+}
+
+bool timeline_peek_prefs_get_watchface_fit_enabled(void) {
+  return s_timeline_peek_watchface_fit_enabled;
+}
+#endif
 
 bool shell_prefs_can_coredump_on_request(void) {
   return s_coredump_on_request_enabled;

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -223,7 +223,7 @@ static uint16_t s_timeline_peek_before_time_m =
 
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
 #define PREF_KEY_TIMELINE_PEEK_WATCHFACE_FIT "timelineQuickViewWatchfaceFit"
-static bool s_timeline_peek_watchface_fit_enabled = true;
+static bool s_timeline_peek_watchface_fit_enabled = false;
 #endif
 
 #define PREF_KEY_POWER_MODE "powerMode"

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -223,7 +223,7 @@ static uint16_t s_timeline_peek_before_time_m =
 
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
 #define PREF_KEY_TIMELINE_PEEK_WATCHFACE_FIT "timelineQuickViewWatchfaceFit"
-static bool s_timeline_peek_watchface_fit_enabled = false;
+static uint8_t s_timeline_peek_unsupported_face_mode = TimelinePeekUnsupportedFaceMode_None;
 #endif
 
 #define PREF_KEY_POWER_MODE "powerMode"
@@ -643,8 +643,11 @@ static bool prv_set_s_timeline_peek_before_time_m(uint16_t *before_time_m) {
 }
 
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
-static bool prv_set_s_timeline_peek_watchface_fit_enabled(bool *enabled) {
-  s_timeline_peek_watchface_fit_enabled = *enabled;
+static bool prv_set_s_timeline_peek_unsupported_face_mode(uint8_t *mode) {
+  if (*mode >= TimelinePeekUnsupportedFaceModeCount) {
+    return false;
+  }
+  s_timeline_peek_unsupported_face_mode = *mode;
   return true;
 }
 #endif
@@ -1738,12 +1741,13 @@ uint16_t timeline_peek_prefs_get_before_time(void) {
 }
 
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
-void timeline_peek_prefs_set_watchface_fit_enabled(bool enabled) {
-  prv_pref_set(PREF_KEY_TIMELINE_PEEK_WATCHFACE_FIT, &enabled, sizeof(enabled));
+void timeline_peek_prefs_set_unsupported_face_mode(TimelinePeekUnsupportedFaceMode mode) {
+  uint8_t mode_value = mode;
+  prv_pref_set(PREF_KEY_TIMELINE_PEEK_WATCHFACE_FIT, &mode_value, sizeof(mode_value));
 }
 
-bool timeline_peek_prefs_get_watchface_fit_enabled(void) {
-  return s_timeline_peek_watchface_fit_enabled;
+TimelinePeekUnsupportedFaceMode timeline_peek_prefs_get_unsupported_face_mode(void) {
+  return (TimelinePeekUnsupportedFaceMode)s_timeline_peek_unsupported_face_mode;
 }
 #endif
 

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -227,7 +227,7 @@ static uint16_t s_timeline_peek_before_time_m =
 
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
 #define PREF_KEY_TIMELINE_PEEK_WATCHFACE_FIT "timelineQuickViewWatchfaceFit"
-static bool s_timeline_peek_watchface_fit_enabled = false;
+static uint8_t s_timeline_peek_unsupported_face_mode = TimelinePeekUnsupportedFaceMode_None;
 #endif
 
 #define PREF_KEY_POWER_MODE "powerMode"
@@ -659,8 +659,11 @@ static bool prv_set_s_timeline_peek_before_time_m(uint16_t *before_time_m) {
 }
 
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
-static bool prv_set_s_timeline_peek_watchface_fit_enabled(bool *enabled) {
-  s_timeline_peek_watchface_fit_enabled = *enabled;
+static bool prv_set_s_timeline_peek_unsupported_face_mode(uint8_t *mode) {
+  if (*mode >= TimelinePeekUnsupportedFaceModeCount) {
+    return false;
+  }
+  s_timeline_peek_unsupported_face_mode = *mode;
   return true;
 }
 #endif
@@ -1808,12 +1811,13 @@ uint16_t timeline_peek_prefs_get_before_time(void) {
 }
 
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
-void timeline_peek_prefs_set_watchface_fit_enabled(bool enabled) {
-  prv_pref_set(PREF_KEY_TIMELINE_PEEK_WATCHFACE_FIT, &enabled, sizeof(enabled));
+void timeline_peek_prefs_set_unsupported_face_mode(TimelinePeekUnsupportedFaceMode mode) {
+  uint8_t mode_value = mode;
+  prv_pref_set(PREF_KEY_TIMELINE_PEEK_WATCHFACE_FIT, &mode_value, sizeof(mode_value));
 }
 
-bool timeline_peek_prefs_get_watchface_fit_enabled(void) {
-  return s_timeline_peek_watchface_fit_enabled;
+TimelinePeekUnsupportedFaceMode timeline_peek_prefs_get_unsupported_face_mode(void) {
+  return (TimelinePeekUnsupportedFaceMode)s_timeline_peek_unsupported_face_mode;
 }
 #endif
 

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -225,6 +225,11 @@ static bool s_timeline_peek_enabled = true;
 static uint16_t s_timeline_peek_before_time_m =
     (TIMELINE_PEEK_DEFAULT_SHOW_BEFORE_TIME_S / SECONDS_PER_MINUTE);
 
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
+#define PREF_KEY_TIMELINE_PEEK_WATCHFACE_FIT "timelineQuickViewWatchfaceFit"
+static bool s_timeline_peek_watchface_fit_enabled = true;
+#endif
+
 #define PREF_KEY_POWER_MODE "powerMode"
 #define PREF_KEY_COREDUMP_ON_REQUEST "coredumpOnRequest"
 #define PREF_KEY_ACCEL_SHAKE_LOG_INFO "accelShakeLogInfo"
@@ -652,6 +657,13 @@ static bool prv_set_s_timeline_peek_before_time_m(uint16_t *before_time_m) {
   timeline_peek_set_show_before_time(*before_time_m * SECONDS_PER_MINUTE);
   return true;
 }
+
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
+static bool prv_set_s_timeline_peek_watchface_fit_enabled(bool *enabled) {
+  s_timeline_peek_watchface_fit_enabled = *enabled;
+  return true;
+}
+#endif
 
 static bool prv_set_s_power_mode(uint8_t *mode) {
   if (*mode >= PowerModeCount) {
@@ -1794,6 +1806,16 @@ void timeline_peek_prefs_set_before_time(uint16_t before_time_m) {
 uint16_t timeline_peek_prefs_get_before_time(void) {
   return s_timeline_peek_before_time_m;
 }
+
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
+void timeline_peek_prefs_set_watchface_fit_enabled(bool enabled) {
+  prv_pref_set(PREF_KEY_TIMELINE_PEEK_WATCHFACE_FIT, &enabled, sizeof(enabled));
+}
+
+bool timeline_peek_prefs_get_watchface_fit_enabled(void) {
+  return s_timeline_peek_watchface_fit_enabled;
+}
+#endif
 
 bool shell_prefs_can_coredump_on_request(void) {
   return s_coredump_on_request_enabled;

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -227,7 +227,7 @@ static uint16_t s_timeline_peek_before_time_m =
 
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
 #define PREF_KEY_TIMELINE_PEEK_WATCHFACE_FIT "timelineQuickViewWatchfaceFit"
-static bool s_timeline_peek_watchface_fit_enabled = true;
+static bool s_timeline_peek_watchface_fit_enabled = false;
 #endif
 
 #define PREF_KEY_POWER_MODE "powerMode"

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -50,7 +50,7 @@
   PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_ENABLED, s_timeline_peek_enabled)
   PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_BEFORE_TIME_M, s_timeline_peek_before_time_m)
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
-  PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_WATCHFACE_FIT, s_timeline_peek_watchface_fit_enabled)
+  PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_WATCHFACE_FIT, s_timeline_peek_unsupported_face_mode)
 #endif
   PREFS_MACRO(PREF_KEY_POWER_MODE, s_power_mode)
   PREFS_MACRO(PREF_KEY_COREDUMP_ON_REQUEST, s_coredump_on_request_enabled)

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -49,6 +49,9 @@
   PREFS_MACRO(PREF_KEY_TIMELINE_SETTINGS_OPENED, s_timeline_settings_opened)
   PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_ENABLED, s_timeline_peek_enabled)
   PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_BEFORE_TIME_M, s_timeline_peek_before_time_m)
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
+  PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_WATCHFACE_FIT, s_timeline_peek_watchface_fit_enabled)
+#endif
   PREFS_MACRO(PREF_KEY_POWER_MODE, s_power_mode)
   PREFS_MACRO(PREF_KEY_COREDUMP_ON_REQUEST, s_coredump_on_request_enabled)
   PREFS_MACRO(PREF_KEY_ACCEL_SHAKE_LOG_INFO, s_accel_shake_log_info_enabled)

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -50,6 +50,9 @@
   PREFS_MACRO(PREF_KEY_TIMELINE_SETTINGS_OPENED, s_timeline_settings_opened)
   PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_ENABLED, s_timeline_peek_enabled)
   PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_BEFORE_TIME_M, s_timeline_peek_before_time_m)
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
+  PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_WATCHFACE_FIT, s_timeline_peek_watchface_fit_enabled)
+#endif
   PREFS_MACRO(PREF_KEY_POWER_MODE, s_power_mode)
   PREFS_MACRO(PREF_KEY_COREDUMP_ON_REQUEST, s_coredump_on_request_enabled)
   PREFS_MACRO(PREF_KEY_ACCEL_SHAKE_LOG_INFO, s_accel_shake_log_info_enabled)

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -51,7 +51,7 @@
   PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_ENABLED, s_timeline_peek_enabled)
   PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_BEFORE_TIME_M, s_timeline_peek_before_time_m)
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
-  PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_WATCHFACE_FIT, s_timeline_peek_watchface_fit_enabled)
+  PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_WATCHFACE_FIT, s_timeline_peek_unsupported_face_mode)
 #endif
   PREFS_MACRO(PREF_KEY_POWER_MODE, s_power_mode)
   PREFS_MACRO(PREF_KEY_COREDUMP_ON_REQUEST, s_coredump_on_request_enabled)

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -19,6 +19,12 @@
 #include "shell/system_theme.h"
 #include "util/uuid.h"
 
+#if CAPABILITY_HAS_APP_SCALING && (PLATFORM_OBELIX || BOARD_QEMU_EMERY)
+#define TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED 1
+#else
+#define TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED 0
+#endif
+
 
 // The clock 12h/24h setting is required by services/clock.c.
 bool shell_prefs_get_clock_24h_style(void);
@@ -142,6 +148,10 @@ void timeline_peek_prefs_set_enabled(bool enabled);
 bool timeline_peek_prefs_get_enabled(void);
 void timeline_peek_prefs_set_before_time(uint16_t before_time_m);
 uint16_t timeline_peek_prefs_get_before_time(void);
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
+void timeline_peek_prefs_set_watchface_fit_enabled(bool enabled);
+bool timeline_peek_prefs_get_watchface_fit_enabled(void);
+#endif
 
 typedef enum PowerMode {
   PowerMode_HighPerformance = 0,

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -149,8 +149,15 @@ bool timeline_peek_prefs_get_enabled(void);
 void timeline_peek_prefs_set_before_time(uint16_t before_time_m);
 uint16_t timeline_peek_prefs_get_before_time(void);
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
-void timeline_peek_prefs_set_watchface_fit_enabled(bool enabled);
-bool timeline_peek_prefs_get_watchface_fit_enabled(void);
+typedef enum TimelinePeekUnsupportedFaceMode {
+  TimelinePeekUnsupportedFaceMode_None = 0,
+  TimelinePeekUnsupportedFaceMode_SquishUp = 1,
+  TimelinePeekUnsupportedFaceMode_ShiftUp = 2,
+  TimelinePeekUnsupportedFaceModeCount,
+} TimelinePeekUnsupportedFaceMode;
+
+void timeline_peek_prefs_set_unsupported_face_mode(TimelinePeekUnsupportedFaceMode mode);
+TimelinePeekUnsupportedFaceMode timeline_peek_prefs_get_unsupported_face_mode(void);
 #endif
 
 typedef enum PowerMode {

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -19,6 +19,13 @@
 #include "shell/system_theme.h"
 #include "util/uuid.h"
 
+#if defined(CONFIG_APP_SCALING) && \
+    (defined(CONFIG_BOARD_FAMILY_OBELIX) || defined(CONFIG_BOARD_QEMU_EMERY))
+#define TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED 1
+#else
+#define TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED 0
+#endif
+
 
 // The clock 12h/24h setting is required by services/clock.c.
 bool shell_prefs_get_clock_24h_style(void);
@@ -159,6 +166,10 @@ void timeline_peek_prefs_set_enabled(bool enabled);
 bool timeline_peek_prefs_get_enabled(void);
 void timeline_peek_prefs_set_before_time(uint16_t before_time_m);
 uint16_t timeline_peek_prefs_get_before_time(void);
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
+void timeline_peek_prefs_set_watchface_fit_enabled(bool enabled);
+bool timeline_peek_prefs_get_watchface_fit_enabled(void);
+#endif
 
 typedef enum PowerMode {
   PowerMode_HighPerformance = 0,

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -167,8 +167,15 @@ bool timeline_peek_prefs_get_enabled(void);
 void timeline_peek_prefs_set_before_time(uint16_t before_time_m);
 uint16_t timeline_peek_prefs_get_before_time(void);
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
-void timeline_peek_prefs_set_watchface_fit_enabled(bool enabled);
-bool timeline_peek_prefs_get_watchface_fit_enabled(void);
+typedef enum TimelinePeekUnsupportedFaceMode {
+  TimelinePeekUnsupportedFaceMode_None = 0,
+  TimelinePeekUnsupportedFaceMode_SquishUp = 1,
+  TimelinePeekUnsupportedFaceMode_ShiftUp = 2,
+  TimelinePeekUnsupportedFaceModeCount,
+} TimelinePeekUnsupportedFaceMode;
+
+void timeline_peek_prefs_set_unsupported_face_mode(TimelinePeekUnsupportedFaceMode mode);
+TimelinePeekUnsupportedFaceMode timeline_peek_prefs_get_unsupported_face_mode(void);
 #endif
 
 typedef enum PowerMode {

--- a/src/fw/shell/sdk/stubs.c
+++ b/src/fw/shell/sdk/stubs.c
@@ -120,6 +120,12 @@ void timeline_peek_prefs_set_before_time(uint16_t before_time_m) {}
 uint16_t timeline_peek_prefs_get_before_time(void) {
   return (TIMELINE_PEEK_DEFAULT_SHOW_BEFORE_TIME_S / SECONDS_PER_MINUTE);
 }
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
+void timeline_peek_prefs_set_watchface_fit_enabled(bool enabled) {}
+bool timeline_peek_prefs_get_watchface_fit_enabled(void) {
+  return true;
+}
+#endif
 
 bool workout_utils_find_ongoing_activity_session(ActivitySession *session_out) {
   return false;

--- a/src/fw/shell/sdk/stubs.c
+++ b/src/fw/shell/sdk/stubs.c
@@ -121,9 +121,9 @@ uint16_t timeline_peek_prefs_get_before_time(void) {
   return (TIMELINE_PEEK_DEFAULT_SHOW_BEFORE_TIME_S / SECONDS_PER_MINUTE);
 }
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
-void timeline_peek_prefs_set_watchface_fit_enabled(bool enabled) {}
-bool timeline_peek_prefs_get_watchface_fit_enabled(void) {
-  return false;
+void timeline_peek_prefs_set_unsupported_face_mode(TimelinePeekUnsupportedFaceMode mode) {}
+TimelinePeekUnsupportedFaceMode timeline_peek_prefs_get_unsupported_face_mode(void) {
+  return TimelinePeekUnsupportedFaceMode_None;
 }
 #endif
 

--- a/src/fw/shell/sdk/stubs.c
+++ b/src/fw/shell/sdk/stubs.c
@@ -123,7 +123,7 @@ uint16_t timeline_peek_prefs_get_before_time(void) {
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
 void timeline_peek_prefs_set_watchface_fit_enabled(bool enabled) {}
 bool timeline_peek_prefs_get_watchface_fit_enabled(void) {
-  return true;
+  return false;
 }
 #endif
 

--- a/src/fw/shell/sdk/stubs.c
+++ b/src/fw/shell/sdk/stubs.c
@@ -130,9 +130,9 @@ uint16_t timeline_peek_prefs_get_before_time(void) {
   return (TIMELINE_PEEK_DEFAULT_SHOW_BEFORE_TIME_S / SECONDS_PER_MINUTE);
 }
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
-void timeline_peek_prefs_set_watchface_fit_enabled(bool enabled) {}
-bool timeline_peek_prefs_get_watchface_fit_enabled(void) {
-  return false;
+void timeline_peek_prefs_set_unsupported_face_mode(TimelinePeekUnsupportedFaceMode mode) {}
+TimelinePeekUnsupportedFaceMode timeline_peek_prefs_get_unsupported_face_mode(void) {
+  return TimelinePeekUnsupportedFaceMode_None;
 }
 #endif
 

--- a/src/fw/shell/sdk/stubs.c
+++ b/src/fw/shell/sdk/stubs.c
@@ -129,6 +129,12 @@ void timeline_peek_prefs_set_before_time(uint16_t before_time_m) {}
 uint16_t timeline_peek_prefs_get_before_time(void) {
   return (TIMELINE_PEEK_DEFAULT_SHOW_BEFORE_TIME_S / SECONDS_PER_MINUTE);
 }
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
+void timeline_peek_prefs_set_watchface_fit_enabled(bool enabled) {}
+bool timeline_peek_prefs_get_watchface_fit_enabled(void) {
+  return true;
+}
+#endif
 
 bool workout_utils_find_ongoing_activity_session(ActivitySession *session_out) {
   return false;

--- a/src/fw/shell/sdk/stubs.c
+++ b/src/fw/shell/sdk/stubs.c
@@ -132,7 +132,7 @@ uint16_t timeline_peek_prefs_get_before_time(void) {
 #if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
 void timeline_peek_prefs_set_watchface_fit_enabled(bool enabled) {}
 bool timeline_peek_prefs_get_watchface_fit_enabled(void) {
-  return true;
+  return false;
 }
 #endif
 

--- a/tests/fw/applib/test_unobstructed_area_service.c
+++ b/tests/fw/applib/test_unobstructed_area_service.c
@@ -85,6 +85,7 @@ void test_unobstructed_area_service__subscribe(void) {
   // Unsubscribing first should not crash
   app_unobstructed_area_service_unsubscribe();
   cl_assert(!unobstructed_area_service_is_subscribed(app_state_get_unobstructed_area_state()));
+  cl_assert(!unobstructed_area_service_has_requested_area(app_state_get_unobstructed_area_state()));
   cl_assert(!app_state_get_unobstructed_area_state()->handlers.will_change);
   cl_assert(!app_state_get_unobstructed_area_state()->handlers.change);
   cl_assert(!app_state_get_unobstructed_area_state()->handlers.did_change);
@@ -267,6 +268,7 @@ void test_unobstructed_area_service__did_change_no_will(void) {
 
 void test_unobstructed_area_service__layer_no_clip(void) {
   app_state_get_unobstructed_area_state()->area = GRect(0, 0, 400, 400);
+  cl_assert(!unobstructed_area_service_has_requested_area(app_state_get_unobstructed_area_state()));
 
   Layer root_layer = {
     .bounds = GRect(100, 100, 200, 200),
@@ -274,6 +276,7 @@ void test_unobstructed_area_service__layer_no_clip(void) {
   GRect unobstructed_bounds;
   layer_get_unobstructed_bounds(&root_layer, &unobstructed_bounds);
   cl_assert_equal_grect(unobstructed_bounds, root_layer.bounds);
+  cl_assert(unobstructed_area_service_has_requested_area(app_state_get_unobstructed_area_state()));
 }
 
 void test_unobstructed_area_service__layer_clip_x_y(void) {

--- a/tests/fw/applib/test_unobstructed_area_service.c
+++ b/tests/fw/applib/test_unobstructed_area_service.c
@@ -4,7 +4,7 @@
 #include "clar.h"
 #include "pebble_asserts.h"
 
-#include "applib/unobstructed_area_service.h"
+#include "applib/unobstructed_area_service_private.h"
 
 // Stubs
 /////////////////////
@@ -84,6 +84,7 @@ void test_unobstructed_area_service__cleanup(void) {
 void test_unobstructed_area_service__subscribe(void) {
   // Unsubscribing first should not crash
   app_unobstructed_area_service_unsubscribe();
+  cl_assert(!unobstructed_area_service_is_subscribed(app_state_get_unobstructed_area_state()));
   cl_assert(!app_state_get_unobstructed_area_state()->handlers.will_change);
   cl_assert(!app_state_get_unobstructed_area_state()->handlers.change);
   cl_assert(!app_state_get_unobstructed_area_state()->handlers.did_change);
@@ -99,9 +100,11 @@ void test_unobstructed_area_service__subscribe(void) {
   cl_assert_equal_p(app_state_get_unobstructed_area_state()->handlers.will_change, prv_will_change);
   cl_assert_equal_p(app_state_get_unobstructed_area_state()->handlers.change, prv_change);
   cl_assert_equal_p(app_state_get_unobstructed_area_state()->handlers.did_change, prv_did_change);
+  cl_assert(unobstructed_area_service_is_subscribed(app_state_get_unobstructed_area_state()));
 
   // Unsubscribing after subscription should cancel subscriptions
   app_unobstructed_area_service_unsubscribe();
+  cl_assert(!unobstructed_area_service_is_subscribed(app_state_get_unobstructed_area_state()));
   cl_assert(!app_state_get_unobstructed_area_state()->handlers.will_change);
   cl_assert(!app_state_get_unobstructed_area_state()->handlers.change);
   cl_assert(!app_state_get_unobstructed_area_state()->handlers.did_change);

--- a/tests/stubs/stubs_unobstructed_area.h
+++ b/tests/stubs/stubs_unobstructed_area.h
@@ -8,6 +8,10 @@
 
 void WEAK unobstructed_area_service_get_area(UnobstructedAreaState *state, GRect *area) { }
 
+bool WEAK unobstructed_area_service_has_requested_area(UnobstructedAreaState *state) {
+  return false;
+}
+
 void WEAK unobstructed_area_service_will_change(int16_t current_y, int16_t final_y) { }
 
 void WEAK unobstructed_area_service_change(int16_t current_y, int16_t final_y,


### PR DESCRIPTION
## Summary

- Replace the old `Squish Faces` toggle with an `Unsupported Faces` setting that offers `Overlay`, `Shift up`, and `Squish up`.
- Keep `Overlay` as the default on install, so unsupported watchfaces are not moved or scaled unless the user opts in.
- Add animated `Shift up`, which translates unsupported watchfaces upward without squishing them.
- Keep `Squish up` available for unsupported faces that should scale into the unobstructed Quick View area.
- Detect watchfaces that already support Quick View through unobstructed-area subscriptions or bounds queries, so those faces are not double-adjusted.
- Expose `timelineQuickViewWatchfaceFit` through Settings BlobDB so the phone can read/write the mode.
- Keep the feature compiled out where unsupported while preserving existing legacy app scaling behavior.

## Mode Values

- `0`: `Overlay`
- `1`: `Squish up`
- `2`: `Shift up`

## Screenshot

![Ten Emery watchfaces with Quick View squish](https://raw.githubusercontent.com/ericmigi/PebbleOS/codex/pr-assets/timeline-squish-faces-20260504/pr-assets/timeline-squish-faces/emery-contact-sheet.png)

## Validation

- `git diff --check`
- `./waf build`
- `./waf qemu_image_micro qemu_image_spi`
- `gitlint --commits HEAD~1..HEAD`
- Installed Vertical Health and TimeStyle in the Emery emulator for Quick View testing.