### PR TITLE
fw/popups/alarm_popup: pop popup before pushing confirmation

### DIFF
--- a/src/fw/popups/alarm_popup.c
+++ b/src/fw/popups/alarm_popup.c
@@ -158,14 +158,14 @@ static void prv_start_vibes(void) {
 //! Click Handler
 static void prv_dismiss_click_handler(ClickRecognizerRef recognizer, void *data) {
   alarm_dismiss_alarm();
-  prv_show_dismiss_confirm_dialog();
   actionable_dialog_pop(s_alarm_popup_data->alarm_popup);
+  prv_show_dismiss_confirm_dialog();
 }
 
 static void prv_snooze_click_handler(ClickRecognizerRef recognizer, void *data) {
   alarm_set_snooze_alarm();
-  prv_show_snooze_confirm_dialog();
   actionable_dialog_pop(s_alarm_popup_data->alarm_popup);
+  prv_show_snooze_confirm_dialog();
 }
 
 static void prv_click_provider(void *context) {


### PR DESCRIPTION
When the user dismissed or snoozed the alarm, the click handler pushed the confirmation dialog onto the alarm-priority modal stack and then popped the alarm popup. With both dialogs in the stack across the animated slide, the alarm popup's animated ALARM_CLOCK_LARGE PDC reel and the confirmation's GENERIC_CONFIRMATION_LARGE PDC reel were live on the kernel heap simultaneously, OOMing on tight boards under memory pressure.

Pop first: with the alarm popup as the only entry on the stack, prv_remove_item takes the window_to == NULL branch and synchronously disappears + unloads it, running prv_cleanup_alarm_popup before the confirmation's PDC is allocated. The animated icon on the alarm popup itself is untouched.

Fixes FIRM-1311