### PR TITLE
third_party/hal_sifli: build HAL modules granularly via Kconfig

### DIFF
--- a/src/bluetooth-fw/Kconfig
+++ b/src/bluetooth-fw/Kconfig
@@ -13,6 +13,8 @@ choice BT_FW
 
 config BT_FW_NIMBLE
     bool "NimBLE"
+    select HAL_SIFLI_IPC_QUEUE if SOC_SF32LB52
+    select HAL_SIFLI_LCPU if SOC_SF32LB52
 
 config BT_FW_QEMU
     bool "QEMU transport"

--- a/src/fw/drivers/display/Kconfig
+++ b/src/fw/drivers/display/Kconfig
@@ -10,6 +10,7 @@ if DISPLAY
 
 config DISPLAY_JDI_SF32LB
     bool "JDI (SiFli SF32LB)"
+    select HAL_SIFLI_LCD
     help
       Support for JDI display via SiFli SF32LB.
 

--- a/src/fw/drivers/exti/Kconfig
+++ b/src/fw/drivers/exti/Kconfig
@@ -15,6 +15,7 @@ config EXTI_NRF5
 
 config EXTI_SF32LB
     bool "SiFli SF32LB"
+    select HAL_SIFLI_GPIO
     help
       Support for the SiFli SF32LB external interrupt controller.
 

--- a/src/fw/drivers/gpio/Kconfig
+++ b/src/fw/drivers/gpio/Kconfig
@@ -15,6 +15,7 @@ config GPIO_NRF5
 
 config GPIO_SF32LB
     bool "SiFli SF32LB"
+    select HAL_SIFLI_GPIO
     help
       Support for the SiFli SF32LB GPIO controller.
 

--- a/src/fw/drivers/i2c/Kconfig
+++ b/src/fw/drivers/i2c/Kconfig
@@ -15,6 +15,7 @@ config I2C_NRF5
 
 config I2C_SF32LB
     bool "SiFli SF32LB I2C Controller"
+    select HAL_SIFLI_I2C
     help
       Support for the SiFli SF32LB I2C controller.
 

--- a/src/fw/drivers/mic/Kconfig
+++ b/src/fw/drivers/mic/Kconfig
@@ -15,6 +15,8 @@ config MIC_NRF5
 
 config MIC_SF32LB
     bool "SiFli SF32LB PDM"
+    select HAL_SIFLI_AUDCODEC
+    select HAL_SIFLI_PDM
     help
       Support for the SiFli SF32LB PDM microphone interface.
 

--- a/src/fw/drivers/pwm/Kconfig
+++ b/src/fw/drivers/pwm/Kconfig
@@ -15,6 +15,7 @@ config PWM_NRF5
 
 config PWM_SF32LB
     bool "SiFli SF32LB"
+    select HAL_SIFLI_GPT
     help
       Support for the SiFli SF32LB PWM controller.
 

--- a/src/fw/drivers/rng/Kconfig
+++ b/src/fw/drivers/rng/Kconfig
@@ -10,6 +10,7 @@ if RNG
 
 config RNG_SF32LB
     bool "SiFli SF32LB"
+    select HAL_SIFLI_RNG
     help
       Support for the SiFli SF32LB RNG.
 

--- a/src/fw/drivers/rtc/Kconfig
+++ b/src/fw/drivers/rtc/Kconfig
@@ -15,6 +15,8 @@ config RTC_NRF5
 
 config RTC_SF32LB
     bool "SiFli SF32LB"
+    select HAL_SIFLI_LRC_CAL
+    select HAL_SIFLI_RTC
     help
       Support for the SiFli SF32LB RTC.
 

--- a/src/fw/drivers/speaker/Kconfig
+++ b/src/fw/drivers/speaker/Kconfig
@@ -15,6 +15,7 @@ config SPEAKER_DA7212
 
 config SPEAKER_SF32LB
     bool "SiFli SF32LB AUDEC"
