### PR TITLE
SF32LB52 MPU tweaks

### DIFF
--- a/src/fw/apps/demo/test_mpu_violation.c
+++ b/src/fw/apps/demo/test_mpu_violation.c
@@ -1,0 +1,291 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "test_mpu_violation.h"
+
+#include "applib/app.h"
+#include "applib/app_timer.h"
+#include "applib/ui/app_window_stack.h"
+#include "applib/ui/click.h"
+#include "applib/ui/text_layer.h"
+#include "applib/ui/window.h"
+#include "font_resource_keys.auto.h"
+#include "kernel/pbl_malloc.h"
+#include "kernel/memory_layout.h"
+#include "process_state/app_state/app_state.h"
+
+#include <stdio.h>
+
+// Demo app that deliberately runs a series of memory accesses that the
+// MPU is supposed to deny for the unprivileged App task. Use up/down to
+// cycle through tests; press select to run the highlighted test. The
+// expected outcome for every test is a MemManage fault: the kernel
+// kills the App task and the launcher reclaims the screen. If the app
+// stays alive long enough to render "SURVIVED!" the MPU let the access
+// through -- that's the regression signal.
+//
+// SimpleMenuLayer would have been a nicer UI but it touches kernel data
+// not accessible to an unprivileged App task, so we use a plain Window
+// + TextLayers and raw click handlers.
+//
+// Linker symbols used for region-specific probes.
+extern const uint32_t __WORKER_RAM__[];
+extern const uint32_t __FLASH_start__[];
+extern const uint32_t __APP_RAM__[];
+extern const uint32_t __kernel_main_stack_start__[];
+
+#ifndef MPU_TYPE_ARMV8M
+KERNEL_READONLY_DATA static uint32_t s_ro_bss_probe;
+#endif
+
+typedef enum {
+  TestKind_WorkerRamWrite,
+  TestKind_WorkerRamRead,
+  TestKind_KernelRamWrite,
+  TestKind_KernelRamRead,
+#ifndef MPU_TYPE_ARMV8M
+  TestKind_RoBssWrite,
+#endif
+  TestKind_FlashWrite,
+#ifndef MPU_TYPE_ARMV8M
+  TestKind_StackGuardWrite,
+#endif
+  TestKind_StackOverflow,
+  TestKindCount,
+} TestKind;
+
+static const char *const s_test_titles[TestKindCount] = {
+    [TestKind_WorkerRamWrite] = "Worker RAM W",
+    [TestKind_WorkerRamRead] = "Worker RAM R",
+    [TestKind_KernelRamWrite] = "Kernel RAM W",
+    [TestKind_KernelRamRead] = "Kernel RAM R",
+#ifndef MPU_TYPE_ARMV8M
+    [TestKind_RoBssWrite] = "RO BSS W",
+#endif
+    [TestKind_FlashWrite] = "Flash W",
+#ifndef MPU_TYPE_ARMV8M
+    [TestKind_StackGuardWrite] = "Stack guard W",
+#endif
+    [TestKind_StackOverflow] = "Stack overflow",
+};
+
+typedef struct {
+  Window window;
+  TextLayer header_text;
+  TextLayer selection_text;
+  TextLayer hint_text;
+
+  char selection_buffer[40];
+
+  int selected_index;
+  bool test_running;
+} AppData;
+
+// Deeply-recursing helper for the stack-overflow test. The non-trivial
+// return value plus the volatile local prevents the compiler from
+// turning this into a tail call (which would not consume stack).
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winfinite-recursion"
+static uint32_t __attribute__((noinline)) prv_overflow_recurse(uint32_t depth) {
+  volatile uint8_t big_local[128];
+  big_local[0] = (uint8_t)depth;
+  return prv_overflow_recurse(depth + 1) + big_local[0];
+}
+#pragma GCC diagnostic pop
+
+static void prv_run_test(TestKind kind) {
+  switch (kind) {
+    case TestKind_WorkerRamWrite: {
+      volatile uint32_t *p = (volatile uint32_t *)__WORKER_RAM__;
+      *p = 0xDEADBEEF;
+      break;
+    }
+    case TestKind_WorkerRamRead: {
+      volatile uint32_t *p = (volatile uint32_t *)__WORKER_RAM__;
+      volatile uint32_t v = *p;
+      (void)v;
+      break;
+    }
+    case TestKind_KernelRamWrite: {
+      // Bottom of the kernel main stack -- well inside kernel RAM and
+      // not covered by any region the App task can see.
+      volatile uint32_t *p = (volatile uint32_t *)__kernel_main_stack_start__;
+      *p = 0xDEADBEEF;
+      break;
+    }
+    case TestKind_KernelRamRead: {
+      volatile uint32_t *p = (volatile uint32_t *)__kernel_main_stack_start__;
+      volatile uint32_t v = *p;
+      (void)v;
+      break;
+    }
+#ifndef MPU_TYPE_ARMV8M
+    case TestKind_RoBssWrite: {
+      // ARMv7-M maps this as priv RW + user RO, so unprivileged writes fault.
+      volatile uint32_t *p = &s_ro_bss_probe;
+      *p = 0xDEADBEEF;
+      break;
+    }
+#endif
+    case TestKind_FlashWrite: {
+      volatile uint32_t *p = (volatile uint32_t *)__FLASH_start__;
+      *p = 0xDEADBEEF;
+      break;
+    }
+#ifndef MPU_TYPE_ARMV8M
+    case TestKind_StackGuardWrite: {
+      // Direct store to the bottom 32 B of App RAM. On ARMv7-M the per-task
+      // stack-guard MPU region blocks this; ARMv8-M uses PSPLIM instead, so
+      // this scenario is omitted there.
+      volatile uint32_t *p = (volatile uint32_t *)__APP_RAM__;
+      *p = 0xDEADBEEF;
+      break;
+    }
+#endif
+    case TestKind_StackOverflow:
+      // Eventually trips PSPLIM (ARMv8-M) or the MPU stack-guard region
+      // (ARMv7-M), since each call frame consumes ~128 B.
+      (void)prv_overflow_recurse(0);
+      break;
+    case TestKindCount:
+      break;
+  }
+}
+
+static void prv_redraw_selection(AppData *data) {
+  snprintf(data->selection_buffer, sizeof(data->selection_buffer),
+           "[%d/%d]\n%s", data->selected_index + 1, TestKindCount,
+           s_test_titles[data->selected_index]);
+  text_layer_set_text(&data->selection_text, data->selection_buffer);
+  layer_mark_dirty(text_layer_get_layer(&data->selection_text));
+}
+
+static void prv_attempt(void *cb_data) {
+  AppData *data = cb_data;
+  prv_run_test((TestKind)data->selected_index);
+
+  // Reaching this point means no fault. Surface that prominently --
+  // the previous "TESTING..." text gets replaced so the survival is
+  // obvious in a screenshot.
+  text_layer_set_text(&data->selection_text, "SURVIVED!\n(MPU MISS)");
+  layer_mark_dirty(text_layer_get_layer(&data->selection_text));
+  data->test_running = false;
+}
+
+static void prv_up_click(ClickRecognizerRef rec, void *ctx) {
+  (void)rec;
+  AppData *data = ctx;
+  if (data->test_running) {
+    return;
+  }
+  data->selected_index =
+      (data->selected_index + TestKindCount - 1) % TestKindCount;
+  prv_redraw_selection(data);
+}
+
+static void prv_down_click(ClickRecognizerRef rec, void *ctx) {
+  (void)rec;
+  AppData *data = ctx;
+  if (data->test_running) {
+    return;
+  }
+  data->selected_index = (data->selected_index + 1) % TestKindCount;
+  prv_redraw_selection(data);
+}
+
+static void prv_select_click(ClickRecognizerRef rec, void *ctx) {
+  (void)rec;
+  AppData *data = ctx;
+  if (data->test_running) {
+    return;
+  }
+  data->test_running = true;
+  text_layer_set_text(&data->selection_text, "TESTING...");
+  layer_mark_dirty(text_layer_get_layer(&data->selection_text));
+  // Wait a tick so the "TESTING..." frame is visible before the access.
+  app_timer_register(300, prv_attempt, data);
+}
+
+static void prv_click_config(void *context) {
+  window_single_click_subscribe(BUTTON_ID_UP, prv_up_click);
+  window_single_click_subscribe(BUTTON_ID_DOWN, prv_down_click);
+  window_single_click_subscribe(BUTTON_ID_SELECT, prv_select_click);
+}
+
+static void prv_window_load(Window *window) {
+  AppData *data = window_get_user_data(window);
+
+  GRect bounds;
+  layer_get_bounds(window_get_root_layer(window), &bounds);
+
+  // Header at the top: "MPU violation".
+  GRect header_frame = bounds;
+  header_frame.size.h = 24;
+  text_layer_init(&data->header_text, &header_frame);
+  text_layer_set_font(&data->header_text,
+                      fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD));
+  text_layer_set_text_alignment(&data->header_text, GTextAlignmentCenter);
+  text_layer_set_text(&data->header_text, "MPU violation");
+  layer_add_child(window_get_root_layer(window),
+                  text_layer_get_layer(&data->header_text));
+
+  // Selection display in the middle.
+  GRect selection_frame = bounds;
+  selection_frame.origin.y = 32;
+  selection_frame.size.h = bounds.size.h - 64;
+  text_layer_init(&data->selection_text, &selection_frame);
+  text_layer_set_font(&data->selection_text,
+                      fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD));
+  text_layer_set_text_alignment(&data->selection_text, GTextAlignmentCenter);
+  layer_add_child(window_get_root_layer(window),
+                  text_layer_get_layer(&data->selection_text));
+
+  // Hint at the bottom: button mapping.
+  GRect hint_frame = bounds;
+  hint_frame.origin.y = bounds.size.h - 24;
+  hint_frame.size.h = 24;
+  text_layer_init(&data->hint_text, &hint_frame);
+  text_layer_set_font(&data->hint_text,
+                      fonts_get_system_font(FONT_KEY_GOTHIC_14));
+  text_layer_set_text_alignment(&data->hint_text, GTextAlignmentCenter);
+  text_layer_set_text(&data->hint_text, "Up/Dn cycle, Sel run");
+  layer_add_child(window_get_root_layer(window),
+                  text_layer_get_layer(&data->hint_text));
+
+  prv_redraw_selection(data);
+}
+
+static void prv_handle_init(void) {
+  AppData *app_data = app_malloc_check(sizeof(AppData));
+  app_data->selected_index = 0;
+  app_data->test_running = false;
+  app_state_set_user_data(app_data);
+
+  window_init(&app_data->window, WINDOW_NAME("test_mpu_violation"));
+  window_set_user_data(&app_data->window, app_data);
+  window_set_window_handlers(&app_data->window, &(WindowHandlers) {
+      .load = prv_window_load,
+  });
+  // Pass app_data as the click context so handlers don't have to reach
+  // for a static (which would live in kernel BSS and fault on write).
+  window_set_click_config_provider_with_context(&app_data->window,
+                                                prv_click_config, app_data);
+
+  app_window_stack_push(&app_data->window, true /* animated */);
+}
+
+static void prv_main(void) {
+  prv_handle_init();
+  app_event_loop();
+}
+
+const PebbleProcessMd* test_mpu_violation_get_info(void) {
+  static const PebbleProcessMdSystem s_info = {
+    .common.main_func = prv_main,
+    // System apps default to privileged; this one must run unprivileged
+    // for the MPU to actually evaluate access against the App task regions.
+    .common.is_unprivileged = true,
+    .name = "MPU violation",
+  };
+  return (const PebbleProcessMd *)&s_info;
+}

