### PR TITLE
drivers/imu: add LSM6DSO gyroscope driver

### DIFF
--- a/src/fw/drivers/gyro.h
+++ b/src/fw/drivers/gyro.h
@@ -1,0 +1,96 @@
+/* SPDX-FileCopyrightText: 2026 Dave Bortz */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+/*! Gyroscope driver interface
+ *  ==========================
+ *
+ * The gyroscope driver mirrors the accelerometer driver interface (see
+ * drivers/accel.h for the design rationale): it is a dumb interface to the
+ * gyroscope hardware with no circular buffers, clients, threads or
+ * subsampling. All of that is handled by higher level code (the gyro
+ * manager service).
+ *
+ * Power: the driver must keep the gyroscope powered down whenever no data
+ * has been requested (sampling interval and num samples both zero). Unlike
+ * the accelerometer, the gyroscope is comparatively power hungry, so there
+ * are no always-on event detection features (shake, tap) in this interface.
+ *
+ * Note that gyroscope hardware typically needs tens of milliseconds to
+ * produce valid samples after power-on. The driver is responsible for
+ * discarding samples taken during the turn-on settling time; callers may
+ * therefore observe a short delay between requesting data and the first
+ * call to gyro_cb_new_sample().
+ */
+
+typedef struct {
+  //! Timestamp of when the sample was taken in microseconds since the epoch.
+  //! The precision of the timestamp is not guaranteed.
+  uint64_t timestamp_us;
+  //! Angular velocity around the x axis in millidegrees per second.
+  int32_t x;
+  //! Angular velocity around the y axis in millidegrees per second.
+  int32_t y;
+  //! Angular velocity around the z axis in millidegrees per second.
+  int32_t z;
+} GyroDriverSample;
+
+//! Initialize the gyroscope. The gyroscope must be left powered down.
+void gyro_init(void);
+
+//! Power up the gyroscope hardware
+void gyro_power_up(void);
+
+//! Power down the gyroscope hardware
+void gyro_power_down(void);
+
+//! Sets the gyroscope sampling interval.
+//!
+//! Not all sampling intervals are supported by all drivers. The driver must
+//! select a sampling interval which is equal to or shorter than the requested
+//! interval, saturating at the shortest interval supported by the hardware.
+//!
+//! @param interval_us The requested sampling interval in microseconds.
+//!   An interval of 0 requests that the gyroscope be powered down.
+//!
+//! @return The actual sampling interval set by the driver.
+uint32_t gyro_set_sampling_interval(uint32_t interval_us);
+
+//! Returns the currently set gyroscope sampling interval.
+uint32_t gyro_get_sampling_interval(void);
+
+//! Set the max number of samples the driver may batch.
+//!
+//! Semantics are identical to accel_set_num_samples() (see drivers/accel.h):
+//! n=0 means gyro_cb_new_sample() must not be called, n=1 requests immediate
+//! per-sample delivery, n>1 allows the driver to batch up to n samples for
+//! power savings.
+void gyro_set_num_samples(uint32_t num_samples);
+
+//! Peek at the most recent gyroscope sample.
+//!
+//! @param[out] data Pointer to a buffer to write the gyroscope sample to
+//!
+//! @return 0 if successful, nonzero on failure. Fails if the gyroscope is
+//!   currently powered down.
+int gyro_peek(GyroDriverSample *data);
+
+//! Function called by the driver whenever a new gyro sample is available.
+//!
+//! @param[in] data pointer to a populated GyroDriverSample struct. The pointer
+//!   is only valid for the duration of the function call.
+//!
+//! This function will always be called with samples monotonically increasing
+//! in time, from a thread context. Implemented by the gyro manager service;
+//! the implementation is responsible for its own locking.
+extern void gyro_cb_new_sample(GyroDriverSample const *data);
+
+//! Function called by the driver when it needs to offload work to a thread
+//! context. Implemented by the gyro manager service.
+typedef void (*GyroOffloadCallback)(void);
+extern void gyro_offload_work(GyroOffloadCallback cb);

--- a/src/fw/drivers/imu/Kconfig
+++ b/src/fw/drivers/imu/Kconfig
@@ -80,6 +80,17 @@ config ACCEL_LIS2DW12_FIFO_THRESHOLD
 
 endif # ACCEL_LIS2DW12
 
+config GYRO
+    bool
+
+config GYRO_LSM6DSO
+    bool "ST LSM6DSO gyroscope"
+    select GYRO
+    help
+      Support for the gyroscope in the ST LSM6DSO IMU. Can be enabled
+      together with ACCEL_LSM6DSO (one chip serving both roles) or on its
+      own when a different chip provides the accelerometer.
+
 menuconfig MAG
     bool "Magnetometer"
     help

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -14,20 +14,14 @@
 #include "lsm6dso_reg.h"
 
 #include "lsm6dso.h"
+#include "lsm6dso_core.h"
 
 PBL_LOG_MODULE_DEFINE(driver_accel_lsm6dso, CONFIG_DRIVER_IMU_LOG_LEVEL);
 
 // Forward declaration of private functions defined below public functions
-static int32_t prv_lsm6dso_read(void *handle, uint8_t reg_addr, uint8_t *buffer,
-                                uint16_t read_size);
-static int32_t prv_lsm6dso_write(void *handle, uint8_t reg_addr, const uint8_t *buffer,
-                                 uint16_t write_size);
-static void prv_lsm6dso_mdelay(uint32_t ms);
 static void prv_lsm6dso_init(void);
 static void prv_lsm6dso_chase_target_state(void);
 static void prv_lsm6dso_configure_interrupts(void);
-static lsm6dso_bdr_xl_t prv_get_fifo_batch_rate(uint32_t interval_us);
-static void prv_lsm6dso_configure_fifo(bool enable);
 static void prv_lsm6dso_configure_double_tap(bool enable);
 static void prv_lsm6dso_configure_shake(bool enable, bool sensitivity_high);
 static void prv_lsm6dso_interrupt_handler(bool *should_context_switch);
