### PR TITLE
fw/shell/normal/watchface: open Quick Launch setup on disabled button long-press

### DIFF
--- a/src/fw/shell/normal/watchface.c
+++ b/src/fw/shell/normal/watchface.c
@@ -146,11 +146,9 @@ static void prv_quick_launch_handler(ClickRecognizerRef recognizer, void *data) 
   if (prv_is_any_combo_active()) {
     return;
   }
-  
-  if (!quick_launch_is_enabled(button)) {
-    return;
-  }
-  AppInstallId app_id = quick_launch_get_app(button);
+
+  AppInstallId app_id = quick_launch_is_enabled(button) ? quick_launch_get_app(button)
+                                                        : INSTALL_ID_INVALID;
   if (app_id == INSTALL_ID_INVALID) {
     app_id = app_install_get_id_for_uuid(&quick_launch_setup_get_app_info()->uuid);
   }


### PR DESCRIPTION
This used to work fine on classic pebbles, but was given an early return between the last public firmware release and the google source code release. No reason to disable it that I can see, so this PR simply just drops that and restores previous behavior by falling back to INSTALL_ID_INVALID (which launches the quick launch settings).

---

Claude description: A long-press from the watchface used to silently bail out when the button's quick launch entry was disabled. Per the file-level comment on quick_launch_setup_menu.c, the setup app is meant to handle that case so the user can re-enable or assign an app directly. Fall through to the setup app whenever no valid app is resolved -- both when the button is disabled and when it is enabled but unassigned.