### PR TITLE
fw/touch: mirror touch coordinates in left-hand mode

### DIFF
--- a/include/pbl/services/touch/touch.h
+++ b/include/pbl/services/touch/touch.h
@@ -53,3 +53,8 @@ void touch_handle_gesture(TouchGesture gesture, int16_t x, int16_t y);
 
 //! Reset the touch service.
 void touch_reset(void);
+
+//! Set whether the display is rotated 180° (left-hand mode). When rotated,
+//! incoming touch coordinates are mirrored to match the rotated framebuffer
+//! before being dispatched to subscribers.
+void touch_set_rotated(bool rotated);

--- a/src/fw/services/orientation_manager/service.c
+++ b/src/fw/services/orientation_manager/service.c
@@ -11,6 +11,9 @@
 #include "drivers/imu/mmc5603nj/mmc5603nj.h"
 #include "kernel/events.h"
 #include "process_management/process_manager.h"
+#ifdef CONFIG_SERVICE_TOUCH
+#include "pbl/services/touch/touch.h"
+#endif
 
 
 void prv_change_orientation(bool rotated) {
@@ -18,6 +21,9 @@ void prv_change_orientation(bool rotated) {
   button_set_rotated(rotated);
   accel_set_rotated(rotated);
   mag_set_rotated(rotated);
+#ifdef CONFIG_SERVICE_TOUCH
+  touch_set_rotated(rotated);
+#endif
 }
 
 void orientation_handle_prefs_changed(void) {

--- a/src/fw/services/touch/touch.c
+++ b/src/fw/services/touch/touch.c
@@ -4,6 +4,7 @@
 #include "pbl/services/touch/touch.h"
 #include "pbl/services/touch/touch_event.h"
 
+#include "drivers/display/display.h"
 #include "drivers/touch/touch_sensor.h"
 #include "kernel/events.h"
 #include "kernel/pebble_tasks.h"
@@ -26,6 +27,14 @@ static PebbleMutex *s_touch_mutex;
 static uint8_t s_subscriber_count = 0;
 static bool s_backlight_subscribed = false;
 static bool s_globally_enabled = true;
+static bool s_rotated = false;
+
+static void prv_apply_rotation(int16_t *x, int16_t *y) {
+  if (s_rotated) {
+    *x = (DISP_COLS - 1) - *x;
+    *y = (DISP_ROWS - 1) - *y;
+  }
+}
 
 static void prv_add_subscriber_cb(PebbleTask task) {
   mutex_lock(s_touch_mutex);
@@ -147,6 +156,8 @@ void touch_handle_update(TouchState touch_state, int16_t x, int16_t y) {
     return;
   }
 
+  prv_apply_rotation(&x, &y);
+
   if (s_touch_state != touch_state) {
     s_touch_state = touch_state;
     s_last_x = x;
@@ -178,9 +189,11 @@ void touch_handle_update(TouchState touch_state, int16_t x, int16_t y) {
 }
 
 void touch_handle_gesture(TouchGesture gesture, int16_t x, int16_t y) {
-  TOUCH_DEBUG("Gesture: %d @ (%" PRId16 ", %" PRId16 ")", gesture, x, y);
-
   mutex_lock(s_touch_mutex);
+
+  prv_apply_rotation(&x, &y);
+
+  TOUCH_DEBUG("Gesture: %d @ (%" PRId16 ", %" PRId16 ")", gesture, x, y);
 
   switch (gesture) {
     case TouchGesture_Tap:
@@ -203,5 +216,11 @@ void touch_reset(void) {
   s_touch_state = TouchState_FingerUp;
   s_last_x = 0;
   s_last_y = 0;
+  mutex_unlock(s_touch_mutex);
+}
+
+void touch_set_rotated(bool rotated) {
+  mutex_lock(s_touch_mutex);
+  s_rotated = rotated;
   mutex_unlock(s_touch_mutex);
 }


### PR DESCRIPTION
In left-hand (display rotated 180°) mode, the framebuffer is mirrored but the touch sensor still reports physical coordinates, so taps land in the diagonally opposite location from where the user sees them.

Add a touch_sensor_set_rotated() driver hook that mirrors reported coordinates around max_x/max_y, and have the orientation manager toggle it alongside the other _set_rotated drivers. Populate max_x/max_y for obelix's CST816 panel from the display dimensions.

Fixes FIRM-1786