### PR TITLE
display settings: display the actual scaling type under Legacy Apps

### DIFF
--- a/src/fw/apps/system/settings/display.c
+++ b/src/fw/apps/system/settings/display.c
@@ -540,8 +540,7 @@ static void prv_display_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
 #if CAPABILITY_HAS_APP_SCALING
     case SettingsDisplayLegacyAppMode:
       title = i18n_noop("Legacy Apps");
-      subtitle = (shell_prefs_get_legacy_app_render_mode() >= LegacyAppRenderMode_ScalingNearest) ?
-                 i18n_noop("Scaled") : i18n_noop("Centered");
+      subtitle = s_legacy_app_mode_labels[shell_prefs_get_legacy_app_render_mode()];
       break;
 #endif
     default:


### PR DESCRIPTION
Old:

<img width="200" height="228" alt="pebble_screenshot (3)" src="https://github.com/user-attachments/assets/bd5aed2a-d4e8-450e-ad52-b99435920a14" />

New:

<img width="200" height="228" alt="screenshot-1" src="https://github.com/user-attachments/assets/99e83a5b-89f2-430e-9d12-42b7de5799fc" />
<img width="200" height="228" alt="screenshot-2" src="https://github.com/user-attachments/assets/6419a085-1a1a-441f-b8bf-b52c7156bb31" />
<img width="200" height="228" alt="screenshot-3" src="https://github.com/user-attachments/assets/9d1119bd-4da4-4bf2-b33e-ac76ef95d83a" />

---

inspired by me asking JP if they know what the power use impact of scaled apps is and JP saying they think it's barely anything, especially if nearest neighbor.

well uh I struggled slightly wih finding out what I had it set to, figured out that entering the setting made it hover on current option, but IDK why this doesn't just show what the setting is and it fits on the screen soooo here's a PR. lmk if I'm missing some big obvious reason why this is a bad idea.