### PR TITLE
Music App Prefs: Allow disabling priority in launcher, configure vibe strength

### DIFF
--- a/include/pbl/services/music.h
+++ b/include/pbl/services/music.h
@@ -7,6 +7,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "util/attributes.h"
+
 #define MUSIC_BUFFER_LENGTH 64
 
 typedef enum {
@@ -36,6 +38,23 @@ typedef enum {
 
   NumMusicCommand,
 } MusicCommand;
+
+
+// Music App Preferences Struct, for storing to prefs
+typedef struct PACKED MusicAppPreferences {
+  bool show_volume_controls;
+  bool show_progress_bar;
+  bool prioritize_when_playing;
+  uint8_t long_press_vibe_strength;
+} MusicAppPreferences;
+
+#define MUSIC_APP_DEFAULT_PREFERENCES { \
+  .show_volume_controls = true, \
+  .show_progress_bar = true, \
+  .prioritize_when_playing = true, \
+  .long_press_vibe_strength = 100, \
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Interface to Music app

--- a/include/pbl/services/music.h
+++ b/include/pbl/services/music.h
@@ -40,22 +40,6 @@ typedef enum {
 } MusicCommand;
 
 
-// Music App Preferences Struct, for storing to prefs
-typedef struct PACKED MusicAppPreferences {
-  bool show_volume_controls;
-  bool show_progress_bar;
-  bool prioritize_when_playing;
-  uint8_t long_press_vibe_strength;
-} MusicAppPreferences;
-
-#define MUSIC_APP_DEFAULT_PREFERENCES { \
-  .show_volume_controls = true, \
-  .show_progress_bar = true, \
-  .prioritize_when_playing = true, \
-  .long_press_vibe_strength = 100, \
-}
-
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Interface to Music app
 

--- a/include/pbl/services/vibes/vibe_score.h
+++ b/include/pbl/services/vibes/vibe_score.h
@@ -53,7 +53,15 @@ unsigned int vibe_score_get_repeat_delay_ms(VibeScore *score);
 
 // Queues the vibe pattern specified by the score and starts the vibe motor
 // If there the system is already playing a vibe, this will do nothing
+//
+// Runs vibe_score_do_vibe_with_strength with the identity note modifier (100% of note's strength)
 void vibe_score_do_vibe(VibeScore *score);
+
+// Queues the vibe pattern specified by the score and starts the vibe motor
+// If there the system is already playing a vibe, this will do nothing
+//
+// Each note within score will have the strength scaled by the supplied integer percentage (0-255%)
+void vibe_score_do_vibe_with_strength(VibeScore *score, uint8_t strength_percentage);
 
 // Frees a vibe created with vibe_score_create_with_resource
 void vibe_score_destroy(VibeScore *score);

