### PR TITLE
fw/services/activity: gate sleep tracking on HRM off-wrist

### DIFF
--- a/include/pbl/services/activity/activity_private.h
+++ b/include/pbl/services/activity/activity_private.h
@@ -67,6 +67,13 @@ typedef uint16_t ActivityScalarStore;
 #define ACTIVITY_HRM_SUBSCRIPTION_ON_PERIOD_SEC  (1)
 #define ACTIVITY_HRM_SUBSCRIPTION_OFF_PERIOD_SEC (SECONDS_PER_DAY)
 
+// After this many seconds without an HRM event, the cached worn-status is considered stale and
+// the sleep algorithm falls back to its accel-based not-worn heuristics. Sized to comfortably
+// cover the default HRMonitoringInterval_10Min cycle (~11 min) — at the longer 30/60-min
+// intervals the cache will simply expire between bursts and sleep detection won't lean on a
+// stale on-wrist reading.
+#define ACTIVITY_HRM_OFFWRIST_STALE_SEC (15 * SECONDS_PER_MINUTE)
+
 // Max number of stored HR samples to compute the median
 #define ACTIVITY_MAX_HR_SAMPLES (3 * SECONDS_PER_MINUTE)
 
@@ -308,6 +315,11 @@ typedef struct {
   uint16_t num_excellent_samples;     // number of samples in the past minute with excellent quality
   uint8_t  samples[ACTIVITY_MAX_HR_SAMPLES]; // HR Samples stored
   uint8_t  weights[ACTIVITY_MAX_HR_SAMPLES]; // HR Sample Weights
+
+  // Worn status from the most recent HRM BPM event. last_quality_event_utc is 0 if we've never
+  // received one. Used by sleep tracking to suppress detection while the watch is off-wrist.
+  time_t last_quality_event_utc;
+  bool last_quality_was_offwrist;
 } ActivityHRSupport;
 
 typedef struct {
@@ -505,6 +517,16 @@ void activity_metrics_prv_reset_hr_stats(void);
 //! the value returned by activity_metrics_prv_get_median_hr_bpm().
 void activity_metrics_prv_add_median_hr_sample(PebbleHRMEvent *hrm_event, time_t now_utc,
                                                time_t now_uptime);
+
+//! Record the worn status reported by the HRM. Called once per BPM event.
+//! @param[in] now_utc current UTC time
+//! @param[in] is_offwrist true if the event's HRMQuality was HRMQuality_OffWrist
+void activity_metrics_prv_set_hrm_worn_status(time_t now_utc, bool is_offwrist);
+
+//! Returns true if the HRM has recently reported the watch is off-wrist. The most recent BPM
+//! event must have been HRMQuality_OffWrist and must have arrived within the last
+//! ACTIVITY_HRM_OFFWRIST_STALE_SEC seconds, otherwise this returns false.
+bool activity_metrics_prv_is_hrm_offwrist(time_t now_utc);
 
 //! Returns the number of steps the user has taken so far today (since midnight)
 uint32_t activity_metrics_prv_get_steps(void);

--- a/include/pbl/services/activity/kraepelin/kraepelin_algorithm.h
+++ b/include/pbl/services/activity/kraepelin/kraepelin_algorithm.h
@@ -125,7 +125,10 @@ uint32_t kalg_analyze_finish_epoch(KAlgState *state);
 // @param[in] steps number of steps taken in the last minute
 // @param[in] vmc VMC for the last minute
 // @param[in] orientation average orientation for the last minute
-// @param[in] plugged_in true if watch is plugged into charger
+// @param[in] definitely_not_worn true if the watch is definitely not being worn this minute
+//                       (caller passes "plugged into charger" OR'd with any other definite
+//                       not-worn hints such as a recent HRM off-wrist reading). Treated as a
+//                       hard "not worn" signal for sleep detection.
 // @param[in] resting_calories number of resting calories burned in the last minute
 // @param[in] active_calories number of active calories burned in the last minute
 // @param[in] distance_mm distance covered in millimeters in the last minute
@@ -133,7 +136,8 @@ uint32_t kalg_analyze_finish_epoch(KAlgState *state);
 //            session that it finds.
 // @param[in] context passed to the sessions_cb
 void kalg_activities_update(KAlgState *state, time_t utc_now, uint16_t steps, uint16_t vmc,
-                            uint8_t orientation, bool plugged_in, uint32_t resting_calories,
+                            uint8_t orientation, bool definitely_not_worn,
+                            uint32_t resting_calories,
                             uint32_t active_calories, uint32_t distance_mm, bool shutting_down,
                             KAlgActivitySessionCallback sessions_cb, void *context);
 

--- a/src/fw/services/activity/activity.c
+++ b/src/fw/services/activity/activity.c
@@ -179,9 +179,15 @@ T_STATIC void prv_hrm_subscription_cb(PebbleHRMEvent *hrm_event, void *context) 
     }
 
     uint32_t now_uptime_ts = time_get_uptime_seconds();
