### PR TITLE
fw/apps/watch/low_power: show date below time on low-power watchface

### DIFF
--- a/include/pbl/services/clock.h
+++ b/include/pbl/services/clock.h
@@ -183,6 +183,11 @@ void clock_get_until_time_without_fulltime(char *buffer, int buf_size, time_t ti
 //! Get the date in MM/DD format
 size_t clock_get_date(char *buffer, int buf_size, time_t timestamp);
 
+//! Same as \ref clock_get_date, but takes a pre-computed `struct tm` instead of
+//! a `time_t`. Useful in tick handlers, where the framework already passes a
+//! `struct tm` and an extra `localtime_r` round-trip would be wasteful.
+size_t clock_get_date_tm(char *buffer, int buf_size, const struct tm *time_tm);
+
 //! Get the day date in DD format
 size_t clock_get_day_date(char *buffer, int buf_size, time_t timestamp);
 

--- a/src/fw/apps/watch/low_power/face.c
+++ b/src/fw/apps/watch/low_power/face.c
@@ -22,8 +22,10 @@
 typedef struct {
   Window low_power_window;
   TextLayer low_power_time_layer;
+  TextLayer low_power_date_layer;
   KinoLayer low_power_kino_layer;
   char time_text[6];
+  char date_text[16];
 } LowPowerFaceData;
 
 static LowPowerFaceData *s_low_power_data;
@@ -49,6 +51,12 @@ static void prv_minute_tick(struct tm *tick_time, TimeUnits units_changed) {
                           s_low_power_data->time_text);
   }
 
+  if (units_changed & DAY_UNIT) {
+    clock_get_date_tm(s_low_power_data->date_text, sizeof(s_low_power_data->date_text),
+                      tick_time);
+    text_layer_set_text(&s_low_power_data->low_power_date_layer,
+                        s_low_power_data->date_text);
+  }
 }
 
 static void deinit(void) {
@@ -76,7 +84,11 @@ static void init(void) {
   const GSize text_size = app_graphics_text_layout_get_content_size("00:00", text_font,
                             s_low_power_data->low_power_window.layer.bounds, text_overflow_mode,
                             text_alignment);
-  const int text_pos_y_adjust = -9;  // small vertical adjustment to match design specification
+#if PBL_DISPLAY_HEIGHT >= 200
+  const int text_pos_y_adjust = -9;
+#else
+  const int text_pos_y_adjust = -20;
+#endif
   const int text_pos_y = (DISP_ROWS / 2) - (font_height / 2) + text_pos_y_adjust;
   const GRect text_container_rect = GRect(0, text_pos_y, DISP_COLS, font_height);
   GRect text_frame = (GRect) { .size = text_size };
@@ -99,11 +111,31 @@ static void init(void) {
   layer_add_child(&s_low_power_data->low_power_window.layer,
                     &s_low_power_data->low_power_time_layer.layer);
 
+#if PBL_DISPLAY_HEIGHT >= 200
+  const GFont date_font = fonts_get_system_font(FONT_KEY_GOTHIC_28_BOLD);
+#else
+  const GFont date_font = fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD);
+#endif
+  const unsigned int date_font_height = fonts_get_font_height(date_font);
+  const GRect icon_bounds = kino_layer_get_reel_bounds(&s_low_power_data->low_power_kino_layer);
+  const int icon_top_y =
+      s_low_power_data->low_power_kino_layer.layer.frame.origin.y + icon_bounds.origin.y;
+  const int time_bottom_y = text_frame.origin.y + text_frame.size.h;
+  const GRect date_frame = (GRect) {
+    .origin = { 0, time_bottom_y + (icon_top_y - time_bottom_y - (int)date_font_height) / 2 - 3 },
+    .size   = { DISP_COLS, date_font_height },
+  };
+  text_layer_init_with_parameters(&s_low_power_data->low_power_date_layer,
+                                  &date_frame, NULL, date_font,
+                                  GColorBlack, GColorClear, text_alignment, text_overflow_mode);
+  layer_add_child(&s_low_power_data->low_power_window.layer,
+                  &s_low_power_data->low_power_date_layer.layer);
+
   // Because of the delay before the tick timer service first calls prv_minute_tick,
   // we call it ourselves to update the time right away
   struct tm current_time;
   clock_get_time_tm(&current_time);
-  prv_minute_tick(&current_time, HOUR_UNIT);
+  prv_minute_tick(&current_time, MINUTE_UNIT | HOUR_UNIT | DAY_UNIT);
 
   tick_timer_service_subscribe(MINUTE_UNIT, prv_minute_tick);
 }

--- a/src/fw/services/clock/service.c
+++ b/src/fw/services/clock/service.c
@@ -501,12 +501,17 @@ void clock_copy_time_string(char *buffer, uint8_t size) {
   clock_copy_time_string_timestamp(buffer, size, t);
 }
 
+static size_t prv_format_time_tm(char *buffer, int buf_size, const char *format,
+                                 const struct tm *time_tm) {
+  const size_t ret_val = strftime(buffer, buf_size, i18n_get(format, buffer), time_tm);
+  i18n_free(format, buffer);
+  return ret_val;
+}
+
 static size_t prv_format_time(char *buffer, int buf_size, const char *format, time_t timestamp) {
   struct tm time_tm;
   localtime_r(&timestamp, &time_tm);
-  const size_t ret_val = strftime(buffer, buf_size, i18n_get(format, buffer), &time_tm);
-  i18n_free(format, buffer);
-  return ret_val;
+  return prv_format_time_tm(buffer, buf_size, format, &time_tm);
 }
 
 size_t clock_get_time_number(char *number_buffer, size_t number_buffer_size, time_t timestamp) {
@@ -966,6 +971,10 @@ static void prv_clock_get_relative_time_string(char *buffer, int buf_size, time_
 
 size_t clock_get_date(char *buffer, int buf_size, time_t timestamp) {
   return prv_format_time(buffer, buf_size, i18n_noop("%m/%d"), timestamp);
+}
+
+size_t clock_get_date_tm(char *buffer, int buf_size, const struct tm *time_tm) {
+  return prv_format_time_tm(buffer, buf_size, i18n_noop("%m/%d"), time_tm);
 }
 
 size_t clock_get_day_date(char *buffer, int buf_size, time_t timestamp) {


### PR DESCRIPTION
Adds a locale-aware day+month date line under the time on the low-power watchface.

<img width="144" height="168" alt="qemu-flint-up3" src="https://github.com/user-attachments/assets/5111526d-6377-4395-aef2-6a47d1123111" />

<img width="200" height="228" alt="qemu-emery-up3" src="https://github.com/user-attachments/assets/ce9a0dea-b29c-4bea-8892-196237ebeecb" />

<img width="200" height="228" alt="rollover-after2" src="https://github.com/user-attachments/assets/1b3f581f-7f43-471f-b027-da53b4393c5f" />

This should hopefully make this view more useful while not having a noticable impact on its power draw, the date display is only updated once a day.

(lmk if `clock_get_date_tm` is too much to add within this PR. Or if you prefer a different font.)