### PR TITLE
bluetooth-fw/nimble: roll back host state on failed start

### DIFF
--- a/src/bluetooth-fw/nimble/init.c
+++ b/src/bluetooth-fw/nimble/init.c
@@ -107,6 +107,11 @@ bool bt_driver_start(BTDriverConfig *config) {
   int rc;
   BaseType_t f_rc;
 
+  if (ble_hs_is_enabled()) {
+    PBL_LOG_D_WRN(LOG_DOMAIN_BT, "NimBLE host already enabled; skipping start");
+    return true;
+  }
+
   s_dis_info = config->dis_info;
   ble_svc_dis_model_number_set(s_dis_info.model_number);
   ble_svc_dis_serial_number_set(s_dis_info.serial_number);
@@ -119,7 +124,7 @@ bool bt_driver_start(BTDriverConfig *config) {
   ble_svc_dis_init();
   pebble_pairing_service_init();
   ble_svc_bas_init();
-  
+
 #ifdef GH3X2X_TUNING_SERVICE_ENABLED
   gh3x2x_tuning_service_init();
 #endif
@@ -128,16 +133,35 @@ bool bt_driver_start(BTDriverConfig *config) {
   f_rc = xSemaphoreTake(s_host_started, milliseconds_to_ticks(s_bt_stack_start_stop_timeout_ms));
   if (f_rc != pdTRUE) {
     PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Host synchronization timed out");
-    return false;
+    goto err;
   }
 
   rc = ble_hs_util_ensure_addr(0);
   if (rc != 0) {
     PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Failed to ensure address: 0x%04x", (uint16_t)rc);
-    return false;
+    goto err;
   }
 
   return true;
+
+err:
+  rc = ble_hs_stop(&s_listener, prv_ble_hs_stop_cb, NULL);
+  if (rc == BLE_HS_EALREADY) {
+    return false;
+  } else if (rc != 0) {
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Failed to stop NimBLE host after start failure: 0x%04x", (uint16_t)rc);
+    return false;
+  }
+
+  f_rc = xSemaphoreTake(s_host_stopped, milliseconds_to_ticks(s_bt_stack_start_stop_timeout_ms));
+  if (f_rc != pdTRUE) {
+    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "NimBLE host stop timed out after start failure");
+    return false;
+  }
+
+  (void)ble_gatts_reset();
+
+  return false;
 }
 
 void bt_driver_stop(void) {


### PR DESCRIPTION
## Summary

- Fixes the `assert(rc == 0)` reboot in `ble_hs_event_start_stage2` that triggers when stationary mode wakes the watch and tries to bring BLE back up (FIRM-1837, dup of FIRM-1699).
- When `bt_driver_start()` fails after `ble_hs_sched_start()` has already enabled the host (sync timeout, `ble_hs_util_ensure_addr` failure), the previous code returned `false` and left `ble_hs_enabled_state = ON` — the next start hit `BLE_HS_EALREADY` and asserted.
- Adds an idempotency guard at the top of `bt_driver_start()` so an already-enabled host returns success, and rolls the host back to `OFF` via `ble_hs_stop()` on the failure paths.

Fixes FIRM-1837.

## Test plan

- [ ] Build clean for `obelix_dvt` (verified locally).
- [ ] Soak test on a Pebble Time 2 with stationary mode enabled for several hours (motion sensitivity Low) — no spontaneous reboot from `ble_hs.c:555` assert.
- [ ] Toggle airplane mode rapidly to exercise stop/start cycling — no `EALREADY` assert.
- [ ] Force the failure path (e.g. simulate `ensure_addr` failure or `host_started` timeout) and verify the next `bt_driver_start()` succeeds instead of asserting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)