### PR TITLE
fw/drivers/display/sf32lb: crash on LCDC silent loss [FIRM-1928]

### DIFF
--- a/src/fw/console/prompt_commands.c
+++ b/src/fw/console/prompt_commands.c
@@ -1105,6 +1105,19 @@ void command_audit_delay_us(void) {
   __enable_irq();
 }
 
+#if !defined(RELEASE) && defined(CONFIG_DISPLAY_JDI_SF32LB)
+#include "drivers/display/sf32lb/display_jdi.h"
+
+// Arms the JDI display driver to drop the next LCDC transfer-complete
+// callback, simulating the silent-loss failure mode (e.g. SiFli HAL ICB
+// overflow). The silent-loss timer should fire ~500ms later and PBL_CROAK,
+// producing a Memfault coredump and a watch reboot.
+void command_display_drop_complete(void) {
+  display_jdi_test_drop_next_complete();
+  prompt_send_response("display: armed drop of next LCDC complete; PBL_CROAK in ~500ms");
+}
+#endif
+
 #if !MICRO_FAMILY_SF32LB52
 // Simply parks the chip permanently in stop mode in whatever state it's currently in. This can be
 // pretty handy when trying to profile power of the chip under certains states

--- a/src/fw/console/prompt_commands.h
+++ b/src/fw/console/prompt_commands.h
@@ -288,6 +288,10 @@ extern void command_console_disable_rx(const char *seconds_str);
 extern void command_force_deepwfi(const char *arg);
 #endif
 
