### PR TITLE
ci: bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       should-build: ${{ github.event_name == 'push' || steps.filter.outputs.src == 'true' }}
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -55,7 +55,7 @@ jobs:
         run: git config --system --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: true
@@ -80,7 +80,7 @@ jobs:
         run: ./waf bundle
 
       - name: Store
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: firmware-${{ matrix.board }}
           path: |
@@ -93,17 +93,21 @@ jobs:
         run: |
           echo "BUILD_ID=$(readelf -n build/src/fw/tintin_fw.elf | sed -n -e 's/^.*Build ID: //p')" >> "$GITHUB_OUTPUT"
 
-      - name: Upload log hash dictionary
-        uses: Noelware/s3-action@2.3.1
+      - name: Configure AWS credentials
         if: ${{ github.event_name == 'push' && github.repository == 'coredevices/PebbleOS' }}
+        uses: aws-actions/configure-aws-credentials@v6
         with:
-          access-key-id: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
-          secret-key: ${{ secrets.LOG_HASH_BUCKET_SECRET }}
-          endpoint: ${{ vars.LOG_HASH_BUCKET_ENDPOINT }}
-          bucket: ${{ vars.LOG_HASH_BUCKET_NAME }}
-          files: |
-            build/src/fw/tintin_fw_loghash_dict.json
-          path-format: ${{ steps.build_id.outputs.BUILD_ID }}-${{ github.sha }}-normal.json
+          aws-access-key-id: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.LOG_HASH_BUCKET_SECRET }}
+          aws-region: us-east-1
+
+      - name: Upload log hash dictionary
+        if: ${{ github.event_name == 'push' && github.repository == 'coredevices/PebbleOS' }}
+        run: |
+          pip install awscli
+          aws s3 cp build/src/fw/tintin_fw_loghash_dict.json \
+            "s3://${{ vars.LOG_HASH_BUCKET_NAME }}/${{ steps.build_id.outputs.BUILD_ID }}-${{ github.sha }}-normal.json" \
+            --endpoint-url "${{ vars.LOG_HASH_BUCKET_ENDPOINT }}"
 
   build-firmware-status:
     needs: [changes-firmware, build-firmware]

--- a/.github/workflows/build-prf.yml
+++ b/.github/workflows/build-prf.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       should-build: ${{ github.event_name == 'push' || steps.filter.outputs.src == 'true' }}
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -56,7 +56,7 @@ jobs:
         run: git config --system --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: true
@@ -86,7 +86,7 @@ jobs:
         run: ./waf bundle
 
       - name: Store
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: prf-${{ matrix.board }}-${{ matrix.mode }}
           path: |
@@ -99,17 +99,21 @@ jobs:
         run: |
           echo "BUILD_ID=$(readelf -n build/src/fw/tintin_fw.elf | sed -n -e 's/^.*Build ID: //p')" >> "$GITHUB_OUTPUT"
 
-      - name: Upload log hash dictionary
-        uses: Noelware/s3-action@2.3.1
+      - name: Configure AWS credentials
         if: ${{ github.event_name == 'push' && github.repository == 'coredevices/PebbleOS' }}
+        uses: aws-actions/configure-aws-credentials@v6
         with:
-          access-key-id: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
-          secret-key: ${{ secrets.LOG_HASH_BUCKET_SECRET }}
-          endpoint: ${{ vars.LOG_HASH_BUCKET_ENDPOINT }}
-          bucket: ${{ vars.LOG_HASH_BUCKET_NAME }}
-          files: |
-            build/src/fw/tintin_fw_loghash_dict.json
-          path-format: ${{ steps.build_id.outputs.BUILD_ID }}-${{ github.sha }}-prf.json
+          aws-access-key-id: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.LOG_HASH_BUCKET_SECRET }}
+          aws-region: us-east-1
+
+      - name: Upload log hash dictionary
+        if: ${{ github.event_name == 'push' && github.repository == 'coredevices/PebbleOS' }}
+        run: |
+          pip install awscli
+          aws s3 cp build/src/fw/tintin_fw_loghash_dict.json \
+            "s3://${{ vars.LOG_HASH_BUCKET_NAME }}/${{ steps.build_id.outputs.BUILD_ID }}-${{ github.sha }}-prf.json" \
+            --endpoint-url "${{ vars.LOG_HASH_BUCKET_ENDPOINT }}"
 
   build-prf-status:
     needs: [changes-prf, build-prf]

