### PR TITLE
fw/coredump: wake LCPU during dump so BLE crashes capture its RAM

### DIFF
--- a/src/bluetooth-fw/nimble/init.c
+++ b/src/bluetooth-fw/nimble/init.c
@@ -27,9 +27,6 @@ static const uint32_t s_bt_stack_start_stop_timeout_ms = 10000;
 
 extern void pebble_pairing_service_init(void);
 extern void nimble_discover_init(void);
-#ifdef CONFIG_SOC_SF32LB52
-extern void ble_transport_ll_wake_lcpu(void);
-#endif
 
 #if NIMBLE_CFG_CONTROLLER
 static TaskHandle_t s_ll_task_handle;
@@ -60,9 +57,8 @@ static void prv_sync_cb(void) {
 static void prv_reset_cb(int reason) {
   PBL_LOG_D_WRN(LOG_DOMAIN_BT, "NimBLE host reset (reason: 0x%04x)", (uint16_t)reason);
 #ifdef CONFIG_SOC_SF32LB52
-  // Controller stopped answering HCI. Keep the LCPU reachable and crash so the
-  // coredump captures LCPU RAM; the reboot cold-recovers the controller.
-  ble_transport_ll_wake_lcpu();
+  // Controller stopped answering HCI. Crash so the coredump captures LCPU RAM
+  // (core_dump wakes the LCPU itself); the reboot cold-recovers the controller.
   PBL_CROAK("NimBLE host reset 0x%04x; captured LCPU RAM", (uint16_t)reason);
 #endif
 }
@@ -155,10 +151,7 @@ bool bt_driver_start(BTDriverConfig *config) {
   ble_hs_sched_start();
   f_rc = xSemaphoreTake(s_host_started, milliseconds_to_ticks(s_bt_stack_start_stop_timeout_ms));
   if (f_rc != pdTRUE) {
-#ifdef CONFIG_SOC_SF32LB52
-    // Keep the LCPU reachable so the coredump captures its RAM.
-    ble_transport_ll_wake_lcpu();
-#endif
+    // core_dump wakes the LCPU itself, so its RAM is captured here too.
     PBL_CROAK("NimBLE host start timed out");
   }
 

--- a/src/fw/kernel/core_dump.c
+++ b/src/fw/kernel/core_dump.c
@@ -447,14 +447,14 @@ static void prv_write_memory_regions(const MemoryRegion *regions, unsigned int c
 }
 
 #if defined(CONFIG_SOC_SF32LB52)
-// LCPU RAM lives in the LPSYS domain; reading it while that domain is powered
-// down hangs/faults. LP_ACTIVE reports whether it is reachable.
+// Wake the LCPU so its LPSYS RAM is reachable, letting BLE crashes (e.g. NimBLE
+// host asserts) capture the controller RAM. HAL_HPAON_WakeCore busy-waits for
+// the LCPU to ack; if it is fully powered down this blocks until the watchdog
+// reboots us, costing only this dump. We reset right after, so the wake request
+// is never balanced.
 static void prv_dump_lcpu_ram(uint32_t flash_base) {
-  if (hwp_hpsys_aon->ISSR & HPSYS_AON_ISSR_LP_ACTIVE) {
-    prv_write_memory_regions(&LCPU_MEMORY_REGION, 1, flash_base);
-  } else {
-    prv_debug_str("CD: LCPU domain off, skipping LCPU RAM");
-  }
+  HAL_HPAON_WakeCore(CORE_ID_LCPU);
+  prv_write_memory_regions(&LCPU_MEMORY_REGION, 1, flash_base);
 }
 #endif
 

--- a/third_party/nimble/transport/hci_sf32lb52.c
+++ b/third_party/nimble/transport/hci_sf32lb52.c
@@ -336,12 +336,6 @@ void ble_transport_ll_init(void) {
   PBL_ASSERTN(s_hci_task_handle);
 }
 
-// Hold the LP active request (no cancel) so LPSYS RAM stays reachable from the
-// HCPU while the coredump runs after a crash on host reset.
-void ble_transport_ll_wake_lcpu(void) {
-  HAL_HPAON_WakeCore(CORE_ID_LCPU);
-}
-
 void ble_transport_ll_deinit(void) {
   NVIC_DisableIRQ(LCPU2HCPU_IRQn);
   ipc_queue_close(s_ipc_port);


### PR DESCRIPTION
## Problem

FIRM-2292 is a NimBLE host assert (`ble_hs.c` `start_stage2`, `rc == 0`) firing on stationary exit. Its coredump captured **no LCPU RAM** (the 24 KB region at `0x20400000` was absent), so the BLE controller state was unavailable for triage.

The LCPU (BLE controller) RAM lives in the LPSYS domain and is only reachable while that domain is powered. Only two hand-picked `PBL_CROAK` sites in the NimBLE init path woke the LCPU first; internal NimBLE asserts crash through the generic `__assert_func` → `core_dump_reset` path, which left the LCPU asleep and dropped its RAM.

## Fix

Wake the LCPU from `prv_dump_lcpu_ram()` via `HAL_HPAON_WakeCore()` so the controller RAM is captured for **every** crash type (asserts, hardfaults, watchdog), not just the two curated sites. If the LCPU is fully powered down the wake busy-waits and the watchdog reboots us — acceptable worst case, costing only this dump. We reset right after, so the wake request is never balanced.

This makes the two `ble_transport_ll_wake_lcpu()` calls in `nimble/init.c` redundant — removed, along with the now-dead wrapper.

## Testing

- `./pbl build` (board `getafix_dvt2`, SF32LB52): builds and links clean under `-Werror`.

Fixes FIRM-2292

🤖 Generated with [Claude Code](https://claude.com/claude-code)