+    select HAL_SIFLI_AUDCODEC
     help
       Support for the SiFli SF32LB audio codec / DAC speaker output.
 

--- a/src/fw/drivers/uart/Kconfig
+++ b/src/fw/drivers/uart/Kconfig
@@ -15,6 +15,7 @@ config UART_NRF5
 
 config UART_SF32LB
     bool "SiFli SF32LB UART Controller"
+    select HAL_SIFLI_UART
     help
       Support for the SiFli SF32LB UART controller.
 

--- a/third_party/hal_sifli/Kconfig
+++ b/third_party/hal_sifli/Kconfig
@@ -7,15 +7,240 @@ menuconfig HAL_SIFLI
       Build the SiFli SDK HAL. This enables the HAL driver
       umbrella (USE_HAL_DRIVER), selects the high-performance CPU
       (SOC_BF0_HCPU), sets the HAL tick rate to 1024 Hz, and lets
-      our NMI handler override SiFli's default.
+      our NMI handler override SiFli's default. The HAL core
+      (bf0_hal, ADC, Cortex, DMA, eFuse, HLP, PMU, RCC, system
+      config) is always built; other modules are gated by the
+      options below.
 
 if HAL_SIFLI
 
 config HAL_SIFLI_SF32LB52
     bool "SF32LB52 SoC variant"
+    select HAL_SIFLI_AON
+    select HAL_SIFLI_GPT
+    select HAL_SIFLI_IPC_QUEUE
+    select HAL_SIFLI_LPTIM
+    select HAL_SIFLI_LRC_CAL
+    select HAL_SIFLI_MPI
+    select HAL_SIFLI_PINMUX
+    select HAL_SIFLI_RTC
     help
       Configure the SiFli HAL for the SF32LB52 SoC. This sets the
