### PR TITLE
blob_db: shrink growable settings files on existing devices [FIRM-1893]

### DIFF
--- a/include/pbl/services/blob_db/api.h
+++ b/include/pbl/services/blob_db/api.h
@@ -110,6 +110,12 @@ typedef BlobDBDirtyItem *(*BlobDBGetDirtyListImpl)(void);
 //! \returns S_SUCCESS if the item was marked synced, an error code otherwise
 typedef status_t (*BlobDBMarkSyncedImpl)(const uint8_t *key, int key_len);
 
+//! Implements the Compact API. Reclaims unused space in the underlying
+//! settings file. Note that this function should be blocking; only blob DBs
+//! backed by a settings_file need to implement this.
+//! \returns S_SUCCESS on success, an error code otherwise
+typedef status_t (*BlobDBCompactImpl)(void);
+
 //! Emits a Blob DB event.
 //! \param type The type of event to emit
 //! \param db_id the ID of the blob DB
@@ -119,6 +125,12 @@ void blob_db_event_put(BlobDBEventType type, BlobDBId db_id, const uint8_t *key,
 
 //! Call the BlobDBInitImpl for all the databases
 void blob_db_init_dbs(void);
+
+//! Call the BlobDBCompactImpl for every database that implements one. Used to
+//! reclaim space in growable settings_file-backed databases. Must be called
+//! after blob_db_init_dbs(). Safe to call from a system task callback; do not
+//! call from the kernel main loop as compaction performs disk I/O.
+void blob_db_compact_growable_dbs(void);
 
 //! Call the BlobDBIsDirtyImpl for each database, and fill the 'ids' list
 //! with all the dirty DB ids

--- a/include/pbl/services/blob_db/app_db.h
+++ b/include/pbl/services/blob_db/app_db.h
@@ -59,5 +59,7 @@ status_t app_db_delete(const uint8_t *key, int key_len);
 
 status_t app_db_flush(void);
 
+status_t app_db_compact(void);
+
 /* TEST */
 AppInstallId app_db_check_next_unique_id(void);

--- a/include/pbl/services/blob_db/app_glance_db.h
+++ b/include/pbl/services/blob_db/app_glance_db.h
@@ -29,6 +29,11 @@ void app_glance_db_init(void);
 
 status_t app_glance_db_flush(void);
 
+//! Compact and shrink the on-disk settings file. Forces growable files that
+//! grew before the growable change landed (or under heavy load) to drop back
+//! toward the initial allocation.
+status_t app_glance_db_compact(void);
+
 status_t app_glance_db_insert(const uint8_t *key, int key_len, const uint8_t *val, int val_len);
 
 int app_glance_db_get_len(const uint8_t *key, int key_len);

--- a/include/pbl/services/blob_db/contacts_db.h
+++ b/include/pbl/services/blob_db/contacts_db.h
@@ -42,3 +42,5 @@ status_t contacts_db_read(const uint8_t *key, int key_len, uint8_t *val_out, int
 status_t contacts_db_delete(const uint8_t *key, int key_len);
 
 status_t contacts_db_flush(void);
+
+status_t contacts_db_compact(void);

--- a/include/pbl/services/blob_db/health_db.h
+++ b/include/pbl/services/blob_db/health_db.h
@@ -45,3 +45,5 @@ status_t health_db_read(const uint8_t *key, int key_len, uint8_t *val_out, int v
 status_t health_db_delete(const uint8_t *key, int key_len);
 
 status_t health_db_flush(void);
+
+status_t health_db_compact(void);

--- a/include/pbl/services/blob_db/ios_notif_pref_db.h
+++ b/include/pbl/services/blob_db/ios_notif_pref_db.h
@@ -57,6 +57,8 @@ status_t ios_notif_pref_db_delete(const uint8_t *key, int key_len);
 
 status_t ios_notif_pref_db_flush(void);
 
+status_t ios_notif_pref_db_compact(void);
+
 status_t ios_notif_pref_db_is_dirty(bool *is_dirty_out);
 
 BlobDBDirtyItem* ios_notif_pref_db_get_dirty_list(void);

--- a/include/pbl/services/blob_db/pin_db.h
+++ b/include/pbl/services/blob_db/pin_db.h
@@ -58,6 +58,8 @@ status_t pin_db_delete(const uint8_t *key, int key_len);
 
 status_t pin_db_flush(void);
 
+status_t pin_db_compact(void);
+
 status_t pin_db_is_dirty(bool *is_dirty_out);
 
 BlobDBDirtyItem* pin_db_get_dirty_list(void);

--- a/include/pbl/services/blob_db/reminder_db.h
+++ b/include/pbl/services/blob_db/reminder_db.h
@@ -73,6 +73,8 @@ status_t reminder_db_delete(const uint8_t *key, int key_len);
 
 status_t reminder_db_flush(void);
 
+status_t reminder_db_compact(void);
+
 status_t reminder_db_is_dirty(bool *is_dirty_out);
 
 BlobDBDirtyItem* reminder_db_get_dirty_list(void);

--- a/include/pbl/services/blob_db/timeline_item_storage.h
+++ b/include/pbl/services/blob_db/timeline_item_storage.h
@@ -31,6 +31,9 @@ void timeline_item_storage_init(TimelineItemStorage *storage,
 
 void timeline_item_storage_deinit(TimelineItemStorage *storage);
 
+//! Compact and shrink the underlying settings file.
+status_t timeline_item_storage_compact(TimelineItemStorage *storage);
+
 bool timeline_item_storage_exists_with_parent(TimelineItemStorage *storage, const Uuid *parent_id);
 
 status_t timeline_item_storage_flush(TimelineItemStorage *storage);

--- a/include/pbl/services/blob_db/watch_app_prefs_db.h
+++ b/include/pbl/services/blob_db/watch_app_prefs_db.h
@@ -43,3 +43,5 @@ status_t watch_app_prefs_db_read(const uint8_t *key, int key_len, uint8_t *val_o
 status_t watch_app_prefs_db_delete(const uint8_t *key, int key_len);
 
 status_t watch_app_prefs_db_flush(void);
+
+status_t watch_app_prefs_db_compact(void);

--- a/include/pbl/services/blob_db/weather_db.h
+++ b/include/pbl/services/blob_db/weather_db.h
@@ -57,6 +57,8 @@ void weather_db_init(void);
 
 status_t weather_db_flush(void);
 
+status_t weather_db_compact(void);
+
 status_t weather_db_insert(const uint8_t *key, int key_len, const uint8_t *val, int val_len);
 
 int weather_db_get_len(const uint8_t *key, int key_len);

--- a/include/pbl/services/settings/settings_file.h
+++ b/include/pbl/services/settings/settings_file.h
@@ -196,3 +196,8 @@ typedef bool (*SettingsFileRewriteFilterCallback)(void *key, size_t key_len, voi
 //! settings_file_rewrite if all you are doing is excluding specific records from the old file.
 status_t settings_file_rewrite_filtered(SettingsFile *file,
                                         SettingsFileRewriteFilterCallback filter_cb, void *context);
+
+//! Compact the file: rewrite all live records and, for growable files, drop
+//! alloc_used_space toward min_alloc_used_space. Useful for shrinking growable
+//! settings files that grew under load and have since had records removed.
+status_t settings_file_compact(SettingsFile *file);

--- a/src/fw/apps/system/settings/system.c
+++ b/src/fw/apps/system/settings/system.c
@@ -39,6 +39,8 @@
 #include "system/version.h"
 
 #include "pbl/services/activity/activity.h"
+#include "pbl/services/blob_db/api.h"
+#include "system/logging.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -71,6 +73,7 @@ enum {
 #endif
   DebuggingItemAccelShakeLogInfo,
   DebuggingItemVibeLogInfo,
+  DebuggingItemCompactSettingsDbs,
   DebuggingItem_Count,
 };
 
@@ -549,6 +552,17 @@ static void prv_power_mode_menu_push(SettingsSystemData *data) {
       true /* icons_enabled */, s_power_mode_labels, data);
 }
 
+// Compact growable settings DBs
+////////////////////////////////
+
+static void prv_compact_settings_dbs_task_cb(void *data) {
+  blob_db_compact_growable_dbs();
+}
+
+static void prv_compact_settings_dbs(void) {
+  system_task_add_callback(prv_compact_settings_dbs_task_cb, NULL);
+}
+
 // Debug options window
 ///////////////////////
 
@@ -565,6 +579,7 @@ static const char* s_debugging_titles[DebuggingItem_Count] = {
 #endif
   [DebuggingItemAccelShakeLogInfo] = i18n_noop("Shake Log Info"),
   [DebuggingItemVibeLogInfo] = i18n_noop("Vibe Log Info"),
+  [DebuggingItemCompactSettingsDbs] = i18n_noop("Compact Settings DBs"),
 };
 
 static void prv_debugging_draw_row_callback(GContext* ctx, const Layer *cell_layer,
@@ -665,6 +680,9 @@ static void prv_debugging_select_callback(MenuLayer *menu_layer,
     case DebuggingItemVibeLogInfo:
       shell_prefs_set_vibe_log_info_enabled(
           !shell_prefs_get_vibe_log_info_enabled());
+      break;
+    case DebuggingItemCompactSettingsDbs:
+      prv_compact_settings_dbs();
       break;
     default:
       WTF;

--- a/src/fw/services/blob_db/api.c
+++ b/src/fw/services/blob_db/api.c
@@ -23,6 +23,8 @@
 #include "kernel/pbl_malloc.h"
 #include "system/logging.h"
 
+#include <inttypes.h>
+
 typedef struct {
   BlobDBInitImpl init;
   BlobDBInsertImpl insert;
@@ -33,6 +35,8 @@ typedef struct {
   BlobDBIsDirtyImpl is_dirty;
   BlobDBGetDirtyListImpl get_dirty_list;
   BlobDBMarkSyncedImpl mark_synced;
+  BlobDBCompactImpl compact;
+  const char *name;
   bool disabled;
 } BlobDB;
 
@@ -47,6 +51,8 @@ static const BlobDB s_blob_dbs[NumBlobDBs] = {
     .is_dirty = pin_db_is_dirty,
     .get_dirty_list = pin_db_get_dirty_list,
     .mark_synced = pin_db_mark_synced,
+    .compact = pin_db_compact,
+    .name = "pin_db",
   },
   [BlobDBIdApps] = {
     .init = app_db_init,
@@ -55,6 +61,8 @@ static const BlobDB s_blob_dbs[NumBlobDBs] = {
     .read = app_db_read,
     .del = app_db_delete,
     .flush = app_db_flush,
+    .compact = app_db_compact,
+    .name = "app_db",
   },
   [BlobDBIdReminders] = {
     .init = reminder_db_init,
@@ -66,6 +74,8 @@ static const BlobDB s_blob_dbs[NumBlobDBs] = {
     .is_dirty = reminder_db_is_dirty,
     .get_dirty_list = reminder_db_get_dirty_list,
     .mark_synced = reminder_db_mark_synced,
+    .compact = reminder_db_compact,
+    .name = "reminder_db",
   },
   [BlobDBIdNotifs] = {
     .init = notif_db_init,
@@ -74,6 +84,7 @@ static const BlobDB s_blob_dbs[NumBlobDBs] = {
     .read = notif_db_read,
     .del = notif_db_delete,
     .flush = notif_db_flush,
+    .name = "notif_db",
   },
   [BlobDBIdWeather] = {
     .init = weather_db_init,
@@ -82,6 +93,8 @@ static const BlobDB s_blob_dbs[NumBlobDBs] = {
     .read = weather_db_read,
     .del = weather_db_delete,
     .flush = weather_db_flush,
+    .compact = weather_db_compact,
+    .name = "weather_db",
   },
   [BlobDBIdiOSNotifPref] = {
     .init = ios_notif_pref_db_init,
@@ -93,6 +106,8 @@ static const BlobDB s_blob_dbs[NumBlobDBs] = {
     .is_dirty = ios_notif_pref_db_is_dirty,
     .get_dirty_list = ios_notif_pref_db_get_dirty_list,
     .mark_synced = ios_notif_pref_db_mark_synced,
+    .compact = ios_notif_pref_db_compact,
+    .name = "ios_notif_pref_db",
   },
   [BlobDBIdPrefs] = {
     .init = prefs_db_init,
@@ -101,6 +116,7 @@ static const BlobDB s_blob_dbs[NumBlobDBs] = {
     .read = prefs_db_read,
     .del = prefs_db_delete,
     .flush = prefs_db_flush,
+    .name = "prefs_db",
   },
   [BlobDBIdContacts] = {
     .init = contacts_db_init,
@@ -109,6 +125,8 @@ static const BlobDB s_blob_dbs[NumBlobDBs] = {
     .read = contacts_db_read,
     .del = contacts_db_delete,
     .flush = contacts_db_flush,
+    .compact = contacts_db_compact,
+    .name = "contacts_db",
   },
   [BlobDBIdWatchAppPrefs] = {
     .init = watch_app_prefs_db_init,
@@ -117,6 +135,8 @@ static const BlobDB s_blob_dbs[NumBlobDBs] = {
     .read = watch_app_prefs_db_read,
     .del = watch_app_prefs_db_delete,
     .flush = watch_app_prefs_db_flush,
+    .compact = watch_app_prefs_db_compact,
+    .name = "watch_app_prefs_db",
   },
   [BlobDBIdHealth] = {
     .init = health_db_init,
@@ -125,6 +145,8 @@ static const BlobDB s_blob_dbs[NumBlobDBs] = {
     .read = health_db_read,
     .del = health_db_delete,
     .flush = health_db_flush,
+    .compact = health_db_compact,
+    .name = "health_db",
   },
   [BlobDBIdAppGlance] = {
     .init = app_glance_db_init,
@@ -133,6 +155,8 @@ static const BlobDB s_blob_dbs[NumBlobDBs] = {
     .read = app_glance_db_read,
     .del = app_glance_db_delete,
     .flush = app_glance_db_flush,
+    .compact = app_glance_db_compact,
+    .name = "app_glance_db",
   },
   [BlobDBIdSettings] = {
     .init = settings_blob_db_init,
@@ -144,6 +168,7 @@ static const BlobDB s_blob_dbs[NumBlobDBs] = {
     .is_dirty = settings_blob_db_is_dirty,
     .get_dirty_list = settings_blob_db_get_dirty_list,
     .mark_synced = settings_blob_db_mark_synced,
+    .name = "settings_blob_db",
   },
 };
 
@@ -179,6 +204,20 @@ void blob_db_init_dbs(void) {
       db->init();
     }
   }
+}
+
+void blob_db_compact_growable_dbs(void) {
+  PBL_LOG_INFO("blob_db_compact_growable_dbs: start");
+  const BlobDB *db = s_blob_dbs;
+  for (int i = 0; i < NumBlobDBs; ++i, ++db) {
+    if (!db->compact) {
+      continue;
+    }
+    const status_t rv = db->compact();
+    PBL_LOG_INFO("blob_db_compact_growable_dbs: %s -> %"PRIi32,
+                 db->name ? db->name : "?", rv);
+  }
+  PBL_LOG_INFO("blob_db_compact_growable_dbs: done");
 }
 
 void blob_db_get_dirty_dbs(uint8_t *ids, uint8_t *num_ids) {

--- a/src/fw/services/blob_db/app_db.c
+++ b/src/fw/services/blob_db/app_db.c
@@ -402,6 +402,16 @@ status_t app_db_flush(void) {
   return S_SUCCESS;
 }
 
+status_t app_db_compact(void) {
+  status_t rv = prv_lock_mutex_and_open_file();
+  if (rv != S_SUCCESS) {
+    return rv;
+  }
+  rv = settings_file_compact(&s_app_db.settings_file);
+  prv_close_file_and_unlock_mutex();
+  return rv;
+}
+
 //////////////////////
 // Test functions
 //////////////////////

--- a/src/fw/services/blob_db/app_glance_db.c
+++ b/src/fw/services/blob_db/app_glance_db.c
@@ -632,6 +632,16 @@ status_t app_glance_db_flush(void) {
   return S_SUCCESS;
 }
 
+status_t app_glance_db_compact(void) {
+  status_t rv = prv_lock_mutex_and_open_file();
+  if (rv != S_SUCCESS) {
+    return rv;
+  }
+  rv = settings_file_compact(&s_app_glance_db.settings_file);
+  prv_close_file_and_unlock_mutex();
+  return rv;
+}
+
 static status_t prv_validate_glance(const Uuid *app_uuid,
                              const SerializedAppGlanceHeader *serialized_glance, size_t *len) {
   // Change this block if we support multiple app glance versions in the future

--- a/src/fw/services/blob_db/contacts_db.c
+++ b/src/fw/services/blob_db/contacts_db.c
@@ -162,3 +162,13 @@ status_t contacts_db_flush(void) {
   mutex_unlock(s_contacts_db.mutex);
   return rv;
 }
+
+status_t contacts_db_compact(void) {
+  status_t rv = prv_lock_mutex_and_open_file();
+  if (rv != S_SUCCESS) {
+    return rv;
+  }
+  rv = settings_file_compact(&s_contacts_db.settings_file);
+  prv_close_file_and_unlock_mutex();
+  return rv;
+}

--- a/src/fw/services/blob_db/health_db.c
+++ b/src/fw/services/blob_db/health_db.c
@@ -423,3 +423,14 @@ status_t health_db_flush(void) {
   return rv;
 }
 
+status_t health_db_compact(void) {
+  SettingsFile file;
+  status_t rv = prv_file_open_and_lock(&file);
+  if (rv != S_SUCCESS) {
+    return rv;
+  }
+  rv = settings_file_compact(&file);
+  prv_file_close_and_unlock(&file);
+  return rv;
+}
+

--- a/src/fw/services/blob_db/ios_notif_pref_db.c
+++ b/src/fw/services/blob_db/ios_notif_pref_db.c
@@ -297,6 +297,17 @@ status_t ios_notif_pref_db_flush(void) {
   return rv;
 }
 
+status_t ios_notif_pref_db_compact(void) {
+  SettingsFile file;
+  status_t rv = prv_file_open_and_lock(&file);
+  if (rv != S_SUCCESS) {
+    return rv;
+  }
+  rv = settings_file_compact(&file);
+  prv_file_close_and_unlock(&file);
+  return rv;
+}
+
 status_t ios_notif_pref_db_is_dirty(bool *is_dirty_out) {
   SettingsFile file;
   status_t rv = prv_file_open_and_lock(&file);

--- a/src/fw/services/blob_db/pin_db.c
+++ b/src/fw/services/blob_db/pin_db.c
@@ -213,6 +213,10 @@ void pin_db_deinit(void) {
   timeline_item_storage_deinit(&s_pin_db_storage);
 }
 
+status_t pin_db_compact(void) {
+  return timeline_item_storage_compact(&s_pin_db_storage);
+}
+
 bool pin_db_has_entry_expired(time_t pin_end_timestamp) {
   return (pin_end_timestamp < (rtc_get_time() - PIN_DB_MAX_AGE));
 }

--- a/src/fw/services/blob_db/reminder_db.c
+++ b/src/fw/services/blob_db/reminder_db.c
@@ -226,6 +226,10 @@ void reminder_db_deinit(void) {
   timeline_item_storage_deinit(&s_storage);
 }
 
+status_t reminder_db_compact(void) {
+  return timeline_item_storage_compact(&s_storage);
+}
+
 status_t reminder_db_insert(const uint8_t *key, int key_len, const uint8_t *val, int val_len) {
   // Records inserted from the phone are synced
   const bool mark_synced = true;

--- a/src/fw/services/blob_db/timeline_item_storage.c
+++ b/src/fw/services/blob_db/timeline_item_storage.c
@@ -277,6 +277,13 @@ void timeline_item_storage_deinit(TimelineItemStorage *storage) {
   settings_file_close(&storage->file);
 }
 
+status_t timeline_item_storage_compact(TimelineItemStorage *storage) {
+  RtcTicks lock_ticks = prv_storage_lock(storage, __func__);
+  status_t rv = settings_file_compact(&storage->file);
+  prv_storage_unlock(storage, lock_ticks, __func__);
+  return rv;
+}
+
 status_t timeline_item_storage_insert(TimelineItemStorage *storage,
     const uint8_t *key, int key_len, const uint8_t *val, int val_len, bool mark_as_synced) {
   if (key_len != UUID_SIZE ||

--- a/src/fw/services/blob_db/watch_app_prefs_db.c
+++ b/src/fw/services/blob_db/watch_app_prefs_db.c
@@ -216,3 +216,13 @@ status_t watch_app_prefs_db_flush(void) {
   mutex_unlock_recursive(s_watch_app_prefs_db.mutex);
   return rv;
 }
+
+status_t watch_app_prefs_db_compact(void) {
+  status_t rv = prv_lock_mutex_and_open_file();
+  if (rv != S_SUCCESS) {
+    return rv;
+  }
+  rv = settings_file_compact(&s_watch_app_prefs_db.settings_file);
+  prv_close_file_and_unlock_mutex();
+  return rv;
+}

--- a/src/fw/services/blob_db/weather_db.c
+++ b/src/fw/services/blob_db/weather_db.c
@@ -114,6 +114,16 @@ status_t weather_db_flush(void) {
   return S_SUCCESS;
 }
 
+status_t weather_db_compact(void) {
+  status_t rv = prv_lock_mutex_and_open_file();
+  if (rv != S_SUCCESS) {
+    return rv;
+  }
+  rv = settings_file_compact(&s_weather_db.settings_file);
+  prv_close_file_and_unlock_mutex();
+  return rv;
+}
+
 status_t weather_db_insert(const uint8_t *key, int key_len, const uint8_t *val, int val_len) {
   if (!weather_service_supported_by_phone()) {
     return E_RANGE;

--- a/src/fw/services/settings/settings_file.c
+++ b/src/fw/services/settings/settings_file.c
@@ -302,7 +302,7 @@ void settings_file_set_change_callback(SettingsFileChangeCallback callback) {
   s_change_callback = callback;
 }
 
-T_STATIC status_t settings_file_compact(SettingsFile *file) {
+status_t settings_file_compact(SettingsFile *file) {
   // For growable files, drop alloc_used_space toward the floor when live data
   // is much smaller than the current allocation. Without this, a file that
   // burst to e.g. 256 KiB and then idled would hold that flash forever even

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -225,6 +225,7 @@ static uint16_t s_timeline_peek_before_time_m =
 #define PREF_KEY_COREDUMP_ON_REQUEST "coredumpOnRequest"
 #define PREF_KEY_ACCEL_SHAKE_LOG_INFO "accelShakeLogInfo"
 #define PREF_KEY_VIBE_LOG_INFO "vibeLogInfo"
+#define PREF_KEY_SETTINGS_DBS_COMPACTED_V1 "settingsDbsCompactedV1"
 #if CAPABILITY_HAS_APP_SCALING
 #define PREF_KEY_LEGACY_APP_RENDER_MODE "legacyAppRenderMode"
 #endif
@@ -232,6 +233,7 @@ static uint8_t s_power_mode = PowerMode_HighPerformance;
 static bool s_coredump_on_request_enabled = false;
 static bool s_accel_shake_log_info_enabled = false;
 static bool s_vibe_log_info_enabled = false;
+static bool s_settings_dbs_compacted_v1 = false;
 #if CAPABILITY_HAS_APP_SCALING
 static uint8_t s_legacy_app_render_mode = 1; // Default to scaled mode
 #endif
@@ -658,6 +660,11 @@ static bool prv_set_s_accel_shake_log_info_enabled(bool *enabled) {
 
 static bool prv_set_s_vibe_log_info_enabled(bool *enabled) {
   s_vibe_log_info_enabled = *enabled;
+  return true;
+}
+
+static bool prv_set_s_settings_dbs_compacted_v1(bool *done) {
+  s_settings_dbs_compacted_v1 = *done;
   return true;
 }
 
@@ -1747,6 +1754,14 @@ bool shell_prefs_get_vibe_log_info_enabled(void) {
 
 void shell_prefs_set_vibe_log_info_enabled(bool enabled) {
   prv_pref_set(PREF_KEY_VIBE_LOG_INFO, &enabled, sizeof(enabled));
+}
+
+bool shell_prefs_get_settings_dbs_compacted_v1(void) {
+  return s_settings_dbs_compacted_v1;
+}
+
+void shell_prefs_set_settings_dbs_compacted_v1(bool done) {
+  prv_pref_set(PREF_KEY_SETTINGS_DBS_COMPACTED_V1, &done, sizeof(done));
 }
 
 #if CAPABILITY_HAS_APP_SCALING

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -53,6 +53,7 @@
   PREFS_MACRO(PREF_KEY_COREDUMP_ON_REQUEST, s_coredump_on_request_enabled)
   PREFS_MACRO(PREF_KEY_ACCEL_SHAKE_LOG_INFO, s_accel_shake_log_info_enabled)
   PREFS_MACRO(PREF_KEY_VIBE_LOG_INFO, s_vibe_log_info_enabled)
+  PREFS_MACRO(PREF_KEY_SETTINGS_DBS_COMPACTED_V1, s_settings_dbs_compacted_v1)
 #if CAPABILITY_HAS_APP_SCALING
   PREFS_MACRO(PREF_KEY_LEGACY_APP_RENDER_MODE, s_legacy_app_render_mode)
 #endif

--- a/src/fw/shell/normal/shell_event_loop.c
+++ b/src/fw/shell/normal/shell_event_loop.c
@@ -19,6 +19,7 @@
 #include "process_management/app_manager.h"
 #include "process_management/process_manager.h"
 #include "pbl/services/analytics/analytics.h"
+#include "pbl/services/blob_db/api.h"
 #include "pbl/services/bluetooth/bluetooth_persistent_storage.h"
 #include "pbl/services/shared_prf_storage/shared_prf_storage.h"
 #include "pbl/services/activity/activity.h"
@@ -29,6 +30,7 @@
 #include "pbl/services/music_endpoint.h"
 #include "pbl/services/notifications/do_not_disturb.h"
 #include "pbl/services/stationary.h"
+#include "pbl/services/system_task.h"
 #include "pbl/services/timeline/event.h"
 #include "shell/normal/app_idle_timeout.h"
 #include "shell/normal/battery_ui.h"
@@ -40,8 +42,25 @@
 
 extern void shell_prefs_init(void);
 
+// Force-compact every growable settings DB on first boot after upgrade. 
+// Pre-growable-files devices keep their original full-size settings file allocation forever otherwise, 
+// which on devices with many installed apps shows up as launcher scroll lag.
+static void prv_settings_dbs_compaction_migration_cb(void *data) {
+  blob_db_compact_growable_dbs();
+  shell_prefs_set_settings_dbs_compacted_v1(true);
+}
+
+static void prv_maybe_run_settings_dbs_compaction_migration(void) {
+  if (shell_prefs_get_settings_dbs_compacted_v1()) {
+    return;
+  }
+  PBL_LOG_INFO("settings_dbs_compaction_migration: scheduling");
+  system_task_add_callback(prv_settings_dbs_compaction_migration_cb, NULL);
+}
+
 void shell_event_loop_init(void) {
   shell_prefs_init();
+  prv_maybe_run_settings_dbs_compaction_migration();
   notification_window_service_init();
   app_inbox_service_init();
   app_outbox_service_init();

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -163,6 +163,13 @@ void shell_prefs_set_accel_shake_log_info_enabled(bool enabled);
 bool shell_prefs_get_vibe_log_info_enabled(void);
 void shell_prefs_set_vibe_log_info_enabled(bool enabled);
 
+// One-time migration flag: set to true once we have force-compacted every
+// growable settings DB at boot. Devices that pre-date the growable-files
+// change still have full-size settings files and only shrink to fit after
+// this migration runs.
+bool shell_prefs_get_settings_dbs_compacted_v1(void);
+void shell_prefs_set_settings_dbs_compacted_v1(bool done);
+
 #if CAPABILITY_HAS_APP_SCALING
 // Legacy app rendering mode - whether to use bezel or scaling for legacy apps
 typedef enum LegacyAppRenderMode {

--- a/src/fw/shell/sdk/prefs.c
+++ b/src/fw/shell/sdk/prefs.c
@@ -334,3 +334,11 @@ bool shell_prefs_get_vibe_log_info_enabled(void) {
 void shell_prefs_set_vibe_log_info_enabled(bool enabled) {
   // Not used in SDK shell
 }
+
+bool shell_prefs_get_settings_dbs_compacted_v1(void) {
+  return true;
+}
+
+void shell_prefs_set_settings_dbs_compacted_v1(bool done) {
+  // Not used in SDK shell
+}

--- a/tests/fakes/fake_settings_file.c
+++ b/tests/fakes/fake_settings_file.c
@@ -108,6 +108,11 @@ status_t settings_file_open_growable(SettingsFile *file, const char *name,
   return settings_file_open(file, name, max_used_space);
 }
 
+status_t settings_file_compact(SettingsFile *file) {
+  cl_assert(s_settings_file.open);
+  return S_SUCCESS;
+}
+
 void settings_file_close(SettingsFile *file) {
   cl_assert(s_settings_file.open);
   s_settings_file.open = false;

--- a/tests/stubs/stubs_app_db.h
+++ b/tests/stubs/stubs_app_db.h
@@ -26,3 +26,7 @@ status_t app_db_delete(const uint8_t *key, int key_len) {
 status_t app_db_flush(void) {
   return S_SUCCESS;
 }
+
+status_t app_db_compact(void) {
+  return S_SUCCESS;
+}

--- a/tests/stubs/stubs_app_glance_db.h
+++ b/tests/stubs/stubs_app_glance_db.h
@@ -24,3 +24,7 @@ status_t app_glance_db_delete(const uint8_t *key, int key_len) {
 status_t app_glance_db_flush(void) {
   return S_SUCCESS;
 }
+
+status_t app_glance_db_compact(void) {
+  return S_SUCCESS;
+}

--- a/tests/stubs/stubs_contacts_db.h
+++ b/tests/stubs/stubs_contacts_db.h
@@ -36,3 +36,7 @@ status_t contacts_db_delete(const uint8_t *key, int key_len) {
 status_t contacts_db_flush(void) {
   return S_SUCCESS;
 }
+
+status_t contacts_db_compact(void) {
+  return S_SUCCESS;
+}

--- a/tests/stubs/stubs_health_db.h
+++ b/tests/stubs/stubs_health_db.h
@@ -47,3 +47,7 @@ status_t health_db_delete(const uint8_t *key, int key_len) {
 status_t health_db_flush(void) {
   return S_SUCCESS;
 }
+
+status_t health_db_compact(void) {
+  return S_SUCCESS;
+}

--- a/tests/stubs/stubs_ios_notif_pref_db.h
+++ b/tests/stubs/stubs_ios_notif_pref_db.h
@@ -58,3 +58,7 @@ BlobDBDirtyItem* ios_notif_pref_db_get_dirty_list(void) {
 status_t ios_notif_pref_db_mark_synced(const uint8_t *key, int key_len) {
   return S_SUCCESS;
 }
+
+status_t ios_notif_pref_db_compact(void) {
+  return S_SUCCESS;
+}

--- a/tests/stubs/stubs_pin_db.h
+++ b/tests/stubs/stubs_pin_db.h
@@ -78,3 +78,7 @@ status_t WEAK pin_db_mark_synced(const uint8_t *key, int key_len) {
 status_t WEAK pin_db_set_status_bits(const TimelineItemId *id, uint8_t status) {
   return S_SUCCESS;
 }
+
+status_t WEAK pin_db_compact(void) {
+  return S_SUCCESS;
+}

--- a/tests/stubs/stubs_reminder_db.h
+++ b/tests/stubs/stubs_reminder_db.h
@@ -71,3 +71,7 @@ BlobDBDirtyItem* reminder_db_get_dirty_list(void) {
 status_t reminder_db_mark_synced(const uint8_t *key, int key_len) {
   return S_SUCCESS;
 }
+
+status_t reminder_db_compact(void) {
+  return S_SUCCESS;
+}

--- a/tests/stubs/stubs_settings_file.h
+++ b/tests/stubs/stubs_settings_file.h
@@ -36,4 +36,8 @@ status_t settings_file_delete(SettingsFile *file, const void *key, size_t key_le
   return S_SUCCESS;
 }
 
+status_t settings_file_compact(SettingsFile *file) {
+  return S_SUCCESS;
+}
+
 void settings_file_close(SettingsFile *file) {}

--- a/tests/stubs/stubs_watch_app_prefs_db.h
+++ b/tests/stubs/stubs_watch_app_prefs_db.h
@@ -35,3 +35,7 @@ status_t watch_app_prefs_db_delete(const uint8_t *key, int key_len) {
 status_t watch_app_prefs_db_flush(void) {
   return S_SUCCESS;
 }
+
+status_t watch_app_prefs_db_compact(void) {
+  return S_SUCCESS;
+}

--- a/tests/stubs/stubs_weather_db.h
+++ b/tests/stubs/stubs_weather_db.h
@@ -26,3 +26,7 @@ status_t weather_db_delete(const uint8_t *key, int key_len) {
 status_t weather_db_flush(void) {
   return S_SUCCESS;
 }
+
+status_t weather_db_compact(void) {
+  return S_SUCCESS;
+}


### PR DESCRIPTION
The growable-settings-file change only shrinks newly-created files, so devices that shipped before it keep their full-size allocation indefinitely, which on devices with many installed apps shows up as launcher scroll lag. This adds *_compact() APIs on every settings-file-backed blob DB plus an aggregate blob_db_compact_growable_dbs() helper, runs it once at boot via a `settingsDbsCompactedV1` shell pref gate, and exposes a Settings -> System -> Debug -> Compact Settings DBs entry to trigger it on demand.