### PR TITLE
i18n: improve Catalan and Spanish watch terminology

### DIFF
--- a/resources/normal/base/lang/ca_ES/tintin.po
+++ b/resources/normal/base/lang/ca_ES/tintin.po
@@ -1008,7 +1008,7 @@ msgstr "Inici ràpid"
 msgid ""
 "Open favorite apps quickly with a long button press from your watchface."
 msgstr ""
-"Obre ràpidament les apps preferides amb una pulsació llarga des de l'esfera."
+"Obre ràpidament les apps preferides amb una pulsació llarga des de la caràtula."
 
 #: ../src/fw/apps/system/settings/quiet_time.c:75
 msgid "Quiet All Notifications"
@@ -1352,7 +1352,7 @@ msgstr "Vista ràpida"
 #. / Help text for the Timeline Quick View first use dialog.
 #: ../src/fw/apps/system/settings/timeline.c:189
 msgid "Appears on your watchface when an event is about to start."
-msgstr "Apareix a l'esfera quan un esdeveniment és a punt de començar."
+msgstr "Apareix a la caràtula quan un esdeveniment és a punt de començar."
 
 #: ../src/fw/apps/system/settings/timeline.c:216
 #: ../src/fw/apps/system/timeline/timeline.c:1311
@@ -1373,7 +1373,7 @@ msgstr "En desconnectar"
 
 #: ../src/fw/apps/system/settings/vibe_patterns.c:265
 msgid "Sounds & Haptics"
-msgstr "Sons i hàptica"
+msgstr "Sons i vibracions"
 
 #: ../src/fw/apps/system/settings/vibe_patterns.c:267
 msgid "Vibrations"
@@ -1463,7 +1463,7 @@ msgstr "Actiu"
 
 #: ../src/fw/apps/system/watchfaces.c:206
 msgid "Watchfaces"
-msgstr "Esferes"
+msgstr "Caràtules"
 
 #. / Shown when neither high nor low temperature is known
 #: ../src/fw/apps/system/weather/layout.c:73
@@ -2845,11 +2845,11 @@ msgstr "Gen"
 
 #: ../src/fw/applib/pbl_std/timelocal.c:38
 msgid "Feb"
-msgstr "Feb"
+msgstr "Febr"
 
 #: ../src/fw/applib/pbl_std/timelocal.c:38
 msgid "Mar"
-msgstr "Mar"
+msgstr "Març"
 
 #: ../src/fw/applib/pbl_std/timelocal.c:38
 msgid "Apr"
@@ -2858,11 +2858,11 @@ msgstr "Abr"
 #: ../src/fw/applib/pbl_std/timelocal.c:38
 #: ../src/fw/applib/pbl_std/timelocal.c:44
 msgid "May"
-msgstr "Mai"
+msgstr "Maig"
 
 #: ../src/fw/applib/pbl_std/timelocal.c:39
 msgid "Jun"
-msgstr "Jun"
+msgstr "Juny"
 
 #: ../src/fw/applib/pbl_std/timelocal.c:39
 msgid "Jul"
@@ -2870,7 +2870,7 @@ msgstr "Jul"
 
 #: ../src/fw/applib/pbl_std/timelocal.c:39
 msgid "Aug"
-msgstr "Ago"
+msgstr "Ag"
 
 #: ../src/fw/applib/pbl_std/timelocal.c:39
 msgid "Sep"

--- a/resources/normal/base/lang/es_ES/tintin.po
+++ b/resources/normal/base/lang/es_ES/tintin.po
@@ -1009,7 +1009,7 @@ msgstr "Inicio rápido"
 #: ../src/fw/apps/system/settings/quick_launch_setup_menu.c:56
 msgid ""
 "Open favorite apps quickly with a long button press from your watchface."
-msgstr "Inicia tus apps favoritas con una pulsación larga desde tu esfera."
+msgstr "Inicia tus apps favoritas con una pulsación larga desde tu carátula."
 
 #: ../src/fw/apps/system/settings/quiet_time.c:75
 msgid "Quiet All Notifications"
@@ -1353,7 +1353,7 @@ msgstr "Vistazos"
 #. / Help text for the Timeline Quick View first use dialog.
 #: ../src/fw/apps/system/settings/timeline.c:189
 msgid "Appears on your watchface when an event is about to start."
-msgstr "Aparecerán sobre tu esfera cuando un evento esté a punto de comenzar."
+msgstr "Aparece en tu carátula cuando un evento está a punto de comenzar."
 
 #: ../src/fw/apps/system/settings/timeline.c:216
 #: ../src/fw/apps/system/timeline/timeline.c:1311
@@ -1374,7 +1374,7 @@ msgstr "Al desconectar"
 
 #: ../src/fw/apps/system/settings/vibe_patterns.c:265
 msgid "Sounds & Haptics"
-msgstr "Sonidos y háptica"
+msgstr "Sonidos y vibraciones"
 
 #: ../src/fw/apps/system/settings/vibe_patterns.c:267
 msgid "Vibrations"
@@ -1456,7 +1456,7 @@ msgstr "Activo"
 
 #: ../src/fw/apps/system/watchfaces.c:206
 msgid "Watchfaces"
-msgstr "Esferas"
+msgstr "Carátulas"
 
 #. / Shown when neither high nor low temperature is known
 #: ../src/fw/apps/system/weather/layout.c:73
@@ -2855,7 +2855,7 @@ msgstr "abr"
 #: ../src/fw/applib/pbl_std/timelocal.c:38
 #: ../src/fw/applib/pbl_std/timelocal.c:44
 msgid "May"
-msgstr "may"
+msgstr "mayo"
 
 #: ../src/fw/applib/pbl_std/timelocal.c:39
 msgid "Jun"


### PR DESCRIPTION
## Summary
- update Catalan watchface terminology to use caràtula and improve haptics/month wording
- update Spanish watchface terminology to use carátula and improve haptics/May wording

## Tests
- msgfmt -c -o /private/tmp/ca_ES_tintin.mo resources/normal/base/lang/ca_ES/tintin.po
- msgfmt -c -o /private/tmp/es_ES_tintin.mo resources/normal/base/lang/es_ES/tintin.po
- gitlint --commits HEAD~2..HEAD