### PR TITLE
phone_call: allow answering calls on Android (PP path)

### DIFF
--- a/src/fw/apps/demo/swap_layer/swap_layer_demo.c
+++ b/src/fw/apps/demo/swap_layer/swap_layer_demo.c
@@ -132,7 +132,7 @@ static void prv_show_incoming_call(void *data) {
     .number = "+55 408-555-1212",
     .name = "Pankajavalli Balamurugan",
   };
-  phone_ui_handle_incoming_call(&caller, true, false, PhoneCallSource_PP);
+  phone_ui_handle_incoming_call(&caller, false, PhoneCallSource_PP);
 }
 
 static void prv_select_single_click_handler(ClickRecognizerRef recognizer, void *context) {

--- a/src/fw/popups/phone_ui.c
+++ b/src/fw/popups/phone_ui.c
@@ -1053,8 +1053,8 @@ static bool prv_check_popups_are_blocked(void) {
 //!
 //! API for updating / creating the phone UI
 //!
-void phone_ui_handle_incoming_call(PebblePhoneCaller *caller, bool can_answer,
-                                   bool show_ongoing_call_ui, PhoneCallSource source) {
+void phone_ui_handle_incoming_call(PebblePhoneCaller *caller, bool show_ongoing_call_ui,
+                                   PhoneCallSource source) {
   if (prv_check_popups_are_blocked()) {
     return;
   }
@@ -1078,12 +1078,9 @@ void phone_ui_handle_incoming_call(PebblePhoneCaller *caller, bool can_answer,
     can_reply = prv_load_sms_reply_action(caller->number, source);
   }
 
-  uint8_t actions = PhoneCallActions_Decline;
+  uint8_t actions = PhoneCallActions_Decline | PhoneCallActions_Answer;
   if (can_reply) {
     actions |= PhoneCallActions_Reply;
-  }
-  if (can_answer) {
-    actions |= PhoneCallActions_Answer;
   }
   prv_action_bar_setup(actions);
 

--- a/src/fw/popups/phone_ui.h
+++ b/src/fw/popups/phone_ui.h
@@ -8,8 +8,8 @@
 
 #include <stdbool.h>
 
-void phone_ui_handle_incoming_call(PebblePhoneCaller *caller, bool can_answer,
-                                   bool show_ongoing_call_ui, PhoneCallSource source);
+void phone_ui_handle_incoming_call(PebblePhoneCaller *caller, bool show_ongoing_call_ui,
+                                   PhoneCallSource source);
 
 void phone_ui_handle_outgoing_call(PebblePhoneCaller *caller);
 

--- a/src/fw/services/phone_call/service.c
+++ b/src/fw/services/phone_call/service.c
@@ -88,11 +88,6 @@ static void prv_cancel_call_watchdog(void) {
   pp_get_phone_state_set_enabled(false);
 }
 
-static bool prv_can_answer(void) {
-  // We can't answer calls with Android
-  return prv_call_is_ancs();
-}
-
 static bool prv_should_show_ongoing_call_ui(void) {
   // We only want to show the ongoing call UI on Android
   return (s_call_source == PhoneCallSource_PP);
@@ -132,7 +127,7 @@ static void prv_handle_incoming_call(const PebblePhoneEvent *event) {
 
   prv_schedule_call_watchdog(600);
 
-  phone_ui_handle_incoming_call(event->caller, prv_can_answer(), prv_should_show_ongoing_call_ui(),
+  phone_ui_handle_incoming_call(event->caller, prv_should_show_ongoing_call_ui(),
                                 s_call_source);
   PBL_ANALYTICS_ADD(phone_call_incoming_count, 1);
   PBL_ANALYTICS_TIMER_START(phone_call_time_ms);

--- a/tests/fw/services/test_phone_call.c
+++ b/tests/fw/services/test_phone_call.c
@@ -44,8 +44,8 @@ void pp_get_phone_state_set_enabled(bool enabled) {}
 
 // Phone UI stubs that allow us to track what phone_call.c is doing
 static PhoneEventType s_last_phone_ui_event;
-void phone_ui_handle_incoming_call(PebblePhoneCaller *caller, bool can_answer,
-                                   bool show_ongoing_call_ui) {
+void phone_ui_handle_incoming_call(PebblePhoneCaller *caller, bool show_ongoing_call_ui,
+                                   PhoneCallSource source) {
   s_last_phone_ui_event = PhoneEventType_Incoming;
 }
 


### PR DESCRIPTION
## Summary

- `prv_can_answer()` returned `true` only when the call source was ANCS, suppressing the action-bar Answer affordance on the incoming-call window for any PP-sourced (Android) call.
- With `can_answer = false`, `phone_ui_handle_incoming_call` skipped `PhoneCallActions_Answer`, `prv_action_bar_setup` never wired the up button to `prv_answer_click_handler`, and the watch silently lacked an accept button on Android — even though the rest of the PP answer path (`pp_answer_call` → endpoint `0x21` cmd `0x01`) was intact and the companion app was wired to receive it.
- This patch returns `true` unconditionally, allowing the existing PP answer codepath to be reachable from the UI.

## Context

The original comment ("We can't answer calls with Android") referred to the legacy Pebble Android app, which pre-dated Android's Telecom framework. The current CoreApp companion handles inbound `PhoneControl.Answer` packets via `LibPebbleInCallService` (registered via `CompanionDeviceManager.AssociationRequest.DEVICE_PROFILE_WATCH` on Android 12+, with a notification-action fallback for older OS or VoIP apps where InCallService isn't bound).

End-to-end flow now works:
- phone rings → `LibPebbleInCallService.onCallAdded` → `libPebble.currentCall = RingingCall(onCallAnswer = { call.answer(...) })`
- `PhoneControlManager` observes `currentCall` → sends `PhoneControl.IncomingCall` on endpoint 33
- watch shows accept button ← **previously blocked here**
- user taps up → `pp_answer_call(cookie)` → `[0x01][cookie:4B]` on endpoint `0x21`
- `PhoneControlService` decodes → emits `CallAction.Answer` → `PhoneControlManager` invokes `call.answerCall()` → `call.answer(VideoProfile.STATE_AUDIO_ONLY)` → Android Telecom answers the call

## Test plan

- [x] Built `obelix_pvt` firmware with this patch, flashed to test watch
- [x] Verified accept button appears in action bar on incoming Android call
- [x] Verified tapping accept actually answers the call on the phone
- [ ] Verify no regression on ANCS (iOS) path — `prv_call_is_ancs()` branch in `phone_call_answer()` still routes iOS through ANCS, this only widens what the watch UI offers
- [ ] Sanity-check decline path is unchanged (still uses `prv_can_hangup` / PP `0x02` on Android)