--- a/src/fw/apps/demo/test_mpu_violation.h
+++ b/src/fw/apps/demo/test_mpu_violation.h
@@ -1,0 +1,8 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include "process_management/pebble_process_md.h"
+
+const PebbleProcessMd* test_mpu_violation_get_info(void);

--- a/src/fw/drivers/display/sf32lb/display_jdi.c
+++ b/src/fw/drivers/display/sf32lb/display_jdi.c
@@ -11,6 +11,7 @@
 #include "kernel/pbl_malloc.h"
 #include "kernel/util/delay.h"
 #include "kernel/util/stop.h"
+#include "mcu/cache.h"
 #include "os/mutex.h"
 #include "system/logging.h"
 #include "system/passert.h"
@@ -108,6 +109,14 @@ static void prv_display_off() {
 
 static HAL_StatusTypeDef prv_display_update_start(void) {
   DisplayJDIState *state = DISPLAY->state;
+
+  // The LCDC reads the framebuffer over DMA, which bypasses the D-cache.
+  // Flush dirty lines for the rows we're about to send so the LCDC sees
+  // the 332-converted pixels instead of stale SRAM.
+  uintptr_t fb_addr = (uintptr_t)&s_framebuffer[s_update_y0 * PBL_DISPLAY_WIDTH];
+  size_t fb_size = (size_t)(s_update_y1 - s_update_y0 + 1) * PBL_DISPLAY_WIDTH;
+  dcache_align(&fb_addr, &fb_size);
+  dcache_flush((const void *)fb_addr, fb_size);
 
   // Only send the dirty region that was converted to RGB332 format
   HAL_LCDC_SetROIArea(&state->hlcdc, 0, s_update_y0, PBL_DISPLAY_WIDTH - 1, s_update_y1);

--- a/src/fw/drivers/mic/sf32lb52/pdm.c
+++ b/src/fw/drivers/mic/sf32lb52/pdm.c
@@ -6,6 +6,7 @@
 #include "board/board.h"
 #include "kernel/kernel_heap.h"
 #include "kernel/pbl_malloc.h"
+#include "mcu/cache.h"
 #include "system/logging.h"
 #include "os/mutex.h"
 #include "system/passert.h"
@@ -226,13 +227,20 @@ static void prv_dma_data_processing(uint8_t* data, uint16_t size)
     PBL_LOG_ERR("No circular buffer storage, ignoring data");
     return;
   }
-  
+
   // Ensure we have valid audio buffer info
   if (!s_state->audio_buffer || s_state->audio_buffer_len == 0) {
     PBL_LOG_ERR("No audio buffer configured, ignoring data");
     return;
   }
-  
+
+  // PDM DMA writes straight to RAM, bypassing D-cache. Drop any stale lines so
+  // the CPU re-fetches the freshly captured samples instead of pre-DMA contents.
+  // Buffer base is cache-line aligned at allocation time and the half-buffer
+  // stride is a multiple of the cache line size, so this invalidate cannot
+  // straddle neighboring allocations.
+  dcache_invalidate(data, size);
+
   // Write samples directly to circular buffer
   // If buffer is full, drop oldest data to make room for fresh audio
   uint16_t write_space = circular_buffer_get_write_space_remaining(&s_state->circ_buffer);
@@ -335,8 +343,14 @@ bool mic_start(const MicDevice *this, MicDataHandlerCB data_handler, void *conte
   }
 
   hpdm->RxXferSize = this->channels * PDM_AUDIO_RECORD_PIPE_SIZE * sizeof(int16_t);
-  hpdm->pRxBuffPtr = kernel_malloc(hpdm->RxXferSize);
-  PBL_ASSERT(hpdm->pRxBuffPtr, "Can not allocate buffer");
+  // Over-allocate by one cache line so the DMA buffer can start on a line
+  // boundary. dcache_invalidate() in the IRQ path would otherwise risk
+  // destroying dirty bytes in lines shared with neighboring allocations.
+  const size_t cache_align = dcache_line_size();
+  state->raw_dma_buffer = kernel_malloc(hpdm->RxXferSize + cache_align - 1U);
+  PBL_ASSERT(state->raw_dma_buffer, "Can not allocate buffer");
+  hpdm->pRxBuffPtr = (uint8_t *)(((uintptr_t)state->raw_dma_buffer + cache_align - 1U) &
+                                 ~(uintptr_t)(cache_align - 1U));
 
   state->data_handler = data_handler;
   state->handler_context = context;
@@ -361,7 +375,8 @@ bool mic_start(const MicDevice *this, MicDataHandlerCB data_handler, void *conte
     HAL_PDM_DeInit(hpdm);
     HAL_RCC_DisableModule(RCC_MOD_PDM1);
 
-    kernel_free(hpdm->pRxBuffPtr);
+    kernel_free(state->raw_dma_buffer);
+    state->raw_dma_buffer = NULL;
     hpdm->pRxBuffPtr = NULL;
 
     stop_mode_enable(InhibitorMic);
@@ -402,9 +417,10 @@ void mic_stop(const MicDevice *this) {
   // Free dynamically allocated buffers
   prv_free_buffers(state);
 
-  kernel_free(hpdm->pRxBuffPtr);
+  kernel_free(state->raw_dma_buffer);
+  state->raw_dma_buffer = NULL;
   hpdm->pRxBuffPtr = NULL;
-  
+
   // Clear state
   state->data_handler = NULL;
   state->handler_context = NULL;

--- a/src/fw/drivers/mic/sf32lb52/pdm_definitions.h
+++ b/src/fw/drivers/mic/sf32lb52/pdm_definitions.h
@@ -12,9 +12,13 @@
 #include <stdint.h>
 
 typedef struct MicState {
-  uint8_t *circ_buffer_storage; 
+  uint8_t *circ_buffer_storage;
   CircularBuffer circ_buffer;
   DMA_HandleTypeDef hdma;
+  //! Raw (unaligned) pointer returned by kernel_malloc for the PDM DMA buffer.
+  //! hpdm->pRxBuffPtr is bumped up to a cache-line boundary so the CPU can
+  //! invalidate it without clobbering adjacent dirty data.
+  uint8_t *raw_dma_buffer;
 
   // User interface
   MicDataHandlerCB data_handler;

--- a/src/fw/drivers/mpu.c
+++ b/src/fw/drivers/mpu.c
@@ -42,6 +42,7 @@ void mpu_set_task_configurable_regions(MemoryRegion_t *memory_regions,
     // If not region defined, use unused
     if (mpu_region == NULL) {
       mpu_region = &unused_region;
+      base_reg = 0;
       attr_reg = 0; // Has a 0 in the enable bit, so this region won't be enabled.
     } else {
       // Make sure that the region numbers passed in jive with the configurable region numbers.
@@ -52,8 +53,18 @@ void mpu_set_task_configurable_regions(MemoryRegion_t *memory_regions,
       mpu_get_register_settings(mpu_region, &base_reg, &attr_reg);
     }
 
+    // On ARMv8-M the FreeRTOS port writes pvBaseAddress straight into
+    // MPU_RBAR, which carries the SH/AP/XN bits. On ARMv7-M RBAR is just
+    // (address | region | VALID) and AP lives in RASR/ulParameters, so the
+    // raw base is what's wanted there.
+#ifdef MPU_TYPE_ARMV8M
+    uintptr_t base_address = base_reg;
+#else
+    uintptr_t base_address = mpu_region->base_address;
+#endif
+
     memory_regions[region_idx] = (MemoryRegion_t) {
-      .pvBaseAddress = (void *)mpu_region->base_address,
+      .pvBaseAddress = (void *)base_address,
       .ulLengthInBytes = mpu_region->size,
       .ulParameters = attr_reg,
     };

--- a/src/fw/drivers/mpu.h
+++ b/src/fw/drivers/mpu.h
@@ -9,14 +9,6 @@
 #include "freertos_types.h"
 
 typedef enum MpuCachePolicy {
-  // FIXME(SF32LB52): system_bf0_ap.c uses now up to 5 attributes as MPU is not fully implemented.
-#ifdef MICRO_FAMILY_SF32LB52
-  MpuCachePolicy_Reserved0,
-  MpuCachePolicy_Reserved1,
-  MpuCachePolicy_Reserved2,
-  MpuCachePolicy_Reserved3,
-  MpuCachePolicy_Reserved4,
-#endif
   MpuCachePolicy_NotCacheable,
   MpuCachePolicy_WriteThrough,
   MpuCachePolicy_WriteBackWriteAllocate,

--- a/src/fw/drivers/mpu.h
+++ b/src/fw/drivers/mpu.h
@@ -9,12 +9,13 @@
 #include "freertos_types.h"
 
 typedef enum MpuCachePolicy {
-  // FIXME(SF32LB52): system_bf0_ap.c uses now up to 4 attributes as MPU is not fully implemented.
+  // FIXME(SF32LB52): system_bf0_ap.c uses now up to 5 attributes as MPU is not fully implemented.
 #ifdef MICRO_FAMILY_SF32LB52
   MpuCachePolicy_Reserved0,
   MpuCachePolicy_Reserved1,
   MpuCachePolicy_Reserved2,
   MpuCachePolicy_Reserved3,
+  MpuCachePolicy_Reserved4,
 #endif
   MpuCachePolicy_NotCacheable,
   MpuCachePolicy_WriteThrough,

--- a/src/fw/drivers/mpu/mpu_armv8m.c
+++ b/src/fw/drivers/mpu/mpu_armv8m.c
@@ -10,6 +10,20 @@
 
 #include <cmsis_core.h>
 
+// On SF32LB52 the SiFli vendor code (system_bf0_ap.c) programs its own MPU
+// regions in SystemInit() and burns MAIR indices 0..2 (code / ram / device)
+// for those. To avoid clobbering them we shift our own MpuCachePolicy values
+// into MAIR indices MAIR_INDEX_BASE..MAIR_INDEX_BASE+3.
+#ifdef MICRO_FAMILY_SF32LB52
+#define MAIR_INDEX_BASE 4U
+#else
+#define MAIR_INDEX_BASE 0U
+#endif
+
+static inline uint8_t mair_index(uint32_t cache_policy) {
+  return (uint8_t)(cache_policy + MAIR_INDEX_BASE);
+}
+
 // ARMv8-M has a 2-bit AP field, which cannot express two of the
 // MpuPermissions values precisely:
 //   - NoAccess: there is no "deny everything" encoding; we degrade to
@@ -56,16 +70,24 @@ static MpuPermissions decode_permission_value(uint8_t ap) {
 }
 
 void mpu_enable(void) {
-  ARM_MPU_SetMemAttr(MpuCachePolicy_NotCacheable,
+  ARM_MPU_SetMemAttr(mair_index(MpuCachePolicy_NotCacheable),
                      s_cache_settings[MpuCachePolicy_NotCacheable]);
-  ARM_MPU_SetMemAttr(MpuCachePolicy_WriteThrough,
+  ARM_MPU_SetMemAttr(mair_index(MpuCachePolicy_WriteThrough),
                      s_cache_settings[MpuCachePolicy_WriteThrough]);
-  ARM_MPU_SetMemAttr(MpuCachePolicy_WriteBackWriteAllocate,
+  ARM_MPU_SetMemAttr(mair_index(MpuCachePolicy_WriteBackWriteAllocate),
                      s_cache_settings[MpuCachePolicy_WriteBackWriteAllocate]);
-  ARM_MPU_SetMemAttr(MpuCachePolicy_WriteBackNoWriteAllocate,
+  ARM_MPU_SetMemAttr(mair_index(MpuCachePolicy_WriteBackNoWriteAllocate),
                      s_cache_settings[MpuCachePolicy_WriteBackNoWriteAllocate]);
 
-  ARM_MPU_Enable(MPU_CTRL_PRIVDEFENA_Msk);
+  // ARM_MPU_Enable() writes MPU_CTRL directly, which would clobber bits set
+  // by another module (e.g. SiFli's SystemInit() turns on HFNMIENA). If the
+  // MPU is already enabled, just OR in PRIVDEFENA so we keep whatever flags
+  // are already there.
+  if (MPU->CTRL & MPU_CTRL_ENABLE_Msk) {
+    MPU->CTRL |= MPU_CTRL_PRIVDEFENA_Msk;
+  } else {
+    ARM_MPU_Enable(MPU_CTRL_PRIVDEFENA_Msk);
+  }
 }
 
 void mpu_get_register_settings(const MpuRegion* region, uint32_t *base_address_reg,
@@ -81,7 +103,8 @@ void mpu_get_register_settings(const MpuRegion* region, uint32_t *base_address_r
                        ((get_permission_value(region) << MPU_RBAR_AP_Pos) & MPU_RBAR_AP_Msk) |
                        ((region->executable ? 0u : 1u) << MPU_RBAR_XN_Pos));
   *attributes_reg = (((region->base_address + region->size - 1U) & MPU_RLAR_LIMIT_Msk) |
-                     ((region->cache_policy << MPU_RLAR_AttrIndx_Pos) & MPU_RLAR_AttrIndx_Msk) |
+                     ((mair_index(region->cache_policy) << MPU_RLAR_AttrIndx_Pos) &
+                      MPU_RLAR_AttrIndx_Msk) |
                      ((region->enabled << MPU_RLAR_EN_Pos) & MPU_RLAR_EN_Msk));
 }
 
@@ -112,7 +135,15 @@ MpuRegion mpu_get_region(int region_num) {
 
   region.size = (rlar & MPU_RLAR_LIMIT_Msk) - region.base_address + 0x20;
   region.enabled = (rlar & MPU_RLAR_EN_Msk) != 0;
-  region.cache_policy = (rlar & MPU_RLAR_AttrIndx_Msk) >> MPU_RLAR_AttrIndx_Pos;
+  // Strip the MAIR_INDEX_BASE offset so the returned cache_policy round-trips
+  // through MpuCachePolicy. Regions programmed by another module that use
+  // raw MAIR indices below MAIR_INDEX_BASE will report as MpuCachePolicy 0.
+  uint8_t attr_idx = (uint8_t)((rlar & MPU_RLAR_AttrIndx_Msk) >> MPU_RLAR_AttrIndx_Pos);
+#if MAIR_INDEX_BASE > 0
+  region.cache_policy = (attr_idx >= MAIR_INDEX_BASE) ? (attr_idx - MAIR_INDEX_BASE) : 0;
+#else
+  region.cache_policy = attr_idx;
+#endif
 
   return region;
 }

--- a/src/fw/drivers/sf32lb52/audio/audec.c
+++ b/src/fw/drivers/sf32lb52/audio/audec.c
@@ -3,6 +3,7 @@
 
 #include "audio_definitions.h"
 #include "kernel/pbl_malloc.h"
+#include "mcu/cache.h"
 #include "system/passert.h"
 #include "system/logging.h"
 #include "util/misc.h"
@@ -317,10 +318,17 @@ bool audec_init(AudioDevice* audio_device) {
 
     if (haudcodec->buf[HAL_AUDCODEC_DAC_CH0] == NULL)
     {
-        haudcodec->buf[HAL_AUDCODEC_DAC_CH0] = kernel_malloc(haudcodec->bufSize);
+        // Over-allocate so the DMA buffer can start on a cache-line boundary.
+        // Each half is consumed by DMA while the CPU fills the other half;
+        // dcache_flush() of one half must not touch lines that belong to the
+        // half currently being DMA'd, so both halves need to be aligned.
+        const size_t cache_align = dcache_line_size();
+        state->raw_dac_buffer = kernel_malloc(haudcodec->bufSize + cache_align - 1U);
+        PBL_ASSERT(state->raw_dac_buffer, "allocated mem error");
+        haudcodec->buf[HAL_AUDCODEC_DAC_CH0] =
+            (uint8_t *)(((uintptr_t)state->raw_dac_buffer + cache_align - 1U) &
+                        ~(uintptr_t)(cache_align - 1U));
         memset(haudcodec->buf[HAL_AUDCODEC_DAC_CH0], 0, haudcodec->bufSize);
-        PBL_ASSERT(haudcodec->buf[HAL_AUDCODEC_DAC_CH0], "allocated mem error");
-
     }
     state->queue_buf[HAL_AUDCODEC_DAC_CH0] = haudcodec->buf[HAL_AUDCODEC_DAC_CH0];
     HAL_AUDCODEC_Config_TChanel(haudcodec, 0, &haudcodec->Init.dac_cfg);
@@ -343,6 +351,10 @@ void audec_start(AudioDevice* audio_device, AudioTransCB cb) {
     prv_bf0_audio_pll_config(audio_device, &codec_dac_clk_config[haudcodec->Init.samplerate_index]);
     HAL_AUDCODEC_Config_TChanel(haudcodec, 0, &haudcodec->Init.dac_cfg);
     HAL_NVIC_SetPriority(audio_device->audec_dma_irq, audio_device->irq_priority, 0);
+    // The buffer was memset() to zero by the CPU at init and is again at stop;
+    // those writes may still be sitting in D-cache. Push them to RAM so the
+    // codec DMA reads silence on the first transfer instead of stale memory.
+    dcache_flush(haudcodec->buf[HAL_AUDCODEC_DAC_CH0], haudcodec->bufSize);
     HAL_AUDCODEC_Transmit_DMA(haudcodec, haudcodec->buf[HAL_AUDCODEC_DAC_CH0], haudcodec->bufSize, HAL_AUDCODEC_DAC_CH0);
     HAL_NVIC_EnableIRQ(audio_device->audec_dma_irq);
     state->tx_instanc = HAL_AUDCODEC_DAC_CH0;
@@ -439,6 +451,11 @@ static void prv_dma_request_processing(AudioDeviceState* state) {
         PBL_ASSERT(bytes_copied == trans_size, "circ buffer read err");
         circular_buffer_consume(&state->circ_buffer, bytes_copied);
     }
+    // Codec DMA reads this half-buffer next time it wraps; flush the CPU-side
+    // writes (memset for underrun and circular_buffer_copy above) so the DAC
+    // doesn't replay stale RAM contents. We always flush a full half because
+    // any bytes we didn't touch were already memset() to silence.
+    dcache_flush(state->queue_buf[HAL_AUDCODEC_DAC_CH0], CFG_AUDIO_PLAYBACK_PIPE_SIZE);
     uint32_t free_size = circular_buffer_get_write_space_remaining(&state->circ_buffer);
     if(state->trans_cb && free_size >= CFG_AUDIO_PLAYBACK_PIPE_SIZE) {
         bool system_task_switch_context = false;

--- a/src/fw/drivers/sf32lb52/audio/audio_definitions.h
+++ b/src/fw/drivers/sf32lb52/audio/audio_definitions.h
@@ -36,9 +36,13 @@ typedef struct AudioState {
   uint8_t tx_instanc;
   bool    tx_rbf_enable;
   uint16_t tx_buffer_size;
-  uint8_t *circ_buffer_storage; 
+  uint8_t *circ_buffer_storage;
   CircularBuffer circ_buffer;
   AudioTransCB trans_cb;
+  //! Raw (unaligned) pointer returned by kernel_malloc for the AUDCODEC DAC
+  //! DMA buffer. haudcodec->buf[] is bumped up to a cache-line boundary so
+  //! dcache_flush() of one half can't touch the other half's lines.
+  uint8_t *raw_dac_buffer;
 } AudioDeviceState;
 
 typedef const struct AudioDevice {

--- a/src/fw/drivers/sf32lb52/qspi.c
+++ b/src/fw/drivers/sf32lb52/qspi.c
@@ -7,6 +7,7 @@
 #include "drivers/flash/qspi_flash_part_definitions.h"
 #include "flash_region/flash_region.h"
 #include "kernel/pbl_malloc.h"
+#include "mcu/cache.h"
 #include "system/passert.h"
 #include "system/status_codes.h"
 #include "util/math.h"
@@ -103,7 +104,15 @@ static int prv_write_nor(QSPIFlash *dev, uint32_t addr, uint8_t *buf, uint32_t s
   } else {
     tbuf = buf;
   }
-  
+
+  // The QSPI write path reads `tbuf` over DMA, which bypasses the D-cache.
+  // Push any CPU-dirtied lines back to SRAM first so the flash receives the
+  // freshly-prepared bytes rather than stale memory.
+  uintptr_t flush_addr = (uintptr_t)tbuf;
+  size_t flush_size = size;
+  dcache_align(&flush_addr, &flush_size);
+  dcache_flush((const void *)flush_addr, flush_size);
+
   taddr = addr - hflash->base;
   remain = size;
 

--- a/src/fw/drivers/uart/sf32lb.c
+++ b/src/fw/drivers/uart/sf32lb.c
@@ -279,6 +279,12 @@ void uart_dma_irq_handler(UARTDevice *dev) {
   HAL_DMA_IRQHandler(&dev->state->hdma);
 }
 
+// FIXME(SF32LB52): the IRQ paths above read `rx_dma_buffer[idx]` straight
+// without invalidating D-cache, so the CPU could pick up stale pre-DMA bytes.
+// There is no active SF32LB52 caller today (dbgserial_set_rx_dma_enabled is a
+// no-op for MICRO_FAMILY_SF32LB52), so this hasn't been wired up. Before
+// enabling, the buffer needs to be cache-line aligned/sized and the callbacks
+// must dcache_invalidate the freshly-DMA'd range.
 void uart_start_rx_dma(UARTDevice *dev, void *buffer, uint32_t length) {
   dev->state->rx_dma_buffer = buffer;
   dev->state->rx_dma_length = length;

--- a/src/fw/kernel/memory_layout.c
+++ b/src/fw/kernel/memory_layout.c
@@ -14,12 +14,13 @@
 
 
 static const char* const MEMORY_REGION_NAMES[] = {
-  // FIXME(SF32LB52): system_bf0_ap.c uses now up to 4 regions as MPU is not fully implemented.
+  // FIXME(SF32LB52): system_bf0_ap.c uses now up to 5 regions as MPU is not fully implemented.
 #ifdef MICRO_FAMILY_SF32LB52
   "RESERVED0",
   "RESERVED1",
   "RESERVED2",
   "RESERVED3",
+  "RESERVED4",
 #endif
   "UNPRIV_FLASH",
   "UNPRIV_RO_BSS",

--- a/src/fw/kernel/memory_layout.c
+++ b/src/fw/kernel/memory_layout.c
@@ -14,13 +14,15 @@
 
 
 static const char* const MEMORY_REGION_NAMES[] = {
-  // FIXME(SF32LB52): system_bf0_ap.c uses now up to 5 regions as MPU is not fully implemented.
+  // Keep the four RESERVED entries in lockstep with MemoryRegion_Reserved*
+  // in memory_layout.h. SiFli's fifth region (mailbox) overlaps with the
+  // "UNPRIV_FLASH" slot at index 4 -- Pebble never programs that index on
+  // SF32LB52, so the cosmetic label is the only casualty.
 #ifdef MICRO_FAMILY_SF32LB52
   "RESERVED0",
   "RESERVED1",
   "RESERVED2",
   "RESERVED3",
-  "RESERVED4",
 #endif
   "UNPRIV_FLASH",
   "UNPRIV_RO_BSS",
@@ -205,15 +207,23 @@ void memory_layout_setup_mpu(void) {
   // Flash parts...
   // Read only for executing code and loading data out of.
 
-#ifndef MICRO_FAMILY_SF32LB52
   // Unprivileged flash, by default anyone can read any part of flash.
+  // On SF32LB52 the SiFli HAL already programs a user-RO executable region
+  // covering 0x10000000..0x1fffffff in SystemInit(), so we skip our own.
+#ifndef MICRO_FAMILY_SF32LB52
   mpu_set_region(&s_microflash_region);
+#endif
 
   // RAM parts
   // The background memory map only allows privileged access. We need to add aditional regions to
   // enable access to unprivileged code.
 
   mpu_set_region(&s_readonly_bss_region);
+  // ARMv8-M tracks per-task stack overflow via PSPLIM in the FreeRTOS CM33
+  // port, so the dedicated ISR stack guard region (no-access) is redundant
+  // and the AP encoding can't even express "no access" precisely. Skip it
+  // on SF32LB52 to reclaim the slot.
+#ifndef MICRO_FAMILY_SF32LB52
   mpu_set_region(&s_isr_stack_guard_region);
 #endif
 

--- a/src/fw/kernel/memory_layout.h
+++ b/src/fw/kernel/memory_layout.h
@@ -10,7 +10,14 @@
 #define KERNEL_READONLY_DATA SECTION(".kernel_unpriv_ro_bss")
 
 enum MemoryRegionAssignments {
-  // FIXME(SF32LB52): system_bf0_ap.c uses now up to 4 regions as MPU is not fully implemented.
+  // SF32LB52: SiFli's system_bf0_ap.c programs MPU regions 0..4 in
+  // SystemInit() (flash, peripherals, .ramfunc, LPSYS RAM, HCPU<->LCPU
+  // mailbox). Reserve four slots here so the per-task configurable
+  // regions still land at indices 8..11 -- matching the FreeRTOS port's
+  // FREERTOS_FIRST_MPU_REGION=8. SiFli's fifth region (mailbox at index
+  // 4) shares its slot with the unused-on-SF32LB52 MemoryRegion_Flash
+  // value; Pebble never programs region 4, so SiFli's mailbox config
+  // stays intact.
 #ifdef MICRO_FAMILY_SF32LB52
   MemoryRegion_Reserved0,
   MemoryRegion_Reserved1,

--- a/src/fw/kernel/pebble_tasks.c
+++ b/src/fw/kernel/pebble_tasks.c
@@ -264,7 +264,6 @@ void pebble_task_create(PebbleTask pebble_task, TaskParameters_t *task_params,
       WTF;
   }
 
-#ifndef MICRO_FAMILY_SF32LB52
   const MpuRegion *stack_guard_region = NULL;
 #ifndef MPU_TYPE_ARMV8M
   // Per-task stack overflow detection: on ARMv7-M we plant a no-access
@@ -297,16 +296,12 @@ void pebble_task_create(PebbleTask pebble_task, TaskParameters_t *task_params,
       WTF;
   }
 #endif
-#endif
 
   const MpuRegion *region_ptrs[portNUM_CONFIGURABLE_REGIONS] = {
-    // FIXME(SF32LB52): Not supported on ARMv8 MPU yet
-#ifndef MICRO_FAMILY_SF32LB52
     &app_region,
     &worker_region,
     stack_guard_region,
     NULL
-#endif
   };
   mpu_set_task_configurable_regions(task_params->xRegions, region_ptrs);
 

--- a/src/fw/shell/normal/system_app_registry_list.json
+++ b/src/fw/shell/normal/system_app_registry_list.json
@@ -555,6 +555,12 @@
       ]
     },
     {
+      "id": -191,
+      "enum": "MPU_VIOLATION_TEST",
+      "md_fn": "test_mpu_violation_get_info",
+      "ifdefs": ["ENABLE_TEST_APPS"]
+    },
+    {
       "id": -92,
       "enum": "QUIET_TIME_TOGGLE",
       "md_fn": "quiet_time_toggle_get_app_info"

--- a/third_party/freertos/wscript
+++ b/third_party/freertos/wscript
@@ -30,12 +30,14 @@ def build(bld):
                            for d in freertos_source_paths], [])
     freertos_defines = []
 
-    # FIXME(SF32LB52): Add valid regions once MPU can be used
-    # This currently results in 0 regions!
+    # SF32LB52: SiFli's HAL programs MPU regions 0..4 and Pebble's static
+    # MPU setup uses 5..7, so per-task configurable regions live at 8..11
+    # (four slots: AppRAM, WorkerRAM, plus two NULL placeholders to satisfy
+    # the FreeRTOS port's multiple-of-four invariant).
     if bld.env.MICRO_FAMILY == 'SF32LB52':
         freertos_defines += [
             'FREERTOS_FIRST_MPU_REGION=8',
-            'FREERTOS_LAST_MPU_REGION=7',
+            'FREERTOS_LAST_MPU_REGION=11',
         ]
 
     # QEMU CM33 also needs MPU region defines (MPU not used in QEMU CM33)

--- a/third_party/hal_sifli/sf32lb52/system_bf0_ap.c
+++ b/third_party/hal_sifli/sf32lb52/system_bf0_ap.c
@@ -13,6 +13,9 @@ uint32_t __Vectors;
 
 uint32_t SystemCoreClock = 48000000UL;
 
+extern uint8_t __ramfunc_start[];
+extern uint8_t __ramfunc_end[];
+
 void SystemCoreClockUpdate(void) {}
 
 enum {
@@ -52,10 +55,12 @@ static void prv_mpu_config(void) {
   rlar = ARM_MPU_RLAR(0x5fffffff, ATTR_DEVICE_IDX);
   ARM_MPU_SetRegion(1U, rbar, rlar);
 
-  // hpsys ram (512K)
+  // hpsys ram, .ramfunc range only: vendor HAL code copied here from flash
+  // must be executable. The rest of HPSYS RAM is reachable for privileged
+  // code via the background map (PRIVDEFENA is set in ARM_MPU_Enable below).
   // Non-shareable, RW, any privilege, executable
-  rbar = ARM_MPU_RBAR(0x20000000, ARM_MPU_SH_NON, 0, 1, 0);
-  rlar = ARM_MPU_RLAR(0x2007ffff, ATTR_RAM_IDX);
+  rbar = ARM_MPU_RBAR((uint32_t)__ramfunc_start, ARM_MPU_SH_NON, 0, 1, 0);
+  rlar = ARM_MPU_RLAR((uint32_t)__ramfunc_end - 1U, ATTR_RAM_IDX);
   ARM_MPU_SetRegion(2U, rbar, rlar);
 
   // lpsys ram
@@ -64,7 +69,7 @@ static void prv_mpu_config(void) {
   rlar = ARM_MPU_RLAR(0x204fffff, ATTR_RAM_IDX);
   ARM_MPU_SetRegion(3U, rbar, rlar);
 
-  ARM_MPU_Enable(MPU_CTRL_HFNMIENA_Msk);
+  ARM_MPU_Enable(MPU_CTRL_HFNMIENA_Msk | MPU_CTRL_PRIVDEFENA_Msk);
 }
 
 int mpu_dcache_invalidate(void *data, uint32_t size) {

--- a/third_party/hal_sifli/sf32lb52/system_bf0_ap.c
+++ b/third_party/hal_sifli/sf32lb52/system_bf0_ap.c
@@ -69,6 +69,14 @@ static void prv_mpu_config(void) {
   rlar = ARM_MPU_RLAR(0x204fffff, ATTR_RAM_IDX);
   ARM_MPU_SetRegion(3U, rbar, rlar);
 
+  // HCPU<->LCPU mailbox (last 1K of HPSYS SRAM). The BT controller running
+  // on LPSYS reads/writes this window directly, so it must be non-cacheable
+  // on the HCPU side -- otherwise the two cores see incoherent contents.
+  // Non-shareable, RW privileged only, non-executable.
+  rbar = ARM_MPU_RBAR(0x2007fc00, ARM_MPU_SH_NON, 0, 0, 1);
+  rlar = ARM_MPU_RLAR(0x2007ffff, ATTR_RAM_IDX);
+  ARM_MPU_SetRegion(4U, rbar, rlar);
+
   ARM_MPU_Enable(MPU_CTRL_HFNMIENA_Msk | MPU_CTRL_PRIVDEFENA_Msk);
 }
 


### PR DESCRIPTION
This PR enables MPU on M33 devices. Things are still a big hacky on SF32LB52, but they work. A next pass will be done by centralizing all MPU operations, allow soc-specific regions, a system-level ramfunc capability, etc.