### PR TITLE
fw/applib: Provide sdk music volume and sound for iOS find phone app and others

### DIFF
--- a/include/pbl/services/music.h
+++ b/include/pbl/services/music.h
@@ -62,7 +62,7 @@ void music_get_pos(uint32_t *track_pos_ms, uint32_t *track_length_ms);
 int32_t music_get_playback_rate_percent(void);
 
 //! @return The volume percentage.
-uint8_t music_get_volume_percent(void);
+uint8_t music_service_get_volume_percent(void);
 
 //! Retrieve the current playback state.
 MusicPlayState music_get_playback_state(void);
@@ -76,7 +76,7 @@ bool music_is_playback_state_reporting_supported(void);
 bool music_is_progress_reporting_supported(void);
 
 //! @return True if the service supports reporting of the current volume.
-//! @see music_get_volume_percent
+//! @see music_service_get_volume_percent
 bool music_is_volume_reporting_supported(void);
 
 //! Sends the command to the server. Commands are "unreliable", they are sent at "best effort".

--- a/sdk/include/_pkjs_message_wrapper.js
+++ b/sdk/include/_pkjs_message_wrapper.js
@@ -118,7 +118,8 @@
   ["addEventListener", "removeEventListener", "showSimpleNotificationOnPebble",
    "sendAppMessage", "getTimelineToken", "timelineSubscribe",
    "timelineUnsubscribe", "timelineSubscriptions", "getActiveWatchInfo",
-   "getAccountToken", "getWatchToken", "appGlanceReload"].forEach(
+   "getAccountToken", "getWatchToken", "appGlanceReload",
+   "playSound", "playSoundById", "playDefaultRingtone", "stopSound"].forEach(
       function(elem, idx, arr) {
         if ((elem in Pebble) || ((typeof __Pebble[elem]) !== 'function')) {
           // This function has already been copied over or doesn't actually exist.

--- a/src/fw/applib/music_service.c
+++ b/src/fw/applib/music_service.c
@@ -1,0 +1,18 @@
+/* SPDX-FileCopyrightText: 2024 Google LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "music_service.h"
+#include "syscall/syscall.h"
+#include "pbl/services/music.h"
+
+void music_volume_up(void) {
+  sys_music_command_send(MusicCommandVolumeUp);
+}
+
+void music_volume_down(void) {
+  sys_music_command_send(MusicCommandVolumeDown);
+}
+
+uint8_t music_get_volume_percent(void) {
+  return sys_music_get_volume_percent();
+}

--- a/src/fw/applib/music_service.h
+++ b/src/fw/applib/music_service.h
@@ -1,0 +1,41 @@
+/* SPDX-FileCopyrightText: 2024 Google LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include <stdint.h>
+
+/**
+ * @file music_service.h
+ * @brief Music Service for controlling mobile device volume.
+ */
+
+/**
+ * @addtogroup Foundation
+ * @{
+ *   @addtogroup MusicService
+ *   @{
+ */
+
+/**
+ * Sends a "Volume Up" command to the mobile device.
+ * This command is sent to the currently active media player on the phone.
+ */
+void music_volume_up(void);
+
+/**
+ * Sends a "Volume Down" command to the mobile device.
+ * This command is sent to the currently active media player on the phone.
+ */
+void music_volume_down(void);
+
+/**
+ * Gets the current volume level of the mobile device's media player.
+ * @return Volume as a percentage from 0 to 100, or 255 if not available.
+ */
+uint8_t music_get_volume_percent(void);
+
+/**
+ *   @} // end addtogroup MusicService
+ * @} // end addtogroup Foundation
+ */

--- a/src/fw/process_management/pebble_process_info.h
+++ b/src/fw/process_management/pebble_process_info.h
@@ -163,10 +163,9 @@ typedef enum {
 // sdk.major:0x5 .minor:0x5f -- speaker_play_tone() now plays the exact frequency (rev 98)
 // sdk.major:0x5 .minor:0x60 -- Add persist_get_max_size() for runtime persist storage capacity (rev 99)
 // sdk.major:0x5 .minor:0x61 -- Add speaker_is_muted() for system-wide speaker mute query (rev 100)
-// sdk.major:0x5 .minor:0x62 -- Add backlight_service_subscribe/unsubscribe for backlight on/off events (rev 101)
-
+// sdk.major:0x5 .minor:0x63 -- Music Service volume control (rev 102)
 #define PROCESS_INFO_CURRENT_SDK_VERSION_MAJOR 0x5
-#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x62
+#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x63
 
 // The first SDK to ship with 2.x APIs
 #define PROCESS_INFO_FIRST_2X_SDK_VERSION_MAJOR 0x4

--- a/src/fw/services/music/service.c
+++ b/src/fw/services/music/service.c
@@ -294,7 +294,7 @@ int32_t music_get_playback_rate_percent(void) {
   return playback_rate_percent;
 }
 
-uint8_t music_get_volume_percent(void) {
+uint8_t music_service_get_volume_percent(void) {
   mutex_lock_recursive(s_music_ctx.mutex);
   int32_t player_volume_percent = s_music_ctx.player_volume_percent;
   mutex_unlock_recursive(s_music_ctx.mutex);

--- a/src/fw/syscall/syscall.h
+++ b/src/fw/syscall/syscall.h
@@ -305,4 +305,8 @@ WatchInfoColor sys_watch_info_get_color(void);
 //! choice and avoid disturbing actions such as vibration if quiet time is active.
 //! @return True, if Quiet Time is currently active.
 bool sys_do_not_disturb_is_active(void);
+// Music control syscalls
+void sys_music_command_send(MusicCommand command);
+uint8_t sys_music_get_volume_percent(void);
+
 //! @} // end addtogroup Preferences

--- a/src/fw/syscall/syscall_music.c
+++ b/src/fw/syscall/syscall_music.c
@@ -1,0 +1,13 @@
+/* SPDX-FileCopyrightText: 2024 Google LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "pbl/services/music.h"
+#include "syscall/syscall_internal.h"
+
+DEFINE_SYSCALL(void, sys_music_command_send, MusicCommand command) {
+  music_command_send(command);
+}
+
+DEFINE_SYSCALL(uint8_t, sys_music_get_volume_percent, void) {
+  return music_service_get_volume_percent();
+}

--- a/tests/fw/services/test_music_endpoint.c
+++ b/tests/fw/services/test_music_endpoint.c
@@ -115,7 +115,7 @@ static void prv_receive_and_assert_volume_info(bool expect_is_handled) {
     cl_assert_equal_i(e.type, PEBBLE_MEDIA_EVENT);
     cl_assert_equal_i(e.media.type, PebbleMediaEventTypeVolumeChanged);
 
-    cl_assert_equal_i(music_get_volume_percent(), 0x33);
+    cl_assert_equal_i(music_service_get_volume_percent(), 0x33);
 
   } else {
     cl_assert_equal_i(e.type, PEBBLE_NULL_EVENT);

--- a/tools/generate_native_sdk/exported_symbols.json
+++ b/tools/generate_native_sdk/exported_symbols.json
@@ -4,7 +4,7 @@
               "You should also make sure you are obeying our API design guidelines:",
               "https://pebbletechnology.atlassian.net/wiki/display/DEV/SDK+API+Design+Guidelines"
             ],
-  "revision" : "101",
+  "revision" : "102",
   "version" : "2.0",
   "files": [
     "fw/drivers/ambient_light.h",
@@ -128,7 +128,8 @@
     "fw/applib/voice/dictation_session.h",
     "fw/applib/ui/content_indicator.h",
     "fw/applib/rockyjs/rocky.h",
-    "fw/applib/unobstructed_area_service.h"
+    "fw/applib/unobstructed_area_service.h",
+    "fw/applib/music_service.h"
   ],
   "exports": [
     {
@@ -849,6 +850,26 @@
             }, {
               "type": "type",
               "name": "AppLogLevel"
+            }
+          ]
+        }, {
+          "type": "group",
+          "name": "MusicService",
+          "exports": [
+            {
+              "type": "function",
+              "name": "music_volume_up",
+              "addedRevision": "102"
+            },
+            {
+              "type": "function",
+              "name": "music_volume_down",
+              "addedRevision": "102"
+            },
+            {
+              "type": "function",
+              "name": "music_get_volume_percent",
+              "addedRevision": "102"
             }
           ]
         }, {


### PR DESCRIPTION
I got tired of forgetting my iPhone in the garage and not being able to find it, so I did some tests to see how to run "Find My Phone" on iOS.

I know there's an app that allows you to do this on Android, but it's missing for iOS since it's more restrictive.
https://apps.repebble.com/find-my-phone_695da4c3fbfdde0009f99799

**Research:**
According to my research, on iOS we can use AudioServicesPlayAlertSound, AudioServicesPlaySystemSound, AudioServicesPlaySystemSoundWithCompletion, AVSpeechSynthesizer, and AVAudioPlayer.

But playing around with different options, not all of them work well for every test scenario. For example, if the volume is low/mute, it will only vibrate; if it's on silent (physical button), it will only vibrate. So, after experimenting, I concluded that the ones that will always play sound, regardless of whether it's on silent or in focus mode, are AVAudioPlayer and AVSpeechSynthesizer.

**Implementations**

- With AVAudioPlayer, we have to use a custom MP3 ringtone. I uploaded a short 3-second example.

- AVSpeechSynthesizer is useful, for example, for speaking a phrase or word aloud. I believe it's primarily used for accessibility, but it could also be useful for finding the phone or for other functionalities the community might come up with.

- I set the sound to a 3-part loop. If we make it infinite, it will keep playing continuously, and if we lose connection/context with the watch, we can't stop it. The only option is to manually close the mobile app. We need to be careful about leaving it playing indefinitely.

- I created a test watch app; here's the code: https://github.com/asyba/PlaySoundMobile obviously, it uses the modifications I made to the SDK in this PR.

- The mobile PR https://github.com/coredevices/mobileapp/pull/199 primarily allows calling SMS/alarm sounds, a default ringtone, synthesized voice, and sounds using the system sound ID.

The FW allows to call those sound methods plus expose the volume and get level control, to also allow the watchapps to set the level to max for find my phone feature.