### PR TITLE
fw/services/light: linearly ramp dynamic backlight intensity

### DIFF
--- a/src/fw/services/light/service.c
+++ b/src/fw/services/light/service.c
@@ -148,15 +148,33 @@ static uint8_t prv_backlight_get_intensity(void) {
   }
   
 #if CAPABILITY_HAS_DYNAMIC_BACKLIGHT && !defined(RECOVERY_FW)
-  // Dynamic backlight: dim in utter darkness, otherwise user max. The
-  // bright-outdoor case is already filtered upstream by prv_light_allowed()
-  // for ambient-sensor-enabled wakes; the few paths that bypass that gate
-  // (app-driven force-on, ambient-sensor pref off) sensibly land at max here.
+  // Dynamic backlight: linear ramp from dim_intensity at dynamic_min_threshold
+  // up to 100% at ambient_light_dark_threshold, then clamped to user_max. This
+  // keeps the slope independent of the user's brightness preference, so a user
+  // who caps their max at e.g. 60% still hits that cap partway up the ALS range
+  // rather than only at the brightest end. prv_light_allowed() rejects wakes
+  // above dark_threshold; paths that bypass it (app-driven force-on,
+  // ambient-sensor pref off) sensibly land at user_max here.
   if (backlight_is_dynamic_intensity_enabled()) {
     const uint8_t dim_intensity = 10;
-    if (prv_get_als_level() <= backlight_get_dynamic_min_threshold()) {
+    const uint8_t user_max = backlight_get_intensity();
+    const uint32_t als = prv_get_als_level();
+    const uint32_t dim_threshold = backlight_get_dynamic_min_threshold();
+    const uint32_t max_threshold = ambient_light_get_dark_threshold();
+
+    if (user_max <= dim_intensity || max_threshold <= dim_threshold) {
+      return user_max;
+    }
+    if (als <= dim_threshold) {
       return dim_intensity;
     }
+    if (als >= max_threshold) {
+      return user_max;
+    }
+    const uint32_t ramped =
+        dim_intensity +
+        ((100 - dim_intensity) * (als - dim_threshold)) / (max_threshold - dim_threshold);
+    return (ramped > user_max) ? user_max : (uint8_t)ramped;
   }
 #endif
   


### PR DESCRIPTION
This one is meant more as an example impl and a space for discussions.

Right now backlight intensity is one of 3:
- 10%, if below user-set dynamic backlight min threshold (default 5, imo should be 2)
- User-set "Max Intensity", if above the user-set dynamic backlight min threshold
- Nothing, if above the hardcoded dark threshold (150 for obelix)

So it's not very much a dynamic backlight. I believe having the value be dynamic based on measured light levels would be more appropriate. If in a dimly lit room (~8 counts on my watch for bedside lamps, 2-3 for ceiling light if very indirect), it can very much benefit from being above 10%, but below user-set max. In a rather bright space (e.g. same room on a brighter day with sunlight, but no direct light to remove need for backlight), it can benefit reaching user-set max (in my case, "blinding").

This is one such demo. This already improves my experience, but I am not maximally happy with it. In a dim room it makes the screen readable, but not properly match ambient levels, while not being blinding, so it's still a partial win.

Several implementation details to figure out would be:
- linear vs not
- whether user's max intensity is used for a range, or as a clamp. this is for a range, but I think clamp may make more sense.

Open to ideas! :D