### PR TITLE
fw/shell/normal: invert back + up combo when display is flipped [FIRM-1975]

### DIFF
--- a/src/fw/shell/normal/watchface.c
+++ b/src/fw/shell/normal/watchface.c
@@ -23,12 +23,18 @@
 #include "pbl/services/notifications/do_not_disturb.h"
 #include "system/logging.h"
 #include "system/passert.h"
+#if CAPABILITY_HAS_ORIENTATION_MANAGER
+#include "shell/prefs.h"
+#endif 
 
 #define QUICK_LAUNCH_HOLD_MS (400)
 #define BIT_SET (1)
 #define BIT_CLEAR (0)
 #define COMBO_BACK_UP_BUTTONS ((BIT_SET << BUTTON_ID_BACK) | (BIT_SET << BUTTON_ID_UP))
 #define COMBO_UP_DOWN_BUTTONS ((BIT_SET << BUTTON_ID_UP) | (BIT_SET << BUTTON_ID_DOWN))
+#if CAPABILITY_HAS_ORIENTATION_MANAGER
+#define COMBO_BACK_UP_FLIPPED_BUTTONS ((BIT_SET << BUTTON_ID_BACK) | (BIT_SET << BUTTON_ID_DOWN))
+#endif
 
 static ClickManager s_click_manager;
 static uint8_t s_buttons_pressed = BIT_CLEAR;
@@ -58,20 +64,41 @@ static bool prv_is_combo_pressed(uint8_t combo_buttons) {
 }
 
 static bool prv_combo_is_enabled(uint8_t combo_buttons) {
+#if CAPABILITY_HAS_ORIENTATION_MANAGER
+  const bool orientation_flipped = display_orientation_is_left();
+  if (orientation_flipped && combo_buttons == COMBO_BACK_UP_FLIPPED_BUTTONS) {
+    return quick_launch_combo_back_up_is_enabled();
+  } else if (!orientation_flipped && combo_buttons == COMBO_BACK_UP_BUTTONS) {
+    return quick_launch_combo_back_up_is_enabled();
+  } else if (combo_buttons == COMBO_UP_DOWN_BUTTONS) {
+    return quick_launch_combo_up_down_is_enabled();
+  }
+#else
   if (combo_buttons == COMBO_BACK_UP_BUTTONS) {
     return quick_launch_combo_back_up_is_enabled();
   } else if (combo_buttons == COMBO_UP_DOWN_BUTTONS) {
     return quick_launch_combo_up_down_is_enabled();
   }
+#endif
   return false;
 }
 
 static AppInstallId prv_combo_get_app(uint8_t combo_buttons) {
+#if CAPABILITY_HAS_ORIENTATION_MANAGER
+  if (combo_buttons == COMBO_BACK_UP_FLIPPED_BUTTONS) {
+    return quick_launch_combo_back_up_get_app();
+  } else if (combo_buttons == COMBO_BACK_UP_BUTTONS) {
+    return quick_launch_combo_back_up_get_app();
+  } else if (combo_buttons == COMBO_UP_DOWN_BUTTONS) {
+    return quick_launch_combo_up_down_get_app();
+  }
+#else
   if (combo_buttons == COMBO_BACK_UP_BUTTONS) {
     return quick_launch_combo_back_up_get_app();
   } else if (combo_buttons == COMBO_UP_DOWN_BUTTONS) {
     return quick_launch_combo_up_down_get_app();
   }
+#endif
   return INSTALL_ID_INVALID;
 }
 
@@ -110,17 +137,41 @@ static void prv_combo_back_timer_callback(void *data) {
 
 static void prv_check_combo_back_hold(void) {
   uint8_t combo_buttons = BIT_CLEAR;
+
+#if CAPABILITY_HAS_ORIENTATION_MANAGER
+  const bool orientation_flipped = display_orientation_is_left();
+  if (orientation_flipped && prv_is_combo_pressed(COMBO_BACK_UP_FLIPPED_BUTTONS)) {
+    combo_buttons = COMBO_BACK_UP_FLIPPED_BUTTONS;
+  } else if (!orientation_flipped && prv_is_combo_pressed(COMBO_BACK_UP_BUTTONS)) {
+    combo_buttons = COMBO_BACK_UP_BUTTONS;
+  } else if (prv_is_combo_pressed(COMBO_UP_DOWN_BUTTONS)) {
+    combo_buttons = COMBO_UP_DOWN_BUTTONS;
+  }
+#else
   if (prv_is_combo_pressed(COMBO_BACK_UP_BUTTONS)) {
     combo_buttons = COMBO_BACK_UP_BUTTONS;
   } else if (prv_is_combo_pressed(COMBO_UP_DOWN_BUTTONS)) {
     combo_buttons = COMBO_UP_DOWN_BUTTONS;
   }
+#endif
 
   if (combo_buttons != BIT_CLEAR) {
     if (s_combo_back_hold_timer == NULL) {
       s_active_combo_buttons = combo_buttons;
       // Cancel individual button timers to prevent them from firing.
       // This ensures only the combo executes, not individual hold handlers.
+#if CAPABILITY_HAS_ORIENTATION_MANAGER
+      if (combo_buttons == COMBO_BACK_UP_FLIPPED_BUTTONS) {
+        click_recognizer_reset(&s_click_manager.recognizers[BUTTON_ID_BACK]);
+        click_recognizer_reset(&s_click_manager.recognizers[BUTTON_ID_DOWN]);
+      } else if (combo_buttons == COMBO_BACK_UP_BUTTONS) {
+        click_recognizer_reset(&s_click_manager.recognizers[BUTTON_ID_BACK]);
+        click_recognizer_reset(&s_click_manager.recognizers[BUTTON_ID_UP]);
+      } else {
+        click_recognizer_reset(&s_click_manager.recognizers[BUTTON_ID_UP]);
+        click_recognizer_reset(&s_click_manager.recognizers[BUTTON_ID_DOWN]);
+      }
+#else
       if (combo_buttons == COMBO_BACK_UP_BUTTONS) {
         click_recognizer_reset(&s_click_manager.recognizers[BUTTON_ID_BACK]);
         click_recognizer_reset(&s_click_manager.recognizers[BUTTON_ID_UP]);
@@ -128,6 +179,7 @@ static void prv_check_combo_back_hold(void) {
         click_recognizer_reset(&s_click_manager.recognizers[BUTTON_ID_UP]);
         click_recognizer_reset(&s_click_manager.recognizers[BUTTON_ID_DOWN]);
       }
+#endif
       s_combo_back_hold_timer =
           app_timer_register(QUICK_LAUNCH_HOLD_MS, prv_combo_back_timer_callback, NULL);
     }


### PR DESCRIPTION
If the user has configured a Back + Up action for Quick Launch, switching the display to left-handed mode will change the physical process of running the shortcut. With the display orientation set to default, Back + Up involves placing the fingers directly across from each other to complete the action. When flipped, Back + Up forces the user to place their fingers at a diagonal, disrupting muscle memory.

This PR fixes this by treating Back + Down as Back + Up when the display orientation is flipped.