@@ -55,13 +49,6 @@ typedef enum {
 static int16_t prv_get_axis_projection_mg(axis_t axis, int16_t *raw_vector);
 static uint64_t prv_get_timestamp_ms(void);
 
-// HAL context for LSM6DSO
-stmdev_ctx_t lsm6dso_ctx = {
-    .write_reg = prv_lsm6dso_write,
-    .read_reg = prv_lsm6dso_read,
-    .mdelay = prv_lsm6dso_mdelay,
-};
-
 // Toplevel module state
 
 static bool s_lsm6dso_initialized = false;
@@ -77,18 +64,13 @@ typedef struct {
 lsm6dso_state_t s_lsm6dso_state = {0};
 lsm6dso_state_t s_lsm6dso_state_target = {0};
 static uint32_t s_tap_threshold = BOARD_CONFIG_ACCEL.accel_config.double_tap_threshold / 1250;
-static bool s_fifo_in_use = false;  // true when we have enabled FIFO batching
 static uint32_t s_last_vibe_detected = 0;
 
 // User-configured sensitivity percentage (0-100), where 100 = most sensitive
 // Default to 100% (maximum sensitivity) to maintain current behavior
 static uint8_t s_user_sensitivity_percent = 100;
 
-// Error tracking and recovery
-static uint32_t s_i2c_error_count = 0;
-static uint32_t s_last_successful_read_ms = 0;
-static uint32_t s_consecutive_errors = 0;
-static bool s_sensor_health_ok = true;
+// Error tracking and recovery (I2C health lives in the shared core)
 static int16_t s_last_sample_mg[3] = {0};
 static uint64_t s_last_sample_timestamp_ms = 0;
 // Interrupt activity instrumentation so we can spot when the sensor stops firing INT1.
@@ -108,9 +90,6 @@ static RegularTimerInfo s_interrupt_watchdog_timer = {
 
 // watch rotation
 static bool s_rotated_180 = false;
-
-// Maximum FIFO watermark supported by hardware (diff_fifo is 10 bits -> 0..1023)
-#define LSM6DSO_FIFO_MAX_WATERMARK 1023
 
 // Maximum allowed sampling interval for tap detection (i.e., slowest rate, in microseconds)
 #define LSM6DSO_TAP_DETECTION_MAX_INTERVAL_US 2398
@@ -203,58 +182,6 @@ void accel_set_shake_sensitivity_percent(uint8_t percent) {
   PBL_LOG_INFO("LSM6DSO: User sensitivity set to %u percent", percent);
 }
 
-// HAL context implementations
-
-static int32_t prv_lsm6dso_read(void *handle, uint8_t reg_addr, uint8_t *buffer,
-                                uint16_t read_size) {
-  i2c_use(I2C_LSM6D);
-  bool result = i2c_write_block(I2C_LSM6D, 1, &reg_addr);
-  if (result) result = i2c_read_block(I2C_LSM6D, read_size, buffer);
-  i2c_release(I2C_LSM6D);
-  
-  if (!result) {
-    s_i2c_error_count++;
-    s_consecutive_errors++;
-    PBL_LOG_ERR("LSM6DSO: I2C read failed (reg=0x%02x, count=%lu)", 
-            reg_addr, s_consecutive_errors);
-    if (s_consecutive_errors >= LSM6DSO_MAX_CONSECUTIVE_FAILURES) {
-      s_sensor_health_ok = false;
-      PBL_LOG_ERR("LSM6DSO: Sensor health degraded after %lu failures", 
-              s_consecutive_errors);
-    }
-    return -1;
-  } else {
-    s_consecutive_errors = 0;
-    s_last_successful_read_ms = prv_get_timestamp_ms();
-    s_sensor_health_ok = true;
-  }
-  
-  return 0;
-}
-
-static int32_t prv_lsm6dso_write(void *handle, uint8_t reg_addr, const uint8_t *buffer,
-                                 uint16_t write_size) {
-  i2c_use(I2C_LSM6D);
-  uint8_t d[write_size + 1];
-  d[0] = reg_addr;
-  memcpy(&d[1], buffer, write_size);
-  bool result = i2c_write_block(I2C_LSM6D, write_size + 1, d);
-  i2c_release(I2C_LSM6D);
-  
-  if (!result) {
-    s_i2c_error_count++;
-    s_consecutive_errors++;
-    PBL_LOG_ERR("LSM6DSO: I2C write failed (reg=0x%02x)", reg_addr);
-    return -1;
-  } else {
-    s_consecutive_errors = 0;
-  }
-  
-  return 0;
-}
-
-static void prv_lsm6dso_mdelay(uint32_t ms) { psleep(ms); }
-
 // Initialization
 
 //! Initialize the LSM6DSO sensor and configure it to a powered down state.
@@ -264,112 +191,19 @@ static void prv_lsm6dso_init(void) {
     return;
   }
 
-  // Initialize error tracking
-  s_i2c_error_count = 0;
-  s_last_successful_read_ms = 0;
-  s_sensor_health_ok = true;
-
-  // Verify sensor is present and functioning
-  uint8_t whoami;
-  if (lsm6dso_device_id_get(&lsm6dso_ctx, &whoami)) {
-    PBL_LOG_ERR("LSM6DSO: Failed to read WHO_AM_I register");
-    return;
-  }
-  if (whoami != LSM6DSO_ID) {
-    PBL_LOG_ERR("LSM6DSO: Sensor not detected or malfunctioning (WHO_AM_I=0x%02x, expecting 0x%02x)",
-            whoami, LSM6DSO_ID);
-    return;
-  }
-  
-  PBL_LOG_DBG("LSM6DSO: Sensor detected successfully (WHO_AM_I=0x%02x)", whoami);
-
-  // Reset sensor to known state
-  if (lsm6dso_reset_set(&lsm6dso_ctx, PROPERTY_ENABLE)) {
-    PBL_LOG_ERR("LSM6DSO: Failed to reset sensor");
-    return;
-  }
-  uint8_t rst;
-  int reset_timeout = 100; // 100ms max wait for reset
-  do {  // Wait for reset to complete with timeout
-    psleep(1);
-    if (lsm6dso_reset_get(&lsm6dso_ctx, &rst) != 0) {
-      PBL_LOG_ERR("LSM6DSO: Failed to read reset status");
-      return;
-    }
-    reset_timeout--;
-  } while (rst && reset_timeout > 0);
-  
-  if (reset_timeout == 0) {
-    PBL_LOG_ERR("LSM6DSO: Reset timeout - sensor may be unresponsive");
-    return;
-  }
-
-  // Disable I3C interface
-  if (lsm6dso_i3c_disable_set(&lsm6dso_ctx, LSM6DSO_I3C_DISABLE)) {
-    PBL_LOG_ERR("LSM6DSO: Failed to disable I3C interface");
-    return;
-  }
-
-  // Enable Block Data Update
-  if (lsm6dso_block_data_update_set(&lsm6dso_ctx, PROPERTY_ENABLE)) {
-    PBL_LOG_ERR("LSM6DSO: Failed to enable block data update");
-    return;
-  }
-
-  // Enable Auto Increment
-  if (lsm6dso_auto_increment_set(&lsm6dso_ctx, PROPERTY_ENABLE)) {
-    PBL_LOG_ERR("LSM6DSO: Failed to enable auto increment");
-    return;
-  }
-
-  // Set FIFO mode to bypass (will be reconfigured as necessary later)
-  if (lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_BYPASS_MODE)) {
-    PBL_LOG_ERR("LSM6DSO: Failed to set FIFO mode to bypass");
-    return;
-  }
-
-  // Set default full scale
-  if (lsm6dso_xl_full_scale_set(&lsm6dso_ctx, LSM6DSO_4g)) {
-    PBL_LOG_ERR("LSM6DSO: Failed to set accelerometer full scale");
-    return;
-  }
-  if (lsm6dso_gy_full_scale_set(&lsm6dso_ctx, LSM6DSO_250dps)) {
-    PBL_LOG_ERR("LSM6DSO: Failed to set gyroscope full scale");
-    return;
-  }
-
-  // Set output rate to zero (disabling sensors)
-  if (lsm6dso_xl_data_rate_set(&lsm6dso_ctx, LSM6DSO_XL_ODR_OFF)) {
-    PBL_LOG_ERR("LSM6DSO: Failed to set accelerometer ODR");
-    return;
-  }
-  if (lsm6dso_gy_data_rate_set(&lsm6dso_ctx, LSM6DSO_GY_ODR_OFF)) {
-    PBL_LOG_ERR("LSM6DSO: Failed to set gyroscope ODR");
+  // Chip-level initialization is shared with the gyro half
+  if (!lsm6dso_core_init()) {
     return;
   }
 
   // Configure interrupts
   // Note that we only configure on interrupt pin for now, since not all devices
   // have enough channels for two (and it is not in any case neccessary).
-  
+
   exti_configure_pin(BOARD_CONFIG_ACCEL.accel_ints[0], ExtiTrigger_Rising,
                      prv_lsm6dso_interrupt_handler);
 
-  // Since we are using only one interrupt pin, it is important that we set
-  // these to pulsed so that if we miss an interrupt due to timing issues we do
-  // not miss subsequent ones.
-  if (lsm6dso_data_ready_mode_set(&lsm6dso_ctx, LSM6DSO_DRDY_PULSED)) {
-    PBL_LOG_ERR("LSM6DSO: Failed to set data ready mode");
-    return;
-  }
-  if (lsm6dso_int_notification_set(&lsm6dso_ctx, LSM6DSO_ALL_INT_PULSED)) {
-    PBL_LOG_ERR("LSM6DSO: Failed to configure interrupt notification");
-    return;
-  }
-
   s_lsm6dso_initialized = true;
-  s_last_successful_read_ms = prv_get_timestamp_ms();
-  s_consecutive_errors = 0;
   PBL_LOG_DBG("LSM6DSO: Initialization complete");
 }
 
@@ -499,12 +333,13 @@ static void prv_lsm6dso_configure_interrupts(void) {
 
   // Configure FIFO first, then set up interrupt routing
   if (use_fifo) {
-    prv_lsm6dso_configure_fifo(true);
+    lsm6dso_core_fifo_request_xl(s_lsm6dso_state.num_samples,
+                                 s_lsm6dso_state.sampling_interval_us);
     int1_routes.fifo_th = 1;  // watermark interrupt
     int1_routes.fifo_ovr = 1; // Enable overflow interrupt to prevent lockup
     int1_routes.drdy_xl = 0;
   } else {
-    prv_lsm6dso_configure_fifo(false);
+    lsm6dso_core_fifo_request_xl(0, 0);
     int1_routes.drdy_xl = s_lsm6dso_state.num_samples > 0;  // single-sample mode
     int1_routes.fifo_th = 0;
     int1_routes.fifo_ovr = 0;
@@ -531,81 +366,6 @@ static void prv_lsm6dso_configure_interrupts(void) {
   if (!routing_configured) {
     PBL_LOG_WRN("LSM6DSO: INT1 routing not updated; external interrupt left enabled for recovery");
   }
-}
-
-// Map output data rate (interval) to FIFO batching rate enum
-static lsm6dso_bdr_xl_t prv_get_fifo_batch_rate(uint32_t interval_us) {
-  if (interval_us >= 625000) return LSM6DSO_XL_BATCHED_AT_6Hz5;  // lowest supported batching
-  if (interval_us >= 80000) return LSM6DSO_XL_BATCHED_AT_12Hz5;
-  if (interval_us >= 38462) return LSM6DSO_XL_BATCHED_AT_26Hz;
-  if (interval_us >= 19231) return LSM6DSO_XL_BATCHED_AT_52Hz;
-  if (interval_us >= 9615) return LSM6DSO_XL_BATCHED_AT_104Hz;
-  if (interval_us >= 4808) return LSM6DSO_XL_BATCHED_AT_208Hz;
-  if (interval_us >= 2398) return LSM6DSO_XL_BATCHED_AT_417Hz;
-  if (interval_us >= 1200) return LSM6DSO_XL_BATCHED_AT_833Hz;
-  if (interval_us >= 600) return LSM6DSO_XL_BATCHED_AT_1667Hz;
-  if (interval_us >= 300) return LSM6DSO_XL_BATCHED_AT_3333Hz;
-  return LSM6DSO_XL_BATCHED_AT_6667Hz;
-}
-
-static void prv_lsm6dso_configure_fifo(bool enable) {
-  // Always (re)program watermark and batch rates when enabling or already enabled,
-  // but only flip FIFO mode when the enabled/disabled state changes.
-  if (enable) {
-    // Proper FIFO watermark calculation to prevent overflow
-    // Setting watermark too high can cause overflow and sensor lockup
-    
-    uint32_t watermark = s_lsm6dso_state.num_samples;
-    if (watermark == 0) watermark = 1;  // safety
-    
-    // Set watermark to 50% of requested samples to prevent overflow
-    // This provides more buffer for timing variations and prevents lockup
-    watermark = watermark / 2;
-    if (watermark == 0) watermark = 1;  // minimum
-    if (watermark > LSM6DSO_FIFO_MAX_WATERMARK) watermark = LSM6DSO_FIFO_MAX_WATERMARK;
-    
-    PBL_LOG_DBG("LSM6DSO: Setting FIFO watermark to %lu (requested %lu samples)", 
-            watermark, s_lsm6dso_state.num_samples);
-    
-    if (lsm6dso_fifo_watermark_set(&lsm6dso_ctx, (uint16_t)watermark)) {
-      PBL_LOG_ERR("LSM6DSO: Failed to set FIFO watermark");
-    }
-    
-    // Enable accelerometer batching at (approx) current ODR
-    lsm6dso_bdr_xl_t batch_rate = prv_get_fifo_batch_rate(s_lsm6dso_state.sampling_interval_us);
-    if (lsm6dso_fifo_xl_batch_set(&lsm6dso_ctx, batch_rate)) {
-      PBL_LOG_ERR("LSM6DSO: Failed to set FIFO batch rate");
-    }
-    
-    // Disable gyro batching to save FIFO space
-    lsm6dso_fifo_gy_batch_set(&lsm6dso_ctx, LSM6DSO_GY_NOT_BATCHED);
-
-    // Always clear and re-enable FIFO to ensure clean state after configuration changes.
-    // This is critical when watermark changes while FIFO is already enabled, as stale
-    // samples in the FIFO can prevent new watermark interrupts from being generated.
-    // For example, if FIFO has 25 samples and watermark is lowered to 3, the sensor
-    // won't generate an interrupt because the FIFO already exceeds the watermark.
-    lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_BYPASS_MODE);
-    psleep(1); // Allow time for FIFO to clear
-
-    // Put FIFO in stream mode so we keep collecting samples and get periodic watermark interrupts
-    if (lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_STREAM_MODE)) {
-      PBL_LOG_ERR("LSM6DSO: Failed to enable FIFO stream mode");
-    }
-  } else {
-    if (s_fifo_in_use) {
-      // Disable batching & return to bypass
-      lsm6dso_fifo_xl_batch_set(&lsm6dso_ctx, LSM6DSO_XL_NOT_BATCHED);
-      lsm6dso_fifo_gy_batch_set(&lsm6dso_ctx, LSM6DSO_GY_NOT_BATCHED);
-      if (lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_BYPASS_MODE)) {
-        PBL_LOG_ERR("LSM6DSO: Failed to disable FIFO");
-      }
-    }
-  }
-
-  s_fifo_in_use = enable;
-  PBL_LOG_DBG("LSM6DSO: FIFO %s (wm=%lu)", enable ? "enabled" : "disabled",
-          (unsigned long)s_lsm6dso_state.num_samples);
 }
 
 void prv_lsm6dso_configure_double_tap(bool enable) {
@@ -738,53 +498,22 @@ static void prv_lsm6dso_process_interrupts(void) {
   
   if (read_attempts >= max_read_attempts) {
     PBL_LOG_ERR("LSM6DSO: Failed to read interrupt sources after retries");
-    s_consecutive_errors++;
-    if (s_consecutive_errors >= LSM6DSO_MAX_CONSECUTIVE_FAILURES) {
-      s_sensor_health_ok = false;
+    Lsm6dsoCoreHealth *health = lsm6dso_core_health();
+    health->consecutive_errors++;
+    if (health->consecutive_errors >= LSM6DSO_MAX_CONSECUTIVE_FAILURES) {
+      health->sensor_health_ok = false;
       PBL_LOG_WRN("LSM6DSO: Interrupt processing failed, sensor health degraded");
     }
     return;
   }
-  
+
   // Reset failure count on successful read
-  s_consecutive_errors = 0;
+  lsm6dso_core_health()->consecutive_errors = 0;
 
   // Prevent FIFO overflow by proper watermark management
   // FIFO overflow causes the sensor to stop generating interrupts
   if (all_sources.fifo_ovr || all_sources.fifo_full) {
-    PBL_LOG_WRN("LSM6DSO: FIFO overflow/full detected, clearing FIFO");
-    
-    // Properly clear FIFO without losing configuration
-    uint16_t current_watermark;
-    lsm6dso_bdr_xl_t current_batch_rate;
-    
-    // Save current FIFO configuration
-    lsm6dso_fifo_watermark_get(&lsm6dso_ctx, &current_watermark);
-    lsm6dso_fifo_xl_batch_get(&lsm6dso_ctx, &current_batch_rate);
-    
-    // Reset FIFO to bypass mode
-    lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_BYPASS_MODE);
-    
-    // Wait for FIFO to actually clear
-    psleep(1);
-    
-    // Clear all interrupt sources after FIFO reset to ensure clean state
-    lsm6dso_all_sources_t clear_sources;
-    lsm6dso_all_sources_get(&lsm6dso_ctx, &clear_sources);
-
-    // Restore FIFO configuration if it was enabled
-    if (s_fifo_in_use) {
-      // Reduce watermark by half to prevent future overflow
-      uint16_t reduced_watermark = current_watermark / 2;
-      if (reduced_watermark == 0) reduced_watermark = 1;
-      
-      lsm6dso_fifo_watermark_set(&lsm6dso_ctx, reduced_watermark);
-      lsm6dso_fifo_xl_batch_set(&lsm6dso_ctx, current_batch_rate);
-      lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_STREAM_MODE);
-
-      PBL_LOG_INFO("LSM6DSO: Reduced FIFO watermark from %u to %u to prevent future overflow",
-              current_watermark, reduced_watermark);
-    }
+    lsm6dso_core_fifo_recover();
 
     // Force re-enable of external interrupt to ensure it's active
     exti_disable(BOARD_CONFIG_ACCEL.accel_ints[0]);
@@ -894,9 +623,11 @@ static bool prv_lsm6dso_force_reinit(void) {
 
   s_lsm6dso_initialized = false;
   s_lsm6dso_running = false;
-  s_fifo_in_use = false;
-  s_sensor_health_ok = false;
-  s_consecutive_errors = 0;
+
+  if (!lsm6dso_core_reinit()) {
+    PBL_LOG_ERR("LSM6DSO: Forced reinit failed; sensor still unresponsive");
+    return false;
+  }
 
   prv_lsm6dso_init();
   if (!s_lsm6dso_initialized) {
@@ -907,6 +638,11 @@ static bool prv_lsm6dso_force_reinit(void) {
   s_lsm6dso_state = (lsm6dso_state_t){0};
 
   prv_lsm6dso_chase_target_state();
+
+#if defined(CONFIG_GYRO_LSM6DSO)
+  // The chip reset wiped the gyro half's configuration too
+  lsm6dso_gyro_handle_core_reinit();
+#endif
 
   return s_lsm6dso_running;
 }
@@ -925,15 +661,15 @@ static void prv_lsm6dso_interrupt_watchdog_callback(void *data) {
     PBL_LOG_WRN("LSM6DSO: Interrupt watchdog triggered - no interrupts for %" PRIu32 " ms, count=%lu; forcing reinit",
             interrupt_age_ms, (unsigned long)s_interrupt_count);
     // Mark sensor as unhealthy
-    s_sensor_health_ok = false;
-    
+    lsm6dso_core_health()->sensor_health_ok = false;
+
     if (!s_lsm6dso_running) {
       return;
     }
 
     // Always escalate to forced reinitialization on watchdog expiry
     if (prv_lsm6dso_force_reinit()) {
-      s_sensor_health_ok = true;
+      lsm6dso_core_health()->sensor_health_ok = true;
       // Reset interrupt timestamp and count to avoid repeated watchdog triggers
       s_last_interrupt_ms = now_ms;
       s_interrupt_count = 0;
@@ -992,10 +728,14 @@ static int32_t prv_lsm6dso_set_sampling_interval(uint32_t interval_us) {
     return -1;
   }
 
-  // For now, gyro is off, so it is fine to use ULP mode.  When we have gyro
-  // support, though, we need to avoid ULP mode (LSM6DSO datasheet section
-  // 6.2.1) -- modify that here once you do that!
   lsm6dso_xl_hm_mode_t new_power_mode = odr_interval.power_mode;
+#if defined(CONFIG_GYRO_LSM6DSO)
+  // The accelerometer must not use ultra-low-power mode while the gyro is
+  // active (LSM6DSO datasheet section 6.2.1)
+  if (lsm6dso_gyro_is_active() && new_power_mode == LSM6DSO_ULTRA_LOW_POWER_MD) {
+    new_power_mode = LSM6DSO_LOW_NORMAL_POWER_MD;
+  }
+#endif
 
   if (old_odr == odr_interval.odr && old_power_mode == new_power_mode) {
     PBL_LOG_DBG("LSM6DSO: we were already in that sampling mode, so we're good");
@@ -1036,74 +776,38 @@ static int32_t prv_lsm6dso_set_sampling_interval(uint32_t interval_us) {
 // Accelerometer sample reading (and reporting)
 
 static void prv_lsm6dso_read_samples(void) {
-  if (s_lsm6dso_state.num_samples <= 1 || !s_fifo_in_use) {
+  if (s_lsm6dso_state.num_samples <= 1 || !lsm6dso_core_fifo_in_use()) {
     // Single sample path
     AccelDriverSample sample;
     prv_lsm6dso_read_sample(&sample);
     return;
   }
 
-  // Drain FIFO
-  uint16_t fifo_level = 0;
-  if (lsm6dso_fifo_data_level_get(&lsm6dso_ctx, &fifo_level) != 0) {
-    PBL_LOG_ERR("LSM6DSO: Failed to read FIFO level");
-    // Reset FIFO on communication error
-    lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_BYPASS_MODE);
-    if (s_fifo_in_use) {
-      lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_STREAM_MODE);
-    }
-    return;
-  }
-  if (fifo_level == 0) {
-    return;  // nothing to do
-  }
+  // Drain the shared FIFO; accel records come back through
+  // lsm6dso_accel_handle_fifo_record() below
+  lsm6dso_core_fifo_drain();
+}
 
-  // Prevent infinite loops on stuck FIFO
-  if (fifo_level > LSM6DSO_FIFO_MAX_WATERMARK) {
-    PBL_LOG_ERR("LSM6DSO: FIFO level too high (%u), resetting", fifo_level);
-    lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_BYPASS_MODE);
-    if (s_fifo_in_use) {
-      lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_STREAM_MODE);
-    }
-    return;
-  }
+void lsm6dso_accel_handle_fifo_record(const uint8_t data[6], uint64_t timestamp_us) {
+  int16_t raw_vector[3];
+  raw_vector[0] = (int16_t)((data[1] << 8) | data[0]);
+  raw_vector[1] = (int16_t)((data[3] << 8) | data[2]);
+  raw_vector[2] = (int16_t)((data[5] << 8) | data[4]);
 
-  const uint64_t now_us = prv_get_timestamp_ms() * 1000ULL;
-  const uint32_t interval_us = s_lsm6dso_state.sampling_interval_us ?: 1000;  // avoid div by zero
+  AccelDriverSample sample = {0};
+  sample.x = prv_get_axis_projection_mg(X_AXIS, raw_vector);
+  sample.y = prv_get_axis_projection_mg(Y_AXIS, raw_vector);
+  sample.z = prv_get_axis_projection_mg(Z_AXIS, raw_vector);
+  sample.timestamp_us = timestamp_us;
+  accel_cb_new_sample(&sample);
+  prv_note_new_sample(&sample);
+}
 
-  for (uint16_t i = 0; i < fifo_level; ++i) {
-    uint8_t raw_bytes[7];
-    if (lsm6dso_read_reg(&lsm6dso_ctx, LSM6DSO_FIFO_DATA_OUT_TAG, raw_bytes, sizeof(raw_bytes)) != 0) {
-      PBL_LOG_ERR("LSM6DSO: Failed to read FIFO sample (%u/%u)", i, fifo_level);
-      // Reset FIFO on communication error
-      lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_BYPASS_MODE);
-      if (s_fifo_in_use) {
-        lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_STREAM_MODE);
-      }
-      break;
-    }
-
-    lsm6dso_fifo_tag_t tag = raw_bytes[0] >> 3;
-    if (tag != LSM6DSO_XL_NC_TAG && tag != LSM6DSO_XL_NC_T_1_TAG && tag != LSM6DSO_XL_NC_T_2_TAG &&
-        tag != LSM6DSO_XL_2XC_TAG && tag != LSM6DSO_XL_3XC_TAG) {
-      // Not an accelerometer sample (e.g., gyro/timestamp/config), ignore
-      continue;
-    }
-
-    int16_t raw_vector[3];
-    raw_vector[0] = (int16_t)((raw_bytes[2] << 8) | raw_bytes[1]);
-    raw_vector[1] = (int16_t)((raw_bytes[4] << 8) | raw_bytes[3]);
-    raw_vector[2] = (int16_t)((raw_bytes[6] << 8) | raw_bytes[5]);
-
-    AccelDriverSample sample = {0};
-    sample.x = prv_get_axis_projection_mg(X_AXIS, raw_vector);
-    sample.y = prv_get_axis_projection_mg(Y_AXIS, raw_vector);
-    sample.z = prv_get_axis_projection_mg(Z_AXIS, raw_vector);
-    // Approximate timestamp: assume fifo_level contiguous samples ending now
-    uint32_t sample_index_from_end = (fifo_level - 1) - i;  // 0 for newest
-    sample.timestamp_us = now_us - (sample_index_from_end * (uint64_t)interval_us);
-    accel_cb_new_sample(&sample);
-    prv_note_new_sample(&sample);
+void lsm6dso_accel_gyro_state_changed(void) {
+  // Re-apply the sampling interval so the power mode is re-evaluated against
+  // the gyro's new state (ULP mode is unavailable while the gyro is active)
+  if (s_lsm6dso_running && s_lsm6dso_state.sampling_interval_us > 0) {
+    prv_lsm6dso_set_sampling_interval(s_lsm6dso_state.sampling_interval_us);
   }
 }
 
@@ -1207,16 +911,17 @@ void lsm6dso_get_diagnostics(Lsm6dsoDiagnostics *diagnostics) {
   diagnostics->last_sample_mg[1] = s_last_sample_mg[1];
   diagnostics->last_sample_mg[2] = s_last_sample_mg[2];
 
+  const Lsm6dsoCoreHealth *health = lsm6dso_core_health();
   const uint64_t now_ms = prv_get_timestamp_ms();
   diagnostics->last_sample_age_ms = prv_compute_age_ms(now_ms, s_last_sample_timestamp_ms);
   diagnostics->last_successful_read_age_ms =
-      prv_compute_age_ms(now_ms, (uint64_t)s_last_successful_read_ms);
+      prv_compute_age_ms(now_ms, (uint64_t)health->last_successful_read_ms);
   diagnostics->last_interrupt_age_ms = prv_compute_age_ms(now_ms, s_last_interrupt_ms);
   diagnostics->last_wake_event_age_ms = prv_compute_age_ms(now_ms, s_last_wake_event_ms);
   diagnostics->last_double_tap_age_ms = prv_compute_age_ms(now_ms, s_last_double_tap_ms);
 
-  diagnostics->i2c_error_count = s_i2c_error_count;
-  diagnostics->consecutive_error_count = s_consecutive_errors;
+  diagnostics->i2c_error_count = health->i2c_error_count;
+  diagnostics->consecutive_error_count = health->consecutive_errors;
   diagnostics->interrupt_count = s_interrupt_count;
   diagnostics->wake_event_count = s_wake_event_count;
   diagnostics->double_tap_event_count = s_double_tap_event_count;
@@ -1231,7 +936,7 @@ void lsm6dso_get_diagnostics(Lsm6dsoDiagnostics *diagnostics) {
   if (s_lsm6dso_running) {
     flags |= LSM6DSO_STATE_FLAG_RUNNING;
   }
-  if (s_sensor_health_ok) {
+  if (health->sensor_health_ok) {
     flags |= LSM6DSO_STATE_FLAG_HEALTH_OK;
   }
   if (s_last_sample_timestamp_ms != 0) {

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.h
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.h
@@ -43,3 +43,14 @@ void lsm6dso_power_down(void);
 
 //! Retrieve a snapshot of sensor diagnostics for telemetry.
 void lsm6dso_get_diagnostics(Lsm6dsoDiagnostics *diagnostics);
+
+//! Board configuration for the LSM6DSO gyroscope (CONFIG_GYRO_LSM6DSO).
+//! Maps board axes (indexed by IMUCoordinateAxis) to hardware axes, mirroring
+//! the accelerometer's axes_offsets/axes_inverts configuration.
+typedef struct {
+  uint8_t axis_map[3];
+  int8_t axis_dir[3];
+} Lsm6dsoGyroConfig;
+
+//! Provided by the board when CONFIG_GYRO_LSM6DSO is enabled.
+extern const Lsm6dsoGyroConfig *const LSM6DSO_GYRO;

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso_core.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso_core.c
@@ -1,0 +1,491 @@
+/* SPDX-FileCopyrightText: 2026 Dave Bortz */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "lsm6dso_core.h"
+
+#include "drivers/accel.h"
+#include "drivers/gyro.h"
+#include "drivers/i2c.h"
+#include "drivers/rtc.h"
+#include "kernel/util/sleep.h"
+#include "system/logging.h"
+#include "util/math.h"
+
+#include <string.h>
+
+PBL_LOG_MODULE_DEFINE(driver_lsm6dso_core, CONFIG_DRIVER_IMU_LOG_LEVEL);
+
+// Maximum FIFO watermark supported by hardware (diff_fifo is 10 bits -> 0..1023)
+#define LSM6DSO_CORE_FIFO_MAX_WATERMARK 1023
+
+#define LSM6DSO_CORE_MAX_CONSECUTIVE_FAILURES 3
+
+static bool s_core_initialized = false;
+
+static Lsm6dsoCoreHealth s_health = {
+  .sensor_health_ok = true,
+};
+
+// Per-half FIFO batching requests
+typedef struct {
+  uint32_t num_samples;
+  uint32_t interval_us;
+} Lsm6dsoFifoRequest;
+
+static Lsm6dsoFifoRequest s_xl_request;
+static Lsm6dsoFifoRequest s_gy_request;
+static bool s_fifo_in_use = false;
+
+static int32_t prv_lsm6dso_read(void *handle, uint8_t reg_addr, uint8_t *buffer,
+                                uint16_t read_size);
+static int32_t prv_lsm6dso_write(void *handle, uint8_t reg_addr, const uint8_t *buffer,
+                                 uint16_t write_size);
+static void prv_lsm6dso_mdelay(uint32_t ms);
+
+stmdev_ctx_t lsm6dso_ctx = {
+    .write_reg = prv_lsm6dso_write,
+    .read_reg = prv_lsm6dso_read,
+    .mdelay = prv_lsm6dso_mdelay,
+};
+
+Lsm6dsoCoreHealth *lsm6dso_core_health(void) { return &s_health; }
+
+uint64_t lsm6dso_core_timestamp_ms(void) {
+  time_t time_s;
+  uint16_t time_ms;
+  rtc_get_time_ms(&time_s, &time_ms);
+  return (((uint64_t)time_s) * 1000 + time_ms);
+}
+
+// HAL context implementations
+
+static int32_t prv_lsm6dso_read(void *handle, uint8_t reg_addr, uint8_t *buffer,
+                                uint16_t read_size) {
+  i2c_use(I2C_LSM6D);
+  bool result = i2c_write_block(I2C_LSM6D, 1, &reg_addr);
+  if (result) result = i2c_read_block(I2C_LSM6D, read_size, buffer);
+  i2c_release(I2C_LSM6D);
+
+  if (!result) {
+    s_health.i2c_error_count++;
+    s_health.consecutive_errors++;
+    PBL_LOG_ERR("LSM6DSO: I2C read failed (reg=0x%02x, count=%lu)",
+            reg_addr, s_health.consecutive_errors);
+    if (s_health.consecutive_errors >= LSM6DSO_CORE_MAX_CONSECUTIVE_FAILURES) {
+      s_health.sensor_health_ok = false;
+      PBL_LOG_ERR("LSM6DSO: Sensor health degraded after %lu failures",
+              s_health.consecutive_errors);
+    }
+    return -1;
+  } else {
+    s_health.consecutive_errors = 0;
+    s_health.last_successful_read_ms = lsm6dso_core_timestamp_ms();
+    s_health.sensor_health_ok = true;
+  }
+
+  return 0;
+}
+
+static int32_t prv_lsm6dso_write(void *handle, uint8_t reg_addr, const uint8_t *buffer,
+                                 uint16_t write_size) {
+  i2c_use(I2C_LSM6D);
+  uint8_t d[write_size + 1];
+  d[0] = reg_addr;
+  memcpy(&d[1], buffer, write_size);
+  bool result = i2c_write_block(I2C_LSM6D, write_size + 1, d);
+  i2c_release(I2C_LSM6D);
+
+  if (!result) {
+    s_health.i2c_error_count++;
+    s_health.consecutive_errors++;
+    PBL_LOG_ERR("LSM6DSO: I2C write failed (reg=0x%02x)", reg_addr);
+    return -1;
+  } else {
+    s_health.consecutive_errors = 0;
+  }
+
+  return 0;
+}
+
+static void prv_lsm6dso_mdelay(uint32_t ms) { psleep(ms); }
+
+// Initialization
+
+bool lsm6dso_core_is_initialized(void) { return s_core_initialized; }
+
+bool lsm6dso_core_init(void) {
+  if (s_core_initialized) {
+    return true;
+  }
+
+  s_health = (Lsm6dsoCoreHealth){
+    .sensor_health_ok = true,
+  };
+
+  // Verify sensor is present and functioning
+  uint8_t whoami;
+  if (lsm6dso_device_id_get(&lsm6dso_ctx, &whoami)) {
+    PBL_LOG_ERR("LSM6DSO: Failed to read WHO_AM_I register");
+    return false;
+  }
+  if (whoami != LSM6DSO_ID) {
+    PBL_LOG_ERR("LSM6DSO: Sensor not detected or malfunctioning (WHO_AM_I=0x%02x, expecting 0x%02x)",
+            whoami, LSM6DSO_ID);
+    return false;
+  }
+
+  PBL_LOG_DBG("LSM6DSO: Sensor detected successfully (WHO_AM_I=0x%02x)", whoami);
+
+  // Reset sensor to known state
+  if (lsm6dso_reset_set(&lsm6dso_ctx, PROPERTY_ENABLE)) {
+    PBL_LOG_ERR("LSM6DSO: Failed to reset sensor");
+    return false;
+  }
+  uint8_t rst;
+  int reset_timeout = 100; // 100ms max wait for reset
+  do {  // Wait for reset to complete with timeout
+    psleep(1);
+    if (lsm6dso_reset_get(&lsm6dso_ctx, &rst) != 0) {
+      PBL_LOG_ERR("LSM6DSO: Failed to read reset status");
+      return false;
+    }
+    reset_timeout--;
+  } while (rst && reset_timeout > 0);
+
+  if (reset_timeout == 0) {
+    PBL_LOG_ERR("LSM6DSO: Reset timeout - sensor may be unresponsive");
+    return false;
+  }
+
+  // Disable I3C interface
+  if (lsm6dso_i3c_disable_set(&lsm6dso_ctx, LSM6DSO_I3C_DISABLE)) {
+    PBL_LOG_ERR("LSM6DSO: Failed to disable I3C interface");
+    return false;
+  }
+
+  // Enable Block Data Update
+  if (lsm6dso_block_data_update_set(&lsm6dso_ctx, PROPERTY_ENABLE)) {
+    PBL_LOG_ERR("LSM6DSO: Failed to enable block data update");
+    return false;
+  }
+
+  // Enable Auto Increment
+  if (lsm6dso_auto_increment_set(&lsm6dso_ctx, PROPERTY_ENABLE)) {
+    PBL_LOG_ERR("LSM6DSO: Failed to enable auto increment");
+    return false;
+  }
+
+  // Set FIFO mode to bypass (will be reconfigured as necessary later)
+  if (lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_BYPASS_MODE)) {
+    PBL_LOG_ERR("LSM6DSO: Failed to set FIFO mode to bypass");
+    return false;
+  }
+
+  // Set default full scales
+  if (lsm6dso_xl_full_scale_set(&lsm6dso_ctx, LSM6DSO_4g)) {
+    PBL_LOG_ERR("LSM6DSO: Failed to set accelerometer full scale");
+    return false;
+  }
+  if (lsm6dso_gy_full_scale_set(&lsm6dso_ctx, LSM6DSO_250dps)) {
+    PBL_LOG_ERR("LSM6DSO: Failed to set gyroscope full scale");
+    return false;
+  }
+
+  // Set output rates to zero (disabling sensors)
+  if (lsm6dso_xl_data_rate_set(&lsm6dso_ctx, LSM6DSO_XL_ODR_OFF)) {
+    PBL_LOG_ERR("LSM6DSO: Failed to set accelerometer ODR");
+    return false;
+  }
+  if (lsm6dso_gy_data_rate_set(&lsm6dso_ctx, LSM6DSO_GY_ODR_OFF)) {
+    PBL_LOG_ERR("LSM6DSO: Failed to set gyroscope ODR");
+    return false;
+  }
+
+  // Use pulsed interrupts so that a missed edge does not suppress subsequent
+  // interrupts (a single interrupt line may be shared by several sources).
+  if (lsm6dso_data_ready_mode_set(&lsm6dso_ctx, LSM6DSO_DRDY_PULSED)) {
+    PBL_LOG_ERR("LSM6DSO: Failed to set data ready mode");
+    return false;
+  }
+  if (lsm6dso_int_notification_set(&lsm6dso_ctx, LSM6DSO_ALL_INT_PULSED)) {
+    PBL_LOG_ERR("LSM6DSO: Failed to configure interrupt notification");
+    return false;
+  }
+
+  s_core_initialized = true;
+  s_health.last_successful_read_ms = lsm6dso_core_timestamp_ms();
+  s_health.consecutive_errors = 0;
+  PBL_LOG_DBG("LSM6DSO: Core initialization complete");
+  return true;
+}
+
+bool lsm6dso_core_reinit(void) {
+  s_core_initialized = false;
+  s_fifo_in_use = false;
+  s_health.sensor_health_ok = false;
+  s_health.consecutive_errors = 0;
+  return lsm6dso_core_init();
+}
+
+// Shared FIFO management
+
+bool lsm6dso_core_fifo_in_use(void) { return s_fifo_in_use; }
+
+// Map a sampling interval to the accelerometer FIFO batching rate enum
+static lsm6dso_bdr_xl_t prv_get_fifo_batch_rate_xl(uint32_t interval_us) {
+  if (interval_us >= 625000) return LSM6DSO_XL_BATCHED_AT_6Hz5;  // lowest supported batching
+  if (interval_us >= 80000) return LSM6DSO_XL_BATCHED_AT_12Hz5;
+  if (interval_us >= 38462) return LSM6DSO_XL_BATCHED_AT_26Hz;
+  if (interval_us >= 19231) return LSM6DSO_XL_BATCHED_AT_52Hz;
+  if (interval_us >= 9615) return LSM6DSO_XL_BATCHED_AT_104Hz;
+  if (interval_us >= 4808) return LSM6DSO_XL_BATCHED_AT_208Hz;
+  if (interval_us >= 2398) return LSM6DSO_XL_BATCHED_AT_417Hz;
+  if (interval_us >= 1200) return LSM6DSO_XL_BATCHED_AT_833Hz;
+  if (interval_us >= 600) return LSM6DSO_XL_BATCHED_AT_1667Hz;
+  if (interval_us >= 300) return LSM6DSO_XL_BATCHED_AT_3333Hz;
+  return LSM6DSO_XL_BATCHED_AT_6667Hz;
+}
+
+// Map a sampling interval to the gyroscope FIFO batching rate enum
+static lsm6dso_bdr_gy_t prv_get_fifo_batch_rate_gy(uint32_t interval_us) {
+  if (interval_us >= 80000) return LSM6DSO_GY_BATCHED_AT_12Hz5;
+  if (interval_us >= 38462) return LSM6DSO_GY_BATCHED_AT_26Hz;
+  if (interval_us >= 19231) return LSM6DSO_GY_BATCHED_AT_52Hz;
+  if (interval_us >= 9615) return LSM6DSO_GY_BATCHED_AT_104Hz;
+  if (interval_us >= 4808) return LSM6DSO_GY_BATCHED_AT_208Hz;
+  if (interval_us >= 2398) return LSM6DSO_GY_BATCHED_AT_417Hz;
+  if (interval_us >= 1200) return LSM6DSO_GY_BATCHED_AT_833Hz;
+  if (interval_us >= 600) return LSM6DSO_GY_BATCHED_AT_1667Hz;
+  if (interval_us >= 300) return LSM6DSO_GY_BATCHED_AT_3333Hz;
+  return LSM6DSO_GY_BATCHED_AT_6667Hz;
+}
+
+static bool prv_request_batching(const Lsm6dsoFifoRequest *req) {
+  return req->num_samples > 1 && req->interval_us > 0;
+}
+
+//! Records per second one side contributes to the FIFO (0 when not batching)
+static uint32_t prv_records_per_second(const Lsm6dsoFifoRequest *req) {
+  if (!prv_request_batching(req)) {
+    return 0;
+  }
+  return (1000000 + req->interval_us - 1) / req->interval_us;
+}
+
+//! Program watermark and batch rates from the current per-half requests.
+//! @param watermark_override when nonzero, use this watermark instead of the
+//!   computed one (used by overflow recovery to back off).
+static void prv_fifo_update(uint16_t watermark_override) {
+  bool xl_batch = prv_request_batching(&s_xl_request);
+  bool gy_batch = prv_request_batching(&s_gy_request);
+
+  if (!xl_batch && !gy_batch) {
+    if (s_fifo_in_use) {
+      // Disable batching & return to bypass
+      lsm6dso_fifo_xl_batch_set(&lsm6dso_ctx, LSM6DSO_XL_NOT_BATCHED);
+      lsm6dso_fifo_gy_batch_set(&lsm6dso_ctx, LSM6DSO_GY_NOT_BATCHED);
+      if (lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_BYPASS_MODE)) {
+        PBL_LOG_ERR("LSM6DSO: Failed to disable FIFO");
+      }
+    }
+    s_fifo_in_use = false;
+    PBL_LOG_DBG("LSM6DSO: FIFO disabled");
+    return;
+  }
+
+  uint16_t watermark;
+  if (watermark_override > 0) {
+    watermark = watermark_override;
+  } else {
+    // The watermark must wake us up before either half's delivery deadline.
+    // Each half wants delivery after num_samples; following the established
+    // pattern we target 50% of that to leave headroom against overflow. With
+    // both halves batching, the FIFO fills at the combined record rate, so
+    // convert the earliest per-half deadline into a record count.
+    uint32_t total_rate = prv_records_per_second(&s_xl_request) +
+                          prv_records_per_second(&s_gy_request);
+    uint64_t deadline_us = UINT64_MAX;
+    if (xl_batch) {
+      uint64_t xl_deadline =
+          ((uint64_t)MAX(s_xl_request.num_samples / 2, 1)) * s_xl_request.interval_us;
+      deadline_us = MIN(deadline_us, xl_deadline);
+    }
+    if (gy_batch) {
+      uint64_t gy_deadline =
+          ((uint64_t)MAX(s_gy_request.num_samples / 2, 1)) * s_gy_request.interval_us;
+      deadline_us = MIN(deadline_us, gy_deadline);
+    }
+    uint64_t watermark64 = (deadline_us * total_rate) / 1000000;
+    if (watermark64 == 0) watermark64 = 1;
+    if (watermark64 > LSM6DSO_CORE_FIFO_MAX_WATERMARK) {
+      watermark64 = LSM6DSO_CORE_FIFO_MAX_WATERMARK;
+    }
+    watermark = (uint16_t)watermark64;
+  }
+
+  PBL_LOG_DBG("LSM6DSO: Setting FIFO watermark to %u (xl=%lu@%luus gy=%lu@%luus)",
+          watermark, s_xl_request.num_samples, s_xl_request.interval_us,
+          s_gy_request.num_samples, s_gy_request.interval_us);
+
+  if (lsm6dso_fifo_watermark_set(&lsm6dso_ctx, watermark)) {
+    PBL_LOG_ERR("LSM6DSO: Failed to set FIFO watermark");
+  }
+
+  if (lsm6dso_fifo_xl_batch_set(&lsm6dso_ctx, xl_batch
+          ? prv_get_fifo_batch_rate_xl(s_xl_request.interval_us)
+          : LSM6DSO_XL_NOT_BATCHED)) {
+    PBL_LOG_ERR("LSM6DSO: Failed to set accel FIFO batch rate");
+  }
+  if (lsm6dso_fifo_gy_batch_set(&lsm6dso_ctx, gy_batch
+          ? prv_get_fifo_batch_rate_gy(s_gy_request.interval_us)
+          : LSM6DSO_GY_NOT_BATCHED)) {
+    PBL_LOG_ERR("LSM6DSO: Failed to set gyro FIFO batch rate");
+  }
+
+  // Always clear and re-enable FIFO to ensure clean state after configuration
+  // changes. This is critical when the watermark changes while the FIFO is
+  // already enabled, as stale samples in the FIFO can prevent new watermark
+  // interrupts from being generated.
+  lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_BYPASS_MODE);
+  psleep(1); // Allow time for FIFO to clear
+
+  // Put FIFO in stream mode so we keep collecting samples and get periodic
+  // watermark interrupts
+  if (lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_STREAM_MODE)) {
+    PBL_LOG_ERR("LSM6DSO: Failed to enable FIFO stream mode");
+  }
+
+  s_fifo_in_use = true;
+}
+
+void lsm6dso_core_fifo_request_xl(uint32_t num_samples, uint32_t interval_us) {
+  s_xl_request = (Lsm6dsoFifoRequest){
+    .num_samples = num_samples,
+    .interval_us = interval_us,
+  };
+  prv_fifo_update(0);
+}
+
+void lsm6dso_core_fifo_request_gy(uint32_t num_samples, uint32_t interval_us) {
+  s_gy_request = (Lsm6dsoFifoRequest){
+    .num_samples = num_samples,
+    .interval_us = interval_us,
+  };
+  prv_fifo_update(0);
+}
+
+void lsm6dso_core_fifo_recover(void) {
+  PBL_LOG_WRN("LSM6DSO: FIFO overflow/full detected, clearing FIFO");
+
+  uint16_t current_watermark = 0;
+  lsm6dso_fifo_watermark_get(&lsm6dso_ctx, &current_watermark);
+
+  // Reset FIFO to bypass mode and wait for it to actually clear
+  lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_BYPASS_MODE);
+  psleep(1);
+
+  // Clear all interrupt sources after FIFO reset to ensure clean state
+  lsm6dso_all_sources_t clear_sources;
+  lsm6dso_all_sources_get(&lsm6dso_ctx, &clear_sources);
+
+  if (s_fifo_in_use) {
+    // Reduce watermark by half to prevent future overflow
+    uint16_t reduced_watermark = current_watermark / 2;
+    if (reduced_watermark == 0) reduced_watermark = 1;
+    prv_fifo_update(reduced_watermark);
+    PBL_LOG_INFO("LSM6DSO: Reduced FIFO watermark from %u to %u to prevent future overflow",
+            current_watermark, reduced_watermark);
+  }
+}
+
+void lsm6dso_core_fifo_drain(void) {
+  uint16_t fifo_level = 0;
+  if (lsm6dso_fifo_data_level_get(&lsm6dso_ctx, &fifo_level) != 0) {
+    PBL_LOG_ERR("LSM6DSO: Failed to read FIFO level");
+    // Reset FIFO on communication error
+    lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_BYPASS_MODE);
+    if (s_fifo_in_use) {
+      lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_STREAM_MODE);
+    }
+    return;
+  }
+  if (fifo_level == 0) {
+    return;  // nothing to do
+  }
+
+  // Prevent infinite loops on stuck FIFO
+  if (fifo_level > LSM6DSO_CORE_FIFO_MAX_WATERMARK) {
+    PBL_LOG_ERR("LSM6DSO: FIFO level too high (%u), resetting", fifo_level);
+    lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_BYPASS_MODE);
+    if (s_fifo_in_use) {
+      lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_STREAM_MODE);
+    }
+    return;
+  }
+
+  const uint64_t now_us = lsm6dso_core_timestamp_ms() * 1000ULL;
+
+  // Records from both sensors are interleaved in the FIFO. For timestamping,
+  // estimate how many records belong to each half from the batch rates, then
+  // assume each half's records are contiguous samples ending now. Timestamps
+  // are documented as approximate.
+  const uint32_t xl_rate = prv_records_per_second(&s_xl_request);
+  const uint32_t gy_rate = prv_records_per_second(&s_gy_request);
+  const uint32_t total_rate = xl_rate + gy_rate;
+  uint32_t xl_expected = 0;
+  uint32_t gy_expected = 0;
+  if (total_rate > 0) {
+    xl_expected = ((uint64_t)fifo_level * xl_rate) / total_rate;
+    gy_expected = fifo_level - xl_expected;
+  }
+  const uint32_t xl_interval_us = s_xl_request.interval_us ?: 1000;  // avoid div by zero
+  const uint32_t gy_interval_us = s_gy_request.interval_us ?: 1000;
+
+  uint32_t xl_seen = 0;
+  uint32_t gy_seen = 0;
+
+  for (uint16_t i = 0; i < fifo_level; ++i) {
+    uint8_t raw_bytes[7];
+    if (lsm6dso_read_reg(&lsm6dso_ctx, LSM6DSO_FIFO_DATA_OUT_TAG, raw_bytes, sizeof(raw_bytes)) != 0) {
+      PBL_LOG_ERR("LSM6DSO: Failed to read FIFO sample (%u/%u)", i, fifo_level);
+      // Reset FIFO on communication error
+      lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_BYPASS_MODE);
+      if (s_fifo_in_use) {
+        lsm6dso_fifo_mode_set(&lsm6dso_ctx, LSM6DSO_STREAM_MODE);
+      }
+      break;
+    }
+
+    lsm6dso_fifo_tag_t tag = raw_bytes[0] >> 3;
+    if (tag == LSM6DSO_XL_NC_TAG || tag == LSM6DSO_XL_NC_T_1_TAG ||
+        tag == LSM6DSO_XL_NC_T_2_TAG || tag == LSM6DSO_XL_2XC_TAG ||
+        tag == LSM6DSO_XL_3XC_TAG) {
+      uint32_t index_from_end = (xl_expected > xl_seen) ? (xl_expected - 1 - xl_seen) : 0;
+      uint64_t timestamp_us = now_us - (index_from_end * (uint64_t)xl_interval_us);
+#if defined(CONFIG_ACCEL_LSM6DSO)
+      lsm6dso_accel_handle_fifo_record(&raw_bytes[1], timestamp_us);
+#else
+      (void)timestamp_us;
+#endif
+      xl_seen++;
+    } else if (tag == LSM6DSO_GYRO_NC_TAG) {
+      uint32_t index_from_end = (gy_expected > gy_seen) ? (gy_expected - 1 - gy_seen) : 0;
+      uint64_t timestamp_us = now_us - (index_from_end * (uint64_t)gy_interval_us);
+#if defined(CONFIG_GYRO_LSM6DSO)
+      lsm6dso_gyro_handle_fifo_record(&raw_bytes[1], timestamp_us);
+#else
+      (void)timestamp_us;
+#endif
+      gy_seen++;
+    }
+    // Other tags (timestamp/config/etc.) are ignored
+  }
+}
+
+void lsm6dso_core_offload_work(Lsm6dsoCoreWorkCallback cb) {
+#if defined(CONFIG_ACCEL_LSM6DSO)
+  accel_offload_work(cb);
+#else
+  gyro_offload_work(cb);
+#endif
+}

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso_core.h
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso_core.h
@@ -1,0 +1,101 @@
+/* SPDX-FileCopyrightText: 2026 Dave Bortz */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "lsm6dso_reg.h"
+
+/*! LSM6DSO shared core
+ *  ===================
+ *
+ * The LSM6DSO is a combined accelerometer + gyroscope. The accelerometer half
+ * is exposed through drivers/accel.h (lsm6dso.c) and the gyroscope half
+ * through drivers/gyro.h (lsm6dso_gyro.c). Either half may be compiled in
+ * independently (CONFIG_ACCEL_LSM6DSO / CONFIG_GYRO_LSM6DSO); this core owns
+ * everything the two halves share: the I2C register interface, one-time chip
+ * initialization, and the single hardware FIFO.
+ */
+
+//! Shared ST HAL context. Defined in lsm6dso_core.c.
+extern stmdev_ctx_t lsm6dso_ctx;
+
+//! I2C/sensor health tracking shared between the two halves.
+typedef struct {
+  uint32_t i2c_error_count;
+  uint32_t consecutive_errors;
+  uint32_t last_successful_read_ms;
+  bool sensor_health_ok;
+} Lsm6dsoCoreHealth;
+
+Lsm6dsoCoreHealth *lsm6dso_core_health(void);
+
+//! One-time chip initialization: WHO_AM_I check, software reset, I3C disable,
+//! block data update, register auto-increment, default full scales, both ODRs
+//! off, pulsed interrupt mode. Idempotent; safe to call from both halves in
+//! any order.
+//! @return true if the chip is initialized
+bool lsm6dso_core_init(void);
+
+//! Force re-initialization (used for watchdog recovery). Both halves must
+//! re-apply their own configuration afterwards.
+bool lsm6dso_core_reinit(void);
+
+bool lsm6dso_core_is_initialized(void);
+
+//! Current time in ms since the epoch (RTC based).
+uint64_t lsm6dso_core_timestamp_ms(void);
+
+// Shared FIFO management
+// ----------------------
+// The chip has a single FIFO. Each half registers its batching needs and the
+// core programs the combined watermark and per-sensor batch rates. Records
+// are dispatched by FIFO tag when draining.
+
+//! Update the accelerometer's batching request. num_samples <= 1 or
+//! interval_us == 0 disables accel batching.
+void lsm6dso_core_fifo_request_xl(uint32_t num_samples, uint32_t interval_us);
+
+//! Update the gyroscope's batching request. num_samples <= 1 or
+//! interval_us == 0 disables gyro batching.
+void lsm6dso_core_fifo_request_gy(uint32_t num_samples, uint32_t interval_us);
+
+//! True when the FIFO is currently in use (either half is batching).
+bool lsm6dso_core_fifo_in_use(void);
+
+//! Drain the FIFO, dispatching each record to the half it belongs to. Must
+//! be called from a thread context with the owning service lock held (see
+//! lsm6dso_core_offload_work).
+void lsm6dso_core_fifo_drain(void);
+
+//! FIFO overflow recovery: clear the FIFO and reprogram it with a reduced
+//! watermark to prevent repeated overflows.
+void lsm6dso_core_fifo_recover(void);
+
+//! Defer work to a thread context with appropriate locking. Routes through
+//! the accel manager's offload mechanism when the accel half is compiled in
+//! (so FIFO drains shared with accel data are serialized with other accel
+//! work), and through the gyro manager's otherwise.
+typedef void (*Lsm6dsoCoreWorkCallback)(void);
+void lsm6dso_core_offload_work(Lsm6dsoCoreWorkCallback cb);
+
+// Per-half hooks, implemented by the respective driver file. Called by the
+// core FIFO drain with the raw 6-byte sample payload and an approximate
+// sample timestamp.
+#if defined(CONFIG_ACCEL_LSM6DSO)
+void lsm6dso_accel_handle_fifo_record(const uint8_t data[6], uint64_t timestamp_us);
+//! Re-evaluate the accelerometer power mode. Called by the gyro half when the
+//! gyro turns on or off: the accel must not use ultra-low-power mode while
+//! the gyro is active (datasheet section 6.2.1).
+void lsm6dso_accel_gyro_state_changed(void);
+#endif
+#if defined(CONFIG_GYRO_LSM6DSO)
+void lsm6dso_gyro_handle_fifo_record(const uint8_t data[6], uint64_t timestamp_us);
+//! True when the gyroscope is currently powered on.
+bool lsm6dso_gyro_is_active(void);
+//! Called after a forced core re-initialization (chip reset) so the gyro half
+//! can re-apply its configuration.
+void lsm6dso_gyro_handle_core_reinit(void);
+#endif

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso_gyro.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso_gyro.c
@@ -1,0 +1,327 @@
+/* SPDX-FileCopyrightText: 2026 Dave Bortz */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "drivers/gyro.h"
+
+#include "pbl/services/new_timer/new_timer.h"
+#include "system/logging.h"
+#include "util/math.h"
+#include "lsm6dso_reg.h"
+
+#include "lsm6dso.h"
+#include "lsm6dso_core.h"
+
+PBL_LOG_MODULE_DEFINE(driver_gyro_lsm6dso, CONFIG_DRIVER_IMU_LOG_LEVEL);
+
+/*
+ * Gyroscope half of the LSM6DSO driver (drivers/gyro.h implementation).
+ *
+ * Sample collection is FIFO-batched and timer-polled: not all boards route
+ * the LSM6DSO interrupt pins (on obelix only the LIS2DW12 interrupt is
+ * wired), so a periodic timer drains the FIFO at the requested batching
+ * cadence. On boards where the accel half is also compiled in and
+ * interrupt-driven (asterix), gyro records are additionally delivered
+ * whenever the accel's FIFO watermark interrupt drains the shared FIFO.
+ *
+ * Power: the gyroscope is left powered down (LSM6DSO_GY_ODR_OFF, ~3 uA for
+ * the whole chip if the accel is also off) unless samples have been
+ * requested. The gyroscope needs ~70 ms plus 2-3 samples to produce valid
+ * data after power-on (AN5192 section 3.11); samples taken during that
+ * window are discarded here in the driver.
+ */
+
+// Settling time after gyro power-on before samples are valid
+#define LSM6DSO_GYRO_TURN_ON_MS 70
+#define LSM6DSO_GYRO_DISCARD_SAMPLES 3
+
+// Minimum poll period; bounds timer load when a client requests per-sample
+// delivery, which cannot be honored faster than this without an interrupt.
+#define LSM6DSO_GYRO_MIN_POLL_MS 10
+
+// Default sampling interval if samples are requested without a rate (~104 Hz)
+#define LSM6DSO_GYRO_DEFAULT_INTERVAL_US 9615
+
+static void prv_gyro_chase_target_state(void);
+
+typedef struct {
+  uint32_t sampling_interval_us;
+  uint32_t num_samples;
+} lsm6dso_gyro_state_t;
+
+static lsm6dso_gyro_state_t s_gyro_state;
+static lsm6dso_gyro_state_t s_gyro_state_target;
+static bool s_gyro_enabled = true;
+static bool s_gyro_running = false;
+
+static TimerID s_gyro_poll_timer = TIMER_INVALID_ID;
+static uint32_t s_gyro_poll_period_ms = 0;
+
+// Samples with timestamps earlier than this are still settling and dropped
+static uint64_t s_gyro_valid_after_ms = 0;
+
+static GyroDriverSample s_gyro_last_sample;
+
+typedef struct {
+  lsm6dso_odr_g_t odr;
+  lsm6dso_g_hm_mode_t power_mode;
+  uint32_t interval_us;
+} odr_g_interval_t;
+
+static odr_g_interval_t prv_get_gyro_odr_for_interval(uint32_t interval_us) {
+  // The gyroscope's slowest ODR is 12.5 Hz. High-performance mode is only
+  // required above 208 Hz; below that the chip selects low-power or normal
+  // mode automatically when high-performance is disabled.
+  if (interval_us >= 80000) return (odr_g_interval_t){LSM6DSO_GY_ODR_12Hz5, LSM6DSO_GY_NORMAL, 80000};
+  if (interval_us >= 38462) return (odr_g_interval_t){LSM6DSO_GY_ODR_26Hz, LSM6DSO_GY_NORMAL, 38462};
+  if (interval_us >= 19231) return (odr_g_interval_t){LSM6DSO_GY_ODR_52Hz, LSM6DSO_GY_NORMAL, 19231};
+  if (interval_us >= 9615) return (odr_g_interval_t){LSM6DSO_GY_ODR_104Hz, LSM6DSO_GY_NORMAL, 9615};
+  if (interval_us >= 4808) return (odr_g_interval_t){LSM6DSO_GY_ODR_208Hz, LSM6DSO_GY_NORMAL, 4808};
+  if (interval_us >= 2398) return (odr_g_interval_t){LSM6DSO_GY_ODR_417Hz, LSM6DSO_GY_HIGH_PERFORMANCE, 2398};
+  if (interval_us >= 1200) return (odr_g_interval_t){LSM6DSO_GY_ODR_833Hz, LSM6DSO_GY_HIGH_PERFORMANCE, 1200};
+  if (interval_us >= 600) return (odr_g_interval_t){LSM6DSO_GY_ODR_1667Hz, LSM6DSO_GY_HIGH_PERFORMANCE, 600};
+  if (interval_us >= 300) return (odr_g_interval_t){LSM6DSO_GY_ODR_3333Hz, LSM6DSO_GY_HIGH_PERFORMANCE, 300};
+  return (odr_g_interval_t){LSM6DSO_GY_ODR_6667Hz, LSM6DSO_GY_HIGH_PERFORMANCE, 150};
+}
+
+//! Convert a raw axis vector to millidegrees per second on a board axis.
+//! At the fixed 250 dps full scale the sensitivity is 8.75 mdps/LSB (35/4).
+static int32_t prv_get_axis_projection_mdps(int axis, const int16_t *raw_vector) {
+  const Lsm6dsoGyroConfig *cfg = LSM6DSO_GYRO;
+  int32_t raw = raw_vector[cfg->axis_map[axis]] * (int32_t)cfg->axis_dir[axis];
+  return (raw * 35) / 4;
+}
+
+static void prv_notify_accel_gyro_state_changed(void) {
+#if defined(CONFIG_ACCEL_LSM6DSO)
+  lsm6dso_accel_gyro_state_changed();
+#endif
+}
+
+static void prv_deliver_sample(const int16_t raw[3], uint64_t timestamp_us) {
+  if (timestamp_us / 1000 < s_gyro_valid_after_ms) {
+    return;  // still settling after power-on
+  }
+
+  GyroDriverSample sample = {
+    .timestamp_us = timestamp_us,
+    .x = prv_get_axis_projection_mdps(0, raw),
+    .y = prv_get_axis_projection_mdps(1, raw),
+    .z = prv_get_axis_projection_mdps(2, raw),
+  };
+  s_gyro_last_sample = sample;
+
+  if (s_gyro_state.num_samples > 0) {
+    gyro_cb_new_sample(&sample);
+  }
+}
+
+void lsm6dso_gyro_handle_fifo_record(const uint8_t data[6], uint64_t timestamp_us) {
+  if (!s_gyro_running) {
+    return;
+  }
+
+  int16_t raw[3];
+  raw[0] = (int16_t)((data[1] << 8) | data[0]);
+  raw[1] = (int16_t)((data[3] << 8) | data[2]);
+  raw[2] = (int16_t)((data[5] << 8) | data[4]);
+  prv_deliver_sample(raw, timestamp_us);
+}
+
+bool lsm6dso_gyro_is_active(void) { return s_gyro_running; }
+
+void lsm6dso_gyro_handle_core_reinit(void) {
+  // The chip was reset; clear achieved state so the chase re-applies
+  // everything the target state still asks for
+  s_gyro_running = false;
+  s_gyro_state = (lsm6dso_gyro_state_t){0};
+  prv_gyro_chase_target_state();
+}
+
+static int prv_read_sample(GyroDriverSample *data) {
+  if (!lsm6dso_core_is_initialized() || !s_gyro_running) {
+    return -1;
+  }
+
+  int16_t raw[3];
+  if (lsm6dso_angular_rate_raw_get(&lsm6dso_ctx, raw) != 0) {
+    PBL_LOG_ERR("LSM6DSO: Failed to read gyroscope data");
+    return -1;
+  }
+
+  data->timestamp_us = lsm6dso_core_timestamp_ms() * 1000ULL;
+  data->x = prv_get_axis_projection_mdps(0, raw);
+  data->y = prv_get_axis_projection_mdps(1, raw);
+  data->z = prv_get_axis_projection_mdps(2, raw);
+  return 0;
+}
+
+static void prv_gyro_poll_work(void) {
+  if (!s_gyro_running || s_gyro_state.num_samples == 0) {
+    return;
+  }
+
+  if (s_gyro_state.num_samples > 1 && lsm6dso_core_fifo_in_use()) {
+    lsm6dso_core_fifo_drain();
+    return;
+  }
+
+  // Per-sample delivery (no FIFO): poll the output registers directly
+  int16_t raw[3];
+  if (lsm6dso_angular_rate_raw_get(&lsm6dso_ctx, raw) != 0) {
+    PBL_LOG_ERR("LSM6DSO: Failed to read gyroscope data");
+    return;
+  }
+  prv_deliver_sample(raw, lsm6dso_core_timestamp_ms() * 1000ULL);
+}
+
+static void prv_gyro_poll_timer_cb(void *data) {
+  lsm6dso_core_offload_work(prv_gyro_poll_work);
+}
+
+static void prv_gyro_update_poll_timer(void) {
+  uint32_t period_ms = 0;
+
+  if (s_gyro_running && s_gyro_state.num_samples > 0) {
+    if (s_gyro_state.num_samples > 1) {
+      // Drain at the FIFO watermark cadence: half the requested batch size
+      period_ms = (MAX(s_gyro_state.num_samples / 2, 1) *
+                   (uint64_t)s_gyro_state.sampling_interval_us) / 1000;
+    } else {
+      period_ms = s_gyro_state.sampling_interval_us / 1000;
+    }
+    period_ms = MAX(period_ms, LSM6DSO_GYRO_MIN_POLL_MS);
+  }
+
+  if (period_ms == s_gyro_poll_period_ms) {
+    return;
+  }
+  s_gyro_poll_period_ms = period_ms;
+
+  if (s_gyro_poll_timer == TIMER_INVALID_ID) {
+    s_gyro_poll_timer = new_timer_create();
+  }
+
+  if (period_ms == 0) {
+    new_timer_stop(s_gyro_poll_timer);
+    return;
+  }
+
+  new_timer_start(s_gyro_poll_timer, period_ms, prv_gyro_poll_timer_cb, NULL,
+                  TIMER_START_FLAG_REPEATING);
+}
+
+static void prv_gyro_chase_target_state(void) {
+  if (!lsm6dso_core_is_initialized()) {
+    PBL_LOG_ERR("LSM6DSO: Cannot chase gyro target state before initialization");
+    return;
+  }
+
+  bool should_be_running = s_gyro_state_target.sampling_interval_us > 0 ||
+                           s_gyro_state_target.num_samples > 0;
+
+  if (!should_be_running || !s_gyro_enabled) {
+    if (s_gyro_running) {
+      PBL_LOG_DBG("LSM6DSO: Stopping gyroscope");
+      lsm6dso_gy_data_rate_set(&lsm6dso_ctx, LSM6DSO_GY_ODR_OFF);
+      s_gyro_running = false;
+      s_gyro_state = (lsm6dso_gyro_state_t){0};
+      lsm6dso_core_fifo_request_gy(0, 0);
+      prv_gyro_update_poll_timer();
+      // The accel may return to ultra-low-power mode now
+      prv_notify_accel_gyro_state_changed();
+    }
+    return;
+  }
+
+  bool starting = !s_gyro_running;
+
+  uint32_t requested_interval = s_gyro_state_target.sampling_interval_us;
+  if (requested_interval == 0) {
+    requested_interval = LSM6DSO_GYRO_DEFAULT_INTERVAL_US;
+  }
+  odr_g_interval_t odr_interval = prv_get_gyro_odr_for_interval(requested_interval);
+
+  bool interval_changed = starting ||
+      odr_interval.interval_us != s_gyro_state.sampling_interval_us;
+
+  if (interval_changed) {
+    if (lsm6dso_gy_power_mode_set(&lsm6dso_ctx, odr_interval.power_mode) != 0) {
+      PBL_LOG_ERR("LSM6DSO: Failed to set gyroscope power mode");
+      return;
+    }
+    if (lsm6dso_gy_data_rate_set(&lsm6dso_ctx, odr_interval.odr) != 0) {
+      PBL_LOG_ERR("LSM6DSO: Failed to set gyroscope ODR");
+      return;
+    }
+    s_gyro_state.sampling_interval_us = odr_interval.interval_us;
+
+    if (starting) {
+      // Discard samples until the gyro has settled (AN5192 section 3.11)
+      uint32_t settle_ms = LSM6DSO_GYRO_TURN_ON_MS +
+          (LSM6DSO_GYRO_DISCARD_SAMPLES * odr_interval.interval_us) / 1000;
+      s_gyro_valid_after_ms = lsm6dso_core_timestamp_ms() + settle_ms;
+    }
+  }
+
+  if (starting) {
+    s_gyro_running = true;
+    PBL_LOG_DBG("LSM6DSO: Starting gyroscope (interval=%lu us)",
+            s_gyro_state.sampling_interval_us);
+  }
+
+  if (interval_changed || s_gyro_state_target.num_samples != s_gyro_state.num_samples) {
+    s_gyro_state.num_samples = s_gyro_state_target.num_samples;
+    lsm6dso_core_fifo_request_gy(
+        s_gyro_state.num_samples > 1 ? s_gyro_state.num_samples : 0,
+        s_gyro_state.sampling_interval_us);
+  }
+
+  prv_gyro_update_poll_timer();
+
+  if (starting) {
+    // The accel must leave ultra-low-power mode while the gyro is active
+    // (datasheet section 6.2.1)
+    prv_notify_accel_gyro_state_changed();
+  }
+
+  PBL_LOG_DBG("LSM6DSO: Reached gyro target state: sampling_interval_us=%lu, num_samples=%lu",
+          s_gyro_state.sampling_interval_us, s_gyro_state.num_samples);
+}
+
+// gyro.h implementation
+
+void gyro_init(void) {
+  // Initialize the chip (idempotent; the accel half may have done it already
+  // on boards where both halves are present). The gyro is left powered down.
+  if (!lsm6dso_core_init()) {
+    PBL_LOG_ERR("LSM6DSO: Gyro init failed; core initialization unsuccessful");
+  }
+}
+
+void gyro_power_up(void) {
+  s_gyro_enabled = true;
+  prv_gyro_chase_target_state();
+}
+
+void gyro_power_down(void) {
+  PBL_LOG_DBG("LSM6DSO: Powering down gyroscope");
+  s_gyro_enabled = false;
+  prv_gyro_chase_target_state();
+}
+
+uint32_t gyro_set_sampling_interval(uint32_t interval_us) {
+  PBL_LOG_DBG("LSM6DSO: Requesting update of gyro sampling interval to %lu us", interval_us);
+  s_gyro_state_target.sampling_interval_us = interval_us;
+  prv_gyro_chase_target_state();
+  return s_gyro_state.sampling_interval_us;
+}
+
+uint32_t gyro_get_sampling_interval(void) { return s_gyro_state.sampling_interval_us; }
+
+void gyro_set_num_samples(uint32_t num_samples) {
+  PBL_LOG_DBG("LSM6DSO: Setting gyro number of samples to %lu", num_samples);
+  s_gyro_state_target.num_samples = num_samples;
+  prv_gyro_chase_target_state();
+}
+
+int gyro_peek(GyroDriverSample *data) { return prv_read_sample(data); }

