### PR TITLE
third_party/nimble/transport/hci_sf32lb52: handle ACL pool exhaustion

### DIFF
--- a/src/fw/comm/ble/gatt_client_subscriptions.c
+++ b/src/fw/comm/ble/gatt_client_subscriptions.c
@@ -29,10 +29,6 @@
 #include "FreeRTOS.h"
 #include "semphr.h"
 
-//! Time to wait/block for when the buffer is full and needs to be drained by the client.
-//! Note that bt_lock() is held while waiting, so this has to be rather small.
-#define GATT_CLIENT_SUBSCRIPTIONS_WRITE_TIMEOUT_MS (100)
-
 // TODO:
 // - Intercept "manual" CCCD writes from the app, error for now? or translate to
 //   ble_client_subscribe calls?
@@ -229,7 +225,7 @@ void gatt_client_subscriptions_handle_server_notification(GAPLEConnection *conne
 
     // If we do not hold the bt_lock() at this point it's safe to block for a little bit waiting
     // for notifications to be consumed
-    uint32_t write_timeout = bt_lock_is_held() ? 0 : GATT_CLIENT_SUBSCRIPTIONS_WRITE_TIMEOUT_MS;
+    uint32_t write_timeout = bt_lock_is_held() ? 0 : CONFIG_BLE_GATT_NOTIF_WRITE_TIMEOUT_MS;
     bool consumed = prv_wait_until_write_space_available(buffer, (sizeof(header) + length),
                                                          write_timeout);
 

--- a/src/fw/comm/ble/gatt_client_subscriptions.h
+++ b/src/fw/comm/ble/gatt_client_subscriptions.h
@@ -14,7 +14,8 @@ struct GAPLEConnection;
 
 #define MAX_ATT_WRITE_PAYLOAD_SIZE (ATT_MAX_SUPPORTED_MTU - 3)
 #define GATT_CLIENT_SUBSCRIPTIONS_BUFFER_SIZE \
-  ((MAX_ATT_WRITE_PAYLOAD_SIZE + sizeof(GATTBufferedNotificationHeader)) * 4)
+  ((MAX_ATT_WRITE_PAYLOAD_SIZE + sizeof(GATTBufferedNotificationHeader)) * \
+   CONFIG_BLE_GATT_SUBSCRIPTION_DEPTH)
 
 //! Data structure representing a subscription of a specific client for
 //! noticications or indications of a GATT characteristic for a specific

--- a/src/fw/services/bluetooth/Kconfig
+++ b/src/fw/services/bluetooth/Kconfig
@@ -5,3 +5,20 @@ config SERVICE_BLUETOOTH
     bool "Bluetooth"
     help
       Core Bluetooth service (pairing, bonding, local id, ...).
+
+config BLE_GATT_NOTIF_WRITE_TIMEOUT_MS
+    int "GATT notification handoff timeout (ms)"
+    default 5 if SOC_SF32LB52
+    default 100
+    help
+      Max time the BT host task blocks for the client to drain the per-client
+      GATT subscription buffer before dropping a notification. Must stay below
+      the HCI transport's tolerance for a stalled host.
+
+config BLE_GATT_SUBSCRIPTION_DEPTH
+    int "GATT subscription buffer depth (notifications)"
+    default 8 if SOC_SF32LB52
+    default 4
+    help
+      Per-client GATT subscription buffer depth, in max-size notifications.
+      Deeper absorbs notification bursts (fewer drops) at the cost of RAM.

--- a/tests/fw/comm/wscript
+++ b/tests/fw/comm/wscript
@@ -80,7 +80,9 @@ def build(bld):
                            "tests/fakes/fake_GATTAPI_test_vectors.c "
                            "tests/fakes/fake_queue.c "
                            "tests/fakes/fake_rtc.c ",
-        test_sources_ant_glob = "test_gatt_client_subscriptions.c")
+        test_sources_ant_glob = "test_gatt_client_subscriptions.c",
+        defines=['CONFIG_BLE_GATT_NOTIF_WRITE_TIMEOUT_MS=100',
+                 'CONFIG_BLE_GATT_SUBSCRIPTION_DEPTH=4'])
 
     clar(bld,
         sources_ant_glob = "src/fw/util/rand/rand.c "

--- a/third_party/nimble/transport/hci_sf32lb52.c
+++ b/third_party/nimble/transport/hci_sf32lb52.c
@@ -42,16 +42,43 @@
 
 static TaskHandle_t s_hci_task_handle;
 static SemaphoreHandle_t s_ipc_data_ready;
+/* Given by prv_acl_put_signal() whenever an LL-direction ACL mbuf is returned
+ * to the transport pool; taken by the HCI RX task when an alloc fails so we
+ * unblock as soon as the host has freed something instead of polling.
+ */
+static SemaphoreHandle_t s_acl_pool_avail;
 static struct hci_h4_sm s_hci_h4sm;
 static ipc_queue_handle_t s_ipc_port;
 
 static struct os_mbuf *prv_alloc_acl_from_ll(void) {
   struct os_mbuf *om = ble_transport_alloc_acl_from_ll();
-  if (!om) {
-    PBL_LOG_ERR("ACL alloc failed");
+  if (om != NULL) {
+    return om;
   }
 
+  /* ACL pool exhausted. Block instead of returning NULL (which the H4 state
+   * machine would treat as a fatal, unrecoverable framing error). While we
+   * wait we stop draining the LCPU->HCPU IPC ring; it fills and backpressures
+   * the controller, i.e. transport-level flow control. prv_acl_put_signal()
+   * wakes us when the host returns a buffer to the pool; the timeout guards
+   * the give-before-wait race and the fact that the from_hs TX path shares
+   * mpool_acl, so a freed buffer may be taken before we retry.
+   */
+  PBL_LOG_D_DBG(LOG_DOMAIN_BT_STACK, "ACL pool empty, waiting for buffer");
+  do {
+    (void)xSemaphoreTake(s_acl_pool_avail, pdMS_TO_TICKS(100));
+    om = ble_transport_alloc_acl_from_ll();
+  } while (om == NULL);
+
   return om;
+}
+
+static os_error_t prv_acl_put_signal(struct os_mempool_ext *mpe, void *data, void *arg) {
+  os_error_t err = os_memblock_put_from_cb(&mpe->mpe_mp, data);
+  if (s_acl_pool_avail != NULL) {
+    (void)xSemaphoreGive(s_acl_pool_avail);
+  }
+  return err;
 }
 
 static void *prv_alloc_evt(int discardable) {
@@ -252,9 +279,13 @@ static void prv_hci_task_main(void *unused) {
         while (len > 0U) {
           int consumed_bytes;
 
+          /* prv_alloc_acl_from_ll() blocks until a buffer is available, so the
+           * H4 state machine never reports an OOM on the ACL path; any
+           * non-positive return here is unexpected.
+           */
           consumed_bytes = hci_h4_sm_rx(&s_hci_h4sm, pbuf, len);
           if (consumed_bytes <= 0) {
-            PBL_LOG_D_ERR(LOG_DOMAIN_BT_STACK, "hci_h4_sm_rx rc=%d", consumed_bytes);
+            PBL_LOG_D_ERR(LOG_DOMAIN_BT_STACK, "hci_h4_sm_rx returned %d", consumed_bytes);
             break;
           }
           len -= consumed_bytes;
@@ -288,6 +319,10 @@ void ble_transport_ll_init(void) {
   ble_transport_ll_reinit();
 
   s_ipc_data_ready = xSemaphoreCreateBinary();
+  s_acl_pool_avail = xSemaphoreCreateBinary();
+  PBL_ASSERTN(s_ipc_data_ready != NULL && s_acl_pool_avail != NULL);
+
+  ble_transport_register_put_acl_from_ll_cb(prv_acl_put_signal);
 
   TaskParameters_t task_params = {
     .pvTaskCode = prv_hci_task_main,

--- a/third_party/nimble/transport/hci_sf32lb52.c
+++ b/third_party/nimble/transport/hci_sf32lb52.c
@@ -42,6 +42,11 @@
 
 static TaskHandle_t s_hci_task_handle;
 static SemaphoreHandle_t s_ipc_data_ready;
+/* Given by prv_acl_put_signal() whenever an LL-direction ACL mbuf is returned
+ * to the transport pool; taken by the HCI RX task when an alloc fails so we
+ * unblock as soon as the host has freed something instead of polling.
+ */
+static SemaphoreHandle_t s_acl_pool_avail;
 static struct hci_h4_sm s_hci_h4sm;
 static ipc_queue_handle_t s_ipc_port;
 
@@ -52,6 +57,14 @@ static struct os_mbuf *prv_alloc_acl_from_ll(void) {
   }
 
   return om;
+}
+
+static os_error_t prv_acl_put_signal(struct os_mempool_ext *mpe, void *data, void *arg) {
+  os_error_t err = os_memblock_put_from_cb(&mpe->mpe_mp, data);
+  if (s_acl_pool_avail != NULL) {
+    (void)xSemaphoreGive(s_acl_pool_avail);
+  }
+  return err;
 }
 
 static void *prv_alloc_evt(int discardable) {
@@ -253,8 +266,19 @@ static void prv_hci_task_main(void *unused) {
           int consumed_bytes;
 
           consumed_bytes = hci_h4_sm_rx(&s_hci_h4sm, pbuf, len);
-          if (consumed_bytes <= 0) {
-            PBL_LOG_D_ERR(LOG_DOMAIN_BT_STACK, "hci_h4_sm_rx rc=%d", consumed_bytes);
+          if (consumed_bytes < 0) {
+            /* Transport ACL pool is empty. Block until the host returns a
+             * buffer to the pool (prv_acl_put_signal()) before retrying
+             * the same input — ipc_queue_read is destructive so dropping
+             * bytes here would desync the H4 stream. The timeout is a
+             * safety net for the case where the freed-buffer signal was
+             * given before we got to wait on it.
+             */
+            (void)xSemaphoreTake(s_acl_pool_avail, pdMS_TO_TICKS(100));
+            continue;
+          }
+          if (consumed_bytes == 0) {
+            PBL_LOG_D_ERR(LOG_DOMAIN_BT_STACK, "hci_h4_sm_rx consumed 0 bytes");
             break;
           }
           len -= consumed_bytes;
@@ -288,6 +312,10 @@ void ble_transport_ll_init(void) {
   ble_transport_ll_reinit();
 
   s_ipc_data_ready = xSemaphoreCreateBinary();
+  s_acl_pool_avail = xSemaphoreCreateBinary();
+  PBL_ASSERTN(s_ipc_data_ready != NULL && s_acl_pool_avail != NULL);
+
+  ble_transport_register_put_acl_from_ll_cb(prv_acl_put_signal);
 
   TaskParameters_t task_params = {
     .pvTaskCode = prv_hci_task_main,


### PR DESCRIPTION
The H4 RX task allocates ACL mbufs from mpool_acl on every inbound packet and forwards them to ble_hs_rx_q. The host event loop drains the queue, but it can be parked for long stretches (e.g. blocked in gatt_client_subscriptions_handle_server_notification() waiting on a full per-client subscription buffer). While the host is parked, ACL packets keep arriving via IPC and accumulate in ble_hs_rx_q, each pinning one mbuf. With BLE_TRANSPORT_ACL_FROM_LL_COUNT = 60, sustained notification backlogs can drain the pool within ~100ms; the next alloc returns NULL and trips the assert at hci_h4.c:289.

Now that the matching submodule change lets hci_h4_sm_rx() propagate -1 instead of asserting, give the transport a clean back-off path:

  * Add s_acl_pool_avail, a binary semaphore signaled from a put callback registered on the LL-direction slot of the transport pool. The callback fires whenever an LL-tagged ACL mbuf is returned to mpool_acl, i.e. once the host has finished processing one packet and ble_l2cap_remove_rx() frees the chain.

  * In prv_hci_task_main(), when hci_h4_sm_rx() returns < 0 (pool exhausted) block on s_acl_pool_avail with a 100ms safety timeout, then retry with the same pbuf/len. The state machine has preserved partial state, so the retry resumes exactly where the failed allocation left off; this matters because ipc_queue_read() is destructive and dropping bytes would desync the H4 stream.

  * Distinguish OOM (rc < 0) from "consumed nothing" (rc == 0): the latter still logs and breaks out of the inner loop.

ble_hs_rx_q is now implicitly bounded by POOL_ACL_COUNT: every queue entry corresponds to one live mbuf, so the queue can never exceed the pool size. The pool itself acts as the back-pressure channel; once it fills, the transport blocks and BLE LE-credit flow control propagates the pressure to the controller via the IPC FIFO.

Also bump the mynewt-nimble submodule to pull in the matching hci_h4.c change that removes the two assert(rc >= 0) lines.