### PR TITLE
fw/services/alarms: add sound playback with selectable tones

### DIFF
--- a/include/pbl/services/alarms/alarm.h
+++ b/include/pbl/services/alarms/alarm.h
@@ -40,6 +40,14 @@ typedef enum AlarmType {
   AlarmTypeCount,
 } AlarmType;
 
+//! Built-in alarm tones, played on speaker hardware when sound is enabled.
+typedef enum AlarmTone {
+  AlarmTone_Reveille = 0,
+  AlarmTone_Beacon,
+  AlarmTone_Bell,
+  AlarmTone_Chime,
+} AlarmTone;
+
 typedef struct AlarmInfo {
   int hour; //<! Range 0-23, where 0 is 12am
   int minute; //<! Range is 0-59
@@ -48,6 +56,9 @@ typedef struct AlarmInfo {
   bool (*scheduled_days)[DAYS_PER_WEEK];
   bool enabled; //<! Whether the alarm to go off at the specified time
   bool is_smart; //<! Whether the alarm is a Smart Alarm
+  bool sound_enabled; //<! Whether the alarm should play a tone on speaker hardware
+  bool vibrate_enabled; //<! Whether the alarm should vibrate
+  AlarmTone tone; //<! Selected tone for this alarm (used when sound_enabled is true)
 } AlarmInfo;
 
 typedef void (*AlarmForEach)(AlarmId id, const AlarmInfo *info, void *context);
@@ -74,6 +85,24 @@ void alarm_set_custom(AlarmId id, const bool scheduled_days[DAYS_PER_WEEK]);
 //! @param id The alarm that should be updated
 //! @param smart Whether the alarm is a smart alarm
 void alarm_set_smart(AlarmId id, bool smart);
+
+//! @param id The alarm that should be updated
+//! @param enabled Whether the alarm should play a tone on speaker hardware
+void alarm_set_sound_enabled(AlarmId id, bool enabled);
+
+//! @param id The alarm that should be updated
+//! @param enabled Whether the alarm should vibrate
+void alarm_set_vibrate_enabled(AlarmId id, bool enabled);
+
+//! @param id The alarm that should be updated
+//! @param tone The tone to play when sound is enabled
+void alarm_set_tone(AlarmId id, AlarmTone tone);
+
+//! @param id The alarm to look up
+//! @param info_out The AlarmInfo struct to fill in. The scheduled_days pointer is set to NULL;
+//! callers needing per-weekday flags should use alarm_get_custom_days() instead.
+//! @return True if the alarm exists, False otherwise
+bool alarm_get_info(AlarmId id, AlarmInfo *info_out);
 
 //! @param id The alarm for which the scheduled_days array should be updated for
 //! @param scheduled_days[DAYS_PER_WEEK] An empty bool array for each weekday (Sunday = index 0)

--- a/include/pbl/services/alarms/alarm.h
+++ b/include/pbl/services/alarms/alarm.h
@@ -104,6 +104,10 @@ void alarm_set_tone(AlarmId id, AlarmTone tone);
 //! @return True if the alarm exists, False otherwise
 bool alarm_get_info(AlarmId id, AlarmInfo *info_out);
 
+//! @return The id of the most recently fired alarm, or ALARM_INVALID_ID if no alarm has fired
+//! since boot. Used by the alarm popup to look up the firing alarm's settings.
+AlarmId alarm_get_most_recent_id(void);
+
 //! @param id The alarm for which the scheduled_days array should be updated for
 //! @param scheduled_days[DAYS_PER_WEEK] An empty bool array for each weekday (Sunday = index 0)
 //! that is to be updated. Alarms will run on each weekday that is marked as true

--- a/src/fw/apps/system/alarms/alarm_detail.c
+++ b/src/fw/apps/system/alarms/alarm_detail.c
@@ -313,15 +313,22 @@ void alarm_detail_window_push(AlarmId alarm_id, AlarmInfo *alarm_info,
     .perform_action = prv_disable_sound_handler,
     .action_data = data,
   };
-  for (int i = 0; i < (int)(sizeof(tone_values) / sizeof(tone_values[0])); i++) {
+  const int num_tones = (int)(sizeof(tone_values) / sizeof(tone_values[0]));
+  for (int i = 0; i < num_tones; i++) {
     sound_level->items[i + 1] = (ActionMenuItem) {
       .label = i18n_get(alarm_tones_get_name(tone_values[i]), data),
       .perform_action = prv_select_tone_handler,
       .action_data = (void *)(uintptr_t)tone_values[i],
     };
   }
-  sound_level->default_selected_item =
-      data->alarm_info.sound_enabled ? (data->alarm_info.tone + 1) : 0;
+  // Bounds-check the stored tone before indexing the menu. The 3-bit storage
+  // field can hold 0..7 but the menu only has num_tones entries; defend
+  // against corrupted storage or future tone-table changes.
+  int selected = 0;
+  if (data->alarm_info.sound_enabled && (int)data->alarm_info.tone < num_tones) {
+    selected = (int)data->alarm_info.tone + 1;
+  }
+  sound_level->default_selected_item = selected;
 #endif
 
   app_action_menu_open(&data->menu_config);

--- a/src/fw/apps/system/alarms/alarm_detail.c
+++ b/src/fw/apps/system/alarms/alarm_detail.c
@@ -16,9 +16,18 @@
 #include "pbl/services/alarms/alarm.h"
 #include "system/logging.h"
 
+#if CAPABILITY_HAS_SPEAKER
+#include "services/alarms/alarm_tones.h"
+#endif
+
 #include <stdio.h>
 
 #define NUM_SNOOZE_MENU_ITEMS 5
+
+#if CAPABILITY_HAS_SPEAKER
+// Sound submenu: "Off" + one entry per AlarmTone (Reveille, Beacon, Bell, Chime).
+#define NUM_SOUND_MENU_ITEMS 5
+#endif
 
 typedef enum DetailMenuItemIndex {
   DetailMenuItemIndexEnable = 0,
@@ -26,6 +35,10 @@ typedef enum DetailMenuItemIndex {
   DetailMenuItemIndexChangeTime,
   DetailMenuItemIndexChangeDays,
   DetailMenuItemIndexConvertSmart,
+#if CAPABILITY_HAS_SPEAKER
+  DetailMenuItemIndexSound,
+#endif
+  DetailMenuItemIndexVibration,
   DetailMenuItemIndexSnooze,
   DetailMenuItemIndexNum,
 } DetailMenuItemIndex;
@@ -115,6 +128,37 @@ static void prv_delete_alarm_handler(ActionMenu *action_menu,
   }
 }
 
+static void prv_toggle_vibrate_handler(ActionMenu *action_menu, const ActionMenuItem *item,
+                                       void *context) {
+  AlarmDetailData *data = (AlarmDetailData *) context;
+  alarm_set_vibrate_enabled(data->alarm_id, !data->alarm_info.vibrate_enabled);
+  if (data->alarm_editor_callback) {
+    data->alarm_editor_callback(EDITED, data->alarm_id, data->callback_context);
+  }
+}
+
+#if CAPABILITY_HAS_SPEAKER
+static void prv_disable_sound_handler(ActionMenu *action_menu, const ActionMenuItem *item,
+                                      void *context) {
+  AlarmDetailData *data = (AlarmDetailData *) context;
+  alarm_set_sound_enabled(data->alarm_id, false);
+  if (data->alarm_editor_callback) {
+    data->alarm_editor_callback(EDITED, data->alarm_id, data->callback_context);
+  }
+}
+
+static void prv_select_tone_handler(ActionMenu *action_menu, const ActionMenuItem *item,
+                                    void *context) {
+  AlarmDetailData *data = (AlarmDetailData *) context;
+  AlarmTone tone = (AlarmTone)(uintptr_t)item->action_data;
+  alarm_set_tone(data->alarm_id, tone);
+  alarm_set_sound_enabled(data->alarm_id, true);
+  if (data->alarm_editor_callback) {
+    data->alarm_editor_callback(EDITED, data->alarm_id, data->callback_context);
+  }
+}
+#endif
+
 static ActionMenuLevel *prv_create_main_menu(void) {
   ActionMenuLevel *level = task_malloc(sizeof(ActionMenuLevel) +
       DetailMenuItemIndexNum * sizeof(ActionMenuItem));
@@ -139,6 +183,20 @@ static ActionMenuLevel *prv_create_snooze_menu(ActionMenuLevel *parent_level) {
   return level;
 }
 
+#if CAPABILITY_HAS_SPEAKER
+static ActionMenuLevel *prv_create_sound_menu(ActionMenuLevel *parent_level) {
+  ActionMenuLevel *level = task_malloc(sizeof(ActionMenuLevel) +
+      NUM_SOUND_MENU_ITEMS * sizeof(ActionMenuItem));
+  if (!level) return NULL;
+  *level = (ActionMenuLevel) {
+    .num_items = NUM_SOUND_MENU_ITEMS,
+    .parent_level = parent_level,
+    .display_mode = ActionMenuLevelDisplayModeWide,
+  };
+  return level;
+}
+#endif
+
 void prv_cleanup_alarm_detail_menu(ActionMenu *action_menu,
                                    const ActionMenuItem *item,
                                    void *context) {
@@ -146,6 +204,9 @@ void prv_cleanup_alarm_detail_menu(ActionMenu *action_menu,
   AlarmDetailData *data = (AlarmDetailData *) context;
   i18n_free_all(data);
   task_free((void *)root_level->items[DetailMenuItemIndexSnooze].next_level);
+#if CAPABILITY_HAS_SPEAKER
+  task_free((void *)root_level->items[DetailMenuItemIndexSound].next_level);
+#endif
   task_free((void *)root_level);
   task_free(data);
   data = NULL;
@@ -196,6 +257,19 @@ void alarm_detail_window_push(AlarmId alarm_id, AlarmInfo *alarm_info,
     .perform_action = prv_toggle_smart_alarm_handler,
     .action_data = data,
   };
+#if CAPABILITY_HAS_SPEAKER
+  main_menu->items[DetailMenuItemIndexSound] = (ActionMenuItem) {
+    .label = i18n_get("Sound", data),
+    .is_leaf = 0,
+    .next_level = prv_create_sound_menu(main_menu),
+  };
+#endif
+  main_menu->items[DetailMenuItemIndexVibration] = (ActionMenuItem) {
+    .label = data->alarm_info.vibrate_enabled ? i18n_get("Vibration: On", data)
+                                              : i18n_get("Vibration: Off", data),
+    .perform_action = prv_toggle_vibrate_handler,
+    .action_data = data,
+  };
   main_menu->items[DetailMenuItemIndexSnooze] = (ActionMenuItem) {
     .label = i18n_get("Snooze Delay", data),
     .is_leaf = 0,
@@ -227,6 +301,28 @@ void alarm_detail_window_push(AlarmId alarm_id, AlarmInfo *alarm_info,
       snooze_level->default_selected_item = i;
     }
   }
+
+#if CAPABILITY_HAS_SPEAKER
+  // Setup sound menu items: Off + one entry per AlarmTone.
+  ActionMenuLevel *sound_level = main_menu->items[DetailMenuItemIndexSound].next_level;
+  static const AlarmTone tone_values[] = {
+    AlarmTone_Reveille, AlarmTone_Beacon, AlarmTone_Bell, AlarmTone_Chime,
+  };
+  sound_level->items[0] = (ActionMenuItem) {
+    .label = i18n_get("Off", data),
+    .perform_action = prv_disable_sound_handler,
+    .action_data = data,
+  };
+  for (int i = 0; i < (int)(sizeof(tone_values) / sizeof(tone_values[0])); i++) {
+    sound_level->items[i + 1] = (ActionMenuItem) {
+      .label = i18n_get(alarm_tones_get_name(tone_values[i]), data),
+      .perform_action = prv_select_tone_handler,
+      .action_data = (void *)(uintptr_t)tone_values[i],
+    };
+  }
+  sound_level->default_selected_item =
+      data->alarm_info.sound_enabled ? (data->alarm_info.tone + 1) : 0;
+#endif
 
   app_action_menu_open(&data->menu_config);
 }

--- a/src/fw/apps/system/alarms/alarm_editor.c
+++ b/src/fw/apps/system/alarms/alarm_editor.c
@@ -162,6 +162,11 @@ static void prv_handle_selection(int index, void *callback_context) {
       .minute = data->alarm_minute,
       .kind = data->alarm_kind,
       .is_smart = (data->alarm_type == AlarmType_Smart),
+      .vibrate_enabled = true,
+#if CAPABILITY_HAS_SPEAKER
+      .sound_enabled = false,
+      .tone = AlarmTone_Reveille,
+#endif
     };
     data->alarm_id = alarm_create(&info);
     data->complete_callback(CREATED, data->alarm_id, data->callback_context);
@@ -370,6 +375,11 @@ static void prv_custom_day_picker_handle_selection(MenuLayer *menu_layer, MenuIn
           .kind = ALARM_KIND_CUSTOM,
           .scheduled_days = &data->scheduled_days,
           .is_smart = (data->alarm_type == AlarmType_Smart),
+          .vibrate_enabled = true,
+#if CAPABILITY_HAS_SPEAKER
+          .sound_enabled = false,
+          .tone = AlarmTone_Reveille,
+#endif
         };
         data->alarm_id = alarm_create(&info);
         data->complete_callback(CREATED, data->alarm_id, data->callback_context);

--- a/src/fw/popups/alarm_popup.c
+++ b/src/fw/popups/alarm_popup.c
@@ -26,6 +26,14 @@
 #include "pbl/services/vibes/vibe_client.h"
 #include "pbl/services/vibes/vibe_score.h"
 
+#if CAPABILITY_HAS_SPEAKER
+#include "applib/event_service_client.h"
+#include "kernel/events.h"
+#include "pbl/services/speaker/speaker_finish_reason.h"
+#include "pbl/services/speaker/speaker_service.h"
+#include "services/alarms/alarm_tones.h"
+#endif
+
 #define DIALOG_TIMEOUT_SNOOZE 2000
 #define DIALOG_TIMEOUT_DISMISS DIALOG_TIMEOUT_SNOOZE
 
@@ -81,6 +89,16 @@ typedef struct {
   int max_vibes;
   int vibe_count;
   VibeScore *vibe_score;
+
+#if CAPABILITY_HAS_SPEAKER
+  // Speaker playback state. sound_active is the single source of truth: it must
+  // be cleared *before* speaker_service_stop() so any in-flight finish event
+  // bails out instead of re-triggering playback.
+  bool sound_active;
+  const SpeakerNote *sound_notes;
+  uint32_t sound_count;
+  EventServiceInfo speaker_event_info;
+#endif
 } AlarmPopupData;
 
 AlarmPopupData *s_alarm_popup_data = NULL;
@@ -105,6 +123,67 @@ static void prv_stop_vibes(void) {
   }
   vibes_cancel();
 }
+
+#if CAPABILITY_HAS_SPEAKER
+// Volume 60/100 is a moderate first cut; tunable, and a per-user volume
+// preference can be added in a follow-up.
+#define ALARM_SPEAKER_VOLUME 60
+
+static void prv_handle_speaker_event(PebbleEvent *e, void *context) {
+  if (!s_alarm_popup_data || !s_alarm_popup_data->sound_active) {
+    return;
+  }
+  if (e->speaker.type != SpeakerEventFinished) {
+    return;
+  }
+  if ((SpeakerFinishReason)e->speaker.finish_reason == SpeakerFinishReasonDone) {
+    // Loop the sequence — alarms ring continuously until dismiss/snooze/timeout.
+    speaker_service_play_note_seq(s_alarm_popup_data->sound_notes,
+                                  s_alarm_popup_data->sound_count,
+                                  SpeakerPriorityCritical, ALARM_SPEAKER_VOLUME);
+  }
+  // Preempted / Stopped / Error: stay silent. Vibration continues until popup teardown.
+}
+
+static void prv_start_sound(AlarmId id) {
+  if (low_power_is_active()) {
+    return;  // Skip sound in LPM to conserve battery; vibration still runs.
+  }
+
+  AlarmInfo info;
+  if (!alarm_get_info(id, &info) || !info.sound_enabled) {
+    return;
+  }
+
+  alarm_tones_get(info.tone, &s_alarm_popup_data->sound_notes, &s_alarm_popup_data->sound_count);
+  if (!s_alarm_popup_data->sound_notes || s_alarm_popup_data->sound_count == 0) {
+    return;
+  }
+
+  s_alarm_popup_data->speaker_event_info = (EventServiceInfo) {
+    .type = PEBBLE_SPEAKER_EVENT,
+    .handler = prv_handle_speaker_event,
+  };
+  event_service_client_subscribe(&s_alarm_popup_data->speaker_event_info);
+  speaker_service_register_finish(PebbleTask_KernelMain);
+
+  s_alarm_popup_data->sound_active = true;
+  speaker_service_play_note_seq(s_alarm_popup_data->sound_notes,
+                                s_alarm_popup_data->sound_count,
+                                SpeakerPriorityCritical, ALARM_SPEAKER_VOLUME);
+}
+
+static void prv_stop_sound(void) {
+  if (!s_alarm_popup_data->sound_active) {
+    return;
+  }
+  // Order matters: clear the flag first so any in-flight finish event bails
+  // out before stop() generates one.
+  s_alarm_popup_data->sound_active = false;
+  speaker_service_stop();
+  event_service_client_unsubscribe(&s_alarm_popup_data->speaker_event_info);
+}
+#endif  // CAPABILITY_HAS_SPEAKER
 
 // ----------------------------------------------------------------------------------------------
 //! Vibe Timer
@@ -193,6 +272,9 @@ static void prv_setup_action_bar(void) {
 static void prv_cleanup_alarm_popup(void *callback_context) {
   if (s_alarm_popup_data) {
     prv_stop_vibes();
+#if CAPABILITY_HAS_SPEAKER
+    prv_stop_sound();
+#endif
     gbitmap_destroy(s_alarm_popup_data->bitmap);
     gbitmap_destroy(s_alarm_popup_data->action_bar_snooze);
     gbitmap_destroy(s_alarm_popup_data->action_bar_dismiss);
@@ -237,7 +319,22 @@ void alarm_popup_push_window(PebbleAlarmClockEvent *event) {
   dialog_set_callbacks(dialog, &callback, NULL);
   actionable_dialog_push(s_alarm_popup_data->alarm_popup, prv_get_window_stack());
 
-  prv_start_vibes();
+  // The alarm id isn't carried in the event (PebbleEvent must stay <= 12 bytes
+  // — see _Static_assert in events.c). Fall back to the most-recently-fired
+  // alarm tracked in the alarm service. Synthetic events (trigger_alarm demo)
+  // get ALARM_INVALID_ID and skip the per-alarm config lookup.
+  const AlarmId alarm_id = alarm_get_most_recent_id();
+  AlarmInfo info;
+  const bool have_info = (alarm_id != ALARM_INVALID_ID) &&
+                         alarm_get_info(alarm_id, &info);
+  if (!have_info || info.vibrate_enabled) {
+    prv_start_vibes();
+  }
+#if CAPABILITY_HAS_SPEAKER
+  if (have_info) {
+    prv_start_sound(alarm_id);
+  }
+#endif
 
   light_enable_interaction();
 }

--- a/src/fw/services/alarms/alarm.c
+++ b/src/fw/services/alarms/alarm.c
@@ -962,6 +962,11 @@ cleanup:
 }
 
 // ----------------------------------------------------------------------------------------------
+AlarmId alarm_get_most_recent_id(void) {
+  return s_most_recent_alarm_id;
+}
+
+// ----------------------------------------------------------------------------------------------
 bool alarm_get_info(AlarmId id, AlarmInfo *info_out) {
   if (!info_out) {
     return false;

--- a/src/fw/services/alarms/alarm.c
+++ b/src/fw/services/alarms/alarm.c
@@ -78,6 +78,15 @@ typedef struct PACKED {
       //! Whether the alarm is a smart alarm or not. Smart alarms attempt to wake the user the
       //! first moment the user is not in deep sleep in the time range T-30min to T every 5 min.
       bool is_smart:1;
+      //! Whether the alarm should play a tone on speaker hardware. Default 0 (off) so legacy
+      //! alarms loaded from older firmware stay silent.
+      bool sound_enabled:1;
+      //! Whether vibration is *disabled* for this alarm. Default 0 (vibration on) so legacy
+      //! alarms loaded from older firmware keep vibrating.
+      bool vibrate_disabled:1;
+      //! Selected tone (AlarmTone enum value). Default 0 (Reveille). Irrelevant when
+      //! sound_enabled is 0.
+      uint8_t tone:3;
     };
     uint8_t flags;
   };
@@ -475,6 +484,9 @@ static void prv_persist_alarm(SettingsFile *fd, Alarm *alarm) {
     .hour = alarm->config.hour,
     .minute = alarm->config.minute,
     .is_smart = alarm->config.is_smart,
+    .sound_enabled = alarm->config.sound_enabled,
+    .vibrate_disabled = alarm->config.vibrate_disabled,
+    .tone = alarm->config.tone,
   };
   memcpy(&config.scheduled_days, alarm->config.scheduled_days, sizeof(config.scheduled_days));
   settings_file_set(fd, &key, sizeof(key), &config, sizeof(config));
@@ -511,6 +523,9 @@ static bool prv_alarm_get_config(SettingsFile *file, AlarmId id, AlarmConfig* co
       .is_disabled = config.is_disabled,
       .kind = config.kind,
       .is_smart = config.is_smart,
+      .sound_enabled = config.sound_enabled,
+      .vibrate_disabled = config.vibrate_disabled,
+      .tone = config.tone,
     };
     memcpy(&config_out->scheduled_days, config.scheduled_days, sizeof(config.scheduled_days));
     return true;
@@ -600,6 +615,9 @@ AlarmId alarm_create(const AlarmInfo *info) {
     .kind = info->kind,
     .is_disabled = false,
     .is_smart = info->is_smart,
+    .sound_enabled = info->sound_enabled,
+    .vibrate_disabled = !info->vibrate_enabled,
+    .tone = info->tone,
   };
   if (info->kind == ALARM_KIND_CUSTOM && info->scheduled_days) {
     prv_set_alarm_custom_op(id, &config, (void *)info->scheduled_days);
@@ -671,6 +689,36 @@ static bool prv_set_alarm_smart_op(AlarmId id, AlarmConfig *config, void *contex
 
 void alarm_set_smart(AlarmId id, bool smart) {
   prv_alarm_operation(id, prv_set_alarm_smart_op, (void *)(uintptr_t)smart);
+}
+
+// ----------------------------------------------------------------------------------------------
+static bool prv_set_sound_enabled_op(AlarmId id, AlarmConfig *config, void *context) {
+  config->sound_enabled = (uintptr_t)context;
+  return true;
+}
+
+void alarm_set_sound_enabled(AlarmId id, bool enabled) {
+  prv_alarm_operation(id, prv_set_sound_enabled_op, (void *)(uintptr_t)enabled);
+}
+
+// ----------------------------------------------------------------------------------------------
+static bool prv_set_vibrate_enabled_op(AlarmId id, AlarmConfig *config, void *context) {
+  config->vibrate_disabled = !(uintptr_t)context;
+  return true;
+}
+
+void alarm_set_vibrate_enabled(AlarmId id, bool enabled) {
+  prv_alarm_operation(id, prv_set_vibrate_enabled_op, (void *)(uintptr_t)enabled);
+}
+
+// ----------------------------------------------------------------------------------------------
+static bool prv_set_tone_op(AlarmId id, AlarmConfig *config, void *context) {
+  config->tone = (uintptr_t)context;
+  return true;
+}
+
+void alarm_set_tone(AlarmId id, AlarmTone tone) {
+  prv_alarm_operation(id, prv_set_tone_op, (void *)(uintptr_t)tone);
 }
 
 // ----------------------------------------------------------------------------------------------
@@ -913,6 +961,40 @@ cleanup:
   return rv;
 }
 
+// ----------------------------------------------------------------------------------------------
+bool alarm_get_info(AlarmId id, AlarmInfo *info_out) {
+  if (!info_out) {
+    return false;
+  }
+
+  SettingsFile file;
+  if (!prv_file_open_and_lock(&file)) {
+    return false;
+  }
+
+  AlarmConfig config;
+  bool rv = prv_alarm_get_config(&file, id, &config);
+  if (!rv) {
+    goto cleanup;
+  }
+
+  *info_out = (AlarmInfo) {
+    .hour = config.hour,
+    .minute = config.minute,
+    .kind = config.kind,
+    .enabled = !config.is_disabled,
+    .is_smart = config.is_smart,
+    .sound_enabled = config.sound_enabled,
+    .vibrate_enabled = !config.vibrate_disabled,
+    .tone = config.tone,
+    .scheduled_days = NULL,
+  };
+
+cleanup:
+  prv_file_close_and_unlock(&file);
+  return rv;
+}
+
 static void prv_snooze_alarm(int snooze_delay_s) {
   prv_clear_snooze_timer();
   PBL_LOG_INFO("Snoozing for %d minutes", snooze_delay_s / SECONDS_PER_MINUTE);
@@ -986,6 +1068,9 @@ static bool alarm_for_each_itr(SettingsFile *file, SettingsRecordInfo *info, voi
     .kind = config.kind,
     .enabled = !config.is_disabled,
     .is_smart = config.is_smart,
+    .sound_enabled = config.sound_enabled,
+    .vibrate_enabled = !config.vibrate_disabled,
+    .tone = config.tone,
     .scheduled_days = &config.scheduled_days,
   };
   itr_data->cb(key.id, &alarm_info, itr_data->cb_data);

--- a/src/fw/services/alarms/alarm_tones.c
+++ b/src/fw/services/alarms/alarm_tones.c
@@ -3,7 +3,7 @@
 
 #include "alarm_tones.h"
 
-#include "applib/i18n.h"
+#include "pbl/services/i18n/i18n.h"
 
 #define ALARM_TONE_COUNT 4
 

--- a/src/fw/services/alarms/alarm_tones.c
+++ b/src/fw/services/alarms/alarm_tones.c
@@ -1,0 +1,92 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "alarm_tones.h"
+
+#include "applib/i18n.h"
+
+#define ALARM_TONE_COUNT 4
+
+#define NOTE(midi, wave, ms) \
+  { .midi_note = (midi), .waveform = (wave), .duration_ms = (ms), .velocity = 0, .reserved = 0 }
+
+// MIDI: C4=60, D4=62, E4=64, F4=65, G4=67, A4=69, B4=71,
+//       C5=72, D5=74, E5=76, F5=77, G5=79, A5=81, C6=84.
+
+// Reveille — a short bugle motif using square waves for clarity over a small mono speaker.
+static const SpeakerNote s_reveille[] = {
+  NOTE(67, SpeakerWaveformSquare, 200),  // G4
+  NOTE(72, SpeakerWaveformSquare, 200),  // C5
+  NOTE(76, SpeakerWaveformSquare, 200),  // E5
+  NOTE(79, SpeakerWaveformSquare, 400),  // G5
+  NOTE(76, SpeakerWaveformSquare, 200),  // E5
+  NOTE(72, SpeakerWaveformSquare, 400),  // C5
+  NOTE(0,  SpeakerWaveformSquare, 150),  // rest
+  NOTE(67, SpeakerWaveformSquare, 200),  // G4
+  NOTE(72, SpeakerWaveformSquare, 200),  // C5
+  NOTE(76, SpeakerWaveformSquare, 600),  // E5
+};
+
+// Beacon — alternating C5/G5 squares, six cycles. Insistent and unambiguous.
+static const SpeakerNote s_beacon[] = {
+  NOTE(72, SpeakerWaveformSquare, 200), NOTE(79, SpeakerWaveformSquare, 200),
+  NOTE(72, SpeakerWaveformSquare, 200), NOTE(79, SpeakerWaveformSquare, 200),
+  NOTE(72, SpeakerWaveformSquare, 200), NOTE(79, SpeakerWaveformSquare, 200),
+  NOTE(72, SpeakerWaveformSquare, 200), NOTE(79, SpeakerWaveformSquare, 200),
+  NOTE(72, SpeakerWaveformSquare, 200), NOTE(79, SpeakerWaveformSquare, 200),
+  NOTE(72, SpeakerWaveformSquare, 200), NOTE(79, SpeakerWaveformSquare, 200),
+};
+
+// Bell — sine wave descending, gentler than Reveille.
+static const SpeakerNote s_bell[] = {
+  NOTE(81, SpeakerWaveformSine, 500),  // A5
+  NOTE(77, SpeakerWaveformSine, 500),  // F5
+  NOTE(74, SpeakerWaveformSine, 500),  // D5
+  NOTE(69, SpeakerWaveformSine, 700),  // A4
+};
+
+// Chime — triangle ascending with brief rests, light and pleasant.
+static const SpeakerNote s_chime[] = {
+  NOTE(72, SpeakerWaveformTriangle, 250),  // C5
+  NOTE(0,  SpeakerWaveformTriangle, 50),
+  NOTE(76, SpeakerWaveformTriangle, 250),  // E5
+  NOTE(0,  SpeakerWaveformTriangle, 50),
+  NOTE(79, SpeakerWaveformTriangle, 250),  // G5
+  NOTE(0,  SpeakerWaveformTriangle, 50),
+  NOTE(84, SpeakerWaveformTriangle, 500),  // C6
+};
+
+#undef NOTE
+
+static const struct {
+  const SpeakerNote *notes;
+  uint32_t count;
+  const char *name;
+} s_tones[ALARM_TONE_COUNT] = {
+  [AlarmTone_Reveille] = { s_reveille, sizeof(s_reveille) / sizeof(s_reveille[0]),
+                           i18n_noop("Reveille") },
+  [AlarmTone_Beacon]   = { s_beacon,   sizeof(s_beacon)   / sizeof(s_beacon[0]),
+                           i18n_noop("Beacon") },
+  [AlarmTone_Bell]     = { s_bell,     sizeof(s_bell)     / sizeof(s_bell[0]),
+                           i18n_noop("Bell") },
+  [AlarmTone_Chime]    = { s_chime,    sizeof(s_chime)    / sizeof(s_chime[0]),
+                           i18n_noop("Chime") },
+};
+
+_Static_assert(AlarmTone_Chime + 1 == ALARM_TONE_COUNT,
+               "alarm_tones table must cover every AlarmTone enum value");
+
+void alarm_tones_get(AlarmTone tone, const SpeakerNote **notes_out, uint32_t *count_out) {
+  if ((unsigned)tone >= ALARM_TONE_COUNT) {
+    tone = AlarmTone_Reveille;
+  }
+  *notes_out = s_tones[tone].notes;
+  *count_out = s_tones[tone].count;
+}
+
+const char *alarm_tones_get_name(AlarmTone tone) {
+  if ((unsigned)tone >= ALARM_TONE_COUNT) {
+    tone = AlarmTone_Reveille;
+  }
+  return s_tones[tone].name;
+}

--- a/src/fw/services/alarms/alarm_tones.h
+++ b/src/fw/services/alarms/alarm_tones.h
@@ -1,0 +1,18 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include "pbl/services/alarms/alarm.h"
+#include "pbl/services/speaker/note_sequence.h"
+
+//! Look up the SpeakerNote sequence for a given alarm tone.
+//! @param tone The tone to look up.
+//! @param notes_out Receives a pointer to the static note array.
+//! @param count_out Receives the number of notes in the array.
+//! Falls back to AlarmTone_Reveille for out-of-range values.
+void alarm_tones_get(AlarmTone tone, const SpeakerNote **notes_out, uint32_t *count_out);
+
+//! Get the i18n_noop()'d display name for a tone. Caller wraps with i18n_get() at display time.
+//! Falls back to the Reveille name for out-of-range values.
+const char *alarm_tones_get_name(AlarmTone tone);

--- a/src/fw/services/alarms/wscript_build
+++ b/src/fw/services/alarms/wscript_build
@@ -4,6 +4,7 @@
 sources = [
     'alarm.c',
     'alarm_pin.c',
+    'alarm_tones.c',
 ]
 
 bld.stlib(


### PR DESCRIPTION
This PR adds audio playback to alarms on speaker-capable hardware (Pebble 2 Duo, Pebble Time 2). Each alarm has independent sound and vibration toggles plus a selectable tone (Reveille, Beacon, Bell, Chime). Off by default for existing alarms; new alarms on speaker hardware default to sound + vibration on.

Changes:

- Add `sound_enabled`, `vibrate_enabled`, `tone` fields to `AlarmConfig`, bit-packed into the existing `is_smart` union no struct size change. Negative-logic `vibrate_disabled` bit chosen so legacy data (all bits 0) loads as vibrate-on, sound-off, preserving current behavior on upgrade.
- Add `alarm_tones` library (`src/fw/services/alarms/alarm_tones.c`) with 4 in-code `SpeakerNote[]` arrays. No resource files needed.
- Wire `speaker_service_play_note_seq` into `alarm_popup.c` at `SpeakerPriorityCritical`, looping via the speaker finish event until dismiss/snooze/timeout. Skipped in low-power mode.
- Extend `alarm_detail.c` with a Sound submenu (Off + 4 tones) and a Vibration toggle, mirroring the existing snooze-delay pattern.
- Add `alarm_id` to `PebbleAlarmClockEvent` so the popup can look up the firing alarm's settings.
- All speaker-side code gated on `CAPABILITY_HAS_SPEAKER`; non-speaker boards are unaffected.

Resolves #1206