### PR TITLE
fw/apps/system/settings: Add Quick Lanuch Combo settings in watch

### DIFF
--- a/src/fw/apps/system/settings/quick_launch.c
+++ b/src/fw/apps/system/settings/quick_launch.c
@@ -25,7 +25,7 @@
 #include "system/passert.h"
 #include "system/status_codes.h"
 
-#define NUM_ROWS (NUM_BUTTONS + 2)  // 4 hold buttons + 2 tap buttons (up and down)
+#define NUM_ROWS (NUM_BUTTONS + 2 + 2)  // 4 hold buttons + 2 tap buttons (up and down) + 2 Combo
 
 typedef enum {
   ROW_TAP_UP = 0,
@@ -34,6 +34,8 @@ typedef enum {
   ROW_HOLD_SELECT,
   ROW_HOLD_DOWN,
   ROW_HOLD_BACK,
+  ROW_HOLD_BACK_UP,
+  ROW_HOLD_UP_DOWN,
 } QuickLaunchRow;
 
 typedef struct QuickLaunchData {
@@ -54,6 +56,10 @@ static const char *s_row_titles[NUM_ROWS] = {
   [ROW_HOLD_DOWN]    = i18n_noop("Hold Down"),
   /// Shown in Quick Launch Settings as the title of the hold back button quick launch option.
   [ROW_HOLD_BACK]    = i18n_noop("Hold Back"),
+  /// Shown in Quick Launch Settings as the title of the hold back+up combo button quick launch option.
+  [ROW_HOLD_BACK_UP]    = i18n_noop("Hold Back+Up"),
+  /// Shown in Quick Launch Settings as the title of the hold up+down combo button quick launch option.
+  [ROW_HOLD_UP_DOWN]    = i18n_noop("Hold Up+Down"),
 };
 
 static void prv_get_subtitle_string(AppInstallId app_id, QuickLaunchData *data,
@@ -98,6 +104,10 @@ static void prv_update_app_names(QuickLaunchData *data) {
                           data->app_names[ROW_HOLD_DOWN], APP_NAME_SIZE_BYTES);
   prv_get_subtitle_string(quick_launch_get_app(BUTTON_ID_BACK), data,
                           data->app_names[ROW_HOLD_BACK], APP_NAME_SIZE_BYTES);
+  prv_get_subtitle_string(quick_launch_combo_back_up_get_app(), data,
+                          data->app_names[ROW_HOLD_BACK_UP], APP_NAME_SIZE_BYTES);
+  prv_get_subtitle_string(quick_launch_combo_up_down_get_app(), data,
+                          data->app_names[ROW_HOLD_UP_DOWN], APP_NAME_SIZE_BYTES);
 }
 
 static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
@@ -130,37 +140,53 @@ static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
   
   ButtonId button;
   bool is_tap;
-  
+  bool is_combo;
   switch (row) {
     case ROW_TAP_UP:
       button = BUTTON_ID_UP;
       is_tap = true;
+      is_combo = false;
       break;
     case ROW_TAP_DOWN:
       button = BUTTON_ID_DOWN;
       is_tap = true;
+      is_combo = false;
       break;
     case ROW_HOLD_UP:
       button = BUTTON_ID_UP;
       is_tap = false;
+      is_combo = false;
       break;
     case ROW_HOLD_SELECT:
       button = BUTTON_ID_SELECT;
       is_tap = false;
+      is_combo = false;
       break;
     case ROW_HOLD_DOWN:
       button = BUTTON_ID_DOWN;
       is_tap = false;
+      is_combo = false;
       break;
     case ROW_HOLD_BACK:
       button = BUTTON_ID_BACK;
       is_tap = false;
+      is_combo = false;
+      break;
+    case ROW_HOLD_BACK_UP:
+      button = BUTTON_ID_BACK;
+      is_tap = false;
+      is_combo = true;
+      break;
+    case ROW_HOLD_UP_DOWN:
+      button = BUTTON_ID_DOWN;
+      is_tap = false;
+      is_combo = true;
       break;
     default:
       return;
   }
   
-  quick_launch_app_menu_window_push(button, is_tap);
+  quick_launch_app_menu_window_push(button, is_tap, is_combo);
 }
 
 static uint16_t prv_num_rows_cb(SettingsCallbacks *context) {

--- a/src/fw/apps/system/settings/quick_launch_app_menu.c
+++ b/src/fw/apps/system/settings/quick_launch_app_menu.c
@@ -28,6 +28,7 @@ typedef struct {
   AppMenuDataSource data_source;
   ButtonId button;
   bool is_tap;
+  bool is_combo;
   int16_t selected;
   OptionMenu *option_menu;
 } QuickLaunchAppMenuData;
@@ -105,7 +106,18 @@ static void prv_menu_select(OptionMenu *option_menu, int selection, void *contex
     if (data->is_tap) {
       quick_launch_single_click_set_app(data->button, INSTALL_ID_INVALID);
       quick_launch_single_click_set_enabled(data->button, false);
-    } else {
+    }
+    else if(data->is_combo){
+      if(data->button == BUTTON_ID_BACK){
+        quick_launch_combo_back_up_set_app(INSTALL_ID_INVALID);
+        quick_launch_combo_back_up_set_enabled(false);
+      }
+      else if(data->button == BUTTON_ID_DOWN){
+        quick_launch_combo_up_down_set_app(INSTALL_ID_INVALID);
+        quick_launch_combo_up_down_set_enabled(false);
+      }
+    }
+    else {
       quick_launch_set_app(data->button, INSTALL_ID_INVALID);
       quick_launch_set_enabled(data->button, false);
     }
@@ -115,7 +127,17 @@ static void prv_menu_select(OptionMenu *option_menu, int selection, void *contex
         app_menu_data_source_get_node_at_index(&data->data_source, selection - NUM_CUSTOM_CELLS);
     if (data->is_tap) {
       quick_launch_single_click_set_app(data->button, app_menu_node->install_id);
-    } else {
+    }
+    else if(data->is_combo){
+      if(data->button == BUTTON_ID_BACK){
+        quick_launch_combo_back_up_set_app(app_menu_node->install_id);
+      }
+      else if(data->button == BUTTON_ID_DOWN){
+        quick_launch_combo_up_down_set_app(app_menu_node->install_id);
+      }
+
+    }
+    else {
       quick_launch_set_app(data->button, app_menu_node->install_id);
     }
     app_window_stack_pop(true);
@@ -136,11 +158,21 @@ static void prv_menu_unload(OptionMenu *option_menu, void *context) {
   app_free(data);
 }
 
-void quick_launch_app_menu_window_push(ButtonId button, bool is_tap) {
+static AppInstallId  prv_get_combo_app(ButtonId button){
+  switch(button){
+    case BUTTON_ID_BACK:
+      return quick_launch_combo_back_up_get_app();
+    case BUTTON_ID_DOWN:
+      return quick_launch_combo_up_down_get_app();
+    default:
+      return INSTALL_ID_INVALID;
+  }
+}
+void quick_launch_app_menu_window_push(ButtonId button, bool is_tap, bool is_combo) {
   QuickLaunchAppMenuData *data = app_zalloc_check(sizeof(*data));
   data->button = button;
   data->is_tap = is_tap;
-
+  data->is_combo = is_combo;
   OptionMenu *option_menu = option_menu_create();
   data->option_menu = option_menu;
 
@@ -150,7 +182,7 @@ void quick_launch_app_menu_window_push(ButtonId button, bool is_tap) {
   }, data);
 
   const AppInstallId install_id = is_tap ? quick_launch_single_click_get_app(button)
-                                          : quick_launch_get_app(button);
+                                          : (is_combo ? prv_get_combo_app(button): quick_launch_get_app(button));
   const int app_index = app_menu_data_source_get_index_of_app_with_install_id(&data->data_source,
                                                                               install_id);
 

--- a/src/fw/apps/system/settings/quick_launch_app_menu.h
+++ b/src/fw/apps/system/settings/quick_launch_app_menu.h
@@ -6,4 +6,4 @@
 #include "shell/normal/quick_launch.h"
 #include <stdbool.h>
 
-void quick_launch_app_menu_window_push(ButtonId button, bool is_tap);
+void quick_launch_app_menu_window_push(ButtonId button, bool is_tap, bool is_combo);


### PR DESCRIPTION
Adds quick launchsettings on the watch for the two Combo actions(Back+Up and Up+Down). This is to separate out this setting from the mobile app ~~and allow users not using Core's Pebble App to set it~~

Verified by building it on obelix_pvt and qemu_emery(builds but can't use combo quick launch. Assuming something is up with how qemu handles button inputs)