### PR TITLE
fw/services/compositor: return after screenshot OOM

### DIFF
--- a/src/fw/services/compositor/screenshot_pp.c
+++ b/src/fw/services/compositor/screenshot_pp.c
@@ -144,6 +144,7 @@ void screenshot_send_next_chunk(void* raw_state) {
     PBL_LOG_WRN("Screenshot aborted, OOM.");
     prv_send_error_response(session, SCREENSHOT_OOM_ERROR);
     prv_finish(state);
+    return;
   }
   uint32_t len = prv_framebuffer_next_chunk(&state->framebuffer, max_buf_len, buffer);
   session_len += len;


### PR DESCRIPTION
When kernel_zalloc fails in screenshot_send_next_chunk, the error path logs, sends the OOM response and calls prv_finish but never returns. Execution then falls through to prv_framebuffer_next_chunk with a NULL buffer, crashing the watch under memory pressure rather than gracefully aborting the screenshot.