+#if !defined(RELEASE) && defined(CONFIG_DISPLAY_JDI_SF32LB)
+extern void command_display_drop_complete(void);
+#endif
+
 #define KEEP_NON_ESSENTIAL_COMMANDS 1
 static const Command s_prompt_commands[] = {
   // PULSE entry point, needed for anything PULSE-related to work
@@ -617,6 +621,9 @@ static const Command s_prompt_commands[] = {
   { "console disable rx", command_console_disable_rx, 1 },
 #if MICRO_FAMILY_SF32LB52
   { "force deepwfi", command_force_deepwfi, 1 },
+#endif
+#if !defined(RELEASE) && defined(CONFIG_DISPLAY_JDI_SF32LB)
+  { "display drop_complete", command_display_drop_complete, 0 },
 #endif
 
 #if MEMFAULT

--- a/src/fw/drivers/display/sf32lb/display_jdi.c
+++ b/src/fw/drivers/display/sf32lb/display_jdi.c
@@ -11,6 +11,7 @@
 #include "kernel/pbl_malloc.h"
 #include "kernel/util/delay.h"
 #include "kernel/util/stop.h"
+#include "kernel/coredump_extra_regions.h"
 #include "mcu/cache.h"
 #include "os/mutex.h"
 #include "pbl/services/new_timer/new_timer.h"
@@ -63,6 +64,17 @@ static volatile bool s_eof_observed;
 // volatile because the only consumer is the postmortem coredump tool, not
 // any C code in this image — without it, the compiler eliminates the stores.
 static volatile uint32_t s_lcdc_pre_crash_regs[DISPLAY_LCDC_REG_DUMP_BYTES / sizeof(uint32_t)];
+
+// Called from coredump_extra_regions_init() in main.c boot path so the
+// snapshot buffer rides in Memfault coredumps. The default Memfault
+// reconstruction only forwards thread stacks + log buffers; without this
+// the LCDC register dump captured by prv_silent_loss_handler stays in flash
+// and never reaches Sifli.
+void display_jdi_register_coredump_regions(void) {
+  coredump_extra_regions_register("lcdc_pre_crash_regs",
+                                  (const void *)s_lcdc_pre_crash_regs,
+                                  sizeof(s_lcdc_pre_crash_regs));
+}
 
 #ifndef RELEASE
 // Test hook: arm a one-shot drop of the next LCDC transfer-complete callback,

--- a/src/fw/drivers/display/sf32lb/display_jdi.c
+++ b/src/fw/drivers/display/sf32lb/display_jdi.c
@@ -13,6 +13,7 @@
 #include "kernel/util/stop.h"
 #include "mcu/cache.h"
 #include "os/mutex.h"
+#include "pbl/services/new_timer/new_timer.h"
 #include "system/logging.h"
 #include "system/passert.h"
 
@@ -27,6 +28,20 @@
 #define POWER_SEQ_DELAY_TIME_US  11000
 #define POWER_RESET_CYCLE_DELAY_TIME_US 500000
 
+// Timeout for detecting the SiFli HAL silent-loss bug: the LCDC kicks off a
+// transfer but never delivers the EOF callback, so the compositor would block
+// forever. A normal full-frame transfer takes well under 20ms; 500ms is a
+// conservative threshold that won't fire on transient stalls but catches a
+// real wedge well before the user perceives the freeze.
+#define DISPLAY_SILENT_LOSS_TIMEOUT_MS 500
+
+// Bytes of the LCDC peripheral register file snapshotted into BSS before
+// crashing. The PebbleOS coredump captures all of HPSYS SRAM but does not
+// capture MMIO; copying registers into SRAM gets them into the coredump that
+// gets shared with Sifli. 2KB covers IRQ/SETTING/COMMAND/CANVAS/LAYER0/JDI_PAR
+// (lcd_if.h struct ends around offset 0x100).
+#define DISPLAY_LCDC_REG_DUMP_BYTES 2048
+
 // Pointer to the compositor's framebuffer - we convert in-place to save 44KB RAM
 static uint8_t *s_framebuffer;
 static uint16_t s_update_y0;
@@ -35,6 +50,26 @@ static bool s_initialized;
 static bool s_updating;
 static UpdateCompleteCallback s_uccb;
 static SemaphoreHandle_t s_sem;
+static TimerID s_silent_loss_timer = TIMER_INVALID_ID;
+// Set from HAL_LCDC_SendLayerDataCpltCbk (ISR). The silent-loss handler checks
+// this to distinguish "EOF truly never fired" (real bug → crash) from "EOF
+// fired but terminate hasn't drained off the KernelMain queue yet" (race
+// against scheduler latency → don't crash).
+static volatile bool s_eof_observed;
+// Captured at silent-loss time so the coredump shipped to Sifli carries the
+// LCDC register state at the moment of the wedge. uint32_t storage (not
+// uint8_t) so the linker word-aligns it — prv_snapshot_lcdc_regs reads MMIO
+// as 32-bit volatiles and would fault on a misaligned destination. Marked
+// volatile because the only consumer is the postmortem coredump tool, not
+// any C code in this image — without it, the compiler eliminates the stores.
+static volatile uint32_t s_lcdc_pre_crash_regs[DISPLAY_LCDC_REG_DUMP_BYTES / sizeof(uint32_t)];
+
+#ifndef RELEASE
+// Test hook: arm a one-shot drop of the next LCDC transfer-complete callback,
+// simulating the silent-loss failure mode. The silent-loss timer should fire
+// ~DISPLAY_SILENT_LOSS_TIMEOUT_MS later and PBL_CROAK.
+static volatile bool s_test_drop_next_complete;
+#endif
 
 #if DISPLAY_ORIENTATION_ROTATED_180
 static bool s_rotated_180 = true;
@@ -134,7 +169,51 @@ static void prv_handle_send_failure(const char *ctx, HAL_StatusTypeDef status) {
   state->hlcdc.ErrorCode = HAL_LCDC_ERROR_NONE;
 }
 
+static void prv_snapshot_lcdc_regs(const LCDC_HandleTypeDef *hlcdc) {
+  // Peripheral MMIO must be read as aligned 32-bit volatile loads; plain
+  // memcpy may emit byte-wise loads on some toolchains and fault.
+  const volatile uint32_t *src = (const volatile uint32_t *)hlcdc->Instance;
+  for (size_t i = 0; i < DISPLAY_LCDC_REG_DUMP_BYTES / sizeof(uint32_t); i++) {
+    s_lcdc_pre_crash_regs[i] = src[i];
+  }
+}
+
+// Runs on PebbleTask_NewTimers if no LCDC EOF callback arrives within
+// DISPLAY_SILENT_LOSS_TIMEOUT_MS of kickoff. Known trigger: SiFli HAL's
+// ICB-overflow path (bf0_hal_lcdc.c HAL_LCDC_IRQHandler) sets
+// HAL_LCDC_ERROR_OVERFLOW without invoking XferCpltCallback / XferErrorCallback,
+// so the firmware silently loses the completion and the compositor wedges.
+// Capture LCDC registers into BSS so they ride in the coredump, then crash —
+// the user sees a reboot instead of a frozen screen, and Memfault captures
+// the state Sifli needs to diagnose the underlying HAL bug.
+static void prv_silent_loss_handler(void *data) {
+  if (s_eof_observed) {
+    // EOF fired between us arming the timer and the timeout — terminate is
+    // queued on KernelMain but hasn't run yet. Don't crash on a scheduler
+    // latency artifact.
+    return;
+  }
+  DisplayJDIState *state = DISPLAY->state;
+  prv_snapshot_lcdc_regs(&state->hlcdc);
+  // HPSYS SRAM is Normal cacheable (since the MPU region shrink in
+  // hal_sifli/sf32lb52 system_bf0_ap.c), so the snapshot stores above land
+  // in D-cache. PebbleOS captures coredump RAM after the crash path may
+  // have already invalidated the cache, so flush the dirty lines back to
+  // physical SRAM before we trip PBL_CROAK.
+  uintptr_t snap_addr = (uintptr_t)s_lcdc_pre_crash_regs;
+  size_t snap_size = sizeof(s_lcdc_pre_crash_regs);
+  dcache_align(&snap_addr, &snap_size);
+  dcache_flush((const void *)snap_addr, snap_size);
+  PBL_CROAK("LCDC silent loss: no EOF in %ums (State=%d Err=0x%lx y=%u..%u)",
+            (unsigned)DISPLAY_SILENT_LOSS_TIMEOUT_MS,
+            (int)state->hlcdc.State,
+            (unsigned long)state->hlcdc.ErrorCode,
+            (unsigned)s_update_y0, (unsigned)s_update_y1);
+}
+
 static void prv_display_update_terminate(void *data) {
+  new_timer_stop(s_silent_loss_timer);
+
   // Convert the updated region back from 332 to 222 format
   for (uint16_t y = s_update_y0; y <= s_update_y1; y++) {
     uint8_t *row = &s_framebuffer[y * PBL_DISPLAY_WIDTH];
@@ -172,6 +251,22 @@ void display_jdi_irq_handler(DisplayJDIDevice *disp) {
 
 void HAL_LCDC_SendLayerDataCpltCbk(LCDC_HandleTypeDef *lcdc) {
   portBASE_TYPE woken = pdFALSE;
+
+#ifndef RELEASE
+  if (s_test_drop_next_complete && s_updating) {
+    s_test_drop_next_complete = false;
+    // Simulate the lost-completion failure mode: leave s_eof_observed false
+    // and don't post the terminate event. The silent-loss timer should fire
+    // ~DISPLAY_SILENT_LOSS_TIMEOUT_MS later and PBL_CROAK.
+    portEND_SWITCHING_ISR(woken);
+    return;
+  }
+#endif
+
+  // Mark EOF before doing anything else so the silent-loss handler's race
+  // check sees it even if the terminate event sits on the KernelMain queue
+  // longer than the timeout.
+  s_eof_observed = true;
 
   if (s_updating) {
     PebbleEvent e = {
@@ -305,10 +400,26 @@ void display_update(NextRowCallback nrcb, UpdateCompleteCallback uccb) {
   // Adjust framebuffer pointer to start of buffer (row 0)
   s_framebuffer = s_framebuffer - (s_update_y0 * PBL_DISPLAY_WIDTH);
 
+  // Lazy-create the silent-loss timer. display_init runs via boot_splash_start
+  // before new_timer_service_init, so creating it in display_init would
+  // silently fail. The compositor doesn't reach this path until well after
+  // the timer service is up.
+  if (s_silent_loss_timer == TIMER_INVALID_ID) {
+    s_silent_loss_timer = new_timer_create();
+  }
+
   s_uccb = uccb;
   s_updating = true;
+  s_eof_observed = false;
 
   stop_mode_disable(InhibitorDisplay);
+  // Arm the timer before kickoff so the EOF IRQ, which can fire as soon as
+  // SendLayerData_IT returns, never races us into a state where the timer
+  // isn't yet armed. prv_display_update_terminate stops it on the normal
+  // completion path; the kickoff-failure path below stops it via the same
+  // terminate call.
+  new_timer_start(s_silent_loss_timer, DISPLAY_SILENT_LOSS_TIMEOUT_MS,
+                  prv_silent_loss_handler, NULL, 0);
   HAL_StatusTypeDef status = prv_display_update_start();
   if (status != HAL_OK) {
     prv_handle_send_failure("update", status);
@@ -346,3 +457,9 @@ void display_update_boot_frame(uint8_t *framebuffer) {
 }
 
 void display_clear(void) {}
+
+#ifndef RELEASE
+void display_jdi_test_drop_next_complete(void) {
+  s_test_drop_next_complete = true;
+}
+#endif

--- a/src/fw/drivers/display/sf32lb/display_jdi.h
+++ b/src/fw/drivers/display/sf32lb/display_jdi.h
@@ -50,3 +50,12 @@ typedef const struct DisplayJDIDevice {
 } DisplayJDIDevice;
 
 void display_jdi_irq_handler(DisplayJDIDevice *disp);
+
+#ifndef RELEASE
+//! Test hook: arm a one-shot drop of the next LCDC transfer-complete callback,
+//! simulating the silent-loss failure mode (e.g. SiFli HAL ICB overflow). The
+//! silent-loss timer should fire ~500ms later and PBL_CROAK, producing a
+//! Memfault coredump and a watch reboot. Intended for verifying the
+//! detect-and-crash path on hardware.
+void display_jdi_test_drop_next_complete(void);
+#endif

--- a/src/fw/kernel/coredump_extra_regions.c
+++ b/src/fw/kernel/coredump_extra_regions.c
@@ -1,0 +1,39 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "kernel/coredump_extra_regions.h"
+
+#include "system/logging.h"
+
+static CoredumpExtraRegion s_regions[COREDUMP_EXTRA_REGIONS_MAX];
+static size_t s_count;
+
+void coredump_extra_regions_register(const char *name, const void *addr, size_t size) {
+  if (s_count >= COREDUMP_EXTRA_REGIONS_MAX) {
+    PBL_LOG_ERR("coredump_extra_regions: registry full, dropping %s", name);
+    return;
+  }
+  s_regions[s_count++] = (CoredumpExtraRegion){
+      .name = name,
+      .addr = (uintptr_t)addr,
+      .size = size,
+  };
+}
+
+const CoredumpExtraRegion *coredump_extra_regions_get(size_t *out_count) {
+  *out_count = s_count;
+  return s_regions;
+}
+
+// Forward declarations for per-driver registration helpers. Each driver
+// provides this function (under its own platform guard); we call them all
+// here under matching guards.
+#if PLATFORM_OBELIX || PLATFORM_GETAFIX
+void display_jdi_register_coredump_regions(void);
+#endif
+
+void coredump_extra_regions_init(void) {
+#if PLATFORM_OBELIX || PLATFORM_GETAFIX
+  display_jdi_register_coredump_regions();
+#endif
+}

--- a/src/fw/kernel/coredump_extra_regions.h
+++ b/src/fw/kernel/coredump_extra_regions.h
@@ -1,0 +1,48 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+//! Driver-registered RAM regions that the Memfault coredump reconstruction
+//! forwards to the cloud in addition to thread stacks and log buffers.
+//!
+//! The Memfault port (third_party/memfault/port/src/memfault_pebble_coredump.c)
+//! packages only a small slice of RAM for cloud upload by default. Drivers
+//! that snapshot diagnostic state into a fixed BSS buffer ahead of a fault
+//! (e.g. a peripheral register dump captured before PBL_CROAK) register that
+//! buffer here so it rides along in the Memfault upload.
+//!
+//! Registration order:
+//!   1. main.c calls coredump_extra_regions_init() early in boot.
+//!   2. coredump_extra_regions_init() calls per-driver register helpers under
+//!      platform conditionals.
+//!   3. main.c calls pbl_analytics_init(), which triggers Memfault coredump
+//!      reconstruction. The reconstruction iterates the registry via
+//!      coredump_extra_regions_get() and includes each region as a cached
+//!      memory region in the upload.
+//!
+//! Keep regions small — every byte adds to the BLE upload size. Sub-KB
+//! buffers of bounded, fault-relevant state are the intended use.
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define COREDUMP_EXTRA_REGIONS_MAX 8
+
+typedef struct {
+  const char *name;
+  uintptr_t addr;
+  size_t size;
+} CoredumpExtraRegion;
+
+//! Add a region to the coredump registry. Drops silently (logged) if the
+//! registry is full — bump COREDUMP_EXTRA_REGIONS_MAX if you hit that.
+void coredump_extra_regions_register(const char *name, const void *addr, size_t size);
+
+//! Iterate the registry. Out-parameter receives the number of registered
+//! regions; the returned pointer is valid until the next register() call.
+const CoredumpExtraRegion *coredump_extra_regions_get(size_t *out_count);
+
+//! Called once from main.c before pbl_analytics_init() to wire up all
+//! per-driver registrations under platform conditionals.
+void coredump_extra_regions_init(void);

--- a/src/fw/main.c
+++ b/src/fw/main.c
@@ -43,6 +43,7 @@
 #include "resource/resource.h"
 #include "resource/system_resource.h"
 
+#include "kernel/coredump_extra_regions.h"
 #include "kernel/util/stop.h"
 #include "kernel/util/task_init.h"
 #include "kernel/util/sleep.h"
@@ -325,6 +326,11 @@ static NOINLINE void prv_main_task_init(void) {
   // from firing if we block other tasks.
   task_watchdog_init();
   task_watchdog_pause(30);
+
+  // Wire up the coredump extra-regions registry before pbl_analytics_init,
+  // which triggers Memfault coredump reconstruction. Reconstruction reads the
+  // registry to decide what beyond-the-defaults RAM to forward to the cloud.
+  coredump_extra_regions_init();
 
   pbl_analytics_init();
   register_system_timers();

--- a/third_party/memfault/port/src/memfault_pebble_coredump.c
+++ b/third_party/memfault/port/src/memfault_pebble_coredump.c
@@ -27,6 +27,7 @@
 
 #include "drivers/flash.h"
 #include "flash_region/flash_region.h"
+#include "kernel/coredump_extra_regions.h"
 #include "kernel/core_dump.h"
 #include "kernel/core_dump_private.h"
 #include "kernel/pbl_malloc.h"
@@ -509,6 +510,15 @@ void memfault_pebble_coredump_reconstruct(void) {
           log_regions.region[i].region_size);
       }
     }
+  }
+
+  // Include driver-registered crash diagnostic regions (e.g. peripheral
+  // register snapshots captured pre-PBL_CROAK). The registry is populated by
+  // coredump_extra_regions_init() in main.c, which runs before this code.
+  size_t extra_count = 0;
+  const CoredumpExtraRegion *extras = coredump_extra_regions_get(&extra_count);
+  for (size_t i = 0; i < extra_count; i++) {
+    ADD_CACHED_REGION((uint32_t)extras[i].addr, extras[i].size);
   }
 
   #undef ADD_CACHED_REGION


### PR DESCRIPTION
Supersedes #1299 per @gmarull's review feedback: instead of recovering
  silently, detect the failure and crash so we get a Memfault coredump for
  Sifli + the user sees a reboot (better than a permanent freeze).

  ## What's here

  - **Detect-and-crash path** in `display_jdi.c`. A 500ms NewTimer arms
    inside `display_update()` alongside the LCDC kickoff. If the EOF
    callback doesn't fire by the timeout, snapshot the first 2KB of the
    LCDC peripheral register file into a static volatile BSS buffer
    (`s_lcdc_pre_crash_regs`) and `PBL_CROAK`. The user sees a clean
    reboot; Memfault gets a coredump with reboot reason `Assert` and the
    croak message embedded in the log.
  - **Race protection**. A volatile `s_eof_observed` flag is set from the
    IRQ before the terminate event is posted. If EOF fires between us
    arming the timer and the timeout (e.g. scheduler latency on the
    KernelMain queue), the silent-loss handler sees the flag and bails
    out before crashing — keeps false-positives off the dashboard.
  - **Coredump extra-regions registry**
  (`src/fw/kernel/coredump_extra_regions.{h,c}`).
    Generic kernel-side API for drivers to register BSS buffers that
    should ride in Memfault coredumps in addition to the default thread
    stacks / TCBs / log buffers. The first user is the LCDC snapshot,
    but the registry is general — any driver that snapshots fault-time
    state can call `coredump_extra_regions_register()`. Wired through
    `main.c` immediately before `pbl_analytics_init()` so the registry
    is populated before Memfault reconstruction reads it.
  - **`display drop_complete` prompt hook** (debug-only, gated on
    `!RELEASE && (PLATFORM_OBELIX || PLATFORM_GETAFIX)`). Arms a one-shot
    drop of the next LCDC transfer-complete callback, simulating the
    silent-loss failure mode. Used to validate the detect-and-crash path
    end-to-end on hardware without needing a real reproduction.