--- a/.github/workflows/build-qemu-sdkshell.yml
+++ b/.github/workflows/build-qemu-sdkshell.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       should-build: ${{ github.event_name == 'push' || steps.filter.outputs.src == 'true' }}
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -49,7 +49,7 @@ jobs:
         run: git config --system --add safe.directory "${GITHUB_WORKSPACE}" 
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: true
@@ -71,7 +71,7 @@ jobs:
         run: ./waf build qemu_image_micro qemu_image_spi
 
       - name: Store
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: firmware-${{ matrix.board }}-qemu
           path: |

--- a/.github/workflows/build-qemu.yml
+++ b/.github/workflows/build-qemu.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       should-build: ${{ github.event_name == 'push' || steps.filter.outputs.src == 'true' }}
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -49,7 +49,7 @@ jobs:
         run: git config --system --add safe.directory "${GITHUB_WORKSPACE}" 
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: true
@@ -71,7 +71,7 @@ jobs:
         run: ./waf build qemu_image_micro qemu_image_spi
 
       - name: Store
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: firmware-${{ matrix.board }}-qemu
           path: |

--- a/.github/workflows/build-translation-source.yml
+++ b/.github/workflows/build-translation-source.yml
@@ -23,7 +23,7 @@ jobs:
         run: git config --system --add safe.directory "${GITHUB_WORKSPACE}" 
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: true

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Pull translations from Crowdin
         uses: crowdin/github-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         run: git config --system --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: true
@@ -67,16 +67,19 @@ jobs:
         run: |
           echo "BUILD_ID=$(readelf -n build/src/fw/tintin_fw.elf | sed -n -e 's/^.*Build ID: //p')" >> "$GITHUB_OUTPUT"
 
-      - name: Upload PRF log hash dictionary
-        uses: Noelware/s3-action@2.3.1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
         with:
-          access-key-id: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
-          secret-key: ${{ secrets.LOG_HASH_BUCKET_SECRET }}
-          endpoint: ${{ vars.LOG_HASH_BUCKET_ENDPOINT }}
-          bucket: ${{ vars.LOG_HASH_BUCKET_NAME }}
-          files: |
-            build/src/fw/tintin_fw_loghash_dict.json
-          path-format: ${{ steps.prf_build_id.outputs.BUILD_ID }}-${{ github.sha }}-prf.json
+          aws-access-key-id: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.LOG_HASH_BUCKET_SECRET }}
+          aws-region: us-east-1
+
+      - name: Upload PRF log hash dictionary
+        run: |
+          pip install awscli
+          aws s3 cp build/src/fw/tintin_fw_loghash_dict.json \
+            "s3://${{ vars.LOG_HASH_BUCKET_NAME }}/${{ steps.prf_build_id.outputs.BUILD_ID }}-${{ github.sha }}-prf.json" \
+            --endpoint-url "${{ vars.LOG_HASH_BUCKET_ENDPOINT }}"
 
       - name: Configure PRF MFG
         run: ./waf configure --board ${{ matrix.board }} --variant=prf --mfg --nohash -DCONFIG_RELEASE=y
@@ -92,7 +95,7 @@ jobs:
           cp build/src/fw/tintin_fw.elf artifacts/prf_mfg_${{ matrix.board }}_${{github.ref_name}}.elf
 
       - name: Store
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: artifacts-prf-${{ matrix.board }}
           path: artifacts
@@ -125,7 +128,7 @@ jobs:
         run: git config --system --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: true
@@ -178,20 +181,24 @@ jobs:
         run: |
           echo "BUILD_ID=$(readelf -n build/src/fw/tintin_fw.elf | sed -n -e 's/^.*Build ID: //p')" >> "$GITHUB_OUTPUT"
 
-      - name: Upload log hash dictionary
-        uses: Noelware/s3-action@2.3.1
+      - name: Configure AWS credentials
         if: ${{ github.repository == 'coredevices/PebbleOS' }}
