### PR TITLE
fw/services/light: pin ALS cache while backlight is on

### DIFF
--- a/src/fw/services/light/service.c
+++ b/src/fw/services/light/service.c
@@ -117,7 +117,10 @@ static void prv_change_state(BacklightState new_state);
 
 static uint32_t prv_get_als_level(void) {
   RtcTicks now = rtc_get_ticks();
-  if (s_als_cached_ticks != 0 && (now - s_als_cached_ticks) < ALS_CACHE_TTL_TICKS) {
+  const bool cache_valid =
+      s_als_cached_ticks != 0 &&
+      (s_current_brightness > 0 || (now - s_als_cached_ticks) < ALS_CACHE_TTL_TICKS);
+  if (cache_valid) {
     return s_als_cached_level;
   }
   s_als_cached_level = ambient_light_get_light_level();


### PR DESCRIPTION
The 1 s ALS cache TTL expires within a single backlight on-cycle, so a second button press in a dark room re-polls the sensor while the LED is shining into it. The contaminated reading pushes the dynamic-backlight algorithm out of the dim zone and the brightness jumps to user-max.

Fixes FIRM-1831