### PR TITLE
fix build on nixos

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,12 @@
               pixman
               zlib
               stdenv.cc.cc.lib
+              SDL2
+              libpng
+              alsa-lib
+              libpulseaudio
+              # sftool host binary
+              systemd
             ]);
 
             dontConfigure = true;


### PR DESCRIPTION
This PR fixes `nix develop` shell and `./pbl build` commands on nixos.

- add necessary build-time dependencies to `flake.nix`
- bump moddable submodule for the inclusion of https://github.com/Moddable-OpenSource/moddable/commit/2c3a2b49918827b40795ee8a68162e838666fb10 (see https://github.com/Moddable-OpenSource/moddable/releases/tag/8.2.0)
