### PR TITLE
fw/applib: expose quick launch button and action to apps

### DIFF
--- a/src/apps/launch_reason_demo/appinfo.json
+++ b/src/apps/launch_reason_demo/appinfo.json
@@ -6,7 +6,11 @@
   "versionCode": 1,
   "versionLabel": "1.0",
   "sdkVersion": "3",
-  "targetPlatforms": ["aplite", "basalt"],
+  "targetPlatforms": [
+    "aplite",
+    "basalt",
+    "emery"
+  ],
   "watchapp": {
     "watchface": false
   },

--- a/src/apps/launch_reason_demo/src/launch_reason_demo.c
+++ b/src/apps/launch_reason_demo/src/launch_reason_demo.c
@@ -22,19 +22,39 @@ static void click_config_provider(void *context) {
 }
 
 static char *get_launch_reason_str(void) {
+  static char s_buffer[64];
   switch (launch_reason()) {
   case APP_LAUNCH_SYSTEM:
     return "SYSTEM";
   case APP_LAUNCH_USER:
-    return "USER";
+  case APP_LAUNCH_QUICK_LAUNCH: {
+    const char *reason = (launch_reason() == APP_LAUNCH_USER) ? "USER" : "QUICK LAUNCH";
+    const char *btn_str = "UNKNOWN";
+    switch (launch_button()) {
+      case BUTTON_ID_BACK: btn_str = "BACK"; break;
+      case BUTTON_ID_UP: btn_str = "UP"; break;
+      case BUTTON_ID_SELECT: btn_str = "SELECT"; break;
+      case BUTTON_ID_DOWN: btn_str = "DOWN"; break;
+      default: break;
+    }
+    const char *action_str = "";
+    if (launch_reason() == APP_LAUNCH_QUICK_LAUNCH) {
+      switch (launch_get_quick_launch_action()) {
+        case APP_QUICK_LAUNCH_ACTION_HOLD: action_str = " [HOLD]"; break;
+        case APP_QUICK_LAUNCH_ACTION_TAP: action_str = " [TAP]"; break;
+        case APP_QUICK_LAUNCH_ACTION_COMBO: action_str = " [COMBO]"; break;
+        default: break;
+      }
+    }
+    snprintf(s_buffer, sizeof(s_buffer), "%s (%s)%s", reason, btn_str, action_str);
+    return s_buffer;
+  }
   case APP_LAUNCH_PHONE:
     return "PHONE";
   case APP_LAUNCH_WAKEUP:
     return "WAKEUP";
   case APP_LAUNCH_WORKER:
     return "WORKER";
-  case APP_LAUNCH_QUICK_LAUNCH:
-    return "QUICK LAUNCH";
   case APP_LAUNCH_TIMELINE_ACTION:
     return "TIMELINE ACTION";
   }

--- a/src/fw/applib/app_launch_button.h
+++ b/src/fw/applib/app_launch_button.h
@@ -5,7 +5,6 @@
 
 #include "drivers/button_id.h"
 
-//! @internal
 //! Get the button id used to launch the app.
 //! Only valid if the launch reason is APP_LAUNCH_USER or APP_LAUNCH_QUICK_LAUNCH.
 ButtonId app_launch_button(void);

--- a/src/fw/applib/app_launch_reason.c
+++ b/src/fw/applib/app_launch_reason.c
@@ -14,3 +14,7 @@ AppLaunchReason app_launch_reason(void) {
 uint32_t app_launch_get_args(void) {
   return sys_process_get_launch_args();
 }
+
+AppQuickLaunchAction app_launch_get_quick_launch_action(void) {
+  return sys_process_get_quick_launch_action();
+}

--- a/src/fw/applib/app_launch_reason.h
+++ b/src/fw/applib/app_launch_reason.h
@@ -37,11 +37,25 @@ typedef enum {
 //! @return The method or reason the current application was launched
 AppLaunchReason app_launch_reason(void);
 
+//! Details about how an app was quick launched.
+//! Returned by \ref app_launch_get_quick_launch_action.
+typedef enum {
+  APP_QUICK_LAUNCH_ACTION_NONE = 0,   //!< App was not launched via Quick Launch
+  APP_QUICK_LAUNCH_ACTION_HOLD,       //!< User held a single button
+  APP_QUICK_LAUNCH_ACTION_TAP,        //!< User tapped a button (single click)
+  APP_QUICK_LAUNCH_ACTION_COMBO,      //!< User held a button combination
+} AppQuickLaunchAction;
+
 //! Get the argument passed to the app when it was launched.
 //! @note Currently the only way to pass arguments to apps is by using an openWatchApp action
 //! on a pin.
 //! @return The argument passed to the app, or 0 if the app wasn't launched from a Launch App action
 uint32_t app_launch_get_args(void);
+
+//! Get the action that was used to quick launch the app.
+//! @return The \ref AppQuickLaunchAction used to launch the app, or
+//! APP_QUICK_LAUNCH_ACTION_NONE if the app was not launched via Quick Launch.
+AppQuickLaunchAction app_launch_get_quick_launch_action(void);
 
 //!   @} // group Launch_Reason
 //! @} // group Foundation

--- a/src/fw/process_management/pebble_process_info.h
+++ b/src/fw/process_management/pebble_process_info.h
@@ -164,9 +164,10 @@ typedef enum {
 // sdk.major:0x5 .minor:0x60 -- Add persist_get_max_size() for runtime persist storage capacity (rev 99)
 // sdk.major:0x5 .minor:0x61 -- Add speaker_is_muted() for system-wide speaker mute query (rev 100)
 // sdk.major:0x5 .minor:0x62 -- Add backlight_service_subscribe/unsubscribe for backlight on/off events (rev 101)
+// sdk.major:0x5 .minor:0x63 -- Export launch_button() (rev 102)
 
 #define PROCESS_INFO_CURRENT_SDK_VERSION_MAJOR 0x5
-#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x62
+#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x63
 
 // The first SDK to ship with 2.x APIs
 #define PROCESS_INFO_FIRST_2X_SDK_VERSION_MAJOR 0x4

--- a/src/fw/process_management/process_manager.c
+++ b/src/fw/process_management/process_manager.c
@@ -712,6 +712,14 @@ DEFINE_SYSCALL(uint32_t, sys_process_get_launch_args, void) {
 }
 
 // -------------------------------------------------------------------------------------------
+DEFINE_SYSCALL(AppQuickLaunchAction, sys_process_get_quick_launch_action, void) {
+  if (sys_process_get_launch_reason() != APP_LAUNCH_QUICK_LAUNCH) {
+    return APP_QUICK_LAUNCH_ACTION_NONE;
+  }
+  return (AppQuickLaunchAction)(uintptr_t) process_manager_get_current_process_args();
+}
+
+// -------------------------------------------------------------------------------------------
 DEFINE_SYSCALL(AppExitReason, sys_process_get_exit_reason, void) {
   return prv_get_context()->exit_reason;
 }

--- a/src/fw/shell/normal/watchface.c
+++ b/src/fw/shell/normal/watchface.c
@@ -19,6 +19,7 @@
 #include "pbl/services/analytics/analytics.h"
 #include "pbl/services/compositor/compositor_transitions.h"
 #include "applib/app_timer.h"
+#include "applib/app_launch_reason.h"
 #include "applib/ui/click_internal.h"
 #include "pbl/services/notifications/do_not_disturb.h"
 #include "system/logging.h"
@@ -131,6 +132,7 @@ static void prv_combo_back_timer_callback(void *data) {
       .id = app_id,
       .common.reason = APP_LAUNCH_QUICK_LAUNCH,
       .common.button = source_button,
+      .common.args = (void*)APP_QUICK_LAUNCH_ACTION_COMBO,
     });
   }
 }
@@ -208,6 +210,7 @@ static void prv_quick_launch_handler(ClickRecognizerRef recognizer, void *data) 
   prv_launch_app_via_button(&(AppLaunchEventConfig) {
     .id = app_id,
     .common.reason = APP_LAUNCH_QUICK_LAUNCH,
+    .common.args = (void*)APP_QUICK_LAUNCH_ACTION_HOLD,
   }, recognizer);
 }
 
