### PR TITLE
apps/system/timeline: fix timeline scrolling bugs

### DIFF
--- a/src/fw/apps/system/timeline/timeline.c
+++ b/src/fw/apps/system/timeline/timeline.c
@@ -173,8 +173,8 @@ static void prv_swap_timeline(void *data) {
   const bool is_future = (s_app_data->timeline_model.direction == TimelineIterDirectionFuture);
   const bool to_timeline = true;
   const CompositorTransition *transition = PBL_IF_RECT_ELSE(
-      compositor_slide_transition_timeline_get(is_future, to_timeline, timeline_model_is_empty()),
-      compositor_dot_transition_timeline_get(is_future, to_timeline));
+      compositor_slide_transition_timeline_get(!is_future, to_timeline, timeline_model_is_empty()),
+      compositor_dot_transition_timeline_get(!is_future, to_timeline));
   static TimelineArgs args = (TimelineArgs) {
     .force_full = true
   };

--- a/src/fw/apps/system/timeline/timeline.c
+++ b/src/fw/apps/system/timeline/timeline.c
@@ -188,10 +188,13 @@ static void prv_swap_timeline(void *data) {
       .common.transition = transition,
     });
   } else {
-    Uuid full_uuid = TIMELINE_FULL_UUID_INIT;
+    Uuid app_uuid;
+    sys_get_app_uuid(&app_uuid);
+    const Uuid target_uuid = uuid_equal(&app_uuid, &(Uuid)TIMELINE_FULL_UUID_INIT) ?
+        (Uuid)TIMELINE_UUID_INIT : (Uuid)TIMELINE_FULL_UUID_INIT;
     args.direction = TimelineIterDirectionFuture;
     app_manager_put_launch_app_event(&(AppLaunchEventConfig) {
-      .id = app_install_get_id_for_uuid((const Uuid *)(&full_uuid)),
+      .id = app_install_get_id_for_uuid((const Uuid *)&target_uuid),
       .common.args = (const void *)&args,
       .common.transition = transition,
     });

--- a/src/fw/shell/normal/system_app_registry_list.json
+++ b/src/fw/shell/normal/system_app_registry_list.json
@@ -88,6 +88,11 @@
       "md_fn": "timeline_get_app_info"
     },
     {
+      "id": -96,
+      "enum": "TIMELINE_PAST",
+      "md_fn": "timeline_past_get_app_info"
+    },
+    {
       "id": -12,
       "enum": "BOUNCING_BOX_DEMO",
       "md_fn": "bouncing_box_demo_get_app_info",
@@ -710,11 +715,6 @@
       "id": -93,
       "enum": "AIRPLANE_MODE_TOGGLE",
       "md_fn": "airplane_mode_toggle_get_app_info"
-    },
-    {
-      "id": -96,
-      "enum": "TIMELINE_PAST",
-      "md_fn": "timeline_past_get_app_info"
     },
     {
       "id": -97,

--- a/src/fw/shell/normal/watchface.c
+++ b/src/fw/shell/normal/watchface.c
@@ -194,6 +194,59 @@ static void prv_check_combo_back_hold(void) {
   }
 }
 
+static void prv_launch_timeline_app(AppInstallId app_id, ClickRecognizerRef recognizer,
+                                    AppLaunchReason reason) {
+  static TimelineArgs s_timeline_args;
+  s_timeline_args.launch_into_pin = true;
+  s_timeline_args.stay_in_list_view = true;
+  timeline_peek_get_item_id(&s_timeline_args.pin_id);
+
+  const ButtonId button = click_recognizer_get_button_id(recognizer);
+  const CompositorTransition *animation = NULL;
+  const bool is_up = (button == BUTTON_ID_UP);
+  const bool is_future = (app_id == APP_ID_TIMELINE) || (app_id == APP_ID_TIMELINE_FULL && !is_up);
+
+  if (app_id == APP_ID_TIMELINE) {
+    s_timeline_args.direction = TimelineIterDirectionFuture;
+  } else if (app_id == APP_ID_TIMELINE_PAST) {
+    s_timeline_args.direction = TimelineIterDirectionPast;
+  } else {
+    s_timeline_args.direction = is_future ? TimelineIterDirectionFuture : TimelineIterDirectionPast;
+  }
+
+  const bool timeline_is_destination = true;
+#if PBL_ROUND
+  animation = compositor_dot_transition_timeline_get(is_future, timeline_is_destination);
+#else
+  const bool jump = (!uuid_is_invalid(&s_timeline_args.pin_id) && !timeline_peek_is_first_event());
+  animation = jump ? compositor_peek_transition_timeline_get() :
+                     compositor_slide_transition_timeline_get(is_future, timeline_is_destination,
+                                                              timeline_peek_is_future_empty());
+#endif
+  prv_launch_app_via_button(&(AppLaunchEventConfig) {
+    .id = app_id,
+    .common.reason = reason,
+    .common.args = &s_timeline_args,
+    .common.transition = animation,
+  }, recognizer);
+}
+
+static void prv_launch_quick_launch_app(AppInstallId app_id, ClickRecognizerRef recognizer,
+                                        AppLaunchReason timeline_reason, void *non_timeline_args) {
+  const bool is_timeline = (app_id == APP_ID_TIMELINE) ||
+                           (app_id == APP_ID_TIMELINE_PAST) ||
+                           (app_id == APP_ID_TIMELINE_FULL);
+  if (is_timeline) {
+    prv_launch_timeline_app(app_id, recognizer, timeline_reason);
+  } else {
+    prv_launch_app_via_button(&(AppLaunchEventConfig) {
+      .id = app_id,
+      .common.reason = APP_LAUNCH_QUICK_LAUNCH,
+      .common.args = non_timeline_args,
+    }, recognizer);
+  }
+}
+
 static void prv_quick_launch_handler(ClickRecognizerRef recognizer, void *data) {
   ButtonId button = click_recognizer_get_button_id(recognizer);
 
@@ -207,11 +260,9 @@ static void prv_quick_launch_handler(ClickRecognizerRef recognizer, void *data) 
     app_id = app_install_get_id_for_uuid(&quick_launch_setup_get_app_info()->uuid);
   }
   s_buttons_pressed = BIT_CLEAR;  // Reset our own tracking
