### PR TITLE
fw/comm/ble/ppogatt: rediscover on stale meta handle

### DIFF
--- a/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
+++ b/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
@@ -147,11 +147,17 @@ static uint8_t s_timer_ticks;
 
 static uint8_t s_disconnect_counter;
 
+//! Caps rediscovery on stale meta handles to once per BLE connection.
+static bool s_rediscovery_requested_this_connection;
+
 // -------------------------------------------------------------------------------------------------
 // Function Prototypes
 
 static void prv_send_next_packets(PPoGATTClient *client);
 static void prv_start_reset(PPoGATTClient *client);
+static void prv_request_meta_rediscovery(PPoGATTClient *client);
+
+extern BTErrno gatt_client_discovery_rediscover_all(const BTDeviceInternal *device);
 
 //! Gets the GAPLEConnection associated with the characteristic reference.
 //! @return The connection or NULL in case it could not be found.
@@ -727,6 +733,32 @@ static void prv_handle_data_notification(PPoGATTClient *client,
 
 // -------------------------------------------------------------------------------------------------
 
+static void prv_rediscover_kernelbg_cb(void *data) {
+  BTDeviceInternal *device = (BTDeviceInternal *)data;
+  const BTErrno e = gatt_client_discovery_rediscover_all(device);
+  kernel_free(device);
+  if (e != BTErrnoOK) {
+    PBL_LOG_ERR("PPoGATT couldn't restart discovery: %d", (int)e);
+  }
+}
+
+static void prv_request_meta_rediscovery(PPoGATTClient *client) {
+  bt_lock_assert_held(true);
+
+  GAPLEConnection *connection =
+      gatt_client_characteristic_get_connection(client->characteristics.meta);
+  if (!connection) {
+    return;
+  }
+
+  BTDeviceInternal *device = kernel_malloc(sizeof(BTDeviceInternal));
+  if (!device) {
+    return;
+  }
+  *device = connection->device;
+  system_task_add_callback(prv_rediscover_kernelbg_cb, device);
+}
+
 static void prv_retry_meta_read(PPoGATTClient *client) {
   bt_lock_assert_held(true);
 
@@ -871,7 +903,13 @@ handle_retriable_error:
   }
   PBL_LOG_ERR("PPoGATT meta read failed after %u retries",
           PPOGATT_META_READ_RETRY_COUNT_MAX);
-  // Fall through to handle_error
+
+  // Cached handle may be stale; try once with fresh discovery.
+  if (!s_rediscovery_requested_this_connection) {
+    PBL_LOG_INFO("Triggering GATT rediscovery for fresh PPoGATT handles");
+    s_rediscovery_requested_this_connection = true;
+    prv_request_meta_rediscovery(client);
+  }
 
 handle_error:
   PBL_LOG_ERR("Failed handling PPoGATT meta: len=%u ver=%x err=%x",
@@ -888,6 +926,7 @@ void ppogatt_create(void) {
     PBL_ASSERT_TASK(PebbleTask_KernelMain);
     PBL_ASSERTN(!s_ppogatt_head);
     s_timer_ticks = 0;
+    s_rediscovery_requested_this_connection = false;
   }
   bt_unlock();
 }
@@ -1403,6 +1442,7 @@ void ppogatt_destroy(void) {
       prv_delete_client(client, true /* is_disconnected */, DeleteReason_DestroyCalled);
       client = next;
     }
+    s_rediscovery_requested_this_connection = false;
   }
   bt_unlock();
 


### PR DESCRIPTION
When the meta-characteristic read fails its 3 retries, the cached handle may be stale (observed on Android with CoreApp re-registering its PPoG service during connection setup, returning BLE_ATT_ERR_INVALID_HANDLE on the handle we just discovered). Trigger a one-shot rediscovery so the next handshake uses fresh handles. The flag is cleared on every BLE connect/disconnect to bound the recovery attempts.



Fixes FIRM-1305