### PR TITLE
fw/services/analytics: actually pack the native heartbeat record

### DIFF
--- a/src/fw/services/analytics/native.c
+++ b/src/fw/services/analytics/native.c
@@ -11,6 +11,7 @@
 #include "pbl/services/data_logging/data_logging_service.h"
 #include "system/logging.h"
 #include "system/passert.h"
+#include "util/attributes.h"
 #include "util/build_id.h"
 #include "util/math.h"
 #include "util/size.h"
@@ -19,7 +20,7 @@
 #define NATIVE_HEARTBEAT_RECORD_VERSION 1
 
 /* Heartbeat record logged to DLS */
-__attribute__((packed)) struct native_heartbeat_record {
+struct PACKED native_heartbeat_record {
   uint8_t version;
   uint64_t timestamp;
   uint8_t build_id[BUILD_ID_EXPECTED_LEN];
@@ -41,6 +42,26 @@ __attribute__((packed)) struct native_heartbeat_record {
 #undef PBL_ANALYTICS_METRIC_DEFINE_TIMER
 #undef PBL_ANALYTICS_METRIC_DEFINE_STRING
 };
+
+/* The record is logged as a raw byte blob, so it must have no padding. */
+_Static_assert(
+    sizeof(struct native_heartbeat_record) ==
+        sizeof(uint8_t) + sizeof(uint64_t) + BUILD_ID_EXPECTED_LEN
+#define PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(key) +sizeof(uint32_t)
+#define PBL_ANALYTICS_METRIC_DEFINE_SIGNED(key) +sizeof(int32_t)
+#define PBL_ANALYTICS_METRIC_DEFINE_SCALED_UNSIGNED(key, scale) +sizeof(uint32_t) + sizeof(uint16_t)
+#define PBL_ANALYTICS_METRIC_DEFINE_SCALED_SIGNED(key, scale) +sizeof(int32_t) + sizeof(uint16_t)
+#define PBL_ANALYTICS_METRIC_DEFINE_TIMER(key) +sizeof(uint32_t)
+#define PBL_ANALYTICS_METRIC_DEFINE_STRING(key, len) +((len) + 1)
+#include "pbl/services/analytics/analytics.def"
+#undef PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED
+#undef PBL_ANALYTICS_METRIC_DEFINE_SIGNED
+#undef PBL_ANALYTICS_METRIC_DEFINE_SCALED_UNSIGNED
+#undef PBL_ANALYTICS_METRIC_DEFINE_SCALED_SIGNED
+#undef PBL_ANALYTICS_METRIC_DEFINE_TIMER
+#undef PBL_ANALYTICS_METRIC_DEFINE_STRING
+    ,
+    "native_heartbeat_record must be packed (no padding)");
 
 /* Type-specific internal index enums (dense, no gaps) */
 


### PR DESCRIPTION
## Problem

Native analytics blobs decode with corrupted data, most visibly in the BLE disconnect counters such as `ble_disconnect_conn_spvn_tmo_count`.

Root cause: the `packed` attribute on `native_heartbeat_record` was written *before* the `struct` keyword:

```c
__attribute__((packed)) struct native_heartbeat_record { ... };
```

In that position GCC **silently ignores it**, so the record was serialized with natural alignment — `timestamp` at offset 8 instead of 1, plus padding between every misaligned member — not the compact layout the source implies.

Confirmed against a captured `v4.9.178` blob: it only decodes under natural alignment (`timestamp@8`, `utc_offset_s=3600`, `fw_version="v4.9.178"`, `uptime_s=9178`).

## Why the BLE fields specifically

The BLE disconnect counters sit at the **end** of the record, so they absorb all the upstream offset drift and read as garbage (e.g. a conn-interval timer value bleeding into the spvn slot). Blobs whose tail fields happened to be zero still decoded plausibly, which masked the issue and produced a misleading "good vs bad" split between otherwise-identical builds.

## Fix

- Use the `PACKED` macro (attribute between the `struct` keyword and the tag, where it is honored), yielding the intended compact layout: `version@0, timestamp@1, build_id@9, first_metric@29`, scaled pairs contiguous — deterministic across compilers/arches.
- Add a `_Static_assert` that the record size equals the sum of its members (computed from `analytics.def` via the same X-macro expansion), so any future padding regression fails the build.

`NATIVE_HEARTBEAT_RECORD_VERSION` is left at 1: decoders resolve each build's layout from DWARF via the embedded `build_id`, so this is not an encoding-scheme change. `tools/analytics_heartbeat_layout.py` reads DWARF and tracks the new layout automatically.

## Note

Already-collected v1 blobs (e.g. v4.9.178) were emitted naturally aligned; decode them with that build's ELF + the DWARF layout tool. This change only affects newly produced blobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)