### PR TITLE
Feature/dual phone notifications

### DIFF
--- a/include/pbl/services/bluetooth/bluetooth_persistent_storage.h
+++ b/include/pbl/services/bluetooth/bluetooth_persistent_storage.h
@@ -65,10 +65,12 @@ bool bt_persistent_storage_get_ble_pairing_by_addr(const BTDeviceInternal *devic
                                                    SMIdentityResolvingKey *IRK_out,
                                                    char name_out[BT_DEVICE_NAME_BUFFER_SIZE]);
 
-//! Returns the first ANCS supported bonding that is found
-//! The case of having multiple supported ANCS bondings isn't handled well yet.
-//! When this happens this could easily be changed to a for_each_ancs_supported_bonding(cb)
+//! Returns the first ANCS supported bonding that is found.
 BTBondingID bt_persistent_storage_get_ble_ancs_bonding(void);
+
+//! Collects all BLE ANCS bondings into @p out, up to @p max_count entries.
+//! @return number of bondings written into @p out.
+int bt_persistent_storage_get_all_ble_ancs_bondings(BTBondingID *out, int max_count);
 
 //! Returns true if the bondings is BLE and supports ANCS
 bool bt_persistent_storage_is_ble_ancs_bonding(BTBondingID bonding);

--- a/src/fw/comm/ble/kernel_le_client/ancs/ancs.c
+++ b/src/fw/comm/ble/kernel_le_client/ancs/ancs.c
@@ -2,6 +2,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include "ancs.h"
+#include "comm/ble/kernel_le_client/multi_phone.h"
 #include "ancs_app_name_storage.h"
 #include "ancs_types.h"
 #include "ancs_util.h"
