### PR TITLE
tools/flash_imaging: increase max retries

### DIFF
--- a/python_libs/pebble-commander/pebble/commander/apps/flash_imaging.py
+++ b/python_libs/pebble-commander/pebble/commander/apps/flash_imaging.py
@@ -183,7 +183,7 @@ class FlashImaging(object):
                 continue
         raise exceptions.CommandTimedOut
 
-    def write(self, address, data, max_retries=5, max_in_flight=5, progress_cb=None):
+    def write(self, address, data, max_retries=10, max_in_flight=5, progress_cb=None):
         mtu = self.socket.mtu - WriteCommand.header_len
         assert mtu > 0
         unsent = collections.deque()

--- a/tools/pulse/flash_imaging.py
+++ b/tools/pulse/flash_imaging.py
@@ -177,7 +177,7 @@ class FlashImagingProtocol(object):
                 continue
         raise exceptions.CommandTimedOut
 
-    def write(self, address, data, max_retries=5, max_in_flight=5, progress_cb=None):
+    def write(self, address, data, max_retries=10, max_in_flight=5, progress_cb=None):
         mtu = self.socket.mtu - WriteCommand.header_len
         assert mtu > 0
         unsent = collections.OrderedDict()


### PR DESCRIPTION
For whatever reason, on my board 5 is sometimes not enough.