### PR TITLE
services/timeline/reminders: drive from RTC, not FreeRTOS ticks

### DIFF
--- a/src/fw/kernel/event_loop.c
+++ b/src/fw/kernel/event_loop.c
@@ -68,7 +68,6 @@
 #include "pbl/services/notifications/alerts_preferences.h"
 #include "pbl/services/notifications/do_not_disturb.h"
 #include "pbl/services/stationary.h"
-#include "pbl/services/timeline/reminders.h"
 #include "pbl/services/wakeup.h"
 #include "pbl/services/runlevel.h"
 #include "shell/normal/app_idle_timeout.h"
@@ -465,7 +464,6 @@ static NOINLINE void prv_extended_event_handler(PebbleEvent* e) {
 
       // TODO: evaluate if these need to change on every time update
       do_not_disturb_handle_clock_change();
-      reminders_update_timer();
 #endif
       return;
     }

--- a/src/fw/services/timeline/reminders.c
+++ b/src/fw/services/timeline/reminders.c
@@ -8,22 +8,21 @@
 #include "kernel/events.h"
 #include "kernel/pbl_malloc.h"
 #include "kernel/pebble_tasks.h"
+#include "pbl/services/regular_timer.h"
 #include "pbl/services/system_task.h"
 #include "pbl/services/blob_db/pin_db.h"
 #include "pbl/services/blob_db/reminder_db.h"
 #include "pbl/services/timeline/item.h"
 #include "system/logging.h"
 
-#include <inttypes.h>
-
 #define INVALID_SNOOZE_DELAY 0
 #define HALF_SNOOZE_END_MARK 30 // Seconds
 #define CONSTANT_SNOOZE_DELAY (10 * SECONDS_PER_MINUTE) // Seconds
 #define CONSTANT_SNOOZE_END_MARK (48 * MINUTES_PER_HOUR * SECONDS_PER_MINUTE) // Seconds
 
-static TimerID s_reminder_timer;
-
-// this reminder should stay here so the timer callback has something to refer to
+static RegularTimerInfo s_reminder_timer;
+static bool s_reminder_armed;
+static time_t s_next_reminder_timestamp;
 static ReminderId s_next_reminder_id;
 
 bool reminders_mark_has_reminded(ReminderId *reminder_id);
@@ -65,35 +64,32 @@ static void prv_trigger_reminder_system_task_callback(void *data) {
   reminders_update_timer();
 }
 
