### PR TITLE
fw/applib/graphics: only pre-load glyph bitmaps when rendering

### DIFF
--- a/src/fw/applib/graphics/text_layout.c
+++ b/src/fw/applib/graphics/text_layout.c
@@ -580,6 +580,9 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
                   CharVisitorCallback char_visitor_cb) {
   PBL_ASSERTN(char_visitor_cb);
 
+  // Render pre-loads glyph bitmaps below; measure must not, or the deep flash load overflows.
+  const bool is_render = (char_visitor_cb != update_dimensions_char_visitor_cb);
+
   // We used to check that the line height was <= the container height here - no longer required,
   // as the vertical overflow is handled during layout.
 
@@ -885,6 +888,12 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
     };
     cursor.origin.x += walked_width_px;
 
+    if (is_render && !codepoint_is_zero_width(current_codepoint) &&
+        !codepoint_is_unicode_space(current_codepoint)) {
+      // Pre-load here so the deeper render_glyph() is a cache hit, not a deep flash read.
+      text_resources_get_glyph(&ctx->font_cache, current_codepoint, text_box_params->font);
+    }
+
     char_visitor_cb(ctx, text_box_params, line, cursor, current_codepoint);
 
     walked_width_px += next_glyph_width_px;
@@ -941,6 +950,9 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
     };
     cursor.origin.x += walked_width_px;
     if (char_visitor_cb) {
+      if (is_render) {
+        text_resources_get_glyph(&ctx->font_cache, line->suffix_codepoint, text_box_params->font);
+      }
       char_visitor_cb(ctx, text_box_params, line, cursor, line->suffix_codepoint);
     }
   }

--- a/src/fw/applib/graphics/text_resources.c
+++ b/src/fw/applib/graphics/text_resources.c
@@ -613,9 +613,8 @@ static const GlyphData *prv_get_glyph(FontCache *font_cache, Codepoint codepoint
 
 int8_t text_resources_get_glyph_horiz_advance(FontCache *font_cache, const Codepoint codepoint,
                                               FontInfo *font_info) {
-  // Pre-load the bitmap so the subsequent render_glyph() call finds it cached in glyph_buffer,
-  // avoiding deep flash I/O calls from within the render call chain (prevents app stack overflow).
-  const GlyphData *g = prv_get_glyph(font_cache, codepoint, font_info, true /* need_bitmap */);
+  // Metadata only: measuring must not pay the deep bitmap load; render pre-loads it in walk_line().
+  const GlyphData *g = prv_get_glyph(font_cache, codepoint, font_info, false /* need_bitmap */);
   if (!g) {
     return 0;
   }

--- a/tests/stubs/stubs_text_resources.h
+++ b/tests/stubs/stubs_text_resources.h
@@ -31,3 +31,7 @@ int8_t text_resources_get_glyph_height(FontCache* font_cache, Codepoint codepoin
   return 10;
 }
 
+const GlyphData *text_resources_get_glyph(FontCache* font_cache, Codepoint codepoint, FontInfo* fontinfo) {
+  return NULL;
+}
+


### PR DESCRIPTION
text_resources_get_glyph_horiz_advance() loaded the glyph bitmap on every call so the following render_glyph() would find it cached. But the advance is also queried from measure/layout passes (e.g. a text node's get_size walk), so measuring paid the deep glyph-bitmap flash load (resource_load -> pfs_open -> flash). Reached through the launcher's app-glance get_size, nested in the menu render, this overflowed the app task's 2 KB stack.

Make the advance metadata-only again and pre-load the bitmap explicitly in walk_line()'s render pass, so the deep flash I/O stays out of the render call chain without charging measure passes for it.

Fixes FIRM-2160