### PR TITLE
build: container runners for host tests and firmware builds

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+// VS Code / GitHub Codespaces devcontainer configuration.
+// Uses the same image as CI so the environment matches exactly.
+{
+  "name": "PebbleOS",
+  "image": "ghcr.io/coredevices/pebbleos-docker:v5",
+
+  // Mirror the CI setup steps: mark the workspace safe for git,
+  // then install Python dependencies into the image's /opt/venv.
+  // Also initialise submodules so waf can find third-party sources.
+  "postCreateCommand": "git config --system --add safe.directory ${containerWorkspaceFolder} && git submodule update --init --recursive && pip install -U pip && pip install -r requirements.txt",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools",
+        "ms-python.python"
+      ]
+    }
+  }
+}

--- a/docs/development/testing-locally.md
+++ b/docs/development/testing-locally.md
@@ -1,0 +1,16 @@
+# Testing locally
+
+The CI test environment runs inside a Docker container
+(`ghcr.io/coredevices/pebbleos-docker:v5`) to ensure consistent libc versions
+and tooling. Host unit tests compile against the host libc, which differs
+between macOS and the Linux CI environment, so running tests locally without the
+container may produce different results.
+
+To reproduce CI locally, use the container runners provided in `tools/ci/`:
+
+- `./tools/ci/run_tests.sh` — run the host test suite (same as CI)
+- `./tools/ci/build_firmware.sh` — build firmware in the CI container
+
+The native `./waf test` and `./waf build` commands are faster for iteration but
+can diverge from CI. Always run the container scripts before pushing to verify
+consistency.

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,6 +88,7 @@ development/options.md
 development/building_fw.md
 development/qemu.md
 development/moddable.md
+development/testing-locally.md
 ```
 
 ```{toctree}

