### PR TITLE
fw/applib/ui: extract day_picker as reusable component from alarm_editor

### DIFF
--- a/src/fw/applib/ui/day_picker.c
+++ b/src/fw/applib/ui/day_picker.c
@@ -1,0 +1,367 @@
+/* SPDX-FileCopyrightText: 2024 Google LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "applib/ui/day_picker.h"
+
+#include "applib/pbl_std/timelocal.h"
+#include "applib/ui/app_window_stack.h"
+#include "applib/ui/menu_layer.h"
+#include "kernel/pbl_malloc.h"
+#include "pbl/services/i18n/i18n.h"
+#include "resource/resource_ids.auto.h"
+#include "shell/prefs.h"
+#include "system/passert.h"
+#include "util/size.h"
+
+#include <string.h>
+
+#define DAY_PICKER_CELL_HEIGHT PBL_IF_RECT_ELSE(menu_cell_small_cell_height(), \
+                                                   menu_cell_basic_cell_height())
+
+typedef struct {
+  Window window;
+  MenuLayer menu_layer;
+  DayPickerResult initial;
+  DayPickerCallback callback;
+  void *callback_context;
+  GColor highlight_color;
+  bool allow_once;
+} DayPickerData;
+
+typedef struct {
+  Window window;
+  MenuLayer menu_layer;
+  bool scheduled_days[DAYS_PER_WEEK];
+  GBitmap deselected_icon;
+  GBitmap selected_icon;
+  GBitmap checkmark_icon;
+  uint32_t current_checkmark_icon_resource_id;
+  bool show_check_something_first_text;
+  bool was_completed;
+  DayPickerCallback callback;
+  void *callback_context;
+  GColor highlight_color;
+} CustomDayPickerData;
+
+static const char *prv_kind_strings[DayPickerKindNumItems] = {
+  [DayPickerKindEveryday] = "Every Day",
+  [DayPickerKindWeekdays] = "Weekdays",
+  [DayPickerKindWeekends] = "Weekends",
+  [DayPickerKindCustom] = "Custom",
+  [DayPickerKindJustOnce] = "Just Once",
+};
+
+const char *day_picker_kind_get_string(DayPickerKind kind) {
+  if (kind >= DayPickerKindNumItems) {
+    return "";
+  }
+  return i18n_noop(prv_kind_strings[kind]);
+}
+
+static DayPickerKind prv_row_to_kind(bool allow_once, int row) {
+  if (allow_once) {
+    if (row == 0) {
+      return DayPickerKindJustOnce;
+    }
+    int kind_row = row - 1;
+    if (kind_row >= 0 && kind_row < (DayPickerKindNumItems - 1)) {
+      return (DayPickerKind)kind_row;
+    }
+    return DayPickerKindEveryday;
+  }
+  if (row >= 0 && row < (DayPickerKindNumItems - 1)) {
+    return (DayPickerKind)row;
+  }
+  return DayPickerKindEveryday;
+}
+
+static int prv_kind_to_row(bool allow_once, DayPickerKind kind) {
+  if (allow_once) {
+    if (kind == DayPickerKindJustOnce) {
+      return 0;
+    }
+    return (int)kind + 1;
+  }
+  if (kind == DayPickerKindJustOnce) {
+    return 0;
+  }
+  return (int)kind;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+//! Day Picker (kind selection)
+
+static uint16_t prv_day_picker_get_num_sections(struct MenuLayer *menu_layer,
+                                                 void *callback_context) {
+  return 1;
+}
+
+static uint16_t prv_day_picker_get_num_rows(struct MenuLayer *menu_layer,
+                                             uint16_t section_index,
+                                             void *callback_context) {
+  DayPickerData *data = (DayPickerData *)callback_context;
+  return (DayPickerKindNumItems - 1) + (data->allow_once ? 1 : 0);
+}
+
+static int16_t prv_day_picker_get_cell_height(struct MenuLayer *menu_layer,
+                                               MenuIndex *cell_index,
+                                               void *callback_context) {
+  return DAY_PICKER_CELL_HEIGHT;
+}
+
+static void prv_day_picker_draw_row(GContext *ctx, const Layer *cell_layer,
+                                    MenuIndex *cell_index, void *callback_context) {
+  DayPickerData *data = (DayPickerData *)callback_context;
+  DayPickerKind kind = prv_row_to_kind(data->allow_once, cell_index->row);
+  const char *cell_text = i18n_get(day_picker_kind_get_string(kind), &data->window);
+  menu_cell_basic_draw(ctx, cell_layer, cell_text, NULL, NULL);
+}
+
+static void prv_day_picker_handle_selection(MenuLayer *menu_layer, MenuIndex *cell_index,
+                                            void *callback_context) {
+  DayPickerData *data = (DayPickerData *)callback_context;
+  DayPickerKind kind = prv_row_to_kind(data->allow_once, cell_index->row);
+  DayPickerResult result = {
+    .kind = kind,
+  };
+  memset(result.custom_days, 0, sizeof(result.custom_days));
+
+  if (kind == DayPickerKindCustom) {
+    bool initial_days[DAYS_PER_WEEK] = {false};
+    if (data->initial.kind == DayPickerKindCustom) {
+      memcpy(initial_days, data->initial.custom_days, sizeof(initial_days));
+    }
+    custom_day_picker_push(initial_days, data->callback, data->callback_context,
+                          data->highlight_color);
+    app_window_stack_remove(&data->window, true);
+    return;
+  }
+
+  if (data->callback) {
+    data->callback(result, data->callback_context);
+  }
+  app_window_stack_remove(&data->window, true);
+}
+
+static void prv_day_picker_window_unload(Window *window) {
+  DayPickerData *data = (DayPickerData *)window_get_user_data(window);
+  menu_layer_deinit(&data->menu_layer);
+  i18n_free_all(&data->window);
+  task_free(data);
+}
+
+void day_picker_push(DayPickerConfig config, DayPickerCallback callback,
+                     void *context) {
+  DayPickerData *data = task_malloc_check(sizeof(DayPickerData));
+  *data = (DayPickerData){
+    .initial = config.initial,
+    .callback = callback,
+    .callback_context = context,
+    .highlight_color = config.highlight_color,
+    .allow_once = config.allow_once,
+  };
+
+  window_init(&data->window, WINDOW_NAME("Day Picker"));
+  window_set_user_data(&data->window, data);
+  data->window.window_handlers.unload = prv_day_picker_window_unload;
+
+  GRect bounds = data->window.layer.bounds;
+#if PBL_ROUND
+  bounds = grect_inset_internal(bounds, 0, STATUS_BAR_LAYER_HEIGHT);
+#endif
+  menu_layer_init(&data->menu_layer, &bounds);
+  menu_layer_set_callbacks(&data->menu_layer, data, &(MenuLayerCallbacks){
+    .get_num_sections = prv_day_picker_get_num_sections,
+    .get_num_rows = prv_day_picker_get_num_rows,
+    .get_cell_height = prv_day_picker_get_cell_height,
+    .draw_row = prv_day_picker_draw_row,
+    .select_click = prv_day_picker_handle_selection,
+  });
+  menu_layer_set_highlight_colors(&data->menu_layer, config.highlight_color, GColorWhite);
+  menu_layer_set_click_config_onto_window(&data->menu_layer, &data->window);
+  menu_layer_set_scroll_wrap_around(&data->menu_layer,
+                                    shell_prefs_get_menu_scroll_wrap_around_enable());
+  menu_layer_set_scroll_vibe_on_wrap(&data->menu_layer,
+                                     shell_prefs_get_menu_scroll_vibe_behavior() == MenuScrollVibeOnWrapAround);
+  menu_layer_set_scroll_vibe_on_blocked(&data->menu_layer,
+                                        shell_prefs_get_menu_scroll_vibe_behavior() == MenuScrollVibeOnLocked);
+  layer_add_child(&data->window.layer, menu_layer_get_layer(&data->menu_layer));
+
+  uint16_t selected_row = (uint16_t)prv_kind_to_row(config.allow_once, config.initial.kind);
+  menu_layer_set_selected_index(&data->menu_layer,
+                                (MenuIndex){.row = selected_row},
+                                MenuRowAlignCenter, false);
+
+  app_window_stack_push(&data->window, true);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+//! Custom Day Picker (day-of-week toggle)
+
+static bool prv_is_custom_day_scheduled(CustomDayPickerData *data) {
+  for (unsigned int i = 0; i < sizeof(data->scheduled_days); i++) {
+    if (data->scheduled_days[i]) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static uint16_t prv_custom_day_picker_get_num_sections(struct MenuLayer *menu_layer,
+                                                        void *callback_context) {
+  return 1;
+}
+
+static uint16_t prv_custom_day_picker_get_num_rows(struct MenuLayer *menu_layer,
+                                                    uint16_t section_index, void *callback_context) {
+  return DAYS_PER_WEEK + 1;
+}
+
+static int16_t prv_custom_day_picker_get_cell_height(struct MenuLayer *menu_layer,
+                                                      MenuIndex *cell_index,
+                                                      void *callback_context) {
+  return DAY_PICKER_CELL_HEIGHT;
+}
+
+static void prv_custom_day_picker_draw_row(GContext *ctx, const Layer *cell_layer,
+                                            MenuIndex *cell_index, void *callback_context) {
+  CustomDayPickerData *data = (CustomDayPickerData *)callback_context;
+  GBitmap *ptr_bitmap;
+
+  if (cell_index->row == 0) {
+    GRect box;
+    uint32_t new_resource_id = RESOURCE_ID_CHECKMARK_ICON_BLACK;
+
+    if (!prv_is_custom_day_scheduled(data)) {
+      if (menu_cell_layer_is_highlighted(cell_layer)) {
+        if (data->show_check_something_first_text) {
+          box.size = GSize(cell_layer->bounds.size.w, DAY_PICKER_CELL_HEIGHT);
+          box.origin = GPoint(0, 4);
+          graphics_draw_text(ctx, i18n_get("Check something first.", &data->window),
+                             fonts_get_system_font(FONT_KEY_GOTHIC_18), box,
+                             GTextOverflowModeFill, GTextAlignmentCenter, NULL);
+          return;
+        } else {
+          new_resource_id = RESOURCE_ID_CHECKMARK_ICON_DOTTED;
+        }
+      }
+    }
+
+    if (new_resource_id != data->current_checkmark_icon_resource_id) {
+      data->current_checkmark_icon_resource_id = new_resource_id;
+      gbitmap_deinit(&data->checkmark_icon);
+      gbitmap_init_with_resource(&data->checkmark_icon, data->current_checkmark_icon_resource_id);
+    }
+
+    box.origin = GPoint((((cell_layer->bounds.size.w) / 2) - ((data->checkmark_icon.bounds.size.w) / 2)),
+                        (((cell_layer->bounds.size.h) / 2) - ((data->checkmark_icon.bounds.size.h) / 2)));
+    box.size = data->checkmark_icon.bounds.size;
+    graphics_context_set_compositing_mode(ctx, GCompOpTint);
+    graphics_draw_bitmap_in_rect(ctx, &data->checkmark_icon, &box);
+  } else {
+    const char *cell_text;
+    uint16_t day_index = cell_index->row % DAYS_PER_WEEK;
+    const struct lc_time_T *time_locale = time_locale_get();
+    cell_text = i18n_get(time_locale->weekday[day_index], &data->window);
+
+    if (data->scheduled_days[(cell_index->row) % DAYS_PER_WEEK]) {
+      ptr_bitmap = &data->selected_icon;
+    } else {
+      ptr_bitmap = &data->deselected_icon;
+    }
+    graphics_context_set_compositing_mode(ctx, GCompOpTint);
+    menu_cell_basic_draw_icon_right(ctx, cell_layer, cell_text, NULL, ptr_bitmap);
+  }
+}
+
+static void prv_custom_day_picker_handle_selection(MenuLayer *menu_layer, MenuIndex *cell_index,
+                                                    void *callback_context) {
+  CustomDayPickerData *data = (CustomDayPickerData *)callback_context;
+
+  if (cell_index->row == 0) {
+    if (!prv_is_custom_day_scheduled(data)) {
+      data->show_check_something_first_text = true;
+      layer_mark_dirty(menu_layer_get_layer(menu_layer));
+    } else {
+      data->was_completed = true;
+      DayPickerResult result = {
+        .kind = DayPickerKindCustom,
+      };
+      memcpy(result.custom_days, data->scheduled_days, sizeof(result.custom_days));
+      if (data->callback) {
+        data->callback(result, data->callback_context);
+      }
+      app_window_stack_pop(true);
+    }
+  } else {
+    uint16_t day_of_week = (cell_index->row) % DAYS_PER_WEEK;
+    data->scheduled_days[day_of_week] = !data->scheduled_days[day_of_week];
+    layer_mark_dirty(menu_layer_get_layer(menu_layer));
+  }
+}
+
+static void prv_custom_day_picker_selection_changed(MenuLayer *menu_layer, MenuIndex new_index,
+                                                     MenuIndex old_index, void *callback_context) {
+  CustomDayPickerData *data = (CustomDayPickerData *)callback_context;
+  if (old_index.row == 0) {
+    data->show_check_something_first_text = false;
+  }
+}
+
+static void prv_custom_day_picker_window_unload(Window *window) {
+  CustomDayPickerData *data = (CustomDayPickerData *)window_get_user_data(window);
+  menu_layer_deinit(&data->menu_layer);
+  gbitmap_deinit(&data->selected_icon);
+  gbitmap_deinit(&data->deselected_icon);
+  gbitmap_deinit(&data->checkmark_icon);
+  i18n_free_all(&data->window);
+  task_free(data);
+}
+
+void custom_day_picker_push(bool initial_days[DAYS_PER_WEEK],
+                            DayPickerCallback callback, void *context,
+                            GColor highlight_color) {
+  CustomDayPickerData *data = task_malloc_check(sizeof(CustomDayPickerData));
+  *data = (CustomDayPickerData){
+    .callback = callback,
+    .callback_context = context,
+    .highlight_color = highlight_color,
+    .was_completed = false,
+    .show_check_something_first_text = false,
+  };
+  memcpy(data->scheduled_days, initial_days, sizeof(data->scheduled_days));
+
+  window_init(&data->window, WINDOW_NAME("Custom Day Picker"));
+  window_set_user_data(&data->window, data);
+  data->window.window_handlers.unload = prv_custom_day_picker_window_unload;
+
+  GRect bounds = data->window.layer.bounds;
+#if PBL_ROUND
+  bounds = grect_inset_internal(bounds, 0, STATUS_BAR_LAYER_HEIGHT);
+#endif
+  menu_layer_init(&data->menu_layer, &bounds);
+  menu_layer_set_callbacks(&data->menu_layer, data, &(MenuLayerCallbacks){
+    .get_num_sections = prv_custom_day_picker_get_num_sections,
+    .get_num_rows = prv_custom_day_picker_get_num_rows,
+    .get_cell_height = prv_custom_day_picker_get_cell_height,
+    .draw_row = prv_custom_day_picker_draw_row,
+    .select_click = prv_custom_day_picker_handle_selection,
+    .selection_changed = prv_custom_day_picker_selection_changed,
+  });
+  menu_layer_set_highlight_colors(&data->menu_layer, highlight_color, GColorWhite);
+  menu_layer_set_click_config_onto_window(&data->menu_layer, &data->window);
+  menu_layer_set_scroll_wrap_around(&data->menu_layer,
+                                     shell_prefs_get_menu_scroll_wrap_around_enable());
+  menu_layer_set_scroll_vibe_on_wrap(&data->menu_layer,
+                                      shell_prefs_get_menu_scroll_vibe_behavior() == MenuScrollVibeOnWrapAround);
+  menu_layer_set_scroll_vibe_on_blocked(&data->menu_layer,
+                                        shell_prefs_get_menu_scroll_vibe_behavior() == MenuScrollVibeOnLocked);
+  layer_add_child(&data->window.layer, menu_layer_get_layer(&data->menu_layer));
+
+  gbitmap_init_with_resource(&data->selected_icon, RESOURCE_ID_CHECKBOX_ICON_CHECKED);
+  gbitmap_init_with_resource(&data->deselected_icon, RESOURCE_ID_CHECKBOX_ICON_UNCHECKED);
+  gbitmap_init_with_resource(&data->checkmark_icon, RESOURCE_ID_CHECKMARK_ICON_BLACK);
+  data->current_checkmark_icon_resource_id = RESOURCE_ID_CHECKMARK_ICON_BLACK;
+
+  app_window_stack_push(&data->window, true);
+}

--- a/src/fw/applib/ui/day_picker.h
+++ b/src/fw/applib/ui/day_picker.h
@@ -1,0 +1,39 @@
+/* SPDX-FileCopyrightText: 2024 Google LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include "applib/ui/ui.h"
+#include "util/time/time.h"
+#include <stdbool.h>
+
+typedef enum {
+  DayPickerKindEveryday = 0,
+  DayPickerKindWeekdays,
+  DayPickerKindWeekends,
+  DayPickerKindCustom,
+  DayPickerKindJustOnce,
+  DayPickerKindNumItems,
+} DayPickerKind;
+
+typedef struct {
+  DayPickerKind kind;
+  bool custom_days[DAYS_PER_WEEK];
+} DayPickerResult;
+
+typedef struct {
+  DayPickerResult initial;
+  GColor highlight_color;
+  bool allow_once;
+} DayPickerConfig;
+
+typedef void (*DayPickerCallback)(DayPickerResult result, void *context);
+
+void day_picker_push(DayPickerConfig config, DayPickerCallback callback,
+                     void *context);
+
+void custom_day_picker_push(bool initial_days[DAYS_PER_WEEK],
+                            DayPickerCallback callback, void *context,
+                            GColor highlight_color);
+
+const char *day_picker_kind_get_string(DayPickerKind kind);

--- a/src/fw/applib/wscript_build
+++ b/src/fw/applib/wscript_build
@@ -36,6 +36,7 @@ if bld.env.VARIANT == 'prf':
                  'ui/date_selection_window.c',
                  'ui/time_selection_window.c',
                  'ui/time_range_selection_window.c',
+                 'ui/day_picker.c',
                  'voice/*']
 
 if not bld.env.CONFIG_BOARD_FAMILY_GETAFIX and not bld.env.CONFIG_BOARD_QEMU_GABBRO:

--- a/src/fw/apps/system/alarms/alarm_editor.c
+++ b/src/fw/apps/system/alarms/alarm_editor.c
@@ -5,6 +5,7 @@
 
 #include "applib/pbl_std/timelocal.h"
 #include "applib/ui/app_window_stack.h"
+#include "applib/ui/day_picker.h"
 #include "applib/ui/number_window.h"
 #include "applib/ui/simple_menu_layer.h"
 #include "applib/ui/time_selection_window.h"
@@ -23,29 +24,12 @@
 
 #include <string.h>
 
-#define ALARM_DAY_LIST_CELL_HEIGHT PBL_IF_RECT_ELSE(menu_cell_small_cell_height(), \
-                                                    menu_cell_basic_cell_height())
-
 typedef struct {
   OptionMenu *alarm_type_menu;
   AlarmType alarm_type;
 
   TimeSelectionWindowData time_picker_window;
   bool time_picker_was_completed;
-
-  Window day_picker_window;
-  MenuLayer day_picker_menu_layer;
-  bool day_picker_was_completed;
-
-  Window custom_day_picker_window;
-  MenuLayer custom_day_picker_menu_layer;
-  bool custom_day_picker_was_completed;
-  bool scheduled_days[DAYS_PER_WEEK];
-  GBitmap deselected_icon;
-  GBitmap selected_icon;
-  GBitmap checkmark_icon;
-  uint32_t current_checkmark_icon_resource_id;
-  bool show_check_something_first_text;
 
   AlarmEditorCompleteCallback complete_callback;
   void *callback_context;
@@ -57,28 +41,9 @@ typedef struct {
   bool creating_alarm;
 } AlarmEditorData;
 
-typedef enum DayPickerMenuItems {
-  DayPickerMenuItemsJustOnce = 0,
-  DayPickerMenuItemsWeekdays,
-  DayPickerMenuItemsWeekends,
-  DayPickerMenuItemsEveryday,
-  DayPickerMenuItemsCustom,
-  DayPickerMenuItemsNumItems,
-} DayPickerMenuItems;
-
-// Forward Declarations
-static void prv_setup_custom_day_picker_window(AlarmEditorData *data);
-static bool prv_is_custom_day_scheduled(AlarmEditorData *data);
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-//! Helper functions
-
 static void prv_remove_windows(AlarmEditorData *data) {
   if (app_window_stack_contains_window(&data->time_picker_window.window)) {
     app_window_stack_remove(&data->time_picker_window.window, false);
-  }
-  if (app_window_stack_contains_window(&data->day_picker_window)) {
-    app_window_stack_remove(&data->day_picker_window, false);
   }
   if (data->alarm_type_menu && app_window_stack_contains_window(&data->alarm_type_menu->window)) {
     app_window_stack_remove(&data->alarm_type_menu->window, false);
@@ -91,353 +56,89 @@ static void prv_call_complete_cancelled_if_no_alarm(AlarmEditorData *data) {
   }
 }
 
-static DayPickerMenuItems prv_alarm_kind_to_index(AlarmKind alarm_kind) {
-  switch (alarm_kind) {
-    case ALARM_KIND_EVERYDAY:
-      return DayPickerMenuItemsEveryday;
-    case ALARM_KIND_WEEKENDS:
-      return DayPickerMenuItemsWeekends;
-    case ALARM_KIND_WEEKDAYS:
-      return DayPickerMenuItemsWeekdays;
-    case ALARM_KIND_JUST_ONCE:
-      return DayPickerMenuItemsJustOnce;
-    case ALARM_KIND_CUSTOM:
-      return DayPickerMenuItemsCustom;
-  }
-  return DayPickerMenuItemsJustOnce;
-}
-
-static AlarmKind prv_index_to_alarm_kind(DayPickerMenuItems index) {
-  switch (index) {
-    case DayPickerMenuItemsWeekdays:
+static AlarmKind prv_day_picker_kind_to_alarm_kind(DayPickerKind kind) {
+  switch (kind) {
+    case DayPickerKindWeekdays:
       return ALARM_KIND_WEEKDAYS;
-    case DayPickerMenuItemsWeekends:
+    case DayPickerKindWeekends:
       return ALARM_KIND_WEEKENDS;
-    case DayPickerMenuItemsEveryday:
+    case DayPickerKindEveryday:
       return ALARM_KIND_EVERYDAY;
-    case DayPickerMenuItemsJustOnce:
-      return ALARM_KIND_JUST_ONCE;
-    case DayPickerMenuItemsCustom:
+    case DayPickerKindCustom:
       return ALARM_KIND_CUSTOM;
-    case DayPickerMenuItemsNumItems:
-      break;
+    case DayPickerKindJustOnce:
+      return ALARM_KIND_JUST_ONCE;
+    default:
+      return ALARM_KIND_EVERYDAY;
   }
-  return ALARM_KIND_EVERYDAY;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
-//! Day Picker
-
-static void prv_day_picker_window_unload(Window *window) {
-  AlarmEditorData *data = (AlarmEditorData*) window_get_user_data(window);
-
-  if (!data->day_picker_was_completed && data->time_picker_was_completed) {
-    // If we cancel the day picker go back to the time picker
-    data->time_picker_was_completed = false;
-    return;
+static DayPickerKind prv_alarm_kind_to_day_picker_kind(AlarmKind kind) {
+  switch (kind) {
+    case ALARM_KIND_WEEKDAYS:
+      return DayPickerKindWeekdays;
+    case ALARM_KIND_WEEKENDS:
+      return DayPickerKindWeekends;
+    case ALARM_KIND_EVERYDAY:
+      return DayPickerKindEveryday;
+    case ALARM_KIND_CUSTOM:
+      return DayPickerKindCustom;
+    case ALARM_KIND_JUST_ONCE:
+      return DayPickerKindJustOnce;
+    default:
+      return DayPickerKindEveryday;
   }
-
-  if (data->creating_alarm) {
-    time_selection_window_deinit(&data->time_picker_window);
-  }
-
-  // Editing recurrence
-  menu_layer_deinit(&data->day_picker_menu_layer);
-  prv_remove_windows(data);
-
-  i18n_free_all(&data->day_picker_window);
-  task_free(data);
-  data = NULL;
 }
 
-static void prv_handle_selection(int index, void *callback_context) {
-  AlarmEditorData *data = (AlarmEditorData *)callback_context;
-  data->day_picker_was_completed = true;
+static void prv_day_picker_callback(DayPickerResult result, void *context) {
+  AlarmEditorData *data = (AlarmEditorData *)context;
 
-  data->alarm_kind = prv_index_to_alarm_kind(index);
+  data->alarm_kind = prv_day_picker_kind_to_alarm_kind(result.kind);
 
   if (data->creating_alarm) {
-    const AlarmInfo info = {
-      .hour = data->alarm_hour,
-      .minute = data->alarm_minute,
-      .kind = data->alarm_kind,
-      .is_smart = (data->alarm_type == AlarmType_Smart),
-      .vibrate_enabled = true,
+    if (data->alarm_kind == ALARM_KIND_CUSTOM) {
+      const AlarmInfo info = {
+        .hour = data->alarm_hour,
+        .minute = data->alarm_minute,
+        .kind = ALARM_KIND_CUSTOM,
+        .scheduled_days = &result.custom_days,
+        .is_smart = (data->alarm_type == AlarmType_Smart),
+        .vibrate_enabled = true,
 #ifdef CONFIG_SPEAKER
-      .sound_enabled = false,
-      .tone = AlarmTone_Reveille,
+        .sound_enabled = false,
+        .tone = AlarmTone_Reveille,
 #endif
-    };
-    data->alarm_id = alarm_create(&info);
+      };
+      data->alarm_id = alarm_create(&info);
+    } else {
+      const AlarmInfo info = {
+        .hour = data->alarm_hour,
+        .minute = data->alarm_minute,
+        .kind = data->alarm_kind,
+        .is_smart = (data->alarm_type == AlarmType_Smart),
+        .vibrate_enabled = true,
+#ifdef CONFIG_SPEAKER
+        .sound_enabled = false,
+        .tone = AlarmTone_Reveille,
+#endif
+      };
+      data->alarm_id = alarm_create(&info);
+    }
     data->complete_callback(CREATED, data->alarm_id, data->callback_context);
-    app_window_stack_remove(&data->day_picker_window, true);
+    time_selection_window_deinit(&data->time_picker_window);
+    prv_remove_windows(data);
+    i18n_free_all(data);
+    task_free(data);
   } else {
-    alarm_set_kind(data->alarm_id, data->alarm_kind);
+    if (data->alarm_kind == ALARM_KIND_CUSTOM) {
+      alarm_set_custom(data->alarm_id, result.custom_days);
+    } else {
+      alarm_set_kind(data->alarm_id, data->alarm_kind);
+    }
     data->complete_callback(EDITED, data->alarm_id, data->callback_context);
-    app_window_stack_pop(true);
+    i18n_free_all(data);
+    task_free(data);
   }
-}
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-//! Custom Day Picker
-
-static void prv_custom_day_picker_window_unload(Window *window) {
-  AlarmEditorData *data = (AlarmEditorData*) window_get_user_data(window);
-
-  if (!data->custom_day_picker_was_completed) {
-    // If we cancel the custom day picker go back to the day picker
-    data->day_picker_was_completed = false;
-    i18n_free_all(&data->custom_day_picker_window);
-    return;
-  }
-
-  menu_layer_deinit(&data->custom_day_picker_menu_layer);
-  prv_remove_windows(data);
-
-  i18n_free_all(&data->custom_day_picker_window);
-}
-
-static void prv_handle_custom_day_selection(int index, void *callback_context) {
-  AlarmEditorData *data = (AlarmEditorData *)callback_context;
-  prv_setup_custom_day_picker_window(data);
-}
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-//! Menu Layer Callbacks
-
-static uint16_t prv_day_picker_get_num_sections(struct MenuLayer *menu_layer,
-                                                void *callback_context) {
-  return 1;
-}
-
-static uint16_t prv_day_picker_get_num_rows(struct MenuLayer *menu_layer,
-                                            uint16_t section_index,
-                                            void *callback_context) {
-  return DayPickerMenuItemsNumItems;
-}
-
-static int16_t prv_day_picker_get_cell_height(struct MenuLayer *menu_layer,
-                                              MenuIndex *cell_index,
-                                              void *callback_context) {
-  return ALARM_DAY_LIST_CELL_HEIGHT;
-}
-
-static void prv_day_picker_draw_row(GContext *ctx, const Layer *cell_layer,
-                                    MenuIndex *cell_index, void *callback_context) {
-  AlarmEditorData *data = (AlarmEditorData *)callback_context;
-  AlarmKind kind = prv_index_to_alarm_kind(cell_index->row);
-  const bool all_caps = false;
-  const char *cell_text = alarm_get_string_for_kind(kind, all_caps);
-  menu_cell_basic_draw(ctx, cell_layer, i18n_get(cell_text, &data->day_picker_window), NULL, NULL);
-}
-
-static void prv_day_picker_handle_selection(MenuLayer *menu_layer, MenuIndex *cell_index,
-                                            void *callback_context) {
-  AlarmEditorData *data = (AlarmEditorData *)callback_context;
-  data->day_picker_was_completed = false;
-
-  if (cell_index->row == DayPickerMenuItemsCustom) {
-    prv_handle_custom_day_selection(cell_index->row, callback_context);
-  } else {
-    data->day_picker_was_completed = true;
-    prv_handle_selection(cell_index->row, callback_context);
-  }
-}
-
-static void prv_setup_day_picker_window(AlarmEditorData *data) {
-  window_init(&data->day_picker_window, WINDOW_NAME("Alarm Day Picker"));
-  window_set_user_data(&data->day_picker_window, data);
-  data->day_picker_window.window_handlers.unload = prv_day_picker_window_unload;
-
-  GRect bounds = data->day_picker_window.layer.bounds;
-#if PBL_ROUND
-  bounds = grect_inset_internal(bounds, 0, STATUS_BAR_LAYER_HEIGHT);
-#endif
-  menu_layer_init(&data->day_picker_menu_layer, &bounds);
-  menu_layer_set_callbacks(&data->day_picker_menu_layer, data, &(MenuLayerCallbacks) {
-    .get_num_sections = prv_day_picker_get_num_sections,
-    .get_num_rows = prv_day_picker_get_num_rows,
-    .get_cell_height = prv_day_picker_get_cell_height,
-    .draw_row = prv_day_picker_draw_row,
-    .select_click = prv_day_picker_handle_selection,
-  });
-  menu_layer_set_highlight_colors(&data->day_picker_menu_layer,
-                                  ALARMS_APP_HIGHLIGHT_COLOR,
-                                  GColorWhite);
-  menu_layer_set_click_config_onto_window(&data->day_picker_menu_layer, &data->day_picker_window);
-  menu_layer_set_scroll_wrap_around(&data->day_picker_menu_layer, shell_prefs_get_menu_scroll_wrap_around_enable());
-  menu_layer_set_scroll_vibe_on_wrap(&data->day_picker_menu_layer, shell_prefs_get_menu_scroll_vibe_behavior() == MenuScrollVibeOnWrapAround);
-  menu_layer_set_scroll_vibe_on_blocked(&data->day_picker_menu_layer, shell_prefs_get_menu_scroll_vibe_behavior() == MenuScrollVibeOnLocked);
-  layer_add_child(&data->day_picker_window.layer,
-                  menu_layer_get_layer(&data->day_picker_menu_layer));
-  if (!alarm_get_kind(data->alarm_id, &data->alarm_kind)) {
-    data->alarm_kind = ALARM_KIND_JUST_ONCE;
-  }
-  menu_layer_set_selected_index(&data->day_picker_menu_layer,
-                                (MenuIndex) { 0, prv_alarm_kind_to_index(data->alarm_kind) },
-                                MenuRowAlignCenter, false);
-}
-
-static uint16_t prv_custom_day_picker_get_num_sections(struct MenuLayer *menu_layer,
-                                                       void *callback_context) {
-  return 1;
-}
-
-static uint16_t prv_custom_day_picker_get_num_rows(struct MenuLayer *menu_layer,
-                                                   uint16_t section_index, void *callback_context) {
-  return DAYS_PER_WEEK + 1;
-}
-
-static int16_t prv_custom_day_picker_get_cell_height(struct MenuLayer *menu_layer,
-                                                     MenuIndex *cell_index,
-                                                     void *callback_context) {
-  return ALARM_DAY_LIST_CELL_HEIGHT;
-}
-
-static void prv_custom_day_picker_draw_row(GContext *ctx, const Layer *cell_layer,
-                                           MenuIndex *cell_index, void *callback_context) {
-  AlarmEditorData *data = (AlarmEditorData *)callback_context;
-  GBitmap *ptr_bitmap;
-
-  if (cell_index->row == 0) { // "completed selection" row
-    GRect box;
-    uint32_t new_resource_id = RESOURCE_ID_CHECKMARK_ICON_BLACK;
-
-    if (!prv_is_custom_day_scheduled(data)) {
-      // no days selected
-      if (menu_cell_layer_is_highlighted(cell_layer)) {
-        if (data->show_check_something_first_text) { // clicking "complete" when no days selected
-          box.size = GSize(cell_layer->bounds.size.w, ALARM_DAY_LIST_CELL_HEIGHT);
-          box.origin = GPoint(0, 4);
-          graphics_draw_text(ctx, i18n_get("Check something first.",
-                                           &data->custom_day_picker_window),
-                             fonts_get_system_font(FONT_KEY_GOTHIC_18), box, GTextOverflowModeFill,
-                             GTextAlignmentCenter, NULL);
-          return;
-        } else { // row highlighted and no days selected
-          new_resource_id = RESOURCE_ID_CHECKMARK_ICON_DOTTED;
-        }
-      }
-    }
-
-    if (new_resource_id != data->current_checkmark_icon_resource_id) {
-      data->current_checkmark_icon_resource_id = new_resource_id;
-      gbitmap_deinit(&data->checkmark_icon);
-      gbitmap_init_with_resource(&data->checkmark_icon, data->current_checkmark_icon_resource_id);
-    }
-
-    box.origin = GPoint((((cell_layer->bounds.size.w)/2)-((data->checkmark_icon.bounds.size.w)/2)),
-                        (((cell_layer->bounds.size.h)/2)-((data->checkmark_icon.bounds.size.h)/2)));
-    box.size = data->checkmark_icon.bounds.size;
-    graphics_context_set_compositing_mode(ctx, GCompOpTint);
-    graphics_draw_bitmap_in_rect(ctx, &data->checkmark_icon, &box);
-
-  } else { // drawing a day of the week
-    const char *cell_text;
-    // List should start off with Monday
-    uint16_t day_index = cell_index->row % DAYS_PER_WEEK;
-    const struct lc_time_T *time_locale = time_locale_get();
-    cell_text = i18n_get(time_locale->weekday[day_index], &data->custom_day_picker_window);
-
-    if (data->scheduled_days[(cell_index->row) % DAYS_PER_WEEK]) {
-      ptr_bitmap = &data->selected_icon;
-    } else {
-      ptr_bitmap = &data->deselected_icon;
-    }
-    graphics_context_set_compositing_mode(ctx, GCompOpTint);
-    menu_cell_basic_draw_icon_right(ctx, cell_layer, cell_text, NULL, ptr_bitmap);
-  }
-}
-
-static bool prv_is_custom_day_scheduled(AlarmEditorData *data) {
-  for (unsigned int i = 0; i < sizeof(data->scheduled_days); i++) {
-    if (data->scheduled_days[i]) {
-      return true;
-    }
-  }
-  return false;
-}
-
-static void prv_custom_day_picker_handle_selection(MenuLayer *menu_layer, MenuIndex *cell_index,
-                                                   void *callback_context) {
-  AlarmEditorData *data = (AlarmEditorData *)callback_context;
-
-  if (cell_index->row == 0) { // selected the "completed day selection" row
-    if (!prv_is_custom_day_scheduled(data)) { // clicking "complete" when no days are selected
-      data->show_check_something_first_text = true;
-      layer_mark_dirty(menu_layer_get_layer(menu_layer));
-    } else {
-      data->custom_day_picker_was_completed = true;
-      if (data->creating_alarm) {
-        const AlarmInfo info = {
-          .hour = data->alarm_hour,
-          .minute = data->alarm_minute,
-          .kind = ALARM_KIND_CUSTOM,
-          .scheduled_days = &data->scheduled_days,
-          .is_smart = (data->alarm_type == AlarmType_Smart),
-          .vibrate_enabled = true,
-#ifdef CONFIG_SPEAKER
-          .sound_enabled = false,
-          .tone = AlarmTone_Reveille,
-#endif
-        };
-        data->alarm_id = alarm_create(&info);
-        data->complete_callback(CREATED, data->alarm_id, data->callback_context);
-      } else {
-        alarm_set_custom(data->alarm_id, data->scheduled_days);
-        data->complete_callback(EDITED, data->alarm_id, data->callback_context);
-      }
-      app_window_stack_pop(true);
-    }
-  } else { // selecting a day of the week
-    // day_of_week index starts from sunday, and printed list starts from monday
-    uint16_t day_of_week = (cell_index->row) % DAYS_PER_WEEK;
-    data->scheduled_days[day_of_week] = !data->scheduled_days[day_of_week]; // toggle selection
-    layer_mark_dirty(menu_layer_get_layer(menu_layer));
-  }
-}
-
-static void prv_custom_day_picker_selection_changed(MenuLayer *menu_layer, MenuIndex new_index,
-                                                    MenuIndex old_index, void *callback_context) {
-  AlarmEditorData *data = (AlarmEditorData*) callback_context;
-  if (old_index.row == 0) {
-    data->show_check_something_first_text = false;
-  }
-}
-
-static void prv_setup_custom_day_picker_window(AlarmEditorData *data) {
-  window_init(&data->custom_day_picker_window, WINDOW_NAME("Alarm Custom Day Picker"));
-  window_set_user_data(&data->custom_day_picker_window, data);
-  data->custom_day_picker_window.window_handlers.unload = prv_custom_day_picker_window_unload;
-
-  GRect bounds = data->custom_day_picker_window.layer.bounds;
-#if PBL_ROUND
-  bounds = grect_inset_internal(bounds, 0, STATUS_BAR_LAYER_HEIGHT);
-#endif
-  menu_layer_init(&data->custom_day_picker_menu_layer, &bounds);
-  menu_layer_set_callbacks(&data->custom_day_picker_menu_layer, data, &(MenuLayerCallbacks) {
-    .get_num_sections = prv_custom_day_picker_get_num_sections,
-    .get_num_rows = prv_custom_day_picker_get_num_rows,
-    .get_cell_height = prv_custom_day_picker_get_cell_height,
-    .draw_row = prv_custom_day_picker_draw_row,
-    .select_click = prv_custom_day_picker_handle_selection,
-    .selection_changed = prv_custom_day_picker_selection_changed
-  });
-  menu_layer_set_highlight_colors(&data->custom_day_picker_menu_layer,
-                                  ALARMS_APP_HIGHLIGHT_COLOR,
-                                  GColorWhite);
-  menu_layer_set_click_config_onto_window(&data->custom_day_picker_menu_layer,
-                                          &data->custom_day_picker_window);
-  menu_layer_set_scroll_wrap_around(&data->custom_day_picker_menu_layer, shell_prefs_get_menu_scroll_wrap_around_enable());
-  menu_layer_set_scroll_vibe_on_wrap(&data->custom_day_picker_menu_layer, shell_prefs_get_menu_scroll_vibe_behavior() == MenuScrollVibeOnWrapAround);
-  menu_layer_set_scroll_vibe_on_blocked(&data->custom_day_picker_menu_layer, shell_prefs_get_menu_scroll_vibe_behavior() == MenuScrollVibeOnLocked);
-  layer_add_child(&data->custom_day_picker_window.layer,
-                  menu_layer_get_layer(&data->custom_day_picker_menu_layer));
-  gbitmap_init_with_resource(&data->selected_icon, RESOURCE_ID_CHECKBOX_ICON_CHECKED);
-  gbitmap_init_with_resource(&data->deselected_icon, RESOURCE_ID_CHECKBOX_ICON_UNCHECKED);
-  gbitmap_init_with_resource(&data->checkmark_icon, RESOURCE_ID_CHECKMARK_ICON_BLACK);
-  data->current_checkmark_icon_resource_id = RESOURCE_ID_CHECKMARK_ICON_BLACK;
-  app_window_stack_push(&data->custom_day_picker_window, true);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -449,7 +150,6 @@ static void prv_time_picker_window_unload(Window *window) {
     return;
   }
 
-  // Editing time
   time_selection_window_deinit(&data->time_picker_window);
 
   if (data->time_picker_was_completed) {
@@ -457,7 +157,6 @@ static void prv_time_picker_window_unload(Window *window) {
   }
   i18n_free_all(data);
   task_free(data);
-  data = NULL;
 }
 
 static void prv_time_picker_window_appear(Window *window) {
@@ -465,10 +164,8 @@ static void prv_time_picker_window_appear(Window *window) {
   const bool is_smart = (data->alarm_type == AlarmType_Smart);
   const char *label = (!data->creating_alarm ? i18n_noop("Change Time") :
                        is_smart ? i18n_noop("New Smart Alarm") : i18n_noop("New Alarm"));
-  /// Displays as "Wake up between" then "8:00 AM - 8:30 AM" below on a separate line
   const char *range_text = PBL_IF_RECT_ELSE(i18n_noop("Wake up between"),
-  /// Displays as "8:00 AM - 8:30 AM" then "Wake up interval" below on a separate line
-                                            i18n_noop("Wake up interval"));
+                                             i18n_noop("Wake up interval"));
   const TimeSelectionWindowConfig config = {
     .label = i18n_get(label, data),
     .range = {
@@ -479,7 +176,6 @@ static void prv_time_picker_window_appear(Window *window) {
     },
   };
   time_selection_window_configure(&data->time_picker_window, &config);
-  // Reset the selection layer to the first cell
   data->time_picker_window.selection_layer.selected_cell_idx = 0;
 }
 
@@ -490,7 +186,16 @@ static void prv_time_picker_complete(TimeSelectionWindowData *time_picker_window
   data->alarm_minute = time_picker_window->time_data.minute;
 
   if (data->creating_alarm) {
-    app_window_stack_push(&data->day_picker_window, true);
+    DayPickerResult initial = {
+      .kind = DayPickerKindEveryday,
+    };
+    memset(initial.custom_days, 0, sizeof(initial.custom_days));
+    DayPickerConfig config = {
+      .initial = initial,
+      .highlight_color = ALARMS_APP_HIGHLIGHT_COLOR,
+      .allow_once = true,
+    };
+    day_picker_push(config, prv_day_picker_callback, data);
   } else {
     alarm_set_time(data->alarm_id, data->alarm_hour, data->alarm_minute);
     app_window_stack_remove(&time_picker_window->window, true);
@@ -535,7 +240,6 @@ static void prv_type_menu_select(OptionMenu *option_menu, int selection, void *c
   data->alarm_type = selection;
 
   if (selection == AlarmType_Smart && !activity_prefs_tracking_is_enabled()) {
-    // Notify about Health and keep the menu open
     health_tracking_ui_feature_show_disabled();
     return;
   }
@@ -579,9 +283,7 @@ Window* alarm_editor_create_new_alarm(AlarmEditorCompleteCallback complete_callb
     .creating_alarm = true,
   };
 
-  // Setup the windows
   prv_setup_time_picker_window(data);
-  prv_setup_day_picker_window(data);
   prv_setup_type_menu_window(data);
   return &data->alarm_type_menu->window;
 }
@@ -611,11 +313,19 @@ void alarm_editor_update_alarm_days(AlarmId alarm_id, AlarmEditorCompleteCallbac
     .callback_context = callback_context,
   };
   alarm_get_kind(alarm_id, &data->alarm_kind);
+
+  DayPickerResult initial;
+  initial.kind = prv_alarm_kind_to_day_picker_kind(data->alarm_kind);
   if (data->alarm_kind == ALARM_KIND_CUSTOM) {
-    alarm_get_custom_days(alarm_id, data->scheduled_days);
+    alarm_get_custom_days(alarm_id, initial.custom_days);
+  } else {
+    memset(initial.custom_days, 0, sizeof(initial.custom_days));
   }
 
-  prv_setup_day_picker_window(data);
-
-  app_window_stack_push(&data->day_picker_window, true);
+  DayPickerConfig config = {
+    .initial = initial,
+    .highlight_color = ALARMS_APP_HIGHLIGHT_COLOR,
+    .allow_once = true,
+  };
+  day_picker_push(config, prv_day_picker_callback, data);
 }


### PR DESCRIPTION
Extract the day picker and custom day picker UI into a standalone reusable component in applib/ui/day_picker.{c,h}, replacing the inline implementation that was embedded in alarm_editor.c.

The new DayPicker API provides:
- DayPickerConfig/DayPickerResult types for configuration and results
- DayPickerKind enum (Everyday, Weekdays, Weekends, Custom, JustOnce)
- day_picker_push() for the kind-selection screen
- custom_day_picker_push() for the day-of-week toggle screen
- day_picker_kind_get_string() for localized string lookup

alarm_editor.c now uses the new component via callback-based API, replacing ~300 lines of inline UI code with thin conversion functions.

This is a requirement for https://github.com/coredevices/PebbleOS/pull/1436  to try and break that work up into more manageable chunks.  First we extract the day picker from the alarms scheduling tool.  Then we can use it when improving quiet time scheduling.  