### PR TITLE
applib/graphics: measure Arabic words using shaped widths

### DIFF
--- a/src/fw/applib/graphics/arabic_shaping.c
+++ b/src/fw/applib/graphics/arabic_shaping.c
@@ -220,6 +220,35 @@ static Codepoint prv_get_shaped_codepoint(const ArabicShapingEntry *entry, Arabi
   }
 }
 
+Codepoint arabic_shape_codepoint(Codepoint prev_cp, Codepoint curr_cp, Codepoint next_cp) {
+  const ArabicShapingEntry *entry = prv_find_shaping_entry(curr_cp);
+  if (entry == NULL) {
+    return curr_cp;
+  }
+
+  const ArabicShapingEntry *prev_entry = prv_find_shaping_entry(prev_cp);
+  const ArabicShapingEntry *next_entry = prv_find_shaping_entry(next_cp);
+
+  bool prev_connects = (prev_entry != NULL) && prv_connects_left(prev_entry);
+  bool next_connects = (next_entry != NULL) && prv_connects_right(next_entry);
+
+  bool can_connect_right = prv_connects_right(entry);
+  bool can_connect_left = prv_connects_left(entry);
+
+  ArabicForm form;
+  if (prev_connects && can_connect_right && next_connects && can_connect_left) {
+    form = ARABIC_FORM_MEDIAL;
+  } else if (prev_connects && can_connect_right) {
+    form = ARABIC_FORM_FINAL;
+  } else if (next_connects && can_connect_left) {
+    form = ARABIC_FORM_INITIAL;
+  } else {
+    form = ARABIC_FORM_ISOLATED;
+  }
+
+  return prv_get_shaped_codepoint(entry, form);
+}
+
 size_t arabic_shape_text(const utf8_t *src, size_t src_len,
                          utf8_t *dest, size_t dest_size) {
   if (src == NULL || dest == NULL || src_len == 0 || dest_size == 0) {
@@ -251,45 +280,9 @@ size_t arabic_shape_text(const utf8_t *src, size_t src_len,
   size_t dest_offset = 0;
 
   for (size_t i = 0; i < num_codepoints; i++) {
-    Codepoint cp = codepoints[i];
-    Codepoint shaped_cp = cp;
-
-    // Check if this is a shapeable Arabic letter
-    const ArabicShapingEntry *entry = prv_find_shaping_entry(cp);
-    if (entry != NULL) {
-      // Determine context: check previous and next letters
-      const ArabicShapingEntry *prev_entry = NULL;
-      const ArabicShapingEntry *next_entry = NULL;
-
-      if (i > 0) {
-        prev_entry = prv_find_shaping_entry(codepoints[i - 1]);
-      }
-      if (i + 1 < num_codepoints) {
-        next_entry = prv_find_shaping_entry(codepoints[i + 1]);
-      }
-
-      // Check connectivity
-      bool prev_connects = (prev_entry != NULL) && prv_connects_left(prev_entry);
-      bool next_connects = (next_entry != NULL) && prv_connects_right(next_entry);
-
-      // Also check if current letter can connect in that direction
-      bool can_connect_right = prv_connects_right(entry);
-      bool can_connect_left = prv_connects_left(entry);
-
-      // Determine the form based on connections
-      ArabicForm form;
-      if (prev_connects && can_connect_right && next_connects && can_connect_left) {
-        form = ARABIC_FORM_MEDIAL;
-      } else if (prev_connects && can_connect_right) {
-        form = ARABIC_FORM_FINAL;
-      } else if (next_connects && can_connect_left) {
-        form = ARABIC_FORM_INITIAL;
-      } else {
-        form = ARABIC_FORM_ISOLATED;
-      }
-
-      shaped_cp = prv_get_shaped_codepoint(entry, form);
-    }
+    Codepoint prev_cp = (i > 0) ? codepoints[i - 1] : 0;
+    Codepoint next_cp = (i + 1 < num_codepoints) ? codepoints[i + 1] : 0;
+    Codepoint shaped_cp = arabic_shape_codepoint(prev_cp, codepoints[i], next_cp);
 
     // Encode the shaped codepoint to UTF-8
     // Ensure we have room for at least 4 bytes (max UTF-8 length)

--- a/src/fw/applib/graphics/arabic_shaping.h
+++ b/src/fw/applib/graphics/arabic_shaping.h
@@ -23,6 +23,18 @@ typedef enum {
 //! @return true if the codepoint is a shapeable Arabic letter
 bool arabic_is_shapeable(Codepoint cp);
 
+//! Shape a single Arabic codepoint based on its neighbors.
+//!
+//! Returns the contextual presentation form for `curr_cp` given the
+//! previous and next codepoints. Pass 0 for `prev_cp` / `next_cp` when
+//! the letter is at a string or segment boundary. Non-Arabic codepoints
+//! are returned unchanged, so this helper is safe to call for any
+//! codepoint and acts as a no-op outside the shapeable range.
+//!
+//! Used by both the renderer and the layout/measurement path so that
+//! width computation matches what is actually drawn.
+Codepoint arabic_shape_codepoint(Codepoint prev_cp, Codepoint curr_cp, Codepoint next_cp);
+
 //! Shape Arabic text by converting basic Arabic letters to their
 //! contextual presentation forms based on position in words.
 //!

--- a/src/fw/applib/graphics/text_layout.c
+++ b/src/fw/applib/graphics/text_layout.c
@@ -253,19 +253,30 @@ bool word_init(GContext* ctx, Word* word, const TextBoxParams* const text_box_pa
     return false;
   }
 
-  // Init the word & state 
+  // Init the word & state
   word->start = utf8_iter_state->current;
+  // Track previous and current codepoints so we can resolve Arabic
+  // contextual presentation forms while measuring. The renderer shapes
+  // letters before drawing (see walk_line()), so unshaped widths would
+  // over- or under-estimate the word and cause spurious wraps.
+  Codepoint prev_cp = 0;
+  Codepoint curr_cp = utf8_iter_state->codepoint;
   WordState state = WordStateStart;
-  state = word_state_update(state, utf8_iter_state->codepoint);
+  state = word_state_update(state, curr_cp);
 
   do {
+    iter_next(&char_iter);
+    Codepoint next_cp = utf8_iter_state->codepoint;
+
     if (state == WordStateGrowing || state == WordStateIdeograph) {
+      Codepoint width_cp = arabic_shape_codepoint(prev_cp, curr_cp, next_cp);
       word->width_px += prv_codepoint_get_horizontal_advance(&ctx->font_cache,
-          text_box_params->font, utf8_iter_state->codepoint);
+          text_box_params->font, width_cp);
     }
 
-    iter_next(&char_iter);
-    state = word_state_update(state, utf8_iter_state->codepoint);
+    prev_cp = curr_cp;
+    curr_cp = next_cp;
+    state = word_state_update(state, curr_cp);
   } while (state != WordStateEnd);
 
   word->end = utf8_iter_state->current;
@@ -649,6 +660,12 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
       // Collect segment (until we hit opposite script type or end)
       utf8_t *segment_end = ptr;
       int segment_width_px = 0;
+      // Track previous codepoint within the segment so Arabic letters are
+      // measured using their contextual presentation form. Without this,
+      // segment width here disagrees with the shaped width used by the
+      // layout (word_init) and by the actual draw pass below — letters at
+      // the line edge get truncated and a gap appears.
+      Codepoint prev_seg_cp = 0;
       while (segment_end < line_end && *segment_end != '\0' && *segment_end != '\n') {
         utf8_t *seg_next = NULL;
         Codepoint seg_cp = utf8_peek_codepoint(segment_end, &seg_next);
@@ -687,12 +704,19 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
           }
         }
 
+        Codepoint next_seg_cp = 0;
+        if (seg_next < line_end && *seg_next != '\0' && *seg_next != '\n') {
+          utf8_t *peek_next = NULL;
+          next_seg_cp = utf8_peek_codepoint(seg_next, &peek_next);
+        }
+        Codepoint width_cp = arabic_shape_codepoint(prev_seg_cp, seg_cp, next_seg_cp);
         int glyph_width = prv_codepoint_get_horizontal_advance(&ctx->font_cache,
-            text_box_params->font, seg_cp);
+            text_box_params->font, width_cp);
         if (total_width_px + segment_width_px + glyph_width + suffix_width_px > available_horiz_px) {
           break;
         }
 
+        prev_seg_cp = seg_cp;
         segment_width_px += glyph_width;
         segment_end = seg_next;
       }


### PR DESCRIPTION
## Summary

Arabic text wrapped to a new line even when the words would have fit, and after the layout fix, lines occasionally lost their last letter or two, leaving a visible gap at the line edge.

The layout engine measured each Arabic letter using its **basic** codepoint (U+0621-U+064A), but the renderer shapes letters into their **contextual presentation forms** (initial / medial / final / isolated) before drawing. Isolated forms are typically wider than the connected forms that actually render, so:

1. `word_init()` over-estimated word widths, causing words to wrap early.
2. The renderer's segment-collection pass measured the same way, so once its (unshaped) running total hit the line's (shaped) budget it stopped collecting, dropping trailing letters.

## Changes

- Extract the per-letter shaping decision out of `arabic_shape_text()` into a new helper `arabic_shape_codepoint(prev, curr, next)` so layout, segment collection, and the draw pass share one source of truth.
- Use the helper for width measurement in:
  - `word_init()` (layout) in `src/fw/applib/graphics/text_layout.c`
  - The BiDi segment-collection loop inside `walk_line()` (renderer pass 1)
- `arabic_shape_text()` is refactored to call the helper, no behavior change for the renderer's existing shaping step.

## Scope / risk

- For non-Arabic codepoints the helper is a no-op (it short-circuits via a U+0621-U+064A bounds check), so Latin, Cyrillic, Hebrew, CJK, emoji, Arabic diacritics, and Arabic-Indic digits all measure exactly as before with byte-identical widths.
- Cost on the hot path is two extra integer comparisons per non-Arabic codepoint.
- Only the 36 basic Arabic letters change measurement, and the new value is what the renderer was already drawing.

This is how the text look after the changes

<img width="144" height="168" alt="pebble_screenshot-2" src="https://github.com/user-attachments/assets/bf790e74-8f23-4949-baae-ce8feb04ef9e" />
