### PR TITLE
build: freestanding host-test compilation

### DIFF
--- a/src/libc/include/math.h
+++ b/src/libc/include/math.h
@@ -87,9 +87,13 @@ float modff(float x, float *iptr);
 
 double nearbyint(double x);
 
+double pow(double x, double y);
+
 double round(double d);
 
 float roundf(float x);
+
+double scalbn(double x, int n);
 
 double sin(double x);
 

--- a/src/libc/include/math.h
+++ b/src/libc/include/math.h
@@ -9,6 +9,7 @@
 #endif
 
 #define INFINITY   ((double)(_HUGE_ENUF * _HUGE_ENUF))
+#define HUGE_VAL   INFINITY
 #define NAN        ((double)(INFINITY * 0.0F))
 
 #define INFINITY_F ((float)INFINITY)

--- a/src/libc/include/stdlib.h
+++ b/src/libc/include/stdlib.h
@@ -44,5 +44,12 @@ void exit(int status) __attribute__((noreturn));
 // Not implemented, but included in the header to build the default platform.c of libs.
 void free(void *ptr);
 void *malloc(size_t bytes);
+// Provided by tests/freestanding/shim.c in freestanding builds; by host libc otherwise.
+void *calloc(size_t nmemb, size_t size);
+void *realloc(void *ptr, size_t size);
+void qsort(void *base, size_t nmemb, size_t size,
+           int (*compar)(const void *, const void *));
+void abort(void) __attribute__((noreturn));
+char *strdup(const char *s);
 
 long jrand48(unsigned short int s[3]);

--- a/src/libc/include/sys/cdefs.h
+++ b/src/libc/include/sys/cdefs.h
@@ -14,3 +14,77 @@
 #define __P(protos) protos
 #define __CONCAT(x, y) x ## y
 #define __STRING(x) #x
+
+/*
+ * Compiler attribute shims expected by platform SDK/libc headers when they
+ * are pulled in via #include_next chains (e.g. setjmp.h, assert.h).
+ *
+ * macOS SDK headers use __dead2, __cold, __disable_tail_calls.
+ * Linux glibc headers use __THROW, __THROWNL, __LEAF, __NTH, __NTHNL.
+ *
+ * GCC/Clang support all underlying attributes, so define them
+ * unconditionally.  On other compilers, expand to nothing.
+ */
+#if defined(__GNUC__) || defined(__clang__)
+
+/* ---- macOS SDK macros --------------------------------------------------- */
+# ifndef __dead2
+#   define __dead2 __attribute__((__noreturn__))
+# endif
+# ifndef __cold
+#   define __cold __attribute__((__cold__))
+# endif
+# ifndef __disable_tail_calls
+#   if defined(__has_attribute) && __has_attribute(__disable_tail_calls__)
+#     define __disable_tail_calls __attribute__((__disable_tail_calls__))
+#   else
+#     define __disable_tail_calls
+#   endif
+# endif
+
+/* ---- Linux glibc macros ------------------------------------------------- */
+# ifndef __LEAF
+#   ifdef __GNUC__
+#     define __LEAF , __leaf__
+#   else
+#     define __LEAF
+#   endif
+# endif
+# ifndef __THROW
+#   define __THROW __attribute__((__nothrow__ __LEAF))
+# endif
+# ifndef __THROWNL
+#   define __THROWNL __attribute__((__nothrow__))
+# endif
+# ifndef __NTH
+#   define __NTH(fct) __attribute__((__nothrow__ __LEAF)) fct
+# endif
+# ifndef __NTHNL
+#   define __NTHNL(fct) __attribute__((__nothrow__)) fct
+# endif
+
+#else /* not GCC/Clang */
+
+# ifndef __dead2
+#   define __dead2
+# endif
+# ifndef __cold
+#   define __cold
+# endif
+# ifndef __disable_tail_calls
+#   define __disable_tail_calls
+# endif
+# ifndef __THROW
+#   define __THROW
+# endif
+# ifndef __THROWNL
+#   define __THROWNL
+# endif
+# ifndef __NTH
+#   define __NTH(fct) fct
+# endif
+# ifndef __NTHNL
+#   define __NTHNL(fct) fct
+# endif
+
+#endif /* GCC/Clang */

--- a/src/libc/include/unistd.h
+++ b/src/libc/include/unistd.h
@@ -3,4 +3,4 @@
 
 #pragma once
 
-// stub
+#include <sys/types.h>

--- a/src/libc/pblibc_private.h
+++ b/src/libc/pblibc_private.h
@@ -3,8 +3,10 @@
 
 #pragma once
 
-// Rename (and re-define) the libc functions
-#if UNITTEST
+// Rename (and re-define) the libc functions. Freestanding host tests compile
+// under -nostdinc against pblibc with no host libc in scope, so there is
+// nothing to collide with and the rename shim is unnecessary there.
+#if UNITTEST && !defined(CLAR_FREESTANDING)
 #include <stddef.h>
 #include <stdarg.h>
 

--- a/src/libc/string/strtol.c
+++ b/src/libc/string/strtol.c
@@ -5,12 +5,12 @@
 // Implements:
 //   long int strtol(const char *nptr, char **endptr, int base);
 
-#include <ctype.h>
 #include <string.h>
 #include <stdint.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <pblibc_private.h>
