### PR TITLE
flake.nix: pin make SHELL to /bin/sh on Darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -110,6 +110,14 @@
                   exit 1
                 fi
                 echo "✓ Apple CLT found: $(/usr/bin/clang --version | head -1)"
+
+                # Moddable's mac/tools.mk generates launcher scripts via
+                # `echo '...\n...'` and depends on `\n` being expanded. macOS
+                # /bin/sh (bash 3.2, XSI-compliant in POSIX mode) does this,
+                # but Nix's bash 5.x — picked up as `sh` via PATH — does not,
+                # producing scripts with a malformed shebang. Pin make's SHELL
+                # to /bin/sh so the recipe runs under the expected shell.
+                export MAKEFLAGS="SHELL=/bin/sh"
               ''}
               # Disable pyenv to avoid conflicts
               export PYENV_VERSION=system


### PR DESCRIPTION
## Summary

- On macOS inside the Nix devshell, `./waf configure` fails with `Failed to build Moddable tools` because Moddable's `build/makefiles/mac/tools.mk` writes launcher scripts via `echo '#!/bin/bash\n…'` and depends on the shell's `echo` builtin expanding `\n` into a real newline.
- macOS `/bin/sh` (bash 3.2, XSI-compliant in POSIX mode) does this; Nix's bash 5.x — which `make` resolves first as `sh` through `PATH` — does not. The generated `mcconfig`/`mcrun`/etc. end up as a single line with a malformed shebang, so subsequent `mcconfig` invocations fail.
- Export `MAKEFLAGS=SHELL=/bin/sh` from the Darwin branch of the devshell's `shellHook`. `make` reads `SHELL=` out of `MAKEFLAGS` like a command-line arg, which overrides the PATH-resolved default — so recipes always run under macOS bash 3.2 regardless of devshell PATH ordering. Linux is unaffected (`lin/tools.mk` already uses `printf`).

## Test plan

- [x] Re-enter devshell, `rm -rf third_party/moddable/moddable/build/bin/mac third_party/moddable/moddable/build/tmp/mac`, then `./waf configure --board qemu_emery` — completes successfully.
- [x] `od -c third_party/moddable/moddable/build/bin/mac/release/mcconfig` shows a real `\n` after `#!/bin/bash`, not literal `\` `n`.
- [ ] Linux devshell still configures cleanly (no behavior change there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)