### PR TITLE
comm: add ams_music_disconnect and use on Android [FIRM-1982]

### DIFF
--- a/src/fw/comm/ble/kernel_le_client/ams/ams.c
+++ b/src/fw/comm/ble/kernel_le_client/ams/ams.c
@@ -274,6 +274,12 @@ static bool prv_set_connected(bool connected) {
   return !has_error;
 }
 
+void ams_music_disconnect(void) {
+  if (s_ams_client && s_ams_client->connected) {
+    prv_set_connected(false);
+  }
+}
+
 // -------------------------------------------------------------------------------------------------
 // Player entity update handlers
 

--- a/src/fw/comm/ble/kernel_le_client/ams/ams.h
+++ b/src/fw/comm/ble/kernel_le_client/ams/ams.h
@@ -75,6 +75,13 @@ void ams_handle_read_or_notification(BLECharacteristic characteristic, const uin
 //! Must only be called from KernelMain!
 void ams_destroy(void);
 
+//! Disconnect AMS from the music service if currently registered. No-op otherwise.
+//! Some Android phones expose something that looks like an AMS GATT service,
+//! letting AMS grab the music slot before we learn the remote is Android. The PP
+//! music endpoint calls this on Android-detect so it can take over the slot.
+//! Must only be called from KernelMain!
+void ams_music_disconnect(void);
+
 //! This function is exported only for (unit) testing purposes!
 //! OK to call from any task.
 void ams_send_command(AMSRemoteCommandID command_id);

--- a/src/fw/comm/prf_stubs/ams.c
+++ b/src/fw/comm/prf_stubs/ams.c
@@ -33,5 +33,8 @@ void ams_handle_service_removed(BLECharacteristic *characteristics, uint8_t num_
 void ams_destroy(void) {
 }
 
+void ams_music_disconnect(void) {
+}
+
 void ams_send_command(AMSRemoteCommandID command_id) {
 }

--- a/src/fw/services/music/endpoint.c
+++ b/src/fw/services/music/endpoint.c
@@ -4,6 +4,7 @@
 #include "pbl/services/music_endpoint.h"
 #include "pbl/services/music_endpoint_types.h"
 
+#include "comm/ble/kernel_le_client/ams/ams.h"
 #include "pbl/services/comm_session/session.h"
 #include "pbl/services/comm_session/session_remote_os.h"
 #include "pbl/services/music_internal.h"
@@ -292,6 +293,8 @@ void music_endpoint_handle_mobile_app_info_event(const PebbleRemoteAppInfoEvent 
     // Only on Android we use Pebble Protocol for music metadata and control.
     return;
   }
+  
+  ams_music_disconnect();
   prv_set_connected(true);
 }
 

--- a/tests/fw/services/test_music_endpoint.c
+++ b/tests/fw/services/test_music_endpoint.c
@@ -33,6 +33,8 @@
 #include "stubs_serial.h"
 #include "stubs_tick.h"
 
+void ams_music_disconnect(void) {}
+
 extern void music_protocol_msg_callback(CommSession *session, const uint8_t* msg, size_t length);
 
 // Helpers


### PR DESCRIPTION
lmao some guys phone advertises a GATT server with the same UUID as AMS
if we *know* were on android and connected to AMS, disconnect from AMS