### PR TITLE
fw/applib/tick_timer_service: only record second-tick subscription for watchfaces

### DIFF
--- a/src/fw/applib/tick_timer_service.c
+++ b/src/fw/applib/tick_timer_service.c
@@ -91,7 +91,7 @@ void tick_timer_service_subscribe(TimeUnits tick_units, TickHandler handler) {
   state->tick_units = tick_units;
   state->first_tick = true;
   event_service_client_subscribe(&state->tick_service_info);
-  if (pebble_task_get_current() == PebbleTask_App) {
+  if (pebble_task_get_current() == PebbleTask_App && sys_app_is_watchface()) {
     PBL_ANALYTICS_SET_UNSIGNED(app_tick_timer_second_subscribed,
                                (tick_units & SECOND_UNIT) ? 1 : 0);
   }
@@ -102,7 +102,7 @@ void tick_timer_service_unsubscribe(void) {
   TickTimerServiceState *state = prv_get_state(PebbleTask_Unknown);
   event_service_client_unsubscribe(&state->tick_service_info);
   state->handler = NULL;
-  if (pebble_task_get_current() == PebbleTask_App) {
+  if (pebble_task_get_current() == PebbleTask_App && sys_app_is_watchface()) {
     PBL_ANALYTICS_SET_UNSIGNED(app_tick_timer_second_subscribed, 0);
   }
 }


### PR DESCRIPTION
## Summary

- Gate the `app_tick_timer_second_subscribed` analytics writes on `sys_app_is_watchface()` so the metric reflects only the active watchface's own tick subscription, not any foreground app's.
- The metric is consumed in eng-dash to surface a battery-coaching warning that names the user's selected watchface. Today the firmware sets it on every `PebbleTask_App` subscribe/unsubscribe, so a non-watchface app subscribing to `SECOND_UNIT` (Music with the progress bar on, a stopwatch, a chronograph app, etc.) flips it to 1 while `watchface_name` remains sticky to the last-launched watchface — and eng-dash then blames the watchface for a non-watchface app's tick.
- The syscall is already declared in `syscall/syscall.h` (already included in this file), so this is a guard-only change with no new dependencies.

Fixes WEB-24

## Test plan

- [ ] Build the firmware and confirm `tick_timer_service.c` compiles unchanged.
- [ ] On a watch running this build, launch a watchface that subscribes to `MINUTE_UNIT` (e.g. Halcyon) → verify `app_tick_timer_second_subscribed` reports 0 in the next heartbeat.
- [ ] On the same watch, play music with the progress bar enabled (Music subscribes to `SECOND_UNIT` from a non-watchface context) → verify `app_tick_timer_second_subscribed` stays 0.
- [ ] Switch to a watchface that genuinely subscribes to `SECOND_UNIT` (e.g. a chronograph face) → verify the metric reports 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)