+        uses: aws-actions/configure-aws-credentials@v6
         with:
-          access-key-id: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
-          secret-key: ${{ secrets.LOG_HASH_BUCKET_SECRET }}
-          endpoint: ${{ vars.LOG_HASH_BUCKET_ENDPOINT }}
-          bucket: ${{ vars.LOG_HASH_BUCKET_NAME }}
-          files: |
-            build/src/fw/tintin_fw_loghash_dict.json
-          path-format: ${{ steps.build_id.outputs.BUILD_ID }}-${{ github.sha }}-normal.json
+          aws-access-key-id: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.LOG_HASH_BUCKET_SECRET }}
+          aws-region: us-east-1
+
+      - name: Upload log hash dictionary
+        if: ${{ github.repository == 'coredevices/PebbleOS' }}
+        run: |
+          pip install awscli
+          aws s3 cp build/src/fw/tintin_fw_loghash_dict.json \
+            "s3://${{ vars.LOG_HASH_BUCKET_NAME }}/${{ steps.build_id.outputs.BUILD_ID }}-${{ github.sha }}-normal.json" \
+            --endpoint-url "${{ vars.LOG_HASH_BUCKET_ENDPOINT }}"
 
       - name: Store
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: artifacts-${{ matrix.board }}${{ steps.slot_suffix.outputs.SLOT_SUFFIX }}
           path: artifacts
@@ -218,10 +225,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
 
       - name: Display artifacts
         run: ls -R
@@ -239,7 +246,7 @@ jobs:
           done
 
       - name: Create release
-        uses: softprops/action-gh-release@v2.2.2
+        uses: softprops/action-gh-release@v3.0.0
         with:
           files: artifacts-*/*
 

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/stale@v9
+    - uses: actions/stale@v10
       with:
         stale-pr-message: 'This pull request has been marked as stale because it has been open (more than) 30 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this pull request will automatically be closed in 7 days. Note, that you can always re-open a closed pull request at any time.'
         days-before-pr-stale: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       should-test: ${{ github.event_name == 'push' || steps.filter.outputs.src == 'true' }}
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -47,7 +47,7 @@ jobs:
         run: git config --system --add safe.directory "${GITHUB_WORKSPACE}" 
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: true
@@ -64,14 +64,14 @@ jobs:
         run: ./waf test
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@v6
         if: (!cancelled())
         with:
           report_paths: build/test/junit.xml
           annotate_only: true
 
       - name: Store failed test images
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: (!cancelled())
         with:
           name: failed_diff_images


### PR DESCRIPTION
GitHub is [deprecating the Node.js 20 actions runtime](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) (forced to Node 24 on 2026-06-16, Node 20 removed 2026-09-16). This bumps every JavaScript action in the repo to a major that defaults to the Node 24 runtime.

## Changes

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v5 |
| `actions/upload-artifact` | v4 | v6 |
| `actions/download-artifact` | v4 | v7 |
| `actions/stale` | v9 | v10 |
| `dorny/paths-filter` | v3 | v4 |
| `mikepenz/action-junit-report` | v5 | v6 |
| `softprops/action-gh-release` | v2.2.2 | v3.0.0 |

`Noelware/s3-action` has **no** Node 24 release (latest 2.3.2/v2 still `node20`), so it is replaced with the official `aws-actions/configure-aws-credentials@v6` (node24) plus an `aws s3 cp --endpoint-url` step. This preserves the custom S3 endpoint and the `${BUILD_ID}-${sha}-{normal,prf}.json` object-key naming, and keeps the existing `if:` repo/event guards. `awscli` is installed in-step via `pip`, matching the existing `memfault-cli` pattern. Region is set to `us-east-1` to match Noelware's previous default (its value is inconsequential — `aws s3 cp` follows S3's region redirect).

`crowdin/github-action` is a Docker action and is unaffected by the Node deprecation, so it is left unchanged.

## Notes
- The artifact action bumps were chosen at the *first* major defaulting to Node 24 to avoid unrelated breaking changes (`upload-artifact` v7 ESM/direct-upload, `download-artifact` v8 hard-error on hash mismatch).
- These Node 24 majors require the Actions runner ≥ 2.327.1 (GitHub-hosted runners already satisfy this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)