### PR TITLE
Utilize continuous sampling on W1160 + increase integration time to 99ms

### DIFF
--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -569,8 +569,8 @@ const BoardConfigPower BOARD_CONFIG_POWER = {
 
 const BoardConfig BOARD_CONFIG = {
   .backlight_on_percent = 45,
-  .ambient_light_dark_threshold = 150,
-  .ambient_k_delta_threshold = 25,
+  .ambient_light_dark_threshold = 600,
+  .ambient_k_delta_threshold = 100,
   .dynamic_backlight_min_threshold = 5,
   .backlight_default_color = BACKLIGHT_COLOR_WARM_WHITE,
 };

--- a/src/fw/drivers/ambient/ambient_light_opt3001.c
+++ b/src/fw/drivers/ambient/ambient_light_opt3001.c
@@ -75,6 +75,15 @@ void ambient_light_init(void) {
   s_initialized = true;
 }
 
+void ambient_light_suspend(void) {
+  // No-op: OPT3001 is either single-shot per read or always-on; the chip
+  // sits in front of a different display stack on these boards and doesn't
+  // need to gate against backlight LED bleed-through the way the W1160 does.
+}
+
+void ambient_light_resume(void) {
+}
+
 uint32_t ambient_light_get_light_level(void) {
   if (!s_initialized) {
     return BOARD_CONFIG.ambient_light_dark_threshold;

--- a/src/fw/drivers/ambient/ambient_light_w1160.c
+++ b/src/fw/drivers/ambient/ambient_light_w1160.c
@@ -62,6 +62,7 @@
 #define W1160_SLOW_ST_CONFIG1       (0x07)   /* 200ms ((0x7CF+1) * 100us) */
 #define W1160_SLOW_ST_CONFIG2       (0xCF)
 #define W1160_SAMPLING_EN           (1<<1)   /* 1:en 0:dis */
+#define W1160_SAMPLING_DIS          (0<<1)   /* 1:en 0:dis */
 #define W1160_CHIP_ID               (0xE5)
 
 #define W1160_RESULT_EXPONENT_SHIFT (12)
@@ -139,6 +140,24 @@ uint32_t ambient_light_get_light_level(void) {
   }
 
   return (((uint16_t)result[1]) << 8) | result[0];
+}
+
+void ambient_light_suspend(void) {
+  if (!s_initialized) {
+    return;
+  }
+  if (!prv_write_register(W1160_STATE_REG, W1160_SAMPLING_DIS)) {
+    PBL_LOG_ERR("Could not suspend W1160 sampling");
+  }
+}
+
+void ambient_light_resume(void) {
+  if (!s_initialized) {
+    return;
+  }
+  if (!prv_write_register(W1160_STATE_REG, W1160_SAMPLING_EN)) {
+    PBL_LOG_ERR("Could not resume W1160 sampling");
+  }
 }
 
 void command_als_read(void) {

--- a/src/fw/drivers/ambient/ambient_light_w1160.c
+++ b/src/fw/drivers/ambient/ambient_light_w1160.c
@@ -57,21 +57,16 @@
 #define W1160_ALSCTRL_DATA_FORMAT12 (0<<2)   /* 1:12bit 0:16bit */
 #define W1160_DATA_GC_LVL           (15<<4)  /* gc lelvel 15 */
 #define W1160_SAT_GC_CONFIG         (0x0A)
-#define W1160_SLOW_IT_CONFIG1       (0x00)   /* 16.830ms */
-#define W1160_SLOW_IT_CONFIG2       (0xA9)
-#define W1160_SLOW_ST_CONFIG1       (0x03)   /* 480ms */
-#define W1160_SLOW_ST_CONFIG2       (0xFF)
+#define W1160_SLOW_IT_CONFIG1       (0x03)   /* 99ms ((0x3E7+1) * 99us) */
+#define W1160_SLOW_IT_CONFIG2       (0xE7)
+#define W1160_SLOW_ST_CONFIG1       (0x07)   /* 200ms ((0x7CF+1) * 100us) */
+#define W1160_SLOW_ST_CONFIG2       (0xCF)
 #define W1160_SAMPLING_EN           (1<<1)   /* 1:en 0:dis */
-#define W1160_SAMPLING_DIS          (0<<1)   /* 1:en 0:dis */
 #define W1160_CHIP_ID               (0xE5)
-#define W1160_FLG_ALS_DR            (1<<7)
 
 #define W1160_RESULT_EXPONENT_SHIFT (12)
 #define W1160_RESULT_MANTISSA_MASK  (0x0FFF)
 #define W1160_ADC2LUX_COEF          (3U)
-
-#define W1160_ALS_POLL_DELAY_MS     (5)    /* ms between data-ready polls */
-#define W1160_ALS_POLL_TIMEOUT_MS   (200)  /* max wait for ALS data-ready */
 
 static bool s_initialized;
 static uint32_t s_sensor_light_dark_threshold;
@@ -119,6 +114,9 @@ void ambient_light_init(void) {
   rv &= prv_write_register(W1160_IT_SLOW2_REG, W1160_SLOW_IT_CONFIG2);
   rv &= prv_write_register(W1160_SAMPLE_SLOW1_REG, W1160_SLOW_ST_CONFIG1);
   rv &= prv_write_register(W1160_SAMPLE_SLOW2_REG, W1160_SLOW_ST_CONFIG2);
+  // Continuous slow-mode sampling: the chip autonomously integrates every
+  // SAMPLE_TIME_SLOW and latches DATA_ALS, so callers can just read it.
+  rv &= prv_write_register(W1160_STATE_REG, W1160_SAMPLING_EN);
 
   PBL_ASSERT(rv, "Failed to initialize W1160");
 
@@ -127,56 +125,20 @@ void ambient_light_init(void) {
 
 uint32_t ambient_light_get_light_level(void) {
   uint8_t result[2] = {0};
-  uint16_t als;
   bool rv;
 
   if (!s_initialized) {
     return 0UL;
   }
 
-  rv = prv_write_register(W1160_STATE_REG, W1160_SAMPLING_EN);
-  if (!rv) {
-    PBL_LOG_ERR("Could not enable W1160 sampling");
-    return 0UL;
-  }
-
-  uint32_t elapsed = 0;
-  do {
-    rv = prv_read_register(W1160_FLAG1_REG, &result[0]);
-    if (!rv) {
-      PBL_LOG_ERR("Could not read W1160 FLAG1");
-      goto disable_and_fail;
-    }
-    if ((result[0] & W1160_FLG_ALS_DR) == 0U) {
-      if (elapsed >= W1160_ALS_POLL_TIMEOUT_MS) {
-        PBL_LOG_ERR("W1160 ALS data-ready timeout");
-        goto disable_and_fail;
-      }
-      psleep(W1160_ALS_POLL_DELAY_MS);
-      elapsed += W1160_ALS_POLL_DELAY_MS;
-    }
-  } while ((result[0] & W1160_FLG_ALS_DR) == 0U);
-
   rv = prv_read_register(W1160_DATA1_ALS_REG, &result[1]);
   rv &= prv_read_register(W1160_DATA2_ALS_REG, &result[0]);
   if (!rv) {
     PBL_LOG_ERR("Could not obtain W1160 data");
-    goto disable_and_fail;
-  }
-
-  rv = prv_write_register(W1160_STATE_REG, W1160_SAMPLING_DIS);
-  if (!rv) {
-    PBL_LOG_ERR("Could not disable W1160 sampling");
     return 0UL;
   }
 
-  als = (((uint16_t)(result[1])) << 8) | result[0];
-
-  return als;
-
-disable_and_fail:
-  (void)prv_write_register(W1160_STATE_REG, W1160_SAMPLING_DIS);
-  return 0UL;
+  return (((uint16_t)result[1]) << 8) | result[0];
 }
 
 void command_als_read(void) {

--- a/src/fw/drivers/ambient_light.h
+++ b/src/fw/drivers/ambient_light.h
@@ -22,6 +22,13 @@ static const uint32_t AMBIENT_LIGHT_LEVEL_MAX  = 4096;   // max 12 bits
 /** Initialize the ambient light sensor */
 void ambient_light_init(void);
 
+//! Pause sampling so the photodiode isn't latching readings while the backlight
+//! LED is illuminating it. Reads keep returning the last latched value.
+void ambient_light_suspend(void);
+
+//! Resume sampling after a suspend.
+void ambient_light_resume(void);
+
 /** get the ambient light level scaled between 0 and AMBIENT_LIGHT_LEVEL_MAX
  */
 uint32_t ambient_light_get_light_level(void);

--- a/src/fw/drivers/stubs/ambient_light.c
+++ b/src/fw/drivers/stubs/ambient_light.c
@@ -6,6 +6,12 @@
 void ambient_light_init(void) {
 }
 
+void ambient_light_suspend(void) {
+}
+
+void ambient_light_resume(void) {
+}
+
 uint32_t ambient_light_get_light_level(void) {
   return 0;
 }

--- a/src/fw/services/light/service.c
+++ b/src/fw/services/light/service.c
@@ -214,6 +214,13 @@ static void prv_change_brightness(uint8_t new_brightness) {
   // Scale the 0-100% to the maximum value allowed in hardware
   uint8_t scaled_brightness = (new_brightness * (uint16_t)BOARD_CONFIG.backlight_on_percent) / 100U;
 
+  // Pause/resume the ALS at the backlight's 0<->on edges so the photodiode
+  // doesn't latch readings while the backlight LED is illuminating it.
+  // While paused the chip preserves the last (clean) DATA_ALS value, which
+  // is also what the service.c cache is pinned to anyway.
+  const bool turning_on = (s_current_brightness == 0U) && (new_brightness > 0U);
+  const bool turning_off = (s_current_brightness > 0U) && (new_brightness == 0U);
+
   if (new_brightness == 0U) {
     PBL_ANALYTICS_TIMER_STOP(backlight_on_time_ms);
   } else {
@@ -222,7 +229,13 @@ static void prv_change_brightness(uint8_t new_brightness) {
 
   prv_update_intensity_analytics(scaled_brightness);
 
+  if (turning_on) {
+    ambient_light_suspend();
+  }
   backlight_set_brightness(scaled_brightness);
+  if (turning_off) {
+    ambient_light_resume();
+  }
   s_current_brightness = new_brightness;
 
 #ifdef CONFIG_BACKLIGHT_HAS_COLOR

--- a/src/fw/services/light/service.c
+++ b/src/fw/services/light/service.c
@@ -148,15 +148,28 @@ static uint8_t prv_backlight_get_intensity(void) {
   }
   
 #if CAPABILITY_HAS_DYNAMIC_BACKLIGHT && !defined(RECOVERY_FW)
-  // Dynamic backlight: dim in utter darkness, otherwise user max. The
-  // bright-outdoor case is already filtered upstream by prv_light_allowed()
-  // for ambient-sensor-enabled wakes; the few paths that bypass that gate
-  // (app-driven force-on, ambient-sensor pref off) sensibly land at max here.
+  // Dynamic backlight: linear ramp from dim_intensity at dynamic_min_threshold
+  // up to user_max at ambient_light_dark_threshold. prv_light_allowed() rejects
+  // wakes above dark_threshold; paths that bypass it (app-driven force-on,
+  // ambient-sensor pref off) sensibly land at user_max here.
   if (backlight_is_dynamic_intensity_enabled()) {
     const uint8_t dim_intensity = 10;
-    if (prv_get_als_level() <= backlight_get_dynamic_min_threshold()) {
+    const uint8_t user_max = backlight_get_intensity();
+    const uint32_t als = prv_get_als_level();
+    const uint32_t dim_threshold = backlight_get_dynamic_min_threshold();
+    const uint32_t max_threshold = ambient_light_get_dark_threshold();
+
+    if (user_max <= dim_intensity || max_threshold <= dim_threshold) {
+      return user_max;
+    }
+    if (als <= dim_threshold) {
       return dim_intensity;
     }
+    if (als >= max_threshold) {
+      return user_max;
+    }
+    return dim_intensity +
+           ((user_max - dim_intensity) * (als - dim_threshold)) / (max_threshold - dim_threshold);
   }
 #endif
   

--- a/tests/stubs/stubs_ambient_light.h
+++ b/tests/stubs/stubs_ambient_light.h
@@ -5,6 +5,10 @@
 
 void ambient_light_init(void) {
 }
+void ambient_light_suspend(void) {
+}
+void ambient_light_resume(void) {
+}
 uint32_t ambient_light_get_light_level(void) {
 	return 0;
 }


### PR DESCRIPTION
(building on #1311, has part of that code here too)

This is very much intended as a demo, and a discussion starter. ~~The code as sent here won't work right as dark-room-threshold (150) is still set for the lower integration time. Trivial fix but not worth it without talking it out first, plus I'd want to measure a bright room which is not so easy at 3:39AM.~~ (4:15 update: I found good thresholds)

This barely changes the overall power usage (prob like 10x from 7uA to 70uA, amounting to almost nothing over a day) per datasheet, makes the sensor read non-blocking, while allowing increasing integration time (how long to capture photons for) by quite a bit. What was 7 samples is ~50 samples, and overall values are a lot less noisy, staying within ~10%. IMO, a solid improvement to data quality of the ambient light sensor.