-  prv_launch_app_via_button(&(AppLaunchEventConfig) {
-    .id = app_id,
-    .common.reason = APP_LAUNCH_QUICK_LAUNCH,
-    .common.args = (void*)APP_QUICK_LAUNCH_ACTION_HOLD,
-  }, recognizer);
+
+  prv_launch_quick_launch_app(app_id, recognizer, APP_LAUNCH_QUICK_LAUNCH,
+                              (void*)APP_QUICK_LAUNCH_ACTION_HOLD);
 }
 
 static void prv_launch_up_down(ClickRecognizerRef recognizer, void *data) {
@@ -222,46 +273,10 @@ static void prv_launch_up_down(ClickRecognizerRef recognizer, void *data) {
   }
   
   if (!quick_launch_single_click_is_enabled(button)) return;
-  //check if quick launch app is not timeline
-  if (quick_launch_single_click_get_app(button) != APP_ID_TIMELINE) {
-    //launch other quick launch apps
-    prv_launch_app_via_button(&(AppLaunchEventConfig) {
-      .id = quick_launch_single_click_get_app(button),
-      .common.reason = APP_LAUNCH_QUICK_LAUNCH,
-      .common.args = (void*)APP_QUICK_LAUNCH_ACTION_TAP,
-    }, recognizer);
-    return;
-  }
+  const AppInstallId app_id = quick_launch_single_click_get_app(button);
 
-  static TimelineArgs s_timeline_args;
-  const bool is_up = (click_recognizer_get_button_id(recognizer) == BUTTON_ID_UP);
-  if (is_up) {
-    PBL_LOG_DBG("Launching timeline in past mode.");
-    s_timeline_args.direction = TimelineIterDirectionPast;
-  } else {
-    PBL_LOG_DBG("Launching timeline in future mode.");
-    s_timeline_args.direction = TimelineIterDirectionFuture;
-  }
-  s_timeline_args.launch_into_pin = true;
-  s_timeline_args.stay_in_list_view = true;
-  timeline_peek_get_item_id(&s_timeline_args.pin_id);
-
-  const CompositorTransition *animation = NULL;
-  const bool is_future = (s_timeline_args.direction == TimelineIterDirectionFuture);
-  const bool timeline_is_destination = true;
-#if PBL_ROUND
-  animation = compositor_dot_transition_timeline_get(is_future, timeline_is_destination);
-#else
-  const bool jump = (!uuid_is_invalid(&s_timeline_args.pin_id) && !timeline_peek_is_first_event());
-  animation = jump ? compositor_peek_transition_timeline_get() :
-                     compositor_slide_transition_timeline_get(is_future, timeline_is_destination,
-                                                              timeline_peek_is_future_empty());
-#endif
-  prv_launch_app_via_button(&(AppLaunchEventConfig) {
-    .id = APP_ID_TIMELINE,
-    .common.args = &s_timeline_args,
-    .common.transition = animation,
-  }, recognizer);
+  prv_launch_quick_launch_app(app_id, recognizer, APP_LAUNCH_SYSTEM,
+                              (void*)APP_QUICK_LAUNCH_ACTION_TAP);
 }
 
 static void prv_configure_click_handler(ButtonId button_id, ClickHandler single_click_handler) {


### PR DESCRIPTION
After the changes in PebbleOS to add a full timeline app (the one with both past and future), I've found some buggy behaviour when scrolling the timeline, particularly when combined with Quick Launch.

Here's what I've found and fixed in this PR:
- Timeline Full uses the wrong animation direction when crossing the past/future boundary.
  Fixed by using the animation for the destination when switching.
- If Timeline Full is launched by either the Tap or Hold Up quick launch, it gets stuck in the past.
  Fixed by launching Timeline Future, instead of attempting to relaunch Timeline Full, which was blocked by the system.
- After Timeline Past is quick-launched, scrolling down takes you to the future, instead of back to the watchface.
  Fixed by correctly setting the launch arguments for all timeline quick launches.

Happy to split this into multiple PRs if needed, and feedback is of course greatly appreciated :)