### PR TITLE
github: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# PebbleOS code owners.
+#
+# Everything is currently owned by the maintainers below. As the project
+# grows, ownership may be split by area.
+
+* @gmarull @jplexer


### PR DESCRIPTION
Catch-all ownership for the maintainers. Areas may be split later as the project grows.