### PR TITLE
fw/services/data_logging: flush on re-open ACK

### DIFF
--- a/src/fw/services/data_logging/dls_endpoint.c
+++ b/src/fw/services/data_logging/dls_endpoint.c
@@ -330,7 +330,9 @@ static void prv_dls_endpoint_handle_ack(uint8_t session_id) {
       break;
     case DataLoggingSessionCommStateOpening:
       update_session_state(session, DataLoggingSessionCommStateIdle, true /*reschedule*/);
-      break;
+      mutex_unlock(s_endpoint_data.mutex);
+      dls_private_send_session(session, true);
+      return;
     case DataLoggingSessionCommStateSending:
       session->comm.nack_count = 0;
       update_session_state(session, DataLoggingSessionCommStateIdle, true /*reschedule*/);


### PR DESCRIPTION
The post-reconnect reopen path sends the OPEN message but defers data until the next 5-min flush tick. Sessions with under 8000 B of accumulated data (activity_sessions tag 84 at 26 B/record is the canonical case) get skipped on every non-empty tick, so they have to wait up to 15 min for the next empty=true pass. That pass tends to land right when BLE has returned to relaxed connection params and the send buffer is contended, the acquire times out, and the data sits another 15 min. Across reconnect cycles this holds sleep / nap records on the watch for days while higher-volume sessions (steps, HR) drain normally -- the "sleep not syncing" symptom users see.

Mirror the post-SENDING-ACK continuation in handle_ack: drop the endpoint mutex and call dls_private_send_session(session, true) so the freshly opened session drains its backlog immediately, while the link is still warm from the open round-trip.

Fixes FIRM-2079