@@ -225,6 +228,7 @@ static void prv_launch_up_down(ClickRecognizerRef recognizer, void *data) {
     prv_launch_app_via_button(&(AppLaunchEventConfig) {
       .id = quick_launch_single_click_get_app(button),
       .common.reason = APP_LAUNCH_QUICK_LAUNCH,
+      .common.args = (void*)APP_QUICK_LAUNCH_ACTION_TAP,
     }, recognizer);
     return;
   }

--- a/src/fw/syscall/syscall.h
+++ b/src/fw/syscall/syscall.h
@@ -255,6 +255,7 @@ time_t sys_wakeup_query(WakeupId wakeup_id);
 AppLaunchReason sys_process_get_launch_reason(void);
 ButtonId sys_process_get_launch_button(void);
 uint32_t sys_process_get_launch_args(void);
+AppQuickLaunchAction sys_process_get_quick_launch_action(void);
 AppExitReason sys_process_get_exit_reason(void);
 void sys_process_set_exit_reason(AppExitReason exit_reason);
 void sys_process_get_wakeup_info(WakeupInfo *info);

--- a/tools/generate_native_sdk/exported_symbols.json
+++ b/tools/generate_native_sdk/exported_symbols.json
@@ -4,7 +4,7 @@
               "You should also make sure you are obeying our API design guidelines:",
               "https://pebbletechnology.atlassian.net/wiki/display/DEV/SDK+API+Design+Guidelines"
             ],
