### PR TITLE
bluetooth-fw/nimble: report persistent bond state in pairing service

### DIFF
--- a/src/bluetooth-fw/nimble/pebble_pairing_service.c
+++ b/src/bluetooth-fw/nimble/pebble_pairing_service.c
@@ -5,6 +5,7 @@
 #include <comm/ble/gap_le_connection.h>
 #include <host/ble_gap.h>
 #include <host/ble_gatt.h>
+#include <host/ble_store.h>
 #include <host/ble_uuid.h>
 #include <os/os_mbuf.h>
 #include <system/logging.h>
@@ -26,10 +27,20 @@ static int pebble_pairing_service_get_connectivity_status(
     return -1;
   }
 
+  struct ble_store_key_sec key_sec = {
+    .peer_addr = desc.peer_id_addr,
+  };
+  struct ble_store_value_sec value_sec;
+  bool is_bonded = (ble_store_read_peer_sec(&key_sec, &value_sec) == 0);
+
+  int bond_count = 0;
+  ble_store_util_count(BLE_STORE_OBJ_TYPE_PEER_SEC, &bond_count);
+
   memset(status, 0, sizeof(*status));
   status->ble_is_connected = true;
-  status->ble_is_bonded = desc.sec_state.bonded;
+  status->ble_is_bonded = is_bonded;
   status->ble_is_encrypted = desc.sec_state.encrypted;
+  status->has_bonded_gateway = (bond_count > 0);
   status->supports_pinning_without_security_request = true;
 
   return 0;


### PR DESCRIPTION
## Summary

The watch could enter a reconnect/re-pair storm on Android (FIRM-2212): the phone shows "Error pairing" and the device flips between connected/saved every second until the user manually forgets it.

Root cause is firmware-side. The Pebble Pairing Service connectivity-status characteristic reported `ble_is_bonded` (the `paired` flag the app reads) from NimBLE's **live link state** (`desc.sec_state.bonded`), which NimBLE only sets *after* encryption is restored on the current link — not because a bond record exists. If the gateway reads the characteristic after connecting but before re-encrypting, the watch reports itself unpaired even though the bond is valid (the peer address resolved via the stored IRK, `is_resolved` in the watch logs).

On Android this drives the loop: app sees `paired=false` → `createBond()` → OS rejects (bond already exists) → link torn down (`reason=0x213`) → reconnect → repeat.

## Fix

Derive `ble_is_bonded` from NimBLE's security store keyed on the peer identity address, and populate `has_bonded_gateway` from the stored bond count. Existing bondings are restored into the store before the link is brought up (`bluetooth_ctl.c` registers them before `bt_driver_start`), so the record is present even pre-re-encryption. After the fix the watch reports `paired=true` → the app takes the "already paired" branch → no `createBond()`, loop broken. `ble_is_encrypted` is left on the live link state (correct as-is).

## Testing

- Builds and links clean (asterix/getafix NimBLE board).
- Verified against the mobile decision logic (`PebbleBle.kt`): the `paired` flag is the load-bearing input; `has_bonded_gateway` is only logged.

Fixes FIRM-2212
