### PR TITLE
sdk: regenerate message key files when keys change

### DIFF
--- a/sdk/waftools/process_message_keys.py
+++ b/sdk/waftools/process_message_keys.py
@@ -155,7 +155,9 @@ def process_message_keys(task_gen):
         ),
     )
     header_task.message_keys = message_keys
-    header_task.dep_vars = message_keys
+    # Track the MESSAGE_KEYS env var so the file is regenerated whenever the
+    # keys change. dep_vars must be a list of env variable names.
+    header_task.dep_vars = ["MESSAGE_KEYS"]
 
     if bld.env.BUILD_TYPE == "lib" or not message_keys:
         return
@@ -168,7 +170,7 @@ def process_message_keys(task_gen):
         ),
     )
     definitions_task.message_keys = message_keys
-    definitions_task.dep_vars = message_keys
+    definitions_task.dep_vars = ["MESSAGE_KEYS"]
 
     # Create a JSON file for apps to require
     bld.path.get_bld().make_node("js").mkdir()
@@ -179,7 +181,7 @@ def process_message_keys(task_gen):
         ),
     )
     json_task.message_keys = message_keys
-    json_task.dep_vars = message_keys
+    json_task.dep_vars = ["MESSAGE_KEYS"]
 
 
 class message_key_header(Task.Task):


### PR DESCRIPTION
## Problem

`build/src/message_keys.auto.c` is not regenerated when `messageKeys` in `package.json` change, so builds fail with `MESSAGE_KEY_* undeclared` errors until a `pebble clean`.

Fixes coredevices/pebble-tool#51

## Root cause

The message key header/C/JSON tasks in `sdk/waftools/process_message_keys.py` set `dep_vars` to the message-keys dict itself:

```python
header_task.dep_vars = message_keys   # {"someKey": 10000, ...}
```

waf expects `dep_vars` to be a **list of env variable names** — it hashes `env[name]` for each entry into the task signature. Iterating the dict yields the message-key *names*, none of which are env vars, so they all resolve to empty. The signature therefore only reflects the *count* of keys.

As a result, renaming a key, changing an array size, or swapping one key for another leaves the signature unchanged, and waf considers the stale `message_keys.auto.c` up to date.

## Fix

Depend on the `MESSAGE_KEYS` env var by name (`conf.env.MESSAGE_KEYS` already holds the computed key dict). waf now hashes the actual key names and values into the task signature, mirroring how the appinfo tasks use `vars=["PROJECT_INFO"]`.

`pebble build` always runs `waf configure` (which re-reads `package.json` and recomputes `MESSAGE_KEYS`) before `waf build`, and each platform env is a flat deep copy carrying `MESSAGE_KEYS`, so the env var is available to every task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)