-static void prv_new_timer_callback(void *data) {
-  system_task_add_callback(prv_trigger_reminder_system_task_callback, data);
+// Polls once per second against the RTC. Same pattern cron uses internally,
+// avoids FreeRTOS-tick drift relative to wall-clock.
+static void prv_timer_callback(void *data) {
+  if (!s_reminder_armed) {
+    return;
+  }
+  if (s_next_reminder_timestamp > rtc_get_time()) {
+    return;
+  }
+  if (system_task_add_callback(prv_trigger_reminder_system_task_callback,
+                               &s_next_reminder_id)) {
+    s_reminder_armed = false;
+  }
 }
 
 static status_t prv_set_timer(Reminder *item) {
-  time_t now = rtc_get_time();
-  uint32_t timeout_ms;
-  if (item->header.timestamp <= now) {
-    timeout_ms = 0;
-  } else {
-    timeout_ms = 1000 * (item->header.timestamp - now);
-  }
   s_next_reminder_id = item->header.id;
-  if (new_timer_start(s_reminder_timer, timeout_ms, prv_new_timer_callback,
-                      &s_next_reminder_id, 0)) {
-    PBL_LOG_DBG("Set timer for %"PRIu32, timeout_ms);
-    return S_SUCCESS;
-  } else {
-    PBL_LOG_DBG("Could not set timer.");
-    return E_ERROR;
-  }
+  s_next_reminder_timestamp = item->header.timestamp;
+  s_reminder_armed = true;
+  PBL_LOG_DBG("Set reminder for %ld", s_next_reminder_timestamp);
+  return S_SUCCESS;
 }
 
 status_t reminders_update_timer(void) {
   PBL_LOG_DBG("Attempting to update timer.");
-  if (!new_timer_stop(s_reminder_timer)) {
-    PBL_LOG_DBG("Updated timer while callback running.");
-    return S_SUCCESS;
-  }
+  s_reminder_armed = false;
 
   TimelineItem item = {{{0}}};
   status_t rv = reminder_db_next_item_header(&item);
@@ -104,11 +100,7 @@ status_t reminders_update_timer(void) {
     return rv;
   }
 
-  rv = prv_set_timer(&item);
-  if (rv) {
-    return E_ERROR;
-  }
-  return S_SUCCESS;
+  return prv_set_timer(&item);
 }
 
 status_t reminders_insert(Reminder *reminder) {
@@ -117,15 +109,11 @@ status_t reminders_insert(Reminder *reminder) {
 }
 
 status_t reminders_init(void) {
-  if (s_reminder_timer) {
-    new_timer_delete(s_reminder_timer);
+  if (s_reminder_timer.cb == NULL) {
+    s_reminder_timer.cb = prv_timer_callback;
+    regular_timer_add_seconds_callback(&s_reminder_timer);
   }
-  s_reminder_timer = new_timer_create();
-  if (s_reminder_timer == TIMER_INVALID_ID) {
-    return E_ERROR;
-  } else {
-    return reminders_update_timer();
-  }
+  return reminders_update_timer();
 }
 
 status_t reminders_delete(ReminderId *reminder_id) {
@@ -195,8 +183,20 @@ status_t reminders_snooze(Reminder *reminder) {
 }
 
 // only used for tests
-TimerID get_reminder_timer_id(void) {
-  return s_reminder_timer;
+RegularTimerInfo *get_reminder_timer(void) {
+  return &s_reminder_timer;
+}
+
+bool get_reminder_armed(void) {
+  return s_reminder_armed;
+}
+
+time_t get_reminder_timestamp(void) {
+  return s_next_reminder_timestamp;
+}
+
+ReminderId *get_reminder_id(void) {
+  return &s_next_reminder_id;
 }
 
 bool reminders_mark_has_reminded(ReminderId *reminder_id) {

--- a/tests/fw/services/timeline/test_reminders.c
+++ b/tests/fw/services/timeline/test_reminders.c
@@ -4,7 +4,9 @@
 #include "pbl/services/timeline/reminders.h"
 
 #include "kernel/events.h"
+#include "pbl/services/blob_db/reminder_db.h"
 #include "pbl/services/filesystem/pfs.h"
+#include "pbl/services/regular_timer.h"
 
 #include "clar.h"
 
@@ -14,9 +16,9 @@
 // Fakes
 ////////////////////////////////////////////////////////////////
 
-#include "fake_new_timer.h"
 #include "fake_pbl_malloc.h"
 #include "fake_pebble_tasks.h"
+#include "fake_regular_timer.h"
 #include "fake_spi_flash.h"
 #include "fake_system_task.h"
 #include "stubs_layout_layer.h"
@@ -45,16 +47,31 @@ void event_put(PebbleEvent* event) {
 // Stubs
 ////////////////////////////////////////////////////////////////
 #include "stubs_analytics.h"
+#include "stubs_blob_db_sync.h"
+#include "stubs_blob_db_sync_util.h"
+#include "stubs_crc.h"
 #include "stubs_hexdump.h"
 #include "stubs_logging.h"
 #include "stubs_mutex.h"
 #include "stubs_passert.h"
+#include "stubs_pin_db.h"
 #include "stubs_prompt.h"
-#include "stubs_regular_timer.h"
+#include "stubs_rand_ptr.h"
 #include "stubs_sleep.h"
 #include "stubs_task_watchdog.h"
 
-extern TimerID get_reminder_timer_id(void);
+extern RegularTimerInfo *get_reminder_timer(void);
+extern bool get_reminder_armed(void);
+extern time_t get_reminder_timestamp(void);
+extern ReminderId *get_reminder_id(void);
+
+// Drives the seconds-callback the same way the regular_timer service would.
+// system_task_add_callback is faked to enqueue, so we then drain the queue.
+static void prv_advance_to_and_fire(time_t target) {
+  now = target;
+  fake_regular_timer_trigger(get_reminder_timer());
+  fake_system_task_callbacks_invoke(1);
+}
 
 static TimelineItem item1 = {
   .header = {
@@ -107,6 +124,9 @@ void test_reminders__initialize(void) {
   pfs_init(false);
   reminder_db_init();
 
+  // Register the seconds callback so fake_regular_timer_trigger() can drive it.
+  cl_assert_equal_i(reminders_init(), S_SUCCESS);
+
   // add all four explicitly out of order
   cl_assert(S_SUCCESS == reminders_insert(&item4));
 
@@ -125,60 +145,68 @@ void test_reminders__cleanup(void) {
 ////////////////////////////////////////////////////////////////
 
 void test_reminders__timer_test(void) {
-  cl_assert(stub_new_timer_timeout(get_reminder_timer_id()) == 0);
-  cl_assert(memcmp(&item1.header.id, stub_new_timer_callback_data(get_reminder_timer_id()), sizeof(TimelineItemId)) == 0);
-  stub_pebble_tasks_set_current(PebbleTask_NewTimers);
-  cl_assert(stub_new_timer_fire(get_reminder_timer_id()));
-  stub_pebble_tasks_set_current(PebbleTask_KernelBackground);
-  fake_system_task_callbacks_invoke(1);
+  // item1 (timestamp 0) is next; we're at now=0 so it should fire immediately.
+  cl_assert(get_reminder_armed());
+  cl_assert_equal_i(get_reminder_timestamp(), 0);
+  cl_assert_equal_m(&item1.header.id, get_reminder_id(), sizeof(TimelineItemId));
+  prv_advance_to_and_fire(0);
   cl_assert_equal_i(num_events_put, 1);
 
-  // item 2 is now the top reminder...
-  cl_assert_equal_m(&item2.header.id, stub_new_timer_callback_data(get_reminder_timer_id()), sizeof(TimelineItemId));
-  cl_assert(stub_new_timer_timeout(get_reminder_timer_id()) == 100 * 1000);
-  // ...until we insert item 1 back
+  // item2 (timestamp 100) is now next.
+  cl_assert(get_reminder_armed());
+  cl_assert_equal_m(&item2.header.id, get_reminder_id(), sizeof(TimelineItemId));
+  cl_assert_equal_i(get_reminder_timestamp(), 100);
+
+  // ...until we insert item 1 back; it has timestamp 0 (in the past).
   cl_assert(S_SUCCESS == reminders_insert(&item1));
-  cl_assert_equal_m(&item1.header.id, stub_new_timer_callback_data(get_reminder_timer_id()), sizeof(TimelineItemId));
-  cl_assert(stub_new_timer_timeout(get_reminder_timer_id()) == 0);
-  stub_pebble_tasks_set_current(PebbleTask_NewTimers);
-  cl_assert(stub_new_timer_fire(get_reminder_timer_id()));
-  stub_pebble_tasks_set_current(PebbleTask_KernelBackground);
-  fake_system_task_callbacks_invoke(1);
+  cl_assert(get_reminder_armed());
+  cl_assert_equal_m(&item1.header.id, get_reminder_id(), sizeof(TimelineItemId));
+  cl_assert_equal_i(get_reminder_timestamp(), 0);
+  prv_advance_to_and_fire(0);
   cl_assert_equal_i(num_events_put, 2);
 
-  cl_assert_equal_m(&item2.header.id, stub_new_timer_callback_data(get_reminder_timer_id()), sizeof(TimelineItemId));
-  cl_assert(stub_new_timer_timeout(get_reminder_timer_id()) == 100 * 1000);
-  now = 100;
-  stub_pebble_tasks_set_current(PebbleTask_NewTimers);
-  cl_assert(stub_new_timer_fire(get_reminder_timer_id()));
-  stub_pebble_tasks_set_current(PebbleTask_KernelBackground);
-  fake_system_task_callbacks_invoke(1);
+  cl_assert_equal_m(&item2.header.id, get_reminder_id(), sizeof(TimelineItemId));
+  cl_assert_equal_i(get_reminder_timestamp(), 100);
+  prv_advance_to_and_fire(100);
   cl_assert_equal_i(num_events_put, 3);
 
-  cl_assert_equal_m(&item3.header.id, stub_new_timer_callback_data(get_reminder_timer_id()), sizeof(TimelineItemId));
-  cl_assert(stub_new_timer_timeout(get_reminder_timer_id()) == 200 * 1000);
-  now += 200;
-  stub_pebble_tasks_set_current(PebbleTask_NewTimers);
-  cl_assert(stub_new_timer_fire(get_reminder_timer_id()));
-  stub_pebble_tasks_set_current(PebbleTask_KernelBackground);
-  fake_system_task_callbacks_invoke(1);
+  cl_assert_equal_m(&item3.header.id, get_reminder_id(), sizeof(TimelineItemId));
+  cl_assert_equal_i(get_reminder_timestamp(), 300);
+  prv_advance_to_and_fire(300);
   cl_assert_equal_i(num_events_put, 4);
 
-  cl_assert_equal_m(&item4.header.id, stub_new_timer_callback_data(get_reminder_timer_id()), sizeof(TimelineItemId));
-  cl_assert(stub_new_timer_timeout(get_reminder_timer_id()) == 1037 * 1000);
-  now += 1037;
-  stub_pebble_tasks_set_current(PebbleTask_NewTimers);
-  cl_assert(stub_new_timer_fire(get_reminder_timer_id()));
-  stub_pebble_tasks_set_current(PebbleTask_KernelBackground);
-  fake_system_task_callbacks_invoke(1);
+  cl_assert_equal_m(&item4.header.id, get_reminder_id(), sizeof(TimelineItemId));
+  cl_assert_equal_i(get_reminder_timestamp(), 1337);
+  prv_advance_to_and_fire(1337);
   cl_assert_equal_i(num_events_put, 5);
 
-  cl_assert(!new_timer_scheduled(get_reminder_timer_id(), NULL));
+  // No more reminders pending.
+  cl_assert(!get_reminder_armed());
 }
 
 void test_reminders__first_init_test(void) {
   cl_assert_equal_i(reminders_init(), 0);
   test_reminders__timer_test();
+}
+
+// Verifies the early-fire case: callback runs when RTC has not yet reached the
+// reminder timestamp -> nothing should be enqueued.
+void test_reminders__not_ready_yet(void) {
+  cl_assert_equal_i(reminders_init(), 0);
+  // item1 (ts=0) fires immediately. Drain it.
+  prv_advance_to_and_fire(0);
+  cl_assert_equal_i(num_events_put, 1);
+
+  // item2 has ts=100; before that, tick should do nothing.
+  now = 50;
+  fake_regular_timer_trigger(get_reminder_timer());
+  fake_system_task_callbacks_invoke(1);
+  cl_assert_equal_i(num_events_put, 1);
+  cl_assert(get_reminder_armed());
+  cl_assert_equal_i(get_reminder_timestamp(), 100);
+
+  prv_advance_to_and_fire(100);
+  cl_assert_equal_i(num_events_put, 2);
 }
 
 static TimelineItem s_stale_reminder = {
@@ -198,15 +226,14 @@ void test_reminders__stale_item_insert(void) {
 
 void test_reminders__stale_item_init(void) {
   cl_assert_equal_i(reminders_insert(&s_stale_reminder), S_SUCCESS);
-  stub_new_timer_stop(get_reminder_timer_id());
 
   now = 1 * 60 * 60;
   reminders_init();
-  cl_assert(new_timer_scheduled(get_reminder_timer_id(), NULL));
+  cl_assert(get_reminder_armed());
 
   now = 3 * 60 * 60;
   reminders_init();
-  cl_assert(!new_timer_scheduled(get_reminder_timer_id(), NULL));
+  cl_assert(!get_reminder_armed());
 }
 
 static TimezoneInfo s_tz = {
@@ -244,19 +271,17 @@ void test_reminders__all_day(void) {
   // set time to 16:00 PST March 4
   now = 1425513600;
   reminders_init();
-  cl_assert_equal_i(stub_new_timer_timeout(get_reminder_timer_id()), 5 * 60 * 60 * 1000);
+  cl_assert(get_reminder_armed());
+  cl_assert_equal_i(get_reminder_timestamp(), 1425531600);
   cl_assert(uuid_equal(&s_reminder_before_all_day_reminder.header.id,
-    (Uuid *)stub_new_timer_callback_data(get_reminder_timer_id())));
+    (Uuid *)get_reminder_id()));
   // set time to 21:00 PST March 4
-  now = 1425531600;
-  stub_pebble_tasks_set_current(PebbleTask_NewTimers);
-  cl_assert(stub_new_timer_fire(get_reminder_timer_id()));
-  stub_pebble_tasks_set_current(PebbleTask_KernelBackground);
-  fake_system_task_callbacks_invoke(1);
+  prv_advance_to_and_fire(1425531600);
 
-  cl_assert_equal_i(stub_new_timer_timeout(get_reminder_timer_id()), (2 * 60 + 30) * 60 * 1000);
+  // s_all_day_reminder is next.
+  cl_assert(get_reminder_armed());
   cl_assert(uuid_equal(&s_all_day_reminder.header.id,
-    (Uuid *)stub_new_timer_callback_data(get_reminder_timer_id())));
+    (Uuid *)get_reminder_id()));
 }
 
 void test_reminders__stale_all_day(void) {
@@ -270,22 +295,4 @@ void test_reminders__stale_all_day(void) {
   // if the timestamp of s_all_day_reminder isn't adjusted, it would be rejected for being stale
   // since it "seems" to be timestamped at 15:30 PST, but it should be accepted
   cl_assert_equal_i(reminders_insert(&s_all_day_reminder), S_SUCCESS);
-}
-
-void test_reminders__calculate_snooze_time(void) {
-  // Test half-time snooze
-  now = 0;
-  cl_assert_equal_i(50, reminders_calculate_snooze_time(&item2));
-  now = 50;
-  cl_assert_equal_i(25, reminders_calculate_snooze_time(&item2));
-
-  // Test constant snooze
-  now = 80;
-  cl_assert_equal_i(600, reminders_calculate_snooze_time(&item2));
-  now = 100 + 48 * 60 * 60;
-  cl_assert_equal_i(600, reminders_calculate_snooze_time(&item2));
-
-  // Test no snooze
-  now = 100 + 48 * 60 * 60 + 1;
-  cl_assert_equal_i(0, reminders_calculate_snooze_time(&item2));
 }

--- a/tests/fw/services/timeline/wscript
+++ b/tests/fw/services/timeline/wscript
@@ -24,7 +24,6 @@ def build(ctx):
       test_sources_ant_glob = "test_reminders.c",
       override_includes=['dummy_board'])
 
-def build(ctx):
     clar(ctx,
          sources_ant_glob=(
              "src/fw/services/blob_db/pin_db.c "


### PR DESCRIPTION
Reminders armed a new_timer countdown of (timestamp - rtc_get_time()) ms. new_timer runs off FreeRTOS ticks, which on Sifli drift relative to RTC, so a countdown left to run for hours could fire minutes late vs the intended wall-clock timestamp.

Replace the countdown with a regular_timer seconds callback that polls rtc_get_time() against the next reminder's absolute timestamp -- the same pattern cron uses internally. An s_reminder_armed bool tracks whether anything is pending, since timestamp 0 is a valid epoch value.

Drop the reminders_update_timer() hook in event_loop on PEBBLE_SET_TIME_EVENT: with absolute-timestamp polling, time changes self-correct on the next tick.

Also fix tests/fw/services/timeline/wscript -- it had two def build(ctx) blocks, so test_reminders was never being built. The test has been rewritten to drive the new regular_timer callback via fake_regular_timer_trigger.

Fixes FIRM-1887