@@ -93,6 +94,9 @@ typedef struct {
 } NotificationQueueNode;
 
 typedef struct ANCSClient {
+  PhoneSlot slot;
+  bool just_connected;
+  RegularTimerInfo notification_connection_delay_timer;
   ANCSClientState state;
   BLECharacteristic characteristics[NumANCSCharacteristic];
   RegularTimerInfo is_alive_timer;
@@ -106,7 +110,19 @@ typedef struct ANCSClient {
   uint8_t alive_checks_without_ns;
 } ANCSClient;
 
+static ANCSClient *s_ancs_clients[MAX_PHONE_CONNECTIONS];
 static ANCSClient *s_ancs_client;
+
+static PhoneSlot prv_slot_for_characteristic(BLECharacteristic c) {
+  for (PhoneSlot slot = 0; slot < MAX_PHONE_CONNECTIONS; slot++) {
+    ANCSClient *client = s_ancs_clients[slot];
+    if (!client) continue;
+    for (int i = 0; i < NumANCSCharacteristic; i++) {
+      if (client->characteristics[i] == c) return slot;
+    }
+  }
+  return PHONE_SLOT_INVALID;
+}
 
 // -----------------------------------------------------------------------------
 // State Machine
@@ -274,7 +290,9 @@ static void prv_reset_and_idle(void) {
   prv_reset_reassembly_context();
 }
 
-static void prv_reset_and_retry(void *unused) {
+static void prv_reset_and_retry(void *data) {
+  PhoneSlot slot = (PhoneSlot)(uintptr_t)data;
+  s_ancs_client = s_ancs_clients[slot];
   if (s_ancs_client == NULL) {
     return;
   }
@@ -325,6 +343,7 @@ static void prv_is_ancs_alive_response_timeout(void *data);
 static void prv_ancs_is_alive_schedule_next_check(void) {
   s_ancs_client->is_alive_timer = (const RegularTimerInfo) {
     .cb = prv_is_ancs_alive_cb,
+    .cb_data = (void *)(uintptr_t)s_ancs_client->slot,
   };
   regular_timer_add_multiminute_callback(&s_ancs_client->is_alive_timer,
                                          ANCS_IS_ALIVE_NEXT_CHECK_TIME_MINUTES);
@@ -333,6 +352,7 @@ static void prv_ancs_is_alive_schedule_next_check(void) {
 static void prv_ancs_is_alive_start_response_wait_timer(void) {
   s_ancs_client->is_alive_timer = (const RegularTimerInfo) {
     .cb = prv_is_ancs_alive_response_timeout,
+    .cb_data = (void *)(uintptr_t)s_ancs_client->slot,
   };
   regular_timer_add_multisecond_callback(&s_ancs_client->is_alive_timer,
                                          ANCS_IS_ALIVE_RESPONSE_WAIT_TIME_SECONDS);
@@ -389,6 +409,8 @@ static void prv_resubscribe_to_ancs(void) {
 }
 
 static void prv_is_ancs_alive_response_timeout_launcher_task_cb(void *data) {
+  PhoneSlot slot = (PhoneSlot)(uintptr_t)data;
+  s_ancs_client = s_ancs_clients[slot];
   if (!s_ancs_client) {
     return;
   }
@@ -462,6 +484,8 @@ T_STATIC void prv_check_ancs_alive(void) {
 }
 
 static void prv_is_ancs_alive_launcher_task_cb(void *data) {
+  PhoneSlot slot = (PhoneSlot)(uintptr_t)data;
+  s_ancs_client = s_ancs_clients[slot];
   if (!s_ancs_client) {
     return;
   }
@@ -479,25 +503,26 @@ static void prv_is_ancs_alive_cb(void *data) {
 // -----------------------------------------------------------------------------
 //! With iOS 8.2 the pre-existing flag seems to be broken. Don't allow notifications for a bit after
 //! reconnection so that all the "real" pre-existing notification don't come through again.
-static RegularTimerInfo s_notification_connection_delay_timer;
-static bool s_just_connected = false;
-
 static void prv_set_no_longer_just_connected(void *data) {
-  s_just_connected = false;
-  regular_timer_remove_callback(&s_notification_connection_delay_timer);
+  PhoneSlot slot = (PhoneSlot)(uintptr_t)data;
+  ANCSClient *client = s_ancs_clients[slot];
+  if (!client) return;
+  client->just_connected = false;
+  regular_timer_remove_callback(&client->notification_connection_delay_timer);
 }
 
 static void prv_start_temp_notification_connection_delay_timer(void) {
-  if (regular_timer_is_scheduled(&s_notification_connection_delay_timer)) {
-    regular_timer_remove_callback(&s_notification_connection_delay_timer);
+  if (regular_timer_is_scheduled(&s_ancs_client->notification_connection_delay_timer)) {
+    regular_timer_remove_callback(&s_ancs_client->notification_connection_delay_timer);
   }
-  s_just_connected = true;
+  s_ancs_client->just_connected = true;
 
   const int post_connection_notification_ignore_seconds = 10;
-  s_notification_connection_delay_timer = (const RegularTimerInfo) {
+  s_ancs_client->notification_connection_delay_timer = (const RegularTimerInfo) {
     .cb = prv_set_no_longer_just_connected,
+    .cb_data = (void *)(uintptr_t)s_ancs_client->slot,
   };
-  regular_timer_add_multisecond_callback(&s_notification_connection_delay_timer,
+  regular_timer_add_multisecond_callback(&s_ancs_client->notification_connection_delay_timer,
                                          post_connection_notification_ignore_seconds);
 }
 
@@ -775,7 +800,8 @@ static void prv_get_notification_attributes(uint32_t uid) {
       prv_reset_and_flush();
     } else {
       prv_set_state(ANCSClientStateRetrying);
-      evented_timer_register(ANCS_RETRY_TIME_MS, false, prv_reset_and_retry, NULL);
+      evented_timer_register(ANCS_RETRY_TIME_MS, false, prv_reset_and_retry,
+                             (void *)(uintptr_t)s_ancs_client->slot);
     }
   }
 }
@@ -830,6 +856,9 @@ static void prv_put_ancs_disconnected_event(void) {
 // Catching the subscription (CCCD write) confirmation for analytics purposes:
 void ancs_handle_subscribe(BLECharacteristic subscribed_characteristic,
                            BLESubscription subscription_type, BLEGATTError error) {
+  PhoneSlot slot = prv_slot_for_characteristic(subscribed_characteristic);
+  if (slot == PHONE_SLOT_INVALID) return;
+  s_ancs_client = s_ancs_clients[slot];
   ANCSCharacteristic characteristic_id = prv_get_id_for_characteristic(subscribed_characteristic);
   if (characteristic_id != ANCSCharacteristicNotification &&
       characteristic_id != ANCSCharacteristicData) {
@@ -849,13 +878,20 @@ void ancs_handle_subscribe(BLECharacteristic subscribed_characteristic,
   }
 }
 
-void ancs_invalidate_all_references(void) {
+void ancs_invalidate_all_references_for_slot(PhoneSlot slot) {
+  s_ancs_client = s_ancs_clients[slot];
+  if (!s_ancs_client) return;
   for (int c = 0; c < NumANCSCharacteristic; c++) {
     s_ancs_client->characteristics[c] = BLE_CHARACTERISTIC_INVALID;
   }
-
   prv_reset_and_flush();
   prv_put_ancs_disconnected_event();
+}
+
+void ancs_invalidate_all_references(void) {
+  for (PhoneSlot slot = 0; slot < MAX_PHONE_CONNECTIONS; slot++) {
+    ancs_invalidate_all_references_for_slot(slot);
+  }
 }
 
 void ancs_handle_service_removed(BLECharacteristic *characteristics, uint8_t num_characteristics) {
@@ -863,7 +899,8 @@ void ancs_handle_service_removed(BLECharacteristic *characteristics, uint8_t num
   ancs_invalidate_all_references();
 }
 
-void ancs_handle_service_discovered(BLECharacteristic *characteristics) {
+void ancs_handle_service_discovered(BLECharacteristic *characteristics, PhoneSlot slot) {
+  s_ancs_client = s_ancs_clients[slot];
   BLE_LOG_DEBUG("In ANCS service discovery CB");
   PBL_ASSERTN(characteristics); // should only be called if we found something!
 
@@ -894,15 +931,7 @@ void ancs_handle_service_discovered(BLECharacteristic *characteristics) {
 }
 
 bool ancs_can_handle_characteristic(BLECharacteristic characteristic) {
-  if (!s_ancs_client) {
-    return false;
-  }
-  for (int c = 0; c < NumANCSCharacteristic; ++c) {
-    if (s_ancs_client->characteristics[c] == characteristic) {
-      return true;
-    }
-  }
-  return false;
+  return prv_slot_for_characteristic(characteristic) != PHONE_SLOT_INVALID;
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -957,7 +986,7 @@ static void prv_handle_ns_notification(uint32_t length, const uint8_t *notificat
       // By skipping the pre-existing check we will re-recieve all the notifications
       // we got in the past 2 hours. To get past this ignore notifications for the first couple
       // seconds after connecting
-      if (s_just_connected && (nsnotification->event_flags & EventFlagPreExisting)) {
+      if (s_ancs_client->just_connected && (nsnotification->event_flags & EventFlagPreExisting)) {
         BLE_LOG_DEBUG("Ignoring notification because we just connected and PreExisting");
       } else {
         BLE_LOG_DEBUG("Added ANCS notification!");
@@ -995,6 +1024,9 @@ static void prv_handle_ds_notification(uint32_t length, const uint8_t *data) {
 
 void ancs_handle_read_or_notification(BLECharacteristic characteristic, const uint8_t *value,
                                       size_t value_length, BLEGATTError error) {
+  PhoneSlot slot = prv_slot_for_characteristic(characteristic);
+  if (slot == PHONE_SLOT_INVALID) return;
+  s_ancs_client = s_ancs_clients[slot];
   if (error != BLEGATTErrorSuccess) {
     PBL_LOG_ERR("Read or notification error: %d", error);
     prv_reset_due_to_bt_error();
@@ -1020,6 +1052,9 @@ void ancs_handle_read_or_notification(BLECharacteristic characteristic, const ui
 // Writing commands to the ANCS Control Point
 
 void ancs_handle_write_response(BLECharacteristic characteristic, BLEGATTError error) {
+  PhoneSlot slot = prv_slot_for_characteristic(characteristic);
+  if (slot == PHONE_SLOT_INVALID) return;
+  s_ancs_client = s_ancs_clients[slot];
   if (error == ANCS_INVALID_PARAM) {
     if (s_ancs_client->state == ANCSClientStateAliveCheck) {
       // We got a response so cancel the response wait timer and setup another check.
@@ -1082,12 +1117,17 @@ static void prv_perform_action(uint32_t notification_uid, ActionId action_id) {
 }
 
 static void prv_serialize_action(const PerformNotificationActionMsg *action_msg) {
-  if (!s_ancs_client) {
-    PBL_LOG_ERR("No ANCS client");
-    return;
+  bool any_client = false;
+  for (PhoneSlot slot = 0; slot < MAX_PHONE_CONNECTIONS; slot++) {
+    if (s_ancs_clients[slot]) {
+      s_ancs_client = s_ancs_clients[slot];
+      any_client = true;
+      prv_notif_queue_push_action(action_msg->notification_uid, action_msg->action_id);
+    }
   }
-
-  prv_notif_queue_push_action(action_msg->notification_uid, action_msg->action_id);
+  if (!any_client) {
+    PBL_LOG_ERR("No ANCS client");
+  }
 }
 
 void prv_serialize_action_launcher_task_cb(void *data) {
@@ -1115,32 +1155,43 @@ void ancs_perform_action(uint32_t notification_uid, uint8_t action_id) {
 }
 
 void ancs_handle_ios9_or_newer_detected(void) {
-  // The ANCSClient is created as soon as the gateway is connected (see kernel_le_client.c).
-  PBL_ASSERTN(s_ancs_client);
-  s_ancs_client->version = ANCSVersion_iOS9OrNewer;
+  for (PhoneSlot slot = 0; slot < MAX_PHONE_CONNECTIONS; slot++) {
+    if (s_ancs_clients[slot]) {
+      s_ancs_clients[slot]->version = ANCSVersion_iOS9OrNewer;
+    }
+  }
 }
 
 // -------------------------------------------------------------------------------------------------
 // Lifecyle
 
-void ancs_create(void) {
-  PBL_ASSERTN(s_ancs_client == NULL);
-  s_ancs_client = (ANCSClient *) kernel_zalloc_check(sizeof(ANCSClient));
+void ancs_create(PhoneSlot slot) {
+  PBL_ASSERTN(s_ancs_clients[slot] == NULL);
+  s_ancs_clients[slot] = (ANCSClient *) kernel_zalloc_check(sizeof(ANCSClient));
+  s_ancs_client = s_ancs_clients[slot];
+  s_ancs_client->slot = slot;
   buffer_init(&s_ancs_client->reassembly_ctx.buffer,
               sizeof(s_ancs_client->reassembly_ctx.buffer_storage));
-  ancs_app_name_storage_init();
+  if (slot == 0) {
+    ancs_app_name_storage_init();
+  }
 }
 
-void ancs_destroy(void) {
+void ancs_destroy(PhoneSlot slot) {
+  s_ancs_client = s_ancs_clients[slot];
   if (!s_ancs_client) {
     return;
   }
   prv_ancs_is_alive_stop_timer();
-
-  ancs_app_name_storage_deinit();
-
+  if (regular_timer_is_scheduled(&s_ancs_client->notification_connection_delay_timer)) {
+    regular_timer_remove_callback(&s_ancs_client->notification_connection_delay_timer);
+  }
+  if (slot == 0) {
+    ancs_app_name_storage_deinit();
+  }
   prv_reset_and_flush();
   kernel_free(s_ancs_client);
+  s_ancs_clients[slot] = NULL;
   s_ancs_client = NULL;
   prv_put_ancs_disconnected_event();
 }

--- a/src/fw/comm/ble/kernel_le_client/ancs/ancs.h
+++ b/src/fw/comm/ble/kernel_le_client/ancs/ancs.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "applib/bluetooth/ble_client.h"
+#include "comm/ble/kernel_le_client/multi_phone.h"
 
 //! @file ancs.h Module implementing an ANCS client.
 //! See http://bit.ly/ancs-spec for Apple's documentation of ANCS
@@ -32,17 +33,23 @@ typedef enum {
   ANCSCharacteristicInvalid = NumANCSCharacteristic,
 } ANCSCharacteristic;
 
-//! Creates the ANCS client.
+//! Creates the ANCS client for the given phone slot.
 //! Must only be called from KernelMain!
-void ancs_create(void);
+void ancs_create(PhoneSlot slot);
 
 //! Updates the BLECharacteristic references, in case new ones have been obtained after a
 //! re-discovery of the remote services.
 //! @param characteristics Matrix of characteristics references of the ANCS service(s)
+//! @param slot            Phone slot (0..MAX_PHONE_CONNECTIONS-1) owning this service
 //! @note This module only uses the first service instance, any others will be ignored.
 //! Must only be called from KernelMain!
-void ancs_handle_service_discovered(BLECharacteristic *characteristics);
+void ancs_handle_service_discovered(BLECharacteristic *characteristics, PhoneSlot slot);
 
+//! Invalidates all ANCS characteristic references for a given phone slot.
+void ancs_invalidate_all_references_for_slot(PhoneSlot slot);
+
+//! Invalidates all ANCS characteristic references across all slots.
+//! Legacy wrapper kept for callers that don't yet carry slot context.
 void ancs_invalidate_all_references(void);
 
 void ancs_handle_service_removed(BLECharacteristic *characteristics, uint8_t num_characteristics);
@@ -68,9 +75,9 @@ void ancs_handle_subscribe(BLECharacteristic characteristic,
 void ancs_handle_read_or_notification(BLECharacteristic characteristic, const uint8_t *value,
                                       size_t value_length, BLEGATTError error);
 
-//! Destroys the ANCS client.
+//! Destroys the ANCS client for the given phone slot.
 //! Must only be called from KernelMain!
-void ancs_destroy(void);
+void ancs_destroy(PhoneSlot slot);
 
 //! This function is safe to call from any task.
 void ancs_perform_action(uint32_t notification_uid, uint8_t action_id);

--- a/src/fw/comm/ble/kernel_le_client/kernel_le_client.c
+++ b/src/fw/comm/ble/kernel_le_client/kernel_le_client.c
@@ -2,6 +2,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include "kernel_le_client.h"
+#include "multi_phone.h"
 
 #include "ancs/ancs_definition.h"
 #include "ams/ams_definition.h"
@@ -33,8 +34,48 @@
 #include "comm/ble/gatt_client_subscriptions.h"
 
 #include <bluetooth/pebble_bt.h>
+#include <btutil/bt_device.h>
 
 #define MAX_SERVICE_INSTANCES (8)
+
+typedef struct {
+  bool active;
+  BTDeviceInternal device;
+} PhoneSlotInfo;
+
+static PhoneSlotInfo s_phone_slots[MAX_PHONE_CONNECTIONS];
+static PhoneSlot s_discovery_slot = PHONE_SLOT_INVALID;
+
+static void prv_ancs_handle_service_discovered_cb(BLECharacteristic *characteristics) {
+  ancs_handle_service_discovered(characteristics, s_discovery_slot);
+}
+
+static PhoneSlot prv_slot_for_device(const BTDeviceInternal *device) {
+  for (PhoneSlot slot = 0; slot < MAX_PHONE_CONNECTIONS; slot++) {
+    if (s_phone_slots[slot].active &&
+        bt_device_internal_equal(&s_phone_slots[slot].device, device)) {
+      return slot;
+    }
+  }
+  return PHONE_SLOT_INVALID;
+}
+
+static PhoneSlot prv_alloc_slot(const BTDeviceInternal *device) {
+  for (PhoneSlot slot = 0; slot < MAX_PHONE_CONNECTIONS; slot++) {
+    if (!s_phone_slots[slot].active) {
+      s_phone_slots[slot].active = true;
+      s_phone_slots[slot].device = *device;
+      return slot;
+    }
+  }
+  return PHONE_SLOT_INVALID;
+}
+
+static void prv_free_slot(PhoneSlot slot) {
+  if (slot < MAX_PHONE_CONNECTIONS) {
+    s_phone_slots[slot] = (PhoneSlotInfo){};
+  }
+}
 
 //! Array indices for the different client "classes"
 enum {
@@ -121,7 +162,7 @@ static const KernelLEClient s_clients[KernelLEClientNum] = {
     .service_uuid = &s_ancs_service_uuid,
     .characteristic_uuids = s_ancs_characteristic_uuids,
     .num_characteristics = NumANCSCharacteristic,
-    .handle_service_discovered = ancs_handle_service_discovered,
+    .handle_service_discovered = prv_ancs_handle_service_discovered_cb,
     .handle_service_removed = ancs_handle_service_removed,
     .invalidate_all_references = ancs_invalidate_all_references,
     .can_handle_characteristic = ancs_can_handle_characteristic,
@@ -206,6 +247,7 @@ static void prv_handle_all_services_invalidated(void) {
 
 static void prv_handle_services_added(
     PebbleBLEGATTClientServicesAdded *added_services, BTDeviceInternal *device) {
+  s_discovery_slot = prv_slot_for_device(device);
   // loop through the new services
   for (int s = 0; s < added_services->num_services_added; s++) {
     // get the uuid for the service
@@ -249,6 +291,7 @@ static void prv_handle_services_added(
       client->handle_service_discovered(characteristics);
     }
   }
+  s_discovery_slot = PHONE_SLOT_INVALID;
 }
 
 static void prv_handle_gatt_service_discovery_event(const PebbleBLEGATTClientServiceEvent *event) {
@@ -440,18 +483,33 @@ static void prv_handle_connection_event(const PebbleBLEConnectionEvent *event) {
   if (connected) {
     PBL_LOG_DBG("Connected to Gateway!");
 
-    ancs_create();
-    ams_create();
-    ppogatt_create();
+    PhoneSlot slot = prv_alloc_slot(&device);
+    if (slot == PHONE_SLOT_INVALID) {
+      PBL_LOG_WRN("No free phone slot for new connection");
+      return;
+    }
+
+    ancs_create(slot);
+    if (slot == 0) {
+      ams_create();
+      ppogatt_create();
+    }
 
     gap_le_slave_reconnect_stop();
     gatt_client_discovery_discover_all(&device);
 
   } else {
     PBL_LOG_DBG("Disconnected from Gateway!");
-    ppogatt_destroy();
-    ams_destroy();
-    ancs_destroy();
+
+    PhoneSlot slot = prv_slot_for_device(&device);
+    if (slot == 0) {
+      ppogatt_destroy();
+      ams_destroy();
+    }
+    if (slot != PHONE_SLOT_INVALID) {
+      ancs_destroy(slot);
+      prv_free_slot(slot);
+    }
     app_launch_handle_disconnection();
     gap_le_slave_reconnect_start();
     gatt_client_op_cleanup(GAPLEClientKernel);
@@ -498,7 +556,9 @@ static void prv_cancel_connect_gateway_bonding(BTBondingID gateway_bonding) {
 
 // -------------------------------------------------------------------------------------------------
 static void prv_cleanup_clients_kernel_main_cb(void *unused) {
-  ancs_destroy();
+  for (PhoneSlot slot = 0; slot < MAX_PHONE_CONNECTIONS; slot++) {
+    ancs_destroy(slot);
+  }
   ams_destroy();
 }
 
@@ -518,9 +578,10 @@ void kernel_le_client_init(void) {
   // Reset analytics
   ppogatt_reset_disconnect_counter();
 
-  BTBondingID gateway_bonding = bt_persistent_storage_get_ble_ancs_bonding();
-  if (gateway_bonding != BT_BONDING_ID_INVALID) {
-    prv_connect_gateway_bonding(gateway_bonding);
+  BTBondingID bondings[MAX_PHONE_CONNECTIONS];
+  int count = bt_persistent_storage_get_all_ble_ancs_bondings(bondings, MAX_PHONE_CONNECTIONS);
+  for (int i = 0; i < count; i++) {
+    prv_connect_gateway_bonding(bondings[i]);
   }
 }
 

--- a/src/fw/comm/ble/kernel_le_client/multi_phone.h
+++ b/src/fw/comm/ble/kernel_le_client/multi_phone.h
@@ -1,0 +1,12 @@
+/* SPDX-FileCopyrightText: 2024 Google LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+//! Maximum number of phones that can be simultaneously connected.
+#define MAX_PHONE_CONNECTIONS 2
+
+//! Identifies which phone slot (0 or 1) a connection occupies.
+typedef uint8_t PhoneSlot;
+
+#define PHONE_SLOT_INVALID 0xFF

--- a/src/fw/services/bluetooth/bluetooth_persistent_storage_normal.c
+++ b/src/fw/services/bluetooth/bluetooth_persistent_storage_normal.c
@@ -2,6 +2,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include "pbl/services/bluetooth/bluetooth_persistent_storage.h"
+#include "comm/ble/kernel_le_client/multi_phone.h"
 #include "pbl/services/bluetooth/bluetooth_persistent_storage_debug.h"
 
 #include "comm/ble/gap_le_connect.h"
@@ -680,7 +681,7 @@ static void prv_prune_stale_ble_bondings(void) {
   };
   prv_file_each(prv_find_most_recent_ble_bonding_itr, &itr_data);
 
-  if (itr_data.ble_count <= 1 || itr_data.key_out == BT_BONDING_ID_INVALID) {
+  if (itr_data.ble_count <= MAX_PHONE_CONNECTIONS || itr_data.key_out == BT_BONDING_ID_INVALID) {
     return;
   }
 
@@ -770,10 +771,8 @@ BTBondingID bt_persistent_storage_store_ble_pairing(const SMPairingInfo *new_pai
 
   prv_call_ble_bonding_change_handlers(key, op);
 
-  // We only support a single BLE pairing at a time. Drop any previous BLE bonding so that
-  // re-pairing with a different phone (or merging a PRF pairing) replaces the old one instead of
-  // leaving it behind and forcing the user to forget it manually.
-  prv_delete_other_ble_bondings(key);
+  // Drop excess BLE bondings so the DB never exceeds MAX_PHONE_CONNECTIONS entries.
+  prv_prune_stale_ble_bondings();
 
   return key;
 }
@@ -1066,6 +1065,33 @@ BTBondingID bt_persistent_storage_get_ble_ancs_bonding(void) {
   prv_file_each(prv_get_first_ancs_bonding_itr, &first_ancs_supported_bonding_found);
 
   return first_ancs_supported_bonding_found;
+}
+
+typedef struct {
+  BTBondingID *out;
+  int max_count;
+  int count;
+} AllAncsItrData;
+
+static bool prv_collect_all_ancs_bondings_itr(SettingsFile *file, SettingsRecordInfo *info,
+                                               void *context) {
+  if (info->val_len == 0 || info->key_len != sizeof(BTBondingID)) return true;
+  AllAncsItrData *data = context;
+  if (data->count >= data->max_count) return false;
+  BTBondingID key;
+  info->get_key(file, (uint8_t *)&key, info->key_len);
+  BtPersistBondingData stored_data;
+  info->get_val(file, (uint8_t *)&stored_data, MIN((unsigned)info->val_len, sizeof(stored_data)));
+  if (stored_data.type == BtPersistBondingTypeBLE && stored_data.ble_data.supports_ancs) {
+    data->out[data->count++] = key;
+  }
+  return true;
+}
+
+int bt_persistent_storage_get_all_ble_ancs_bondings(BTBondingID *out, int max_count) {
+  AllAncsItrData data = { .out = out, .max_count = max_count, .count = 0 };
+  prv_file_each(prv_collect_all_ancs_bondings_itr, &data);
+  return data.count;
 }
 
 bool bt_persistent_storage_is_ble_ancs_bonding(BTBondingID bonding) {


### PR DESCRIPTION
## Summary

- Add `multi_phone.h` with `PhoneSlot` type and `MAX_PHONE_CONNECTIONS=2`
- Refactor `ancs.c` to maintain a per-slot array of `ANCSClient` instances; GATT events are routed to the correct slot via characteristic lookup
- Update `kernel_le_client.c` with per-connection slot tracking and a service-discovery shim that passes slot context to ANCS; AMS and PPoGATT remain slot-0 only
- Add `bt_persistent_storage_get_all_ble_ancs_bondings()` and relax stale-bonding pruning to retain up to `MAX_PHONE_CONNECTIONS` entries

## Test plan

- [ ] Pair two iOS phones simultaneously and verify notifications arrive from both
- [ ] Disconnect one phone, verify the other continues delivering notifications
- [ ] Reconnect the disconnected phone, verify both resume
- [ ] Verify ANCS action (dismiss/reply) works with two phones connected
- [ ] Verify single-phone behavior is unchanged
