### PR TITLE
fw/boards: tweak battery capacity hours

### DIFF
--- a/src/fw/board/boards/board_asterix.h
+++ b/src/fw/board/boards/board_asterix.h
@@ -51,9 +51,7 @@ static const BoardConfigPower BOARD_CONFIG_POWER = {
   .pmic_int = { NRFX_GPIOTE_INSTANCE(0), 1, NRF_GPIO_PIN_MAP(1, 12) },
   .pmic_int_gpio = { NRF5_GPIO_RESOURCE_EXISTS, NRF_GPIO_PIN_MAP(1, 12) },
   .low_power_threshold = 2,
-
-  // Memfault is currently estimates a bit above 400 hours as the median
-  .battery_capacity_hours = 400,
+  .battery_capacity_hours = 450,
 };
 
 static const BoardConfigActuator BOARD_CONFIG_VIBE = {

--- a/src/fw/board/boards/board_getafix.c
+++ b/src/fw/board/boards/board_getafix.c
@@ -499,7 +499,7 @@ const BoardConfigPower BOARD_CONFIG_POWER = {
     .gpio_pin = 44,
   },
   .low_power_threshold = 5U,
-  .battery_capacity_hours = 100U,
+  .battery_capacity_hours = 150U,
 };
 
 const BoardConfig BOARD_CONFIG = {

--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -572,7 +572,7 @@ const BoardConfigPower BOARD_CONFIG_POWER = {
     .gpio_pin = 26,
   },
   .low_power_threshold = 4U,
-  .battery_capacity_hours = 370U,
+  .battery_capacity_hours = 400U,
 };
 
 const BoardConfig BOARD_CONFIG = {


### PR DESCRIPTION
Adjust hours based on measured median. This is still hacky/inaccurate, but it's "ok for now". For getafix, add a number based on Obelix (similar hardware) scaled using battery capacity.

Fixes FIRM-1550