### PR TITLE
agents: ask for short and concise comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,8 @@ PebbleOS is the operating system running on Pebble smartwatches.
 
 - clang-format for C code
 - ruff for Python code
+- Keep code comments short and concise. Extended descriptions can be kept in
+  the Git commit message.
 
 ## Logging
 


### PR DESCRIPTION
It looks like Claude loves to write lots of text to often explain simple changes. Ask agents to use Git history for that, instead of comments in the code.