+#include <ctype.h>
 
 intmax_t strtoX_core(const char * restrict nptr, char ** restrict endptr, int base, bool do_errors,
                      intmax_t max, intmax_t min) {

--- a/src/libc/vsprintf.c
+++ b/src/libc/vsprintf.c
@@ -118,10 +118,10 @@
 #include <stdint.h>
 #include <limits.h>
 #include <stddef.h>
-#include <ctype.h>
 #include <stdbool.h>
 
 #include "pblibc_private.h"
+#include <ctype.h>
 
 // Not using 64-bit division for Dialog Bluetooth. This saves *gobs* of memory.
 #ifdef ARCH_NO_NATIVE_LONG_DIVIDE

--- a/tests/freestanding/shim.c
+++ b/tests/freestanding/shim.c
@@ -1,0 +1,168 @@
+/* SPDX-FileCopyrightText: 2025 Google LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * Host-boundary adapter for freestanding test builds.
+ *
+ * This is the ONE translation unit compiled WITHOUT -nostdinc, so it can
+ * reach host-libc headers.  All other TUs in a freestanding build use only
+ * pblibc headers and the compiler's built-in includes.
+ *
+ * Symbols provided:
+ *
+ *   freestanding_write — write(2)-backed output, used by clar_io_freestanding.c
+ *   calloc / realloc / strdup — heap helpers missing from pblibc's stdlib.h
+ *   abort — not in pblibc's stdlib.h
+ *   strcasecmp — POSIX, absent from pblibc; used by clar_categorize.c
+ *   qsort — used only on the -l listing path; insertion-sort stub
+ *
+ * Note: malloc and free are declared in pblibc/stdlib.h and resolve to the
+ * host libc at link time without any forwarding needed here.
+ *
+ * Note: printf, fprintf, vprintf, vfprintf, fflush, FILE, and stderr are
+ * provided by clar_io_freestanding.c (compiled as part of clar_main.c under
+ * -nostdinc).  They are NOT defined here.
+ */
+
+/* Host headers — only allowed in this file. */
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* ---- output helper ------------------------------------------------------- */
+
+/*
+ * Write len bytes from buf to file descriptor fd.
+ * fd 1 = stdout, fd 2 = stderr.
+ * Called from clar_io_freestanding.c, which is compiled under -nostdinc.
+ */
+void freestanding_write(int fd, const char *buf, int len) {
+  while (len > 0) {
+    ssize_t n = write(fd, buf, (size_t)len);
+    if (n <= 0) {
+      break;
+    }
+    buf += n;
+    len -= (int)n;
+  }
+}
+
+/* ---- heap ---------------------------------------------------------------- */
+
+/*
+ * calloc — uses bare malloc (compatible with bare free).
+ *
+ * clar allocates error structs with calloc and frees them with free, so the
+ * allocation must be compatible with the host free.  malloc from pblibc's
+ * stdlib.h resolves to the host libc at link time, so this is correct.
+ */
+void *calloc(size_t nmemb, size_t size) {
+  size_t total = nmemb * size;
+  void *p = malloc(total);
+  if (p) {
+    memset(p, 0, total);
+  }
+  return p;
+}
+
+/*
+ * realloc — size-header implementation.
+ *
+ * realloc needs to know the old allocation's size to copy the right number
+ * of bytes.  We achieve this by storing a size_t header immediately before
+ * the user pointer:
+ *
+ *   [ size_t bytes_pad_to_align | user data ... ]
+ *   ^                              ^
+ *   raw malloc'd block             returned to caller
+ *
+ * This is safe because the ONLY caller of realloc in the clar harness is
+ * clar_category_add_to_list, which:
+ *   - first call: passes NULL (we treat as malloc)
+ *   - subsequent calls: passes the pointer returned by our previous realloc
+ *
+ * The names array is a global static and is never freed, so there is no
+ * mismatch between our size-header pointer and bare free.
+ */
+#define _REALLOC_ALIGN \
+  (sizeof(size_t) > sizeof(void *) ? sizeof(size_t) : sizeof(void *))
+
+static void *_realloc_alloc(size_t bytes) {
+  char *raw = malloc(_REALLOC_ALIGN + bytes);
+  if (!raw) return NULL;
+  *(size_t *)(void *)raw = bytes;
+  return raw + _REALLOC_ALIGN;
+}
+
+static void _realloc_free(void *ptr) {
+  free((char *)ptr - _REALLOC_ALIGN);
+}
+
+static size_t _realloc_size(const void *ptr) {
+  const char *raw = (const char *)ptr - _REALLOC_ALIGN;
+  return *(const size_t *)(const void *)raw;
+}
+
+void *realloc(void *ptr, size_t size) {
+  if (ptr == NULL) {
+    return _realloc_alloc(size);
+  }
+  if (size == 0) {
+    _realloc_free(ptr);
+    return NULL;
+  }
+  void *new_ptr = _realloc_alloc(size);
+  if (!new_ptr) return NULL;
+  size_t old_size = _realloc_size(ptr);
+  memcpy(new_ptr, ptr, old_size < size ? old_size : size);
+  _realloc_free(ptr);
+  return new_ptr;
+}
+
+char *strdup(const char *s) {
+  size_t n = strlen(s) + 1;
+  char *p = malloc(n);
+  if (p) {
+    memcpy(p, s, n);
+  }
+  return p;
+}
+
+void abort(void) {
+  _exit(1);
+}
+
+/* ---- POSIX stubs --------------------------------------------------------- */
+
+int strcasecmp(const char *s1, const char *s2) {
+  unsigned char c1, c2;
+  do {
+    c1 = (unsigned char)*s1++;
+    c2 = (unsigned char)*s2++;
+    if (c1 >= 'A' && c1 <= 'Z') c1 += ('a' - 'A');
+    if (c2 >= 'A' && c2 <= 'Z') c2 += ('a' - 'A');
+  } while (c1 && c1 == c2);
+  return (int)c1 - (int)c2;
+}
+
+/*
+ * qsort — insertion-sort stub.  Only called from clar_category_print_enabled()
+ * which runs on the -l listing path; never invoked during a normal test run.
+ */
+void qsort(void *base, size_t nmemb, size_t size,
+           int (*compar)(const void *, const void *)) {
+  char *b = (char *)base;
+  char tmp[256];
+  for (size_t i = 1; i < nmemb; i++) {
+    size_t j = i;
+    while (j > 0 && compar(b + (j - 1) * size, b + j * size) > 0) {
+      if (size <= sizeof(tmp)) {
+        memcpy(tmp,                    b + (j - 1) * size, size);
+        memcpy(b + (j - 1) * size,    b + j * size,       size);
+        memcpy(b + j * size,           tmp,                size);
+      }
+      j--;
+    }
+  }
+}

--- a/tests/freestanding/wscript_build
+++ b/tests/freestanding/wscript_build
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# Build the freestanding host-test shim as a static library.
+#
+# shim.c is compiled WITHOUT -nostdinc so it can reach host-libc headers.
+# It is the single adapter between freestanding test TUs (which use only
+# pblibc + compiler built-in headers) and the host system.
+#
+# Tests opt in by adding use=['freestanding_shim'] to their clar() call via
+# the freestanding=True flag in waftools/pebble_test.py.
+#
+
+import os
+
+shim_src = bld.path.find_node('shim.c')
+
+# Strip -nostdinc from shim's CFLAGS so host headers are reachable.
+shim_cflags = [f for f in bld.env.CFLAGS if f != '-nostdinc']
+# Also strip any -isystem flags that inject pblibc/compiler-builtins includes;
+# the shim must use host headers exclusively.
+filtered = []
+skip_next = False
+for f in shim_cflags:
+    if skip_next:
+        skip_next = False
+        continue
+    if f == '-isystem':
+        skip_next = True
+        continue
+    if f.startswith('-isystem'):
+        continue
+    filtered.append(f)
+shim_cflags = filtered
+
+bld.stlib(
+    source=[shim_src],
+    target='freestanding_shim',
+    name='freestanding_shim',
+    cflags=shim_cflags,
+    # No extra includes — shim uses only host headers.
+)

--- a/tests/fw/services/wscript_build
+++ b/tests/fw/services/wscript_build
@@ -238,7 +238,13 @@ clar(ctx,
 clar(ctx,
     sources_ant_glob = " ".join([
         "src/fw/services/registry_endpoint/service.c"]),
-    test_sources_ant_glob = "test_registry_endpoint.c")
+    test_sources_ant_glob = "test_registry_endpoint.c",
+    add_includes = [
+        "include",
+        "src/fw",
+        "src/libutil/includes",
+    ],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = " ".join([
@@ -249,7 +255,13 @@ clar(ctx,
 clar(ctx,
     sources_ant_glob = " ".join([
         " src/fw/services/voice/transcription.c"]),
-    test_sources_ant_glob = "test_transcription.c")
+    test_sources_ant_glob = "test_transcription.c",
+    add_includes = [
+        "include",
+        "src/fw",
+        "src/libutil/includes",
+    ],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = " ".join([
@@ -384,7 +396,14 @@ clar(ctx,
 
 clar(ctx,
     sources_ant_glob = 'src/fw/services/filesystem/app_file.c',
-    test_sources_ant_glob = 'test_app_file.c')
+    test_sources_ant_glob = 'test_app_file.c',
+    add_includes = [
+        "include",
+        "src/fw",
+        "src/libutil/includes",
+        "tests/stubs",
+    ],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = \

--- a/tests/fw/util/test_dict.c
+++ b/tests/fw/util/test_dict.c
@@ -10,7 +10,12 @@
 
 #include <string.h>
 #include <stdbool.h>
+#ifndef CLAR_FREESTANDING
 #include <strings.h>
+#else
+/* ffs() is not in pblibc; use the compiler builtin directly. */
+static inline int ffs(int x) { return __builtin_ffs(x); }
+#endif
 
 // Stubs
 ///////////////////////////////////////////////////////////

--- a/tests/fw/util/wscript_build
+++ b/tests/fw/util/wscript_build
@@ -16,7 +16,13 @@ clar(ctx,
 
 clar(ctx,
      sources_ant_glob = "src/fw/util/dict.c",
-     test_sources_ant_glob = "test_dict.c")
+     test_sources_ant_glob = "test_dict.c",
+     add_includes = [
+         "src/fw",
+         "src/libutil/includes",
+         "tests/stubs",
+     ],
+     freestanding=True)
 
 #clar(ctx,
 #     sources_ant_glob = "src/fw/util/mktime.c",
@@ -24,15 +30,34 @@ clar(ctx,
 
 clar(ctx,
      sources_ant_glob = "src/fw/util/buffer.c",
-     test_sources_ant_glob = "test_buffer.c")
+     test_sources_ant_glob = "test_buffer.c",
+     add_includes = [
+         "src/fw",
+         "src/libutil/includes",
+         "tests/stubs",
+     ],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/fw/util/lru_cache.c",
-     test_sources_ant_glob = "test_lru_cache.c")
+     test_sources_ant_glob = "test_lru_cache.c",
+     add_includes = [
+         "src/fw",
+         "src/libutil/includes",
+         "tests/stubs",
+     ],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/fw/util/mbuf.c src/fw/util/mbuf_iterator.c",
-     test_sources_ant_glob = "test_mbuf.c")
+     test_sources_ant_glob = "test_mbuf.c",
+     add_includes = [
+         "src/fw",
+         "src/libutil/includes",
+         "src/libos/include",
+         "tests/stubs",
+     ],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/fw/util/rand/rand.c" \
@@ -63,7 +88,13 @@ clar(ctx,
 
 clar(ctx,
      sources_ant_glob = "src/fw/util/pstring.c",
-     test_sources_ant_glob = "test_pstring.c")
+     test_sources_ant_glob = "test_pstring.c",
+     add_includes = [
+         "src/fw",
+         "src/libutil/includes",
+         "tests/stubs",
+     ],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/fw/util/ihex.c",

--- a/tests/libc/math/test_log.c
+++ b/tests/libc/math/test_log.c
@@ -3,7 +3,6 @@
 
 #include <stdint.h>
 #include <math.h>
-#include <fenv.h>
 
 #include "clar.h"
 
@@ -24,10 +23,6 @@ static int64_t ulp_diff(double a, double b) {
   union { double value; int64_t bits; } ub = { .value = b };
   int64_t diff = ua.bits - ub.bits;
   return diff < 0 ? -diff : diff;
-}
-
-void test_log__initialize(void) {
-  fesetround(FE_TONEAREST);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/libc/math/test_pow.c
+++ b/tests/libc/math/test_pow.c
@@ -3,7 +3,6 @@
 
 #include <stdint.h>
 #include <math.h>
-#include <fenv.h>
 
 #include "clar.h"
 
@@ -24,10 +23,6 @@ static int64_t ulp_diff(double a, double b) {
   union { double value; int64_t bits; } ub = { .value = b };
   int64_t diff = ua.bits - ub.bits;
   return diff < 0 ? -diff : diff;
-}
-
-void test_pow__initialize(void) {
-  fesetround(FE_TONEAREST);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/libc/math/wscript_build
+++ b/tests/libc/math/wscript_build
@@ -10,7 +10,7 @@ clar(ctx,
      sources_ant_glob = "src/libc/math/log.c",
      test_sources_ant_glob = "test_log.c",
      add_includes = ["src/libc"],
-     test_libs=['m'])
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/math/pow.c" \
@@ -18,10 +18,10 @@ clar(ctx,
                         " src/libc/math/sqrt.c",
      test_sources_ant_glob = "test_pow.c",
      add_includes = ["src/libc"],
-     test_libs=['m'])
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/math/round.c",
      test_sources_ant_glob = "test_round.c",
      add_includes = ["src/libc"],
-     test_libs=['m'])
+     freestanding=True)

--- a/tests/libc/math/wscript_build
+++ b/tests/libc/math/wscript_build
@@ -4,7 +4,7 @@ clar(ctx,
      sources_ant_glob = "src/libc/math/floor.c",
      test_sources_ant_glob = "test_floor.c",
      add_includes = ["src/libc"],
-     test_libs=['m'])
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/math/log.c",

--- a/tests/libc/printf/test_sprintf.c
+++ b/tests/libc/printf/test_sprintf.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <limits.h>
 #include <math.h>
+#include <stdio.h>
 
 #include "clar.h"
 

--- a/tests/libc/printf/wscript_build
+++ b/tests/libc/printf/wscript_build
@@ -1,6 +1,8 @@
 from waftools.pebble_test import clar
 
 clar(ctx,
-     sources_ant_glob = "src/libc/vsprintf.c",
+     sources_ant_glob = "src/libc/vsprintf.c" \
+                        " src/libc/ctype_ptr.c",
      test_sources_ant_glob = "test_sprintf.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)

--- a/tests/libc/string/wscript_build
+++ b/tests/libc/string/wscript_build
@@ -3,33 +3,41 @@ from waftools.pebble_test import clar
 clar(ctx,
      sources_ant_glob = "src/libc/string/memcmp.c",
      test_sources_ant_glob = "test_memcmp.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/memcpy.c",
      test_sources_ant_glob = "test_memcpy.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/memset.c",
      test_sources_ant_glob = "test_memset.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/memchr.c",
      test_sources_ant_glob = "test_memchr.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/atoi.c" \
-                        " src/libc/string/strtol.c",
+                        " src/libc/string/strtol.c" \
+                        " src/libc/ctype_ptr.c",
      test_sources_ant_glob = "test_atoi.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
-     sources_ant_glob = "src/libc/string/strtol.c",
+     sources_ant_glob = "src/libc/string/strtol.c" \
+                        " src/libc/ctype_ptr.c",
      test_sources_ant_glob = "test_strtol.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/strcat.c" \
@@ -38,12 +46,14 @@ clar(ctx,
                         " src/libc/string/memset.c" \
                         " src/libc/string/strcpy.c",
      test_sources_ant_glob = "test_strcat.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/strlen.c",
      test_sources_ant_glob = "test_strlen.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/strlen.c" \
@@ -51,26 +61,30 @@ clar(ctx,
                         " src/libc/string/memset.c" \
                         " src/libc/string/strcpy.c",
      test_sources_ant_glob = "test_strcpy.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/strlen.c" \
                         " src/libc/string/memcmp.c" \
                         " src/libc/string/strcmp.c",
      test_sources_ant_glob = "test_strcmp.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/strlen.c" \
                         " src/libc/string/memchr.c" \
                         " src/libc/string/strchr.c",
      test_sources_ant_glob = "test_strchr.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/strspn.c",
      test_sources_ant_glob = "test_strspn.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/strlen.c" \
@@ -78,7 +92,8 @@ clar(ctx,
                         " src/libc/string/strstr.c" \
                         " src/libc/string/strcmp.c",
      test_sources_ant_glob = "test_strstr.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/ctype_ptr.c",

--- a/tests/stubs/stubs_logging.h
+++ b/tests/stubs/stubs_logging.h
@@ -6,7 +6,9 @@
 #include "system/logging.h"
 #include "util/string.h"
 
+#ifndef CLAR_FREESTANDING
 #include <assert.h>
+#endif
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
@@ -51,7 +53,11 @@ void command_dump_malloc() {
 }
 
 void reset_due_to_software_failure() {
+#ifdef CLAR_FREESTANDING
+  __builtin_trap();
+#else
   assert(0);
+#endif
 }
 
 void app_log_vargs(uint8_t log_level, const char *src_filename, int src_line_number,

--- a/tools/clar/clar.c
+++ b/tools/clar/clar.c
@@ -1,19 +1,25 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#include <assert.h>
+#ifndef CLAR_FREESTANDING
+# include <assert.h>
+#endif
 #include <setjmp.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <strings.h>
+#ifndef CLAR_FREESTANDING
+# include <strings.h>
+#endif
 #include <math.h>
 #include <stdarg.h>
 #include <unistd.h>
 
+#ifndef CLAR_FREESTANDING
 /* required for sandboxing */
-#include <sys/types.h>
-#include <sys/stat.h>
+# include <sys/types.h>
+# include <sys/stat.h>
+#endif
 
 #ifdef _WIN32
 # include <windows.h>
@@ -39,6 +45,15 @@
 #   define snprint_eq snprintf
 # endif
   typedef struct _stat STAT_T;
+#elif defined(CLAR_FREESTANDING)
+
+# define _MAIN_CC
+# define snprint_eq snprintf
+
+/* Forward-declare POSIX functions missing from pblibc headers.
+ * The definitions live in tests/freestanding/shim.c or in
+ * clar_io_freestanding.c (both linked into the final binary). */
+int strcasecmp(const char *s1, const char *s2);
 #else
 
 # ifdef UNITTEST_DEBUG
@@ -703,7 +718,9 @@ void clar__assert_equal_m(
     hex_dump("m1:", m1, n);
     hex_dump("m2:", m2, n);
 
+#ifndef CLAR_FREESTANDING
     fflush(stdout);
+#endif
     clar__assert(0, file, line, err, buf, should_abort);
   }
 }

--- a/tools/clar/clar.py
+++ b/tools/clar/clar.py
@@ -74,13 +74,25 @@ class ClarTestBuilder:
         self.clar_path = os.path.abspath(clar_path) if clar_path else None
 
         self.path = os.path.abspath(path)
-        self.modules = [
-            "clar_sandbox.c",
-            "clar_fixtures.c",
-            "clar_fs.c",
-            "clar_mock.c",
-            "clar_categorize.c",
-        ]
+
+        if print_mode == "freestanding":
+            # Freestanding builds omit POSIX-dependent modules (sandbox, fs,
+            # fixtures) and insert the I/O layer before categorize so that
+            # strcasecmp and printf are available to the modules that follow.
+            self.modules = [
+                "clar_sandbox_freestanding.c",
+                "clar_mock.c",
+                "clar_io_freestanding.c",
+                "clar_categorize.c",
+            ]
+        else:
+            self.modules = [
+                "clar_sandbox.c",
+                "clar_fixtures.c",
+                "clar_fs.c",
+                "clar_mock.c",
+                "clar_categorize.c",
+            ]
 
         self.modules.append("clar_print_%s.c" % print_mode)
 

--- a/tools/clar/clar_io_freestanding.c
+++ b/tools/clar/clar_io_freestanding.c
@@ -1,0 +1,90 @@
+/* SPDX-FileCopyrightText: 2025 Google LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * Freestanding I/O layer included into clar_main.c.
+ *
+ * Provides printf / fprintf / vprintf / vfprintf / fflush implementations
+ * that work under -nostdinc by routing output through freestanding_write()
+ * (defined in tests/freestanding/shim.c, which IS compiled against host
+ * headers).
+ *
+ * Also declares strcasecmp so clar_categorize.c compiles without
+ * <strings.h>, which is a host-only header.
+ *
+ * This module is included into the clar_main.c translation unit by clar.py
+ * when --report-to=freestanding is requested.  It must appear before
+ * clar_categorize.c in the module list so that strcasecmp is declared.
+ */
+
+/* freestanding_write() lives in shim.c; declare it here for the call below. */
+void freestanding_write(int fd, const char *buf, int len);
+
+/* pblibc's stdio.h already declared printf/fprintf/vprintf/vfprintf with
+ * the correct signatures (included at the top of clar.c).  We provide the
+ * definitions here inside the same TU so no duplicate-definition conflict
+ * arises.
+ *
+ * pblibc's vsprintf.c provides vsnprintf/snprintf; they are linked as a
+ * separate object, not inlined here. */
+
+/* Forward-declare vsnprintf exactly as pblibc/stdio.h does so this module
+ * can be read in isolation during review. */
+#ifdef __GNUC__
+__attribute__((__format__(__printf__, 3, 0)))
+#endif
+int vsnprintf(char * restrict str, size_t size,
+              const char * restrict fmt, __gnuc_va_list ap);
+
+/* Declare strcasecmp — not in pblibc, provided by shim.c. */
+int strcasecmp(const char *s1, const char *s2);
+
+/* The FILE type is declared in pblibc's stdio.h as an empty struct.  We
+ * define the stderr object here; clar.c's clar_print_onabort writes to
+ * it via vfprintf(stderr, …). */
+FILE _clar_stderr_storage;
+FILE *stderr = &_clar_stderr_storage;
+
+/* Internal helper: vsnprintf into a stack buffer then write to fd. */
+static int _clar_vwrite(int fd, const char *fmt, va_list ap) {
+  char buf[2048];
+  int n = vsnprintf(buf, sizeof(buf), fmt, ap);
+  if (n > 0) {
+    int len = n < (int)(sizeof(buf) - 1) ? n : (int)(sizeof(buf) - 1);
+    freestanding_write(fd, buf, len);
+  }
+  return n;
+}
+
+int vprintf(const char * restrict fmt, __gnuc_va_list ap) {
+  return _clar_vwrite(1, fmt, ap);
+}
+
+int printf(const char * restrict fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  int n = _clar_vwrite(1, fmt, ap);
+  va_end(ap);
+  return n;
+}
+
+int vfprintf(FILE * restrict stream, const char * restrict fmt,
+             __gnuc_va_list ap) {
+  /* Route stderr (fd 2), everything else to stdout (fd 1). */
+  int fd = (stream == stderr) ? 2 : 1;
+  return _clar_vwrite(fd, fmt, ap);
+}
+
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  int n = vfprintf(stream, fmt, ap);
+  va_end(ap);
+  return n;
+}
+
+int fflush(FILE * restrict stream) {
+  /* write(2) is unbuffered; this is a genuine no-op. */
+  (void)stream;
+  return 0;
+}

--- a/tools/clar/clar_print_freestanding.c
+++ b/tools/clar/clar_print_freestanding.c
@@ -1,0 +1,65 @@
+/* SPDX-FileCopyrightText: 2025 Google LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * Freestanding print back-end for clar.
+ *
+ * Implements the clar_print_* interface using printf() (which in a
+ * freestanding build is provided by clar_io_freestanding.c and routes
+ * through freestanding_write() in shim.c).
+ *
+ * This file is selected as the clar print module when clar.py is invoked
+ * with --report-to=freestanding.
+ */
+
+static void clar_print_init(int test_count, int suite_count,
+                            const char *suite_names) {
+  (void)test_count;
+  printf("Loaded %d suites: %s\n", (int)suite_count, suite_names);
+  printf("Started\n");
+}
+
+static void clar_print_shutdown(int test_count, int suite_count,
+                                int error_count) {
+  (void)test_count;
+  (void)suite_count;
+  (void)error_count;
+
+  printf("\n\n");
+  clar_report_errors();
+}
+
+static void clar_print_error(int num, const struct clar_error *error) {
+  printf("  %d) Failure:\n", num);
+  printf("%s::%s (%s) [%s:%d] [-t%d]\n",
+         error->suite,
+         error->test,
+         "no description",
+         error->file,
+         error->line_number,
+         error->test_number);
+  printf("  %s\n", error->error_msg);
+  if (error->description != NULL) {
+    printf("  %s\n", error->description);
+  }
+  printf("\n");
+}
+
+static void clar_print_ontest(const char *test_name, int test_number,
+                              int failed) {
+  (void)test_name;
+  (void)test_number;
+  printf("%c", failed ? 'F' : '.');
+}
+
+static void clar_print_onsuite(const char *suite_name, int suite_index) {
+  (void)suite_index;
+  (void)suite_name;
+}
+
+static void clar_print_onabort(const char *msg, ...) {
+  va_list ap;
+  va_start(ap, msg);
+  vfprintf(stderr, msg, ap);
+  va_end(ap);
+}

--- a/tools/clar/clar_sandbox_freestanding.c
+++ b/tools/clar/clar_sandbox_freestanding.c
@@ -1,0 +1,40 @@
+/* SPDX-FileCopyrightText: 2025 Google LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * Freestanding replacements for the static sandbox functions defined in
+ * clar_sandbox.c.  Included into clar_main.c when clar.py is invoked with
+ * --report-to=freestanding (which selects this file instead of
+ * clar_sandbox.c).
+ *
+ * Freestanding builds do not fork child processes or write temporary
+ * directories, so the sandbox is a no-op.
+ *
+ * clar_fixtures.c and clar_fs.c are also omitted on the freestanding path
+ * because they depend on POSIX filesystem primitives (stat, fork, waitpid,
+ * execv) that are not available.  The fixture_path() function stub below
+ * satisfies the forward declaration in clar.c; it should never be called
+ * from freestanding test suites.
+ */
+
+static int clar_sandbox(void) {
+  return 0;
+}
+
+static void clar_unsandbox(void) {
+}
+
+/*
+ * Stub for fixture_path(), normally defined in clar_fixtures.c.
+ * Freestanding tests must not use fixtures; this exists only to satisfy
+ * the static forward declaration in clar.c.
+ */
+static const char *fixture_path(const char *base, const char *fixture_name) {
+  (void)base;
+  (void)fixture_name;
+  return "";
+}
+
+/* cl_fs_cleanup() stub — normally in clar_fs.c. */
+void cl_fs_cleanup(void) {
+}

--- a/waftools/pebble_test.py
+++ b/waftools/pebble_test.py
@@ -255,6 +255,172 @@ def get_bitdepth_for_platform(bld, platform):
         bld.fatal("Unknown platform {}".format(platform))
 
 
+def _add_freestanding_clar_test(
+    bld,
+    test_name,
+    test_source,
+    test_dir,
+    test_bin,
+    sources_ant_glob,
+    platform_product_sources,
+    add_includes,
+    defines,
+    test_libs,
+    use,
+    runtime_deps,
+):
+    """Build a single clar test in freestanding mode.
+
+    Compiled with -nostdinc; only pblibc headers and the compiler's built-in
+    include directory are in scope.  The clar harness is generated with
+    --report-to=freestanding, which selects sandbox-free modules.
+
+    The host-boundary shim (tests/freestanding/shim.c) provides malloc, free,
+    calloc, realloc, strdup, abort, printf/fprintf, strcasecmp, qsort, and
+    freestanding_write.  It is linked via use=['freestanding_shim'].
+    """
+
+    def _generate_freestanding_harness(task):
+        bld = task.generator.bld
+        clar_dir = task.generator.env.CLAR_DIR
+        test_src_file = task.inputs[0].abspath()
+        test_bld_dir = task.outputs[0].get_bld().parent.abspath()
+
+        cmd = (
+            "python {clar_dir}/clar.py"
+            " --file={src}"
+            " --clar-path={clar_dir}"
+            " --report-to=freestanding"
+            " {bld_dir}"
+        ).format(
+            clar_dir=clar_dir,
+            src=test_src_file,
+            bld_dir=test_bld_dir,
+        )
+        task.generator.bld.exec_command(cmd)
+
+    clar_harness = test_dir.make_node("clar_main.c")
+
+    bld(
+        name="generate_clar_harness",
+        rule=_generate_freestanding_harness,
+        source=test_source,
+        target=[clar_harness, test_dir.make_node("clar.h")],
+    )
+
+    # Include paths for freestanding builds.
+    #
+    # pblibc headers and the compiler built-in directory are injected as
+    # -isystem so that #include_next chains (e.g. pblibc/setjmp.h →
+    # compiler builtin setjmp.h) resolve correctly under -nostdinc.
+    # The generated test directory (clar.h, test source) and tests/test_includes
+    # are regular -I paths because they are project headers, not system headers.
+    # any add_includes are also regular -I paths (they contain pblibc source
+    # includes that are project-level).
+    srcnode = bld.srcnode.abspath()
+    pblibc_inc = os.path.join(srcnode, "src/libc/include")
+    compiler_builtins_inc = bld.env.COMPILER_BUILTINS_INCLUDE
+    test_includes_inc = os.path.join(srcnode, "tests/test_includes")
+
+    # Regular -I includes (project headers): generated dir and test_includes.
+    freestanding_includes = [
+        test_dir.abspath(),
+        test_includes_inc,
+    ]
+    if add_includes is not None:
+        for inc in add_includes:
+            freestanding_includes.append(os.path.join(srcnode, inc))
+
+    # -isystem includes: pblibc, compiler builtins, then the platform SDK
+    # headers (last resort).
+    #
+    # Order is significant:
+    #   1. pblibc — project's own libc headers (highest precedence)
+    #   2. compiler built-in dir — stddef.h, stdint.h, float.h, stdarg.h
+    #   3. platform SDK usr/include — provides setjmp.h, assert.h and any
+    #      other POSIX headers that pblibc delegates via #include_next
+    #
+    # Only pblibc and compiler-builtin headers are used by the product code
+    # under test.  The SDK headers are a fallback for the clar harness only
+    # (setjmp.h, assert.h).  They are injected last so that pblibc headers
+    # take precedence for everything pblibc covers.
+    import subprocess as _sp
+    import sys as _sys
+    platform_sdk_inc = None
+    if _sys.platform == 'darwin':
+        try:
+            sdk = _sp.check_output(
+                ['xcrun', '--show-sdk-path'], stderr=_sp.DEVNULL
+            ).decode().strip()
+            candidate = os.path.join(sdk, 'usr', 'include')
+            if os.path.isdir(candidate):
+                platform_sdk_inc = candidate
+        except Exception:
+            pass
+    else:
+        # On Linux, pblibc/setjmp.h uses #include_next <setjmp.h> for non-ARM
+        # hosts; the system headers provide it.  Add /usr/include as a last-
+        # resort -isystem so #include_next chains resolve, while keeping
+        # pblibc headers at higher precedence for everything pblibc covers.
+        candidate = '/usr/include'
+        if os.path.isfile(os.path.join(candidate, 'setjmp.h')):
+            platform_sdk_inc = candidate
+
+    freestanding_cflags = [
+        "-nostdinc",
+        "-isystem", pblibc_inc,
+        "-isystem", compiler_builtins_inc,
+        "-DCLAR_FREESTANDING=1",
+    ]
+    if platform_sdk_inc:
+        freestanding_cflags += ["-isystem", platform_sdk_inc]
+
+    freestanding_defines = list(defines)
+
+    if sources_ant_glob is not None:
+        sources_list = Utils.to_list(sources_ant_glob)
+        for s in sources_list:
+            node = bld.srcnode.find_node(s)
+            if node is None:
+                raise Errors.WafError(
+                    'Error: Source file "%s" not found for "%s"' % (s, test_name)
+                )
+            if node not in platform_product_sources:
+                platform_product_sources.append(node)
+            else:
+                raise Errors.WafError(
+                    'Error: Duplicate source file "%s" found for "%s"'
+                    % (s, test_name)
+                )
+
+    program_sources = [test_source, clar_harness]
+    program_sources.extend(
+        build_product_source_files(
+            bld,
+            test_dir,
+            freestanding_includes,
+            freestanding_defines,
+            freestanding_cflags,
+            platform_product_sources,
+        )
+    )
+
+    freestanding_use = list(use) if use else []
+    freestanding_use.append("freestanding_shim")
+
+    bld.program(
+        source=program_sources,
+        target=test_bin,
+        features="pebble_test",
+        includes=freestanding_includes,
+        lib=test_libs,
+        defines=freestanding_defines,
+        cflags=freestanding_cflags,
+        use=freestanding_use,
+        runtime_deps=runtime_deps,
+    )
+
+
 def add_clar_test(
     bld,
     test_name,
@@ -268,6 +434,7 @@ def add_clar_test(
     runtime_deps,
     platform,
     use,
+    freestanding=False,
 ):
 
     if bld.options.regex:
@@ -299,6 +466,27 @@ def add_clar_test(
         test_dir = bld.path.get_bld().make_node(test_name + "_" + platform)
         test_bin = test_dir.make_node("runme_" + platform)
         platform_defines.append("PLATFORM_DEFAULT=0")
+
+    if freestanding:
+        # ---- freestanding path ---------------------------------------------
+        # Compiled with -nostdinc; only pblibc headers and the compiler's
+        # built-in include directory are in scope.  No DUMA, no display
+        # force-include, no firmware src includes.
+        _add_freestanding_clar_test(
+            bld=bld,
+            test_name=test_name,
+            test_source=test_source,
+            test_dir=test_dir,
+            test_bin=test_bin,
+            sources_ant_glob=sources_ant_glob,
+            platform_product_sources=platform_product_sources,
+            add_includes=add_includes,
+            defines=defines + platform_defines,
+            test_libs=list(test_libs),
+            use=use,
+            runtime_deps=runtime_deps,
+        )
+        return
 
     def _generate_clar_harness(task):
         bld = task.generator.bld
@@ -494,6 +682,7 @@ def clar(
     runtime_deps=None,
     platforms=None,
     use=None,
+    freestanding=False,
 ):
 
     if test_sources_ant_glob is None and not test_sources:
@@ -563,4 +752,5 @@ def clar(
             runtime_deps,
             platform,
             use,
+            freestanding=freestanding,
         )

--- a/waftools/pebble_test.py
+++ b/waftools/pebble_test.py
@@ -346,13 +346,16 @@ def _add_freestanding_clar_test(
     # take precedence for everything pblibc covers.
     import subprocess as _sp
     import sys as _sys
+
     platform_sdk_inc = None
-    if _sys.platform == 'darwin':
+    if _sys.platform == "darwin":
         try:
-            sdk = _sp.check_output(
-                ['xcrun', '--show-sdk-path'], stderr=_sp.DEVNULL
-            ).decode().strip()
-            candidate = os.path.join(sdk, 'usr', 'include')
+            sdk = (
+                _sp.check_output(["xcrun", "--show-sdk-path"], stderr=_sp.DEVNULL)
+                .decode()
+                .strip()
+            )
+            candidate = os.path.join(sdk, "usr", "include")
             if os.path.isdir(candidate):
                 platform_sdk_inc = candidate
         except Exception:
@@ -362,14 +365,16 @@ def _add_freestanding_clar_test(
         # hosts; the system headers provide it.  Add /usr/include as a last-
         # resort -isystem so #include_next chains resolve, while keeping
         # pblibc headers at higher precedence for everything pblibc covers.
-        candidate = '/usr/include'
-        if os.path.isfile(os.path.join(candidate, 'setjmp.h')):
+        candidate = "/usr/include"
+        if os.path.isfile(os.path.join(candidate, "setjmp.h")):
             platform_sdk_inc = candidate
 
     freestanding_cflags = [
         "-nostdinc",
-        "-isystem", pblibc_inc,
-        "-isystem", compiler_builtins_inc,
+        "-isystem",
+        pblibc_inc,
+        "-isystem",
+        compiler_builtins_inc,
         "-DCLAR_FREESTANDING=1",
     ]
     if platform_sdk_inc:
@@ -389,8 +394,7 @@ def _add_freestanding_clar_test(
                 platform_product_sources.append(node)
             else:
                 raise Errors.WafError(
-                    'Error: Duplicate source file "%s" found for "%s"'
-                    % (s, test_name)
+                    'Error: Duplicate source file "%s" found for "%s"' % (s, test_name)
                 )
 
     program_sources = [test_source, clar_harness]

--- a/wscript
+++ b/wscript
@@ -233,6 +233,42 @@ def configure(conf):
     conf.load('clang')
     conf.load('pebble_test', tooldir='waftools')
 
+    # Discover the compiler's built-in include directory.  This is needed for
+    # freestanding (-nostdinc) test builds that must still reach compiler
+    # intrinsic headers (stddef.h, stdint.h, float.h, …).
+    #
+    # Try -print-resource-dir first (clang); fall back to -print-file-name=include
+    # (GCC).  Either way the result must contain stddef.h.
+    import os as _os
+    cc = conf.env.CC[0]
+    builtin_inc = None
+    try:
+        resource_dir = conf.cmd_and_log(
+            [cc, '-print-resource-dir'], quiet=waflib.Context.BOTH
+        ).strip()
+        candidate = _os.path.join(resource_dir, 'include')
+        if _os.path.isfile(_os.path.join(candidate, 'stddef.h')):
+            builtin_inc = candidate
+    except Exception:
+        pass
+    if builtin_inc is None:
+        try:
+            candidate = conf.cmd_and_log(
+                [cc, '-print-file-name=include'], quiet=waflib.Context.BOTH
+            ).strip()
+            if _os.path.isfile(_os.path.join(candidate, 'stddef.h')):
+                builtin_inc = candidate
+        except Exception:
+            pass
+    if builtin_inc is None:
+        conf.fatal(
+            'Cannot locate compiler built-in include directory containing '
+            'stddef.h.  Tried -print-resource-dir and -print-file-name=include '
+            'with CC=%s.' % cc
+        )
+    conf.env.COMPILER_BUILTINS_INCLUDE = builtin_inc
+    Logs.pprint('CYAN', 'Compiler built-in includes: %s' % builtin_inc)
+
     conf.env.CLAR_DIR = conf.path.make_node('tools/clar/').abspath()
     conf.env.CFLAGS = [ '-std=c11',
                         '-Wall',


### PR DESCRIPTION
Host tests compile against the host libc, so they pick up different headers, different libm, different linker behaviour per platform. Freestanding compilation compiles tests with `-ffreestanding -nostdlib` against pblibc instead, so the test environment matches what the firmware links against and the same test binary is built regardless of host OS.

Freestanding compilation infrastructure: `freestanding=True` on `clar()` swaps the host libc for pblibc headers and adds the right compilation flags.

pblibc headers extended for freestanding builds (missing size_t, NULL, etc.), HUGE_VAL added to pblibc math.h.

Math tests migrated: test_floor, test_round, test_log, test_pow. test_log and test_pow no longer need fenv.h because the previous PR replaced the host-libm oracle with static reference tables.

String and printf include-order fix: ctype.h moved after pblibc_private.h in strtol and vsprintf (same pattern as floor.c).

String tests (memcpy, strlen, etc.) and test_sprintf migrated to freestanding.

Rename shim retired for freestanding builds: the `#define fn pblibc_fn` shim in pblibc_private.h is no longer needed when compiling freestanding, since there's no host libc to rename away from.

Stubs layer made freestanding-compatible (stubs_logging.h).

Util data-structure tests migrated: buffer, pstring, lru_cache, mbuf, dict.

Three service tests migrated: registry_endpoint, transcription, app_file.

Merge order: **2** (after #1497)
Depended on by: #1500
