### PR TITLE
applib: reset touch state via syscall

### DIFF
--- a/src/fw/applib/touch_service.c
+++ b/src/fw/applib/touch_service.c
@@ -13,8 +13,6 @@
 #include "syscall/syscall.h"
 #include "system/passert.h"
 
-bool sys_touch_service_is_enabled(void);
-
 //! @return the per-task touch service state, or NULL if the current task is
 //! not permitted to use the touch service (e.g. background workers, or
 //! watchfaces). Callers must no-op when this returns NULL.
@@ -56,7 +54,7 @@ void touch_service_subscribe(TouchServiceHandler handler, void *context) {
     .type = PEBBLE_TOUCH_EVENT,
     .handler = prv_handle_touch_event,
   };
-  touch_reset();
+  sys_touch_reset();
   if (!state->raw_subscribed) {
     event_service_client_subscribe(&state->raw_event_info);
     state->raw_subscribed = true;

--- a/src/fw/services/touch/touch.c
+++ b/src/fw/services/touch/touch.c
@@ -104,6 +104,10 @@ DEFINE_SYSCALL(bool, sys_touch_service_is_enabled, void) {
   return touch_service_is_globally_enabled();
 }
 
+DEFINE_SYSCALL(void, sys_touch_reset, void) {
+  touch_reset();
+}
+
 void touch_set_backlight_enabled(bool enabled) {
   mutex_lock(s_touch_mutex);
   if (enabled && !s_backlight_subscribed) {

--- a/src/fw/syscall/syscall.h
+++ b/src/fw/syscall/syscall.h
@@ -214,6 +214,9 @@ void sys_light_set_system_color(void);
 bool sys_mobile_app_is_connected_debounced(void);
 bool sys_pebblekit_is_connected_debounced(void);
 
+bool sys_touch_service_is_enabled(void);
+void sys_touch_reset(void);
+
 
 bool sys_app_inbox_service_register(uint8_t *storage, size_t storage_size,
                                     AppInboxMessageHandler message_handler,


### PR DESCRIPTION
## Summary
- route touch_service_subscribe() reset through a privileged syscall
- avoid app MPU faults when subscribing to touch events during launch

Fixes FIRM-1957
Fixes FIRM-1958

## Testing
- ./waf build
- gitlint