### PR TITLE
build: migrate remaining tests to freestanding compilation

### DIFF
--- a/docs/development/native-platform-agnostic-tests.md
+++ b/docs/development/native-platform-agnostic-tests.md
@@ -1,0 +1,206 @@
+# Native platform-agnostic host tests
+
+## Goal
+
+Host unit tests — those compiled for and run on the developer's own machine
+rather than on a target board or under QEMU — should produce identical
+results on macOS and Linux without requiring a container or cross-compilation
+environment. A developer running `./waf test` on an Apple silicon MacBook and
+a colleague running the same command on an Ubuntu x86-64 box should see the
+same pass/fail outcomes, the same assertion values, and the same binary output
+from every test that exercises firmware logic.
+
+That goal has two parts. The first is eliminating host-toolchain divergence:
+differences in how macOS Clang and Linux GCC/Clang handle tentative
+definitions, floating-point contraction, and excess precision. The second is
+eliminating host-libc divergence: differences in how Apple's libm and glibc
+implement functions such as `log` and `pow` that affect correctness assertions
+in tests of pblibc's own implementations.
+
+## Work landed in this track
+
+Five changes narrowed the gap between hosts.
+
+`-fno-common` was added to the host-test CFLAGS. macOS ld64 silently merges
+tentative definitions (bare enumerations or object declarations at file scope
+in a header included by more than one translation unit), whereas GNU ld rejects
+the resulting duplicate symbol. Without `-fno-common` a collision that is
+harmless on macOS is a linker error on Linux, meaning some bugs only surface
+on one host. With the flag, both toolchains reject the collision at compile
+time, so the error appears on whichever host runs first.
+
+`pblibc_private.h` include ordering was fixed in `src/libc/math/floor.c`.
+`pblibc_private.h` emits `#undef floor; #define floor pblibc_floor` so that
+the function definition below it provides the pblibc implementation rather
+than shadowing the system symbol. On glibc, if `<math.h>` is included *after*
+`pblibc_private.h`, glibc sees `floor` already redefined when it tries to emit
+its `__DECL_SIMD_*` SIMD-variant declarations, and the translation unit fails
+to compile. The fix is to place all system headers (`<math.h>`, `<stdbool.h>`,
+`<stdint.h>`) before `pblibc_private.h`, which is the pattern already used
+by `pow.c`, `scalbn.c`, and `sqrt.c`. With the include order corrected,
+`test_floor.c` and `test_pow.c` were removed from `BROKEN_TESTS`.
+
+Floating-point determinism flags were added to the host-test CFLAGS:
+`-ffp-contract=off` and `-fexcess-precision=standard`. macOS Clang contracts
+multiply-add pairs into FMA instructions by default; Linux Clang does not.
+FMA changes intermediate precision and is the classic source of last-ULP
+differences between platforms. `-ffp-contract=off` disables contraction on
+both hosts so the same intermediate values are produced everywhere.
+`-fexcess-precision=standard` is a no-op on SSE-only x86-64 but prevents
+80-bit x87 register intermediates on any 32-bit or legacy host path. Together
+these flags make floating-point computations deterministic across all supported
+host toolchains.
+
+The `test_log` and `test_pow` suites replaced their host-libm oracle pattern
+with precomputed reference tables. Both tests previously called the host's own
+`log` or `pow` at runtime to generate expected values, then compared pblibc's
+result within one ULP. glibc and Apple's libm disagree in the last ULP on some
+inputs, so the expected values were host-dependent and the tests were
+inherently non-portable. The replacement approach evaluates each input offline
+in Python's `decimal` module at 80 significant digits and rounds to the nearest
+representable `double` (round-half-to-even), producing a correctly-rounded
+reference that is the same on every host. The reference values and their
+corresponding inputs are stored as IEEE-754 bit patterns in a checked-in
+header, and the generator script is included so the table can be regenerated if
+the test inputs change.
+
+These five changes together remove the known sources of host-toolchain and
+host-libm divergence from the currently active test suite. CI on both macOS
+and Linux should now see identical outcomes.
+
+## The remaining boundary: host-libc inclusion
+
+The changes above are sufficient to make the existing tests deterministic, but
+they do not sever the dependency on the host's standard library. Every host
+unit test still compiles against the host libc and libm. That means:
+
+- The `pblibc_private.h` rename shim is necessary. Without it, a test that
+  includes `<string.h>` and then calls `memcpy` calls the host `memcpy`, not
+  pblibc's. The shim papers over this by macro-renaming every covered symbol
+  before the function definitions are reached.
+- The `__DECL_SIMD_*` issue is structural, not just an include-order problem.
+  Those macros appear because glibc injects SIMD-variant attribute declarations
+  into its own `<math.h>` that assume the standard symbol names are available.
+  As long as `<math.h>` must be included to satisfy other headers in the
+  compilation unit, the tension between glibc's expectations and pblibc's
+  renaming can recur.
+- Any new pblibc function that needs to be tested — or any test that exercises
+  a firmware module pulling in pblibc headers — risks the same class of
+  collision unless every author remembers to get the include order right.
+
+The root cause is that host tests live in two worlds simultaneously: they
+include firmware headers that expect pblibc's symbols, and they compile against
+a host libc that provides its own versions of those symbols. The shim bridges
+the gap, but it is fragile and must be maintained as pblibc's symbol set grows.
+
+## Next step: freestanding compilation against pblibc
+
+The proper fix is to compile host unit tests under `-nostdinc`, with the
+include search path limited to pblibc's own headers plus a small set of
+compiler built-in headers, so the host libc is never in scope. Tests would
+then see exactly the same symbols, with exactly the same definitions, as
+firmware does. The `pblibc_private.h` rename shim becomes unnecessary because
+there is nothing to rename away from: there is only one `memcpy`, and it is
+pblibc's. The `__DECL_SIMD_*` corruption disappears because glibc's `<math.h>`
+is never reached.
+
+### Shape of the change
+
+The change has three parts.
+
+**A host-abstraction port.** A thin shim library — roughly a hundred lines of
+C — provides the symbols that pblibc and clar need in order to run on a hosted
+OS but that pblibc itself does not implement. Under firmware these come from the
+RTOS or the hardware; under a freestanding host build they come from the shim.
+The minimum set is:
+
+- `write` (or equivalent) for clar's output. clar uses `printf` and
+  `fputs`; those need to ultimately call the host's `write(2)`.
+- `malloc` / `free` for clar's bookkeeping and for any test fixture that
+  allocates memory. pblibc does not provide a heap allocator.
+- `abort` for assertion failure.
+- A clock source, if any test uses `time(3)` or `clock(3)`.
+- `exit`, since clar calls it to report the final result.
+
+Everything else — string functions, math functions, printf formatting — is
+provided by pblibc and exercised by the tests rather than assumed from the
+host.
+
+**Freestanding CFLAGS for test compilation.** The waf test environment gains a
+new flag set:
+
+```
+-nostdinc
+-isystem <path-to-pblibc-include>
+-isystem <path-to-compiler-clang-or-gcc-built-ins>
+```
+
+The compiler built-in headers (`stddef.h`, `stdint.h`, `stdarg.h`, `limits.h`,
+`stdbool.h`) live in the compiler's own resource directory
+(`clang -print-resource-dir` or `gcc -print-file-name=include`) and are
+independent of the host libc. They are the only system headers that should
+remain in scope. All of `<string.h>`, `<math.h>`, `<stdlib.h>`, `<stdio.h>`,
+and `<unistd.h>` come from pblibc's `src/libc/include/` instead.
+
+**Tests that cannot move.** Some tests have a genuine host dependency that
+cannot be replaced by pblibc. Graphics snapshot tests compare pixel buffers
+against PNG reference images and use libpng. Tests that exercise file I/O
+(fixture loading, PFS tests) call POSIX file operations directly. Any test
+that uses `popen`, `system`, or spawns subprocesses is similarly anchored to
+the host. These tests should remain in a separate compilation group that keeps
+`-nostdinc` off and continues to link the host libc. The goal is not to
+eliminate that group but to shrink it to only tests that genuinely require
+host facilities, so the boundary is explicit rather than accidental.
+
+The libc/math tests — `test_log`, `test_pow`, `test_floor`, `test_round`,
+`test_sqrt`, and so on — are the natural first target for the freestanding
+group. They already include `pblibc_private.h` and have no POSIX dependencies.
+The libc/string and libc/printf tests follow immediately behind them.
+
+### Open questions
+
+Several points need resolution before the migration can be completed.
+
+Which libm-only symbols still need a host backing? pblibc covers the functions
+that firmware uses, but `fesetround` and `fegetenv` (needed by `test_log` and
+`test_pow` to set rounding mode for the suite setup) come from the host's
+`<fenv.h>`. pblibc does not implement `<fenv.h>`. Either the rounding-mode
+setup moves into the host-abstraction shim, or pblibc gains minimal fenv
+stubs, or the tests stop calling `fesetround` and rely instead on the
+determinism flags to guarantee round-to-nearest.
+
+How does clar's `main` entry point interact with a freestanding build? clar
+generates a `main` function that calls `exit`. A freestanding binary needs a
+real `main` that the host linker can resolve, so clar's generated harness
+continues to work as-is. The complication is that clar also uses `printf`,
+`snprintf`, `fputs`, `fflush`, and `stderr`/`stdout`. `printf` and `snprintf`
+are covered by pblibc's `vsprintf`. `fputs` and `fflush` are not; the
+host-abstraction shim must provide them, or clar's print back-end must be
+patched to call `write(2)` directly, bypassing stdio buffering.
+
+Are there firmware modules whose headers pull in non-pblibc system headers
+transitively? Some tests of non-libc firmware code include headers that
+eventually reach `<sys/types.h>` or `<pthread.h>`. Those tests need either
+a stub header placed ahead of the system path, or they remain in the hosted
+group. A sweep of transitive includes across the tests directory is needed
+before the split can be made cleanly.
+
+### Why this is a separate piece of work
+
+The freestanding migration is a larger undertaking than the changes landed in
+this track. It touches the waf build system (new compilation group, new
+toolchain flag set), the clar harness (print back-end), and potentially dozens
+of test files that need their includes audited. It also requires a decision
+about `fenv.h` before the math tests can fully move.
+
+More importantly, it changes what "compiles" means for a host test, and any
+mistake in the shim or the include path configuration will produce confusing
+link errors or silent wrong behaviour. That risk is better managed as a focused
+change with its own review, rather than bundled with the toolchain hygiene work
+that preceded it.
+
+The changes already landed establish the invariants that the freestanding
+migration depends on: reference-table tests that do not call the host libm,
+deterministic FP flags that remove cross-platform ULP disagreement, and a
+correct include order in pblibc source files. The next step is to make those
+invariants structural by removing the host libc from the picture entirely.