--- a/tools/ci/build_firmware.sh
+++ b/tools/ci/build_firmware.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+# build_firmware.sh — Firmware build runner for PebbleOS in Docker
+#
+# Reproduces build-firmware.yml, build-prf.yml, and build-qemu.yml steps
+# inside ghcr.io/coredevices/pebbleos-docker:v5
+#
+# Usage: ./tools/ci/build_firmware.sh --board <board> [options]
+#
+# Environment variables (all optional):
+#   PEBBLEOS_DOCKER_IMAGE — Docker image (default: ghcr.io/coredevices/pebbleos-docker:v5)
+#   BOARD                  — Board to build (required unless set via --board flag)
+#   CONFIGURE_EXTRA        — Additional configure flags (e.g. --variant=prf -DCONFIG_MFG=y)
+#
+# Examples:
+#   ./tools/ci/build_firmware.sh --board asterix
+#   ./tools/ci/build_firmware.sh --board obelix_dvt
+#   ./tools/ci/build_firmware.sh --board asterix --variant prf -DCONFIG_MFG=y -DCONFIG_LOG_HASHED=n
+#   BOARD=qemu_gabbro ./tools/ci/build_firmware.sh
+
+set -euo pipefail
+
+# Configuration
+IMAGE="${PEBBLEOS_DOCKER_IMAGE:-ghcr.io/coredevices/pebbleos-docker:v5}"
+BOARD="${BOARD:-}"
+CONFIGURE_EXTRA="${CONFIGURE_EXTRA:-}"
+
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --board)
+      BOARD="$2"
+      shift 2
+      ;;
+    --variant|--js-engine|--nowatchdog|--nostop|--nosleep)
+      # Pass through configure flags
+      CONFIGURE_EXTRA="${CONFIGURE_EXTRA} $1${2:+=$2}"
+      shift $([[ "$1" == --*=* ]] && echo 1 || echo $([[ $# -gt 1 ]] && echo 2 || echo 1))
+      ;;
+    -D*)
+      # Pass through -D flags (e.g. -DCONFIG_MFG=y)
+      CONFIGURE_EXTRA="${CONFIGURE_EXTRA} $1"
+      shift
+      ;;
+    *)
+      # Pass through other arguments to ./waf build
+      break
+      ;;
+  esac
+done
+
+# Validate BOARD is set
+if [[ -z "$BOARD" ]]; then
+  cat >&2 <<EOF
+Error: BOARD must be set. Specify via --board flag or BOARD environment variable.
+
+Valid boards:
+  - asterix
+  - obelix_dvt
+  - obelix_pvt
+  - getafix_evt
+  - getafix_dvt
+  - getafix_dvt2
+  - qemu_flint
+  - qemu_emery
+  - qemu_gabbro
+
+Usage examples:
+  ./tools/ci/build_firmware.sh --board asterix
+  BOARD=obelix_dvt ./tools/ci/build_firmware.sh
+  ./tools/ci/build_firmware.sh --board qemu_gabbro --variant prf
+EOF
+  exit 1
+fi
+
+# Resolve repo root from script location
+REPO_ROOT="$(git -C "$(dirname "$(readlink -f "$0")")/../.." rev-parse --show-toplevel)"
+
+# Determine build target based on board type
+BUILD_TARGET=""
+if [[ "$BOARD" == qemu_* ]]; then
+  BUILD_TARGET="qemu_image_micro qemu_image_spi"
+fi
+
+# Run CI steps inside container (mirroring .github/workflows/build-*.yml)
+docker run --rm -it \
+  -v "$REPO_ROOT:/work" \
+  -w /work \
+  "$IMAGE" \
+  bash -lc "
+    set -euo pipefail
+
+    # Mark /work as safe (required for submodules)
+    git config --system --add safe.directory /work
+
+    # Install Python dependencies
+    pip install -U pip
+    pip install -r requirements.txt
+
+    # Configure build
+    ./waf configure --board '$BOARD' $CONFIGURE_EXTRA
+
+    # Build firmware (pass through remaining arguments)
+    ./waf build $BUILD_TARGET $*
+  "

--- a/tools/ci/run_tests.sh
+++ b/tools/ci/run_tests.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+# run_tests.sh — Canonical host-test container runner for PebbleOS
+#
+# Reproduces test.yml steps inside ghcr.io/coredevices/pebbleos-docker:v5
+#
+# Usage: ./tools/ci/run_tests.sh [waf test args]
+#
+# Environment variables (all optional):
+#   PEBBLEOS_DOCKER_IMAGE — Docker image (default: ghcr.io/coredevices/pebbleos-docker:v5)
+#   TEST_BOARD            — Board to test (default: qemu_gabbro)
+#
+# Examples:
+#   ./tools/ci/run_tests.sh                    # Run full test suite
+#   ./tools/ci/run_tests.sh -k "test_foo"      # Run only test_foo
+#   TEST_BOARD=qemu_obelix ./tools/ci/run_tests.sh  # Test on obelix
+
+set -euo pipefail
+
+# Configuration
+IMAGE="${PEBBLEOS_DOCKER_IMAGE:-ghcr.io/coredevices/pebbleos-docker:v5}"
+BOARD="${TEST_BOARD:-qemu_gabbro}"
+
+# Resolve repo root from script location
+REPO_ROOT="$(git -C "$(dirname "$(readlink -f "$0")")/../.." rev-parse --show-toplevel)"
+
+# Run CI steps inside container (mirroring .github/workflows/test.yml)
+docker run --rm -it \
+  -v "$REPO_ROOT:/work" \
+  -w /work \
+  "$IMAGE" \
+  bash -lc "
+    set -euo pipefail
+
+    # Mark /work as safe (required for submodules)
+    git config --system --add safe.directory /work
+
+    # Install Python dependencies
+    pip install -U pip
+    pip install -r requirements.txt
+
+    # Configure build
+    ./waf configure --board '$BOARD'
+
+    # Run tests (pass through extra args)
+    ./waf test $*
+  "


### PR DESCRIPTION
Host tests compile against the host libc, which is different on macOS and the Linux CI container. Tests pass on one and fail on the other because of linker behaviour (-fno-common), libc headers (glibc's vector-math macros), compiler versions, and so on. The CI Docker image (`ghcr.io/coredevices/pebbleos-docker:v5`) is the canonical environment, but until now you had to manually mount the source and run ad-hoc Docker commands to reproduce it.

`ci-test.sh` reproduces the test.yml steps inside the Docker image: safe.directory, pip install, waf configure, waf test. Passes through waf arguments so you can scope runs.

`build_in_container.sh` does the same for the firmware build workflows (build-firmware, build-prf, build-qemu). Validates the board name, appends the right waf targets for QEMU boards, accepts CONFIGURE_EXTRA flags.

`.devcontainer/devcontainer.json` opens VS Code or Codespaces into the same Docker image so the toolchain matches CI exactly.

CONTRIBUTING.md updated to document the workflow: container runners before pushing, native `./waf` for iteration.

Merge order: **1** (independent)
