### PR TITLE
backlight: recover from silent AW2016 chip resets

### DIFF
--- a/src/fw/drivers/backlight.h
+++ b/src/fw/drivers/backlight.h
@@ -18,6 +18,10 @@ void backlight_init(void);
 //! @param brightness Brightness level (0-100)
 void backlight_set_brightness(uint8_t brightness);
 
+//! Re-apply the cached driver state to the backlight hardware. No-op if the
+//! firmware believes the backlight is already off.
+void backlight_refresh(void);
+
 #ifdef CONFIG_BACKLIGHT_HAS_COLOR
 void backlight_set_color(uint32_t rgb_color);
 

--- a/src/fw/drivers/backlight/aw2016.c
+++ b/src/fw/drivers/backlight/aw2016.c
@@ -138,3 +138,18 @@ void backlight_set_color(uint32_t rgb_color) {
 uint32_t backlight_get_color(void) {
   return s_rgb_current_color;
 }
+
+void backlight_refresh(void) {
+  bool ret;
+
+  if (s_brightness == 0U) {
+    return;
+  }
+
+  ret = prv_write_register(AW2016_REG_GCR1,
+                           AW2016_REG_GCR1_CHGDIS_DIS | AW2016_REG_GCR1_CHIPEN_EN);
+  ret &= prv_configure_registers();
+  PBL_ASSERTN(ret);
+
+  backlight_set_color(s_rgb_current_color);
+}

--- a/src/fw/drivers/backlight/aw9364e.c
+++ b/src/fw/drivers/backlight/aw9364e.c
@@ -48,3 +48,6 @@ void backlight_set_brightness(uint8_t brightness) {
     delay_us(i == 0U ? AW9364E_TON_US : AW9364E_THI_US);
   }
 }
+
+void backlight_refresh(void) {
+}

--- a/src/fw/drivers/backlight/pwm.c
+++ b/src/fw/drivers/backlight/pwm.c
@@ -41,3 +41,6 @@ void backlight_set_brightness(uint8_t brightness) {
     pwm_set_duty_cycle(&BACKLIGHT_PWM.pwm, desired_duty_cycle);
   }
 }
+
+void backlight_refresh(void) {
+}

--- a/src/fw/drivers/backlight/qemu.c
+++ b/src/fw/drivers/backlight/qemu.c
@@ -79,6 +79,9 @@ void backlight_set_brightness(uint8_t brightness) {
 #endif
 }
 
+void backlight_refresh(void) {
+}
+
 #ifdef CONFIG_BACKLIGHT_QEMU_COLOR
 void backlight_set_color(uint32_t rgb_color) {
   uint8_t r = ((rgb_color >> 16) & 0xFFU) * s_brightness / 100U;

--- a/src/fw/drivers/stubs/backlight.c
+++ b/src/fw/drivers/stubs/backlight.c
@@ -9,5 +9,8 @@ void backlight_init(void) {
 void backlight_set_brightness(uint8_t brightness) {
 }
 
+void backlight_refresh(void) {
+}
+
 void command_backlight_ctl(const char *arg) {
 }

--- a/src/fw/services/light/service.c
+++ b/src/fw/services/light/service.c
@@ -285,6 +285,11 @@ static void prv_change_state(BacklightState new_state) {
 
   if (s_current_brightness != new_brightness) {
     prv_change_brightness(new_brightness);
+  } else if (new_state == LIGHT_STATE_ON || new_state == LIGHT_STATE_ON_TIMED) {
+    // A user-initiated wake with unchanged brightness would otherwise
+    // short-circuit. Re-apply the driver state so the hardware is brought back
+    // in sync if it has drifted from what the firmware believes.
+    backlight_refresh();
   }
 
   // Notify subscribers when the backlight transitions between on and off.

--- a/tests/fw/services/test_light.c
+++ b/tests/fw/services/test_light.c
@@ -69,6 +69,9 @@ void backlight_set_brightness(uint8_t brightness) {
   s_backlight_brightness = brightness;
 }
 
+void backlight_refresh(void) {
+}
+
 bool backlight_is_motion_enabled(void) {
   return false;
 }


### PR DESCRIPTION
The AW2016 backlight driver can silently power-cycle on a VBAT dip or I2C watchdog with no signal back to the MCU, leaving the chip stuck off while firmware still thinks the light is on; add a backlight_refresh() API and call it from the light service on no-op wake transitions so user taps/wrist-flicks heal the desync instead of getting absorbed by the fade-out timer (fixes FIRM-1929)