### PR TITLE
fw/apps/system/notifications: vertically center "Clear all" label

### DIFF
--- a/src/fw/apps/system/notifications.c
+++ b/src/fw/apps/system/notifications.c
@@ -550,7 +550,7 @@ static void prv_draw_row_callback(GContext *ctx, const Layer *cell_layer, MenuIn
 #else
     const GFont font = system_theme_get_font_for_default_size(TextStyleFont_MenuCellTitle);
     GRect box = cell_layer->bounds;
-    box.origin.y += 6;
+    box.origin.y += (box.size.h - fonts_get_font_height(font)) / 2 - fonts_get_font_cap_offset(font);
 
     graphics_draw_text(ctx, i18n_get("Clear All", data), font, box,
                        GTextOverflowModeTrailingEllipsis, GTextAlignmentCenter, NULL);


### PR DESCRIPTION
Previously, the "Clear all" action label in the Notifications app had a hard-coded y value, causing it to be vertically misaligned in its cell on obelix. This PR removes the hard-coded value in exchange for a computed value based on the cell height and font used.