### PR TITLE
resources/lang: avoid glyphs missing from LECO fonts in ca/es

### DIFF
--- a/resources/normal/base/lang/ca_ES/tintin.po
+++ b/resources/normal/base/lang/ca_ES/tintin.po
@@ -2329,12 +2329,12 @@ msgstr "FC mitjana"
 #: ../src/fw/services/activity/health_util.c:32
 #, c-format
 msgid "%dH"
-msgstr "%d h"
+msgstr "%dH"
 
 #: ../src/fw/services/activity/health_util.c:38
 #, c-format
 msgid "%dM"
-msgstr "%d min"
+msgstr "%dM"
 
 #: ../src/fw/services/activity/health_util.c:61
 #, c-format
@@ -2343,7 +2343,7 @@ msgstr "%d:%d"
 
 #: ../src/fw/services/activity/health_util.c:98
 msgid "H"
-msgstr "h"
+msgstr "H"
 
 #: ../src/fw/services/activity/health_util.c:104
 msgid " "
@@ -2351,7 +2351,7 @@ msgstr " "
 
 #: ../src/fw/services/activity/health_util.c:114
 msgid "M"
-msgstr "m"
+msgstr "M"
 
 #: ../src/fw/services/activity/health_util.c:133
 #, c-format

--- a/resources/normal/base/lang/es_ES/tintin.po
+++ b/resources/normal/base/lang/es_ES/tintin.po
@@ -421,7 +421,7 @@ msgstr "TIEMPO EN ZONAS"
 
 #: ../src/fw/apps/system/health/hr_summary_card.c:116
 msgid "BPM"
-msgstr "LAT/MIN"
+msgstr "PPM"
 
 #. / HRM disabled
 #: ../src/fw/apps/system/health/hr_summary_card.c:160


### PR DESCRIPTION
The LECO_*_BOLD_NUMBERS fonts used to render values in the sleep and heart-rate summary cards include only digits, uppercase letters and a small punctuation set. Translations that fall outside that set render as replacement boxes:

- ca_ES translates the time-unit strings "H" / "M" and the formats "%dH" / "%dM" to lowercase ("h" / "m", "%d h" / "%d min"). The sleep summary card showed garbled glyphs in place of the unit suffixes.
- es_ES translates "BPM" to "LAT/MIN". The heart-rate summary card showed "85 ▢A▢/MI▢" because L, T and N are missing from LECO_26_BOLD_NUMBERS_AM_PM. Reuse "PPM", which already matches the "%d BPM" → "%d PPM" translation elsewhere.

Fixes FIRM-2032
Fixes FIRM-2056