### PR TITLE
fw/services/clock: skip hourly chime on the first timer tick

### DIFF
--- a/src/fw/services/clock/service.c
+++ b/src/fw/services/clock/service.c
@@ -43,6 +43,11 @@ static const uint16_t protocol_time_endpoint_id = 11;
 
 static RegularTimerInfo s_dst_checker;
 
+#ifndef RECOVERY_FW
+// Armed on the first timer tick, after init has settled.
+static bool s_hourly_chime_armed;
+#endif
+
 static time_t prv_migrate_local_time_to_UTC(time_t local_time) {
   return time_local_to_utc(local_time);
 }
@@ -386,20 +391,21 @@ void clock_protocol_msg_callback(CommSession *session, const uint8_t* data, unsi
 }
 
 // TODO: Using a regular timer is pretty gross...
-static void prv_watch_dst(void* user) {
+T_STATIC void prv_watch_dst(void* user) {
   const bool was_dst = (bool)user;
   const bool is_dst = time_get_isdst(rtc_get_time());
   
 #ifndef RECOVERY_FW
-  if (alerts_should_vibrate_for_type(AlertOther)) {
-    if (time_utc_to_local(rtc_get_time()) % 3600 == 0) {
-      uint32_t vibe_id = vibe_score_info_get_resource_id(
-          alerts_preferences_get_vibe_score_for_client(VibeClient_Hourly)); 
-      VibeScore *score = vibe_score_create_with_resource_system(0, vibe_id);
-      if (score) {
-        vibe_score_do_vibe(score);
-        vibe_score_destroy(score);
-      }
+  if (!s_hourly_chime_armed) {
+    s_hourly_chime_armed = true;
+  } else if (alerts_should_vibrate_for_type(AlertOther) &&
+             (time_utc_to_local(rtc_get_time()) % SECONDS_PER_HOUR == 0)) {
+    uint32_t vibe_id = vibe_score_info_get_resource_id(
+        alerts_preferences_get_vibe_score_for_client(VibeClient_Hourly));
+    VibeScore *score = vibe_score_create_with_resource_system(0, vibe_id);
+    if (score) {
+      vibe_score_do_vibe(score);
+      vibe_score_destroy(score);
     }
   }
 #endif
@@ -438,6 +444,9 @@ void clock_init(void) {
     .cb = prv_watch_dst,
     .cb_data = (void*)time_get_isdst(rtc_get_time()),
   };
+#ifndef RECOVERY_FW
+  s_hourly_chime_armed = false;
+#endif
   regular_timer_add_seconds_callback(&s_dst_checker);
 }
 

--- a/tests/fw/services/test_clock.c
+++ b/tests/fw/services/test_clock.c
@@ -4,8 +4,10 @@
 #include "clar.h"
 
 #include "pbl/services/clock.h"
+#include "pbl/services/notifications/alerts.h"
 #include "pbl/services/timezone_database.h"
 #include "pbl/services/filesystem/pfs.h"
+#include "pbl/services/vibes/vibe_score.h"
 #include "resource/resource_ids.auto.h"
 #include "resource/resource.h"
 #include "resource/resource_version.auto.h"
@@ -23,10 +25,8 @@
 
 // Stubs
 ////////////////////////////////////
-#include "stubs_alerts.h"
 #include "stubs_alerts_preferences.h"
 #include "stubs_analytics.h"
-#include "stubs_vibe_score.h"
 #include "stubs_vibe_score_info.h"
 #include "stubs_hexdump.h"
 #include "stubs_language_ui.h"
@@ -57,6 +57,25 @@ void test_clock__initialize(void) {
 }
 
 extern void prv_update_time_info_and_generate_event(time_t *t, TimezoneInfo *tz_info);
+extern void prv_watch_dst(void *user);
+
+// Hourly chime instrumentation
+//////////////////////////////
+static bool s_should_vibrate;
+static int s_vibe_create_count;
+
+bool alerts_should_vibrate_for_type(AlertType type) {
+  return s_should_vibrate;
+}
+
+VibeScore *vibe_score_create_with_resource_system(ResAppNum app_num, uint32_t resource_id) {
+  s_vibe_create_count++;
+  return NULL;
+}
+
+void vibe_score_do_vibe(VibeScore *score) {}
+
+void vibe_score_destroy(VibeScore *score) {}
 
 static void prv_clock_reset(int32_t gmtoff) {
   TimezoneInfo tzinfo = {{0}};
@@ -117,6 +136,68 @@ void launcher_task_add_callback(void (*callback)(void *data), void *data) {
 
 // Tests
 ///////////////////////////
+
+// FIRM-2072: on first boot after an OTA the RTC is snapped to a timestamp that
+// is exactly on the hour, and the per-second DST timer is registered before
+// resource_init() runs. The chime must not touch the (uninitialized) resource
+// subsystem on that first tick.
+void test_clock__hourly_chime_skips_first_tick_after_boot(void) {
+  s_prefs_24h_style = false;
+  fake_rtc_init(0, 0);
+  rtc_timezone_clear();
+  rtc_set_time(1262304000);  // 2010-01-01 00:00:00 UTC, divisible by 3600
+  clock_init();
+
+  s_should_vibrate = true;
+  s_vibe_create_count = 0;
+
+  // First tick after boot: must not create a vibe score even though we are
+  // exactly on the hour.
+  prv_watch_dst((void *)false);
+  cl_assert_equal_i(s_vibe_create_count, 0);
+
+  // A later tick still on the hour chimes normally.
+  prv_watch_dst((void *)false);
+  cl_assert_equal_i(s_vibe_create_count, 1);
+}
+
+void test_clock__hourly_chime_only_on_the_hour(void) {
+  s_prefs_24h_style = false;
+  fake_rtc_init(0, 0);
+  rtc_timezone_clear();
+  rtc_set_time(1262304000);
+  clock_init();
+
+  s_should_vibrate = true;
+  s_vibe_create_count = 0;
+
+  prv_watch_dst((void *)false);  // arm
+  cl_assert_equal_i(s_vibe_create_count, 0);
+
+  rtc_set_time(1262304000 + 42);  // not on the hour
+  prv_watch_dst((void *)false);
+  cl_assert_equal_i(s_vibe_create_count, 0);
+
+  rtc_set_time(1262304000 + SECONDS_PER_HOUR);  // top of the hour
+  prv_watch_dst((void *)false);
+  cl_assert_equal_i(s_vibe_create_count, 1);
+}
+
+void test_clock__hourly_chime_respects_vibrate_setting(void) {
+  s_prefs_24h_style = false;
+  fake_rtc_init(0, 0);
+  rtc_timezone_clear();
+  rtc_set_time(1262304000);
+  clock_init();
+
+  s_should_vibrate = false;
+  s_vibe_create_count = 0;
+
+  prv_watch_dst((void *)false);  // arm
+  prv_watch_dst((void *)false);  // on the hour but vibing disabled
+  cl_assert_equal_i(s_vibe_create_count, 0);
+}
+
 void test_clock__basic_no_timezone_set_time(void) {
   s_prefs_24h_style = false;
   fake_rtc_init(0, 0);


### PR DESCRIPTION
## Summary

On the first boot after an OTA from PRF, Obelix gets stuck on the boot logo, watchdog-resets, then boots normally on the second try. Root cause is a boot-time race introduced by the hourly chime (4808b8d4).

`prv_watch_dst()` is a per-second regular-timer callback registered by `clock_init()` (`main.c:341`), which runs **before** `resource_init()` (`main.c:369`). The timer fires on the NewTimer task, so the callback can run while the resource/vibe subsystem is still initializing.

On first boot after an OTA the RTC is lost, so `clock_init()` snaps it to `MIN_VALID_BOOT_TIMESTAMP` (`1262304000`), which is exactly on the hour. The `% 3600 == 0` top-of-hour check then passes on the very first tick and calls `vibe_score_create_with_resource_system()` against the half-initialized resource subsystem → heap corruption → task watchdog reset. `resource_init()` is also slower right after an OTA because it installs the freshly received resource pack, which widens the race window. On the second boot resources are already installed and the clock has advanced past `:00:00`, so it boots clean.

## Fix

Arm the chime on the first timer tick and only vibe on subsequent ticks, so the resource-loading path is never reached until init has settled. (Also switched the literal `3600` to `SECONDS_PER_HOUR`.)

## Testing

- Added 3 regression tests in `tests/fw/services/test_clock.c` (exposing `prv_watch_dst` via `T_STATIC`). They fail against the buggy code (vibe created on the first on-the-hour tick) and pass with the fix.
- `./waf test -M '.*test_clock.*'` → green.
- Normal firmware builds for `obelix_dvt`. `clock/service.c` also compiles for `RECOVERY_FW` (the unrelated, pre-existing PRF link error is not affected by this change).

Fixes FIRM-2072.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
