### PR TITLE
ci: drop configure-aws-credentials for log hash upload

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -93,16 +93,12 @@ jobs:
         run: |
           echo "BUILD_ID=$(readelf -n build/src/fw/tintin_fw.elf | sed -n -e 's/^.*Build ID: //p')" >> "$GITHUB_OUTPUT"
 
-      - name: Configure AWS credentials
-        if: ${{ github.event_name == 'push' && github.repository == 'coredevices/PebbleOS' }}
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          aws-access-key-id: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.LOG_HASH_BUCKET_SECRET }}
-          aws-region: us-east-1
-
       - name: Upload log hash dictionary
         if: ${{ github.event_name == 'push' && github.repository == 'coredevices/PebbleOS' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.LOG_HASH_BUCKET_SECRET }}
+          AWS_DEFAULT_REGION: us-east-1
         run: |
           pip install awscli
           aws s3 cp build/src/fw/tintin_fw_loghash_dict.json \

--- a/.github/workflows/build-prf.yml
+++ b/.github/workflows/build-prf.yml
@@ -99,16 +99,12 @@ jobs:
         run: |
           echo "BUILD_ID=$(readelf -n build/src/fw/tintin_fw.elf | sed -n -e 's/^.*Build ID: //p')" >> "$GITHUB_OUTPUT"
 
-      - name: Configure AWS credentials
-        if: ${{ github.event_name == 'push' && github.repository == 'coredevices/PebbleOS' }}
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          aws-access-key-id: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.LOG_HASH_BUCKET_SECRET }}
-          aws-region: us-east-1
-
       - name: Upload log hash dictionary
         if: ${{ github.event_name == 'push' && github.repository == 'coredevices/PebbleOS' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.LOG_HASH_BUCKET_SECRET }}
+          AWS_DEFAULT_REGION: us-east-1
         run: |
           pip install awscli
           aws s3 cp build/src/fw/tintin_fw_loghash_dict.json \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,14 +67,11 @@ jobs:
         run: |
           echo "BUILD_ID=$(readelf -n build/src/fw/tintin_fw.elf | sed -n -e 's/^.*Build ID: //p')" >> "$GITHUB_OUTPUT"
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          aws-access-key-id: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.LOG_HASH_BUCKET_SECRET }}
-          aws-region: us-east-1
-
       - name: Upload PRF log hash dictionary
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.LOG_HASH_BUCKET_SECRET }}
+          AWS_DEFAULT_REGION: us-east-1
         run: |
           pip install awscli
           aws s3 cp build/src/fw/tintin_fw_loghash_dict.json \
@@ -181,16 +178,12 @@ jobs:
         run: |
           echo "BUILD_ID=$(readelf -n build/src/fw/tintin_fw.elf | sed -n -e 's/^.*Build ID: //p')" >> "$GITHUB_OUTPUT"
 
-      - name: Configure AWS credentials
-        if: ${{ github.repository == 'coredevices/PebbleOS' }}
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          aws-access-key-id: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.LOG_HASH_BUCKET_SECRET }}
-          aws-region: us-east-1
-
       - name: Upload log hash dictionary
         if: ${{ github.repository == 'coredevices/PebbleOS' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.LOG_HASH_BUCKET_SECRET }}
+          AWS_DEFAULT_REGION: us-east-1
         run: |
           pip install awscli
           aws s3 cp build/src/fw/tintin_fw_loghash_dict.json \


### PR DESCRIPTION
Follow-up fix to #1433.

The `aws-actions/configure-aws-credentials` step added in #1433 fails on `main`:

```
Retry exportAccountId: attempt 1 of 12 failed: The security token included in the request is invalid.
...
##[error]The security token included in the request is invalid.
```

The action **always** validates credentials via an STS `GetCallerIdentity` call and offers no flag to skip it. The log hash bucket (`LOG_HASH_BUCKET_ENDPOINT`) is a **non-AWS** S3-compatible service, so its access keys are not valid AWS IAM credentials and STS rejects them — breaking every `build-prf`/`build-firmware`/`release` job.

## Fix

Drop the `configure-aws-credentials` step and pass the credentials directly to the existing `aws s3 cp` step via environment variables:

```yaml
- name: Upload log hash dictionary
  env:
    AWS_ACCESS_KEY_ID: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
    AWS_SECRET_ACCESS_KEY: ${{ secrets.LOG_HASH_BUCKET_SECRET }}
    AWS_DEFAULT_REGION: us-east-1
  run: |
    pip install awscli
    aws s3 cp ... --endpoint-url "${{ vars.LOG_HASH_BUCKET_ENDPOINT }}"
```

`aws s3 cp` makes no STS call, so this restores the exact behavior of the original `Noelware/s3-action` (raw S3 API against a custom endpoint). The Node 20 deprecation stays resolved — there's no longer any JS action involved in the upload at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)