--- a/src/fw/drivers/imu/wscript_build
+++ b/src/fw/drivers/imu/wscript_build
@@ -23,6 +23,33 @@ if accel_sources:
     )
     bld.env.DRIVERS.append('driver_accel')
 
+# Gyroscope
+
+gyro_sources = []
+gyro_use = ['fw_includes', 'pbl_includes']
+
+if bld.env.CONFIG_GYRO_LSM6DSO:
+    gyro_sources.append('lsm6dso/lsm6dso_gyro.c')
+    gyro_use.append('hal_lsm6dso')
+
+if gyro_sources:
+    bld.objects(
+        name='driver_gyro',
+        source=gyro_sources,
+        use=gyro_use,
+    )
+    bld.env.DRIVERS.append('driver_gyro')
+
+# LSM6DSO shared core (the accelerometer and gyroscope halves share one chip)
+
+if bld.env.CONFIG_ACCEL_LSM6DSO or bld.env.CONFIG_GYRO_LSM6DSO:
+    bld.objects(
+        name='driver_lsm6dso_core',
+        source=['lsm6dso/lsm6dso_core.c'],
+        use=['fw_includes', 'pbl_includes', 'hal_lsm6dso'],
+    )
+    bld.env.DRIVERS.append('driver_lsm6dso_core')
+
 # Magnetometer
 
 mag_sources = []

