### PR TITLE
fw/comm/bluetooth: count BLE disconnect reasons

### DIFF
--- a/include/pbl/services/analytics/analytics.def
+++ b/include/pbl/services/analytics/analytics.def
@@ -90,6 +90,13 @@ PBL_ANALYTICS_METRIC_DEFINE_TIMER(ble_adv_long_intvl_time_ms)
 PBL_ANALYTICS_METRIC_DEFINE_TIMER(ble_conn_itvl_min_time_ms)
 PBL_ANALYTICS_METRIC_DEFINE_TIMER(ble_conn_itvl_mid_time_ms)
 PBL_ANALYTICS_METRIC_DEFINE_TIMER(ble_conn_itvl_max_time_ms)
+// BLE disconnect reason counters (HCI status code, see nimble/ble.h:ble_error_codes)
+PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(ble_disconnect_conn_spvn_tmo_count)       // 0x08
+PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(ble_disconnect_rem_user_term_count)       // 0x13
+PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(ble_disconnect_conn_term_local_count)     // 0x16
+PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(ble_disconnect_lmp_ll_rsp_tmo_count)      // 0x22
+PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(ble_disconnect_conn_establishment_count)  // 0x3e
+PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(ble_disconnect_other_count)
 
 // Settings
 PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(settings_health_tracking_enabled)

--- a/src/fw/comm/bluetooth_analytics.c
+++ b/src/fw/comm/bluetooth_analytics.c
@@ -65,6 +65,29 @@ void bluetooth_analytics_handle_connection_disconnection_event(
     last_reset_counter_ticks = rtc_get_ticks();
   }
 
+  // Per-reason counters — see nimble/ble.h ble_error_codes. The NimBLE BLE_HS_HCI_ERR
+  // (0x200) prefix is dropped by the uint8_t narrowing, so the raw HCI status remains.
+  switch (reason) {
+    case 0x08:  // BLE_ERR_CONN_SPVN_TMO
+      PBL_ANALYTICS_ADD(ble_disconnect_conn_spvn_tmo_count, 1);
+      break;
+    case 0x13:  // BLE_ERR_REM_USER_CONN_TERM
+      PBL_ANALYTICS_ADD(ble_disconnect_rem_user_term_count, 1);
+      break;
+    case 0x16:  // BLE_ERR_CONN_TERM_LOCAL
+      PBL_ANALYTICS_ADD(ble_disconnect_conn_term_local_count, 1);
+      break;
+    case 0x22:  // BLE_ERR_LMP_LL_RSP_TMO
+      PBL_ANALYTICS_ADD(ble_disconnect_lmp_ll_rsp_tmo_count, 1);
+      break;
+    case 0x3e:  // BLE_ERR_CONN_ESTABLISHMENT
+      PBL_ANALYTICS_ADD(ble_disconnect_conn_establishment_count, 1);
+      break;
+    default:
+      PBL_ANALYTICS_ADD(ble_disconnect_other_count, 1);
+      break;
+  }
+
   if (num_events_logged > 100) { // don't log a ridiculous amount of tightly looped disconnects
     return;
   }


### PR DESCRIPTION
Add per-reason counters for the most common HCI disconnect status codes seen across recent obelix/getafix logs (supervision timeout, remote/local user terminated, LMP/LL response timeout, connection failed to establish), plus an "other" bucket for anything else.

Counters are incremented in the existing disconnect handler and flow through the analytics.def pipeline to Memfault automatically.