--- a/docs/development/native-platform-agnostic-tests.md
+++ b/docs/development/native-platform-agnostic-tests.md
@@ -93,6 +93,35 @@ include firmware headers that expect pblibc's symbols, and they compile against
 a host libc that provides its own versions of those symbols. The shim bridges
 the gap, but it is fragile and must be maintained as pblibc's symbol set grows.
 
+## Status: freestanding compilation has landed
+
+The migration described below is now implemented for the libc test groups. A
+host-boundary shim (`tests/freestanding/shim.c`) provides the handful of
+host-OS primitives pblibc does not (`malloc`/`free`, `abort`, `exit`, and a
+`write(2)`-backed console writer for clar), and is the only translation unit
+that sees the host libc. A `freestanding=True` option on the `clar()` waf
+helper compiles a test with `-nostdinc -isystem <pblibc> -isystem <compiler
+builtins>` (the builtin path is discovered at configure time, never hardcoded),
+drops the firmware include tree and the `m`/`pthread` libs, and routes clar
+through a sandbox-free `vsnprintf`+`write` print back-end. The fenv question was
+resolved by deletion: `fesetround(FE_TONEAREST)` was a no-op given the
+power-on default and the determinism flags, so it and `<fenv.h>` were removed.
+
+Eighteen libc suites now compile freestanding: the math (floor, log, pow,
+round), string, and printf groups. `test_ctype` and `test_strftime` stay hosted
+on purpose, the former because it uses the host ctype as its oracle.
+
+The `pblibc_private.h` rename shim is now retired for these tests. Its rename
+block is gated on `!defined(CLAR_FREESTANDING)`, which the freestanding group
+defines, so under `-nostdinc` the tests and the pblibc implementation sources
+both use the real symbol names (there is no host libc to collide with). For
+this to work pblibc's own headers must declare everything the tests call, so
+`<math.h>` gained the `pow` and `scalbn` declarations it was missing. The
+hosted group keeps the rename shim, which it still needs.
+
+What remains: a transitive-include sweep of the wider non-libc `tests/` tree and
+migrating any libc tests beyond math/string/printf.
+
 ## Next step: freestanding compilation against pblibc
 
 The proper fix is to compile host unit tests under `-nostdinc`, with the

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,6 +88,7 @@ development/options.md
 development/building_fw.md
 development/qemu.md
 development/moddable.md
+development/native-platform-agnostic-tests.md
 ```
 
 ```{toctree}

--- a/src/fw/util/graphics.h
+++ b/src/fw/util/graphics.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <stdint.h>
+#include "util/attributes.h"
 
 //! This function extracts a value for a specific bit per pixel depth from an image buffer
 //! at a specific x y position.

--- a/src/libc/include/math.h
+++ b/src/libc/include/math.h
@@ -87,9 +87,13 @@ float modff(float x, float *iptr);
 
 double nearbyint(double x);
 
+double pow(double x, double y);
+
 double round(double d);
 
 float roundf(float x);
+
+double scalbn(double x, int n);
 
 double sin(double x);
 

--- a/src/libc/include/math.h
+++ b/src/libc/include/math.h
@@ -9,6 +9,7 @@
 #endif
 
 #define INFINITY   ((double)(_HUGE_ENUF * _HUGE_ENUF))
+#define HUGE_VAL   INFINITY
 #define NAN        ((double)(INFINITY * 0.0F))
 
 #define INFINITY_F ((float)INFINITY)

--- a/src/libc/include/stdlib.h
+++ b/src/libc/include/stdlib.h
@@ -44,5 +44,12 @@ void exit(int status) __attribute__((noreturn));
 // Not implemented, but included in the header to build the default platform.c of libs.
 void free(void *ptr);
 void *malloc(size_t bytes);
+// Provided by tests/freestanding/shim.c in freestanding builds; by host libc otherwise.
+void *calloc(size_t nmemb, size_t size);
+void *realloc(void *ptr, size_t size);
+void qsort(void *base, size_t nmemb, size_t size,
+           int (*compar)(const void *, const void *));
+void abort(void) __attribute__((noreturn));
+char *strdup(const char *s);
 
 long jrand48(unsigned short int s[3]);

--- a/src/libc/include/sys/cdefs.h
+++ b/src/libc/include/sys/cdefs.h
@@ -16,6 +16,17 @@
 #define __STRING(x) #x
 
 /*
+ * macOS SDK compat: assert.h selects the safe __assert_rtn() path only when
+ * __DARWIN_UNIX03 is set.  Without it, the fallback __assert() macro uses
+ * __unsafe_forge_null_terminated, which is a clang pointer-safety extension
+ * not available in all build modes.  Define it here so that assert.h always
+ * takes the UNIX03 path under pblibc.
+ */
+#if defined(__APPLE__) && !defined(__DARWIN_UNIX03)
+# define __DARWIN_UNIX03 1
+#endif
+
+/*
  * Compiler attribute shims expected by platform SDK/libc headers when they
  * are pulled in via #include_next chains (e.g. setjmp.h, assert.h).
  *

--- a/src/libc/include/sys/cdefs.h
+++ b/src/libc/include/sys/cdefs.h
@@ -14,3 +14,77 @@
 #define __P(protos) protos
 #define __CONCAT(x, y) x ## y
 #define __STRING(x) #x
+
+/*
+ * Compiler attribute shims expected by platform SDK/libc headers when they
+ * are pulled in via #include_next chains (e.g. setjmp.h, assert.h).
+ *
+ * macOS SDK headers use __dead2, __cold, __disable_tail_calls.
+ * Linux glibc headers use __THROW, __THROWNL, __LEAF, __NTH, __NTHNL.
+ *
+ * GCC/Clang support all underlying attributes, so define them
+ * unconditionally.  On other compilers, expand to nothing.
+ */
+#if defined(__GNUC__) || defined(__clang__)
+
+/* ---- macOS SDK macros --------------------------------------------------- */
+# ifndef __dead2
+#   define __dead2 __attribute__((__noreturn__))
+# endif
+# ifndef __cold
+#   define __cold __attribute__((__cold__))
+# endif
+# ifndef __disable_tail_calls
+#   if defined(__has_attribute) && __has_attribute(__disable_tail_calls__)
+#     define __disable_tail_calls __attribute__((__disable_tail_calls__))
+#   else
+#     define __disable_tail_calls
+#   endif
+# endif
+
+/* ---- Linux glibc macros ------------------------------------------------- */
+# ifndef __LEAF
+#   ifdef __GNUC__
+#     define __LEAF , __leaf__
+#   else
+#     define __LEAF
+#   endif
+# endif
+# ifndef __THROW
+#   define __THROW __attribute__((__nothrow__ __LEAF))
+# endif
+# ifndef __THROWNL
+#   define __THROWNL __attribute__((__nothrow__))
+# endif
+# ifndef __NTH
+#   define __NTH(fct) __attribute__((__nothrow__ __LEAF)) fct
+# endif
+# ifndef __NTHNL
+#   define __NTHNL(fct) __attribute__((__nothrow__)) fct
+# endif
+
+#else /* not GCC/Clang */
+
+# ifndef __dead2
+#   define __dead2
+# endif
+# ifndef __cold
+#   define __cold
+# endif
+# ifndef __disable_tail_calls
+#   define __disable_tail_calls
+# endif
+# ifndef __THROW
+#   define __THROW
+# endif
+# ifndef __THROWNL
+#   define __THROWNL
+# endif
+# ifndef __NTH
+#   define __NTH(fct) fct
+# endif
+# ifndef __NTHNL
+#   define __NTHNL(fct) fct
+# endif
+
+#endif /* GCC/Clang */

--- a/src/libc/include/unistd.h
+++ b/src/libc/include/unistd.h
@@ -3,4 +3,4 @@
 
 #pragma once
 
-// stub
+#include <sys/types.h>

--- a/src/libc/pblibc_private.h
+++ b/src/libc/pblibc_private.h
@@ -3,8 +3,10 @@
 
 #pragma once
 
-// Rename (and re-define) the libc functions
-#if UNITTEST
+// Rename (and re-define) the libc functions. Freestanding host tests compile
+// under -nostdinc against pblibc with no host libc in scope, so there is
+// nothing to collide with and the rename shim is unnecessary there.
+#if UNITTEST && !defined(CLAR_FREESTANDING)
 #include <stddef.h>
 #include <stdarg.h>
 

--- a/src/libc/string/strtol.c
+++ b/src/libc/string/strtol.c
@@ -5,12 +5,12 @@
 // Implements:
 //   long int strtol(const char *nptr, char **endptr, int base);
 
-#include <ctype.h>
 #include <string.h>
 #include <stdint.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <pblibc_private.h>