-      SF32LB52X target define and adds the SF32LB52-specific cmsis,
-      ipc_queue port, and local glue sources to the build.
+      SF32LB52X target define and adds the SF32LB52-specific cmsis
+      and local glue sources to the build. It also selects the HAL
+      modules required by SoC-level PebbleOS code (clock/tick,
+      sleep, flash XIP, pinmux, RTC and RC calibration).
+
+config HAL_SIFLI_AES
+    bool "AES HAL module"
+    help
+      Enable the AES SiFli HAL module driver.
+
+config HAL_SIFLI_AON
+    bool "AON HAL module"
+    select HAL_SIFLI_RTC
+    help
+      Enable the AON (always-on, HPSYS/LPSYS power and wakeup)
+      SiFli HAL module driver.
+
+config HAL_SIFLI_ATIM
+    bool "ATIM HAL module"
+    help
+      Enable the ATIM (advanced timer) SiFli HAL module driver.
+
+config HAL_SIFLI_AUDCODEC
+    bool "AUDCODEC HAL module"
+    help
+      Enable the AUDCODEC SiFli HAL module driver.
+
+config HAL_SIFLI_AUDPRC
+    bool "AUDPRC HAL module"
+    help
+      Enable the AUDPRC (audio processor) SiFli HAL module driver.
+
+config HAL_SIFLI_BUSMON
+    bool "BUSMON HAL module"
+    help
+      Enable the BUSMON (bus monitor) SiFli HAL module driver.
+
+config HAL_SIFLI_CRC
+    bool "CRC HAL module"
+    help
+      Enable the CRC SiFli HAL module driver.
+
+config HAL_SIFLI_EPIC
+    bool "EPIC HAL module"
+    help
+      Enable the EPIC (graphics engine) SiFli HAL module driver.
+
+config HAL_SIFLI_EXTDMA
+    bool "EXTDMA HAL module"
+    help
+      Enable the EXTDMA SiFli HAL module driver.
+
+config HAL_SIFLI_EZIP
+    bool "EZIP HAL module"
+    help
+      Enable the EZIP (image decompression) SiFli HAL module
+      driver.
+
+config HAL_SIFLI_GPIO
+    bool "GPIO HAL module"
+    select HAL_SIFLI_AON
+    help
+      Enable the GPIO SiFli HAL module driver.
+
+config HAL_SIFLI_GPT
+    bool "GPT HAL module"
+    help
+      Enable the GPT (general purpose timer) SiFli HAL module
+      driver.
+
+config HAL_SIFLI_HASH
+    bool "HASH HAL module"
+    help
+      Enable the HASH SiFli HAL module driver.
+
+config HAL_SIFLI_HCD
+    bool "HCD HAL module"
+    help
+      Enable the HCD (USB host controller) SiFli HAL module
+      driver.
+
+config HAL_SIFLI_I2C
+    bool "I2C HAL module"
+    help
+      Enable the I2C SiFli HAL module driver.
+
+config HAL_SIFLI_I2S
+    bool "I2S HAL module"
+    help
+      Enable the I2S SiFli HAL module driver.
+
+config HAL_SIFLI_IPC_QUEUE
+    bool "IPC queue"
+    select HAL_SIFLI_MAILBOX
+    help
+      Enable the IPC queue middleware for inter-core
+      communication.
+
+config HAL_SIFLI_LCD
+    bool "LCDC HAL module"
+    help
+      Enable the LCDC (LCD controller) SiFli HAL module driver.
+
+config HAL_SIFLI_LCPU
+    bool "LCPU boot support"
+    depends on HAL_SIFLI_SF32LB52
+    select HAL_SIFLI_LCPU_CONFIG
+    select HAL_SIFLI_LCPU_PATCH
+    help
+      Enable LCPU power-on, patch installation and BT RF
+      calibration support.
+
+config HAL_SIFLI_LCPU_CONFIG
+    bool "LCPU_CONFIG HAL module"
+    help
+      Enable the LCPU_CONFIG (LCPU configuration exchange) SiFli
+      HAL module.
+
+config HAL_SIFLI_LCPU_PATCH
+    bool "LCPU_PATCH HAL module"
+    help
+      Enable the LCPU_PATCH (ROM patch) SiFli HAL module.
+
+config HAL_SIFLI_LPTIM
+    bool "LPTIM HAL module"
+    help
+      Enable the LPTIM (low-power timer) SiFli HAL module driver.
+
+config HAL_SIFLI_LRC_CAL
+    bool "LRC_CAL HAL module"
+    select HAL_SIFLI_LCPU_CONFIG
+    select HAL_SIFLI_MAILBOX
+    help
+      Enable the LRC_CAL (low-power RC oscillator calibration)
+      SiFli HAL module.
+
+config HAL_SIFLI_MAILBOX
+    bool "MAILBOX HAL module"
+    help
+      Enable the MAILBOX (inter-core mailbox) SiFli HAL module
+      driver.
+
+config HAL_SIFLI_MPI
+    bool "MPI HAL module"
+    help
+      Enable the MPI (memory peripheral interface, NOR flash)
+      SiFli HAL module driver.
+
+config HAL_SIFLI_PCD
+    bool "PCD HAL module"
+    help
+      Enable the PCD (USB device controller) SiFli HAL module
+      driver.
+
+config HAL_SIFLI_PDM
+    bool "PDM HAL module"
+    help
+      Enable the PDM (digital microphone) SiFli HAL module driver.
+
+config HAL_SIFLI_PINMUX
+    bool "PINMUX HAL module"
+    help
+      Enable the PINMUX SiFli HAL module driver.
+
+config HAL_SIFLI_PTC
+    bool "PTC HAL module"
+    help
+      Enable the PTC (peripheral-to-peripheral trigger) SiFli HAL
+      module driver.
+
+config HAL_SIFLI_RNG
+    bool "RNG HAL module"
+    help
+      Enable the RNG SiFli HAL module driver.
+
+config HAL_SIFLI_RTC
+    bool "RTC HAL module"
+    help
+      Enable the RTC SiFli HAL module driver.
+
+config HAL_SIFLI_SD
+    bool "SD HAL module"
+    help
+      Enable the SD/MMC SiFli HAL module driver.
+
+config HAL_SIFLI_SDHCI
+    bool "SDHCI HAL module"
+    help
+      Enable the SDHCI SiFli HAL module driver.
+
+config HAL_SIFLI_SECU
+    bool "SECU HAL module"
+    help
+      Enable the SECU (security configuration) SiFli HAL module
+      driver.
+
+config HAL_SIFLI_SPI
+    bool "SPI HAL module"
+    help
+      Enable the SPI SiFli HAL module driver.
+
+config HAL_SIFLI_TSEN
+    bool "TSEN HAL module"
+    help
+      Enable the TSEN (temperature sensor) SiFli HAL module
+      driver.
+
+config HAL_SIFLI_UART
+    bool "UART HAL module"
+    help
+      Enable the UART SiFli HAL module driver.
+
+config HAL_SIFLI_WDT
+    bool "WDT HAL module"
+    help
+      Enable the WDT (watchdog) SiFli HAL module driver.
 
 endif # HAL_SIFLI