--- a/src/fw/main.c
+++ b/src/fw/main.c
@@ -24,6 +24,7 @@
 #include "drivers/battery.h"
 #include "drivers/display/display.h"
 #include "drivers/gpio.h"
+#include "drivers/gyro.h"
 #include "drivers/hrm.h"
 #include "drivers/mag.h"
 #include "drivers/mic.h"
@@ -259,6 +260,9 @@ static void init_drivers(void) {
 #endif
 
   accel_init();
+#ifdef CONFIG_GYRO
+  gyro_init();
+#endif
 #ifdef CONFIG_MAG
   mag_init();
 #endif

--- a/third_party/wscript_build
+++ b/third_party/wscript_build
@@ -17,7 +17,7 @@ if bld.env.CONFIG_HAL_SIFLI:
 if bld.env.CONFIG_BT_FW_NIMBLE:
     bld.recurse('nimble')
 
-if bld.env.CONFIG_BOARD_FAMILY_ASTERIX:
+if bld.env.CONFIG_ACCEL_LSM6DSO or bld.env.CONFIG_GYRO_LSM6DSO:
     bld.recurse('hal_lsm6dso')
 
 bld.recurse('memfault')


### PR DESCRIPTION
Splitting the original combined PR into smaller, layered PRs as requested (#1510 has the full context/RFC). This is the **first** of three:

1. **this PR** — the LSM6DSO gyroscope driver
2. *(next)* `gyro_manager` service + board enablement
3. *(after that)* applib `gyro_service` + SDK export (`PBL_GYRO`)

I'll open each subsequent PR once the previous lands.

## What this PR does

- Refactors the LSM6DSO chip management (init, I2C, the shared hardware FIFO) out of the accelerometer driver into a small `lsm6dso_core`, so the accel and gyro halves can be compiled independently (`CONFIG_ACCEL_LSM6DSO` / `CONFIG_GYRO_LSM6DSO`). FIFO records from the two sensors are interleaved and dispatched by tag.
- Adds the `drivers/gyro.h` interface and its LSM6DSO implementation (`lsm6dso_gyro.c`). The gyro is FIFO-batched and timer-polled (not all boards route an LSM6DSO interrupt pin) and stays powered down until samples are requested.
- Resolves the existing ULP-mode TODO in `lsm6dso.c`: the accelerometer now leaves ultra-low-power mode while the gyro is active (datasheet §6.2.1).

## On building / coverage

The driver isn't enabled on any board here — the service that consumes it (and the board enablement that links the two) is the next PR, so they can be reviewed separately as you asked. Concretely:

- The **`lsm6dso_core` refactor is exercised in CI** via the existing accelerometer on `asterix` (no behavior change).
- **`lsm6dso_gyro.c` and the gyro-specific `#if CONFIG_GYRO_LSM6DSO` paths compile once the service PR enables a board** — this is the usual driver-then-enable split. I've verified the full 3-PR series builds clean on `obelix` and `asterix`.

If you'd rather have the driver and service land together (so every line is exercised in this PR's own CI), I'm happy to combine those two — just say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
