### PR TITLE
kernel: align writable data after ramfunc

### DIFF
--- a/src/fw/fw_common.ld
+++ b/src/fw/fw_common.ld
@@ -114,7 +114,7 @@ SECTIONS {
         . = ALIGN(8);
     } >FLASH
 
-    .kernel_data : ALIGN(8) {
+    .kernel_data : ALIGN(32) {
         __data_start = .; /* This is used by the startup in order to initialize the .data secion */
 
         *(.data)


### PR DESCRIPTION
Align the kernel data section to the ARMv8-M MPU granularity.

This keeps data out of the protected tail of the RAM function region.

It also keeps PULSE prompt state writable when .ramfunc is not 32-byte aligned.