### PR TITLE
fw/touch: honor global kill switch for gestures and sensor power

### DIFF
--- a/src/fw/services/touch/touch.c
+++ b/src/fw/services/touch/touch.c
@@ -81,12 +81,10 @@ void touch_service_set_globally_enabled(bool enabled) {
     return;
   }
   s_globally_enabled = enabled;
-  const bool has_subscribers = s_subscriber_count > 0;
+  const bool sensor_enabled = enabled && (s_subscriber_count > 0);
   mutex_unlock(s_touch_mutex);
 
-  if (has_subscribers) {
-    touch_sensor_set_enabled(enabled);
-  }
+  touch_sensor_set_enabled(sensor_enabled);
   if (!enabled) {
     // Avoid delivering stale position on re-enable.
     touch_reset();
@@ -194,6 +192,11 @@ void touch_handle_update(TouchState touch_state, int16_t x, int16_t y) {
 
 void touch_handle_gesture(TouchGesture gesture, int16_t x, int16_t y) {
   mutex_lock(s_touch_mutex);
+
+  if (!s_globally_enabled) {
+    mutex_unlock(s_touch_mutex);
+    return;
+  }
 
   prv_apply_rotation(&x, &y);
 

--- a/tests/fw/services/test_touch.c
+++ b/tests/fw/services/test_touch.c
@@ -261,3 +261,39 @@ void test_touch__subscribe_while_disabled_keeps_sensor_off(void) {
 
   s_remove_subscriber_cb(PebbleTask_App);
 }
+
+void test_touch__global_disable_drops_gestures(void) {
+  // Gestures (tap/double-tap) must honor the kill switch too, not just the
+  // finger up/down updates.
+  touch_service_set_globally_enabled(false);
+
+  touch_handle_gesture(TouchGesture_Tap, 10, 20);
+  cl_assert_equal_i(fake_event_get_count(), 0);
+
+  touch_handle_gesture(TouchGesture_DoubleTap, 30, 40);
+  cl_assert_equal_i(fake_event_get_count(), 0);
+
+  touch_service_set_globally_enabled(true);
+}
+
+void test_touch__gestures_delivered_when_enabled(void) {
+  touch_handle_gesture(TouchGesture_Tap, 10, 20);
+  cl_assert_equal_i(fake_event_get_count(), 1);
+
+  PebbleEvent event = fake_event_get_last();
+  cl_assert_equal_i(event.type, PEBBLE_GESTURE_EVENT);
+  cl_assert_equal_i(event.gesture.event.type, GestureEvent_Tap);
+}
+
+void test_touch__global_disable_sleeps_unsubscribed_sensor(void) {
+  // The driver can re-arm the sensor outside the service's subscriber
+  // bookkeeping (e.g. its I2C error-recovery path). Disabling globally must
+  // still put the chip to sleep, even when s_subscriber_count is 0.
+  s_touch_sensor_enabled = true;
+
+  touch_service_set_globally_enabled(false);
+  cl_assert(!s_touch_sensor_enabled);
+  cl_assert(s_touch_sensor_disable_count >= 1);
+
+  touch_service_set_globally_enabled(true);
+}


### PR DESCRIPTION
## Summary

Fixes FIRM-2284: disabling touch from **Settings → Display → Touch** had no effect until the watch was reset.

The global kill switch (`s_globally_enabled`) was wired into only one of the two event-delivery paths in `src/fw/services/touch/touch.c`:

- `touch_handle_update()` (finger down/up/position) honored the flag.
- `touch_handle_gesture()` (tap / double-tap) did **not** — so on getafix, where the CST816 reports taps as hardware gestures and the UI is tap-driven, touch kept working after being disabled.

It only appeared to "work after reboot" because at runtime the sensor stays powered for the default double-tap-to-wake subscriber, whereas after a reset `prv_add_subscriber_cb()` refuses to power the sensor while disabled. Additionally, `touch_service_set_globally_enabled()` only slept the chip `if (has_subscribers)`, so a sensor re-armed outside the subscriber bookkeeping (e.g. the driver's I2C recovery path) would not be put to sleep.

## Changes

- Gate `touch_handle_gesture()` on `s_globally_enabled`, mirroring `touch_handle_update()`.
- Always drive the sensor to the kill-switch state: disabling sleeps the chip regardless of subscriber count; enabling powers it up only if subscribed.

Note: with this change, disabling touch also disables double-tap-to-wake (consistent with the post-reboot behavior).

## Known residual

The cst816 I2C error-recovery path (`cst816.c:271,281`) calls `touch_sensor_set_enabled(true)` without consulting the global flag, so a narrow race could re-arm the chip while touch is disabled. Input still cannot leak (the event handlers are gated), but the HW would not stay asleep. Can be closed in a follow-up by having that path check `touch_service_is_globally_enabled()`.

## Test

TDD via `tests/fw/services/test_touch.c`:
- `global_disable_drops_gestures` — gestures dropped when disabled
- `gestures_delivered_when_enabled` — gestures delivered when enabled
- `global_disable_sleeps_unsubscribed_sensor` — chip slept even with no subscriber

Both new failure-tests reproduced the bug against the old code; the full `test_touch` suite passes after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)