### PR TITLE
fw/applib/graphics: fall back between base and extension fonts on glyph miss

### DIFF
--- a/src/fw/applib/graphics/text_resources.c
+++ b/src/fw/applib/graphics/text_resources.c
@@ -596,10 +596,36 @@ static const GlyphData *prv_get_glyph_in_font(FontCache *font_cache, Codepoint c
   return prv_get_glyph_metadata_from_spi(codepoint, font_cache, font_res, need_bitmap);
 }
 
+// Leaf glyph lookup against an explicit sub-font resource, bypassing the base/extension routing.
+// Used for the base<->extension sibling fallback.
+static const GlyphData *prv_get_glyph_in_font_res(FontCache *font_cache, Codepoint codepoint,
+                                                  const FontResource *font_res, bool need_bitmap) {
+  prv_check_font_cache(font_cache, font_res);
+  return prv_get_glyph_metadata_from_spi(codepoint, font_cache, font_res, need_bitmap);
+}
+
+//! The other of base/extension, used as fallback when the routed font lacks
+//! the glyph. NULL when no extension is loaded or when the routed font is not
+//! part of this FontInfo (e.g. the emoji font).
+static const FontResource *prv_alt_font_res(const FontResource *font_res,
+                                            const FontInfo *font_info) {
+  if (!font_info->extended) {
+    return NULL;
+  }
+  if (font_res == &font_info->base) {
+    return &font_info->extension;
+  }
+  if (font_res == &font_info->extension) {
+    return &font_info->base;
+  }
+  return NULL;
+}
+
 // When source_out is non-NULL it receives the FontResource that actually
