### PR TITLE
fw/services/clock: drop legacy localtime->UTC pivot

### DIFF
--- a/src/fw/services/clock/service.c
+++ b/src/fw/services/clock/service.c
@@ -43,39 +43,17 @@ static const uint16_t protocol_time_endpoint_id = 11;
 
 static RegularTimerInfo s_dst_checker;
 
-//! Migrations for services that use timezone info
-static void prv_migrate_timezone_info(int utc_diff) {
-#ifndef RECOVERY_FW
-  // Since all migrations are to UTC time, we are passed the relative offset from UTC
-  notifications_migrate_timezone(utc_diff);
-  wakeup_migrate_timezone(utc_diff);
-#endif
-}
-
 static time_t prv_migrate_local_time_to_UTC(time_t local_time) {
   return time_local_to_utc(local_time);
 }
 
 // Should only called by prv_update_time_info_and_generate_event()!
 static void prv_handle_timezone_set(TimezoneInfo *tz_info) {
-  // Check if the timezone is set before setting it.  This ensures that this
-  // will only be false once as needed for us to migrate.
-  bool timezone_migration_needed = !clock_is_timezone_set();
-
   time_util_update_timezone(tz_info);
 
   // Update the RTC registers with the latest timezone info
   rtc_set_timezone(tz_info);
 
-  // We are pivoting to UTC from localtime for the first time
-  if (timezone_migration_needed) {
-    time_t t0 = rtc_get_time();
-    time_t t1 = prv_migrate_local_time_to_UTC(t0);
-    rtc_sanitize_time_t(&t1);
-    PBL_LOG_INFO("Pivot RTC from localtime to UTC (%lu -> %lu)", t0, t1);
-    rtc_set_time(t1);  // Pivot RTC from localtime to UTC
-    prv_migrate_timezone_info(tz_info->tm_gmtoff);
-  }
 }
 
 typedef struct PACKED {


### PR DESCRIPTION
prv_handle_timezone_set() ran a one-shot "pivot RTC from localtime to UTC" block whenever clock_is_timezone_set() was false. That migration was meant for the era when classic Pebbles stored wall-clock localtime in the RTC; modern firmware always stores UTC, and on Asterix/Obelix the RTC has never held anything else.

The pivot re-arms on every dead-battery boot, because retained RAM is wiped and rtc_is_timezone_set() goes back to returning false. When a subsequent timezone-only update comes in (e.g.
clock_set_timezone_by_region_id() triggered by the BlobDB watch-prefs sync of timezoneSource shortly after reconnect), there is no UTC time in the same call to overwrite the pivot's result, so it adds the timezone offset (+7h for PDT) to an already-correct UTC value and leaves the RTC permanently shifted.

Drop the pivot. The migration has been a no-op on every supported platform for years, and removing it eliminates the double-offset path.

Fixes FIRM-2000