### PR TITLE
fw/drivers/touch/cst816: recover when touch IC cannot communicate with MCU

### DIFF
--- a/src/fw/drivers/touch/cst816/cst816.c
+++ b/src/fw/drivers/touch/cst816/cst816.c
@@ -265,14 +265,20 @@ static void prv_process_pending_messages(void* context) {
   uint8_t id;
   rv = prv_read_data(CST816_GESTURE_ID, &id, 1, 1);
   if (!rv) {
-    PBL_LOG_ERR("Failed to read gesture ID, dropping event");
+    PBL_LOG_ERR("Failed to read gesture ID, trying to recover");
+    touch_handle_update(TouchState_FingerUp, 0, 0);
+    exti_disable(CST816->int_exti);
+    touch_sensor_set_enabled(true);
     return;
   }
 
   uint8_t data[CST816_TOUCH_DATA_SIZE] = {0};
   rv = prv_read_data(CST816_TOUCH_DATA_REG, data, CST816_TOUCH_DATA_SIZE, 1);
   if (!rv) {
-    PBL_LOG_ERR("Failed to read touch data, dropping event");
+    PBL_LOG_ERR("Failed to read touch data, trying to recover");
+    touch_handle_update(TouchState_FingerUp, 0, 0);
+    exti_disable(CST816->int_exti);
+    touch_sensor_set_enabled(true);
     return;
   }
 


### PR DESCRIPTION
## Summary
- When the CST816 fails an I2C read (e.g. ESD-induced hang), release any held touch state and HW-reset the IC so touch input resumes without a watch reboot.
- Same idea as #999 but ported to current `main`: applied to both read failures (gesture ID and touch data), using main's 3-arg `touch_handle_update` signature. `touch_sensor_set_enabled` is already declared via `touch_sensor.h`, so no forward decl needed.

Fixes FIRM-2088

## Test plan
- [x] Builds clean for `--board obelix_pvt`
- [ ] Validate on an Obelix PVT unit that triggers the failure mode (touch dead, double-tap backlight dead) — confirm touch recovers without reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)