-// supplied the returned glyph -- the primary sub-font, the system fallback, or
-// the wildcard's sub-font -- which is not always the one nominally mapped from
-// the requested codepoint. Baseline alignment needs the real source.
+// supplied the returned glyph -- the primary sub-font, the base<->extension
+// sibling, the system fallback, or the wildcard's sub-font -- which is not
+// always the one nominally mapped from the requested codepoint. Baseline
+// alignment needs the real source.
 static const GlyphData *prv_get_glyph(FontCache *font_cache, Codepoint codepoint,
                                       FontInfo *font_info, bool need_bitmap,
                                       const FontResource **source_out) {
@@ -607,16 +633,34 @@ static const GlyphData *prv_get_glyph(FontCache *font_cache, Codepoint codepoint
     sys_font_reload_font(font_info);
   }
 
-  // (a) Requested codepoint in the primary font.
-  const GlyphData *data = prv_get_glyph_in_font(font_cache, codepoint, font_info, need_bitmap);
+  // (a) Requested codepoint in the routed (base/extension) sub-font.
+  const FontResource *primary_res = prv_font_res_for_codepoint(codepoint, font_info);
+  const GlyphData *data = prv_get_glyph_in_font_res(font_cache, codepoint, primary_res, need_bitmap);
   if (data) {
     if (source_out) {
-      *source_out = prv_font_res_for_codepoint(codepoint, font_info);
+      *source_out = primary_res;
     }
     return data;
   }
 
-  // (b) Missing from the primary font: retry the SAME codepoint once against the system fallback
+  // (a2) Missing from the routed sub-font: try the sibling sub-font (base<->extension) of the same
+  //      FontInfo before going wider. prv_font_res_for_codepoint routes each codepoint to exactly
+  //      one of base/extension, but a glyph can live in the other one: Latin-classified codepoints
+  //      supplied by a language pack (e.g. Vietnamese ơ/ư at U+01A1/U+01B0), or base-only glyphs
+  //      like ﬁ/π that get routed to the extension once a pack is installed. The sibling is part of
+  //      this FontInfo, so source_out keeps baseline alignment correct.
+  const FontResource *alt_res = prv_alt_font_res(primary_res, font_info);
+  if (alt_res != NULL) {
+    data = prv_get_glyph_in_font_res(font_cache, codepoint, alt_res, need_bitmap);
+    if (data) {
+      if (source_out) {
+        *source_out = alt_res;
+      }
+      return data;
+    }
+  }
+
+  // (b) Missing from this FontInfo: retry the SAME codepoint once against the system fallback
   //     font, which carries a wider character set. The fallback is a process-global, not per-font
   //     state, so it lives here in the renderer rather than on FontInfo (whose layout is frozen
   //     applib ABI). It is fetched via the syscall directly (the NULL key is the fallback font),

--- a/tests/fw/applib/test_text_resources.c
+++ b/tests/fw/applib/test_text_resources.c
@@ -227,6 +227,38 @@ void test_text_resources__extended_font(void) {
   cl_assert_equal_m(chinese_wildcard_bytes, glyph->data, glyph_size_bytes);
 }
 
+void test_text_resources__extension_miss_falls_back_to_base(void) {
+  // ﬁ (U+FB01) is not latin-classified, so with an extension installed it is
+  // routed to the extension font. The chinese pbpack does not contain it but
+  // the base font does: the lookup must fall back to the base sub-font glyph
+  // instead of degrading to the wildcard.
+  const Codepoint LATIN_SMALL_LIGATURE_FI = 0xFB01;
+  static uint8_t base_bytes[64];
+
+  // reference: the glyph as served by the base font alone
+  cl_assert(text_resources_init_font(0, RESOURCE_ID_GOTHIC_18, 0, &s_font_info));
+  const GlyphData *glyph = text_resources_get_glyph(&s_font_cache, LATIN_SMALL_LIGATURE_FI,
+                                                    &s_font_info);
+  cl_assert(glyph != NULL);
+  const GlyphHeaderData base_header = glyph->header;
+  const uint8_t base_size_bytes = glyph_get_size_bytes(glyph);
+  cl_assert(base_size_bytes <= sizeof(base_bytes));
+  memcpy(base_bytes, glyph->data, base_size_bytes);
+  // sanity: the base font really has it (a wildcard would be 7px wide)
+  cl_assert(base_header.width_px != 7);
+
+  // same lookup with the extension installed must yield the same glyph
+  memset(&s_font_info, 0, sizeof(s_font_info));
+  cl_assert(text_resources_init_font(0, RESOURCE_ID_GOTHIC_18, RESOURCE_ID_GOTHIC_18_EXTENDED,
+                                     &s_font_info));
+  cl_assert(s_font_info.extended);
+  glyph = text_resources_get_glyph(&s_font_cache, LATIN_SMALL_LIGATURE_FI, &s_font_info);
+  cl_assert(glyph != NULL);
+  cl_assert_equal_i(glyph->header.width_px, base_header.width_px);
+  cl_assert_equal_i(glyph->header.height_px, base_header.height_px);
+  cl_assert_equal_m(base_bytes, glyph->data, base_size_bytes);
+}
+
 void test_text_resources__baseline_offset(void) {
   cl_assert(text_resources_init_font(0, RESOURCE_ID_GOTHIC_18, RESOURCE_ID_GOTHIC_18_EXTENDED,
                                      &s_font_info));


### PR DESCRIPTION
## Problem

`prv_font_res_for_codepoint()` routes each codepoint to exactly one font: Latin-classified codepoints (`<= U+02AF` and the `U+2000–U+2BFF` symbols range) always go to the **base** font, while everything else goes to the language-pack **extension** font when one is loaded.  If this routed font (e.g. base font) does not contain the glyph, the renderer falls straight back to the wildcard box (▯), even when the other font (e.g. extension font) contains a valid glyph.

This means that **Latin-classified codepoints missing from the base fonts** (e.g. Vietnamese ơ/ư at U+01A1/U+01B0) can never be supplied by a language pack. This has been a known issue in the Vietnamese Pebble community since at least 2016 (issue: https://github.com/MarSoft/pebble-firmware-utils/issues/17) as language packs could not fix the missing ơ/ư.

I originally attempted to patch the base Gothic fonts to include these characters, but noticed that this fonts cover only about 360 of the roughly 3,650 codepoints this classification routes to them. With this fallback logic, any Latin-classified codepoint missing from the base font can instead be supplied by a community extension pack, which seems like a better long-term fix (Happy to discuss more on this if needed).

This also fixes the inverse issue: **glyphs that exist only in the base font but are not Latin-classified** (e.g. ﬁ U+FB01 and π U+03C0, both present in GOTHIC_18) stop rendering as soon as *any* language pack is installed, because they are then routed to an extension font that does not contain them.

## Fix

On a miss for the requested codepoint, try the other of base/extension before falling back to the wildcard.

Safety properties:

- The extra lookup only runs on the miss path, and only when an extension is loaded (`font_info->extended`) — app fonts and pack-less systems see zero change.
- The wildcard and space fallbacks still come exclusively from the base font, preserving the existing "extension pack may be deleted" guarantee.
- Glyph cache entries are keyed by resource id, so base and extension lookups (including cached negative results) cannot collide.

## Testing

- New regression test `test_text_resources__extension_miss_falls_back_to_base`: ﬁ (U+FB01) is present in GOTHIC_18 but absent from the Chinese language-pack fixture; with the extension installed, the lookup must return the base-font glyph. Verified the test **fails without the fix** (returns the 7 px wildcard instead of the 6 px ligature) and passes with it.
- Existing suite passes, including the "missing in both fonts → wildcard" case (`./pbl test -M ".*test_text_resources.*"`).
- Firmware builds clean for qemu_emery.

🤖 Generated with [Claude Code](https://claude.com/claude-code) and manually edited by me
