### PR TITLE
bluetooth-fw/nimble: re-sync NimBLE when host enabled but driver stat…

### DIFF
--- a/src/bluetooth-fw/nimble/init.c
+++ b/src/bluetooth-fw/nimble/init.c
@@ -144,10 +144,33 @@ bool bt_driver_start(BTDriverConfig *config) {
     }
   }
 
-  if (s_driver_state == DriverStateStarted || ble_hs_is_enabled()) {
-    PBL_LOG_D_WRN(LOG_DOMAIN_BT, "NimBLE host already enabled; skipping start");
-    s_driver_state = DriverStateStarted;
+  if (s_driver_state == DriverStateStarted) {
+    PBL_LOG_D_WRN(LOG_DOMAIN_BT, "Driver already started; skipping start");
     return true;
+  }
+
+  if (ble_hs_is_enabled()) {
+    // State mismatch: stop NimBLE so the fresh-start path re-runs
+    // ble_hs_util_ensure_addr.
+    PBL_LOG_D_WRN(LOG_DOMAIN_BT, "NimBLE host enabled but driver state is %u; resyncing",
+                  (unsigned)s_driver_state);
+    s_driver_state = DriverStateStopping;
+    (void)xSemaphoreTake(s_host_stopped, 0);
+    rc = ble_hs_stop(&s_listener, prv_ble_hs_stop_cb, NULL);
+    if (rc == BLE_HS_EALREADY) {
+      s_driver_state = DriverStateStopped;
+    } else if (rc != 0) {
+      PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Failed to stop NimBLE host for resync: 0x%04x", (uint16_t)rc);
+      return false;
+    } else {
+      f_rc = xSemaphoreTake(s_host_stopped, milliseconds_to_ticks(s_bt_stack_start_stop_timeout_ms));
+      if (f_rc != pdTRUE) {
+        // Leave state as STOPPING; the next start attempt will retry the wait.
+        PBL_LOG_D_ERR(LOG_DOMAIN_BT, "NimBLE host stop timed out during resync");
+        return false;
+      }
+      s_driver_state = DriverStateStopped;
+    }
   }
 
   if (s_driver_state != DriverStateStopped) {


### PR DESCRIPTION
…e is not Started

The idempotency guard in bt_driver_start() short-circuited whenever ble_hs_is_enabled() reported true, regardless of our own driver state, and returned without running ble_hs_util_ensure_addr(0). After a prior ble_hs_stop (e.g. an err-path stop) had run ble_hs_id_reset(), the identity addresses were left empty, and the next call to bt_driver_id_copy_local_identity_address from bt_local_id_configure_driver tripped PBL_ASSERTN(rc == 0) on the return value of ble_hs_id_infer_auto.

Split the guard: keep the no-op only when our driver state already says Started. If NimBLE thinks the host is on but our state disagrees, drive a clean stop and fall into the fresh-start path so ble_hs_util_ensure_addr runs.