### PR TITLE
memfault: eliminate remaining "Unknown Location" crash buckets

### DIFF
--- a/src/fw/drivers/stubs/watchdog.c
+++ b/src/fw/drivers/stubs/watchdog.c
@@ -19,8 +19,10 @@ bool watchdog_check_reset_flag(void) {
   return 0;
 }
 
+static McuRebootReason s_cached_reset_flag;
+
 McuRebootReason watchdog_clear_reset_flag(void) {
-  McuRebootReason mcu_reboot_reason = {
+  s_cached_reset_flag = (McuRebootReason){
     .brown_out_reset = 0,
     .pin_reset = 0,
     .power_on_reset = 1,
@@ -30,5 +32,9 @@ McuRebootReason watchdog_clear_reset_flag(void) {
     .low_power_manager_reset = 0,
   };
 
-  return mcu_reboot_reason;
+  return s_cached_reset_flag;
+}
+
+McuRebootReason watchdog_get_reset_flag(void) {
+  return s_cached_reset_flag;
 }

--- a/src/fw/drivers/task_watchdog.c
+++ b/src/fw/drivers/task_watchdog.c
@@ -108,6 +108,27 @@ static void prv_log_stuck_task(RebootReason *reboot_reason, PebbleTask task) {
   reboot_reason->watchdog.stuck_task_lr = (uint32_t)current_lr;
 }
 
+// TCB-only variant of prv_log_failed_message; no logging or FreeRTOS calls
+// so it's safe from above configMAX_SYSCALL_INTERRUPT_PRIORITY.
+static void prv_capture_stuck_task_info(RebootReason *reboot_reason) {
+  const PebbleTask tasks_in_reverse_priority[] = {
+    PebbleTask_KernelBackground,
+    PebbleTask_KernelMain,
+    PebbleTask_PULSE,
+    PebbleTask_NewTimers
+  };
+
+  for (unsigned int i = 0; i < ARRAY_LENGTH(tasks_in_reverse_priority); ++i) {
+    const uint8_t task_index = tasks_in_reverse_priority[i];
+    const PebbleTaskBitset task_mask = (1 << task_index);
+    if ((s_watchdog_mask & task_mask) && !(s_watchdog_bits & task_mask)) {
+      TaskHandle_t *task_handle = pebble_task_get_handle_for_task(task_index);
+      reboot_reason->watchdog.stuck_task_pc = (uint32_t)ulTaskDebugGetStackedPC(task_handle);
+      reboot_reason->watchdog.stuck_task_lr = (uint32_t)ulTaskDebugGetStackedLR(task_handle);
+    }
+  }
+}
+
 static void prv_log_failed_message(RebootReason *reboot_reason) {
   PBL_LOG_SYNC_WRN("Watchdog feed failed, last feed %dms ago, current status 0x%"PRIx16" mask 0x%"PRIx16,
       (s_ticks_since_successful_feed * 1000) / TIMER_INTERRUPT_HZ,
@@ -366,6 +387,11 @@ static void prv_task_watchdog_feed(void) {
     // an ISR or low priority interrupts are disabled, so coredump now
     if (s_ticks_since_successful_feed >= WATCHDOG_COREDUMP_TICK_CNT) {
 #if !defined(NO_WATCHDOG)
+      // Low-pri handler didn't run; capture stuck_task_pc/lr ourselves so
+      // Memfault has a real PC to fingerprint on.
+      prv_capture_stuck_task_info(&reboot_reason);
+      reboot_reason_clear();
+      reboot_reason_set(&reboot_reason);
       reset_due_to_software_failure();
 #endif
     }

--- a/src/fw/drivers/watchdog.h
+++ b/src/fw/drivers/watchdog.h
@@ -14,3 +14,6 @@ void watchdog_feed(void);
 
 bool watchdog_check_reset_flag(void);
 McuRebootReason watchdog_clear_reset_flag(void);
+
+//! Returns the cached value from the most recent watchdog_clear_reset_flag().
+McuRebootReason watchdog_get_reset_flag(void);

--- a/src/fw/drivers/watchdog/nrf5.c
+++ b/src/fw/drivers/watchdog/nrf5.c
@@ -30,11 +30,13 @@ bool watchdog_check_reset_flag(void) {
   return (nrfx_reset_reason_get() & NRFX_RESET_REASON_DOG_MASK) != 0;
 }
 
+static McuRebootReason s_cached_reset_flag;
+
 McuRebootReason watchdog_clear_reset_flag(void) {
   uint32_t reason = nrfx_reset_reason_get();
   nrfx_reset_reason_clear(0xFFFFFFFF);
 
-  McuRebootReason mcu_reboot_reason = {
+  s_cached_reset_flag = (McuRebootReason){
     .brown_out_reset = 0,
     .pin_reset = (reason & NRFX_RESET_REASON_RESETPIN_MASK) != 0,
     .power_on_reset = (reason & NRFX_RESET_REASON_VBUS_MASK) != 0,
@@ -44,5 +46,9 @@ McuRebootReason watchdog_clear_reset_flag(void) {
     .low_power_manager_reset = 0,
   };
 
-  return mcu_reboot_reason;
+  return s_cached_reset_flag;
+}
+
+McuRebootReason watchdog_get_reset_flag(void) {
+  return s_cached_reset_flag;
 }

--- a/src/fw/drivers/watchdog/sf32lb.c
+++ b/src/fw/drivers/watchdog/sf32lb.c
@@ -12,6 +12,8 @@ static WDT_HandleTypeDef hwdt = {
     .Instance = hwp_wdt1,
 };
 
+static McuRebootReason s_cached_reset_flag;
+
 void watchdog_init(void) {
   // On PebbleOS, we use RC32K as WDT clock source.
   hwdt.Init.Reload = 32000 * WDT_TIMEOUT_S;
@@ -45,7 +47,7 @@ McuRebootReason watchdog_clear_reset_flag(void) {
   pm_power_on_mode_t boot = SystemPowerOnModeGet();
   HAL_PMU_CLEAR_WSR(0xFFFFFFFF);
 
-  McuRebootReason mcu_reboot_reason = {
+  s_cached_reset_flag = (McuRebootReason){
       .brown_out_reset = 0,
       .pin_reset = (((wsr & PMUC_WSR_PIN0) != 0) || ((wsr & PMUC_WSR_PIN1) != 0)),
       .power_on_reset = (boot & PM_COLD_BOOT) != 0,
@@ -55,5 +57,9 @@ McuRebootReason watchdog_clear_reset_flag(void) {
       .low_power_manager_reset = 0,
   };
 
-  return mcu_reboot_reason;
+  return s_cached_reset_flag;
+}
+
+McuRebootReason watchdog_get_reset_flag(void) {
+  return s_cached_reset_flag;
 }

--- a/src/fw/hardfault_handler.c
+++ b/src/fw/hardfault_handler.c
@@ -132,9 +132,18 @@ void fault_handler_dump(char buffer[80], unsigned int *stacked_args) {
 }
 
 static void hard_fault_handler_c(unsigned int* hardfault_args) {
-  // Log the lr instead of the pc. We frequently crash due to PC being madness. While the lr may be a little further
-  // than the actual crash, it should give us enough context.
-  const unsigned int stacked_lr = ((unsigned long) hardfault_args[5]);
+  // Prefer LR (PC is often madness on a hardfault). Fall back through PC,
+  // BFAR, MMFAR so Memfault always has a non-zero address to fingerprint on.
+  unsigned int stacked_lr = ((unsigned long) hardfault_args[5]);
+  if (stacked_lr == 0) {
+    stacked_lr = ((unsigned long) hardfault_args[6]);
+  }
+  if (stacked_lr == 0 && (SCB->CFSR & (1 << 15))) {  // BFARVALID
+    stacked_lr = SCB->BFAR;
+  }
+  if (stacked_lr == 0 && (SCB->CFSR & (1 << 7))) {  // MMFARVALID
+    stacked_lr = SCB->MMFAR;
+  }
   RebootReason reason = { .code = RebootReasonCode_HardFault, .extra = { .value = stacked_lr } };
   reboot_reason_set(&reason);
 

--- a/src/fw/kernel/events.c
+++ b/src/fw/kernel/events.c
@@ -240,8 +240,8 @@ void event_deinit(PebbleEvent* event) {
 }
 
 void event_put(PebbleEvent* event) {
-  register uintptr_t lr __asm("lr");
-  uintptr_t saved_lr = lr;
+  // Caller LR; more reliable than reading lr register from a deeper helper.
+  uintptr_t saved_lr = (uintptr_t)__builtin_return_address(0);
   // If we are posting from the KernelMain task, use the dedicated s_from_kernel_event_queue queue for that
   // See comments above where s_from_kernel_event_queue is declared.
   if (pebble_task_get_current() == PebbleTask_KernelMain) {
@@ -252,15 +252,13 @@ void event_put(PebbleEvent* event) {
 }
 
 bool event_put_isr(PebbleEvent* event) {
-  register uintptr_t lr __asm("lr");
-  uintptr_t saved_lr = lr;
+  uintptr_t saved_lr = (uintptr_t)__builtin_return_address(0);
 
   return prv_event_put_isr(s_kernel_event_queue, "kernel", saved_lr, event);
 }
 
 void event_put_from_process(PebbleTask task, PebbleEvent* event) {
-  register uintptr_t lr __asm("lr");
-  uintptr_t saved_lr = lr;
+  uintptr_t saved_lr = (uintptr_t)__builtin_return_address(0);
 
   QueueHandle_t queue = event_get_to_kernel_queue(task);
   prv_event_put(queue, "from app", saved_lr, event);

--- a/src/fw/kernel/fault_handling.c
+++ b/src/fw/kernel/fault_handling.c
@@ -264,13 +264,17 @@ static void prv_return_to_landing_zone(uintptr_t stacked_pc, uintptr_t stacked_l
   // Now return to hardware_fault_landing_zone...
 }
 
-static void attempt_handle_stack_overflow(unsigned int* stacked_args) {
+static void attempt_handle_stack_overflow(unsigned int* stacked_args, uintptr_t fault_pc) {
   PebbleTask task = pebble_task_get_current();
   PBL_LOG_SYNC_ERR("Stack overflow [task: %s]", pebble_task_get_name(task));
 
   if (mcu_state_is_thread_privileged()) {
     // We're hosed! We can't recover so just reboot everything.
-    RebootReason reason = { .code = RebootReasonCode_StackOverflow, .data8[0] = task };
+    RebootReason reason = {
+      .code = RebootReasonCode_StackOverflow,
+      .data8[0] = task,
+      .extra = { .value = fault_pc },
+    };
     reboot_reason_set(&reason);
     reset_due_to_software_failure();
     return;
@@ -344,13 +348,23 @@ static void mem_manage_handler_c(unsigned int* stacked_args, unsigned int lr) {
     // the cfsr.
     fault_handler_dump_cfsr(buffer);
 
+    // Read user PC before moving SP up; only safe if MMSTKERR is clear
+    // (frame was pushed). Otherwise fall back to MMFAR.
+    uintptr_t fault_pc = 0;
+    if (!(mmfsr & (1 << 4)) /* MMSTKERR */) {
+      fault_pc = (uintptr_t)stacked_args[6];
+    }
+    if (fault_pc == 0) {
+      fault_pc = SCB->MMFAR;
+    }
+
     stacked_args += 256;     // Should be enough to get above the guard region and execute hardware_fault_landing_zone
     if (lr & 0x04) {
       __set_PSP((uint32_t)stacked_args);
     } else {
       __set_MSP((uint32_t)stacked_args);
     }
-    attempt_handle_stack_overflow(stacked_args);
+    attempt_handle_stack_overflow(stacked_args, fault_pc);
 
   } else {
     prv_save_debug_registers(stacked_args);
@@ -413,13 +427,14 @@ static void usagefault_handler_c(unsigned int* stacked_args, unsigned int lr) {
   if (cfsr & SCB_CFSR_STKOF_Msk) {
     SCB->CFSR = SCB_CFSR_STKOF_Msk;  // Clear by writing 1
 
+    // No exception frame stacked on STKOF, so no PC available.
     stacked_args += 256;  // Back up SP to give landing zone room (see mem_manage_handler_c)
     if (lr & 0x04) {
       __set_PSP((uint32_t)stacked_args);
     } else {
       __set_MSP((uint32_t)stacked_args);
     }
-    attempt_handle_stack_overflow(stacked_args);
+    attempt_handle_stack_overflow(stacked_args, 0);
     return;
   }
 

--- a/src/fw/kernel/fault_handling.c
+++ b/src/fw/kernel/fault_handling.c
@@ -218,7 +218,15 @@ DEFINE_SYSCALL(NORETURN, sys_app_fault, uint32_t stashed_lr) {
 static void hardware_fault_landing_zone(void) {
   prv_log_app_lr_and_pc_system_task(&s_current_app_crash_info);
 
-  prv_kill_user_process(0);
+  // Pass the original LR/PC down so a Worker hardfault gets a real address
+  // when it routes to kernel_fault.
+  uintptr_t lr = 0;
+  if (s_current_app_crash_info.lr_known && s_current_app_crash_info.lr != 0) {
+    lr = s_current_app_crash_info.lr;
+  } else if (s_current_app_crash_info.pc_known && s_current_app_crash_info.pc != 0) {
+    lr = s_current_app_crash_info.pc;
+  }
+  prv_kill_user_process(lr);
 }
 
 static void prv_return_to_landing_zone(uintptr_t stacked_pc, uintptr_t stacked_lr, unsigned int* stacked_args) {
@@ -279,7 +287,7 @@ static void attempt_handle_generic_fault(unsigned int* stacked_args) {
 
   if (mcu_state_is_thread_privileged()) {
     // We're hosed! We can't recover so just reboot everything.
-    kernel_fault(RebootReasonCode_HardFault, stacked_lr);
+    kernel_fault(RebootReasonCode_HardFault, stacked_lr ? stacked_lr : stacked_pc);
     return;
   }
 

--- a/src/fw/services/system_task/service.c
+++ b/src/fw/services/system_task/service.c
@@ -120,16 +120,13 @@ void system_task_watchdog_feed(void) {
   task_watchdog_bit_set(PebbleTask_KernelBackground);
 }
 
-static void handle_system_task_send_failure(SystemTaskEventCallback cb) {
-  register uintptr_t lr __asm("lr");
-  uintptr_t saved_lr = lr;
-
+static void handle_system_task_send_failure(SystemTaskEventCallback cb, uintptr_t caller_lr) {
   PBL_LOG_ERR("System task queue full. Dropped cb: %p, current cb: %p", cb, s_current_cb);
 
   RebootReason reason = {
     .code = RebootReasonCode_EventQueueFull,
     .event_queue = {
-      .push_lr = (uint32_t) saved_lr,
+      .push_lr = (uint32_t) caller_lr,
       .current_event = (uint32_t) s_current_cb,
       .dropped_event = (uint32_t) cb
     }
@@ -140,6 +137,8 @@ static void handle_system_task_send_failure(SystemTaskEventCallback cb) {
 }
 
 bool system_task_add_callback_from_isr(SystemTaskEventCallback cb, void *data, bool* should_context_switch) {
+  // Capture caller LR at entry; reading from a deeper helper is unreliable.
+  uintptr_t caller_lr = (uintptr_t)__builtin_return_address(0);
   if (!prv_is_accepting_callbacks()) {
     return false;
   }
@@ -151,7 +150,7 @@ bool system_task_add_callback_from_isr(SystemTaskEventCallback cb, void *data, b
   signed portBASE_TYPE tmp;
   bool success = (xQueueSendToBackFromISR(s_system_task_queue, &event, &tmp) == pdTRUE);
   if (!success) {
-    handle_system_task_send_failure(cb);
+    handle_system_task_send_failure(cb, caller_lr);
   }
 
   *should_context_switch = (tmp == pdTRUE);
@@ -160,6 +159,7 @@ bool system_task_add_callback_from_isr(SystemTaskEventCallback cb, void *data, b
 }
 
 bool system_task_add_callback(SystemTaskEventCallback cb, void *data) {
+  uintptr_t caller_lr = (uintptr_t)__builtin_return_address(0);
   if (!prv_is_accepting_callbacks()) {
     return false;
   }
@@ -179,7 +179,7 @@ bool system_task_add_callback(SystemTaskEventCallback cb, void *data) {
     // we want to fall through to the handle_system_task_send_failure and not just get killed by the watchdog.
     bool success = (xQueueSendToBack(s_system_task_queue, &event, milliseconds_to_ticks(3000)) == pdTRUE);
     if (!success) {
-      handle_system_task_send_failure(cb);
+      handle_system_task_send_failure(cb, caller_lr);
     }
   }
 

--- a/src/fw/system/passert.c
+++ b/src/fw/system/passert.c
@@ -160,6 +160,6 @@ NORETURN app_error_fault_handler(uint32_t id, uint32_t pc, uint32_t info) {
 }
 
 NORETURN app_error_handler_bare(uint32_t error_code) {
-  app_error_fault_handler(error_code, 0, 0);
+  app_error_fault_handler(error_code, (uint32_t)__builtin_return_address(0), 0);
 }
 #endif

--- a/third_party/memfault/port/src/memfault_pebble_coredump.c
+++ b/third_party/memfault/port/src/memfault_pebble_coredump.c
@@ -543,6 +543,7 @@ void memfault_pebble_coredump_reconstruct(void) {
     case RebootReasonCode_HardFault:
     case RebootReasonCode_LauncherPanic:
     case RebootReasonCode_WorkerHardFault:
+    case RebootReasonCode_StackOverflow:
       real_pc = reason.extra.value;
       break;
     case RebootReasonCode_OutOfMemory:

--- a/third_party/memfault/port/src/memfault_pebble_coredump.c
+++ b/third_party/memfault/port/src/memfault_pebble_coredump.c
@@ -547,15 +547,19 @@ void memfault_pebble_coredump_reconstruct(void) {
       break;
     case RebootReasonCode_OutOfMemory:
       real_pc = reason.heap_data.heap_alloc_lr;
+      // Per-heap bucketing if no LR.
+      if (real_pc == 0) real_pc = reason.heap_data.heap_ptr;
       break;
     case RebootReasonCode_Watchdog:
       real_pc = reason.watchdog.stuck_task_pc;
-      if (real_pc == 0) {
-        real_pc = reason.watchdog.stuck_task_lr;
-      }
+      if (real_pc == 0) real_pc = reason.watchdog.stuck_task_lr;
+      if (real_pc == 0) real_pc = reason.watchdog.stuck_task_callback;
       break;
     case RebootReasonCode_EventQueueFull:
       real_pc = reason.event_queue.push_lr;
+      // Dropped callback's address is the buggy code.
+      if (real_pc == 0) real_pc = reason.event_queue.dropped_event;
+      if (real_pc == 0) real_pc = reason.event_queue.current_event;
       break;
     default:
       break;

--- a/third_party/memfault/port/src/reboot_tracking.c
+++ b/third_party/memfault/port/src/reboot_tracking.c
@@ -1,3 +1,4 @@
+#include "drivers/watchdog.h"
 #include "system/reboot_reason.h"
 #include "memfault/ports/reboot_reason.h"
 
@@ -65,13 +66,41 @@ static eMemfaultRebootReason prv_pbl_reboot_to_mflt_reboot(RebootReasonCode reas
   return kMfltRebootReason_Unknown;
 }
 
+// Used when the RTC backup register holding the firmware RebootReason was
+// cleared (hardware reset path). Most-specific cause first.
+static eMemfaultRebootReason prv_mcu_reboot_to_mflt_reboot(McuRebootReason mcu) {
+  if (mcu.brown_out_reset) {
+    return kMfltRebootReason_BrownOutReset;
+  }
+  if (mcu.independent_watchdog_reset || mcu.window_watchdog_reset) {
+    return kMfltRebootReason_HardwareWatchdog;
+  }
+  if (mcu.pin_reset) {
+    return kMfltRebootReason_PinReset;
+  }
+  if (mcu.low_power_manager_reset) {
+    return kMfltRebootReason_DeepSleep;
+  }
+  if (mcu.power_on_reset) {
+    return kMfltRebootReason_PowerOnReset;
+  }
+  if (mcu.software_reset) {
+    return kMfltRebootReason_SoftwareReset;
+  }
+  return kMfltRebootReason_Unknown;
+}
+
 void memfault_reboot_reason_get(sResetBootupInfo *reset_info) {
   // TODO: currently reboot_reason_get() is not implemented on the NRF5
   // platform, see reboot_reason.c
   RebootReason reason = { RebootReasonCode_Unknown, 0 };
   reboot_reason_get(&reason);
+  eMemfaultRebootReason mflt_reason = prv_pbl_reboot_to_mflt_reboot(reason.code);
+  if (mflt_reason == kMfltRebootReason_Unknown) {
+    mflt_reason = prv_mcu_reboot_to_mflt_reboot(watchdog_get_reset_flag());
+  }
   *reset_info = (sResetBootupInfo){
     .reset_reason_reg = reason.code,
-    .reset_reason = prv_pbl_reboot_to_mflt_reboot(reason.code),
+    .reset_reason = mflt_reason,
   };
 }


### PR DESCRIPTION
Fixes Memfault issues by capturing a real PC in the residual paths the previous PC-override fix (61a47aac) didn't cover: watchdog immediate-coredump, hardware-reset Unexpected Reset, HardFault with corrupted stack, Assert/EventQueueFull zero-LR sites, and StackOverflow (which was missing from the override switch entirely).

Thank you memfault MCP