### PR TITLE
sf32lb52: respect NO_WATCHDOG in SoC init

### DIFF
--- a/src/fw/soc/sf32lb/sf32lb52x/init.c
+++ b/src/fw/soc/sf32lb/sf32lb52x/init.c
@@ -47,8 +47,10 @@ void soc_early_init(void) {
 
   HAL_PMU_LpCLockSelect(PMU_LPCLK_RC32);
 
+#ifndef NO_WATCHDOG
   watchdog_init();
   watchdog_start();
+#endif
 
   HAL_PMU_EnableDLL(1);
 #ifdef SF32LB52_USE_LXT


### PR DESCRIPTION
## Summary
- When the firmware is built with `--nowatchdog`, `soc_early_init` was still calling `watchdog_init()` / `watchdog_start()`, leaving the hardware WDT running. Once the task watchdog stopped feeding it (since `NO_WATCHDOG` short-circuits `task_watchdog_feed`), the chip would reset after the timeout.
- Guard the init/start pair with `#ifndef NO_WATCHDOG` so the WDT stays stopped when the build asks for it. The earlier `watchdog_stop()` remains unconditional so any WDT left running across reset is still disarmed.

## Test plan
- [ ] Build an SF32LB52 board with `./waf configure --board <board> --nowatchdog && ./waf build` and verify the WDT no longer resets the chip.
- [ ] Build without `--nowatchdog` to confirm normal watchdog behavior is unchanged.