--- a/src/fw/apps/system/music.c
+++ b/src/fw/apps/system/music.c
@@ -266,7 +266,7 @@ static void prv_trigger_cassette_icon_switch(GBitmap *bitmap, bool animated);
 static void prv_update_cassette_icon(MusicAppData *data, bool animated);
 
 static void prv_do_haptic_feedback_vibe(MusicAppData *data) {
-  vibe_score_do_vibe_with_strength(data->score, music_app_prefs_get_long_press_vibe_strength());
+  vibe_score_do_vibe_with_strength(data->score, music_app_prefs_get_long_press_vibe_intensity());
 }
 
 static void prv_handle_volume_icon_timer(void *context) {

--- a/src/fw/apps/system/music.c
+++ b/src/fw/apps/system/music.c
@@ -266,7 +266,7 @@ static void prv_trigger_cassette_icon_switch(GBitmap *bitmap, bool animated);
 static void prv_update_cassette_icon(MusicAppData *data, bool animated);
 
 static void prv_do_haptic_feedback_vibe(MusicAppData *data) {
-  vibe_score_do_vibe(data->score);
+  vibe_score_do_vibe_with_strength(data->score, music_app_prefs_get_long_press_vibe_strength());
 }
 
 static void prv_handle_volume_icon_timer(void *context) {
@@ -486,7 +486,7 @@ static void prv_update_ui_state_skipping(MusicAppData *data, bool animated) {
                                      &data->icon_skip_forward, animated);
   action_bar_layer_set_icon_animated(&data->action_bar, BUTTON_BACKWARD,
                                      &data->icon_skip_backward, animated);
-  const bool show_volume_controls = shell_prefs_get_music_show_volume_controls();
+  const bool show_volume_controls = music_app_prefs_get_show_volume_controls_enabled();
   if (music_get_playback_state() == MusicPlayStatePaused) {
     action_bar_layer_set_icon_animated(&data->action_bar, BUTTON_ID_SELECT, &data->icon_play,
                                        animated);
@@ -571,7 +571,7 @@ static void prv_volume_click_handler(ClickRecognizerRef recognizer, void *contex
 }
 
 static void prv_ellipsis_click_handler(ClickRecognizerRef recognizer, void *context) {
-  if (!shell_prefs_get_music_show_volume_controls()) {
+  if (!music_app_prefs_get_show_volume_controls_enabled()) {
     music_command_send(MusicCommandTogglePlayPause);
     return;
   }
@@ -621,7 +621,7 @@ static void prv_volume_long_click_end_handler(ClickRecognizerRef recognizer, voi
 }
 
 static void prv_play_pause_long_click_start_handler(ClickRecognizerRef recognizer, void *context) {
-  if (!shell_prefs_get_music_show_volume_controls()) {
+  if (!music_app_prefs_get_show_volume_controls_enabled()) {
     return;
   }
 
@@ -637,7 +637,7 @@ static void prv_play_pause_long_click_end_handler(ClickRecognizerRef recognizer,
 static void prv_skipping_click_config_provider(void *context) {
   window_single_click_subscribe(BUTTON_ID_UP, prv_skip_click_handler);
   window_single_click_subscribe(BUTTON_ID_DOWN, prv_skip_click_handler);
-  const bool show_volume_controls = shell_prefs_get_music_show_volume_controls();
+  const bool show_volume_controls = music_app_prefs_get_show_volume_controls_enabled();
   if (music_get_playback_state() == MusicPlayStatePaused) {
     window_single_click_subscribe(BUTTON_ID_SELECT, prv_play_pause_click_handler);
   } else if (show_volume_controls) {
@@ -664,7 +664,7 @@ static void prv_volume_click_config_provider(void *context) {
 }
 
 static void prv_update_layout(MusicAppData *data) {
-  const bool show_progress_bar = shell_prefs_get_music_show_progress_bar();
+  const bool show_progress_bar = music_app_prefs_get_show_progress_bar_enabled();
   bool hide_layer = !show_progress_bar || !music_is_progress_reporting_supported();
   layer_set_hidden(&data->track_pos_bar.layer, hide_layer);
   layer_set_hidden(&data->position_text_layer.layer, hide_layer);
@@ -738,7 +738,7 @@ static void prv_pop_no_music_window(MusicAppData *data) {
 }
 
 static void prv_update_now_playing(MusicAppData *data) {
-  const bool show_progress_bar = shell_prefs_get_music_show_progress_bar();
+  const bool show_progress_bar = music_app_prefs_get_show_progress_bar_enabled();
   layer_set_hidden((Layer *)&data->track_pos_bar,
                    !show_progress_bar || !music_is_progress_reporting_supported());
 
@@ -784,7 +784,7 @@ static void prv_update_track_progress(MusicAppData *data) {
   if (data->pause_track_pos_updates) {
     return;
   }
-  if (!shell_prefs_get_music_show_progress_bar()) {
+  if (!music_app_prefs_get_show_progress_bar_enabled()) {
     return;
   }
   if (!music_is_progress_reporting_supported()) {
@@ -815,7 +815,7 @@ static void prv_handle_tick_time(struct tm *time, TimeUnits units_changed) {
 }
 
 static void prv_set_pos_update_timer(MusicAppData* data, MusicPlayState playstate) {
-  if (!music_is_progress_reporting_supported() || !shell_prefs_get_music_show_progress_bar()) {
+  if (!music_is_progress_reporting_supported() || !music_app_prefs_get_show_progress_bar_enabled()) {
     tick_timer_service_unsubscribe();
     return;
   }

--- a/src/fw/services/blob_db/settings_blob_db.c
+++ b/src/fw/services/blob_db/settings_blob_db.c
@@ -109,8 +109,7 @@ static const char *s_syncable_settings[] = {
   "workerId",
 
   // Music preferences
-  "musicShowVolumeControls",
-  "musicShowProgressBar",
+  "musicAppPreferences",
 };
 
 static const size_t s_num_syncable_settings = ARRAY_LENGTH(s_syncable_settings);

--- a/src/fw/services/blob_db/settings_blob_db.c
+++ b/src/fw/services/blob_db/settings_blob_db.c
@@ -109,7 +109,10 @@ static const char *s_syncable_settings[] = {
   "workerId",
 
   // Music preferences
-  "musicAppPreferences",
+  "musicShowVolumeControls",
+  "musicShowProgressBar",
+  "musicPrioritizeWhenPlaying",
+  "musicLongPressVibeIntensity",
 };
 
 static const size_t s_num_syncable_settings = ARRAY_LENGTH(s_syncable_settings);

--- a/src/fw/services/vibes/vibe_score.c
+++ b/src/fw/services/vibes/vibe_score.c
@@ -35,7 +35,7 @@ static uint8_t prv_scale_note_strength(uint8_t note_strength, uint8_t percentage
         return note_strength;
     }
 
-    uint16_t scaled = (uint16_t) note_strength * (uint16_t) percentage;
+    const uint16_t scaled = (uint16_t) note_strength * (uint16_t) percentage;
 
     if (scaled > 100 * 100) {
         return 100;

--- a/src/fw/services/vibes/vibe_score.c
+++ b/src/fw/services/vibes/vibe_score.c
@@ -30,6 +30,20 @@ static unsigned int prv_vibe_score_get_pattern_length(GenericAttribute *pattern_
   return pattern_attribute->length / sizeof(VibeNoteIndex);
 }
 
+static uint8_t prv_scale_note_strength(uint8_t note_strength, uint8_t percentage) {
+    if (percentage == 100) {
+        return note_strength;
+    }
+
+    uint16_t scaled = (uint16_t) note_strength * (uint16_t) percentage;
+
+    if (scaled > 100 * 100) {
+        return 100;
+    } else {
+        return ((scaled + (100 - 1)) / 100);
+    }
+}
+
 static bool prv_vibe_score_resource_is_valid(ResAppNum app_num, uint32_t resource_id,
                                              uint32_t expected_signature, uint32_t *data_size) {
   // Load file signature, and check that it matches the expected_signature
@@ -185,7 +199,7 @@ unsigned int vibe_score_get_repeat_delay_ms(VibeScore *score) {
   return 0;
 }
 
-void vibe_score_do_vibe(VibeScore *score) {
+void vibe_score_do_vibe_with_strength(VibeScore *score, uint8_t strength_percentage) {
   PBL_ASSERTN(score);
   GenericAttribute *notes_attribute = generic_attribute_find_attribute(&score->attr_list,
                                                                        VibeAttributeId_Notes,
@@ -204,7 +218,7 @@ void vibe_score_do_vibe(VibeScore *score) {
     VibeNote *note = &note_list[pattern_list[i]];
     total_duration_ms += note->vibe_duration_ms + note->brake_duration_ms;
     if (note->vibe_duration_ms > 0) {
-      sys_vibe_pattern_enqueue_step_raw(note->vibe_duration_ms, note->strength);
+      sys_vibe_pattern_enqueue_step_raw(note->vibe_duration_ms, prv_scale_note_strength(note->strength, strength_percentage));
     }
     if (note->brake_duration_ms > 0) {
       sys_vibe_pattern_enqueue_step_raw(note->brake_duration_ms, vibe_get_braking_strength());
@@ -214,6 +228,10 @@ void vibe_score_do_vibe(VibeScore *score) {
   PBL_LOG_INFO("vibe_score: do_vibe, %u notes, %ums total, repeat_delay=%ums",
                pattern_length, total_duration_ms, repeat_delay);
   sys_vibe_pattern_trigger_start();
+}
+
+void vibe_score_do_vibe(VibeScore *score) {
+    vibe_score_do_vibe_with_strength(score, 100);
 }
 
 VibeScore *vibe_score_create_with_resource(uint32_t resource_id) {

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -254,12 +254,15 @@ static GColor s_theme_highlight_color = GColorVividCerulean;
 static bool s_menu_scroll_wrap_around = false;
 static MenuScrollVibeBehavior s_menu_scroll_vibe_behavior = MenuScrollNoVibe;
 
-#define PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS_DEPRECATED "musicShowVolumeControls"
-#define PREF_KEY_MUSIC_SHOW_PROGRESS_BAR_DEPRECATED "musicShowProgressBar"
+#define PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS "musicShowVolumeControls"
+#define PREF_KEY_MUSIC_SHOW_PROGRESS_BAR "musicShowProgressBar"
+#define PREF_KEY_MUSIC_PRIORITIZE_WHEN_PLAYING "musicPrioritizeWhenPlaying"
+#define PREF_KEY_MUSIC_LONG_PRESS_VIBE_INTENSITY "musicLongPressVibeIntensity"
 
-#define PREF_KEY_MUSIC_APP_PREFERENCES "musicAppPreferences"
-
-static MusicAppPreferences s_music_app_preferences = MUSIC_APP_DEFAULT_PREFERENCES;
+static bool s_music_show_volume_controls = true;
+static bool s_music_show_progress_bar = true;
+static bool s_music_prioritize_when_playing = true;
+static uint8_t s_music_long_press_vibe_intensity = 100;
 
 // ============================================================================================
 // Handlers for each pref that validate the new setting and store the new value in our globals.
@@ -685,12 +688,26 @@ static bool prv_set_s_settings_dbs_compacted_v1(bool *done) {
   return true;
 }
 
-static bool prv_set_s_music_app_preferences(MusicAppPreferences *new_settings) {
-  if (new_settings->long_press_vibe_strength > 100) {
+static bool prv_set_s_music_show_volume_controls(bool *enabled) {
+  s_music_show_volume_controls = *enabled;
+  return true;
+}
+
+static bool prv_set_s_music_show_progress_bar(bool *enabled) {
+  s_music_show_progress_bar = *enabled;
+  return true;
+}
+
+static bool prv_set_s_music_prioritize_when_playing(bool *enabled) {
+  s_music_prioritize_when_playing = *enabled;
+  return true;
+}
+
+static bool prv_set_s_music_long_press_vibe_intensity(uint8_t *intensity) {
+  if (*intensity > 100) {
     return false;
   }
-
-  s_music_app_preferences = *new_settings;
+  s_music_long_press_vibe_intensity = *intensity;
   return true;
 }
 
@@ -807,43 +824,6 @@ static void prv_convert_deprecated_backlight_behaviour_key(SettingsFile *file) {
   }
 }
 
-static void prv_convert_deprecated_music_app_preferences(SettingsFile *file) {
-  // if present, convert deprecated volume controls/progress bar controls to the new music app prefs struct
-  bool volume_controls_file_exists = settings_file_exists(file, PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS_DEPRECATED,
-                           sizeof(PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS_DEPRECATED));
-  bool progress_bar_file_exists = settings_file_exists(file, PREF_KEY_MUSIC_SHOW_PROGRESS_BAR_DEPRECATED,
-                           sizeof(PREF_KEY_MUSIC_SHOW_PROGRESS_BAR_DEPRECATED));
-  if (volume_controls_file_exists || progress_bar_file_exists) {
-    bool temp;
-
-    MusicAppPreferences new_preferences = MUSIC_APP_DEFAULT_PREFERENCES;
-
-    if (volume_controls_file_exists) {
-        settings_file_get(file, PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS_DEPRECATED,
-                          sizeof(PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS_DEPRECATED),
-                          &temp, sizeof(temp));
-
-        new_preferences.show_volume_controls = temp;
-
-        settings_file_delete(file, PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS_DEPRECATED,
-                             sizeof(PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS_DEPRECATED));
-    }
-
-    if (progress_bar_file_exists) {
-        settings_file_get(file, PREF_KEY_MUSIC_SHOW_PROGRESS_BAR_DEPRECATED,
-                          sizeof(PREF_KEY_MUSIC_SHOW_PROGRESS_BAR_DEPRECATED),
-                          &temp, sizeof(temp));
-
-        new_preferences.show_progress_bar = temp;
-
-        settings_file_delete(file, PREF_KEY_MUSIC_SHOW_PROGRESS_BAR_DEPRECATED,
-                             sizeof(PREF_KEY_MUSIC_SHOW_PROGRESS_BAR_DEPRECATED));
-    }
-
-    settings_file_set(file, PREF_KEY_MUSIC_APP_PREFERENCES,
-                      sizeof(PREF_KEY_MUSIC_APP_PREFERENCES), &new_preferences, sizeof(new_preferences));
-  }
-}
 
 // ------------------------------------------------------------------------------------
 void shell_prefs_init(void) {
@@ -871,7 +851,6 @@ void shell_prefs_init(void) {
   }
 
   prv_convert_deprecated_backlight_behaviour_key(&file);
-  prv_convert_deprecated_music_app_preferences(&file);
 
   // Init state for each pref from our backing store
   uint32_t num_entries = ARRAY_LENGTH(s_prefs_table);
@@ -1868,19 +1847,19 @@ void shell_prefs_set_settings_dbs_compacted_v1(bool done) {
 }
 
 bool music_app_prefs_get_show_volume_controls_enabled(void) {
-  return s_music_app_preferences.show_volume_controls;
+  return s_music_show_volume_controls;
 }
 
 bool music_app_prefs_get_show_progress_bar_enabled(void) {
-  return s_music_app_preferences.show_progress_bar;
+  return s_music_show_progress_bar;
 }
 
 bool music_app_prefs_get_prioritize_when_playing_enabled(void) {
-  return s_music_app_preferences.prioritize_when_playing;
+  return s_music_prioritize_when_playing;
 }
 
-uint8_t music_app_prefs_get_long_press_vibe_strength(void) {
-  return s_music_app_preferences.long_press_vibe_strength;
+uint8_t music_app_prefs_get_long_press_vibe_intensity(void) {
+  return s_music_long_press_vibe_intensity;
 }
 
 #ifdef CONFIG_APP_SCALING

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -250,13 +250,16 @@ static GColor s_theme_highlight_color = GColorVividCerulean;
 
 #define PREF_KEY_MENU_SCROLL_WRAP_AROUND "menuScrollWrapAround"
 #define PREF_KEY_MENU_SCROLL_VIBE_BEHAVIOR "menuScrollVibeBehavior"
-#define PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS "musicShowVolumeControls"
-#define PREF_KEY_MUSIC_SHOW_PROGRESS_BAR "musicShowProgressBar"
 
 static bool s_menu_scroll_wrap_around = false;
 static MenuScrollVibeBehavior s_menu_scroll_vibe_behavior = MenuScrollNoVibe;
-static bool s_music_show_volume_controls = true;
-static bool s_music_show_progress_bar = true;
+
+#define PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS_DEPRECATED "musicShowVolumeControls"
+#define PREF_KEY_MUSIC_SHOW_PROGRESS_BAR_DEPRECATED "musicShowProgressBar"
+
+#define PREF_KEY_MUSIC_APP_PREFERENCES "musicAppPreferences"
+
+static MusicAppPreferences s_music_app_preferences = MUSIC_APP_DEFAULT_PREFERENCES;
 
 // ============================================================================================
 // Handlers for each pref that validate the new setting and store the new value in our globals.
@@ -682,6 +685,15 @@ static bool prv_set_s_settings_dbs_compacted_v1(bool *done) {
   return true;
 }
 
+static bool prv_set_s_music_app_preferences(MusicAppPreferences *new_settings) {
+  if (new_settings->long_press_vibe_strength > 100) {
+    return false;
+  }
+
+  s_music_app_preferences = *new_settings;
+  return true;
+}
+
 #ifdef CONFIG_APP_SCALING
 static bool prv_set_s_legacy_app_render_mode(uint8_t *mode) {
   if (*mode >= LegacyAppRenderModeCount) {
@@ -747,16 +759,6 @@ static bool prv_set_s_menu_scroll_vibe_behavior(MenuScrollVibeBehavior *new_beha
   return true;
 }
 
-static bool prv_set_s_music_show_volume_controls(bool *enabled) {
-  s_music_show_volume_controls = *enabled;
-  return true;
-}
-
-static bool prv_set_s_music_show_progress_bar(bool *enabled) {
-  s_music_show_progress_bar = *enabled;
-  return true;
-}
-  
 // ------------------------------------------------------------------------------------
 // Table of all prefs
 typedef bool (*PrefSetHandler)(const void *value, size_t val_len);
@@ -805,6 +807,43 @@ static void prv_convert_deprecated_backlight_behaviour_key(SettingsFile *file) {
   }
 }
 
+static void prv_convert_deprecated_music_app_preferences(SettingsFile *file) {
+  // if present, convert deprecated volume controls/progress bar controls to the new music app prefs struct
+  bool volume_controls_file_exists = settings_file_exists(file, PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS_DEPRECATED,
+                           sizeof(PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS_DEPRECATED));
+  bool progress_bar_file_exists = settings_file_exists(file, PREF_KEY_MUSIC_SHOW_PROGRESS_BAR_DEPRECATED,
+                           sizeof(PREF_KEY_MUSIC_SHOW_PROGRESS_BAR_DEPRECATED));
+  if (volume_controls_file_exists || progress_bar_file_exists) {
+    bool temp;
+
+    MusicAppPreferences new_preferences = MUSIC_APP_DEFAULT_PREFERENCES;
+
+    if (volume_controls_file_exists) {
+        settings_file_get(file, PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS_DEPRECATED,
+                          sizeof(PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS_DEPRECATED),
+                          &temp, sizeof(temp));
+
+        new_preferences.show_volume_controls = temp;
+
+        settings_file_delete(file, PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS_DEPRECATED,
+                             sizeof(PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS_DEPRECATED));
+    }
+
+    if (progress_bar_file_exists) {
+        settings_file_get(file, PREF_KEY_MUSIC_SHOW_PROGRESS_BAR_DEPRECATED,
+                          sizeof(PREF_KEY_MUSIC_SHOW_PROGRESS_BAR_DEPRECATED),
+                          &temp, sizeof(temp));
+
+        new_preferences.show_progress_bar = temp;
+
+        settings_file_delete(file, PREF_KEY_MUSIC_SHOW_PROGRESS_BAR_DEPRECATED,
+                             sizeof(PREF_KEY_MUSIC_SHOW_PROGRESS_BAR_DEPRECATED));
+    }
+
+    settings_file_set(file, PREF_KEY_MUSIC_APP_PREFERENCES,
+                      sizeof(PREF_KEY_MUSIC_APP_PREFERENCES), &new_preferences, sizeof(new_preferences));
+  }
+}
 
 // ------------------------------------------------------------------------------------
 void shell_prefs_init(void) {
@@ -832,6 +871,7 @@ void shell_prefs_init(void) {
   }
 
   prv_convert_deprecated_backlight_behaviour_key(&file);
+  prv_convert_deprecated_music_app_preferences(&file);
 
   // Init state for each pref from our backing store
   uint32_t num_entries = ARRAY_LENGTH(s_prefs_table);
@@ -1827,6 +1867,22 @@ void shell_prefs_set_settings_dbs_compacted_v1(bool done) {
   prv_pref_set(PREF_KEY_SETTINGS_DBS_COMPACTED_V1, &done, sizeof(done));
 }
 
+bool music_app_prefs_get_show_volume_controls_enabled(void) {
+  return s_music_app_preferences.show_volume_controls;
+}
+
+bool music_app_prefs_get_show_progress_bar_enabled(void) {
+  return s_music_app_preferences.show_progress_bar;
+}
+
+bool music_app_prefs_get_prioritize_when_playing_enabled(void) {
+  return s_music_app_preferences.prioritize_when_playing;
+}
+
+uint8_t music_app_prefs_get_long_press_vibe_strength(void) {
+  return s_music_app_preferences.long_press_vibe_strength;
+}
+
 #ifdef CONFIG_APP_SCALING
 LegacyAppRenderMode shell_prefs_get_legacy_app_render_mode(void) {
   return (LegacyAppRenderMode)s_legacy_app_render_mode;
@@ -1890,20 +1946,4 @@ void pbl_analytics_external_collect_settings(void) {
 #endif
   PBL_ANALYTICS_SET_UNSIGNED(settings_power_mode, shell_prefs_get_power_mode());
   PBL_ANALYTICS_SET_UNSIGNED(settings_motion_sensitivity, shell_prefs_get_motion_sensitivity());
-}
-
-bool shell_prefs_get_music_show_volume_controls(void) {
-  return s_music_show_volume_controls;
-}
-
-void shell_prefs_set_music_show_volume_controls(bool enable) {
-  prv_pref_set(PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS, &enable, sizeof(enable));
-}
-
-bool shell_prefs_get_music_show_progress_bar(void) {
-  return s_music_show_progress_bar;
-}
-
-void shell_prefs_set_music_show_progress_bar(bool enable) {
-  prv_pref_set(PREF_KEY_MUSIC_SHOW_PROGRESS_BAR, &enable, sizeof(enable));
 }

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -9,6 +9,7 @@
 #include "shell/prefs_private.h"
 #include "shell/system_theme.h"
 
+#include "apps/system_app_ids.h"
 #include "apps/system/timeline/timeline.h"
 #include "apps/system/toggle/quiet_time.h"
 #include "board/board.h"
@@ -700,6 +701,9 @@ static bool prv_set_s_music_show_progress_bar(bool *enabled) {
 
 static bool prv_set_s_music_prioritize_when_playing(bool *enabled) {
   s_music_prioritize_when_playing = *enabled;
+  if (!s_music_prioritize_when_playing) {
+    app_install_unmark_prioritized(APP_ID_MUSIC);
+  }
   return true;
 }
 

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -65,4 +65,7 @@
 
   PREFS_MACRO(PREF_KEY_MENU_SCROLL_WRAP_AROUND, s_menu_scroll_wrap_around)
   PREFS_MACRO(PREF_KEY_MENU_SCROLL_VIBE_BEHAVIOR, s_menu_scroll_vibe_behavior)
-  PREFS_MACRO(PREF_KEY_MUSIC_APP_PREFERENCES, s_music_app_preferences)
+  PREFS_MACRO(PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS, s_music_show_volume_controls)
+  PREFS_MACRO(PREF_KEY_MUSIC_SHOW_PROGRESS_BAR, s_music_show_progress_bar)
+  PREFS_MACRO(PREF_KEY_MUSIC_PRIORITIZE_WHEN_PLAYING, s_music_prioritize_when_playing)
+  PREFS_MACRO(PREF_KEY_MUSIC_LONG_PRESS_VIBE_INTENSITY, s_music_long_press_vibe_intensity)

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -65,5 +65,4 @@
 
   PREFS_MACRO(PREF_KEY_MENU_SCROLL_WRAP_AROUND, s_menu_scroll_wrap_around)
   PREFS_MACRO(PREF_KEY_MENU_SCROLL_VIBE_BEHAVIOR, s_menu_scroll_vibe_behavior)
-  PREFS_MACRO(PREF_KEY_MUSIC_SHOW_VOLUME_CONTROLS, s_music_show_volume_controls)
-  PREFS_MACRO(PREF_KEY_MUSIC_SHOW_PROGRESS_BAR, s_music_show_progress_bar)
+  PREFS_MACRO(PREF_KEY_MUSIC_APP_PREFERENCES, s_music_app_preferences)

--- a/src/fw/shell/normal/shell_event_loop.c
+++ b/src/fw/shell/normal/shell_event_loop.c
@@ -157,7 +157,7 @@ void shell_event_loop_handle_event(PebbleEvent *e) {
       return;
 
     case PEBBLE_MEDIA_EVENT:
-      if (e->media.playback_state == MusicPlayStatePlaying) {
+      if (e->media.playback_state == MusicPlayStatePlaying && music_app_prefs_get_prioritize_when_playing_enabled()) {
         app_install_mark_prioritized(APP_ID_MUSIC, true /* can_expire */);
       }
       return;

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -221,8 +221,7 @@ typedef enum MenuScrollVibeBehavior {
 MenuScrollVibeBehavior shell_prefs_get_menu_scroll_vibe_behavior(void);
 void shell_prefs_set_menu_scroll_vibe_behavior(MenuScrollVibeBehavior behavior);
 
-bool shell_prefs_get_music_show_volume_controls(void);
-void shell_prefs_set_music_show_volume_controls(bool enable);
-
-bool shell_prefs_get_music_show_progress_bar(void);
-void shell_prefs_set_music_show_progress_bar(bool enable);
+bool music_app_prefs_get_show_volume_controls_enabled(void);
+bool music_app_prefs_get_show_progress_bar_enabled(void);
+bool music_app_prefs_get_prioritize_when_playing_enabled(void);
+uint8_t music_app_prefs_get_long_press_vibe_strength(void);

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -224,4 +224,4 @@ void shell_prefs_set_menu_scroll_vibe_behavior(MenuScrollVibeBehavior behavior);
 bool music_app_prefs_get_show_volume_controls_enabled(void);
 bool music_app_prefs_get_show_progress_bar_enabled(void);
 bool music_app_prefs_get_prioritize_when_playing_enabled(void);
-uint8_t music_app_prefs_get_long_press_vibe_strength(void);
+uint8_t music_app_prefs_get_long_press_vibe_intensity(void);

--- a/tests/fw/services/test_vibe_score.c
+++ b/tests/fw/services/test_vibe_score.c
@@ -251,3 +251,107 @@ void test_vibe_score__get_duration_returns_zero_for_null_score(void) {
 void test_vibe_score__get_repeat_delay_returns_zero_for_null_score(void) {
   cl_assert_equal_i(vibe_score_get_repeat_delay_ms(NULL), 0);
 }
+
+void test_vibe_score__triple_pulse_half_strength(void) {
+  uint8_t buffer[] = {
+      'V', 'I', 'B', 'E', // FourCC
+      1, 0, // version
+      0, 0, 0, 0, // reserved bytes
+      24, 0, // attr_list_size
+      2, // GenericAttributeList.num_attributes
+      VibeAttributeId_Notes,
+      12, 0, // GenericAttribute.length
+      15, 0, // VibeNote.vibe_duration_ms
+      9, // VibeNote.brake_duration_ms
+      100, // VibeNote.strength
+      15, 0, // VibeNote.vibe_duration_ms
+      9, // VibeNote.brake_duration_ms
+      50, // VibeNote.strength
+      100, 0, // VibeNote.vibe_duration_ms
+      0, // VibeNote.brake_duration_ms
+      0, // VibeNote.strength
+      VibeAttributeId_Pattern,
+      5, 0, // GenericAttribute.length
+      0, // 100
+      2, // 0
+      1, // 50
+      2, // 0
+      0  // 100
+  };
+  s_resource_buffer = buffer;
+  s_resource_buffer_size = sizeof(buffer);
+  VibeScore *score = vibe_score_create_with_resource_system(0, 0);
+  cl_assert(score);
+  vibe_score_do_vibe_with_strength(score, 50);
+  vibe_score_destroy(score);
+
+  cl_assert_equal_i(s_vibe_queue_index, 8);
+  cl_assert_equal_i(s_vibe_queue[0].duration_ms, 15);
+  cl_assert_equal_i(s_vibe_queue[0].strength, 50);
+  cl_assert_equal_i(s_vibe_queue[1].duration_ms, 9);
+  cl_assert_equal_i(s_vibe_queue[1].strength, -100);
+  cl_assert_equal_i(s_vibe_queue[2].duration_ms, 100);
+  cl_assert_equal_i(s_vibe_queue[2].strength, 0);
+  cl_assert_equal_i(s_vibe_queue[3].duration_ms, 15);
+  cl_assert_equal_i(s_vibe_queue[3].strength, 25);
+  cl_assert_equal_i(s_vibe_queue[4].duration_ms, 9);
+  cl_assert_equal_i(s_vibe_queue[4].strength, -100);
+  cl_assert_equal_i(s_vibe_queue[5].duration_ms, 100);
+  cl_assert_equal_i(s_vibe_queue[5].strength, 0);
+  cl_assert_equal_i(s_vibe_queue[6].duration_ms, 15);
+  cl_assert_equal_i(s_vibe_queue[6].strength, 50);
+  cl_assert_equal_i(s_vibe_queue[7].duration_ms, 9);
+  cl_assert_equal_i(s_vibe_queue[7].strength, -100);
+}
+
+void test_vibe_score__triple_pulse_extra_strength(void) {
+  uint8_t buffer[] = {
+      'V', 'I', 'B', 'E', // FourCC
+      1, 0, // version
+      0, 0, 0, 0, // reserved bytes
+      24, 0, // attr_list_size
+      2, // GenericAttributeList.num_attributes
+      VibeAttributeId_Notes,
+      12, 0, // GenericAttribute.length
+      15, 0, // VibeNote.vibe_duration_ms
+      9, // VibeNote.brake_duration_ms
+      100, // VibeNote.strength
+      15, 0, // VibeNote.vibe_duration_ms
+      9, // VibeNote.brake_duration_ms
+      50, // VibeNote.strength
+      100, 0, // VibeNote.vibe_duration_ms
+      0, // VibeNote.brake_duration_ms
+      0, // VibeNote.strength
+      VibeAttributeId_Pattern,
+      5, 0, // GenericAttribute.length
+      0, // 100
+      2, // 0
+      1, // 50
+      2, // 0
+      0  // 100
+  };
+  s_resource_buffer = buffer;
+  s_resource_buffer_size = sizeof(buffer);
+  VibeScore *score = vibe_score_create_with_resource_system(0, 0);
+  cl_assert(score);
+  vibe_score_do_vibe_with_strength(score, 150);
+  vibe_score_destroy(score);
+
+  cl_assert_equal_i(s_vibe_queue_index, 8);
+  cl_assert_equal_i(s_vibe_queue[0].duration_ms, 15);
+  cl_assert_equal_i(s_vibe_queue[0].strength, 100);
+  cl_assert_equal_i(s_vibe_queue[1].duration_ms, 9);
+  cl_assert_equal_i(s_vibe_queue[1].strength, -100);
+  cl_assert_equal_i(s_vibe_queue[2].duration_ms, 100);
+  cl_assert_equal_i(s_vibe_queue[2].strength, 0);
+  cl_assert_equal_i(s_vibe_queue[3].duration_ms, 15);
+  cl_assert_equal_i(s_vibe_queue[3].strength, 75);
+  cl_assert_equal_i(s_vibe_queue[4].duration_ms, 9);
+  cl_assert_equal_i(s_vibe_queue[4].strength, -100);
+  cl_assert_equal_i(s_vibe_queue[5].duration_ms, 100);
+  cl_assert_equal_i(s_vibe_queue[5].strength, 0);
+  cl_assert_equal_i(s_vibe_queue[6].duration_ms, 15);
+  cl_assert_equal_i(s_vibe_queue[6].strength, 100);
+  cl_assert_equal_i(s_vibe_queue[7].duration_ms, 9);
+  cl_assert_equal_i(s_vibe_queue[7].strength, -100);
+}


### PR DESCRIPTION
Howdy! Happy to rejoin the Pebble family, but in open source this time! It was really fun editing the source of my favorite smartwatch, looking forward to doing more!

I keep Music bound to "Quick Launch: Hold Select", so the prioritization in the Launcher just gets annoying when the app at the top gets shifted without my consent.

Additionally the HAPTIC_FEEDBACK vibe score uses a short 100% pattern, and I felt that was a little aggressive (especially with the repeating vibes from holding Up/Down), so I've added an option to allow changing it with the mobile app's settings page.

---

My work is based off of PR #1071, and in which I noticed the desire to bundle these preferences by application. I even attempted to do so within [the first commit](https://github.com/coredevices/PebbleOS/commit/ba5bf727c4f3937830aeb9e883b9b513b1299402), consolidating:

```
  "musicShowVolumeControls",
  "musicShowProgressBar",
  "musicPrioritizeWhenPlaying",
  "musicLongPressVibeIntensity",
```

into

```
  "musicAppPreferences",
```

***But***, I don't know any Kotlin! (I'm a C and Rust fellow!) So following the flow of something like `"hrmPreferences"` is non-trivial for me at the moment. **I'd be more than happy to help return it to a consolidated struct**, but I'd need someone to help me with the Kotlin side of things!