+#include <ctype.h>
 
 intmax_t strtoX_core(const char * restrict nptr, char ** restrict endptr, int base, bool do_errors,
                      intmax_t max, intmax_t min) {

--- a/src/libc/vsprintf.c
+++ b/src/libc/vsprintf.c
@@ -118,10 +118,10 @@
 #include <stdint.h>
 #include <limits.h>
 #include <stddef.h>
-#include <ctype.h>
 #include <stdbool.h>
 
 #include "pblibc_private.h"
+#include <ctype.h>
 
 // Not using 64-bit division for Dialog Bluetooth. This saves *gobs* of memory.
 #ifdef ARCH_NO_NATIVE_LONG_DIVIDE

--- a/tests/fakes/fake_rtc.c
+++ b/tests/fakes/fake_rtc.c
@@ -3,9 +3,11 @@
 
 #include "fake_rtc.h"
 
+#ifndef CLAR_FREESTANDING
 #include <stdlib.h>
-#include <string.h>
 #include <time.h>
+#endif
+#include <string.h>
 
 static RtcTicks s_rtc_tick_count;
 static RtcTicks s_rtc_auto_increment = 0;

--- a/tests/fakes/fake_rtc.h
+++ b/tests/fakes/fake_rtc.h
@@ -7,7 +7,9 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#ifndef CLAR_FREESTANDING
 #include <time.h>
+#endif
 
 void fake_rtc_init(RtcTicks initial_ticks, time_t initial_time);
 

--- a/tests/fakes/fake_spi_flash.c
+++ b/tests/fakes/fake_spi_flash.c
@@ -100,6 +100,7 @@ int32_t fake_spi_flash_find_next_write(int32_t offset) {
   return E_DOES_NOT_EXIST;
 }
 
+#ifndef CLAR_FREESTANDING
 void fake_spi_flash_populate_from_file(char *path, uint32_t offset) {
   cl_assert(s_state.storage);
   cl_assert(offset >= s_state.offset);
@@ -119,6 +120,7 @@ void fake_spi_flash_populate_from_file(char *path, uint32_t offset) {
   // copy file to fake flash storage
   cl_assert(fread(&s_state.storage[fake_offset], 1, st.st_size, file) > 0);
 }
+#endif /* CLAR_FREESTANDING */
 
 void fake_spi_flash_force_future_failure(int after_n_bytes, jmp_buf *retire_to) {
   s_state.bytes_left_till_write_failure = after_n_bytes;

--- a/tests/freestanding/shim.c
+++ b/tests/freestanding/shim.c
@@ -30,6 +30,17 @@
 #include <string.h>
 #include <unistd.h>
 
+/* Platform allocation-size query — needed for a free-compatible realloc. */
+#if defined(__APPLE__)
+#  include <malloc/malloc.h>
+#  define _host_malloc_size(p) malloc_size(p)
+#elif defined(__linux__)
+#  include <malloc.h>
+#  define _host_malloc_size(p) malloc_usable_size(p)
+#else
+#  error "Unsupported platform: cannot determine allocation size for realloc"
+#endif
+
 /* ---- output helper ------------------------------------------------------- */
 
 /*
@@ -67,56 +78,29 @@ void *calloc(size_t nmemb, size_t size) {
 }
 
 /*
- * realloc — size-header implementation.
+ * realloc — malloc/memcpy/free implementation using the platform allocator's
+ * own size query so that all pointers are fully compatible with bare free().
  *
- * realloc needs to know the old allocation's size to copy the right number
- * of bytes.  We achieve this by storing a size_t header immediately before
- * the user pointer:
- *
- *   [ size_t bytes_pad_to_align | user data ... ]
- *   ^                              ^
- *   raw malloc'd block             returned to caller
- *
- * This is safe because the ONLY caller of realloc in the clar harness is
- * clar_category_add_to_list, which:
- *   - first call: passes NULL (we treat as malloc)
- *   - subsequent calls: passes the pointer returned by our previous realloc
- *
- * The names array is a global static and is never freed, so there is no
- * mismatch between our size-header pointer and bare free.
+ * The old size-header trick (_REALLOC_ALIGN prefix) broke as soon as product
+ * code called realloc() and then later called free() on the returned pointer,
+ * because free() saw an interior pointer rather than the raw malloc block.
+ * Using malloc_size (macOS) / malloc_usable_size (Linux) avoids the header
+ * entirely: every returned pointer is a plain malloc'd block that free() can
+ * release without any special handling.
  */
-#define _REALLOC_ALIGN \
-  (sizeof(size_t) > sizeof(void *) ? sizeof(size_t) : sizeof(void *))
-
-static void *_realloc_alloc(size_t bytes) {
-  char *raw = malloc(_REALLOC_ALIGN + bytes);
-  if (!raw) return NULL;
-  *(size_t *)(void *)raw = bytes;
-  return raw + _REALLOC_ALIGN;
-}
-
-static void _realloc_free(void *ptr) {
-  free((char *)ptr - _REALLOC_ALIGN);
-}
-
-static size_t _realloc_size(const void *ptr) {
-  const char *raw = (const char *)ptr - _REALLOC_ALIGN;
-  return *(const size_t *)(const void *)raw;
-}
-
 void *realloc(void *ptr, size_t size) {
   if (ptr == NULL) {
-    return _realloc_alloc(size);
+    return malloc(size);
   }
   if (size == 0) {
-    _realloc_free(ptr);
+    free(ptr);
     return NULL;
   }
-  void *new_ptr = _realloc_alloc(size);
+  void *new_ptr = malloc(size);
   if (!new_ptr) return NULL;
-  size_t old_size = _realloc_size(ptr);
+  size_t old_size = _host_malloc_size(ptr);
   memcpy(new_ptr, ptr, old_size < size ? old_size : size);
-  _realloc_free(ptr);
+  free(ptr);
   return new_ptr;
 }
 

--- a/tests/freestanding/shim.c
+++ b/tests/freestanding/shim.c
@@ -1,0 +1,168 @@
+/* SPDX-FileCopyrightText: 2025 Google LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * Host-boundary adapter for freestanding test builds.
+ *
+ * This is the ONE translation unit compiled WITHOUT -nostdinc, so it can
+ * reach host-libc headers.  All other TUs in a freestanding build use only
+ * pblibc headers and the compiler's built-in includes.
+ *
+ * Symbols provided:
+ *
+ *   freestanding_write — write(2)-backed output, used by clar_io_freestanding.c
+ *   calloc / realloc / strdup — heap helpers missing from pblibc's stdlib.h
+ *   abort — not in pblibc's stdlib.h
+ *   strcasecmp — POSIX, absent from pblibc; used by clar_categorize.c
+ *   qsort — used only on the -l listing path; insertion-sort stub
+ *
+ * Note: malloc and free are declared in pblibc/stdlib.h and resolve to the
+ * host libc at link time without any forwarding needed here.
+ *
+ * Note: printf, fprintf, vprintf, vfprintf, fflush, FILE, and stderr are
+ * provided by clar_io_freestanding.c (compiled as part of clar_main.c under
+ * -nostdinc).  They are NOT defined here.
+ */
+
+/* Host headers — only allowed in this file. */
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* ---- output helper ------------------------------------------------------- */
+
+/*
+ * Write len bytes from buf to file descriptor fd.
+ * fd 1 = stdout, fd 2 = stderr.
+ * Called from clar_io_freestanding.c, which is compiled under -nostdinc.
+ */
+void freestanding_write(int fd, const char *buf, int len) {
+  while (len > 0) {
+    ssize_t n = write(fd, buf, (size_t)len);
+    if (n <= 0) {
+      break;
+    }
+    buf += n;
+    len -= (int)n;
+  }
+}
+
+/* ---- heap ---------------------------------------------------------------- */
+
+/*
+ * calloc — uses bare malloc (compatible with bare free).
+ *
+ * clar allocates error structs with calloc and frees them with free, so the
+ * allocation must be compatible with the host free.  malloc from pblibc's
+ * stdlib.h resolves to the host libc at link time, so this is correct.
+ */
+void *calloc(size_t nmemb, size_t size) {
+  size_t total = nmemb * size;
+  void *p = malloc(total);
+  if (p) {
+    memset(p, 0, total);
+  }
+  return p;
+}
+
+/*
+ * realloc — size-header implementation.
+ *
+ * realloc needs to know the old allocation's size to copy the right number
+ * of bytes.  We achieve this by storing a size_t header immediately before
+ * the user pointer:
+ *
+ *   [ size_t bytes_pad_to_align | user data ... ]
+ *   ^                              ^
+ *   raw malloc'd block             returned to caller
+ *
+ * This is safe because the ONLY caller of realloc in the clar harness is
+ * clar_category_add_to_list, which:
+ *   - first call: passes NULL (we treat as malloc)
+ *   - subsequent calls: passes the pointer returned by our previous realloc
+ *
+ * The names array is a global static and is never freed, so there is no
+ * mismatch between our size-header pointer and bare free.
+ */
+#define _REALLOC_ALIGN \
+  (sizeof(size_t) > sizeof(void *) ? sizeof(size_t) : sizeof(void *))
+
+static void *_realloc_alloc(size_t bytes) {
+  char *raw = malloc(_REALLOC_ALIGN + bytes);
+  if (!raw) return NULL;
+  *(size_t *)(void *)raw = bytes;
+  return raw + _REALLOC_ALIGN;
+}
+
+static void _realloc_free(void *ptr) {
+  free((char *)ptr - _REALLOC_ALIGN);
+}
+
+static size_t _realloc_size(const void *ptr) {
+  const char *raw = (const char *)ptr - _REALLOC_ALIGN;
+  return *(const size_t *)(const void *)raw;
+}
+
+void *realloc(void *ptr, size_t size) {
+  if (ptr == NULL) {
+    return _realloc_alloc(size);
+  }
+  if (size == 0) {
+    _realloc_free(ptr);
+    return NULL;
+  }
+  void *new_ptr = _realloc_alloc(size);
+  if (!new_ptr) return NULL;
+  size_t old_size = _realloc_size(ptr);
+  memcpy(new_ptr, ptr, old_size < size ? old_size : size);
+  _realloc_free(ptr);
+  return new_ptr;
+}
+
+char *strdup(const char *s) {
+  size_t n = strlen(s) + 1;
+  char *p = malloc(n);
+  if (p) {
+    memcpy(p, s, n);
+  }
+  return p;
+}
+
+void abort(void) {
+  _exit(1);
+}
+
+/* ---- POSIX stubs --------------------------------------------------------- */
+
+int strcasecmp(const char *s1, const char *s2) {
+  unsigned char c1, c2;
+  do {
+    c1 = (unsigned char)*s1++;
+    c2 = (unsigned char)*s2++;
+    if (c1 >= 'A' && c1 <= 'Z') c1 += ('a' - 'A');
+    if (c2 >= 'A' && c2 <= 'Z') c2 += ('a' - 'A');
+  } while (c1 && c1 == c2);
+  return (int)c1 - (int)c2;
+}
+
+/*
+ * qsort — insertion-sort stub.  Only called from clar_category_print_enabled()
+ * which runs on the -l listing path; never invoked during a normal test run.
+ */
+void qsort(void *base, size_t nmemb, size_t size,
+           int (*compar)(const void *, const void *)) {
+  char *b = (char *)base;
+  char tmp[256];
+  for (size_t i = 1; i < nmemb; i++) {
+    size_t j = i;
+    while (j > 0 && compar(b + (j - 1) * size, b + j * size) > 0) {
+      if (size <= sizeof(tmp)) {
+        memcpy(tmp,                    b + (j - 1) * size, size);
+        memcpy(b + (j - 1) * size,    b + j * size,       size);
+        memcpy(b + j * size,           tmp,                size);
+      }
+      j--;
+    }
+  }
+}

--- a/tests/freestanding/wscript_build
+++ b/tests/freestanding/wscript_build
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# Build the freestanding host-test shim as a static library.
+#
+# shim.c is compiled WITHOUT -nostdinc so it can reach host-libc headers.
+# It is the single adapter between freestanding test TUs (which use only
+# pblibc + compiler built-in headers) and the host system.
+#
+# Tests opt in by adding use=['freestanding_shim'] to their clar() call via
+# the freestanding=True flag in waftools/pebble_test.py.
+#
+
+import os
+
+shim_src = bld.path.find_node('shim.c')
+
+# Strip -nostdinc from shim's CFLAGS so host headers are reachable.
+shim_cflags = [f for f in bld.env.CFLAGS if f != '-nostdinc']
+# Also strip any -isystem flags that inject pblibc/compiler-builtins includes;
+# the shim must use host headers exclusively.
+filtered = []
+skip_next = False
+for f in shim_cflags:
+    if skip_next:
+        skip_next = False
+        continue
+    if f == '-isystem':
+        skip_next = True
+        continue
+    if f.startswith('-isystem'):
+        continue
+    filtered.append(f)
+shim_cflags = filtered
+
+bld.stlib(
+    source=[shim_src],
+    target='freestanding_shim',
+    name='freestanding_shim',
+    cflags=shim_cflags,
+    # No extra includes — shim uses only host headers.
+)

--- a/tests/fw/services/blob_db/wscript_build
+++ b/tests/fw/services/blob_db/wscript_build
@@ -53,7 +53,23 @@ clar(ctx,
         " tests/fakes/ram_storage.c" \
         " tests/fakes/test_db.c" \
         " tests/fakes/fake_blobdb.c",
-    test_sources_ant_glob = "test_blob_db_sync.c")
+    test_sources_ant_glob = "test_blob_db_sync.c",
+    add_includes=[
+        "tests/overrides/default",
+        "src/fw",
+        "src/libos/include",
+        "src/libutil/includes",
+        "include",
+        "tests/fakes",
+        "tests/stubs",
+        "tests",
+        "third_party/freertos",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+    ],
+    defines=["CONFIG_PLATFORM_GABBRO=1"],
+    use=["libutil"],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = \

--- a/tests/fw/services/timeline/wscript_build
+++ b/tests/fw/services/timeline/wscript_build
@@ -109,7 +109,21 @@ clar(ctx,
      " tests/fixtures/resources/timeline_resource_table.auto.c"
   ),
   test_sources_ant_glob = "test_timeline_resources.c",
-  override_includes=['dummy_board'])
+  add_includes=[
+      "include",
+      "src/fw",
+      "src/libutil/includes",
+      "src/libos/include",
+      "src/fw/applib/vendor/uPNG",
+      "tests/stubs",
+      "tests/overrides/default",
+      "tests/overrides/default/resources/obelix",
+      "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+      "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+  ],
+  defines=["CONFIG_PLATFORM_EMERY=1"],
+  use=["libutil"],
+  freestanding=True)
 
 clar(ctx,
   sources_ant_glob = \

--- a/tests/fw/services/timeline/wscript_build
+++ b/tests/fw/services/timeline/wscript_build
@@ -66,7 +66,14 @@ clar(ctx,
 clar(ctx,
   sources_ant_glob = \
      " src/fw/services/timeline/attribute.c",
-  test_sources_ant_glob = "test_attribute.c")
+  test_sources_ant_glob = "test_attribute.c",
+  add_includes=[
+      "include",
+      "src/fw",
+      "src/libutil/includes",
+      "tests/stubs",
+  ],
+  freestanding=True)
 
 clar(ctx,
   sources_ant_glob = \

--- a/tests/fw/services/wscript_build
+++ b/tests/fw/services/wscript_build
@@ -238,7 +238,13 @@ clar(ctx,
 clar(ctx,
     sources_ant_glob = " ".join([
         "src/fw/services/registry_endpoint/service.c"]),
-    test_sources_ant_glob = "test_registry_endpoint.c")
+    test_sources_ant_glob = "test_registry_endpoint.c",
+    add_includes = [
+        "include",
+        "src/fw",
+        "src/libutil/includes",
+    ],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = " ".join([
@@ -249,7 +255,13 @@ clar(ctx,
 clar(ctx,
     sources_ant_glob = " ".join([
         " src/fw/services/voice/transcription.c"]),
-    test_sources_ant_glob = "test_transcription.c")
+    test_sources_ant_glob = "test_transcription.c",
+    add_includes = [
+        "include",
+        "src/fw",
+        "src/libutil/includes",
+    ],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = " ".join([
@@ -384,7 +396,14 @@ clar(ctx,
 
 clar(ctx,
     sources_ant_glob = 'src/fw/services/filesystem/app_file.c',
-    test_sources_ant_glob = 'test_app_file.c')
+    test_sources_ant_glob = 'test_app_file.c',
+    add_includes = [
+        "include",
+        "src/fw",
+        "src/libutil/includes",
+        "tests/stubs",
+    ],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = \

--- a/tests/fw/services/wscript_build
+++ b/tests/fw/services/wscript_build
@@ -72,7 +72,23 @@ clar(ctx,
 clar(ctx,
     sources_ant_glob = \
         " src/fw/services/evented_timer/service.c",
-    test_sources_ant_glob = "test_evented_timer.c")
+    test_sources_ant_glob = "test_evented_timer.c",
+    defines=["CONFIG_PLATFORM_EMERY=1"],
+    add_includes = [
+        "include",
+        "src/fw",
+        "src/libos/include",
+        "src/libutil/includes",
+        "tests/fakes",
+        "tests/stubs",
+        "tests/overrides/default",
+        "tests/overrides/default/resources/obelix",
+        "third_party/freertos",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+    ],
+    use=["libutil"],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = \
@@ -86,13 +102,36 @@ clar(ctx,
 clar(ctx,
     sources_ant_glob = \
         " src/fw/services/ecompass/correction.c",
-    test_sources_ant_glob = "test_compass_cal.c")
+    test_sources_ant_glob = "test_compass_cal.c",
+    add_includes = [
+        "include",
+        "src/fw",
+        "src/libutil/includes",
+        "tests/stubs",
+    ],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = \
         " src/fw/services/light/service.c",
     test_sources_ant_glob = "test_light.c",
-    override_includes=['dummy_board'])
+    defines=["CONFIG_PLATFORM_EMERY=1"],
+    add_includes = [
+        "tests/overrides/dummy_board",
+        "include",
+        "src/fw",
+        "src/libos/include",
+        "src/libutil/includes",
+        "tests/fakes",
+        "tests/stubs",
+        "tests/overrides/default",
+        "tests/overrides/default/resources/obelix",
+        "third_party/freertos",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+    ],
+    use=["libutil"],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = \
@@ -101,12 +140,44 @@ clar(ctx,
         " src/fw/services/phone_call/util.c" \
         " src/fw/services/phone_pp/service.c",
     test_sources_ant_glob = "test_phone_pp.c",
-    override_includes=['dummy_board'])
+    defines=["CONFIG_PLATFORM_EMERY=1"],
+    add_includes = [
+        "tests/overrides/dummy_board",
+        "include",
+        "src/fw",
+        "src/libos/include",
+        "src/libutil/includes",
+        "tests/fakes",
+        "tests/stubs",
+        "tests/overrides/default",
+        "tests/overrides/default/resources/obelix",
+        "third_party/freertos",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+    ],
+    use=["libutil"],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = \
         " src/fw/services/phone_call/service.c",
-    test_sources_ant_glob = "test_phone_call.c",)
+    test_sources_ant_glob = "test_phone_call.c",
+    defines=["CONFIG_PLATFORM_EMERY=1"],
+    add_includes = [
+        "include",
+        "src/fw",
+        "src/libos/include",
+        "src/libutil/includes",
+        "tests/fakes",
+        "tests/stubs",
+        "tests/overrides/default",
+        "tests/overrides/default/resources/obelix",
+        "third_party/freertos",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+    ],
+    use=["libutil"],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = \
@@ -249,8 +320,25 @@ clar(ctx,
 clar(ctx,
     sources_ant_glob = " ".join([
         " src/fw/services/audio_endpoint/service.c " \
-        " tests/fakes/fake_session.c"]),\
-    test_sources_ant_glob = "test_audio_endpoint.c")
+        " tests/fakes/fake_session.c"]),
+    test_sources_ant_glob = "test_audio_endpoint.c",
+    defines=["CONFIG_PLATFORM_EMERY=1"],
+    add_includes = [
+        "tests/overrides/dummy_board",
+        "include",
+        "src/fw",
+        "src/libos/include",
+        "src/libutil/includes",
+        "tests/fakes",
+        "tests/stubs",
+        "tests/overrides/default",
+        "tests/overrides/default/resources/obelix",
+        "third_party/freertos",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+    ],
+    use=["libutil"],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = " ".join([
@@ -382,7 +470,23 @@ clar(ctx,
         "  tests/fakes/fake_events.c " \
         ,
     test_sources_ant_glob = "test_accel_manager.c",
-    override_includes=['dummy_board'])
+    defines=["CONFIG_PLATFORM_EMERY=1"],
+    add_includes = [
+        "tests/overrides/dummy_board",
+        "include",
+        "src/fw",
+        "src/libos/include",
+        "src/libutil/includes",
+        "tests/fakes",
+        "tests/stubs",
+        "tests/overrides/default",
+        "tests/overrides/default/resources/obelix",
+        "third_party/freertos",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+    ],
+    use=["libutil"],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = " ".join([
@@ -457,16 +561,60 @@ clar(ctx,
 clar(ctx,
     sources_ant_glob = "src/fw/services/vibes/vibe_score.c" \
         " src/fw/util/generic_attribute.c",
-    test_sources_ant_glob = "test_vibe_score.c")
+    test_sources_ant_glob = "test_vibe_score.c",
+    defines=["CONFIG_PLATFORM_EMERY=1"],
+    add_includes = [
+        "include",
+        "src/fw",
+        "src/libos/include",
+        "src/libutil/includes",
+        "tests/stubs",
+        "tests/overrides/default",
+        "tests/overrides/default/resources/obelix",
+        "third_party/freertos",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+    ],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = "src/fw/services/vibes/vibe_score_info.c",
-    test_sources_ant_glob = "test_vibe_score_info.c")
+    test_sources_ant_glob = "test_vibe_score_info.c",
+    defines=["CONFIG_PLATFORM_EMERY=1"],
+    add_includes = [
+        "include",
+        "src/fw",
+        "src/libos/include",
+        "src/libutil/includes",
+        "tests/stubs",
+        "tests/overrides/default/resources/obelix",
+    ],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = "src/fw/services/touch/touch.c" \
         " tests/fakes/fake_events.c",
-    test_sources_ant_glob = "test_touch.c")
+    test_sources_ant_glob = "test_touch.c",
+    defines=[
+        "CONFIG_PLATFORM_EMERY=1",
+        "PBL_DISPLAY_WIDTH=200",
+        "PBL_DISPLAY_HEIGHT=228",
+    ],
+    add_includes = [
+        "include",
+        "src/fw",
+        "src/libos/include",
+        "src/libutil/includes",
+        "tests/fakes",
+        "tests/stubs",
+        "tests/overrides/default",
+        "tests/overrides/default/resources/obelix",
+        "third_party/freertos",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+    ],
+    use=["libutil"],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = \
@@ -488,6 +636,22 @@ clar(ctx,
          " tests/fakes/fake_settings_file.c"
      ),
      test_sources_ant_glob="test_app_glance_service.c",
-     override_includes=['dummy_board'])
+     defines=["CONFIG_PLATFORM_EMERY=1"],
+     add_includes=[
+         "tests/overrides/dummy_board",
+         "include",
+         "src/fw",
+         "src/libos/include",
+         "src/libutil/includes",
+         "tests/fakes",
+         "tests/stubs",
+         "tests/overrides/default",
+         "tests/overrides/default/resources/obelix",
+         "third_party/freertos",
+         "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+         "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+     ],
+     use=["libutil"],
+     freestanding=True)
 
 # vim:filetype=python

--- a/tests/fw/services/wscript_build
+++ b/tests/fw/services/wscript_build
@@ -41,7 +41,23 @@ clar(ctx,
         " src/fw/services/cron/service.c" \
         " src/fw/util/time/time.c" \
         " src/fw/util/time/mktime.c",
-    test_sources_ant_glob = "test_cron.c")
+    test_sources_ant_glob = "test_cron.c",
+    defines=["CONFIG_PLATFORM_EMERY=1"],
+    add_includes = [
+        "include",
+        "src/fw",
+        "src/libos/include",
+        "src/libutil/includes",
+        "tests/fakes",
+        "tests/stubs",
+        "tests/overrides/default",
+        "tests/overrides/default/resources/obelix",
+        "third_party/freertos",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+    ],
+    use=["libutil"],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = \
@@ -67,7 +83,23 @@ clar(ctx,
         " src/fw/util/time/time.c" \
         " third_party/tinymt/TinyMT/tinymt/tinymt32.c",
     test_sources_ant_glob = "test_contacts.c",
-    override_includes=['dummy_board'])
+    defines=["CONFIG_PLATFORM_EMERY=1", "CONFIG_FLASH_QEMU=1"],
+    add_includes = [
+        "include",
+        "src/fw",
+        "src/libos/include",
+        "src/libutil/includes",
+        "tests/fakes",
+        "tests/stubs",
+        "tests/overrides/default",
+        "tests/overrides/default/resources/obelix",
+        "third_party/freertos",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+        "third_party/tinymt/TinyMT/tinymt",
+    ],
+    use=["libutil"],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = \
@@ -97,7 +129,23 @@ clar(ctx,
         " tests/fakes/fake_rtc.c" \
         " src/fw/services/music/endpoint.c" \
         " src/fw/services/music/service.c",
-    test_sources_ant_glob = "test_music_endpoint.c")
+    test_sources_ant_glob = "test_music_endpoint.c",
+    defines=["CONFIG_PLATFORM_EMERY=1"],
+    add_includes = [
+        "include",
+        "src/fw",
+        "src/libos/include",
+        "src/libutil/includes",
+        "tests/fakes",
+        "tests/stubs",
+        "tests/overrides/default",
+        "tests/overrides/default/resources/obelix",
+        "third_party/freertos",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+    ],
+    use=["libutil"],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = \
@@ -185,7 +233,23 @@ clar(ctx,
         " tests/fakes/fake_rtc.c" \
         " tests/fakes/fake_session.c" \
         " src/fw/services/debounced_connection_service/service.c",
-    test_sources_ant_glob = "test_debounced_connection_service.c")
+    test_sources_ant_glob = "test_debounced_connection_service.c",
+    defines=["CONFIG_PLATFORM_EMERY=1"],
+    add_includes = [
+        "include",
+        "src/fw",
+        "src/libos/include",
+        "src/libutil/includes",
+        "tests/fakes",
+        "tests/stubs",
+        "tests/overrides/default",
+        "tests/overrides/default/resources/obelix",
+        "third_party/freertos",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+    ],
+    use=["libutil"],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = \
@@ -198,7 +262,24 @@ clar(ctx,
         " src/fw/services/timeline/attribute.c" \
         " src/fw/util/stringlist.c" \
         " src/fw/util/time/time.c",
-    test_sources_ant_glob = "test_timeline_item.c")
+    test_sources_ant_glob = "test_timeline_item.c",
+    defines=["CONFIG_PLATFORM_EMERY=1"],
+    add_includes = [
+        "include",
+        "src/fw",
+        "src/libos/include",
+        "src/libutil/includes",
+        "tests/fakes",
+        "tests/stubs",
+        "tests/overrides/default",
+        "tests/overrides/default/resources/obelix",
+        "third_party/freertos",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+        "third_party/tinymt/TinyMT/tinymt",
+    ],
+    use=["libutil"],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = \
@@ -303,7 +384,24 @@ clar(ctx,
         " tests/fixtures/resources/pfs_resource_table.c" \
     ]),
     test_sources_ant_glob = "test_migrate_wakeup.c",
-    override_includes=['dummy_board'])
+    defines=["CONFIG_PLATFORM_EMERY=1", "CONFIG_FLASH_QEMU=1"],
+    add_includes = [
+        "include",
+        "src/fw",
+        "src/fw/applib/vendor/uPNG",
+        "src/libos/include",
+        "src/libutil/includes",
+        "tests/fakes",
+        "tests/stubs",
+        "tests/overrides/default",
+        "tests/overrides/default/resources/obelix",
+        "third_party/freertos",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+        "third_party/tinymt/TinyMT/tinymt",
+    ],
+    use=["libutil"],
+    freestanding=True)
 
 
 clar(ctx,
@@ -525,7 +623,23 @@ clar(ctx,
         " tests/fakes/fake_rtc.c" \
         " tests/fakes/fake_spi_flash.c",
     test_sources_ant_glob = "test_do_not_disturb.c",
-    override_includes=['dummy_board'])
+    defines=["CONFIG_PLATFORM_EMERY=1", "CONFIG_FLASH_QEMU=1"],
+    add_includes = [
+        "include",
+        "src/fw",
+        "src/fw/applib/vendor/uPNG",
+        "src/libos/include",
+        "src/libutil/includes",
+        "tests/fakes",
+        "tests/stubs",
+        "tests/overrides/default",
+        "tests/overrides/default/resources/obelix",
+        "third_party/freertos",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+    ],
+    use=["libutil"],
+    freestanding=True)
 
 clar(ctx,
     sources_ant_glob = \
@@ -552,11 +666,42 @@ clar(ctx,
         " src/fw/applib/ui/vibes.c" \
         " tests/fakes/fake_events.c" \
         " tests/fakes/fake_rtc.c",
-    test_sources_ant_glob = "test_vibe.c")
+    test_sources_ant_glob = "test_vibe.c",
+    defines=["CONFIG_PLATFORM_EMERY=1"],
+    add_includes = [
+        "include",
+        "src/fw",
+        "src/libos/include",
+        "src/libutil/includes",
+        "tests/fakes",
+        "tests/stubs",
+        "tests/overrides/default",
+        "tests/overrides/default/resources/obelix",
+        "third_party/freertos",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+    ],
+    use=["libutil"],
+    freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/fw/services/vibes/vibe_intensity.c",
-     test_sources_ant_glob = "test_vibe_intensity.c")
+     test_sources_ant_glob = "test_vibe_intensity.c",
+     defines=["CONFIG_PLATFORM_EMERY=1"],
+     add_includes = [
+         "include",
+         "src/fw",
+         "src/libos/include",
+         "src/libutil/includes",
+         "tests/stubs",
+         "tests/overrides/default",
+         "tests/overrides/default/resources/obelix",
+         "third_party/freertos",
+         "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+         "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+     ],
+     use=["libutil"],
+     freestanding=True)
 
 clar(ctx,
     sources_ant_glob = "src/fw/services/vibes/vibe_score.c" \
@@ -624,7 +769,24 @@ clar(ctx,
         "tests/fakes/fake_rtc.c " \
         "tests/fakes/fake_accel_service.c ",
     test_sources_ant_glob = "test_hrm_manager.c",
-    override_includes=['dummy_board'])
+    defines=["CONFIG_PLATFORM_EMERY=1"],
+    add_includes = [
+        "tests/overrides/dummy_board",
+        "include",
+        "include/pbl",
+        "src/fw",
+        "src/libos/include",
+        "src/libutil/includes",
+        "tests/fakes",
+        "tests/stubs",
+        "tests/overrides/default",
+        "tests/overrides/default/resources/obelix",
+        "third_party/freertos",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+        "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+    ],
+    use=["libutil"],
+    freestanding=True)
 
 clar(ctx,
      sources_ant_glob=(

--- a/tests/fw/util/test_dict.c
+++ b/tests/fw/util/test_dict.c
@@ -10,7 +10,12 @@
 
 #include <string.h>
 #include <stdbool.h>
+#ifndef CLAR_FREESTANDING
 #include <strings.h>
+#else
+/* ffs() is not in pblibc; use the compiler builtin directly. */
+static inline int ffs(int x) { return __builtin_ffs(x); }
+#endif
 
 // Stubs
 ///////////////////////////////////////////////////////////

--- a/tests/fw/util/wscript_build
+++ b/tests/fw/util/wscript_build
@@ -17,7 +17,19 @@ clar(ctx,
      sources_ant_glob = " src/fw/util/time/time.c" \
                         " src/fw/util/time/mktime.c" \
                         " tests/fakes/fake_rtc.c",
-     test_sources_ant_glob = "test_time.c")
+     test_sources_ant_glob = "test_time.c",
+     add_includes = [
+         "tests/overrides/default",
+         "src/fw",
+         "src/libos/include",
+         "src/libutil/includes",
+         "tests/stubs",
+         "tests/fakes",
+         "third_party/freertos",
+         "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/include",
+         "third_party/freertos/FreeRTOS-Kernel/FreeRTOS/Source/portable/GCC/ARM_CM3",
+     ],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/fw/util/dict.c",

--- a/tests/fw/util/wscript_build
+++ b/tests/fw/util/wscript_build
@@ -16,7 +16,13 @@ clar(ctx,
 
 clar(ctx,
      sources_ant_glob = "src/fw/util/dict.c",
-     test_sources_ant_glob = "test_dict.c")
+     test_sources_ant_glob = "test_dict.c",
+     add_includes = [
+         "src/fw",
+         "src/libutil/includes",
+         "tests/stubs",
+     ],
+     freestanding=True)
 
 #clar(ctx,
 #     sources_ant_glob = "src/fw/util/mktime.c",
@@ -24,15 +30,34 @@ clar(ctx,
 
 clar(ctx,
      sources_ant_glob = "src/fw/util/buffer.c",
-     test_sources_ant_glob = "test_buffer.c")
+     test_sources_ant_glob = "test_buffer.c",
+     add_includes = [
+         "src/fw",
+         "src/libutil/includes",
+         "tests/stubs",
+     ],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/fw/util/lru_cache.c",
-     test_sources_ant_glob = "test_lru_cache.c")
+     test_sources_ant_glob = "test_lru_cache.c",
+     add_includes = [
+         "src/fw",
+         "src/libutil/includes",
+         "tests/stubs",
+     ],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/fw/util/mbuf.c src/fw/util/mbuf_iterator.c",
-     test_sources_ant_glob = "test_mbuf.c")
+     test_sources_ant_glob = "test_mbuf.c",
+     add_includes = [
+         "src/fw",
+         "src/libutil/includes",
+         "src/libos/include",
+         "tests/stubs",
+     ],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/fw/util/rand/rand.c" \
@@ -63,7 +88,13 @@ clar(ctx,
 
 clar(ctx,
      sources_ant_glob = "src/fw/util/pstring.c",
-     test_sources_ant_glob = "test_pstring.c")
+     test_sources_ant_glob = "test_pstring.c",
+     add_includes = [
+         "src/fw",
+         "src/libutil/includes",
+         "tests/stubs",
+     ],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/fw/util/ihex.c",

--- a/tests/fw/util/wscript_build
+++ b/tests/fw/util/wscript_build
@@ -1,12 +1,17 @@
 from waftools.pebble_test import clar
 
 clar(ctx,
-     sources_ant_glob = "src/fw/util/base64.c",
-     test_sources_ant_glob = "test_base64.c")
+     sources_ant_glob = "src/fw/util/base64.c src/libc/ctype_ptr.c",
+     test_sources_ant_glob = "test_base64.c",
+     add_includes = ["src/fw", "src/libutil/includes", "tests/stubs", "src/libc"],
+     freestanding=True)
 
 clar(ctx,
-     sources_ant_glob = "src/fw/util/shared_circular_buffer.c",
-     test_sources_ant_glob = "test_shared_circular_buffer.c")
+     sources_ant_glob = "src/fw/util/shared_circular_buffer.c"
+                        " src/libutil/list.c src/libutil/platform.c",
+     test_sources_ant_glob = "test_shared_circular_buffer.c",
+     add_includes = ["src/fw", "src/libutil/includes", "tests/stubs"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = " src/fw/util/time/time.c" \
@@ -65,12 +70,22 @@ clar(ctx,
      test_sources_ant_glob = "test_rand.c")
 
 clar(ctx,
-     sources_ant_glob = "src/fw/util/stats.c",
-     test_sources_ant_glob = "test_stats.c")
+     sources_ant_glob = "src/fw/util/stats.c src/libutil/sort.c",
+     test_sources_ant_glob = "test_stats.c",
+     add_includes = ["src/fw", "src/libutil/includes", "tests/stubs"],
+     freestanding=True)
+
+clar(ctx,
+     sources_ant_glob = None,
+     test_sources_ant_glob = "test_graphics.c",
+     add_includes = ["src/fw", "src/libutil/includes"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob='src/fw/util/legacy_checksum.c',
-     test_sources_ant_glob='test_legacy_checksum.c')
+     test_sources_ant_glob='test_legacy_checksum.c',
+     add_includes = ["src/fw"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = " src/fw/util/rand/rand.c" \
@@ -80,11 +95,15 @@ clar(ctx,
 
 clar(ctx,
     sources_ant_glob = "src/fw/util/hdlc.c",
-    test_sources_ant_glob = "test_hdlc.c")
+    test_sources_ant_glob = "test_hdlc.c",
+    add_includes = ["src/fw", "src/libutil/includes", "tests/stubs"],
+    freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/fw/util/stringlist.c",
-     test_sources_ant_glob = "test_stringlist.c")
+     test_sources_ant_glob = "test_stringlist.c",
+     add_includes = ["src/fw", "src/libutil/includes"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/fw/util/pstring.c",
@@ -98,10 +117,14 @@ clar(ctx,
 
 clar(ctx,
      sources_ant_glob = "src/fw/util/ihex.c",
-     test_sources_ant_glob = "test_ihex.c")
+     test_sources_ant_glob = "test_ihex.c",
+     add_includes = ["src/fw"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/fw/util/sle.c",
-     test_sources_ant_glob = "test_sle.c")
+     test_sources_ant_glob = "test_sle.c",
+     add_includes = ["src/fw", "src/libutil/includes", "tests"],
+     freestanding=True)
 
 # vim:filetype=python

--- a/tests/libc/math/test_log.c
+++ b/tests/libc/math/test_log.c
@@ -3,7 +3,6 @@
 
 #include <stdint.h>
 #include <math.h>
-#include <fenv.h>
 
 #include "clar.h"
 
@@ -24,10 +23,6 @@ static int64_t ulp_diff(double a, double b) {
   union { double value; int64_t bits; } ub = { .value = b };
   int64_t diff = ua.bits - ub.bits;
   return diff < 0 ? -diff : diff;
-}
-
-void test_log__initialize(void) {
-  fesetround(FE_TONEAREST);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/libc/math/test_pow.c
+++ b/tests/libc/math/test_pow.c
@@ -3,7 +3,6 @@
 
 #include <stdint.h>
 #include <math.h>
-#include <fenv.h>
 
 #include "clar.h"
 
@@ -24,10 +23,6 @@ static int64_t ulp_diff(double a, double b) {
   union { double value; int64_t bits; } ub = { .value = b };
   int64_t diff = ua.bits - ub.bits;
   return diff < 0 ? -diff : diff;
-}
-
-void test_pow__initialize(void) {
-  fesetround(FE_TONEAREST);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/libc/math/wscript_build
+++ b/tests/libc/math/wscript_build
@@ -10,7 +10,7 @@ clar(ctx,
      sources_ant_glob = "src/libc/math/log.c",
      test_sources_ant_glob = "test_log.c",
      add_includes = ["src/libc"],
-     test_libs=['m'])
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/math/pow.c" \
@@ -18,10 +18,10 @@ clar(ctx,
                         " src/libc/math/sqrt.c",
      test_sources_ant_glob = "test_pow.c",
      add_includes = ["src/libc"],
-     test_libs=['m'])
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/math/round.c",
      test_sources_ant_glob = "test_round.c",
      add_includes = ["src/libc"],
-     test_libs=['m'])
+     freestanding=True)

--- a/tests/libc/math/wscript_build
+++ b/tests/libc/math/wscript_build
@@ -4,7 +4,7 @@ clar(ctx,
      sources_ant_glob = "src/libc/math/floor.c",
      test_sources_ant_glob = "test_floor.c",
      add_includes = ["src/libc"],
-     test_libs=['m'])
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/math/log.c",

--- a/tests/libc/printf/test_sprintf.c
+++ b/tests/libc/printf/test_sprintf.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <limits.h>
 #include <math.h>
+#include <stdio.h>
 
 #include "clar.h"
 

--- a/tests/libc/printf/wscript_build
+++ b/tests/libc/printf/wscript_build
@@ -1,6 +1,8 @@
 from waftools.pebble_test import clar
 
 clar(ctx,
-     sources_ant_glob = "src/libc/vsprintf.c",
+     sources_ant_glob = "src/libc/vsprintf.c" \
+                        " src/libc/ctype_ptr.c",
      test_sources_ant_glob = "test_sprintf.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)

--- a/tests/libc/string/wscript_build
+++ b/tests/libc/string/wscript_build
@@ -3,33 +3,41 @@ from waftools.pebble_test import clar
 clar(ctx,
      sources_ant_glob = "src/libc/string/memcmp.c",
      test_sources_ant_glob = "test_memcmp.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/memcpy.c",
      test_sources_ant_glob = "test_memcpy.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/memset.c",
      test_sources_ant_glob = "test_memset.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/memchr.c",
      test_sources_ant_glob = "test_memchr.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/atoi.c" \
-                        " src/libc/string/strtol.c",
+                        " src/libc/string/strtol.c" \
+                        " src/libc/ctype_ptr.c",
      test_sources_ant_glob = "test_atoi.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
-     sources_ant_glob = "src/libc/string/strtol.c",
+     sources_ant_glob = "src/libc/string/strtol.c" \
+                        " src/libc/ctype_ptr.c",
      test_sources_ant_glob = "test_strtol.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/strcat.c" \
@@ -38,12 +46,14 @@ clar(ctx,
                         " src/libc/string/memset.c" \
                         " src/libc/string/strcpy.c",
      test_sources_ant_glob = "test_strcat.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/strlen.c",
      test_sources_ant_glob = "test_strlen.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/strlen.c" \
@@ -51,26 +61,30 @@ clar(ctx,
                         " src/libc/string/memset.c" \
                         " src/libc/string/strcpy.c",
      test_sources_ant_glob = "test_strcpy.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/strlen.c" \
                         " src/libc/string/memcmp.c" \
                         " src/libc/string/strcmp.c",
      test_sources_ant_glob = "test_strcmp.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/strlen.c" \
                         " src/libc/string/memchr.c" \
                         " src/libc/string/strchr.c",
      test_sources_ant_glob = "test_strchr.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/strspn.c",
      test_sources_ant_glob = "test_strspn.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/string/strlen.c" \
@@ -78,7 +92,8 @@ clar(ctx,
                         " src/libc/string/strstr.c" \
                         " src/libc/string/strcmp.c",
      test_sources_ant_glob = "test_strstr.c",
-     add_includes = ["src/libc"])
+     add_includes = ["src/libc"],
+     freestanding=True)
 
 clar(ctx,
      sources_ant_glob = "src/libc/ctype_ptr.c",

--- a/tests/stubs/stubs_logging.h
+++ b/tests/stubs/stubs_logging.h
@@ -6,7 +6,9 @@
 #include "system/logging.h"
 #include "util/string.h"
 
+#ifndef CLAR_FREESTANDING
 #include <assert.h>
+#endif
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
@@ -51,7 +53,11 @@ void command_dump_malloc() {
 }
 
 void reset_due_to_software_failure() {
+#ifdef CLAR_FREESTANDING
+  __builtin_trap();
+#else
   assert(0);
+#endif
 }
 
 void app_log_vargs(uint8_t log_level, const char *src_filename, int src_line_number,

--- a/tests/stubs/stubs_syscalls.h
+++ b/tests/stubs/stubs_syscalls.h
@@ -7,7 +7,11 @@
 #include "util/attributes.h"
 
 struct tm *WEAK sys_localtime_r(const time_t *timep, struct tm *result) {
+#ifndef CLAR_FREESTANDING
   return localtime_r(timep, result);
+#else
+  return NULL;
+#endif
 }
 
 ResAppNum WEAK sys_get_current_resource_num(void) {

--- a/tools/clar/clar.c
+++ b/tools/clar/clar.c
@@ -1,19 +1,25 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#include <assert.h>
+#ifndef CLAR_FREESTANDING
+# include <assert.h>
+#endif
 #include <setjmp.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <strings.h>
+#ifndef CLAR_FREESTANDING
+# include <strings.h>
+#endif
 #include <math.h>
 #include <stdarg.h>
 #include <unistd.h>
 
+#ifndef CLAR_FREESTANDING
 /* required for sandboxing */
-#include <sys/types.h>
-#include <sys/stat.h>
+# include <sys/types.h>
+# include <sys/stat.h>
+#endif
 
 #ifdef _WIN32
 # include <windows.h>
@@ -39,6 +45,15 @@
 #   define snprint_eq snprintf
 # endif
   typedef struct _stat STAT_T;
+#elif defined(CLAR_FREESTANDING)
+
+# define _MAIN_CC
+# define snprint_eq snprintf
+
+/* Forward-declare POSIX functions missing from pblibc headers.
+ * The definitions live in tests/freestanding/shim.c or in
+ * clar_io_freestanding.c (both linked into the final binary). */
+int strcasecmp(const char *s1, const char *s2);
 #else
 
 # ifdef UNITTEST_DEBUG
@@ -703,7 +718,9 @@ void clar__assert_equal_m(
     hex_dump("m1:", m1, n);
     hex_dump("m2:", m2, n);
 
+#ifndef CLAR_FREESTANDING
     fflush(stdout);
+#endif
     clar__assert(0, file, line, err, buf, should_abort);
   }
 }

--- a/tools/clar/clar.py
+++ b/tools/clar/clar.py
@@ -74,13 +74,25 @@ class ClarTestBuilder:
         self.clar_path = os.path.abspath(clar_path) if clar_path else None
 
         self.path = os.path.abspath(path)
-        self.modules = [
-            "clar_sandbox.c",
-            "clar_fixtures.c",
-            "clar_fs.c",
-            "clar_mock.c",
-            "clar_categorize.c",
-        ]
+
+        if print_mode == "freestanding":
+            # Freestanding builds omit POSIX-dependent modules (sandbox, fs,
+            # fixtures) and insert the I/O layer before categorize so that
+            # strcasecmp and printf are available to the modules that follow.
+            self.modules = [
+                "clar_sandbox_freestanding.c",
+                "clar_mock.c",
+                "clar_io_freestanding.c",
+                "clar_categorize.c",
+            ]
+        else:
+            self.modules = [
+                "clar_sandbox.c",
+                "clar_fixtures.c",
+                "clar_fs.c",
+                "clar_mock.c",
+                "clar_categorize.c",
+            ]
 
         self.modules.append("clar_print_%s.c" % print_mode)
 

--- a/tools/clar/clar_io_freestanding.c
+++ b/tools/clar/clar_io_freestanding.c
@@ -1,0 +1,90 @@
+/* SPDX-FileCopyrightText: 2025 Google LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * Freestanding I/O layer included into clar_main.c.
+ *
+ * Provides printf / fprintf / vprintf / vfprintf / fflush implementations
+ * that work under -nostdinc by routing output through freestanding_write()
+ * (defined in tests/freestanding/shim.c, which IS compiled against host
+ * headers).
+ *
+ * Also declares strcasecmp so clar_categorize.c compiles without
+ * <strings.h>, which is a host-only header.
+ *
+ * This module is included into the clar_main.c translation unit by clar.py
+ * when --report-to=freestanding is requested.  It must appear before
+ * clar_categorize.c in the module list so that strcasecmp is declared.
+ */
+
+/* freestanding_write() lives in shim.c; declare it here for the call below. */
+void freestanding_write(int fd, const char *buf, int len);
+
+/* pblibc's stdio.h already declared printf/fprintf/vprintf/vfprintf with
+ * the correct signatures (included at the top of clar.c).  We provide the
+ * definitions here inside the same TU so no duplicate-definition conflict
+ * arises.
+ *
+ * pblibc's vsprintf.c provides vsnprintf/snprintf; they are linked as a
+ * separate object, not inlined here. */
+
+/* Forward-declare vsnprintf exactly as pblibc/stdio.h does so this module
+ * can be read in isolation during review. */
+#ifdef __GNUC__
+__attribute__((__format__(__printf__, 3, 0)))
+#endif
+int vsnprintf(char * restrict str, size_t size,
+              const char * restrict fmt, __gnuc_va_list ap);
+
+/* Declare strcasecmp — not in pblibc, provided by shim.c. */
+int strcasecmp(const char *s1, const char *s2);
+
+/* The FILE type is declared in pblibc's stdio.h as an empty struct.  We
+ * define the stderr object here; clar.c's clar_print_onabort writes to
+ * it via vfprintf(stderr, …). */
+FILE _clar_stderr_storage;
+FILE *stderr = &_clar_stderr_storage;
+
+/* Internal helper: vsnprintf into a stack buffer then write to fd. */
+static int _clar_vwrite(int fd, const char *fmt, va_list ap) {
+  char buf[2048];
+  int n = vsnprintf(buf, sizeof(buf), fmt, ap);
+  if (n > 0) {
+    int len = n < (int)(sizeof(buf) - 1) ? n : (int)(sizeof(buf) - 1);
+    freestanding_write(fd, buf, len);
+  }
+  return n;
+}
+
+int vprintf(const char * restrict fmt, __gnuc_va_list ap) {
+  return _clar_vwrite(1, fmt, ap);
+}
+
+int printf(const char * restrict fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  int n = _clar_vwrite(1, fmt, ap);
+  va_end(ap);
+  return n;
+}
+
+int vfprintf(FILE * restrict stream, const char * restrict fmt,
+             __gnuc_va_list ap) {
+  /* Route stderr (fd 2), everything else to stdout (fd 1). */
+  int fd = (stream == stderr) ? 2 : 1;
+  return _clar_vwrite(fd, fmt, ap);
+}
+
+int fprintf(FILE * restrict stream, const char * restrict fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  int n = vfprintf(stream, fmt, ap);
+  va_end(ap);
+  return n;
+}
+
+int fflush(FILE * restrict stream) {
+  /* write(2) is unbuffered; this is a genuine no-op. */
+  (void)stream;
+  return 0;
+}

--- a/tools/clar/clar_print_freestanding.c
+++ b/tools/clar/clar_print_freestanding.c
@@ -1,0 +1,65 @@
+/* SPDX-FileCopyrightText: 2025 Google LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * Freestanding print back-end for clar.
+ *
+ * Implements the clar_print_* interface using printf() (which in a
+ * freestanding build is provided by clar_io_freestanding.c and routes
+ * through freestanding_write() in shim.c).
+ *
+ * This file is selected as the clar print module when clar.py is invoked
+ * with --report-to=freestanding.
+ */
+
+static void clar_print_init(int test_count, int suite_count,
+                            const char *suite_names) {
+  (void)test_count;
+  printf("Loaded %d suites: %s\n", (int)suite_count, suite_names);
+  printf("Started\n");
+}
+
+static void clar_print_shutdown(int test_count, int suite_count,
+                                int error_count) {
+  (void)test_count;
+  (void)suite_count;
+  (void)error_count;
+
+  printf("\n\n");
+  clar_report_errors();
+}
+
+static void clar_print_error(int num, const struct clar_error *error) {
+  printf("  %d) Failure:\n", num);
+  printf("%s::%s (%s) [%s:%d] [-t%d]\n",
+         error->suite,
+         error->test,
+         "no description",
+         error->file,
+         error->line_number,
+         error->test_number);
+  printf("  %s\n", error->error_msg);
+  if (error->description != NULL) {
+    printf("  %s\n", error->description);
+  }
+  printf("\n");
+}
+
+static void clar_print_ontest(const char *test_name, int test_number,
+                              int failed) {
+  (void)test_name;
+  (void)test_number;
+  printf("%c", failed ? 'F' : '.');
+}
+
+static void clar_print_onsuite(const char *suite_name, int suite_index) {
+  (void)suite_index;
+  (void)suite_name;
+}
+
+static void clar_print_onabort(const char *msg, ...) {
+  va_list ap;
+  va_start(ap, msg);
+  vfprintf(stderr, msg, ap);
+  va_end(ap);
+}

--- a/tools/clar/clar_sandbox_freestanding.c
+++ b/tools/clar/clar_sandbox_freestanding.c
@@ -1,0 +1,40 @@
+/* SPDX-FileCopyrightText: 2025 Google LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * Freestanding replacements for the static sandbox functions defined in
+ * clar_sandbox.c.  Included into clar_main.c when clar.py is invoked with
+ * --report-to=freestanding (which selects this file instead of
+ * clar_sandbox.c).
+ *
+ * Freestanding builds do not fork child processes or write temporary
+ * directories, so the sandbox is a no-op.
+ *
+ * clar_fixtures.c and clar_fs.c are also omitted on the freestanding path
+ * because they depend on POSIX filesystem primitives (stat, fork, waitpid,
+ * execv) that are not available.  The fixture_path() function stub below
+ * satisfies the forward declaration in clar.c; it should never be called
+ * from freestanding test suites.
+ */
+
+static int clar_sandbox(void) {
+  return 0;
+}
+
+static void clar_unsandbox(void) {
+}
+
+/*
+ * Stub for fixture_path(), normally defined in clar_fixtures.c.
+ * Freestanding tests must not use fixtures; this exists only to satisfy
+ * the static forward declaration in clar.c.
+ */
+static const char *fixture_path(const char *base, const char *fixture_name) {
+  (void)base;
+  (void)fixture_name;
+  return "";
+}
+
+/* cl_fs_cleanup() stub — normally in clar_fs.c. */
+void cl_fs_cleanup(void) {
+}

--- a/waftools/pebble_test.py
+++ b/waftools/pebble_test.py
@@ -255,6 +255,172 @@ def get_bitdepth_for_platform(bld, platform):
         bld.fatal("Unknown platform {}".format(platform))
 
 
+def _add_freestanding_clar_test(
+    bld,
+    test_name,
+    test_source,
+    test_dir,
+    test_bin,
+    sources_ant_glob,
+    platform_product_sources,
+    add_includes,
+    defines,
+    test_libs,
+    use,
+    runtime_deps,
+):
+    """Build a single clar test in freestanding mode.
+
+    Compiled with -nostdinc; only pblibc headers and the compiler's built-in
+    include directory are in scope.  The clar harness is generated with
+    --report-to=freestanding, which selects sandbox-free modules.
+
+    The host-boundary shim (tests/freestanding/shim.c) provides malloc, free,
+    calloc, realloc, strdup, abort, printf/fprintf, strcasecmp, qsort, and
+    freestanding_write.  It is linked via use=['freestanding_shim'].
+    """
+
+    def _generate_freestanding_harness(task):
+        bld = task.generator.bld
+        clar_dir = task.generator.env.CLAR_DIR
+        test_src_file = task.inputs[0].abspath()
+        test_bld_dir = task.outputs[0].get_bld().parent.abspath()
+
+        cmd = (
+            "python {clar_dir}/clar.py"
+            " --file={src}"
+            " --clar-path={clar_dir}"
+            " --report-to=freestanding"
+            " {bld_dir}"
+        ).format(
+            clar_dir=clar_dir,
+            src=test_src_file,
+            bld_dir=test_bld_dir,
+        )
+        task.generator.bld.exec_command(cmd)
+
+    clar_harness = test_dir.make_node("clar_main.c")
+
+    bld(
+        name="generate_clar_harness",
+        rule=_generate_freestanding_harness,
+        source=test_source,
+        target=[clar_harness, test_dir.make_node("clar.h")],
+    )
+
+    # Include paths for freestanding builds.
+    #
+    # pblibc headers and the compiler built-in directory are injected as
+    # -isystem so that #include_next chains (e.g. pblibc/setjmp.h →
+    # compiler builtin setjmp.h) resolve correctly under -nostdinc.
+    # The generated test directory (clar.h, test source) and tests/test_includes
+    # are regular -I paths because they are project headers, not system headers.
+    # any add_includes are also regular -I paths (they contain pblibc source
+    # includes that are project-level).
+    srcnode = bld.srcnode.abspath()
+    pblibc_inc = os.path.join(srcnode, "src/libc/include")
+    compiler_builtins_inc = bld.env.COMPILER_BUILTINS_INCLUDE
+    test_includes_inc = os.path.join(srcnode, "tests/test_includes")
+
+    # Regular -I includes (project headers): generated dir and test_includes.
+    freestanding_includes = [
+        test_dir.abspath(),
+        test_includes_inc,
+    ]
+    if add_includes is not None:
+        for inc in add_includes:
+            freestanding_includes.append(os.path.join(srcnode, inc))
+
+    # -isystem includes: pblibc, compiler builtins, then the platform SDK
+    # headers (last resort).
+    #
+    # Order is significant:
+    #   1. pblibc — project's own libc headers (highest precedence)
+    #   2. compiler built-in dir — stddef.h, stdint.h, float.h, stdarg.h
+    #   3. platform SDK usr/include — provides setjmp.h, assert.h and any
+    #      other POSIX headers that pblibc delegates via #include_next
+    #
+    # Only pblibc and compiler-builtin headers are used by the product code
+    # under test.  The SDK headers are a fallback for the clar harness only
+    # (setjmp.h, assert.h).  They are injected last so that pblibc headers
+    # take precedence for everything pblibc covers.
+    import subprocess as _sp
+    import sys as _sys
+    platform_sdk_inc = None
+    if _sys.platform == 'darwin':
+        try:
+            sdk = _sp.check_output(
+                ['xcrun', '--show-sdk-path'], stderr=_sp.DEVNULL
+            ).decode().strip()
+            candidate = os.path.join(sdk, 'usr', 'include')
+            if os.path.isdir(candidate):
+                platform_sdk_inc = candidate
+        except Exception:
+            pass
+    else:
+        # On Linux, pblibc/setjmp.h uses #include_next <setjmp.h> for non-ARM
+        # hosts; the system headers provide it.  Add /usr/include as a last-
+        # resort -isystem so #include_next chains resolve, while keeping
+        # pblibc headers at higher precedence for everything pblibc covers.
+        candidate = '/usr/include'
+        if os.path.isfile(os.path.join(candidate, 'setjmp.h')):
+            platform_sdk_inc = candidate
+
+    freestanding_cflags = [
+        "-nostdinc",
+        "-isystem", pblibc_inc,
+        "-isystem", compiler_builtins_inc,
+        "-DCLAR_FREESTANDING=1",
+    ]
+    if platform_sdk_inc:
+        freestanding_cflags += ["-isystem", platform_sdk_inc]
+
+    freestanding_defines = list(defines)
+
+    if sources_ant_glob is not None:
+        sources_list = Utils.to_list(sources_ant_glob)
+        for s in sources_list:
+            node = bld.srcnode.find_node(s)
+            if node is None:
+                raise Errors.WafError(
+                    'Error: Source file "%s" not found for "%s"' % (s, test_name)
+                )
+            if node not in platform_product_sources:
+                platform_product_sources.append(node)
+            else:
+                raise Errors.WafError(
+                    'Error: Duplicate source file "%s" found for "%s"'
+                    % (s, test_name)
+                )
+
+    program_sources = [test_source, clar_harness]
+    program_sources.extend(
+        build_product_source_files(
+            bld,
+            test_dir,
+            freestanding_includes,
+            freestanding_defines,
+            freestanding_cflags,
+            platform_product_sources,
+        )
+    )
+
+    freestanding_use = list(use) if use else []
+    freestanding_use.append("freestanding_shim")
+
+    bld.program(
+        source=program_sources,
+        target=test_bin,
+        features="pebble_test",
+        includes=freestanding_includes,
+        lib=test_libs,
+        defines=freestanding_defines,
+        cflags=freestanding_cflags,
+        use=freestanding_use,
+        runtime_deps=runtime_deps,
+    )
+
+
 def add_clar_test(
     bld,
     test_name,
@@ -268,6 +434,7 @@ def add_clar_test(
     runtime_deps,
     platform,
     use,
+    freestanding=False,
 ):
 
     if bld.options.regex:
@@ -299,6 +466,27 @@ def add_clar_test(
         test_dir = bld.path.get_bld().make_node(test_name + "_" + platform)
         test_bin = test_dir.make_node("runme_" + platform)
         platform_defines.append("PLATFORM_DEFAULT=0")
+
+    if freestanding:
+        # ---- freestanding path ---------------------------------------------
+        # Compiled with -nostdinc; only pblibc headers and the compiler's
+        # built-in include directory are in scope.  No DUMA, no display
+        # force-include, no firmware src includes.
+        _add_freestanding_clar_test(
+            bld=bld,
+            test_name=test_name,
+            test_source=test_source,
+            test_dir=test_dir,
+            test_bin=test_bin,
+            sources_ant_glob=sources_ant_glob,
+            platform_product_sources=platform_product_sources,
+            add_includes=add_includes,
+            defines=defines + platform_defines,
+            test_libs=list(test_libs),
+            use=use,
+            runtime_deps=runtime_deps,
+        )
+        return
 
     def _generate_clar_harness(task):
         bld = task.generator.bld
@@ -494,6 +682,7 @@ def clar(
     runtime_deps=None,
     platforms=None,
     use=None,
+    freestanding=False,
 ):
 
     if test_sources_ant_glob is None and not test_sources:
@@ -563,4 +752,5 @@ def clar(
             runtime_deps,
             platform,
             use,
+            freestanding=freestanding,
         )

--- a/waftools/pebble_test.py
+++ b/waftools/pebble_test.py
@@ -346,13 +346,16 @@ def _add_freestanding_clar_test(
     # take precedence for everything pblibc covers.
     import subprocess as _sp
     import sys as _sys
+
     platform_sdk_inc = None
-    if _sys.platform == 'darwin':
+    if _sys.platform == "darwin":
         try:
-            sdk = _sp.check_output(
-                ['xcrun', '--show-sdk-path'], stderr=_sp.DEVNULL
-            ).decode().strip()
-            candidate = os.path.join(sdk, 'usr', 'include')
+            sdk = (
+                _sp.check_output(["xcrun", "--show-sdk-path"], stderr=_sp.DEVNULL)
+                .decode()
+                .strip()
+            )
+            candidate = os.path.join(sdk, "usr", "include")
             if os.path.isdir(candidate):
                 platform_sdk_inc = candidate
         except Exception:
@@ -362,14 +365,16 @@ def _add_freestanding_clar_test(
         # hosts; the system headers provide it.  Add /usr/include as a last-
         # resort -isystem so #include_next chains resolve, while keeping
         # pblibc headers at higher precedence for everything pblibc covers.
-        candidate = '/usr/include'
-        if os.path.isfile(os.path.join(candidate, 'setjmp.h')):
+        candidate = "/usr/include"
+        if os.path.isfile(os.path.join(candidate, "setjmp.h")):
             platform_sdk_inc = candidate
 
     freestanding_cflags = [
         "-nostdinc",
-        "-isystem", pblibc_inc,
-        "-isystem", compiler_builtins_inc,
+        "-isystem",
+        pblibc_inc,
+        "-isystem",
+        compiler_builtins_inc,
         "-DCLAR_FREESTANDING=1",
     ]
     if platform_sdk_inc:
@@ -389,8 +394,7 @@ def _add_freestanding_clar_test(
                 platform_product_sources.append(node)
             else:
                 raise Errors.WafError(
-                    'Error: Duplicate source file "%s" found for "%s"'
-                    % (s, test_name)
+                    'Error: Duplicate source file "%s" found for "%s"' % (s, test_name)
                 )
 
     program_sources = [test_source, clar_harness]

--- a/wscript
+++ b/wscript
@@ -233,6 +233,42 @@ def configure(conf):
     conf.load('clang')
     conf.load('pebble_test', tooldir='waftools')
 
+    # Discover the compiler's built-in include directory.  This is needed for
+    # freestanding (-nostdinc) test builds that must still reach compiler
+    # intrinsic headers (stddef.h, stdint.h, float.h, …).
+    #
+    # Try -print-resource-dir first (clang); fall back to -print-file-name=include
+    # (GCC).  Either way the result must contain stddef.h.
+    import os as _os
+    cc = conf.env.CC[0]
+    builtin_inc = None
+    try:
+        resource_dir = conf.cmd_and_log(
+            [cc, '-print-resource-dir'], quiet=waflib.Context.BOTH
+        ).strip()
+        candidate = _os.path.join(resource_dir, 'include')
+        if _os.path.isfile(_os.path.join(candidate, 'stddef.h')):
+            builtin_inc = candidate
+    except Exception:
+        pass
+    if builtin_inc is None:
+        try:
+            candidate = conf.cmd_and_log(
+                [cc, '-print-file-name=include'], quiet=waflib.Context.BOTH
+            ).strip()
+            if _os.path.isfile(_os.path.join(candidate, 'stddef.h')):
+                builtin_inc = candidate
+        except Exception:
+            pass
+    if builtin_inc is None:
+        conf.fatal(
+            'Cannot locate compiler built-in include directory containing '
+            'stddef.h.  Tried -print-resource-dir and -print-file-name=include '
+            'with CC=%s.' % cc
+        )
+    conf.env.COMPILER_BUILTINS_INCLUDE = builtin_inc
+    Logs.pprint('CYAN', 'Compiler built-in includes: %s' % builtin_inc)
+
     conf.env.CLAR_DIR = conf.path.make_node('tools/clar/').abspath()
     conf.env.CFLAGS = [ '-std=c11',
                         '-Wall',


### PR DESCRIPTION
Three more test migrations to freestanding compilation, building on the freestanding-host-tests branch.

blob_db_sync migrated to freestanding.

Nine remaining util tests migrated (utf8, crc, ring_buffer, etc.).

test_time migrated to freestanding.

Merge order: **3** (after #1499)
Depends on: #1497 → #1499
