### PR TITLE
fw/drivers/display/sf32lb: log and recover from SendLayerData_IT failure [FIRM-1740]

### DIFF
--- a/src/fw/drivers/display/sf32lb/display_jdi.c
+++ b/src/fw/drivers/display/sf32lb/display_jdi.c
@@ -106,14 +106,23 @@ static void prv_display_off() {
   gpio_output_set(&DISPLAY->vlcd, false);
 }
 
-static void prv_display_update_start(void) {
+static HAL_StatusTypeDef prv_display_update_start(void) {
   DisplayJDIState *state = DISPLAY->state;
 
   // Only send the dirty region that was converted to RGB332 format
   HAL_LCDC_SetROIArea(&state->hlcdc, 0, s_update_y0, PBL_DISPLAY_WIDTH - 1, s_update_y1);
   HAL_LCDC_LayerSetData(&state->hlcdc, HAL_LCDC_LAYER_DEFAULT, s_framebuffer, 0, s_update_y0,
                         PBL_DISPLAY_WIDTH - 1, s_update_y1);
-  HAL_LCDC_SendLayerData_IT(&state->hlcdc);
+  return HAL_LCDC_SendLayerData_IT(&state->hlcdc);
+}
+
+static void prv_handle_send_failure(const char *ctx, HAL_StatusTypeDef status) {
+  DisplayJDIState *state = DISPLAY->state;
+  PBL_LOG_ERR("display: %s SendLayerData_IT=%d State=%d ErrorCode=0x%08lx",
+              ctx, (int)status, (int)state->hlcdc.State,
+              (unsigned long)state->hlcdc.ErrorCode);
+  state->hlcdc.State = HAL_LCDC_STATE_READY;
+  state->hlcdc.ErrorCode = HAL_LCDC_ERROR_NONE;
 }
 
 static void prv_display_update_terminate(void *data) {
@@ -291,7 +300,11 @@ void display_update(NextRowCallback nrcb, UpdateCompleteCallback uccb) {
   s_updating = true;
 
   stop_mode_disable(InhibitorDisplay);
-  prv_display_update_start();
+  HAL_StatusTypeDef status = prv_display_update_start();
+  if (status != HAL_OK) {
+    prv_handle_send_failure("update", status);
+    prv_display_update_terminate(NULL);
+  }
 }
 
 void display_update_boot_frame(uint8_t *framebuffer) {
@@ -312,8 +325,14 @@ void display_update_boot_frame(uint8_t *framebuffer) {
   s_update_y1 = PBL_DISPLAY_HEIGHT - 1;
 
   stop_mode_disable(InhibitorDisplay);
-  prv_display_update_start();
-  xSemaphoreTake(s_sem, portMAX_DELAY);
+  HAL_StatusTypeDef status = prv_display_update_start();
+  if (status == HAL_OK) {
+    xSemaphoreTake(s_sem, portMAX_DELAY);
+  } else {
+    // Without this guard a failed kickoff would block boot forever on s_sem,
+    // since the EOF IRQ that gives the semaphore never fires.
+    prv_handle_send_failure("boot", status);
+  }
   stop_mode_enable(InhibitorDisplay);
 }
 


### PR DESCRIPTION
The JDI display driver was dropping the return value from HAL_LCDC_SendLayerData_IT in prv_display_update_start.
The HAL can return non-OK in three cases that all leave no DMA running and no EOF IRQ pending:

HAL_BUSY  : lcdc->State != READY (e.g. a previous transfer's EOF IRQ went missing, leaving State stuck at BUSY)
HAL_TIMEOUT: WaitBusy spun for 1s waiting on LCD_BUSY
HAL_ERROR  : LayerUpdate / LayerSetData rejected the geometry

In any of those, s_updating latched true forever: prv_display_update_terminate is only ever called from the EOF completion path, so the framebuffer stayed half-converted to RGB332.

Capture the failure with State / ErrorCode so we can attribute future field reports, force lcdc->State back to READY (the HAL doesn't reset it on the BUSY/TIMEOUT path), and run prv_display_update_terminate synchronously to convert the framebuffer back and clear s_updating