### PR TITLE
fw/comm/ble: fix ANCS error handling, filtering and endless call ring

### DIFF
--- a/include/pbl/services/notifications/ancs/ancs_filtering.h
+++ b/include/pbl/services/notifications/ancs/ancs_filtering.h
@@ -31,7 +31,9 @@ uint8_t ancs_filtering_get_mute_type(const iOSNotifPrefs *app_notif_prefs);
 //! Returns true when the app's rules say to filter a notification.
 //! @param app_notif_prefs Prefs for the given app loaded from the notif pref db
 //! @param title Notification title
+//! @param subtitle Notification subtitle, matched as part of the title field
 //! @param body Notification body/message
 bool ancs_filtering_matches_rules(const iOSNotifPrefs *app_notif_prefs,
                                   const ANCSAttribute *title,
+                                  const ANCSAttribute *subtitle,
                                   const ANCSAttribute *body);

--- a/src/bluetooth-fw/nimble/gatt_client_operations.c
+++ b/src/bluetooth-fw/nimble/gatt_client_operations.c
@@ -6,6 +6,21 @@
 #include <bluetooth/gatt.h>
 
 #include <host/ble_gatt.h>
+#include <host/ble_hs.h>
+
+// NimBLE reports ATT-layer failures as BLE_HS_ERR_ATT_BASE + the ATT error
+// code. GATT clients match responses against spec-level BLEGATTError values
+// (e.g. ANCS treats ATT Invalid Parameter 0xA2 as an expected reply), so hand
+// ATT errors back raw; everything else stays in the BTErrno internal range.
+static BLEGATTError prv_gatt_error_code(uint16_t status) {
+  if (status == 0) {
+    return BLEGATTErrorSuccess;
+  }
+  if ((status > BLE_HS_ERR_ATT_BASE) && (status <= BLE_HS_ERR_ATT_BASE + UINT8_MAX)) {
+    return (BLEGATTError)(status - BLE_HS_ERR_ATT_BASE);
+  }
+  return (BLEGATTError)(BTErrnoInternalErrorBegin + status);
+}
 
 static int prv_gatt_write_event_cb(uint16_t conn_handle, const struct ble_gatt_error *error,
                                    struct ble_gatt_attr *attr, void *arg) {
@@ -17,7 +32,7 @@ static int prv_gatt_write_event_cb(uint16_t conn_handle, const struct ble_gatt_e
   GattClientOpWriteReponse resp = {
       .hdr = {
           .type = GattClientOpResponseWrite,
-          .error_code = error->status == 0 ? 0 : BTErrnoInternalErrorBegin + error->status,
+          .error_code = prv_gatt_error_code(error->status),
           .context = arg,
       }};
   bt_driver_cb_gatt_client_operations_handle_response(&resp.hdr);
@@ -35,7 +50,7 @@ static int prv_gatt_read_event_cb(uint16_t conn_handle, const struct ble_gatt_er
       .hdr =
           {
               .type = GattClientOpResponseRead,
-              .error_code = error->status == 0 ? 0 : BTErrnoInternalErrorBegin + error->status,
+              .error_code = prv_gatt_error_code(error->status),
               .context = arg,
           },
       .value = attr->om->om_data,

--- a/src/fw/comm/ble/kernel_le_client/ancs/ancs_types.h
+++ b/src/fw/comm/ble/kernel_le_client/ancs/ancs_types.h
@@ -136,7 +136,10 @@ typedef enum {
 
 // FIXME AS: APP ID max length determined by looking through installed apps on iOS. Not sure what actual maximum is
 #define APP_ID_MAX_LENGTH (60)
-#define TITLE_MAX_LENGTH (40)
+// Long enough that notification filtering rules can match text near the end
+// of verbose titles (e.g. Discord's "Sender (#channel · Server Name)").
+// Must fit FetchedAttribute.max_length (uint8_t).
+#define TITLE_MAX_LENGTH (128)
 #define SUBTITLE_MAX_LENGTH (40)
 #define MESSAGE_MAX_LENGTH (200)
 #define MESSAGE_SIZE_MAX_LENGTH (3)

--- a/src/fw/popups/phone_ui.c
+++ b/src/fw/popups/phone_ui.c
@@ -55,6 +55,9 @@
 #define CALL_END_DELAY_MS 5000
 #define OUTGOING_CALL_DELAY_MS 5000
 #define MISSED_CALL_DELAY_MS 180000
+// Phones stop ringing well within this window (carriers give up after at most
+// ~60s). Past it, assume we missed the call-ended event and stop vibing.
+#define MAX_RING_DURATION_S 90
 
 #define NAME_BUFFER_LENGTH 32
 #define CALL_STATUS_BUFFER_LENGTH 32
@@ -163,6 +166,7 @@ typedef struct {
   time_t call_start_time;
   VibeScore *vibe_score;
   RegularTimerInfo ring_timer;
+  time_t ring_start_time;
   bool show_ongoing_call_ui;
 
   // Incoming call reply data
@@ -436,12 +440,22 @@ static void prv_window_update_proc(Layer *layer, GContext *ctx) {
 //! Ring functionality
 static void prv_ring(void *unused) {
   PBL_LOG_DBG("RING");
+  if (!s_phone_ui_data) {
+    // There is a mutex-related issue that can appear where the timer callback will execute after
+    // phone_ui cancels the timer and frees the vibe_score / s_phone_ui_data. Thus, bail early
+    // if we detect this bad state.
+    // See PBL-35548
+    return;
+  }
+  if ((rtc_get_time() - s_phone_ui_data->ring_start_time) > MAX_RING_DURATION_S) {
+    // The call-ended event never arrived (e.g. an ANCS removal lost across a
+    // re-subscription); don't vibe until the user dismisses the window.
+    PBL_LOG_WRN("Still ringing after %ds; stopping the vibe loop", MAX_RING_DURATION_S);
+    regular_timer_remove_callback(&s_phone_ui_data->ring_timer);
+    return;
+  }
   if (alerts_should_vibrate_for_type(AlertPhoneCall)) {
-    if (!s_phone_ui_data || !s_phone_ui_data->vibe_score) {
-      // There is a mutex-related issue that can appear where the timer callback will execute after
-      // phone_ui cancels the timer and frees the vibe_score / s_phone_ui_data. Thus, bail early
-      // if we detect this bad state.
-      // See PBL-35548
+    if (!s_phone_ui_data->vibe_score) {
       return;
     }
     vibe_score_do_vibe(s_phone_ui_data->vibe_score);
@@ -456,6 +470,7 @@ static void prv_start_ringing(void) {
   s_phone_ui_data->ring_timer = (const RegularTimerInfo) {
     .cb = prv_ring,
   };
+  s_phone_ui_data->ring_start_time = rtc_get_time();
   unsigned int vibe_repeat_interval_sec;
   s_phone_ui_data->vibe_score = vibe_client_get_score(VibeClient_PhoneCalls);
   if (!s_phone_ui_data->vibe_score) {

--- a/src/fw/services/notifications/ancs/ancs_filtering.c
+++ b/src/fw/services/notifications/ancs/ancs_filtering.c
@@ -72,9 +72,21 @@ static bool prv_match_contains(const char *haystack, size_t haystack_len, const 
   return false;
 }
 
+static char *prv_attr_to_cstring(const ANCSAttribute *attr, size_t *len_out) {
+  if (!attr || (attr->length == 0)) {
+    *len_out = 0;
+    return NULL;
+  }
+  char *str = kernel_zalloc_check(attr->length + 1);
+  pstring_pstring16_to_string(&attr->pstr, str);
+  *len_out = strlen(str);
+  return str;
+}
+
 static bool prv_match_rule(uint8_t match_type, uint8_t match_field, bool case_sensitive,
                            const char *pattern, size_t pattern_len, const char *title,
-                           size_t title_len, const char *body, size_t body_len) {
+                           size_t title_len, const char *subtitle, size_t subtitle_len,
+                           const char *body, size_t body_len) {
   if (match_type == FilteringMatchTypeRegex) {
     // Regex support is not available in firmware at the moment.
     return false;
@@ -85,12 +97,17 @@ static bool prv_match_rule(uint8_t match_type, uint8_t match_field, bool case_se
   const bool match_body =
       ((match_field == FilteringMatchFieldBody) || (match_field == FilteringMatchFieldAny));
 
-  return ((match_title && prv_match_contains(title, title_len, pattern, pattern_len, case_sensitive))
+  // The subtitle is displayed as part of the title line, so title rules cover
+  // both attributes.
+  return ((match_title &&
+           (prv_match_contains(title, title_len, pattern, pattern_len, case_sensitive) ||
+            prv_match_contains(subtitle, subtitle_len, pattern, pattern_len, case_sensitive)))
       || (match_body && prv_match_contains(body, body_len, pattern, pattern_len, case_sensitive)));
 }
 
 bool ancs_filtering_matches_rules(const iOSNotifPrefs *app_notif_prefs,
                                   const ANCSAttribute *title_attr,
+                                  const ANCSAttribute *subtitle_attr,
                                   const ANCSAttribute *body_attr) {
   if (!app_notif_prefs) {
     return false;
@@ -102,25 +119,17 @@ bool ancs_filtering_matches_rules(const iOSNotifPrefs *app_notif_prefs,
     return false;
   }
 
-  const char *title = "";
   size_t title_len = 0;
-  char *allocated_title = NULL;
-  if (title_attr && (title_attr->length > 0)) {
-    allocated_title = kernel_zalloc_check(title_attr->length + 1);
-    pstring_pstring16_to_string(&title_attr->pstr, allocated_title);
-    title = allocated_title;
-    title_len = strlen(title);
-  }
+  char *allocated_title = prv_attr_to_cstring(title_attr, &title_len);
+  const char *title = allocated_title ? allocated_title : "";
 
-  const char *body = "";
+  size_t subtitle_len = 0;
+  char *allocated_subtitle = prv_attr_to_cstring(subtitle_attr, &subtitle_len);
+  const char *subtitle = allocated_subtitle ? allocated_subtitle : "";
+
   size_t body_len = 0;
-  char *allocated_body = NULL;
-  if (body_attr && (body_attr->length > 0)) {
-    allocated_body = kernel_zalloc_check(body_attr->length + 1);
-    pstring_pstring16_to_string(&body_attr->pstr, allocated_body);
-    body = allocated_body;
-    body_len = strlen(body);
-  }
+  char *allocated_body = prv_attr_to_cstring(body_attr, &body_len);
+  const char *body = allocated_body ? allocated_body : "";
 
   const FilteringRulesSerialized *serialized_rules = (const FilteringRulesSerialized *)rules->data;
   size_t remaining = rules->serialized_byte_length - 1;
@@ -144,7 +153,8 @@ bool ancs_filtering_matches_rules(const iOSNotifPrefs *app_notif_prefs,
 
     const size_t pattern_len = (size_t)(terminator - pattern);
     matched = prv_match_rule(rule->match_type, rule->match_field, (rule->case_sensitive != 0),
-                             pattern, pattern_len, title, title_len, body, body_len);
+                             pattern, pattern_len, title, title_len, subtitle, subtitle_len,
+                             body, body_len);
 
     cursor = (const uint8_t *)(terminator + 1);
     remaining -= (pattern_len + 1);
@@ -155,6 +165,7 @@ bool ancs_filtering_matches_rules(const iOSNotifPrefs *app_notif_prefs,
   }
 
   kernel_free(allocated_body);
+  kernel_free(allocated_subtitle);
   kernel_free(allocated_title);
   return matched;
 }

--- a/src/fw/services/notifications/ancs/ancs_notifications.c
+++ b/src/fw/services/notifications/ancs/ancs_notifications.c
@@ -234,6 +234,7 @@ static bool prv_should_ignore_notification(uint32_t uid,
   const ANCSAttribute *app_id = notif_attributes[FetchedNotifAttributeIndexAppID];
   const ANCSAttribute *message = notif_attributes[FetchedNotifAttributeIndexMessage];
   const ANCSAttribute *title = notif_attributes[FetchedNotifAttributeIndexTitle];
+  const ANCSAttribute *subtitle = notif_attributes[FetchedNotifAttributeIndexSubtitle];
   const ANCSAttribute *negative_action =
       notif_attributes[FetchedNotifAttributeIndexNegativeActionLabel];
 
@@ -245,7 +246,7 @@ static bool prv_should_ignore_notification(uint32_t uid,
     return true;
   }
 
-  if (ancs_filtering_matches_rules(app_notif_prefs, title, message)) {
+  if (ancs_filtering_matches_rules(app_notif_prefs, title, subtitle, message)) {
     char app_id_buffer[app_id->length + 1];
     pstring_pstring16_to_string(&app_id->pstr, app_id_buffer);
 

--- a/tests/fw/services/notifications/test_ancs_filtering.c
+++ b/tests/fw/services/notifications/test_ancs_filtering.c
@@ -430,7 +430,7 @@ void test_ancs_filtering__matches_text_rule_body_case_insensitive(void) {
     },
   };
 
-  cl_assert(ancs_filtering_matches_rules(&prefs, s_title_attr, body_attr));
+  cl_assert(ancs_filtering_matches_rules(&prefs, s_title_attr, NULL, body_attr));
 }
 
 void test_ancs_filtering__matches_text_rule_title_case_sensitive(void) {
@@ -455,7 +455,7 @@ void test_ancs_filtering__matches_text_rule_title_case_sensitive(void) {
     },
   };
 
-  cl_assert(ancs_filtering_matches_rules(&prefs, s_title_attr, NULL));
+  cl_assert(ancs_filtering_matches_rules(&prefs, s_title_attr, NULL, NULL));
 }
 
 void test_ancs_filtering__does_not_match_regex_rule(void) {
@@ -480,5 +480,40 @@ void test_ancs_filtering__does_not_match_regex_rule(void) {
     },
   };
 
-  cl_assert(!ancs_filtering_matches_rules(&prefs, s_title_attr, NULL));
+  cl_assert(!ancs_filtering_matches_rules(&prefs, s_title_attr, NULL, NULL));
+}
+
+void test_ancs_filtering__matches_text_rule_title_via_subtitle(void) {
+  static uint8_t subtitle_data[] = {
+    0x02,                                                            // id
+    0x0B, 0x00,                                                      // length
+    'S', 'o', 'm', 'e', ' ', 'S', 'e', 'r', 'v', 'e', 'r'           // Value
+  };
+  ANCSAttribute *subtitle_attr = (ANCSAttribute *)&subtitle_data;
+
+  struct {
+    StringList list;
+    char data[11];
+  } filtering_rules = {
+    .list = {
+      .serialized_byte_length = 11,
+    },
+    // count=1, type=text, field=title, case=insensitive, pattern="server\0"
+    .data = { 0x01, 0x00, 0x01, 0x00, 's', 'e', 'r', 'v', 'e', 'r', '\0' },
+  };
+
+  iOSNotifPrefs prefs = {
+    .attr_list = {
+      .num_attributes = 1,
+      .attributes = (Attribute[]) {
+        { .id = AttributeIdNotificationFilteringRules, .string_list = &filtering_rules.list },
+      },
+    },
+  };
+
+  // "server" is in the subtitle, not the title: a title rule must match it.
+  cl_assert(ancs_filtering_matches_rules(&prefs, s_title_attr, subtitle_attr, NULL));
+  // A body rule must not consider the subtitle.
+  filtering_rules.data[2] = 0x02;
+  cl_assert(!ancs_filtering_matches_rules(&prefs, s_title_attr, subtitle_attr, NULL));
 }

--- a/tests/fw/services/notifications/test_ancs_notifications.c
+++ b/tests/fw/services/notifications/test_ancs_notifications.c
@@ -44,6 +44,7 @@ bool ancs_filtering_is_muted(const iOSNotifPrefs *app_notif_prefs) {
 
 bool ancs_filtering_matches_rules(const iOSNotifPrefs *app_notif_prefs,
                                   const ANCSAttribute *title,
+                                  const ANCSAttribute *subtitle,
                                   const ANCSAttribute *body) {
   return false;
 }


### PR DESCRIPTION
## Problem

Three related iOS notification issues, all rooted in or amplified by ANCS handling:

- **FIRM-2191** — Gmail (and other bursty apps) notifications intermittent on iOS. The NimBLE driver re-encodes ATT-layer errors as `BTErrnoInternalErrorBegin + (0x100 + att_code)`, but the ANCS client matches the spec-level code: iOS's expected ATT Invalid Parameter (0xA2) replies arrive as 9418 and are misclassified as hard BT errors. That flushes the entire pending notification queue and forces an ANCS re-subscribe on every 15-minute alive-check probe (visible in user logs as `Control point error response: 9418` → `Re-subscribing to ANCS characteristics`), and drops whole notification bursts whenever one queued UID was already retracted on the phone — which Gmail does constantly.
- **FIRM-2448** — Notification filtering rules can't match Discord server names. Titles are fetched truncated to 40 bytes, so the rule text is cut off before the rules engine ever sees it; the subtitle attribute was fetched but never evaluated at all.
- **FIRM-2319** — Watch vibrates endlessly after a notification until Back is pressed. The incoming-call ring loop has no timeout, so a lost ANCS removal (e.g. across a re-subscription, which the 9418 bug made routine) rings forever.

## Changes

1. **bluetooth-fw/nimble:** translate ATT-range NimBLE errors back to raw ATT codes in the GATT read/write callbacks; other error ranges keep the internal-error offset. No other GATT client matches specific error values (they only check `!= BLEGATTErrorSuccess`), so this only restores the semantics the FW side was written against.
2. **fw/comm/ble/ancs:** raise the fetched title length 40 → 128 bytes (fits `FetchedAttribute.max_length`; +88 B in the heap-allocated reassembly buffer).
3. **fw/services/notifications:** evaluate the subtitle as part of the title field in filtering rules (title/"any" rules consider it, body rules don't), with a new unit test.
4. **fw/popups/phone_ui:** stop the ring vibe loop after 90 s — phones never ring that long, so treat it as a missed call-ended event. The call window stays up.

## Testing

- asterix and obelix_pvt builds pass.
- `test_ancs_filtering` 13/13 green (incl. new subtitle test); `test_ancs_notifications` green.
- Needs on-iPhone validation: after this change, watch logs should no longer show the 15-minute `9418` / re-subscribe cycle, and Gmail notification delivery should stabilize.

Fixes FIRM-2191, FIRM-2448, FIRM-2319

🤖 Generated with [Claude Code](https://claude.com/claude-code)