### PR TITLE
tools/gitlint: enforce Signed-off-by matches commit author

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,4 +1,5 @@
 [general]
+extra-path=tools/gitlint
 contrib=contrib-body-requires-signed-off-by,contrib-disallow-cleanup-commits
 ignore-merge-commits=false
 ignore-fixup-commits=false

--- a/tools/gitlint/signoff_matches_author.py
+++ b/tools/gitlint/signoff_matches_author.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from gitlint.rules import CommitRule, RuleViolation
+
+SIGNOFF_PREFIX = "signed-off-by:"
+
+
+class SignoffMatchesAuthor(CommitRule):
+    name = "signoff-matches-author"
+    id = "UC1"
+
+    def validate(self, commit):
+        if not commit.author_name and not commit.author_email:
+            # No commit metadata (e.g. linting piped stdin); nothing to check.
+            return
+
+        expected = f"{commit.author_name} <{commit.author_email}>"
+        signoffs = [
+            line.strip()[len(SIGNOFF_PREFIX) :].strip()
+            for line in commit.message.body
+            if line.strip().lower().startswith(SIGNOFF_PREFIX)
+        ]
+
+        if not signoffs:
+            # Absence is handled by contrib-body-requires-signed-off-by.
+            return
+
+        if expected not in signoffs:
+            return [
+                RuleViolation(
+                    self.id,
+                    f"Signed-off-by does not match commit author '{expected}'",
+                    line_nr=1,
+                )
+            ]


### PR DESCRIPTION
Add a gitlint user-defined rule (UC1) that fails a commit when its Signed-off-by trailer does not match the commit author. Wire it in via extra-path in .gitlint so it runs by default. Absence of a sign-off is still handled by contrib-body-requires-signed-off-by; the rule no-ops when no commit author metadata is available (e.g. piped stdin).