### PR TITLE
fw/kernel: don't trap divide-by-zero in user code

### DIFF
--- a/src/fw/kernel/fault_handling.c
+++ b/src/fw/kernel/fault_handling.c
@@ -45,6 +45,10 @@ void enable_fault_handlers(void) {
   SCB->SHCSR |= SCB_SHCSR_MEMFAULTENA_Msk;
   SCB->SHCSR |= SCB_SHCSR_BUSFAULTENA_Msk;
   SCB->SHCSR |= SCB_SHCSR_USGFAULTENA_Msk;
+
+  SCB->CCR &= ~SCB_CCR_DIV_0_TRP_Msk;
+  __DSB();
+  __ISB();
 }
 
 


### PR DESCRIPTION
Fixes FIRM-1830