--- a/third_party/hal_sifli/wscript_build
+++ b/third_party/hal_sifli/wscript_build
@@ -9,26 +9,168 @@ bld.env.append_unique('LINKFLAGS', '-Wl,--undefined=HAL_GetTick')
 if bld.env.CONFIG_HAL_SIFLI_SF32LB52:
     bld.env.append_unique('DEFINES', 'SF32LB52X')
 
-micro_sources = bld.path.ant_glob('SiFli-SDK/drivers/hal/*.c', excl=['**/bf0_hal_audcodec.c'])
-
-micro_sources += [
-    'SiFli-SDK/middleware/ipc_queue/common/circular_buf.c',
-    'SiFli-SDK/middleware/ipc_queue/common/ipc_hw.c',
-    'SiFli-SDK/middleware/ipc_queue/common/ipc_queue.c',
+# HAL core. ADC, DMA and system config are pulled in by bf0_hal.c (HAL_Init)
+# and bf0_hal_pmu.c since the SDK enables all HAL_x_MODULE_ENABLED macros.
+# HLP provides the backup registers and debug print helpers.
+micro_sources = [
+    'SiFli-SDK/drivers/hal/bf0_hal.c',
+    'SiFli-SDK/drivers/hal/bf0_hal_adc.c',
+    'SiFli-SDK/drivers/hal/bf0_hal_cortex.c',
+    'SiFli-SDK/drivers/hal/bf0_hal_dma.c',
+    'SiFli-SDK/drivers/hal/bf0_hal_efuse.c',
+    'SiFli-SDK/drivers/hal/bf0_hal_hlp.c',
+    'SiFli-SDK/drivers/hal/bf0_hal_pmu.c',
+    'SiFli-SDK/drivers/hal/bf0_hal_rcc.c',
+    'SiFli-SDK/drivers/hal/bf0_sys_cfg.c',
 ]
+
+# bf0_hal_aes.c implements both AES and HASH
+if bld.env.CONFIG_HAL_SIFLI_AES or bld.env.CONFIG_HAL_SIFLI_HASH:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_aes.c']
+
+if bld.env.CONFIG_HAL_SIFLI_AON:
+    micro_sources += [
+        'SiFli-SDK/drivers/hal/bf0_hal_hpaon.c',
+        'SiFli-SDK/drivers/hal/bf0_hal_lpaon.c',
+    ]
+
+if bld.env.CONFIG_HAL_SIFLI_ATIM:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_tim_ex.c']
+
+if bld.env.CONFIG_HAL_SIFLI_AUDCODEC:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_audcodec_m.c']
+
+if bld.env.CONFIG_HAL_SIFLI_AUDPRC:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_audprc.c']
+
+if bld.env.CONFIG_HAL_SIFLI_BUSMON:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_busmon.c']
+
+if bld.env.CONFIG_HAL_SIFLI_CRC:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_crc.c']
+
+if bld.env.CONFIG_HAL_SIFLI_EPIC:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_epic.c']
+
+if bld.env.CONFIG_HAL_SIFLI_EXTDMA:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_ext_dma.c']
+
+if bld.env.CONFIG_HAL_SIFLI_EZIP:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_ezip.c']
+
+if bld.env.CONFIG_HAL_SIFLI_GPIO:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_gpio.c']
+
+if bld.env.CONFIG_HAL_SIFLI_GPT:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_tim.c']
+
+if bld.env.CONFIG_HAL_SIFLI_HCD:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_hcd.c']
+
+if bld.env.CONFIG_HAL_SIFLI_I2C:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_i2c.c']
+
+if bld.env.CONFIG_HAL_SIFLI_I2S:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_i2s.c']
+
+if bld.env.CONFIG_HAL_SIFLI_LCD:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_lcdc.c']
+
+if bld.env.CONFIG_HAL_SIFLI_LCPU_CONFIG:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_lcpu_config.c']
+
+if bld.env.CONFIG_HAL_SIFLI_LCPU_PATCH:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_patch.c']
+
+if bld.env.CONFIG_HAL_SIFLI_LPTIM:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_lptim.c']
+
+if bld.env.CONFIG_HAL_SIFLI_LRC_CAL:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_lrc_cal.c']
+
+if bld.env.CONFIG_HAL_SIFLI_MAILBOX:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_mailbox.c']
+
+if bld.env.CONFIG_HAL_SIFLI_MPI:
+    micro_sources += [
+        'SiFli-SDK/drivers/hal/bf0_hal_mpi.c',
+        'SiFli-SDK/drivers/hal/bf0_hal_mpi_ex.c',
+        'SiFli-SDK/drivers/hal/flash_table.c',
+    ]
+
+if bld.env.CONFIG_HAL_SIFLI_PCD:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_pcd.c']
+
+if bld.env.CONFIG_HAL_SIFLI_PDM:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_pdm.c']
+
+if bld.env.CONFIG_HAL_SIFLI_PINMUX:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_pinmux.c']
+
+if bld.env.CONFIG_HAL_SIFLI_PTC:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_ptc.c']
+
+if bld.env.CONFIG_HAL_SIFLI_RNG:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_rng.c']
+
+if bld.env.CONFIG_HAL_SIFLI_RTC:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_rtc.c']
+
+if bld.env.CONFIG_HAL_SIFLI_SD:
+    micro_sources += [
+        'SiFli-SDK/drivers/hal/bf0_hal_sdmmc.c',
+        'SiFli-SDK/drivers/hal/bf0_hal_sd_ex.c',
+    ]
+
+if bld.env.CONFIG_HAL_SIFLI_SDHCI:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_sdhci.c']
+
+if bld.env.CONFIG_HAL_SIFLI_SECU:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_secu.c']
+
+if bld.env.CONFIG_HAL_SIFLI_SPI:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_spi.c']
+
+if bld.env.CONFIG_HAL_SIFLI_TSEN:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_tsen.c']
+
+if bld.env.CONFIG_HAL_SIFLI_UART:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_uart.c']
+
+if bld.env.CONFIG_HAL_SIFLI_WDT:
+    micro_sources += ['SiFli-SDK/drivers/hal/bf0_hal_wdt.c']
+
+if bld.env.CONFIG_HAL_SIFLI_IPC_QUEUE:
+    micro_sources += [
+        'SiFli-SDK/middleware/ipc_queue/common/circular_buf.c',
+        'SiFli-SDK/middleware/ipc_queue/common/ipc_hw.c',
+        'SiFli-SDK/middleware/ipc_queue/common/ipc_queue.c',
+    ]
 
 if bld.env.CONFIG_HAL_SIFLI_SF32LB52:
     micro_sources += [
         'SiFli-SDK/drivers/cmsis/sf32lb52x/bf0_pin_const.c',
-        'SiFli-SDK/drivers/cmsis/sf32lb52x/bf0_lcpu_init.c',
-        'SiFli-SDK/drivers/cmsis/sf32lb52x/lcpu_patch.c',
-        'SiFli-SDK/drivers/cmsis/sf32lb52x/lcpu_config_type.c',
-        'SiFli-SDK/drivers/cmsis/sf32lb52x/lcpu_patch_rev_b.c',
-        'SiFli-SDK/drivers/cmsis/sf32lb52x/bt_rf_fulcal.c',
-        'SiFli-SDK/middleware/ipc_queue/porting/sf32lb52x/hcpu/ipc_hw_port.c',
         'sf32lb52/system_bf0_ap.c',
-        'sf32lb52/lcpu_config.c',
     ]
+
+    if bld.env.CONFIG_HAL_SIFLI_IPC_QUEUE:
+        micro_sources += [
+            'SiFli-SDK/middleware/ipc_queue/porting/sf32lb52x/hcpu/ipc_hw_port.c',
+        ]
+
+    if bld.env.CONFIG_HAL_SIFLI_LCPU_CONFIG:
+        micro_sources += [
+            'SiFli-SDK/drivers/cmsis/sf32lb52x/lcpu_config_type.c',
+        ]
+
+    if bld.env.CONFIG_HAL_SIFLI_LCPU:
+        micro_sources += [
+            'SiFli-SDK/drivers/cmsis/sf32lb52x/bf0_lcpu_init.c',
+            'SiFli-SDK/drivers/cmsis/sf32lb52x/lcpu_patch.c',
+            'SiFli-SDK/drivers/cmsis/sf32lb52x/lcpu_patch_rev_b.c',
+            'SiFli-SDK/drivers/cmsis/sf32lb52x/bt_rf_fulcal.c',
+            'sf32lb52/lcpu_config.c',
+        ]
 
 micro_includes = [
     'SiFli-SDK/customer/boards/include',


### PR DESCRIPTION
## Summary

Replace the `drivers/hal/*.c` glob in `third_party/hal_sifli` with per-module `HAL_SIFLI_*` Kconfig options, mirroring [Zephyr's `modules/hal_sifli/Kconfig`](https://github.com/zephyrproject-rtos/zephyr/blob/main/modules/hal_sifli/Kconfig). Granularity is purely at the source-list level: the SDK conf header keeps every `HAL_x_MODULE_ENABLED` macro defined, so no SDK changes are needed.

- The always-built HAL core is `bf0_hal`, `adc`, `cortex`, `dma`, `efuse`, `hlp`, `pmu`, `rcc`, `bf0_sys_cfg`: `HAL_Init()` calls `HAL_ADC_HwInit()` (which needs DMA), PMU pulls `BSP_CONFIG_get()` from `bf0_sys_cfg.c`, and HLP provides the backup registers and `HAL_DBG_printf` used by core code.
- Intra-HAL dependencies are encoded as selects on the HAL options themselves (`AON→RTC`, `GPIO→AON`, `LRC_CAL→LCPU_CONFIG+MAILBOX`, `IPC_QUEUE→MAILBOX`, `LCPU→LCPU_CONFIG+LCPU_PATCH`).
- Consumers select what they use: SF32LB driver symbols select their HAL module, `BT_FW_NIMBLE` selects `IPC_QUEUE` and the new `HAL_SIFLI_LCPU` (LCPU boot/patch/BT RF cal) on SF32LB52, and `HAL_SIFLI_SF32LB52` selects the modules required by unconditional SoC/kernel/system code.
- 24 of 63 HAL sources had no users and are no longer compiled; hal_sifli compiles drop from 74 to 41 TUs on obelix.

## Testing

- `obelix_pvt` (normal + PRF): builds; the set of `hal_sifli` objects pulled into the final link is byte-identical to the pre-change baseline map.
- `getafix_dvt2` and `asterix` build clean, no Kconfig warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)