### PR TITLE
fw/services/speaker: serialize public API and refill with a mutex

### DIFF
--- a/src/fw/services/speaker/speaker_service.c
+++ b/src/fw/services/speaker/speaker_service.c
@@ -14,6 +14,7 @@
 #include "board/board.h"
 #include "kernel/events.h"
 #include "kernel/pbl_malloc.h"
+#include "os/mutex.h"
 #include "pbl/services/analytics/analytics.h"
 #include "pbl/services/notifications/alerts_preferences.h"
 #include "pbl/services/notifications/do_not_disturb.h"
@@ -76,6 +77,9 @@ typedef struct {
 
 static SpeakerServiceState s_state;
 
+// Serializes public APIs against prv_refill_bg (system task).
+static PebbleMutex *s_lock;
+
 //! Analytics: time-weighted average volume, reset on heartbeat.
 static uint64_t s_volume_time_product_sum;     // Sum of (volume_pct × time_ms)
 static RtcTicks s_last_volume_sample_ticks;    // Timestamp of last sample
@@ -118,6 +122,8 @@ static void prv_update_volume_analytics(uint8_t new_volume_pct) {
 }
 
 void speaker_service_init(void) {
+  s_lock = mutex_create();
+
   memset(&s_state, 0, sizeof(s_state));
   s_state.state = SpeakerStateIdle;
   s_state.source_type = SpeakerSourceNone;
@@ -178,10 +184,15 @@ static void prv_post_finish_event(SpeakerFinishReason reason) {
   event_put(&e);
 }
 
+//! Caller must hold s_lock.
 static void prv_stop_internal(SpeakerFinishReason reason) {
   if (s_state.state == SpeakerStateIdle) {
     return;
   }
+  const SpeakerSourceType source_type = s_state.source_type;
+  s_state.state = SpeakerStateIdle;
+  s_state.source_type = SpeakerSourceNone;
+  s_state.owner_task = PebbleTask_Unknown;
 
   if (reason == SpeakerFinishReasonPreempted) {
     PBL_ANALYTICS_ADD(speaker_preempted_count, 1);
@@ -189,24 +200,20 @@ static void prv_stop_internal(SpeakerFinishReason reason) {
 
   prv_stop_audio();
 
-  if (s_state.source_type == SpeakerSourceNoteSeq) {
+  if (source_type == SpeakerSourceNoteSeq) {
     note_seq_deinit(&s_state.note_seq);
     if (s_state.note_buf) {
       kernel_free(s_state.note_buf);
       s_state.note_buf = NULL;
     }
-  } else if (s_state.source_type == SpeakerSourceStream) {
+  } else if (source_type == SpeakerSourceStream) {
     pcm_stream_deinit(&s_state.pcm_stream);
-  } else if (s_state.source_type == SpeakerSourceTracks) {
+  } else if (source_type == SpeakerSourceTracks) {
     prv_free_tracks();
-  } else if (s_state.source_type == SpeakerSourceTone) {
+  } else if (source_type == SpeakerSourceTone) {
     s_state.tone_samples_remaining = 0;
     s_state.tone_phase_inc = 0;
   }
-
-  s_state.state = SpeakerStateIdle;
-  s_state.source_type = SpeakerSourceNone;
-  s_state.owner_task = PebbleTask_Unknown;
 
   PBL_LOG_DBG("Speaker stopped (reason=%d)", reason);
 
@@ -331,7 +338,8 @@ static uint32_t prv_read_and_convert_pcm(int16_t *out, uint32_t max_out_samples)
   return out_pos;
 }
 
-static void prv_refill_bg(void *data) {
+//! Caller must hold s_lock.
+static void prv_refill_locked(void) {
   if (s_state.state == SpeakerStateIdle) {
     return;
   }
@@ -412,13 +420,23 @@ static void prv_refill_bg(void *data) {
   }
 }
 
+static void prv_refill_bg(void *data) {
+  mutex_lock(s_lock);
+  prv_refill_locked();
+  mutex_unlock(s_lock);
+}
+
 bool speaker_service_play_note_seq(const SpeakerNote *notes, uint32_t num_notes,
                                    SpeakerPriority pri, uint8_t vol) {
+  mutex_lock(s_lock);
+
   if (!s_state.initialized || !notes || num_notes == 0) {
+    mutex_unlock(s_lock);
     return false;
   }
 
   if (!prv_can_preempt(pri)) {
+    mutex_unlock(s_lock);
     return false;
   }
 
@@ -432,6 +450,7 @@ bool speaker_service_play_note_seq(const SpeakerNote *notes, uint32_t num_notes,
   s_state.note_buf = kernel_malloc(notes_size);
   if (!s_state.note_buf) {
     PBL_LOG_ERR("Failed to allocate note buffer");
+    mutex_unlock(s_lock);
     return false;
   }
   memcpy(s_state.note_buf, notes, notes_size);
@@ -446,19 +465,24 @@ bool speaker_service_play_note_seq(const SpeakerNote *notes, uint32_t num_notes,
   prv_start_audio(vol);
 
   // Prime the audio buffer with initial data
-  prv_refill_bg(NULL);
+  prv_refill_locked();
 
+  mutex_unlock(s_lock);
   return true;
 }
 
 bool speaker_service_play_tone(uint16_t freq_hz, uint16_t duration_ms,
                                uint8_t waveform, uint8_t velocity,
                                SpeakerPriority pri, uint8_t vol) {
+  mutex_lock(s_lock);
+
   if (!s_state.initialized || duration_ms == 0) {
+    mutex_unlock(s_lock);
     return false;
   }
 
   if (!prv_can_preempt(pri)) {
+    mutex_unlock(s_lock);
     return false;
   }
 
@@ -481,15 +505,19 @@ bool speaker_service_play_tone(uint16_t freq_hz, uint16_t duration_ms,
   s_state.volume = vol;
 
   prv_start_audio(vol);
-  prv_refill_bg(NULL);
+  prv_refill_locked();
 
+  mutex_unlock(s_lock);
   return true;
 }
 
 bool speaker_service_play_tracks(const SpeakerTrack *tracks, uint32_t num_tracks,
                                  SpeakerPriority pri, uint8_t vol) {
+  mutex_lock(s_lock);
+
   if (!s_state.initialized || !tracks || num_tracks == 0 ||
       num_tracks > SPEAKER_MAX_TRACKS) {
+    mutex_unlock(s_lock);
     return false;
   }
 
@@ -497,20 +525,24 @@ bool speaker_service_play_tracks(const SpeakerTrack *tracks, uint32_t num_tracks
   for (uint32_t i = 0; i < num_tracks; i++) {
     const SpeakerTrack *t = &tracks[i];
     if (!t->notes || t->num_notes == 0) {
+      mutex_unlock(s_lock);
       return false;
     }
     if (t->sample) {
       if (!t->sample->data || t->sample->num_bytes == 0) {
+        mutex_unlock(s_lock);
         return false;
       }
       total_sample_bytes += t->sample->num_bytes;
       if (total_sample_bytes > SPEAKER_MAX_SAMPLE_BYTES_TOTAL) {
+        mutex_unlock(s_lock);
         return false;
       }
     }
   }
 
   if (!prv_can_preempt(pri)) {
+    mutex_unlock(s_lock);
     return false;
   }
 
@@ -561,8 +593,9 @@ bool speaker_service_play_tracks(const SpeakerTrack *tracks, uint32_t num_tracks
   s_state.volume = vol;
 
   prv_start_audio(vol);
-  prv_refill_bg(NULL);
+  prv_refill_locked();
 
+  mutex_unlock(s_lock);
   return true;
 
 alloc_fail:
@@ -576,15 +609,20 @@ alloc_fail:
       s_state.track_sample_data[i] = NULL;
     }
   }
+  mutex_unlock(s_lock);
   return false;
 }
 
 bool speaker_service_stream_open(SpeakerPriority pri, uint8_t vol, SpeakerPcmFormat fmt) {
+  mutex_lock(s_lock);
+
   if (!s_state.initialized) {
+    mutex_unlock(s_lock);
     return false;
   }
 
   if (!prv_can_preempt(pri)) {
+    mutex_unlock(s_lock);
     return false;
   }
 
@@ -595,6 +633,7 @@ bool speaker_service_stream_open(SpeakerPriority pri, uint8_t vol, SpeakerPcmFor
 
   if (!pcm_stream_init(&s_state.pcm_stream, PCM_STREAM_DEFAULT_SIZE_BYTES)) {
     PBL_LOG_ERR("Failed to allocate PCM stream buffer");
+    mutex_unlock(s_lock);
     return false;
   }
 
@@ -608,20 +647,29 @@ bool speaker_service_stream_open(SpeakerPriority pri, uint8_t vol, SpeakerPcmFor
 
   prv_start_audio(vol);
 
+  mutex_unlock(s_lock);
   return true;
 }
 
 uint32_t speaker_service_stream_write(const void *data, uint32_t num_bytes) {
+  mutex_lock(s_lock);
+
   if (s_state.state == SpeakerStateIdle ||
       s_state.source_type != SpeakerSourceStream) {
+    mutex_unlock(s_lock);
     return 0;
   }
 
-  return pcm_stream_write(&s_state.pcm_stream, data, num_bytes);
+  uint32_t written = pcm_stream_write(&s_state.pcm_stream, data, num_bytes);
+  mutex_unlock(s_lock);
+  return written;
 }
 
 void speaker_service_stream_close(void) {
+  mutex_lock(s_lock);
+
   if (s_state.source_type != SpeakerSourceStream) {
+    mutex_unlock(s_lock);
     return;
   }
 
@@ -632,19 +680,25 @@ void speaker_service_stream_close(void) {
   } else {
     prv_stop_internal(SpeakerFinishReasonDone);
   }
+
+  mutex_unlock(s_lock);
 }
 
 void speaker_service_stop(void) {
+  mutex_lock(s_lock);
   prv_stop_internal(SpeakerFinishReasonStopped);
+  mutex_unlock(s_lock);
 }
 
 void speaker_service_set_volume(uint8_t vol) {
+  mutex_lock(s_lock);
   s_state.volume = vol;
   if (s_state.state != SpeakerStateIdle) {
     const uint8_t effective_vol = prv_effective_volume(vol);
     prv_update_volume_analytics(effective_vol);
     audio_set_volume((AudioDevice *)AUDIO, effective_vol);
   }
+  mutex_unlock(s_lock);
 }
 
 bool speaker_service_is_muted(void) {
@@ -652,12 +706,15 @@ bool speaker_service_is_muted(void) {
 }
 
 void speaker_service_handle_mute_state_changed(void) {
+  mutex_lock(s_lock);
   if (s_state.state == SpeakerStateIdle) {
+    mutex_unlock(s_lock);
     return;
   }
   const uint8_t effective_vol = prv_effective_volume(s_state.volume);
   prv_update_volume_analytics(effective_vol);
   audio_set_volume((AudioDevice *)AUDIO, effective_vol);
+  mutex_unlock(s_lock);
 }
 
 SpeakerState speaker_service_get_state(void) {
@@ -665,6 +722,7 @@ SpeakerState speaker_service_get_state(void) {
 }
 
 void speaker_service_stop_for_task(PebbleTask task) {
+  mutex_lock(s_lock);
   if (s_state.state != SpeakerStateIdle && s_state.owner_task == task) {
     // App is going away — no one to receive the finish event.
     s_state.finish_enabled = false;
@@ -674,6 +732,7 @@ void speaker_service_stop_for_task(PebbleTask task) {
     s_state.finish_enabled = false;
     s_state.finish_task = PebbleTask_Unknown;
   }
+  mutex_unlock(s_lock);
 }
 
 void speaker_service_set_owner_task(PebbleTask task) {
@@ -681,11 +740,15 @@ void speaker_service_set_owner_task(PebbleTask task) {
 }
 
 void speaker_service_register_finish(PebbleTask task) {
+  mutex_lock(s_lock);
   s_state.finish_enabled = true;
   s_state.finish_task = task;
+  mutex_unlock(s_lock);
 }
 
 void pbl_analytics_external_collect_speaker_stats(void) {
+  mutex_lock(s_lock);
+
   // Capture one final sample to account for time since last volume change.
   prv_update_volume_analytics(s_last_sampled_volume_pct);
 
@@ -699,6 +762,8 @@ void pbl_analytics_external_collect_speaker_stats(void) {
   s_volume_time_product_sum = 0;
   s_total_speaker_on_time_ms = 0;
   s_last_volume_sample_ticks = rtc_get_ticks();
+
+  mutex_unlock(s_lock);
 }
 
 #else // !CAPABILITY_HAS_SPEAKER


### PR DESCRIPTION
prv_refill_bg (system task) and the public speaker_service APIs (KernelMain / app threads) had no synchronization. The observed fallout was a PBL_ASSERTN in stop_mode_enable: two callers of prv_stop_internal both passed the state==Idle guard before either cleared state, so audec_stop()->stop_mode_enable(InhibitorAudio) ran twice and underflowed s_num_items_disallowing_stop_mode. The same race also lets a stop on one thread interleave with a play on another — both touching the AUDCODEC HAL, DMA buffers and pcm_stream lifecycle.

Add s_lock (PebbleMutex *) and take it on every public entry point that mutates state or audio HW, plus prv_refill_bg's system-task callback. prv_refill_bg becomes a lock-take wrapper around prv_refill_locked; the priming callers (play_note_seq / play_tone / play_tracks) already hold the lock and call prv_refill_locked directly. Keep state-first ordering inside prv_stop_internal so it stays idempotent if called twice.

Trivial single-word getters (get_state, is_muted, set_owner_task) are left unlocked.

No ISR enters speaker_service.c directly (DMA ISR posts via system_task_add_callback_from_isr), so a plain PebbleMutex matches the pattern used by voice.c.