### PR TITLE
fw/services/settings: recreate file on bad magic, not just remove

### DIFF
--- a/src/fw/services/settings/settings_file.c
+++ b/src/fw/services/settings/settings_file.c
@@ -68,15 +68,23 @@ static status_t prv_open(SettingsFile *file, const char *name, uint8_t flags,
   }
 
   if (memcmp(&file_hdr.magic, SETTINGS_FILE_MAGIC, sizeof(file_hdr.magic)) != 0) {
-    PBL_LOG_ERR("Attempted to open %s, not a settings file.", name);
-    pfs_close_and_remove(fd);
-    return E_INVALID_OPERATION;
+    PBL_LOG_ERR("Attempted to open %s, not a settings file. Removing and recreating.", name);
+    status_t rv = pfs_close_and_remove(fd);
+    if (rv < 0) {
+      PBL_LOG_ERR("Could not remove corrupt settings file %s: %"PRId32, name, rv);
+      return rv;
+    }
+    return prv_open(file, name, flags, max_used_space, alloc_used_space, min_alloc_used_space);
   }
 
   if (file_hdr.version > SETTINGS_FILE_VERSION) {
     PBL_LOG_WRN("Unrecognized version %d for file %s, removing...",
             file_hdr.version, name);
-    pfs_close_and_remove(fd);
+    status_t rv = pfs_close_and_remove(fd);
+    if (rv < 0) {
+      PBL_LOG_ERR("Could not remove old-version settings file %s: %"PRId32, name, rv);
+      return rv;
+    }
     return prv_open(file, name, flags, max_used_space, alloc_used_space, min_alloc_used_space);
   }
 


### PR DESCRIPTION
When a settings file is opened with a corrupt magic, prv_open removed the file but then returned E_INVALID_OPERATION instead of retrying. Callers (e.g. timeline_item_storage_init) log the failure but proceed with an uninitialized SettingsFile, and the next iteration call hits fatal_logic_error -> PBL_CROAK, rebooting. Three crashes drop the watch into PRF, the app re-pushes the same firmware, and the cycle repeats forever.

Mirror the version-check path one block below: recurse into prv_open after the remove, so the next open hits the uninitialized-header branch and writes a fresh magic. Also check the pfs_close_and_remove return value on both paths -- when the underlying PFS delete fails (seen in the field as "Delete of N did not complete"), naive recursion would trade an infinite reboot loop for a stack overflow. Return the error to the caller instead.

The same fix delivered via OTA also self-heals devices already stuck in the loop: when PRF accepts the updated firmware, the corrupt pindb is recreated on first boot instead of crashing.



Fixes FIRM-2055