### PR TITLE
tools/gitlint: author name and blocked email domain rules

### DIFF
--- a/tools/gitlint/author_name_words.py
+++ b/tools/gitlint/author_name_words.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from gitlint.rules import CommitRule, RuleViolation
+
+
+class AuthorNameWords(CommitRule):
+    name = "author-name-words"
+    id = "UC2"
+
+    def validate(self, commit):
+        if not commit.author_name:
+            # No commit metadata (e.g. linting piped stdin); nothing to check.
+            return
+
+        if len(commit.author_name.split()) < 2:
+            return [
+                RuleViolation(
+                    self.id,
+                    f"Author name '{commit.author_name}' must contain at least 2 words",
+                    line_nr=1,
+                )
+            ]

--- a/tools/gitlint/blocked_email_domains.py
+++ b/tools/gitlint/blocked_email_domains.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+from gitlint.rules import CommitRule, RuleViolation
+
+BLOCKLIST_FILE = Path(__file__).with_name("blocked_email_domains.txt")
+
+
+def _load_blocked_domains():
+    domains = set()
+    for line in BLOCKLIST_FILE.read_text().splitlines():
+        line = line.split("#", 1)[0].strip().lower()
+        if line:
+            domains.add(line.lstrip("@"))
+    return domains
+
+
+class BlockedEmailDomains(CommitRule):
+    name = "blocked-email-domains"
+    id = "UC3"
+
+    def validate(self, commit):
+        if not commit.author_email:
+            # No commit metadata (e.g. linting piped stdin); nothing to check.
+            return
+
+        domain = commit.author_email.rsplit("@", 1)[-1].lower()
+        if domain in _load_blocked_domains():
+            return [
+                RuleViolation(
+                    self.id,
+                    f"Author email domain '{domain}' is blocked",
+                    line_nr=1,
+                )
+            ]

--- a/tools/gitlint/blocked_email_domains.txt
+++ b/tools/gitlint/blocked_email_domains.txt
@@ -1,0 +1,3 @@
+# Blocked author email domains, one per line.
+# Lines starting with '#' and blank lines are ignored.
+users.noreply.github.com


### PR DESCRIPTION
Two new gitlint user-defined rules, auto-loaded via the existing `extra-path=tools/gitlint`:

- **UC2 `author-name-words`** — fails a commit when the author name has fewer than 2 whitespace-separated words.
- **UC3 `blocked-email-domains`** — fails a commit when the author email domain appears in a blocklist. The blocklist lives in `tools/gitlint/blocked_email_domains.txt` (one domain per line, `#` comments and blank lines ignored), seeded with `users.noreply.github.com`. Add domains by editing the file — no code change needed.

Both rules no-op when no author metadata is available (e.g. piped stdin), matching the existing UC1 rule's behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)