### PR TITLE
build: update pbl for Kconfig env migration

### DIFF
--- a/pbl
+++ b/pbl
@@ -187,12 +187,12 @@ def _check_firmware_image_size(env, path):
     BYTES_PER_K = 1024
     firmware_size = os.path.getsize(path)
     if env.CONFIG_SOC_NRF52:
-        if env.VARIANT == "prf" and not env.IS_MFG:
+        if env.VARIANT == "prf" and not env.CONFIG_MFG:
             max_firmware_size = 512 * BYTES_PER_K
         else:
             max_firmware_size = (1024 - 32) * BYTES_PER_K
     elif env.CONFIG_SOC_SF32LB52:
-        if env.VARIANT == "prf" and not env.IS_MFG:
+        if env.VARIANT == "prf" and not env.CONFIG_MFG:
             max_firmware_size = 576 * BYTES_PER_K
         else:
             max_firmware_size = 3072 * BYTES_PER_K
@@ -211,7 +211,7 @@ def _check_firmware_image_size(env, path):
 
 
 def _is_pulse_everywhere(env):
-    return "PULSE_EVERYWHERE=1" in env["DEFINES"]
+    return bool(env.CONFIG_PULSE_EVERYWHERE)
 
 
 def _get_pulse_flash_tool(env, options):


### PR DESCRIPTION
## Summary

`pbl` was split out of `wscript` before the Kconfig migration series landed and kept reading the pre-migration build env:

- `_check_firmware_image_size` read `env.IS_MFG`, removed by the `CONFIG_MFG` migration (8fc2b3b1). Since the `Env` wrapper returns a falsy `[]` for missing keys, MFG PRF builds were checked against the smaller non-MFG firmware size limit (e.g. 576K instead of 3072K on SF32LB52).
- `_is_pulse_everywhere` grepped `DEFINES` for `PULSE_EVERYWHERE=1`, renamed to `CONFIG_PULSE_EVERYWHERE=1` (fbb949ae). It always returned False, so `./pbl console` fell back to miniterm instead of the PULSE console and `image_*` picked the legacy flashing tool.

## Testing

Loaded the helpers against a configured obelix_pvt MFG PRF build cache: `CONFIG_MFG` and pulse-everywhere now detected, flash tool resolves to `sftool_flash_imaging`, and the size check passes with the correct 3MB limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)