### PR TITLE
fw/comm/ble: use slave latency for relaxed connection params

### DIFF
--- a/src/fw/comm/ble/gap_le_connect_params.c
+++ b/src/fw/comm/ble/gap_le_connect_params.c
@@ -70,20 +70,17 @@
 //! Try 3 times before giving up.
 #define MAX_UPDATE_REQUEST_ATTEMPTS (3)
 
-// TODO: Check slave_latency_events values. We currently observe some connection
-// drops that *may* be related to the slave latency being "too high". Let's just
-// remove slave latency for now, and see if that helps.
 static const GAPLEConnectRequestParams s_default_connection_params_table[NumResponseTimeState] = {
   [ResponseTimeMax] = {
-    .slave_latency_events = 0,
-    .connection_interval_min_1_25ms = 120, // 150ms
-    .connection_interval_max_1_25ms = 144, // 180ms
+    .slave_latency_events = 3,
+    .connection_interval_min_1_25ms = 24, // 30ms
+    .connection_interval_max_1_25ms = 36, // 45ms
     .supervision_timeout_10ms = 600, // 6s
   },
   [ResponseTimeMiddle] = {
-    .slave_latency_events = 0,
-    .connection_interval_min_1_25ms = 120, // 150ms
-    .connection_interval_max_1_25ms = 144, // 180ms
+    .slave_latency_events = 3,
+    .connection_interval_min_1_25ms = 24, // 30ms
+    .connection_interval_max_1_25ms = 36, // 45ms
     .supervision_timeout_10ms = 600, // 6s
   },
   [ResponseTimeMin] = {


### PR DESCRIPTION
ResponseTimeMax (idle) and ResponseTimeMiddle both sat at a 150-180 ms interval with no slave latency. Fleet telemetry shows BLE supervision timeouts (0x08) concentrated on iOS and tied to time spent at this long interval: the watch, mostly asleep, misses connection events and the link crosses the 6 s supervision window. See FIRM-2064.

Use a short 30-45 ms base interval with slave latency 3 (effective ~180 ms, battery-neutral) so the link re-syncs every ~45 ms instead of drifting a full 180 ms. Max and Middle keep the same values as each other, as before; ResponseTimeMin (active data) is unchanged.