### PR TITLE
fw/drivers/speaker/nrf5: apply volume across codec power states

### DIFF
--- a/src/fw/drivers/speaker/nrf5/da7212.c
+++ b/src/fw/drivers/speaker/nrf5/da7212.c
@@ -68,6 +68,9 @@ static void prv_idle_shutdown(void *data);
 
 // DAC_R_GAIN value corresponding to 0 dB per DA7212 datasheet.
 #define DA7212_DAC_R_GAIN_0DB        0x6f
+// Attenuation span, in 0.75 dB DAC_R_GAIN steps, that volume 1..100 maps
+// onto (64 steps = 48 dB).
+#define DA7212_DAC_GAIN_VOL_RANGE_STEPS 64
 
 #define I2S_BUF_SAMPLES_STEREO       (NRF5_AUDIO_I2S_BUF_SAMPLES_MONO * 2)
 #define I2S_BUF_SIZE_BYTES           (I2S_BUF_SAMPLES_STEREO * sizeof(int16_t))
@@ -95,6 +98,27 @@ static uint8_t prv_codec_read(AudioDevice *dev, uint8_t reg) {
   i2c_release(dev->codec);
   PBL_ASSERTN(ok);
   return value;
+}
+
+// DAC_R_GAIN is 0.75 dB per step with 0x6F = 0 dB. Volume 100 maps to 0 dB
+// (codes above 0x6F amplify and can clip full-scale samples); lower volumes
+// attenuate linearly in dB, which tracks perceived loudness better than
+// scaling the register code linearly.
+static uint8_t prv_volume_to_dac_gain(uint8_t volume) {
+  return DA7212_DAC_R_GAIN_0DB -
+         (uint8_t)(((100 - volume) * DA7212_DAC_GAIN_VOL_RANGE_STEPS) / 100);
+}
+
+// Push the cached volume to the codec: soft-mute at 0, otherwise the mapped
+// DAC gain with soft-mute cleared.
+static void prv_apply_volume(AudioDevice *dev) {
+  AudioDeviceState *state = dev->state;
+  if (state->volume == 0) {
+    prv_codec_write(dev, DA7212_DAC_FILTERS5, 0x80);
+    return;
+  }
+  prv_codec_write(dev, DA7212_DAC_R_GAIN, prv_volume_to_dac_gain(state->volume));
+  prv_codec_write(dev, DA7212_DAC_FILTERS5, 0x00);
 }
 
 // Bring the DA7212 out of standby, lock its PLL and configure the DAC/LINE
@@ -143,7 +167,6 @@ static void prv_codec_prepare(AudioDevice *dev) {
   prv_codec_write(dev, DA7212_DIG_ROUTING_DAI, 0x32);
   prv_codec_write(dev, DA7212_DIG_ROUTING_DAC, 0xba);
 
-  prv_codec_write(dev, DA7212_DAC_R_GAIN, DA7212_DAC_R_GAIN_0DB);
   prv_codec_write(dev, DA7212_DAC_R_CTRL, 0x80);
   prv_codec_write(dev, DA7212_MIXOUT_R_SELECT, 0x08);
   // amp + mix enable, softmix off (softmix slow-ramps each routing change).
@@ -154,8 +177,9 @@ static void prv_codec_prepare(AudioDevice *dev) {
 
   prv_codec_write(dev, DA7212_SYSTEM_MODES_OUTPUT, 0x89);
 
-  // Clear soft mute now that the path is up (DAI still disabled).
-  prv_codec_write(dev, DA7212_DAC_FILTERS5, 0x00);
+  // Apply the cached volume (gain + soft-mute state) now that the path is up
+  // (DAI still disabled).
+  prv_apply_volume(dev);
 }
 
 // Enable the DA7212 DAI as I2S master. This is the point at which BCLK/WCLK
@@ -331,6 +355,7 @@ void audio_init(AudioDevice *audio_device) {
   // still in use and would be leaked / clobbered.
   if (s_pwr_state == AudioPwrCold) {
     memset(state, 0, sizeof(*state));
+    state->volume = 100;
   }
 }
 
@@ -456,25 +481,20 @@ uint32_t audio_write(AudioDevice *audio_device, void *write_buf, uint32_t size) 
 void audio_set_volume(AudioDevice *audio_device, int volume) {
   PBL_ASSERTN(audio_device);
   AudioDeviceState *state = audio_device->state;
-  if (!state->is_running) {
+
+  state->volume = (uint8_t)MIN(MAX(volume, 0), 100);
+
+  if (s_pwr_state == AudioPwrCold) {
+    // Codec is powered down (or audio_init hasn't run yet);
+    // prv_codec_prepare() applies the cached value on the next start.
     return;
   }
 
-  if (volume <= 0) {
-    prv_codec_write(audio_device, DA7212_DAC_FILTERS5, 0x80);
-    return;
+  mutex_lock(s_audio_mutex);
+  if (s_pwr_state != AudioPwrCold) {
+    prv_apply_volume(audio_device);
   }
-  if (volume > 100) {
-    volume = 100;
-  }
-
-  // Map 1..100 onto the DAC_R_GAIN range 0x01..0x7F.
-  uint8_t gain = (uint8_t)((volume * 0x7F) / 100);
-  if (gain == 0) {
-    gain = 1;
-  }
-  prv_codec_write(audio_device, DA7212_DAC_R_GAIN, gain);
-  prv_codec_write(audio_device, DA7212_DAC_FILTERS5, 0x00);
+  mutex_unlock(s_audio_mutex);
 }
 
 void audio_stop(AudioDevice *audio_device) {

--- a/src/fw/drivers/speaker/nrf5/da7212_definitions.h
+++ b/src/fw/drivers/speaker/nrf5/da7212_definitions.h
@@ -30,6 +30,10 @@ typedef struct AudioDeviceState {
   bool callback_pending;
   uint8_t buf_idx;
 
+  // Requested volume in percent, cached so it can be applied whenever the
+  // codec is (re)powered.
+  uint8_t volume;
+
   int16_t *i2s_bufs[NRF5_AUDIO_I2S_BUF_COUNT];
 
   uint8_t *circ_buffer_storage;


### PR DESCRIPTION
audio_set_volume() returned early whenever the codec wasn't running, and prv_codec_prepare() then reset DAC_R_GAIN to 0 dB on every cold start. Since the speaker service sets volume before audio_start(), every volume request was silently dropped and playback always ran at fixed 0 dB gain on asterix — speaker_play_tone() volume, speaker_set_volume() and the system volume setting all had no effect, and a pre-start mute (volume 0) was undone by the unconditional soft-mute clear in prepare.

Cache the requested volume in AudioDeviceState (default 100) and apply it both immediately when the codec is powered and from prv_codec_prepare() on cold start. Codec writes from audio_set_volume() take the audio mutex so they can't race the deferred idle shutdown's power-down.

Also fix the gain mapping: DAC_R_GAIN is a 0.75 dB-per-step register with 0 dB at 0x6F, but the old code scaled the register code linearly across 0x01..0x7F, so volume 100 amplified +11 dB into clipping while volume 10 sat near -74 dB. Map volume 100 to 0 dB and attenuate linearly in dB over a 48 dB range below it.

Fixes FIRM-2464