### PR TITLE
fw/comm/ble/ancs: keep alive-check timer alive after failed recovery

### DIFF
--- a/src/fw/comm/ble/kernel_le_client/ancs/ancs.c
+++ b/src/fw/comm/ble/kernel_le_client/ancs/ancs.c
@@ -390,6 +390,15 @@ static void prv_is_ancs_alive_response_timeout_launcher_task_cb(void *data) {
   // This handles the case where iOS has dropped the GATT subscription
   // without the watch knowing about it (common during PPoGATT resets)
   prv_resubscribe_to_ancs();
+
+  // Always re-arm the alive-check timer here, even though a successful
+  // resubscribe will also re-arm it from ancs_handle_subscribe(). Recovery is
+  // not guaranteed: characteristics may be invalidated, the CCCD write may
+  // fail synchronously, or iOS may never reply with a CCCD response. Without
+  // this re-arm those paths leave the timer permanently stopped and the watch
+  // stays connected but silent until reboot. The call is idempotent --
+  // prv_ancs_is_alive_start_tracking() cancels and reschedules.
+  prv_ancs_is_alive_schedule_next_check();
 }
 
 static void prv_is_ancs_alive_response_timeout(void *data) {


### PR DESCRIPTION
## Summary

Fixes the recurring iOS-only failure mode where the watch shows connected but never delivers notifications until reboot (FIRM-1936, also reported in FIRM-1692, FIRM-951).

The ANCS alive-check fires every 15 minutes. If iOS doesn't reply within 5 s, the response-timeout handler tries to recover by re-subscribing. The next alive check is only re-armed on success, via `ancs_handle_subscribe()` when the Data CCCD response arrives without error.

When the recovery path itself fails — characteristics invalidated, `gatt_client_subscriptions_subscribe()` returns non-OK synchronously, or iOS never sends a CCCD response — the timer stays stopped permanently and no further recovery is ever attempted.

This change always re-schedules the next alive check at the end of the timeout handler. On the happy path `ancs_handle_subscribe()` still cancels and reschedules; on failure paths we keep ticking and get another shot at recovery instead of going silently dead.

Fixes FIRM-1936.
Related: FIRM-1692, FIRM-951, FIRM-1828, FIRM-1412 (10831a1a).

## Test plan

- [ ] Force the alive-check failure path (e.g. by killing the Pebble app on iPhone while connected) and confirm the watch keeps re-checking and eventually re-subscribes instead of going silent forever
- [ ] Normal ANCS flow still works end-to-end on obelix/asterix
- [ ] No regression in alive-check timing under healthy conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)