+    time_t now_utc = rtc_get_time();
+
+    // Cache the worn-status from this event so sleep tracking can use it as a strong off-wrist
+    // signal (PPG off-wrist detection is far more reliable than the accel-only heuristics).
+    activity_metrics_prv_set_hrm_worn_status(
+        now_utc, hrm_event->bpm.quality == HRMQuality_OffWrist);
+
     if (valid_hr_reading) {
       // Update the heart rate metrics
-      time_t now_utc = rtc_get_time();
       activity_metrics_prv_add_median_hr_sample(hrm_event, now_utc, now_uptime_ts);
 
       // Log it to the mobile

--- a/src/fw/services/activity/activity_metrics.c
+++ b/src/fw/services/activity/activity_metrics.c
@@ -583,6 +583,33 @@ void activity_metrics_prv_reset_hr_stats(void) {
 }
 
 // --------------------------------------------------------------------------------------------
+void activity_metrics_prv_set_hrm_worn_status(time_t now_utc, bool is_offwrist) {
+  ActivityState *state = activity_private_state();
+  mutex_lock_recursive(state->mutex);
+  {
+    state->hr.last_quality_event_utc = now_utc;
+    state->hr.last_quality_was_offwrist = is_offwrist;
+  }
+  mutex_unlock_recursive(state->mutex);
+}
+
+// --------------------------------------------------------------------------------------------
+bool activity_metrics_prv_is_hrm_offwrist(time_t now_utc) {
+  ActivityState *state = activity_private_state();
+  bool offwrist = false;
+  mutex_lock_recursive(state->mutex);
+  {
+    if (state->hr.last_quality_event_utc != 0 &&
+        state->hr.last_quality_was_offwrist &&
+        (now_utc - state->hr.last_quality_event_utc) <= ACTIVITY_HRM_OFFWRIST_STALE_SEC) {
+      offwrist = true;
+    }
+  }
+  mutex_unlock_recursive(state->mutex);
+  return offwrist;
+}
+
+// --------------------------------------------------------------------------------------------
 void activity_metrics_prv_add_median_hr_sample(PebbleHRMEvent *hrm_event, time_t now_utc,
                                                time_t now_uptime) {
   ActivityState *state = activity_private_state();

--- a/src/fw/services/activity/kraepelin/activity_algorithm_kraepelin.c
+++ b/src/fw/services/activity/kraepelin/activity_algorithm_kraepelin.c
@@ -970,14 +970,22 @@ static void prv_activity_update_states(time_t utc_sec, AlgMinuteRecord *record_o
 
   prv_reset_state_minute_handler(m_rec);
 
+  // Treat a recent HRM off-wrist reading as a definite not-worn signal for sleep tracking.
+  // The PPG-based off-wrist detection is far more reliable than the accel-only heuristic in
+  // kraepelin, which can take 30+ minutes to fire and is easily defeated by ambient vibration
+  // (see FIRM-1901, FIRM-1804, FIRM-1533). plugged_in keeps its original "charging" meaning
+  // in the logged record.
+  const bool hrm_offwrist = activity_metrics_prv_is_hrm_offwrist(utc_sec);
+  const bool not_worn = m_rec->base.plugged_in || hrm_offwrist;
+
   ACTIVITY_LOG_DEBUG("minute handler: steps: %"PRIu8", orientation: 0x%"PRIx8", vmc: %"PRIu16", "
-                     "light: %"PRIu8", plugged_in: %d",
+                     "light: %"PRIu8", plugged_in: %d, hrm_offwrist: %d",
                      m_rec->base.steps, m_rec->base.orientation, m_rec->base.vmc,
-                     m_rec->base.light, (int) m_rec->base.plugged_in);
+                     m_rec->base.light, (int) m_rec->base.plugged_in, (int) hrm_offwrist);
 
   // Pass the minute data onto the activity detection logic
   kalg_activities_update(s_alg_state->k_state, utc_sec, m_rec->base.steps, m_rec->base.vmc,
-                         m_rec->base.orientation, m_rec->base.plugged_in, m_rec->resting_calories,
+                         m_rec->base.orientation, not_worn, m_rec->resting_calories,
                          m_rec->active_calories, minute_distance_mm, shutting_down,
                          prv_create_activity_session_cb, NULL);
 }

--- a/src/fw/services/activity/kraepelin/kraepelin_algorithm.c
+++ b/src/fw/services/activity/kraepelin/kraepelin_algorithm.c
@@ -126,7 +126,7 @@ typedef struct {
 typedef struct {
   uint16_t vmc;
   uint8_t orientation;
-  bool plugged_in;
+  bool definitely_not_worn;
 } KAlgSleepMinute;
 
 // State information for sleep detection
@@ -1378,7 +1378,7 @@ uint32_t kalg_analyze_finish_epoch(KAlgState *state) {
 // Update the not-worn detection state machine. This state machine gets called on every minute
 // update. It returns true if it determines the watch was not worn
 static bool prv_not_worn_update(KAlgState *alg_state, time_t utc_now, uint16_t vmc,
-                                uint8_t orientation, bool plugged_in) {
+                                uint8_t orientation, bool definitely_not_worn) {
   // Handy access to some variables
   const KAlgNotWornParams *params = &KALG_NOT_WORN_PARAMS;
   KAlgNotWornState *state = &alg_state->not_worn_state;
@@ -1401,7 +1401,7 @@ static bool prv_not_worn_update(KAlgState *alg_state, time_t utc_now, uint16_t v
   }
 
   // Look for specific VMC values here that indicate definite worn or not-worn status
-  bool definite_not_worn = plugged_in;
+  bool definite_not_worn = definitely_not_worn;
 
   // Update stats
   if (maybe_not_worn || definite_not_worn) {
@@ -1659,7 +1659,7 @@ static void prv_deep_sleep_update(KAlgState *alg_state, time_t sample_time, uint
 // called at the beginning of prv_sleep_activity_update().
 // @return true if we have enough data to compute the score for this minute
 static bool prv_sleep_activity_update_stats(KAlgState *alg_state, time_t utc_now, uint16_t vmc,
-                                            uint8_t orientation, bool plugged_in,
+                                            uint8_t orientation, bool definitely_not_worn,
                                             uint32_t *score_ret, time_t *sample_utc_ret,
                                             bool *is_sleep_minute_ret) {
   // Handy access to some variables
@@ -1676,11 +1676,11 @@ static bool prv_sleep_activity_update_stats(KAlgState *alg_state, time_t utc_now
   state->minute_history[state->num_history_entries++] = (KAlgSleepMinute) {
     .vmc = vmc,
     .orientation = orientation,
-    .plugged_in = plugged_in,
+    .definitely_not_worn = definitely_not_worn,
   };
 
   // Get the not-worn status
-  bool not_worn = prv_not_worn_update(alg_state, utc_now, vmc, orientation, plugged_in);
+  bool not_worn = prv_not_worn_update(alg_state, utc_now, vmc, orientation, definitely_not_worn);
 
   // We have to have at least a filter's worth of data
   if (state->num_history_entries < history_capacity) {
@@ -1829,7 +1829,8 @@ static void prv_sleep_activity_update_session_state(
 // ------------------------------------------------------------------------------------------
 // Process the minute data for sleep detection
 static void prv_sleep_activity_update(KAlgState *alg_state, time_t utc_now, uint16_t vmc,
-                                      uint8_t orientation, bool plugged_in, bool shutting_down,
+                                      uint8_t orientation, bool definitely_not_worn,
+                                      bool shutting_down,
                                       KAlgActivitySessionCallback sessions_cb, void *context) {
   // Handy access to some variables
   const KAlgSleepParams *params = &KALG_SLEEP_PARAMS;
@@ -1845,8 +1846,9 @@ static void prv_sleep_activity_update(KAlgState *alg_state, time_t utc_now, uint
     // because the sleep algorithm can only be run when we accumulated enough minutes. We
     // essentially run it with old data, but with the added constraint that we are shutting down.
     sample_utc = alg_state->sleep_state.last_sample_utc;
-  } else if (!prv_sleep_activity_update_stats(alg_state, utc_now, vmc, orientation, plugged_in,
-                                              &score, &sample_utc, &is_sleep_minute)) {
+  } else if (!prv_sleep_activity_update_stats(alg_state, utc_now, vmc, orientation,
+                                              definitely_not_worn, &score, &sample_utc,
+                                              &is_sleep_minute)) {
     return;
   }
 
@@ -2082,7 +2084,8 @@ static void prv_step_activity_update(KAlgState *alg_state, KAlgStepActivityState
 // Feed new minute data into the activity detection state machine. This logic looks for non-sleep
 // activities, like walks, runs, etc.
 void kalg_activities_update(KAlgState *state, time_t utc_now, uint16_t steps, uint16_t vmc,
-                            uint8_t orientation, bool plugged_in, uint32_t resting_calories,
+                            uint8_t orientation, bool definitely_not_worn,
+                            uint32_t resting_calories,
                             uint32_t active_calories, uint32_t distance_mm, bool shutting_down,
                             KAlgActivitySessionCallback sessions_cb, void *context) {
   // If we've encountered a significant change in UTC time (connecting to a new phone, factory
@@ -2107,8 +2110,8 @@ void kalg_activities_update(KAlgState *state, time_t utc_now, uint16_t steps, ui
                              KAlgActivityType_Run);
 
     // Pass onto the sleep detector
-    prv_sleep_activity_update(state, utc_now, vmc, orientation, plugged_in, shutting_down,
-                              sessions_cb, context);
+    prv_sleep_activity_update(state, utc_now, vmc, orientation, definitely_not_worn,
+                              shutting_down, sessions_cb, context);
   }
 }
 

--- a/tests/fw/services/activity/test_activity_algorithm_kraepelin.c
+++ b/tests/fw/services/activity/test_activity_algorithm_kraepelin.c
@@ -233,6 +233,13 @@ void activity_metrics_prv_reset_hr_stats(void) {
   s_activity_next_heart_rate_zone = 0;
 }
 
+void activity_metrics_prv_set_hrm_worn_status(time_t now_utc, bool is_offwrist) {
+}
+
+bool activity_metrics_prv_is_hrm_offwrist(time_t now_utc) {
+  return false;
+}
+
 
 // =============================================================================================
 // Algorithm stubs
@@ -260,7 +267,8 @@ void kalg_set_weight(KAlgState *state, uint32_t grams) {
 }
 
 void kalg_activities_update(KAlgState *state, time_t utc_now, uint16_t steps, uint16_t vmc,
-                            uint8_t orientation, bool plugged_in, uint32_t resting_calories,
+                            uint8_t orientation, bool definitely_not_worn,
+                            uint32_t resting_calories,
                             uint32_t active_calories, uint32_t distance_mm, bool shutting_down,
                             KAlgActivitySessionCallback sessions_cb, void *context) {
 }

--- a/tests/fw/services/activity/test_kraepelin_algorithm.c
+++ b/tests/fw/services/activity/test_kraepelin_algorithm.c
@@ -1766,7 +1766,7 @@ void test_kraepelin_algorithm__activity_tests(void) {
     for (int i = 0; i < entry->num_samples; i++) {
       const bool shutting_down = (entry->force_shut_down_at == i);
       kalg_activities_update(s_kalg_state, now, entry->samples[i].v5_fields.steps, 0 /*vmc*/,
-                             0 /*orientation*/, false /*plugged_in*/, 0 /*rest_cals*/,
+                             0 /*orientation*/, false /*definitely_not_worn*/, 0 /*rest_cals*/,
                              0 /*active_cals*/, 0 /*distance*/, shutting_down,
                              prv_activity_session_callback, NULL);
       if (shutting_down) {
@@ -1995,7 +1995,7 @@ static void prv_feed_activity_minutes(KAlgTestActivityMinute *samples, int sampl
     // NOTE: We feed in a significant VMC to simulate activity so that the sleep algorithm
     // doesn't think we're sleeping
     kalg_activities_update(s_kalg_state, now, samples[i].steps, 7000 /*vmc*/, 0 /*orientation*/,
-                           true /*plugged_in*/, samples[i].resting_calories,
+                           true /*definitely_not_worn*/, samples[i].resting_calories,
                            samples[i].active_calories, samples[i].distance_mm, false /* shutting_down */,
                            prv_activity_session_callback, NULL);
     now += SECONDS_PER_MINUTE;


### PR DESCRIPTION
The kraepelin sleep detector already treats charging as a definite not-worn signal, but its accel-only off-wrist heuristic takes 30+ minutes to fire and is easily defeated by ambient vibration. Users report multi-hour false sleep sessions when the watch sits on a desk.

Cache the worn-status from each HRM BPM event in the activity service and OR a recent HRMQuality_OffWrist reading into the not-worn signal passed to kalg_activities_update. The logged AlgMinuteDLSSample.plugged_in field keeps its original "is charging" meaning; only kraepelin's internal definite-not-worn decision sees the combined signal.

The cached reading goes stale after 15 minutes, which comfortably covers the default HRMonitoringInterval_10Min (~11-min) cycle. At the 30/60-min intervals the cache will expire between bursts and sleep detection falls back to the existing accel heuristic, rather than leaning on a possibly-stale on-wrist reading.

Fixes FIRM-1901