### PR TITLE
qemu: regenerate SPI flash image by default

### DIFF
--- a/docs/development/qemu.md
+++ b/docs/development/qemu.md
@@ -29,10 +29,10 @@ You can launch QEMU with the built image using:
 ./waf qemu
 ```
 
-The flash image is built automatically the first time. To force rebuilding it, pass `--new-flash-image`:
+The flash image is rebuilt by default on every launch. To keep the existing flash image (e.g. to preserve stored apps), pass `--keep-flash-image`:
 
 ```shell
-./waf qemu --new-flash-image
+./waf qemu --keep-flash-image
 ```
 
 ## Console

--- a/wscript
+++ b/wscript
@@ -148,8 +148,8 @@ def options(opt):
     opt.add_option('--compile_commands', action='store_true', help='Create a clang compile_commands.json')
     opt.add_option('--file', action='store', help='Specify a file to use with the flash command')
     opt.add_option('--resources', action='store_true', help='Also flash system resources alongside the firmware')
-    opt.add_option('--new-flash-image', action='store_true',
-                   help='Rebuild the QEMU SPI flash image before launching qemu')
+    opt.add_option('--keep-flash-image', action='store_true',
+                   help='Keep the existing QEMU SPI flash image instead of rebuilding it')
     opt.add_option('--tty',
         help='Selects a tty to use for serial imaging. Must be specified for all image commands')
     opt.add_option('--baudrate', action='store', type=int, help='Optional: specifies the baudrate to run the targetted uart at')
@@ -935,13 +935,13 @@ def console(ctx):
 
 
 def qemu(ctx):
-    # Make sure the micro-flash image is up to date. By default, we don't rebuild the
-    # SPI flash image in case you want to continue with the stored apps, etc. you had before.
-    # Rebuild it when --new-flash-image is passed or when the image is missing.
+    # Make sure the micro-flash image is up to date. By default, we always rebuild the
+    # SPI flash image. Pass --keep-flash-image to continue with the stored apps, etc.
+    # you had before.
     from waflib import Context, Options
     spi_flash = os.path.join(Context.out_dir, 'qemu_spi_flash.bin')
     pre_cmds = ['qemu_image_micro']
-    if ctx.options.new_flash_image or not os.path.isfile(spi_flash):
+    if not ctx.options.keep_flash_image or not os.path.isfile(spi_flash):
         pre_cmds.append('qemu_image_spi')
     Options.commands = pre_cmds + ['qemu_launch'] + Options.commands
 


### PR DESCRIPTION
## Summary
- Reverse the flash-image flag on `./waf qemu`: the SPI flash image is now rebuilt on every launch.
- Add `--keep-flash-image` for the rarer case of preserving stored apps/state across runs.
- Update `docs/development/qemu.md` to match the new default.

## Test plan
- [ ] `./waf qemu` rebuilds `qemu_spi_flash.bin` on every launch.
- [ ] `./waf qemu --keep-flash-image` reuses the existing `qemu_spi_flash.bin` when present.
- [ ] `./waf qemu --keep-flash-image` still rebuilds the image when `qemu_spi_flash.bin` is missing.
- [ ] `./waf qemu --help` shows the new option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)