-  "revision" : "101",
+  "revision" : "102",
   "version" : "2.0",
   "files": [
     "fw/drivers/ambient_light.h",
@@ -50,6 +50,7 @@
     "fw/applib/app_wakeup.h",
     "fw/applib/app_exit_reason.h",
     "fw/applib/app_launch_reason.h",
+    "fw/applib/app_launch_button.h",
     "fw/applib/cpu_cache.h",
     "fw/applib/health_service.h",
     "fw/applib/moddable/moddable.h",
@@ -1832,6 +1833,9 @@
               "type": "type",
               "name": "AppLaunchReason"
             }, {
+              "type": "type",
+              "name": "AppQuickLaunchAction"
+            }, {
               "type": "function",
               "name": "launch_reason",
               "implName": "app_launch_reason",
@@ -1841,6 +1845,16 @@
               "name": "launch_get_args",
               "implName": "app_launch_get_args",
               "addedRevision": "38"
+            }, {
+              "type": "function",
+              "name": "launch_button",
+              "implName": "app_launch_button",
+              "addedRevision": "102"
+            }, {
+              "type": "function",
+              "name": "launch_get_quick_launch_action",
+              "implName": "app_launch_get_quick_launch_action",
+              "addedRevision": "102"
             }
           ]
         },


### PR DESCRIPTION
## Motivation

Apps are limited to a single one-click-action. But there are usecases where it makes sense for a single app to be able to handle different actions based on how it was launched. Having to install multiple apps is inconvenient. For example these three apps could be a single app: [Tasker Trigger 1](https://apps.repebble.com/tasker-trigger-1_d5b31ed4979844058be9afb0), [Tasker Trigger 2](https://apps.repebble.com/tasker-trigger-2_57502ac0f87a4fa195c8caa6), and [Tasker Trigger 3](https://apps.repebble.com/tasker-trigger-3_077f768ca7f94d1d950b4c30). Especially something like a Home Assistant app could use this. There's probably not multiple copies of that same app in the store, and they'd all need to be setup etc. Letting a single app handle multiple different one-click-actions makes more sense. 
With this change a single app can inspect `launch_button()` and `launch_get_quick_launch_action()` to know exactly how it was invoked, and branch accordingly.

## Demo
![Demo](https://github.com/FWeynschenk/PebbleOS/releases/download/untagged-bdce3ac1e2bfc0e3c167/pebble-multiple-one-click-actions_2.gif)

## Summary

- Drops the `@internal` marker on `app_launch_button()`, making it public so apps launched via `APP_LAUNCH_USER` or `APP_LAUNCH_QUICK_LAUNCH` can query which button was used.
- Adds `AppQuickLaunchAction` (`NONE`/`HOLD`/`TAP`/`COMBO`) and a dedicated `launch_get_quick_launch_action()` accessor, backed by a new `sys_process_get_quick_launch_action()` syscall.
- Tags each quick launch from the watchface with its action: single-button tap, single-button hold, or a back+up / up+down combo.
- Bumps the SDK version and exports `launch_button()`, `launch_get_quick_launch_action()`, and `AppQuickLaunchAction`.
- Adds an `apps/launch_reason_demo` example that prints the launch reason, button, and action.


Existing apps should be unaffected.


## Post-merge TODOs

- [ ] Update the [Launch Reason API docs](https://developer.repebble.com/docs/c/Foundation/Launch_Reason/) to document `launch_button()`, `launch_get_quick_launch_action()`, and `AppQuickLaunchAction`.
- [ ] Update the [One Click Actions guide](https://developer.repebble.com/guides/design-and-interaction/one-click-actions/) to show how a single app can branch on button and action type.