### PR TITLE
Zephyr-style log modules

### DIFF
--- a/include/logging/log_hashing.h
+++ b/include/logging/log_hashing.h
@@ -46,6 +46,9 @@
  *         internally consistent.
  *  - .log_string
  *    which is a list of <token-list> representing the log strings from the source code.
+ *    Entries of the form "MODULE:<file>:<module-name>", emitted by PBL_LOG_MODULE_DEFINE /
+ *    PBL_LOG_MODULE_DECLARE, are metadata mapping a source file to its log module; they are
+ *    never referenced by a token.
  *
  * Note: this code must be compiled with -Os or the codesize will explode!
  *
@@ -74,7 +77,7 @@
 #include <string.h>
 #include "util/attributes.h"
 
-#define NEW_LOG_VERSION "0101"
+#define NEW_LOG_VERSION "0102"
 
 #define LOG_STRINGS_SECTION_ADDRESS 0xC0000000
 

--- a/python_libs/pebble-loghash/pebble/loghashing/newlogging.py
+++ b/python_libs/pebble-loghash/pebble/loghashing/newlogging.py
@@ -22,7 +22,7 @@ from pebble.loghashing.constants import (
 hex_digits = set(string.hexdigits)
 
 LOG_DICT_KEY_VERSION = "new_logging_version"
-NEW_LOGGING_VERSION = "NL0101"
+NEW_LOGGING_VERSION = "NL0102"
 
 LOG_LEVEL_ALWAYS = 0
 LOG_LEVEL_ERROR = 1
@@ -215,6 +215,10 @@ def parse_message(msg, log_dict):
         output_msg = safe_output_msg % tuple(arg_list)
     except (TypeError, ValueError, UnicodeDecodeError) as e:
         output_msg = msg + " ----> ERROR: " + str(e)
+
+    # Prefix the message with the log module name, if any
+    if "module" in output_dict:
+        output_msg = "{}: {}".format(output_dict["module"], output_msg)
 
     # Add the formatted msg to the copy of our line dict
     output_dict["formatted_msg"] = output_msg

--- a/python_libs/pebble-loghash/pebble/loghashing/newlogging.py
+++ b/python_libs/pebble-loghash/pebble/loghashing/newlogging.py
@@ -31,13 +31,14 @@ LOG_LEVEL_INFO = 100
 LOG_LEVEL_DEBUG = 200
 LOG_LEVEL_DEBUG_VERBOSE = 255
 
+# Zephyr-style severity tags; ALWAYS logs carry no tag
 level_strings_map = {
-    LOG_LEVEL_ALWAYS: "*",
-    LOG_LEVEL_ERROR: "E",
-    LOG_LEVEL_WARNING: "W",
-    LOG_LEVEL_INFO: "I",
-    LOG_LEVEL_DEBUG: "D",
-    LOG_LEVEL_DEBUG_VERBOSE: "V",
+    LOG_LEVEL_ALWAYS: "",
+    LOG_LEVEL_ERROR: "err",
+    LOG_LEVEL_WARNING: "wrn",
+    LOG_LEVEL_INFO: "inf",
+    LOG_LEVEL_DEBUG: "dbg",
+    LOG_LEVEL_DEBUG_VERBOSE: "vrb",
 }
 
 # Location of the core number in the message hash
@@ -82,19 +83,24 @@ def dehash_line(line, log_dict):
     if not line_dict:
         return line
 
+    # Zephyr-like format: [timestamp] <lvl> task source: msg. Messages from a
+    # log module already carry a "module: " prefix in formatted_msg; others get
+    # their file:line as the source.
     output = []
-    if "date" not in line_dict and "re_level" in line_dict:
-        output.append(line_dict["re_level"])
+
+    timestamp = " ".join(line_dict[key] for key in ("date", "time") if key in line_dict)
+    if timestamp:
+        output.append("[{}]".format(timestamp))
+
+    if "date" not in line_dict and line_dict.get("re_level"):
+        output.append("<{}>".format(line_dict["re_level"]))
+
     if "task" in line_dict:
         output.append(line_dict["task"])
-    if "date" in line_dict:
-        output.append(line_dict["date"])
-    if "time" in line_dict:
-        output.append(line_dict["time"])
 
-    if "file" in line_dict and "line" in line_dict:
+    if "module" not in line_dict and "file" in line_dict and "line" in line_dict:
         filename = os.path.basename(line_dict["file"])
-        output.append("{}:{}>".format(filename, line_dict["line"]))
+        output.append("{}:{}:".format(filename, line_dict["line"]))
 
     output.append(line_dict["formatted_msg"])
 

--- a/python_libs/pebble-loghash/pebble/loghashing/newlogging.py
+++ b/python_libs/pebble-loghash/pebble/loghashing/newlogging.py
@@ -95,7 +95,8 @@ def dehash_line(line, log_dict):
     if "date" not in line_dict and line_dict.get("re_level"):
         output.append("<{}>".format(line_dict["re_level"]))
 
-    if "task" in line_dict:
+    # "-" means the task prefix is disabled (CONFIG_LOG_TASK_PREFIX)
+    if line_dict.get("task", "-") != "-":
         output.append(line_dict["task"])
 
     if "module" not in line_dict and "file" in line_dict and "line" in line_dict:

--- a/python_libs/pebble-loghash/test_newlogging.py
+++ b/python_libs/pebble-loghash/test_newlogging.py
@@ -55,6 +55,14 @@ test_log_dict = {
         "line": "120",
         "msg": "0x%lx != 0x%lx",
     },
+    "75": {
+        "file": "../src/fw/activity/activity.c",
+        "line": "804",
+        "level": "200",
+        "color": "YELLOW",
+        "msg": "activity tracking started",
+        "module": "activity",
+    },
     "1073741824": {
         "color": "GREY",
         "file": "hc_protocol.c",
@@ -62,7 +70,7 @@ test_log_dict = {
         "line": "69",
         "msg": "Init BLE SPI Protocol",
     },
-    "new_logging_version": "NL0101",
+    "new_logging_version": "NL0102",
 }
 
 
@@ -72,28 +80,35 @@ def test_dehash_line():
     """
     # Console Line - No arguments
     line = "? A 21:35:14.375 :0> NL:{:x}".format(43)
-    assert "D A 21:35:14.375 activity.c:804> activity tracking started" == dehash_line(
-        line, test_log_dict
+    assert (
+        "[21:35:14.375] <dbg> A activity.c:804: activity tracking started"
+        == dehash_line(line, test_log_dict)
     )
 
     # Console Line - Arguments
     line = "? A 21:35:14.375 :0> NL:{:x} a a `Success`".format(114)
     assert (
-        "* A 21:35:14.375 ispp.c:1872> Start Authentication Process 10 (a) Success"
+        "[21:35:14.375] A ispp.c:1872: Start Authentication Process 10 (a) Success"
         == dehash_line(line, test_log_dict)
+    )
+
+    # Console Line - Log module
+    line = "? A 21:35:14.375 :0> NL:{:x}".format(75)
+    assert "[21:35:14.375] <dbg> A activity: activity tracking started" == dehash_line(
+        line, test_log_dict
     )
 
     # Support Line - No arguments
     line = "2015-09-05 02:16:16:000GMT :0> NL:{:x}".format(43)
     assert (
-        "2015-09-05 02:16:16:000GMT activity.c:804> activity tracking started"
+        "[2015-09-05 02:16:16:000GMT] activity.c:804: activity tracking started"
         == dehash_line(line, test_log_dict)
     )
 
     # Support Line - Arguments
     line = "2015-09-05 02:16:19:000GMT :0> NL:{:x} 10 10 `Success`".format(114)
     assert (
-        "2015-09-05 02:16:19:000GMT ispp.c:1872> Start Authentication Process 16 (10) Success"
+        "[2015-09-05 02:16:19:000GMT] ispp.c:1872: Start Authentication Process 16 (10) Success"
         == dehash_line(line, test_log_dict)
     )
 
@@ -104,46 +119,49 @@ def test_dehash_line():
     # Pointer format conversion
     line = "2015-09-05 02:16:19:000GMT :0> NL:{:x} 164 1FfF".format(214)
     assert (
-        "2015-09-05 02:16:19:000GMT pointer_print.c:1872> My address is 164 1fff"
+        "[2015-09-05 02:16:19:000GMT] pointer_print.c:1872: My address is 164 1fff"
         == dehash_line(line, test_log_dict)
     )
 
     # Two's compliment negative value
     line = "2015-09-05 02:16:19:000GMT :0> NL:{:x} 10 ffff8170".format(64856)
     assert (
-        "2015-09-05 02:16:19:000GMT clock.c:768> Changed timezone to id 16, gmtoff is -32400"
+        "[2015-09-05 02:16:19:000GMT] clock.c:768: Changed timezone to id 16, gmtoff is -32400"
         == dehash_line(line, test_log_dict)
     )
 
     # Two's compliment negative value
     line = "2015-09-05 02:16:19:000GMT :0> NL:{:x} 9AEBC155 43073997".format(11082)
     assert (
-        "2015-09-05 02:16:19:000GMT resource_storage.c:120> 0x9aebc155 != 0x43073997"
+        "[2015-09-05 02:16:19:000GMT] resource_storage.c:120: 0x9aebc155 != 0x43073997"
         == dehash_line(line, test_log_dict)
     )
 
     # Empty string parameter - 1
     line = "? A 21:35:14.375 :0> NL:{:x} `` `string`".format(100000)
-    assert "D A 21:35:14.375 string.c:111> string 1 , string 2 string" == dehash_line(
-        line, test_log_dict
+    assert (
+        "[21:35:14.375] <dbg> A string.c:111: string 1 , string 2 string"
+        == dehash_line(line, test_log_dict)
     )
 
     # Empty string parameter - 2 - trailing space
     line = "? A 21:35:14.375 :0> NL:{:x} `string` `` ".format(100000)
-    assert "D A 21:35:14.375 string.c:111> string 1 string, string 2 " == dehash_line(
-        line, test_log_dict
+    assert (
+        "[21:35:14.375] <dbg> A string.c:111: string 1 string, string 2 "
+        == dehash_line(line, test_log_dict)
     )
 
     # Empty string parameter - 2 - no trailing space
     line = "? A 21:35:14.375 :0> NL:{:x} `string` ``".format(100000)
-    assert "D A 21:35:14.375 string.c:111> string 1 string, string 2 " == dehash_line(
-        line, test_log_dict
+    assert (
+        "[21:35:14.375] <dbg> A string.c:111: string 1 string, string 2 "
+        == dehash_line(line, test_log_dict)
     )
 
     # Missing closing `
     line = "? A 21:35:14.375 :0> NL:{:x} `string` `string".format(100000)
     assert (
-        "D A 21:35:14.375 string.c:111> string 1 string, string 2 string"
+        "[21:35:14.375] <dbg> A string.c:111: string 1 string, string 2 string"
         == dehash_line(line, test_log_dict)
     )
 
@@ -156,7 +174,7 @@ def test_dehash_invalid_parameters():
     # Not enough parameters
     line = "2015-09-05 02:16:19:000GMT :0> NL:{:x} 164".format(214)
     assert (
-        "2015-09-05 02:16:19:000GMT pointer_print.c:1872> :0> NL:d6 164 "
+        "[2015-09-05 02:16:19:000GMT] pointer_print.c:1872: :0> NL:d6 164 "
         "----> ERROR: not enough arguments for format string"
         == dehash_line(line, test_log_dict)
     )
@@ -164,7 +182,7 @@ def test_dehash_invalid_parameters():
     # Too many parameters
     line = "2015-09-05 02:16:19:000GMT :0> NL:{:x} 164 1FfF 17".format(214)
     assert (
-        "2015-09-05 02:16:19:000GMT pointer_print.c:1872> :0> NL:d6 164 1FfF 17 "
+        "[2015-09-05 02:16:19:000GMT] pointer_print.c:1872: :0> NL:d6 164 1FfF 17 "
         "----> ERROR: not all arguments converted during string formatting"
         == dehash_line(line, test_log_dict)
     )
@@ -172,36 +190,36 @@ def test_dehash_invalid_parameters():
     # Unterminated string (last `)
     line = "2015-09-05 02:16:19:000GMT :0> NL:{:x} 10 10 `Success".format(114)
     assert (
-        "2015-09-05 02:16:19:000GMT ispp.c:1872> Start Authentication Process 16 (10) Success"
+        "[2015-09-05 02:16:19:000GMT] ispp.c:1872: Start Authentication Process 16 (10) Success"
         == dehash_line(line, test_log_dict)
     )
 
     # Unterminated string (first `)
     line = "2015-09-05 02:16:19:000GMT :0> NL:{:x} 10 10 Success`".format(114)
     assert (
-        "2015-09-05 02:16:19:000GMT ispp.c:1872> Start Authentication Process 16 (10) Success"
+        "[2015-09-05 02:16:19:000GMT] ispp.c:1872: Start Authentication Process 16 (10) Success"
         == dehash_line(line, test_log_dict)
     )
 
     # Unterminated string (No `s)
     line = "2015-09-05 02:16:19:000GMT :0> NL:{:x} 10 10 Success".format(114)
     assert (
-        "2015-09-05 02:16:19:000GMT ispp.c:1872> Start Authentication Process 16 (10) Success"
+        "[2015-09-05 02:16:19:000GMT] ispp.c:1872: Start Authentication Process 16 (10) Success"
         == dehash_line(line, test_log_dict)
     )
 
     # Invalid hex character
     line = "2015-09-05 02:16:19:000GMT :0> NL:{:x} 10 1q0 Success".format(114)
     assert (
-        "2015-09-05 02:16:19:000GMT ispp.c:1872> :0> NL:72 10 1q0 Success "
-        "----> ERROR: %x format: a number is required, not str"
+        "[2015-09-05 02:16:19:000GMT] ispp.c:1872: :0> NL:72 10 1q0 Success "
+        "----> ERROR: %x format: an integer is required, not str"
         == dehash_line(line, test_log_dict)
     )
 
     # Unicode
     line = "? A 21:35:14.375 :0> NL:{:x} `unicode` `Pebble β`".format(100000)
     assert (
-        "D A 21:35:14.375 string.c:111> string 1 unicode, string 2 Pebble β"
+        "[21:35:14.375] <dbg> A string.c:111: string 1 unicode, string 2 Pebble β"
         == dehash_line(line, test_log_dict)
     )
 
@@ -214,7 +232,7 @@ def test_legacy_dehash_line():
     # Console Line - No arguments
     line = "? A 21:35:14.375 :0> NL:{:x}".format(43)
     assert (
-        "D A 21:35:14.375 activity.c:804> activity tracking started"
+        "[21:35:14.375] <dbg> A activity.c:804: activity tracking started"
         == legacy_dehash_line(line, test_log_dict)
     )
 

--- a/src/bluetooth-fw/Kconfig
+++ b/src/bluetooth-fw/Kconfig
@@ -22,6 +22,10 @@ config BT_FW_STUB
 
 endchoice
 
+module = BT
+module-str = Bluetooth
+source "src/fw/Kconfig.template.log_level"
+
 config GH3X2X_TUNING_SERVICE_ENABLED
     bool "GH3X2X tuning service"
     depends on HRM_GH3X2X

--- a/src/bluetooth-fw/nimble/advert.c
+++ b/src/bluetooth-fw/nimble/advert.c
@@ -16,6 +16,8 @@
 
 #include "nimble_type_conversions.h"
 
+PBL_LOG_MODULE_DECLARE(bt, CONFIG_BT_LOG_LEVEL);
+
 static const ble_uuid16_t s_device_name_chr_uuid = BLE_UUID16_INIT(0x2A00);
 static char s_device_name[BT_DEVICE_NAME_BUFFER_SIZE];
 static bool s_pairing_in_progress;
@@ -49,14 +51,14 @@ bool bt_driver_advert_set_advertising_data(const BLEAdData *ad_data) {
 
   rc = ble_gap_adv_set_data((uint8_t *)&ad_data->data, ad_data->ad_data_length);
   if (rc != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Failed to set advertising data (0x%04x)", (uint16_t)rc);
+    PBL_LOG_ERR("Failed to set advertising data (0x%04x)", (uint16_t)rc);
     return false;
   }
 
   rc = ble_gap_adv_rsp_set_data((uint8_t *)&ad_data->data[ad_data->ad_data_length],
                                 ad_data->scan_resp_data_length);
   if (rc != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Failed to set scan response data (0x%04x)", (uint16_t)rc);
+    PBL_LOG_ERR("Failed to set scan response data (0x%04x)", (uint16_t)rc);
     return false;
   }
 
@@ -69,7 +71,7 @@ static void prv_handle_connection_event(struct ble_gap_event *event) {
 
   struct ble_gap_conn_desc desc;
   if (ble_gap_conn_find(event->connect.conn_handle, &desc) != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_handle_connection_event: Failed to find connection descriptor");
+    PBL_LOG_ERR("prv_handle_connection_event: Failed to find connection descriptor");
     return;
   }
 
@@ -135,7 +137,7 @@ static void prv_handle_disconnection_event(struct ble_gap_event *event) {
 static void prv_handle_enc_change_event(struct ble_gap_event *event) {
   struct ble_gap_conn_desc desc;
   if (ble_gap_conn_find(event->enc_change.conn_handle, &desc) != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_handle_enc_change_event: Failed to find connection descriptor");
+    PBL_LOG_ERR("prv_handle_enc_change_event: Failed to find connection descriptor");
     return;
   }
 
@@ -150,18 +152,18 @@ static void prv_handle_enc_change_event(struct ble_gap_event *event) {
 
 static void prv_handle_conn_params_updated_event(struct ble_gap_event *event) {
   if (event->conn_update.status != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Connection parameters update failed: 0x%04x",
+    PBL_LOG_ERR("Connection parameters update failed: 0x%04x",
               (uint16_t)event->conn_update.status);
     return;
   }
 
   struct ble_gap_conn_desc desc;
   if (ble_gap_conn_find(event->conn_update.conn_handle, &desc) != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_handle_conn_params_updated_event: Failed to find connection descriptor");
+    PBL_LOG_ERR("prv_handle_conn_params_updated_event: Failed to find connection descriptor");
     return;
   }
 
-  PBL_LOG_D_INFO(LOG_DOMAIN_BT, "Connection parameters updated: "
+  PBL_LOG_INFO("Connection parameters updated: "
             "itvl=%u ms, latency=%u, spvn timeout=%u ms",
             desc.conn_itvl * BLE_HCI_CONN_ITVL / 1000, desc.conn_latency,
             desc.supervision_timeout * BLE_HCI_CONN_SPVN_TMO_UNITS);
@@ -178,7 +180,7 @@ static void prv_handle_conn_params_updated_event(struct ble_gap_event *event) {
 static void prv_handle_conn_update_req_event(struct ble_gap_event *event) {
   *event->conn_update_req.self_params = *event->conn_update_req.peer_params;
 
-  PBL_LOG_D_INFO(LOG_DOMAIN_BT, "Connection update request: "
+  PBL_LOG_INFO("Connection update request: "
             "itvl=(%u, %u) ms, latency=%u, spvn timeout=%u ms",
             event->conn_update_req.self_params->itvl_min * BLE_HCI_CONN_ITVL / 1000,
             event->conn_update_req.self_params->itvl_max * BLE_HCI_CONN_ITVL / 1000,
@@ -220,7 +222,7 @@ static void prv_handle_pairing_complete_event(struct ble_gap_event *event) {
 static void prv_handle_identity_resolved_event(struct ble_gap_event *event) {
   struct ble_gap_conn_desc desc;
   if (ble_gap_conn_find(event->identity_resolved.conn_handle, &desc) != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_handle_identity_resolved_event: Failed to find connection descriptor");
+    PBL_LOG_ERR("prv_handle_identity_resolved_event: Failed to find connection descriptor");
     return;
   }
 
@@ -233,7 +235,7 @@ static void prv_handle_identity_resolved_event(struct ble_gap_event *event) {
 static void prv_handle_mtu_change_event(struct ble_gap_event *event) {
   struct ble_gap_conn_desc desc;
   if (ble_gap_conn_find(event->mtu.conn_handle, &desc) != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_handle_mtu_change_event: Failed to find connection descriptor");
+    PBL_LOG_ERR("prv_handle_mtu_change_event: Failed to find connection descriptor");
     return;
   }
 
@@ -245,7 +247,7 @@ static void prv_handle_mtu_change_event(struct ble_gap_event *event) {
 extern int pebble_pairing_service_get_connectivity_send_notification(uint16_t conn_handle,
                                                                      uint16_t attr_handle);
 static void prv_handle_subscription_event(struct ble_gap_event *event) {
-  PBL_LOG_D_DBG(LOG_DOMAIN_BT, "prv_handle_subscription_event: connhandle: %d attr:%d notify:%d/%d indicate:%d/%d",
+  PBL_LOG_DBG("prv_handle_subscription_event: connhandle: %d attr:%d notify:%d/%d indicate:%d/%d",
             event->subscribe.conn_handle, event->subscribe.attr_handle,
             event->subscribe.prev_notify, event->subscribe.cur_notify,
             event->subscribe.prev_indicate, event->subscribe.cur_indicate);
@@ -254,7 +256,7 @@ static void prv_handle_subscription_event(struct ble_gap_event *event) {
 static void prv_handle_notification_rx_event(struct ble_gap_event *event) {
   struct ble_gap_conn_desc desc;
   if (ble_gap_conn_find(event->notify_rx.conn_handle, &desc) != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_handle_notification_rx_event: Failed to find connection descriptor");
+    PBL_LOG_ERR("prv_handle_notification_rx_event: Failed to find connection descriptor");
     return;
   }
 
@@ -273,7 +275,7 @@ static void prv_handle_notification_rx_event(struct ble_gap_event *event) {
 }
 
 static void prv_handle_notification_tx_event(struct ble_gap_event *event) {
-  PBL_LOG_D_DBG(LOG_DOMAIN_BT, "notification tx event; status=%d attr_handle=%d indication=%d\n",
+  PBL_LOG_DBG("notification tx event; status=%d attr_handle=%d indication=%d\n",
             event->notify_tx.status,
             event->notify_tx.attr_handle,
             event->notify_tx.indication);
@@ -297,14 +299,14 @@ static int prv_handle_repeat_pairing_event(struct ble_gap_event *event) {
 
   return BLE_GAP_REPEAT_PAIRING_RETRY;
 #else
-  PBL_LOG_D_WRN(LOG_DOMAIN_BT, "BLE_GAP_EVENT_REPEAT_PAIRING ignored");
+  PBL_LOG_WRN("BLE_GAP_EVENT_REPEAT_PAIRING ignored");
   return BLE_GAP_REPEAT_PAIRING_IGNORE;
 #endif
 }
 
 static void prv_handle_phy_update_event(struct ble_gap_event *event) {
   if (event->phy_updated.status != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "PHY update failed: 0x%04x",
+    PBL_LOG_ERR("PHY update failed: 0x%04x",
               (uint16_t)event->phy_updated.status);
     return;
   }
@@ -316,44 +318,44 @@ static void prv_handle_phy_update_event(struct ble_gap_event *event) {
 static int prv_handle_gap_event(struct ble_gap_event *event, void *arg) {
   switch (event->type) {
     case BLE_GAP_EVENT_CONNECT:
-      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_CONNECT");
+      PBL_LOG_DBG("BLE_GAP_EVENT_CONNECT");
       prv_handle_connection_event(event);
       break;
     case BLE_GAP_EVENT_DISCONNECT:
-      PBL_LOG_D_INFO(LOG_DOMAIN_BT, "BLE_GAP_EVENT_DISCONNECT reason=0x%x",
+      PBL_LOG_INFO("BLE_GAP_EVENT_DISCONNECT reason=0x%x",
               event->disconnect.reason);
       prv_handle_disconnection_event(event);
       break;
     case BLE_GAP_EVENT_ENC_CHANGE:
-      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_ENC_CHANGE");
+      PBL_LOG_DBG("BLE_GAP_EVENT_ENC_CHANGE");
       prv_handle_enc_change_event(event);
       break;
     case BLE_GAP_EVENT_CONN_UPDATE:
-      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_CONN_UPDATE");
+      PBL_LOG_DBG("BLE_GAP_EVENT_CONN_UPDATE");
       prv_handle_conn_params_updated_event(event);
       break;
     case BLE_GAP_EVENT_CONN_UPDATE_REQ:
-      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_CONN_UPDATE_REQ");
+      PBL_LOG_DBG("BLE_GAP_EVENT_CONN_UPDATE_REQ");
       prv_handle_conn_update_req_event(event);
       break;
     case BLE_GAP_EVENT_PASSKEY_ACTION:
-      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_PASSKEY_ACTION");
+      PBL_LOG_DBG("BLE_GAP_EVENT_PASSKEY_ACTION");
       prv_handle_passkey_event(event);
       break;
     case BLE_GAP_EVENT_IDENTITY_RESOLVED:
-      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_IDENTITY_RESOLVED");
+      PBL_LOG_DBG("BLE_GAP_EVENT_IDENTITY_RESOLVED");
       prv_handle_identity_resolved_event(event);
       break;
     case BLE_GAP_EVENT_PAIRING_COMPLETE:
-      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_PAIRING_COMPLETE");
+      PBL_LOG_DBG("BLE_GAP_EVENT_PAIRING_COMPLETE");
       prv_handle_pairing_complete_event(event);
       break;
     case BLE_GAP_EVENT_MTU:
-      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_MTU");
+      PBL_LOG_DBG("BLE_GAP_EVENT_MTU");
       prv_handle_mtu_change_event(event);
       break;
     case BLE_GAP_EVENT_SUBSCRIBE:
-      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_SUBSCRIBE");
+      PBL_LOG_DBG("BLE_GAP_EVENT_SUBSCRIBE");
       prv_handle_subscription_event(event);
       break;
     case BLE_GAP_EVENT_NOTIFY_RX:
@@ -361,18 +363,18 @@ static int prv_handle_gap_event(struct ble_gap_event *event, void *arg) {
       prv_handle_notification_rx_event(event);
       break;
     case BLE_GAP_EVENT_NOTIFY_TX:
-      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_NOTIFY_TX");
+      PBL_LOG_DBG("BLE_GAP_EVENT_NOTIFY_TX");
       prv_handle_notification_tx_event(event);
       break;
     case BLE_GAP_EVENT_REPEAT_PAIRING:
-      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_REPEAT_PAIRING");
+      PBL_LOG_DBG("BLE_GAP_EVENT_REPEAT_PAIRING");
       return prv_handle_repeat_pairing_event(event);
     case BLE_GAP_EVENT_PHY_UPDATE_COMPLETE:
-      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "BLE_GAP_EVENT_PHY_UPDATE_COMPLETE");
+      PBL_LOG_DBG("BLE_GAP_EVENT_PHY_UPDATE_COMPLETE");
       prv_handle_phy_update_event(event);
       break;
     default:
-      PBL_LOG_D_WRN(LOG_DOMAIN_BT, "Unhandled GAP event: %d", event->type);
+      PBL_LOG_WRN("Unhandled GAP event: %d", event->type);
       break;
   }
   return 0;
@@ -390,13 +392,13 @@ bool bt_driver_advert_advertising_enable(uint32_t min_interval_ms, uint32_t max_
 
   rc = ble_hs_id_infer_auto(0, &own_addr_type);
   if (rc != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Failed to infer own address type (%d)", rc);
+    PBL_LOG_ERR("Failed to infer own address type (%d)", rc);
     return false;
   }
 
   rc = ble_gap_adv_start(own_addr_type, NULL, BLE_HS_FOREVER, &advp, prv_handle_gap_event, NULL);
   if (rc != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Failed to start advertising (0x%04x)", (uint16_t)rc);
+    PBL_LOG_ERR("Failed to start advertising (0x%04x)", (uint16_t)rc);
     return false;
   }
 

--- a/src/bluetooth-fw/nimble/gap_le_connect.c
+++ b/src/bluetooth-fw/nimble/gap_le_connect.c
@@ -3,20 +3,23 @@
 
 #include <bluetooth/gap_le_connect.h>
 #include <host/ble_gap.h>
+#include <system/logging.h>
 
 #include "nimble_type_conversions.h"
+
+PBL_LOG_MODULE_DECLARE(bt, CONFIG_BT_LOG_LEVEL);
 
 int bt_driver_gap_le_disconnect(const BTDeviceInternal *peer_address) {
   uint16_t conn_handle;
 
   if (!pebble_device_to_nimble_conn_handle(peer_address, &conn_handle)) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "bt_driver_gap_le_disconnect: Failed to find connection handle");
+    PBL_LOG_ERR("bt_driver_gap_le_disconnect: Failed to find connection handle");
     return -1;
   }
 
   int rc = ble_gap_terminate(conn_handle, BLE_ERR_REM_USER_CONN_TERM);
   if (rc != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "ble_gap_terminate rc=0x%04x", (uint16_t)rc);
+    PBL_LOG_ERR("ble_gap_terminate rc=0x%04x", (uint16_t)rc);
   }
 
   return rc;

--- a/src/bluetooth-fw/nimble/gap_le_device_name.c
+++ b/src/bluetooth-fw/nimble/gap_le_device_name.c
@@ -6,8 +6,11 @@
 #include <host/ble_gatt.h>
 #include <host/ble_uuid.h>
 #include <pbl/services/system_task.h>
+#include <system/logging.h>
 
 #include "nimble_type_conversions.h"
+
+PBL_LOG_MODULE_DECLARE(bt, CONFIG_BT_LOG_LEVEL);
 
 #define GAP_DEVICE_NAME_CHR (0x2A00)
 
@@ -17,7 +20,7 @@ static int prv_device_name_read_event_cb(uint16_t conn_handle, const struct ble_
                                          struct ble_gatt_attr *attr, void *arg) {
   if (error->status != 0) {
     if (error->status != BLE_HS_EDONE) {
-      PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_device_name_read_event_cb error=%d",
+      PBL_LOG_ERR("prv_device_name_read_event_cb error=%d",
                 error->status);
     }
     return 0;
@@ -46,14 +49,14 @@ static int prv_device_name_read_event_cb(uint16_t conn_handle, const struct ble_
 static void prv_gap_le_device_name_request(GAPLEConnection *connection) {
   uint16_t conn_handle;
   if (!pebble_device_to_nimble_conn_handle(&connection->device, &conn_handle)) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_gap_le_device_name_request: Failed to find connection handle");
+    PBL_LOG_ERR("prv_gap_le_device_name_request: Failed to find connection handle");
     return;
   }
 
   int rc = ble_gattc_read_by_uuid(conn_handle, 1, UINT16_MAX, (ble_uuid_t *)&device_name_chr_uuid,
                                   prv_device_name_read_event_cb, (void *)connection);
   if (rc != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_gap_le_device_name_request ble_gattc_read_by_uuid rc=0x%04x", (uint16_t)rc);
+    PBL_LOG_ERR("prv_gap_le_device_name_request ble_gattc_read_by_uuid rc=0x%04x", (uint16_t)rc);
   }
 }
 
@@ -64,7 +67,7 @@ static void prv_request_device_name_cb(GAPLEConnection *connection, void *data) 
 void bt_driver_gap_le_device_name_request(const BTDeviceInternal *device) {
   GAPLEConnection *connection = gap_le_connection_by_device(device);
   if (connection == NULL) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "bt_driver_gap_le_device_name_request gap_le_connection_by_device returned NULL");
+    PBL_LOG_ERR("bt_driver_gap_le_device_name_request gap_le_connection_by_device returned NULL");
     return;
   }
   prv_gap_le_device_name_request(connection);

--- a/src/bluetooth-fw/nimble/gatt_client_discovery.c
+++ b/src/bluetooth-fw/nimble/gatt_client_discovery.c
@@ -13,6 +13,8 @@
 
 #include "nimble_type_conversions.h"
 
+PBL_LOG_MODULE_DECLARE(bt, CONFIG_BT_LOG_LEVEL);
+
 static bool s_discovery_in_progress;
 static bool s_stop_discovery_requested;
 static SemaphoreHandle_t s_discovery_stopped;
@@ -185,14 +187,14 @@ typedef struct {
 static int prv_on_svc_chgd_subscribe(uint16_t conn_handle, const struct ble_gatt_error *error,
                                      struct ble_gatt_attr *attr, void *arg) {
   if (error->status != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Failed to subscribe to service changed: 0x%" PRIx16,
+    PBL_LOG_ERR("Failed to subscribe to service changed: 0x%" PRIx16,
               error->status);
   } else {
     GATTServiceDiscoveryDescriptorContext *ctx = arg;
     bt_driver_cb_gatt_client_discovery_handle_service_changed(ctx->connection,
                                                               ctx->chr_handle);
 
-    PBL_LOG_D_DBG(LOG_DOMAIN_BT, "Subscribed to service changed");
+    PBL_LOG_DBG("Subscribed to service changed");
   }
 
   kernel_free(arg);
@@ -222,7 +224,7 @@ static void prv_convert_service_and_notify_os(uint16_t conn_handle, GATTServiceD
     ret = ble_gattc_write_flat(conn_handle, dsc_handle,
                                &value, sizeof(value), prv_on_svc_chgd_subscribe, ctx);
     if (ret != 0) {
-        PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Failed to subscribe to service changed: %d", ret);
+        PBL_LOG_ERR("Failed to subscribe to service changed: %d", ret);
     }
   }
 
@@ -254,7 +256,7 @@ static void prv_discover_next_dscs(uint16_t conn_handle, GATTServiceDiscoveryCon
   uint16_t end_handle = prv_get_last_dsc_handle(context);
   int rc = ble_gattc_disc_all_dscs(conn_handle, start_handle, end_handle, prv_find_dsc_cb, context);
   if (rc != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "ble_gattc_disc_all_dscs rc=0x%04x (0x%04x -> 0x%04x)",
+    PBL_LOG_ERR("ble_gattc_disc_all_dscs rc=0x%04x (0x%04x -> 0x%04x)",
               (uint16_t)rc, start_handle, end_handle);
   }
 }
@@ -265,7 +267,7 @@ static void prv_discover_next_chrs(uint16_t conn_handle, GATTServiceDiscoveryCon
   int rc = ble_gattc_disc_all_chrs(conn_handle, service_node->service.start_handle,
                                    service_node->service.end_handle, prv_find_chr_cb, context);
   if (rc != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "ble_gattc_disc_all_chrs rc=0x%04x (0x%04x -> 0x%04x)",
+    PBL_LOG_ERR("ble_gattc_disc_all_chrs rc=0x%04x (0x%04x -> 0x%04x)",
               (uint16_t)rc, service_node->service.start_handle, service_node->service.end_handle);
   }
 }
@@ -329,7 +331,7 @@ static int prv_find_dsc_cb(uint16_t conn_handle, const struct ble_gatt_error *er
     case 0:
       char chr_uuid_str[BLE_UUID_STR_LEN];
       ble_uuid_to_str(&dsc->uuid.u, chr_uuid_str);
-      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "Found descriptor %s (hdl: 0x%" PRIx16 ")",
+      PBL_LOG_DBG("Found descriptor %s (hdl: 0x%" PRIx16 ")",
                 chr_uuid_str, dsc->handle);
 
       GATTServiceDiscoveryDescriptorNode *dsc_node = prv_create_descriptor_node(dsc);
@@ -342,7 +344,7 @@ static int prv_find_dsc_cb(uint16_t conn_handle, const struct ble_gatt_error *er
 
       break;
     case BLE_HS_EDONE:
-      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "Descriptor discovery done");
+      PBL_LOG_DBG("Descriptor discovery done");
 
       context->current_characteristic = list_get_next(context->current_characteristic);
 
@@ -374,7 +376,7 @@ static int prv_find_dsc_cb(uint16_t conn_handle, const struct ble_gatt_error *er
       break;
 
     default:
-      PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Descriptor discovery error: %d",
+      PBL_LOG_ERR("Descriptor discovery error: %d",
                 error->status);
       if (error->status == BLE_HS_ETIMEOUT) {
         errno = BTErrnoServiceDiscoveryTimeout;
@@ -409,7 +411,7 @@ static int prv_find_chr_cb(uint16_t conn_handle, const struct ble_gatt_error *er
     case 0:
       char chr_uuid_str[BLE_UUID_STR_LEN];
       ble_uuid_to_str(&chr->uuid.u, chr_uuid_str);
-      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "Found characteristic %s (val hdl: 0x%" PRIx16 ", def hdl: 0x%" PRIx16 ")",
+      PBL_LOG_DBG("Found characteristic %s (val hdl: 0x%" PRIx16 ", def hdl: 0x%" PRIx16 ")",
                 chr_uuid_str, chr->val_handle, chr->def_handle);
 
       GATTServiceDiscoveryCharacteristicNode *chr_node = prv_create_chr_node(chr);
@@ -420,7 +422,7 @@ static int prv_find_chr_cb(uint16_t conn_handle, const struct ble_gatt_error *er
       break;
 
     case BLE_HS_EDONE:
-      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "Characteristic discovery done");
+      PBL_LOG_DBG("Characteristic discovery done");
 
       context->current_service = list_get_next(context->current_service);
 
@@ -446,7 +448,7 @@ static int prv_find_chr_cb(uint16_t conn_handle, const struct ble_gatt_error *er
       break;
 
     default:
-      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "Characteristic discovery error: %d",
+      PBL_LOG_DBG("Characteristic discovery error: %d",
                 error->status);
       if (error->status == BLE_HS_ETIMEOUT) {
         errno = BTErrnoServiceDiscoveryTimeout;
@@ -489,13 +491,13 @@ static int prv_find_inc_svc_cb(uint16_t conn_handle, const struct ble_gatt_error
 
       char service_uuid_str[BLE_UUID_STR_LEN];
       ble_uuid_to_str(&service->uuid.u, service_uuid_str);
-      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "Found service %s, 0x%" PRIx16 "-0x%" PRIx16 " (total %lu)",
+      PBL_LOG_DBG("Found service %s, 0x%" PRIx16 "-0x%" PRIx16 " (total %lu)",
                 service_uuid_str, service->start_handle, service->end_handle,
                 list_count(context->services));
       break;
 
     case BLE_HS_EDONE:
-      PBL_LOG_D_DBG(LOG_DOMAIN_BT, "Service discovery complete");
+      PBL_LOG_DBG("Service discovery complete");
 
       if (context->services != NULL) {
         // got services, start discovering characteristics
@@ -511,7 +513,7 @@ static int prv_find_inc_svc_cb(uint16_t conn_handle, const struct ble_gatt_error
       break;
 
     default:
-      PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Service discovery error: %d", error->status);
+      PBL_LOG_ERR("Service discovery error: %d", error->status);
       if (error->status == BLE_HS_ETIMEOUT) {
         errno = BTErrnoServiceDiscoveryTimeout;
       } else if (error->status == BLE_HS_ENOTCONN) {

--- a/src/bluetooth-fw/nimble/gatt_client_operations.c
+++ b/src/bluetooth-fw/nimble/gatt_client_operations.c
@@ -7,6 +7,9 @@
 
 #include <host/ble_gatt.h>
 #include <host/ble_hs.h>
+#include <system/logging.h>
+
+PBL_LOG_MODULE_DECLARE(bt, CONFIG_BT_LOG_LEVEL);
 
 // NimBLE reports ATT-layer failures as BLE_HS_ERR_ATT_BASE + the ATT error
 // code. GATT clients match responses against spec-level BLEGATTError values
@@ -25,7 +28,7 @@ static BLEGATTError prv_gatt_error_code(uint16_t status) {
 static int prv_gatt_write_event_cb(uint16_t conn_handle, const struct ble_gatt_error *error,
                                    struct ble_gatt_attr *attr, void *arg) {
   if (error->status != 0U) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "GATT write failed (hdl: 0x%" PRIx16 "): 0x%" PRIx16,
+    PBL_LOG_ERR("GATT write failed (hdl: 0x%" PRIx16 "): 0x%" PRIx16,
               error->att_handle, error->status);
   }
 
@@ -42,7 +45,7 @@ static int prv_gatt_write_event_cb(uint16_t conn_handle, const struct ble_gatt_e
 static int prv_gatt_read_event_cb(uint16_t conn_handle, const struct ble_gatt_error *error,
                                   struct ble_gatt_attr *attr, void *arg) {
   if (error->status != 0U) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "GATT read failed (hdl: 0x%" PRIx16 "): 0x%" PRIx16,
+    PBL_LOG_ERR("GATT read failed (hdl: 0x%" PRIx16 "): 0x%" PRIx16,
               error->att_handle, error->status);
   }
 
@@ -62,7 +65,7 @@ static int prv_gatt_read_event_cb(uint16_t conn_handle, const struct ble_gatt_er
 
 BTErrno bt_driver_gatt_write_without_response(GAPLEConnection *connection, const uint8_t *value,
                                               size_t value_length, uint16_t att_handle) {
-  PBL_LOG_D_VERBOSE(LOG_DOMAIN_BT, "bt_driver_gatt_write_without_response: %d",
+  PBL_LOG_VERBOSE("bt_driver_gatt_write_without_response: %d",
             att_handle);
   uint16_t conn_handle;
   if (!pebble_device_to_nimble_conn_handle(&connection->device, &conn_handle)) {
@@ -71,7 +74,7 @@ BTErrno bt_driver_gatt_write_without_response(GAPLEConnection *connection, const
 
   int rc = ble_gattc_write_no_rsp_flat(conn_handle, att_handle, value, value_length);
   if (rc != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Failed to write without response: %d", rc);
+    PBL_LOG_ERR("Failed to write without response: %d", rc);
     return BTErrnoInternalErrorBegin + rc;
   }
 
@@ -80,7 +83,7 @@ BTErrno bt_driver_gatt_write_without_response(GAPLEConnection *connection, const
 
 BTErrno bt_driver_gatt_write(GAPLEConnection *connection, const uint8_t *value, size_t value_length,
                              uint16_t att_handle, void *context) {
-  PBL_LOG_D_VERBOSE(LOG_DOMAIN_BT, "bt_driver_gatt_write: %d", att_handle);
+  PBL_LOG_VERBOSE("bt_driver_gatt_write: %d", att_handle);
   uint16_t conn_handle;
   if (!pebble_device_to_nimble_conn_handle(&connection->device, &conn_handle)) {
     return BTErrnoInvalidState;
@@ -89,7 +92,7 @@ BTErrno bt_driver_gatt_write(GAPLEConnection *connection, const uint8_t *value, 
   int rc = ble_gattc_write_flat(conn_handle, att_handle, value, value_length,
                                 prv_gatt_write_event_cb, context);
   if (rc != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Failed to write: %d", rc);
+    PBL_LOG_ERR("Failed to write: %d", rc);
     return BTErrnoInternalErrorBegin + rc;
   }
 
@@ -97,7 +100,7 @@ BTErrno bt_driver_gatt_write(GAPLEConnection *connection, const uint8_t *value, 
 }
 
 BTErrno bt_driver_gatt_read(GAPLEConnection *connection, uint16_t att_handle, void *context) {
-  PBL_LOG_D_VERBOSE(LOG_DOMAIN_BT, "bt_driver_gatt_read: %d", att_handle);
+  PBL_LOG_VERBOSE("bt_driver_gatt_read: %d", att_handle);
   uint16_t conn_handle;
   if (!pebble_device_to_nimble_conn_handle(&connection->device, &conn_handle)) {
     return BTErrnoInvalidState;
@@ -105,7 +108,7 @@ BTErrno bt_driver_gatt_read(GAPLEConnection *connection, uint16_t att_handle, vo
 
   int rc = ble_gattc_read(conn_handle, att_handle, prv_gatt_read_event_cb, context);
   if (rc != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Failed to read: %d", rc);
+    PBL_LOG_ERR("Failed to read: %d", rc);
     return BTErrnoInternalErrorBegin + rc;
   }
 

--- a/src/bluetooth-fw/nimble/init.c
+++ b/src/bluetooth-fw/nimble/init.c
@@ -23,6 +23,8 @@
 
 #include "nimble_store.h"
 
+PBL_LOG_MODULE_DEFINE(bt, CONFIG_BT_LOG_LEVEL);
+
 static const uint32_t s_bt_stack_start_stop_timeout_ms = 10000;
 
 extern void pebble_pairing_service_init(void);
@@ -49,13 +51,13 @@ typedef enum {
 static DriverState s_driver_state = DriverStateStopped;
 
 static void prv_sync_cb(void) {
-  PBL_LOG_D_DBG(LOG_DOMAIN_BT, "NimBLE host synchronized");
+  PBL_LOG_DBG("NimBLE host synchronized");
   xSemaphoreGive(s_host_started);
   bt_driver_handle_host_resynced();
 }
 
 static void prv_reset_cb(int reason) {
-  PBL_LOG_D_WRN(LOG_DOMAIN_BT, "NimBLE host reset (reason: 0x%04x)", (uint16_t)reason);
+  PBL_LOG_WRN("NimBLE host reset (reason: 0x%04x)", (uint16_t)reason);
 #ifdef CONFIG_SOC_SF32LB52
   // Controller stopped answering HCI. Crash so the coredump captures LCPU RAM
   // (core_dump wakes the LCPU itself); the reboot cold-recovers the controller.
@@ -64,7 +66,7 @@ static void prv_reset_cb(int reason) {
 }
 
 static void prv_host_task_main(void *unused) {
-  PBL_LOG_D_DBG(LOG_DOMAIN_BT, "NimBLE host task started");
+  PBL_LOG_DBG("NimBLE host task started");
 
   ble_hs_cfg.sync_cb = prv_sync_cb;
   ble_hs_cfg.reset_cb = prv_reset_cb;
@@ -116,12 +118,12 @@ bool bt_driver_start(BTDriverConfig *config) {
   BaseType_t f_rc;
 
   if (s_driver_state == DriverStateStarted) {
-    PBL_LOG_D_WRN(LOG_DOMAIN_BT, "Driver already started; skipping start");
+    PBL_LOG_WRN("Driver already started; skipping start");
     return true;
   }
 
   if (s_driver_state != DriverStateStopped) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Unexpected driver state %u; refusing to start",
+    PBL_LOG_ERR("Unexpected driver state %u; refusing to start",
                   (unsigned)s_driver_state);
     return false;
   }
@@ -157,7 +159,7 @@ bool bt_driver_start(BTDriverConfig *config) {
 
   rc = ble_hs_util_ensure_addr(0);
   if (rc != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Failed to ensure address: 0x%04x", (uint16_t)rc);
+    PBL_LOG_ERR("Failed to ensure address: 0x%04x", (uint16_t)rc);
     goto err;
   }
 
@@ -172,7 +174,7 @@ err:
     s_driver_state = DriverStateStopped;
     return false;
   } else if (rc != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Failed to stop NimBLE host after start failure: 0x%04x", (uint16_t)rc);
+    PBL_LOG_ERR("Failed to stop NimBLE host after start failure: 0x%04x", (uint16_t)rc);
     return false;
   }
 

--- a/src/bluetooth-fw/nimble/nimble_store.c
+++ b/src/bluetooth-fw/nimble/nimble_store.c
@@ -16,6 +16,8 @@
 
 #include "nimble_type_conversions.h"
 
+PBL_LOG_MODULE_DECLARE(bt, CONFIG_BT_LOG_LEVEL);
+
 #define KEY_SIZE 16
 
 #define BLE_FLAG_SECURE_CONNECTIONS 0x01
@@ -205,14 +207,14 @@ static void prv_notify_host_bonding_changed(const int obj_type,
   if (bonding.pairing_info.is_remote_encryption_info_valid) {
     bt_driver_cb_handle_create_bonding(&bonding, &addr);
   } else {
-    PBL_LOG_D_DBG(LOG_DOMAIN_BT, "Skipping notifying OS of our keys");
+    PBL_LOG_DBG("Skipping notifying OS of our keys");
   }
 }
 
 static int prv_nimble_store_write_sec(const int obj_type,
                                       const struct ble_store_value_sec *value_sec) {
   if (value_sec->key_size != KEY_SIZE || value_sec->csrk_present) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Unsupported security parameters");
+    PBL_LOG_ERR("Unsupported security parameters");
     return BLE_HS_ENOTSUP;
   }
 
@@ -430,7 +432,7 @@ static int prv_nimble_store_gen_key(uint8_t key, struct ble_store_gen_key *gen_k
 
     ret = ble_hs_hci_rand(stored_keys, sizeof(stored_keys));
     if (ret != 0) {
-      PBL_LOG_D_ERR(LOG_DOMAIN_BT, "Could not generate root keys: %d", ret);
+      PBL_LOG_ERR("Could not generate root keys: %d", ret);
       return ret;
     }
 

--- a/src/bluetooth-fw/nimble/nimble_type_conversions.c
+++ b/src/bluetooth-fw/nimble/nimble_type_conversions.c
@@ -6,6 +6,9 @@
 #include <btutil/bt_uuid.h>
 #include <host/ble_gap.h>
 #include <string.h>
+#include <system/logging.h>
+
+PBL_LOG_MODULE_DECLARE(bt, CONFIG_BT_LOG_LEVEL);
 
 void nimble_addr_to_pebble_addr(const ble_addr_t *addr, BTDeviceAddress *addr_out) {
   memcpy(&addr_out->octets, &addr->val, BLE_DEV_ADDR_LEN);
@@ -30,7 +33,7 @@ bool pebble_device_to_nimble_conn_handle(const BTDeviceInternal *device, uint16_
 
   int rc = ble_gap_conn_find_by_addr(&addr, &desc);
   if (rc != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "failed to find connection handle for addr" BT_DEVICE_ADDRESS_FMT,
+    PBL_LOG_ERR("failed to find connection handle for addr" BT_DEVICE_ADDRESS_FMT,
       BT_DEVICE_ADDRESS_XPLODE(device->address));
   } else {
     *handle = desc.conn_handle;

--- a/src/bluetooth-fw/nimble/pairing_confirm.c
+++ b/src/bluetooth-fw/nimble/pairing_confirm.c
@@ -7,6 +7,8 @@
 #include <stdint.h>
 #include <system/logging.h>
 
+PBL_LOG_MODULE_DECLARE(bt, CONFIG_BT_LOG_LEVEL);
+
 void bt_driver_pairing_confirm(const PairingUserConfirmationCtx *ctx, bool is_confirmed) {
   uint16_t conn_handle = (uintptr_t)ctx;
   struct ble_sm_io key = {
@@ -15,5 +17,5 @@ void bt_driver_pairing_confirm(const PairingUserConfirmationCtx *ctx, bool is_co
   };
   int rc = ble_sm_inject_io(conn_handle, &key);
 
-  PBL_LOG_D_DBG(LOG_DOMAIN_BT, "ble_sm_inject_io rc=0x%04x", (uint16_t)rc);
+  PBL_LOG_DBG("ble_sm_inject_io rc=0x%04x", (uint16_t)rc);
 }

--- a/src/bluetooth-fw/nimble/pebble_pairing_service.c
+++ b/src/bluetooth-fw/nimble/pebble_pairing_service.c
@@ -13,6 +13,8 @@
 
 #include "nimble_type_conversions.h"
 
+PBL_LOG_MODULE_DECLARE(bt, CONFIG_BT_LOG_LEVEL);
+
 #define TRIGGER_PAIRING_NO_SEC_REQ    (1U << 1U)
 #define TRIGGER_PAIRING_FORCE_SEC_REQ (1U << 2U)
 
@@ -21,8 +23,8 @@ static int pebble_pairing_service_get_connectivity_status(
   struct ble_gap_conn_desc desc;
   int rc = ble_gap_conn_find(conn_handle, &desc);
   if (rc != 0) {
-    PBL_LOG_D_ERR(
-        LOG_DOMAIN_BT, "Failed to find connection descriptor for %d when reading connection status, code: %d",
+    PBL_LOG_ERR(
+        "Failed to find connection descriptor for %d when reading connection status, code: %d",
         conn_handle, rc);
     return -1;
   }
@@ -51,14 +53,14 @@ int pebble_pairing_service_get_connectivity_send_notification(uint16_t conn_hand
   PebblePairingServiceConnectivityStatus status;
   int rc = pebble_pairing_service_get_connectivity_status(conn_handle, &status);
   if (rc != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "pebble_pairing_service_get_connectivity_status failed: %d", rc);
+    PBL_LOG_ERR("pebble_pairing_service_get_connectivity_status failed: %d", rc);
     return rc;
   }
 
   struct os_mbuf *om = ble_hs_mbuf_from_flat(&status, sizeof(status));
   rc = ble_gatts_notify_custom(conn_handle, attr_handle, om);
   if (rc != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "ble_gatts_notify_custom failed for attr %d: 0x%04x", attr_handle, (uint16_t)rc);
+    PBL_LOG_ERR("ble_gatts_notify_custom failed for attr %d: 0x%04x", attr_handle, (uint16_t)rc);
     return rc;
   }
 
@@ -72,7 +74,7 @@ static int prv_access_connection_status(uint16_t conn_handle, uint16_t attr_hand
   PebblePairingServiceConnectivityStatus status;
   int rc = pebble_pairing_service_get_connectivity_status(conn_handle, &status);
   if (rc != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_access_connection_status failed: %d", rc);
+    PBL_LOG_ERR("prv_access_connection_status failed: %d", rc);
     return 0;
   }
 
@@ -103,7 +105,7 @@ static int prv_access_trigger_pairing(uint16_t conn_handle, uint16_t attr_handle
       return rc;
     }
 
-    PBL_LOG_D_INFO(LOG_DOMAIN_BT, "Trigger pairing flags 0x%x", flags);
+    PBL_LOG_INFO("Trigger pairing flags 0x%x", flags);
 
     if ((((flags & TRIGGER_PAIRING_NO_SEC_REQ) == 0U) && !desc.sec_state.encrypted) ||
         ((flags & TRIGGER_PAIRING_FORCE_SEC_REQ) != 0U)) {
@@ -161,14 +163,14 @@ void prv_notify_chr_updated(const GAPLEConnection *connection, const ble_uuid_t 
   uint16_t conn_handle;
 
   if (!pebble_device_to_nimble_conn_handle(&connection->device, &conn_handle)) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_notify_chr_updated: failed to find connection handle");
+    PBL_LOG_ERR("prv_notify_chr_updated: failed to find connection handle");
     return;
   }
 
   uint16_t attr_handle;
   rc = ble_gatts_find_chr(pebble_pairing_svc[0].uuid, chr_uuid, NULL, &attr_handle);
   if (rc != 0) {
-    PBL_LOG_D_ERR(LOG_DOMAIN_BT, "prv_notify_chr_updated: failed to find characteristic handle");
+    PBL_LOG_ERR("prv_notify_chr_updated: failed to find characteristic handle");
     return;
   }
   pebble_pairing_service_get_connectivity_send_notification(conn_handle, attr_handle);

--- a/src/bluetooth-fw/nimble/responsiveness.c
+++ b/src/bluetooth-fw/nimble/responsiveness.c
@@ -3,8 +3,11 @@
 
 #include <bluetooth/responsiveness.h>
 #include <host/ble_gap.h>
+#include <system/logging.h>
 
 #include "nimble_type_conversions.h"
+
+PBL_LOG_MODULE_DECLARE(bt, CONFIG_BT_LOG_LEVEL);
 
 bool bt_driver_le_connection_parameter_update(const BTDeviceInternal *addr,
                                               const BleConnectionParamsUpdateReq *req) {

--- a/src/fw/Kconfig
+++ b/src/fw/Kconfig
@@ -130,6 +130,13 @@ config FLASH_LOG_LEVEL_DEBUG_VERBOSE
 
 endchoice
 
+config LOG_TASK_PREFIX
+    bool "Task prefix"
+    depends on LOG
+    help
+      Prefix log messages with the originating task identifier char
+      (uppercase when logged from privileged mode).
+
 config PULSE_EVERYWHERE
     bool "PULSE everywhere"
     default y if !RELEASE || MFG

--- a/src/fw/Kconfig.template.log_level
+++ b/src/fw/Kconfig.template.log_level
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# Per-module log level template. Include with:
+#
+#   module = MYMODULE
+#   module-str = My module
+#   source "src/fw/Kconfig.template.log_level"
+#
+# Defines CONFIG_<module>_LOG_LEVEL, consumed by PBL_LOG_MODULE_DEFINE /
+# PBL_LOG_MODULE_DECLARE (see system/logging.h). 0 means "use the default
+# log level".
+
+choice
+    prompt "$(module-str) log level"
+    default $(module)_LOG_LEVEL_DEFAULT
+    depends on LOG
+
+config $(module)_LOG_LEVEL_DEFAULT
+    bool "Default"
+    help
+      Use the global default log level.
+
+config $(module)_LOG_LEVEL_ERROR
+    bool "Error"
+
+config $(module)_LOG_LEVEL_WARNING
+    bool "Warning"
+
+config $(module)_LOG_LEVEL_INFO
+    bool "Info"
+
+config $(module)_LOG_LEVEL_DEBUG
+    bool "Debug"
+
+config $(module)_LOG_LEVEL_DEBUG_VERBOSE
+    bool "Debug verbose"
+
+endchoice
+
+config $(module)_LOG_LEVEL
+    int
+    default 1 if $(module)_LOG_LEVEL_ERROR
+    default 50 if $(module)_LOG_LEVEL_WARNING
+    default 100 if $(module)_LOG_LEVEL_INFO
+    default 200 if $(module)_LOG_LEVEL_DEBUG
+    default 255 if $(module)_LOG_LEVEL_DEBUG_VERBOSE
+    default 0

--- a/src/fw/drivers/imu/Kconfig
+++ b/src/fw/drivers/imu/Kconfig
@@ -53,4 +53,8 @@ endchoice
 
 endif # MAG
 
+module = IMU
+module-str = IMU
+source "src/fw/Kconfig.template.log_level"
+
 endmenu

--- a/src/fw/drivers/imu/lis2dw12/lis2dw12.c
+++ b/src/fw/drivers/imu/lis2dw12/lis2dw12.c
@@ -15,6 +15,8 @@
 #include "kernel/util/sleep.h"
 #include "util/math.h"
 
+PBL_LOG_MODULE_DEFINE(lis2dw12, CONFIG_IMU_LOG_LEVEL);
+
 // Implementation notes:
 //
 // - Peeking returns the last FIFO sample when sampling is active, otherwise

--- a/src/fw/kernel/logging.c
+++ b/src/fw/kernel/logging.c
@@ -74,10 +74,14 @@ static void prv_log_serial(
 
   // Log the log level and the current task+privilege level
   {
+#ifdef CONFIG_LOG_TASK_PREFIX
     unsigned char task_char = pebble_task_get_char(pebble_task_get_current());
     if (mcu_state_is_privileged()) {
       task_char = toupper(task_char);
     }
+#else
+    unsigned char task_char = '-';
+#endif
 
     char buffer[] = { pbl_log_get_level_char(log_level), ' ', task_char, ' ', 0 };
     serial_console_write_log_message(buffer);

--- a/src/fw/kernel/pulse_logging.c
+++ b/src/fw/kernel/pulse_logging.c
@@ -61,10 +61,14 @@ static size_t prv_serialize_log_header(MessageContents *contents,
 
   // Log the log level and the current task+privilege level
   contents->log_level_char = pbl_log_get_level_char(log_level);
+#ifdef CONFIG_LOG_TASK_PREFIX
   contents->task_char = pebble_task_get_char(task);
   if (mcu_state_is_privileged()) {
     contents->task_char = toupper(contents->task_char);
   }
+#else
+  contents->task_char = '-';
+#endif
 
   contents->time_ms = timestamp_ms;
 

--- a/src/fw/services/activity/Kconfig
+++ b/src/fw/services/activity/Kconfig
@@ -5,3 +5,11 @@ config SERVICE_ACTIVITY
     bool "Activity"
     help
       Activity (step/sleep/workout) tracking service.
+
+if SERVICE_ACTIVITY
+
+module = ACTIVITY
+module-str = Activity
+source "src/fw/Kconfig.template.log_level"
+
+endif

--- a/src/fw/services/activity/activity.c
+++ b/src/fw/services/activity/activity.c
@@ -44,6 +44,8 @@
 #include "pbl/services/activity/activity_insights.h"
 #include "pbl/services/activity/activity_private.h"
 
+PBL_LOG_MODULE_DEFINE(activity, CONFIG_ACTIVITY_LOG_LEVEL);
+
 // Our globals
 static ActivityState s_activity_state;
 static bool s_activity_initialized = false;

--- a/src/fw/services/activity/activity_insights.c
+++ b/src/fw/services/activity/activity_insights.c
@@ -37,6 +37,8 @@
 
 #include <stdio.h>
 
+PBL_LOG_MODULE_DECLARE(activity, CONFIG_ACTIVITY_LOG_LEVEL);
+
 #define INSIGHTS_LOG_DEBUG(fmt, args...) \
         PBL_LOG_D_DBG(LOG_DOMAIN_ACTIVITY_INSIGHTS, fmt, ## args)
 

--- a/src/fw/services/activity/activity_metrics.c
+++ b/src/fw/services/activity/activity_metrics.c
@@ -25,6 +25,8 @@
 #include "pbl/services/activity/activity_insights.h"
 #include "pbl/services/activity/activity_private.h"
 
+PBL_LOG_MODULE_DECLARE(activity, CONFIG_ACTIVITY_LOG_LEVEL);
+
 
 // ---------------------------------------------------------------------------------------
 // Storage converters. These convert metrics from their storage type (ActivityScalarStore,

--- a/src/fw/services/activity/activity_sessions.c
+++ b/src/fw/services/activity/activity_sessions.c
@@ -10,6 +10,7 @@
 #include "pbl/services/alarms/alarm.h"
 #include "syscall/syscall.h"
 #include "syscall/syscall_internal.h"
+#include "system/logging.h"
 #include "system/passert.h"
 #include "util/size.h"
 
@@ -19,6 +20,8 @@
 #include "pbl/services/activity/activity_algorithm.h"
 #include "pbl/services/activity/activity_insights.h"
 #include "pbl/services/activity/activity_private.h"
+
+PBL_LOG_MODULE_DECLARE(activity, CONFIG_ACTIVITY_LOG_LEVEL);
 
 
 // ------------------------------------------------------------------------------------

--- a/src/fw/services/activity/insights_settings.c
+++ b/src/fw/services/activity/insights_settings.c
@@ -12,6 +12,8 @@
 #include "system/logging.h"
 #include "util/size.h"
 
+PBL_LOG_MODULE_DECLARE(activity, CONFIG_ACTIVITY_LOG_LEVEL);
+
 #define ACTIVITY_INSIGHTS_SETTINGS_FILENAME "insights"
 #define ACTIVITY_INSIGHTS_SETTINGS_DEFAULT_FILE_SIZE 4096
 

--- a/src/fw/services/activity/kraepelin/activity_algorithm_kraepelin.c
+++ b/src/fw/services/activity/kraepelin/activity_algorithm_kraepelin.c
@@ -26,6 +26,8 @@
 #include "pbl/services/activity/kraepelin/activity_algorithm_kraepelin.h"
 #include "pbl/services/activity/kraepelin/kraepelin_algorithm.h"
 
+PBL_LOG_MODULE_DECLARE(activity, CONFIG_ACTIVITY_LOG_LEVEL);
+
 // NOTE: This file is called "activity_sleep" for legacy reasons. A better name now would be
 // something like "activity_minute_data", but we want to maintain compatibility with prior
 // releases that only used it for sleep data.

--- a/src/fw/services/activity/kraepelin/kraepelin_algorithm.c
+++ b/src/fw/services/activity/kraepelin/kraepelin_algorithm.c
@@ -42,6 +42,8 @@ Pebble App roject.
 
 #include "pbl/services/activity/kraepelin/kraepelin_algorithm.h"
 
+PBL_LOG_MODULE_DECLARE(activity, CONFIG_ACTIVITY_LOG_LEVEL);
+
 #define KALG_LOG_DEBUG(fmt, args...) \
         PBL_LOG_D_DBG(LOG_DOMAIN_ACTIVITY, fmt, ## args)
 

--- a/src/fw/services/activity/workout_service.c
+++ b/src/fw/services/activity/workout_service.c
@@ -16,11 +16,14 @@
 #include "kernel/pbl_malloc.h"
 #include "pbl/services/evented_timer.h"
 #include "pbl/services/regular_timer.h"
+#include "system/logging.h"
 #include "system/passert.h"
 #include "util/time/time.h"
 #include "util/units.h"
 
 #include <os/mutex.h>
+
+PBL_LOG_MODULE_DECLARE(activity, CONFIG_ACTIVITY_LOG_LEVEL);
 
 #define WORKOUT_HR_READING_TS_EXPIRE (SECONDS_PER_MINUTE)
 #define WORKOUT_ENDED_HR_SUBSCRIPTION_TS_EXPIRE (10 * SECONDS_PER_MINUTE)

--- a/src/fw/system/logging.h
+++ b/src/fw/system/logging.h
@@ -195,7 +195,38 @@ int pbl_log_get_bin_format(char* buffer, int buffer_len, const uint8_t log_level
   #define DEFAULT_LOG_DOMAIN LOG_DOMAIN_MISC
 #endif // DEFAULT_LOG_DOMAIN
 
-#define PBL_SHOULD_LOG(level) ((level) <= DEFAULT_LOG_LEVEL)
+// Per-module compile-time log level and name. PBL_LOG_MODULE_DEFINE /
+// PBL_LOG_MODULE_DECLARE override these tentative definitions, e.g.
+// PBL_LOG_MODULE_DEFINE(activity, CONFIG_ACTIVITY_LOG_LEVEL) (see
+// Kconfig.template.log_level); level 0 selects DEFAULT_LOG_LEVEL.
+__attribute__((unused)) static const uint8_t _pbl_log_module_level;
+__attribute__((unused)) static const char *const _pbl_log_module_name;
+
+// Unit tests build with CONFIG_LOG but without the board Kconfig symbols,
+// so module levels fall back to the default there.
+#if defined(CONFIG_LOG) && !defined(UNITTEST)
+  #ifdef CONFIG_LOG_HASHED
+    // The MODULE map entry gives the loghash dict generator the
+    // file -> module mapping; the module name costs nothing at runtime.
+    #define PBL_LOG_MODULE_DEFINE(name, level) \
+      __attribute__((unused)) static const uint8_t _pbl_log_module_level = (level); \
+      __attribute__((unused)) static const char *const _pbl_log_module_name = #name; \
+      __attribute__((used, nocommon, section(".log_strings"))) \
+      static const char _pbl_log_module_map[] = "MODULE:" __FILE__ ":" #name
+  #else
+    #define PBL_LOG_MODULE_DEFINE(name, level) \
+      __attribute__((unused)) static const uint8_t _pbl_log_module_level = (level); \
+      __attribute__((unused)) static const char *const _pbl_log_module_name = #name
+  #endif
+#else
+  #define PBL_LOG_MODULE_DEFINE(name, level) \
+    __attribute__((unused)) static const uint8_t _pbl_log_module_level = 0
+#endif
+
+#define PBL_LOG_MODULE_DECLARE(name, level) PBL_LOG_MODULE_DEFINE(name, level)
+
+#define PBL_SHOULD_LOG(level) \
+  ((level) <= (_pbl_log_module_level != 0 ? _pbl_log_module_level : DEFAULT_LOG_LEVEL))
 
 
 // Internal implementation macros (use level-named macros below instead)
@@ -222,15 +253,29 @@ int pbl_log_get_bin_format(char* buffer, int buffer_len, const uint8_t log_level
   #else
     #define PBL_LOG_COLOR_D(domain, level, color, fmt, ...) \
       do { \
-        if (domain) { \
-          pbl_log(level, __FILE__, __LINE__, fmt, ## __VA_ARGS__); \
+        if (PBL_SHOULD_LOG(level)) { \
+          if (domain) { \
+            if (_pbl_log_module_name != NULL) { \
+              pbl_log(level, __FILE__, __LINE__, "%s: " fmt, _pbl_log_module_name, \
+                      ## __VA_ARGS__); \
+            } else { \
+              pbl_log(level, __FILE__, __LINE__, fmt, ## __VA_ARGS__); \
+            } \
+          } \
         } \
       } while (0)
 
     #define PBL_LOG_COLOR_D_SYNC(domain, level, color, fmt, ...) \
       do { \
-        if (domain) { \
-          pbl_log_sync(level, __FILE__, __LINE__, fmt, ## __VA_ARGS__); \
+        if (PBL_SHOULD_LOG(level)) { \
+          if (domain) { \
+            if (_pbl_log_module_name != NULL) { \
+              pbl_log_sync(level, __FILE__, __LINE__, "%s: " fmt, _pbl_log_module_name, \
+                           ## __VA_ARGS__); \
+            } else { \
+              pbl_log_sync(level, __FILE__, __LINE__, fmt, ## __VA_ARGS__); \
+            } \
+          } \
         } \
       } while (0)
   #endif

--- a/tools/log_hashing/logdehash.py
+++ b/tools/log_hashing/logdehash.py
@@ -186,7 +186,8 @@ class LogDehash(object):
             output.append("<{}>".format(line_dict["re_level"]))
         if self.print_core and "core_number" in line_dict:
             output.append(line_dict["core_number"])
-        if "task" in line_dict:
+        # "-" means the task prefix is disabled (CONFIG_LOG_TASK_PREFIX)
+        if line_dict.get("task", "-") != "-":
             output.append(line_dict["task"])
 
         if "module" not in line_dict and "file" in line_dict and "line" in line_dict:

--- a/tools/log_hashing/logdehash.py
+++ b/tools/log_hashing/logdehash.py
@@ -164,32 +164,34 @@ class LogDehash(object):
             return {"formatted_msg": string, "unhashed": True}
 
     def basic_format_line(self, line_dict):
+        # Zephyr-like format: [timestamp] <lvl> task source: msg. Messages from
+        # a log module already carry a "module: " prefix in formatted_msg;
+        # others get their file:line as the source.
         output = []
 
-        if "support" not in line_dict and "re_level" in line_dict:
-            output.append(line_dict["re_level"])
-        if self.print_core and "core_number" in line_dict:
-            output.append(line_dict["core_number"])
-        if "task" in line_dict:
-            output.append(line_dict["task"])
-        if "date" in line_dict:
-            output.append(line_dict["date"])
-        if "time" in line_dict:
-            output.append(line_dict["time"])
+        timestamp = " ".join(
+            line_dict[key] for key in ("date", "time") if key in line_dict
+        )
+        if timestamp:
+            output.append("[{}]".format(timestamp))
         elif "support" not in line_dict:
             # Use the current time if one isn't provided by the system
             now = datetime.now()
             output.append(
-                "%02d:%02d:%02d.%03d"
+                "[%02d:%02d:%02d.%03d]"
                 % (now.hour, now.minute, now.second, now.microsecond / 1000)
             )
 
-        pre_padding = ""
-        post_padding = ""
+        if "support" not in line_dict and line_dict.get("re_level"):
+            output.append("<{}>".format(line_dict["re_level"]))
+        if self.print_core and "core_number" in line_dict:
+            output.append(line_dict["core_number"])
+        if "task" in line_dict:
+            output.append(line_dict["task"])
 
-        if "file" in line_dict and "line" in line_dict:
+        if "module" not in line_dict and "file" in line_dict and "line" in line_dict:
             filename = os.path.basename(line_dict["file"])
-            file_line = "{}:{}>".format(filename, line_dict["line"])
+            file_line = "{}:{}:".format(filename, line_dict["line"])
             if self.justify_size < 0:
                 output.append(file_line.rjust(abs(self.justify_size)))
             else:

--- a/tools/log_hashing/newlogging.py
+++ b/tools/log_hashing/newlogging.py
@@ -13,8 +13,11 @@ BUILD_ID_SECTION_NAME = ".note.gnu.build-id"
 BUILD_ID_NOTE_OWNER_NAME = "GNU"
 BUILD_ID_NOTE_TYPE_NAME = "NT_GNU_BUILD_ID"
 
-NEW_LOGGING_VERSION = "NL0101"
+NEW_LOGGING_VERSION = "NL0102"
 NEW_LOGGING_HEADER_OFFSET = 0
+
+# File -> module map entries emitted by PBL_LOG_MODULE_DEFINE/PBL_LOG_MODULE_DECLARE
+MODULE_LINE_PREFIX = "MODULE:"
 
 LOG_LINE_SPLIT_REGEX = r"([^\0]+)\0"
 LOG_LINE_SPLIT_PATTERN = re.compile(
@@ -110,15 +113,33 @@ class LogDict:
 
         # First, split the section by '\0' characters, keeping track of the start.
         # There may be padding, so ignore any empty strings.
+        modules = {}
+        entries = {}
         for line in LOG_LINE_SPLIT_PATTERN.finditer(section):
             # Skip the header line
             if line.start() == NEW_LOGGING_HEADER_OFFSET:
                 continue
 
+            # Collect file -> module map entries
+            if line.group(1).startswith(MODULE_LINE_PREFIX):
+                file_name, _, module = line.group(1)[
+                    len(MODULE_LINE_PREFIX) :
+                ].rpartition(":")
+                modules[file_name] = module
+                continue
+
             tags = self.log_line_regex.match(line.group(1))
 
             # Add the core offset to the 'offset' parameter
-            self.log_dict[str(line.start() + self.core_id_offset)] = tags.groupdict()
+            entries[str(line.start() + self.core_id_offset)] = tags.groupdict()
+
+        # Attach the module name to every message from a mapped file
+        for tags in entries.values():
+            module = modules.get(tags.get("file"))
+            if module:
+                tags["module"] = module
+
+        self.log_dict.update(entries)
 
     def get_log_dict(self):
         return self.log_dict


### PR DESCRIPTION
Add Zephyr-style per-module logging:

- `PBL_LOG_MODULE_DEFINE(name, CONFIG_<NAME>_LOG_LEVEL)` / `PBL_LOG_MODULE_DECLARE(...)` bind a compilation unit to a named log module. Per-module compile-time levels come from Kconfig via a new `Kconfig.template.log_level` template (3 lines per module). Call sites below the module level are eliminated at compile time, format strings included; files without a module are unchanged.
- Log output carries the module name, Zephyr style. On hashed builds this costs nothing at runtime: `PBL_LOG_MODULE_DEFINE` emits a `MODULE:<file>:<name>` metadata entry into `.log_strings` (format bumped to NL0102) which the dict generator joins per message; non-hashed builds prepend the name at runtime.
- Dehashed output adopts the Zephyr default format: `[timestamp] <lvl> module: message`, with severity tags (`<err>/<wrn>/<inf>/<dbg>/<vrb>`, no tag for ALWAYS) and `file.c:line:` as the source fallback for unmigrated files.
- The task identifier prefix is now opt-in via `CONFIG_LOG_TASK_PREFIX` (analogous to Zephyr's `CONFIG_LOG_THREAD_ID_PREFIX`), default off.
- First migrations: `activity` (service, cross-unit), `bt` (nimble backend, replacing `LOG_DOMAIN_BT` call sites), and `lis2dw12` under a shared IMU level (`CONFIG_IMU_LOG_LEVEL`).

Example output:

```
[21:35:14.375] <dbg> lis2dw12: Shake detected
[21:35:14.375] <err> bt: prv_handle_connection_event: Failed to find connection descriptor
[21:35:14.375] <inf> settings_blob_db.c:638: Marking all settings as dirty for full sync
```

Verified: asterix (hashed, debug + release + `LOG_TASK_PREFIX=y`), qemu_flint (non-hashed) and getafix_dvt2 builds; firmware size is byte-identical at default levels; setting the bt module to Error drops 576 bytes of text. Full unit-test suite and loghash python tests pass (including fixing a pre-existing Python 3.14 wording failure).

Note for tooling: older checkouts' dict generators cannot parse new ELFs (hard version check); JSON dict consumers are unaffected — the new `module` key is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
