### PR TITLE
fw/drivers/speaker/sf32lb52: stop leaking DMA handle in audec_init

### DIFF
--- a/src/fw/drivers/speaker/sf32lb52/audec.c
+++ b/src/fw/drivers/speaker/sf32lb52/audec.c
@@ -286,10 +286,8 @@ bool audec_init(AudioDevice* audio_device) {
     AudioDeviceState* state = audio_device->state;
     AUDCODEC_HandleTypeDef *haudcodec = &state->audcodec;
     haudcodec->Instance = hwp_audcodec;
-    haudcodec->hdma[HAL_AUDCODEC_DAC_CH0] = malloc(sizeof(DMA_HandleTypeDef));
-
-    PBL_ASSERT(haudcodec->hdma[HAL_AUDCODEC_DAC_CH0], "allocated mem error");
-    memset(haudcodec->hdma[HAL_AUDCODEC_DAC_CH0], 0, sizeof(DMA_HandleTypeDef));
+    memset(&state->dac_dma_handle, 0, sizeof(state->dac_dma_handle));
+    haudcodec->hdma[HAL_AUDCODEC_DAC_CH0] = &state->dac_dma_handle;
 
     haudcodec->hdma[HAL_AUDCODEC_DAC_CH0]->Instance = audio_device->audec_dma_channel;
     haudcodec->hdma[HAL_AUDCODEC_DAC_CH0]->Init.Request = audio_device->audec_dma_request;

--- a/src/fw/drivers/speaker/sf32lb52/audio_definitions.h
+++ b/src/fw/drivers/speaker/sf32lb52/audio_definitions.h
@@ -27,6 +27,7 @@ typedef enum AUDIO_PLL_STATE_TAG
 
 typedef struct AudioState {
   AUDCODEC_HandleTypeDef audcodec;
+  DMA_HandleTypeDef dac_dma_handle;
   AUDPRC_HandleTypeDef audprc;
   uint32_t slot_valid;
   uint8_t *queue_buf[HAL_AUDPRC_INSTANC_CNT];


### PR DESCRIPTION
audec_init() allocated a fresh DMA_HandleTypeDef on every call but audec_stop() never freed it, and the previous pointer was overwritten with no cleanup guard. speaker_service re-enters audec_init via audio_init() on every play/stream_open, so each cycle leaked one handle (~500 B), matching what apps observed across repeated speaker_stream_open/close.

Embed the handle as a member of AudioDeviceState (which is statically allocated per AudioDevice) and point haudcodec->hdma[CH0] at it, so re-init just zeroes the existing struct instead of allocating.