### PR TITLE
drivers/ambient: event-gated semi-continuous ALS sampling

### DIFF
--- a/src/fw/apps/system/settings/display.c
+++ b/src/fw/apps/system/settings/display.c
@@ -39,6 +39,7 @@ typedef struct SettingsBacklightData {
   char als_value_buffer[16];  // Buffer for ALS value display
   char backlight_percent_buffer[16];  // Buffer for backlight percentage display
   AppTimer *update_timer;  // Timer for live updating debug values
+  bool als_primed;  // Whether we currently hold an ambient_light_prime() ref
 } SettingsBacklightData;
 
 static const char *s_language_labels[] = {
@@ -426,6 +427,12 @@ static void prv_backlight_appear_cb(SettingsCallbacks *context) {
     data->update_timer = app_timer_register(UPDATE_INTERVAL_MS,
                                             prv_backlight_update_timer_cb, data);
   }
+  // Hold the ALS in continuous mode while this submenu is visible so the
+  // 500 ms refresh tick doesn't pay a full integration time per read.
+  if (!data->als_primed) {
+    ambient_light_prime();
+    data->als_primed = true;
+  }
 }
 
 static void prv_backlight_hide_cb(SettingsCallbacks *context) {
@@ -434,6 +441,10 @@ static void prv_backlight_hide_cb(SettingsCallbacks *context) {
     app_timer_cancel(data->update_timer);
     data->update_timer = NULL;
   }
+  if (data->als_primed) {
+    ambient_light_release();
+    data->als_primed = false;
+  }
 }
 
 static void prv_backlight_deinit_cb(SettingsCallbacks *context) {
@@ -441,6 +452,10 @@ static void prv_backlight_deinit_cb(SettingsCallbacks *context) {
   if (data->update_timer) {
     app_timer_cancel(data->update_timer);
     data->update_timer = NULL;
+  }
+  if (data->als_primed) {
+    ambient_light_release();
+    data->als_primed = false;
   }
   i18n_free_all(data);
   app_free(data);

--- a/src/fw/board/boards/board_getafix.c
+++ b/src/fw/board/boards/board_getafix.c
@@ -503,8 +503,8 @@ const BoardConfigPower BOARD_CONFIG_POWER = {
 
 const BoardConfig BOARD_CONFIG = {
   .backlight_on_percent = 25,
-  .ambient_light_dark_threshold = 150,
-  .ambient_k_delta_threshold = 25,
+  .ambient_light_dark_threshold = 2000,
+  .ambient_k_delta_threshold = 200,
 };
 
 const BoardConfigButton BOARD_CONFIG_BUTTON = {

--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -576,8 +576,8 @@ const BoardConfigPower BOARD_CONFIG_POWER = {
 
 const BoardConfig BOARD_CONFIG = {
   .backlight_on_percent = 45,
-  .ambient_light_dark_threshold = 150,
-  .ambient_k_delta_threshold = 25,
+  .ambient_light_dark_threshold = 1400,
+  .ambient_k_delta_threshold = 200,
   .dynamic_backlight_min_threshold = 5,
   .backlight_default_color = BACKLIGHT_COLOR_WARM_WHITE,
 };

--- a/src/fw/drivers/ambient/ambient_light_common.c
+++ b/src/fw/drivers/ambient/ambient_light_common.c
@@ -1,0 +1,69 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "drivers/ambient_light.h"
+
+#include "os/mutex.h"
+#include "system/passert.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// Refcount framework for prime/release/suspend/resume. Drivers receive only
+// the resulting (active, sampling) booleans via ambient_light_driver_set_state.
+
+static PebbleMutex *s_mutex;
+static uint16_t s_prime_refcount;
+static uint16_t s_suspend_refcount;
+
+static void prv_apply_locked(void) {
+  const bool active = (s_prime_refcount > 0U);
+  const bool sampling = active && (s_suspend_refcount == 0U);
+  ambient_light_driver_set_state(active, sampling);
+}
+
+void ambient_light_common_init(void) {
+  s_mutex = mutex_create();
+}
+
+void ambient_light_prime(void) {
+  if (s_mutex == NULL) {
+    return;
+  }
+  mutex_lock(s_mutex);
+  s_prime_refcount++;
+  prv_apply_locked();
+  mutex_unlock(s_mutex);
+}
+
+void ambient_light_release(void) {
+  if (s_mutex == NULL) {
+    return;
+  }
+  mutex_lock(s_mutex);
+  PBL_ASSERTN(s_prime_refcount > 0U);
+  s_prime_refcount--;
+  prv_apply_locked();
+  mutex_unlock(s_mutex);
+}
+
+void ambient_light_suspend(void) {
+  if (s_mutex == NULL) {
+    return;
+  }
+  mutex_lock(s_mutex);
+  s_suspend_refcount++;
+  prv_apply_locked();
+  mutex_unlock(s_mutex);
+}
+
+void ambient_light_resume(void) {
+  if (s_mutex == NULL) {
+    return;
+  }
+  mutex_lock(s_mutex);
+  PBL_ASSERTN(s_suspend_refcount > 0U);
+  s_suspend_refcount--;
+  prv_apply_locked();
+  mutex_unlock(s_mutex);
+}

--- a/src/fw/drivers/ambient/ambient_light_opt3001.c
+++ b/src/fw/drivers/ambient/ambient_light_opt3001.c
@@ -72,7 +72,14 @@ void ambient_light_init(void) {
     prv_write_register(OPT3001_CONFIG, OPT3001_CONFIG_RANGE_AUTO | OPT3001_CONFIG_CONVTIME_100MSEC | OPT3001_CONFIG_MODE_CONTINUOUS);
   }
 
+  ambient_light_common_init();
   s_initialized = true;
+}
+
+void ambient_light_driver_set_state(bool active, bool sampling) {
+  // OPT3001 is configured at boot per BOARD_CONFIG.als_always_on; no gate needed.
+  (void)active;
+  (void)sampling;
 }
 
 uint32_t ambient_light_get_light_level(void) {

--- a/src/fw/drivers/ambient/ambient_light_w1160.c
+++ b/src/fw/drivers/ambient/ambient_light_w1160.c
@@ -6,8 +6,10 @@
 #include "drivers/ambient_light.h"
 #include "drivers/i2c.h"
 #include "drivers/periph_config.h"
+#include "drivers/rtc.h"
 #include "kernel/util/sleep.h"
 #include "mfg/mfg_info.h"
+#include "os/mutex.h"
 #include "system/logging.h"
 #include "system/passert.h"
 
@@ -57,10 +59,10 @@
 #define W1160_ALSCTRL_DATA_FORMAT12 (0<<2)   /* 1:12bit 0:16bit */
 #define W1160_DATA_GC_LVL           (15<<4)  /* gc lelvel 15 */
 #define W1160_SAT_GC_CONFIG         (0x0A)
-#define W1160_SLOW_IT_CONFIG1       (0x00)   /* 16.830ms */
-#define W1160_SLOW_IT_CONFIG2       (0xA9)
-#define W1160_SLOW_ST_CONFIG1       (0x03)   /* 480ms */
-#define W1160_SLOW_ST_CONFIG2       (0xFF)
+#define W1160_SLOW_IT_CONFIG1       (0x03)   /* 99ms ((0x3E7+1) * 99us) */
+#define W1160_SLOW_IT_CONFIG2       (0xE7)
+#define W1160_SLOW_ST_CONFIG1       (0x07)   /* 200ms ((0x7CF+1) * 100us) */
+#define W1160_SLOW_ST_CONFIG2       (0xCF)
 #define W1160_SAMPLING_EN           (1<<1)   /* 1:en 0:dis */
 #define W1160_SAMPLING_DIS          (0<<1)   /* 1:en 0:dis */
 #define W1160_CHIP_ID               (0xE5)
@@ -76,6 +78,18 @@
 static bool s_initialized;
 static uint32_t s_sensor_light_dark_threshold;
 
+// DATA_ALS reads zero while SAMPLING_EN=0, so we cache the last known-good
+// value. Cache is served during suspend windows and invalidated when the
+// active window drops (so the next unprimed read does a fresh one-shot
+// instead of returning a stale value from an earlier primed window).
+#define W1160_SETTLE_AFTER_ENABLE_MS (W1160_ALS_POLL_TIMEOUT_MS)
+static PebbleMutex *s_state_mutex;
+static bool s_active;
+static bool s_sampling_active;
+static RtcTicks s_sampling_started_ticks;
+static uint16_t s_cached_value;
+static bool s_cache_valid;
+
 static bool prv_read_register(uint8_t register_address, uint8_t *result) {
   i2c_use(I2C_W1160);
   bool rv = i2c_read_register_block(I2C_W1160, register_address, 1, result);
@@ -90,10 +104,23 @@ static bool prv_write_register(uint8_t register_address, uint8_t datum) {
   return rv;
 }
 
+static bool prv_read_data_register(uint16_t *als_out) {
+  uint8_t hi, lo;
+  if (!prv_read_register(W1160_DATA1_ALS_REG, &hi)) {
+    return false;
+  }
+  if (!prv_read_register(W1160_DATA2_ALS_REG, &lo)) {
+    return false;
+  }
+  *als_out = (((uint16_t)hi) << 8) | lo;
+  return true;
+}
+
 void ambient_light_init(void) {
   uint8_t chip_id;
   bool rv;
 
+  s_state_mutex = mutex_create();
   s_sensor_light_dark_threshold = BOARD_CONFIG.ambient_light_dark_threshold;
 
   psleep(W1160_POR_WAIT_TIME);
@@ -122,61 +149,125 @@ void ambient_light_init(void) {
 
   PBL_ASSERT(rv, "Failed to initialize W1160");
 
+  ambient_light_common_init();
   s_initialized = true;
 }
 
-uint32_t ambient_light_get_light_level(void) {
-  uint8_t result[2] = {0};
-  uint16_t als;
-  bool rv;
+// Block-poll FLG_ALS_DR, then read DATA_ALS. Caller must have SAMPLING_EN=1.
+static bool prv_read_data_polled(uint16_t *als_out) {
+  uint8_t flag;
+  uint32_t elapsed = 0;
+  while (true) {
+    if (!prv_read_register(W1160_FLAG1_REG, &flag)) {
+      PBL_LOG_ERR("Could not read W1160 FLAG1");
+      return false;
+    }
+    if (flag & W1160_FLG_ALS_DR) {
+      break;
+    }
+    if (elapsed >= W1160_ALS_POLL_TIMEOUT_MS) {
+      PBL_LOG_ERR("W1160 ALS data-ready timeout");
+      return false;
+    }
+    psleep(W1160_ALS_POLL_DELAY_MS);
+    elapsed += W1160_ALS_POLL_DELAY_MS;
+  }
+  return prv_read_data_register(als_out);
+}
 
+// True if SAMPLING_EN has been on long enough for DATA_ALS to hold a real
+// sample. Caller holds s_state_mutex and has checked s_sampling_active.
+static bool prv_sampling_has_settled_locked(void) {
+  const RtcTicks now = rtc_get_ticks();
+  const RtcTicks elapsed = now - s_sampling_started_ticks;
+  return elapsed >= ((RtcTicks)W1160_SETTLE_AFTER_ENABLE_MS * RTC_TICKS_HZ / 1000U);
+}
+
+uint32_t ambient_light_get_light_level(void) {
   if (!s_initialized) {
     return 0UL;
   }
 
-  rv = prv_write_register(W1160_STATE_REG, W1160_SAMPLING_EN);
-  if (!rv) {
-    PBL_LOG_ERR("Could not enable W1160 sampling");
-    return 0UL;
-  }
+  mutex_lock(s_state_mutex);
 
-  uint32_t elapsed = 0;
-  do {
-    rv = prv_read_register(W1160_FLAG1_REG, &result[0]);
-    if (!rv) {
-      PBL_LOG_ERR("Could not read W1160 FLAG1");
-      goto disable_and_fail;
-    }
-    if ((result[0] & W1160_FLG_ALS_DR) == 0U) {
-      if (elapsed >= W1160_ALS_POLL_TIMEOUT_MS) {
-        PBL_LOG_ERR("W1160 ALS data-ready timeout");
-        goto disable_and_fail;
+  if (s_active) {
+    if (s_sampling_active && prv_sampling_has_settled_locked()) {
+      uint16_t als = 0;
+      bool ok = prv_read_data_register(&als);
+      if (ok) {
+        s_cached_value = als;
+        s_cache_valid = true;
       }
-      psleep(W1160_ALS_POLL_DELAY_MS);
-      elapsed += W1160_ALS_POLL_DELAY_MS;
+      mutex_unlock(s_state_mutex);
+      return ok ? als : 0UL;
     }
-  } while ((result[0] & W1160_FLG_ALS_DR) == 0U);
 
-  rv = prv_read_register(W1160_DATA1_ALS_REG, &result[1]);
-  rv &= prv_read_register(W1160_DATA2_ALS_REG, &result[0]);
-  if (!rv) {
-    PBL_LOG_ERR("Could not obtain W1160 data");
-    goto disable_and_fail;
+    if (s_cache_valid) {
+      uint16_t cached = s_cached_value;
+      mutex_unlock(s_state_mutex);
+      return cached;
+    }
+
+    if (!s_sampling_active) {
+      mutex_unlock(s_state_mutex);
+      return 0UL;
+    }
+    uint16_t als = 0;
+    bool ok = prv_read_data_polled(&als);
+    if (ok) {
+      s_cached_value = als;
+      s_cache_valid = true;
+    }
+    mutex_unlock(s_state_mutex);
+    return ok ? als : 0UL;
   }
 
-  rv = prv_write_register(W1160_STATE_REG, W1160_SAMPLING_DIS);
-  if (!rv) {
-    PBL_LOG_ERR("Could not disable W1160 sampling");
+  // Unprimed one-shot: enable, poll, read, disable.
+  if (!prv_write_register(W1160_STATE_REG, W1160_SAMPLING_EN)) {
+    PBL_LOG_ERR("Could not enable W1160 sampling");
+    mutex_unlock(s_state_mutex);
     return 0UL;
   }
 
-  als = (((uint16_t)(result[1])) << 8) | result[0];
+  uint16_t als = 0;
+  bool ok = prv_read_data_polled(&als);
+  if (ok) {
+    s_cached_value = als;
+    s_cache_valid = true;
+  }
 
-  return als;
+  if (!prv_write_register(W1160_STATE_REG, W1160_SAMPLING_DIS)) {
+    PBL_LOG_ERR("Could not disable W1160 sampling");
+    mutex_unlock(s_state_mutex);
+    return 0UL;
+  }
 
-disable_and_fail:
-  (void)prv_write_register(W1160_STATE_REG, W1160_SAMPLING_DIS);
-  return 0UL;
+  mutex_unlock(s_state_mutex);
+  return ok ? als : 0UL;
+}
+
+void ambient_light_driver_set_state(bool active, bool sampling) {
+  if (!s_initialized) {
+    return;
+  }
+  mutex_lock(s_state_mutex);
+  if (sampling != s_sampling_active) {
+    const uint8_t reg = sampling ? W1160_SAMPLING_EN : W1160_SAMPLING_DIS;
+    if (prv_write_register(W1160_STATE_REG, reg)) {
+      s_sampling_active = sampling;
+      if (sampling) {
+        s_sampling_started_ticks = rtc_get_ticks();
+      }
+    } else {
+      PBL_LOG_ERR("Could not write W1160 STATE_REG");
+    }
+  }
+  if (s_active && !active) {
+    // Window closed: drop the cache so the next unprimed read is fresh.
+    s_cache_valid = false;
+  }
+  s_active = active;
+  mutex_unlock(s_state_mutex);
 }
 
 void command_als_read(void) {

--- a/src/fw/drivers/ambient/wscript_build
+++ b/src/fw/drivers/ambient/wscript_build
@@ -9,6 +9,9 @@ if bld.env.CONFIG_AMBIENT_LIGHT_OPT3001:
 elif bld.env.CONFIG_AMBIENT_LIGHT_W1160:
     sources.append('ambient_light_w1160.c')
 
+if sources:
+    sources.append('ambient_light_common.c')
+
 bld.objects(
     name='driver_ambient_light',
     source=sources,

--- a/src/fw/drivers/ambient_light.h
+++ b/src/fw/drivers/ambient_light.h
@@ -31,6 +31,24 @@ void ambient_light_init(void);
  */
 uint32_t ambient_light_get_light_level(void);
 
+//! Refcounted "I will want ALS readings soon" hint; bookkeeping lives in
+//! ambient_light_common.c and reaches the driver via
+//! ambient_light_driver_set_state().
+void ambient_light_prime(void);
+void ambient_light_release(void);
+
+//! Refcounted "stop sampling right now" gate (e.g. backlight bleed-through).
+//! Physical sampling is on iff prime > 0 && suspend == 0.
+void ambient_light_suspend(void);
+void ambient_light_resume(void);
+
+//! Init the refcount framework. Called from the per-chip ambient_light_init().
+void ambient_light_common_init(void);
+
+//! Driver hook. `active` = prime > 0; `sampling` = active && suspend == 0.
+//! No-op for drivers without a sampling gate.
+void ambient_light_driver_set_state(bool active, bool sampling);
+
 //! get the threshold between light and dark
 uint32_t ambient_light_get_dark_threshold(void);
 

--- a/src/fw/drivers/stubs/ambient_light.c
+++ b/src/fw/drivers/stubs/ambient_light.c
@@ -6,6 +6,18 @@
 void ambient_light_init(void) {
 }
 
+void ambient_light_prime(void) {
+}
+
+void ambient_light_release(void) {
+}
+
+void ambient_light_suspend(void) {
+}
+
+void ambient_light_resume(void) {
+}
+
 uint32_t ambient_light_get_light_level(void) {
   return 0;
 }

--- a/src/fw/services/light/service.c
+++ b/src/fw/services/light/service.c
@@ -114,7 +114,48 @@ static uint32_t s_als_cached_level;
 static RtcTicks s_als_cached_ticks;  // 0 = invalid
 #define ALS_CACHE_TTL_TICKS (RTC_TICKS_HZ)  // 1 second
 
+//! Event-gated continuous ALS:
+//!
+//! Wake-related entry points call prv_als_prime_for_interaction(), which (if
+//! not already primed) takes a single ambient_light_prime() refcount and
+//! starts a release timer for ALS_PRIME_HOLDOFF_MS. Each subsequent wake-y
+//! call rearms the timer. When it eventually fires, we drop the prime so the
+//! sensor goes back to idle.
+//!
+//! While primed, the W1160 runs in continuous mode: ALS reads collapse to a
+//! plain register read once one IT has elapsed, and the cache hits more often
+//! because reads are cheap enough that callers don't gate on them. The
+//! holdoff is sized to cover typical multi-wake patterns ("raise wrist, lower,
+//! raise again a few seconds later") so we keep sampling across them rather
+//! than re-paying the first-IT wait per wake.
+static TimerID s_als_prime_release_timer_id;
+static bool s_als_primed;
+#define ALS_PRIME_HOLDOFF_MS (5000)
+
 static void prv_change_state(BacklightState new_state);
+
+//! Timer callback: holdoff expired, drop the prime so the W1160 stops
+//! integrating in the background. Runs on the new_timer task.
+static void prv_als_prime_release_callback(void *data) {
+  mutex_lock(s_mutex);
+  if (s_als_primed) {
+    s_als_primed = false;
+    ambient_light_release();
+  }
+  mutex_unlock(s_mutex);
+}
+
+//! Open or extend an "interaction window" during which the W1160 is held in
+//! continuous-sampling mode. Call from any wake-event-y entry point before
+//! consulting ALS. Caller must hold s_mutex.
+static void prv_als_prime_for_interaction(void) {
+  if (!s_als_primed) {
+    s_als_primed = true;
+    ambient_light_prime();
+  }
+  new_timer_start(s_als_prime_release_timer_id, ALS_PRIME_HOLDOFF_MS,
+                  prv_als_prime_release_callback, NULL, 0 /* flags */);
+}
 
 static uint32_t prv_get_als_level(void) {
   RtcTicks now = rtc_get_ticks();
@@ -219,6 +260,15 @@ static void prv_change_brightness(uint8_t new_brightness) {
   // Scale the 0-100% to the maximum value allowed in hardware
   uint8_t scaled_brightness = (new_brightness * (uint16_t)BOARD_CONFIG.backlight_on_percent) / 100U;
 
+  // Bleed-through gate around backlight 0↔on edges: while the LED is
+  // illuminating the cover glass, the W1160 photodiode would latch
+  // contaminated readings even though our cache pins to the pre-on value.
+  // Suspending stops integration entirely, so the chip preserves the last
+  // clean DATA_ALS until we resume. No-op while not primed (driver
+  // composes suspend with the prime refcount).
+  const bool turning_on = (s_current_brightness == 0U) && (new_brightness > 0U);
+  const bool turning_off = (s_current_brightness > 0U) && (new_brightness == 0U);
+
   if (new_brightness == 0U) {
     PBL_ANALYTICS_TIMER_STOP(backlight_on_time_ms);
   } else {
@@ -227,7 +277,13 @@ static void prv_change_brightness(uint8_t new_brightness) {
 
   prv_update_intensity_analytics(scaled_brightness);
 
+  if (turning_on) {
+    ambient_light_suspend();
+  }
   backlight_set_brightness(scaled_brightness);
+  if (turning_off) {
+    ambient_light_resume();
+  }
   s_current_brightness = new_brightness;
 
 #ifdef CONFIG_BACKLIGHT_HAS_COLOR
@@ -325,7 +381,6 @@ static bool prv_light_allowed(void) {
 void light_init(void) {
   s_light_state = LIGHT_STATE_OFF;
   s_current_brightness = 0;
-  s_timer_id = new_timer_create();
   s_num_buttons_down = 0;
   s_user_controlled_state = false;
   s_fade_start_intensity = 0;
@@ -340,6 +395,13 @@ void light_init(void) {
 
   s_als_cached_level = 0;
   s_als_cached_ticks = 0;
+
+  // Create the ALS release timer before the fade timer so existing tests that
+  // pluck the most-recently-created idle timer (test_light.c:149) still pick
+  // up s_timer_id.
+  s_als_prime_release_timer_id = new_timer_create();
+  s_als_primed = false;
+  s_timer_id = new_timer_create();
 }
 
 void light_button_pressed(void) {
@@ -350,6 +412,8 @@ void light_button_pressed(void) {
     PBL_LOG_ERR("More buttons were pressed than have been released.");
     s_num_buttons_down = 0;
   }
+
+  prv_als_prime_for_interaction();
 
   // set the state to be on; releasing buttons will start the timer counting down
   if (prv_light_allowed()) {
@@ -386,6 +450,8 @@ void light_enable_interaction(void) {
     mutex_unlock(s_mutex);
     return;
   }
+
+  prv_als_prime_for_interaction();
 
   if (prv_light_allowed()) {
     prv_change_state(LIGHT_STATE_ON_TIMED);
@@ -424,6 +490,7 @@ void light_enable_respect_settings(bool enable) {
   s_user_controlled_state = enable;
 
   if (enable) {
+    prv_als_prime_for_interaction();
     if (prv_light_allowed()) {
       prv_change_state(LIGHT_STATE_ON);
     }
@@ -507,6 +574,7 @@ static void prv_light_reset_to_timed_mode(void) {
 
   if (s_user_controlled_state) {
     s_user_controlled_state = false;
+    prv_als_prime_for_interaction();
     if (prv_light_allowed()) {
       prv_change_state(LIGHT_STATE_ON_TIMED);
     }

--- a/tests/stubs/stubs_ambient_light.h
+++ b/tests/stubs/stubs_ambient_light.h
@@ -5,6 +5,14 @@
 
 void ambient_light_init(void) {
 }
+void ambient_light_prime(void) {
+}
+void ambient_light_release(void) {
+}
+void ambient_light_suspend(void) {
+}
+void ambient_light_resume(void) {
+}
 uint32_t ambient_light_get_light_level(void) {
 	return 0;
 }


### PR DESCRIPTION
Gates W1160 continuous sampling to short interaction windows (wake events open a 5s holdoff, settings menus prime explicitly) so the SNR win from bumping IT to 99 ms doesn't come with the always-on power cost. Average sensor current scales with wake rate × 5 s × ~70 µA which is roughly 0.1 µAh per wake, vs. the ~70 µA continuous draw that killed the previous continuous-mode attempt (#1313). Also bumps obelix dark thresholds to match the new IT and adds a software cache so primed reads stay snappy across suspend/resume (e.g. backlight-on bleed gating).