### PR TITLE
bluetooth: advertise BR/EDR Not Supported on BLE-only watches

### DIFF
--- a/src/fw/comm/ble/gap_le_slave_discovery.c
+++ b/src/fw/comm/ble/gap_le_slave_discovery.c
@@ -54,7 +54,11 @@ static void prv_schedule_ad_job(void) {
   // central is only doing a scan request if the Service UUID matches with their
   // interests, to save radio time / battery life we keep the advertisement part
   // as "small" as possible (21 bytes currently).
-  ble_ad_set_flags(ad, GAP_LE_AD_FLAGS_GEN_DISCOVERABLE_MASK);
+  // Advertise "BR/EDR Not Supported" alongside General Discoverable: these are
+  // BLE-only watches, so dual-mode hosts must connect over LE instead of attempting
+  // a classic page (which would time out).
+  ble_ad_set_flags(ad, GAP_LE_AD_FLAGS_GEN_DISCOVERABLE_MASK |
+                       GAP_LE_AD_FLAGS_BR_EDR_NOT_SUPPORTED_MASK);
 
   // *DO NOT* use pebble_bt_uuid_expand() here!
   // ble_ad_set_service_uuids() will be "smart" and include only the 16-bit UUID, but only if the

--- a/src/fw/comm/ble/gap_le_slave_reconnect.c
+++ b/src/fw/comm/ble/gap_le_slave_reconnect.c
@@ -83,7 +83,9 @@ static void prv_evaluate(ReconnectType prev_type) {
       // Create adv payload with only flags + HR service UUID. This is enough for various mobile
       // fitness apps to be able to reconnect to Pebble as BLE HRM.
       ad = ble_ad_create();
-      ble_ad_set_flags(ad, GAP_LE_AD_FLAGS_GEN_DISCOVERABLE_MASK);
+      // BLE-only watch: advertise "BR/EDR Not Supported" so dual-mode hosts use LE.
+      ble_ad_set_flags(ad, GAP_LE_AD_FLAGS_GEN_DISCOVERABLE_MASK |
+                           GAP_LE_AD_FLAGS_BR_EDR_NOT_SUPPORTED_MASK);
       Uuid service_uuid = bt_uuid_expand_16bit(0x180D);
       ble_ad_set_service_uuids(ad, &service_uuid, 1);
     } else {


### PR DESCRIPTION
Fixes #1439

  ## Summary

  While LE-discoverable, the watch advertises an AD **Flags** structure (AD type
  `0x01`) of `0x02` — only the *LE General Discoverable* bit. It never sets bit 2,
  *BR/EDR Not Supported* (`0x04`).

  Because the watch advertises from a **Public** address with that bit clear, a
  dual-mode host (e.g. BlueZ) treats it as potentially Bluetooth Classic-capable
  and issues a classic **BR/EDR Create Connection** (HCI `0x01|0x0005`). That
  returns **Page Timeout (0x04)** — these watches have no connectable BR/EDR — and
  the host never falls back to LE, so the connection fails. The only host-side
  workaround is forcing the controller LE-only (`btmgmt bredr off`), after which
  LE connect and SMP pairing work fine.

  All watches supported by this firmware are BLE-only (NimBLE, no Classic
  transport), so this advertises **Flags = `0x06`** (*LE General Discoverable* +
  *BR/EDR Not Supported*) from both the discovery and HRM-reconnect advertising
  paths. The General Discoverable bit is preserved.

  ## Root cause

  `gap_le_slave_discovery.c` (and the HRM path in `gap_le_slave_reconnect.c`) call
  `ble_ad_set_flags(ad, GAP_LE_AD_FLAGS_GEN_DISCOVERABLE_MASK)`, omitting
  `GAP_LE_AD_FLAGS_BR_EDR_NOT_SUPPORTED_MASK`. Per the Core Spec Supplement
  (CSSv6, Part A §1.3), a peer that does not advertise *BR/EDR Not Supported* may
  be assumed to support Classic, which is exactly what BlueZ does here.

  ## Change

  ```c
  ble_ad_set_flags(ad, GAP_LE_AD_FLAGS_GEN_DISCOVERABLE_MASK |
                       GAP_LE_AD_FLAGS_BR_EDR_NOT_SUPPORTED_MASK);

  at both advertising sites. No change to pairing/SMP or PPoGATT. The plain
  (empty-payload) reconnect path is untouched — it intentionally advertises no
  Flags AD.

  Flags semantics check (0x06)

  ┌─────┬───────────────────────────────────────┬───────┐
  │ bit │                meaning                │ value │
  ├─────┼───────────────────────────────────────┼───────┤
  │ 0   │ LE Limited Discoverable               │ 0     │
  ├─────┼───────────────────────────────────────┼───────┤
  │ 1   │ LE General Discoverable               │ 1     │
  ├─────┼───────────────────────────────────────┼───────┤
  │ 2   │ BR/EDR Not Supported                  │ 1     │
  ├─────┼───────────────────────────────────────┼───────┤
  │ 3   │ Simultaneous LE + BR/EDR (Controller) │ 0     │
  ├─────┼───────────────────────────────────────┼───────┤
  │ 4   │ Simultaneous LE + BR/EDR (Host)       │ 0     │
  └─────┴───────────────────────────────────────┴───────┘

  = 0x06. Discoverable bit retained.

  Testing

  How to verify on the BlueZ host while the watch re-advertises:

  sudo btmon | grep -A6 'Flags' & bluetoothctl connect <WATCH_MAC>

  Expected: advertising Flags reports 0x06, and the host issues an LE
  Create Connection instead of a classic page — no btmgmt bredr off needed.

  ⚠️ On-hardware verification still pending — the root cause was confirmed from
  host-side btmon captures; I'll confirm the fix on a Pebble Time 2 (Emery) and
  update this PR.
  ```