### PR TITLE
fw/popups/alarm_popup: cancel stale steps before re-vibing

### DIFF
--- a/src/fw/popups/alarm_popup.c
+++ b/src/fw/popups/alarm_popup.c
@@ -218,6 +218,7 @@ static void prv_vibe_kernel_main_cb(void *callback_context) {
   if (s_alarm_popup_data) {
     if (s_alarm_popup_data->vibe_count < s_alarm_popup_data->max_vibes) {
       s_alarm_popup_data->vibe_count++;
+      vibes_cancel();
       vibe_score_do_vibe(s_alarm_popup_data->vibe_score);
 #ifdef CONFIG_SPEAKER
       if (s_alarm_popup_data->sound_active &&


### PR DESCRIPTION
The repeat timer fires at (pattern_duration + repeat_delay) ms, which for Reveille is ~17 s with only 1.5 s of margin. Reveille expands to ~180 chained step timers; if cumulative scheduling drift outlives the margin, the previous pattern is still draining when the next iteration starts. The vibe service silently no-ops both enqueue and trigger_start while s_pattern_in_progress is true, so every step is dropped and the alarm goes quiet on screen until the popup auto-dismisses.

Cancel before re-enqueuing so the new iteration always starts from a clean state. Cheap in the normal case (mutex + queue empty).

Fixes FIRM-2065