### PR TITLE
drivers/ambient_light: raise level max to 16 bits on W1160

### DIFF
--- a/src/fw/drivers/ambient/Kconfig
+++ b/src/fw/drivers/ambient/Kconfig
@@ -18,4 +18,13 @@ config AMBIENT_LIGHT_W1160
     help
       Support for the W1160 ambient light sensor.
 
+config AMBIENT_LIGHT_BITS
+    int "Ambient light sensor resolution (bits)"
+    default 12 if AMBIENT_LIGHT_OPT3001
+    default 16 if AMBIENT_LIGHT_W1160
+    help
+      Number of bits in the ambient light sensor reading. Used to derive
+      AMBIENT_LIGHT_LEVEL_MAX, which bounds the dark/backlight thresholds
+      exposed to the shell and settings UI.
+
 endif # AMBIENT_LIGHT

--- a/src/fw/drivers/ambient_light.h
+++ b/src/fw/drivers/ambient_light.h
@@ -17,7 +17,12 @@ typedef enum AmbientLightLevel {
 
 #define AMBIENT_LIGHT_LEVEL_ENUM_COUNT (AmbientLightLevelVeryLight + 1)
 
-static const uint32_t AMBIENT_LIGHT_LEVEL_MAX  = 4096;   // max 12 bits
+#ifndef CONFIG_AMBIENT_LIGHT_BITS
+// Fallback for header parsers (e.g. SDK generator) that don't preload autoconf.h.
+#define CONFIG_AMBIENT_LIGHT_BITS 12
+#endif
+
+static const uint32_t AMBIENT_LIGHT_LEVEL_MAX = (1U << CONFIG_AMBIENT_LIGHT_BITS);
 
 /** Initialize the ambient light sensor */
 void ambient_light_init(void);


### PR DESCRIPTION
The W1160 ALS is configured in 16-bit data format and ambient_light_get_light_level() can return up to 65535. The shared AMBIENT_LIGHT_LEVEL_MAX was 4096, which tripped
ambient_light_set_dark_threshold()'s assert and clamped backlight threshold prefs/settings UI to the OPT3001 12-bit range.

Select the constant by Kconfig so W1160 boards use the full sensor range while OPT3001 stays at 4096.

Fixes #1310