### PR TITLE
services/light: clear stuck user-controlled flag on settings toggle and mic window disappear

### DIFF
--- a/src/fw/applib/voice/voice_window.c
+++ b/src/fw/applib/voice/voice_window.c
@@ -1283,6 +1283,10 @@ static void prv_mic_window_unload(Window *window) {
 
 static void prv_mic_window_disappear(Window *window) {
   VoiceUiData *data = window_get_user_data(window);
+  // prv_mic_window_appear pinned the backlight via sys_light_enable_respect_settings(true).
+  // Release it here so the appear/disappear pair is symmetric, even if a later
+  // exit path (prv_exit_and_send_result_event, voice_window_pop) never runs.
+  sys_light_reset_to_timed_mode();
   if (data->state != StateError) {
     // Do not indicate that an error occurred when a session is interrupted by a window transition
     if (data->state != StateFinished) {

--- a/src/fw/services/light/service.c
+++ b/src/fw/services/light/service.c
@@ -518,6 +518,11 @@ static void prv_light_reset_to_timed_mode(void) {
 void light_toggle_enabled(void) {
   mutex_lock(s_mutex);
 
+  // Toggling the setting is the user's only escape hatch if some path left
+  // s_user_controlled_state stuck on. Clear it here so a subsequent button
+  // release will actually start the auto-off timer.
+  s_user_controlled_state = false;
+
   backlight_set_enabled(!backlight_is_enabled());
   if (prv_light_allowed()) {
     prv_change_state(LIGHT_STATE_ON_TIMED);
@@ -529,6 +534,7 @@ void light_toggle_enabled(void) {
 
 void light_toggle_ambient_sensor_enabled(void) {
   mutex_lock(s_mutex);
+  s_user_controlled_state = false;
   backlight_set_ambient_sensor_enabled(!backlight_is_ambient_sensor_enabled());
   if (prv_light_allowed() && !prv_als_is_light()) {
     prv_change_state(LIGHT_STATE_ON_TIMED);


### PR DESCRIPTION
## Summary

Two defense-in-depth fixes for FIRM-1874 (backlight stays on indefinitely, drains battery, requires manual reset).

The root mechanism is `s_user_controlled_state` getting stuck at `true` in the light service. When that happens, button release skips the auto-off transition in `light_button_released`, so the backlight stays in `LIGHT_STATE_ON` with no timer. App-crash cleanup already clears the flag via `light_reset_user_controlled()` in `prv_app_cleanup()` (app_manager.c:446), so the most-cited theory (HardFault → stuck flag) is already covered. These two changes close the remaining holes I could find:

- **`services/light`**: `light_toggle_enabled()` and `light_toggle_ambient_sensor_enabled()` now clear `s_user_controlled_state`. This is the user's documented escape hatch — toggle the setting off and back on — but before this change the flag survived the round-trip, so the next button press would still get stuck. The light would go off via the timed path, giving the user the impression things were back to normal, but the underlying state was still wrong.
- **`fw/applib/voice`**: `prv_mic_window_disappear` now calls `sys_light_reset_to_timed_mode()` so its appear/disappear pair is symmetric. `prv_mic_window_appear` pins the backlight via `sys_light_enable_respect_settings(true)`; previously the disappear handler only canceled the dictation and left the light held. Normal exits (back button, success, error retries, `voice_window_pop`) all reset it later, but a disappear caused by focus loss or modal preempt without a follow-up `voice_window_pop` leaks the flag.

The FIRM-1874 reporter was actively using voice dictation (with "Failed to get send buffer" and "Unrecognized transcription format" warnings in the watch logs), making the dictation path a plausible source of the leak — but the toggle fix is the load-bearing one because it makes the user-facing workaround actually work regardless of where the leak originated.

## Test plan

- [x] `./waf configure --board obelix_pvt && ./waf build` succeeds
- [ ] Manual: reproduce stuck-backlight state by holding `s_user_controlled_state = true` via debugger, toggle backlight setting off/on, verify next button press now starts the fade-out timer
- [ ] Manual: start a voice dictation, force-pop the mic window via a modal preempt, verify backlight is not pinned afterward

Fixes FIRM-1874

🤖 Generated with [Claude Code](https://claude.com/claude-code)