### PR TITLE
ble: simultaneous dual-phone connections with full ANCS and PPoGATT support

### DIFF
--- a/include/pbl/services/bluetooth/bluetooth_persistent_storage.h
+++ b/include/pbl/services/bluetooth/bluetooth_persistent_storage.h
@@ -65,10 +65,12 @@ bool bt_persistent_storage_get_ble_pairing_by_addr(const BTDeviceInternal *devic
                                                    SMIdentityResolvingKey *IRK_out,
                                                    char name_out[BT_DEVICE_NAME_BUFFER_SIZE]);
 
-//! Returns the first ANCS supported bonding that is found
-//! The case of having multiple supported ANCS bondings isn't handled well yet.
-//! When this happens this could easily be changed to a for_each_ancs_supported_bonding(cb)
+//! Returns the first ANCS supported bonding that is found.
 BTBondingID bt_persistent_storage_get_ble_ancs_bonding(void);
+
+//! Collects all BLE ANCS bondings into @p out, up to @p max_count entries.
+//! @return number of bondings written into @p out.
+int bt_persistent_storage_get_all_ble_ancs_bondings(BTBondingID *out, int max_count);
 
 //! Returns true if the bondings is BLE and supports ANCS
 bool bt_persistent_storage_is_ble_ancs_bonding(BTBondingID bonding);

--- a/src/fw/comm/ble/gap_le_advert.c
+++ b/src/fw/comm/ble/gap_le_advert.c
@@ -3,6 +3,7 @@
 
 #include "gap_le_advert.h"
 #include "gap_le_connect.h"
+#include "kernel_le_client/multi_phone.h"
 
 #include <bluetooth/bt_driver_advert.h>
 #include <bluetooth/init.h>
@@ -97,7 +98,7 @@ static RegularTimerInfo s_cycle_regular_timer;
 
 static bool s_is_advertising;
 
-static bool s_is_connected;
+static uint8_t s_slave_connection_count;
 
 //! Cache of the last advertising transmission power in dBm. A cache is kept in
 //! case the API call fails, for example because Bluetooth is disabled.
@@ -254,8 +255,8 @@ static void prv_cycle_timer_callback(void *unused) {
       goto unlock;
     }
 
-    if (s_is_connected) {
-      // Don't do anything if connected
+    if (s_slave_connection_count >= MAX_PHONE_CONNECTIONS) {
+      // All slots full; don't cycle ads
       goto unlock;
     }
 
@@ -589,7 +590,11 @@ void gap_le_advert_handle_connect_as_slave(void) {
     s_is_advertising = false;
     prv_analytics_stop_timers();
 
-    s_is_connected = true;
+    s_slave_connection_count++;
+    if (s_slave_connection_count < MAX_PHONE_CONNECTIONS) {
+      // Still have free slots; resume advertising so the next phone can connect.
+      prv_perform_next_job(true /* force refresh */);
+    }
   }
 unlock:
   bt_unlock();
@@ -603,7 +608,7 @@ void gap_le_advert_handle_disconnect_as_slave(void) {
       goto unlock;
     }
 
-    s_is_connected = false;
+    if (s_slave_connection_count > 0) s_slave_connection_count--;
 
     // Call prv_perform_next_job() to trigger refreshing the configuration of
     // the controller: it can advertise connectable packets again.
@@ -627,7 +632,7 @@ void bt_driver_handle_host_resynced(void) {
     s_current_ad_data = NULL;
     s_is_advertising = false;
 
-    if (s_current && !s_is_connected) {
+    if (s_current && s_slave_connection_count < MAX_PHONE_CONNECTIONS) {
       prv_perform_next_job(true /* force refresh */);
     }
   }

--- a/src/fw/comm/ble/gap_le_connect.c
+++ b/src/fw/comm/ble/gap_le_connect.c
@@ -3,6 +3,7 @@
 
 #include "gap_le_connect.h"
 
+#include "kernel_le_client/multi_phone.h"
 #include "comm/bluetooth_analytics.h"
 #include "comm/bt_conn_mgr.h"
 #include "comm/bt_lock.h"
@@ -132,8 +133,8 @@ static GAPLEConnectionIntent * s_intents;
 //! True if there is a pending LE Create Connection call, false if not.
 static bool s_has_pending_create_connection;
 
-//! True if the device is currently connected as LE Slave (4.0)
-static bool s_is_connected_as_slave;
+//! Number of active slave connections (0..MAX_PHONE_CONNECTIONS).
+static uint8_t s_slave_connection_count;
 
 //! TODO: Implement role-switching (PBL-20368)
 //! This is just a placeholder / stop-gap for now that is always set to GAPLERoleSlave, so that we
@@ -385,7 +386,7 @@ void bt_driver_handle_le_connection_complete_event(const BleConnectionCompleteEv
       const bool local_is_master = event->is_master;
 
       if (!local_is_master) {
-        s_is_connected_as_slave = true;
+        s_slave_connection_count++;
         gap_le_advert_handle_connect_as_slave();
 
         prv_put_legacy_connection_event(&event->peer_address, true /* connected */);
@@ -511,7 +512,7 @@ void bt_driver_handle_le_disconnection_complete_event(const BleDisconnectionComp
           event->reason, &connection->remote_version_info);
 
       if (!local_is_master) {
-        s_is_connected_as_slave = false;
+        if (s_slave_connection_count > 0) s_slave_connection_count--;
         gap_le_advert_handle_disconnect_as_slave();
 
         prv_put_legacy_connection_event(&event->peer_address, false /* disconnected */);
@@ -1148,7 +1149,7 @@ bool gap_le_connect_is_connected_as_slave(void) {
   bool connected;
   bt_lock();
   {
-    connected = s_is_connected_as_slave;
+    connected = (s_slave_connection_count >= MAX_PHONE_CONNECTIONS);
   }
   bt_unlock();
   return connected;
@@ -1188,12 +1189,12 @@ void gap_le_connect_deinit(void) {
       intent = next;
     }
 
-    if (s_is_connected_as_slave) {
-      // The BT controller will not send an etLE_Disconnection_Complete event
+    while (s_slave_connection_count > 0) {
+      // The BT controller will not send an LE_Disconnection_Complete event
       // when going to airplane mode while being connected.
       // Stop analytics stopwatches manually:
       bluetooth_analytics_handle_disconnect(false);
-      s_is_connected_as_slave = false;
+      s_slave_connection_count--;
     }
   }
   bt_unlock();

--- a/src/fw/comm/ble/kernel_le_client/ancs/ancs.c
+++ b/src/fw/comm/ble/kernel_le_client/ancs/ancs.c
@@ -114,6 +114,65 @@ typedef struct ANCSClient {
 static ANCSClient *s_ancs_clients[MAX_PHONE_CONNECTIONS];
 static ANCSClient *s_ancs_client;
 
+// UID-to-slot map: routes notification actions to the correct phone.
+// ANCS UIDs are only unique per-connection; without this a dismiss on one
+// phone would accidentally fire on the other if both share the same UID.
+#define ANCS_UID_SLOT_MAP_SIZE 32
+
+typedef struct {
+  uint32_t uid;
+  PhoneSlot slot;
+  bool valid;
+} UIDSlotEntry;
+
+static UIDSlotEntry s_uid_slot_map[ANCS_UID_SLOT_MAP_SIZE];
+
+static void prv_uid_slot_record(uint32_t uid, PhoneSlot slot) {
+  int free_idx = -1;
+  for (int i = 0; i < ANCS_UID_SLOT_MAP_SIZE; i++) {
+    if (s_uid_slot_map[i].valid && s_uid_slot_map[i].uid == uid) {
+      s_uid_slot_map[i].slot = slot;
+      return;
+    }
+    if (!s_uid_slot_map[i].valid && free_idx < 0) {
+      free_idx = i;
+    }
+  }
+  if (free_idx >= 0) {
+    s_uid_slot_map[free_idx] = (UIDSlotEntry){ .uid = uid, .slot = slot, .valid = true };
+  } else {
+    // Table full: evict entry 0 (oldest by position)
+    s_uid_slot_map[0] = (UIDSlotEntry){ .uid = uid, .slot = slot, .valid = true };
+  }
+}
+
+static void prv_uid_slot_forget(uint32_t uid) {
+  for (int i = 0; i < ANCS_UID_SLOT_MAP_SIZE; i++) {
+    if (s_uid_slot_map[i].valid && s_uid_slot_map[i].uid == uid) {
+      s_uid_slot_map[i].valid = false;
+      return;
+    }
+  }
+}
+
+static void prv_uid_slot_clear_slot(PhoneSlot slot) {
+  for (int i = 0; i < ANCS_UID_SLOT_MAP_SIZE; i++) {
+    if (s_uid_slot_map[i].valid && s_uid_slot_map[i].slot == slot) {
+      s_uid_slot_map[i].valid = false;
+    }
+  }
+}
+
+static bool prv_uid_slot_lookup(uint32_t uid, PhoneSlot *slot_out) {
+  for (int i = 0; i < ANCS_UID_SLOT_MAP_SIZE; i++) {
+    if (s_uid_slot_map[i].valid && s_uid_slot_map[i].uid == uid) {
+      *slot_out = s_uid_slot_map[i].slot;
+      return true;
+    }
+  }
+  return false;
+}
+
 static PhoneSlot prv_slot_for_characteristic(BLECharacteristic c) {
   for (PhoneSlot slot = 0; slot < MAX_PHONE_CONNECTIONS; slot++) {
     ANCSClient *client = s_ancs_clients[slot];
@@ -991,16 +1050,19 @@ static void prv_handle_ns_notification(uint32_t length, const uint8_t *notificat
         PBL_LOG_DBG("Ignoring notification because we just connected and PreExisting");
       } else {
         PBL_LOG_DBG("Added ANCS notification!");
+        prv_uid_slot_record(nsnotification->uid, s_ancs_client->slot);
         prv_notif_queue_push_attr_request(nsnotification->uid, properties);
       }
 
       break;
     case EventIDNotificationModified:
       PBL_LOG_DBG("Modified ANCS notification!");
+      prv_uid_slot_record(nsnotification->uid, s_ancs_client->slot);
       prv_notif_queue_push_attr_request(nsnotification->uid, properties);
       break;
     case EventIDNotificationRemoved:
       PBL_LOG_DBG("Removed ANCS notification");
+      prv_uid_slot_forget(nsnotification->uid);
       ancs_notifications_handle_notification_removed(nsnotification->uid, properties);
       break;
   }
@@ -1118,17 +1180,20 @@ static void prv_perform_action(uint32_t notification_uid, ActionId action_id) {
 }
 
 static void prv_serialize_action(const PerformNotificationActionMsg *action_msg) {
-  bool any_client = false;
-  for (PhoneSlot slot = 0; slot < MAX_PHONE_CONNECTIONS; slot++) {
-    if (s_ancs_clients[slot]) {
-      s_ancs_client = s_ancs_clients[slot];
-      any_client = true;
-      prv_notif_queue_push_action(action_msg->notification_uid, action_msg->action_id);
+  PhoneSlot slot = PHONE_SLOT_INVALID;
+  if (!prv_uid_slot_lookup(action_msg->notification_uid, &slot) ||
+      !s_ancs_clients[slot]) {
+    // UID not in map or that slot disconnected; fall back to first active slot
+    for (PhoneSlot s = 0; s < MAX_PHONE_CONNECTIONS; s++) {
+      if (s_ancs_clients[s]) { slot = s; break; }
     }
   }
-  if (!any_client) {
-    PBL_LOG_ERR("No ANCS client");
+  if (slot == PHONE_SLOT_INVALID || !s_ancs_clients[slot]) {
+    PBL_LOG_ERR("No ANCS client for action uid=%"PRIu32, action_msg->notification_uid);
+    return;
   }
+  s_ancs_client = s_ancs_clients[slot];
+  prv_notif_queue_push_action(action_msg->notification_uid, action_msg->action_id);
 }
 
 void prv_serialize_action_launcher_task_cb(void *data) {
@@ -1191,6 +1256,7 @@ void ancs_destroy(PhoneSlot slot) {
     ancs_app_name_storage_deinit();
   }
   prv_reset_and_flush();
+  prv_uid_slot_clear_slot(slot);
   kernel_free(s_ancs_client);
   s_ancs_clients[slot] = NULL;
   s_ancs_client = NULL;

--- a/src/fw/comm/ble/kernel_le_client/ancs/ancs.c
+++ b/src/fw/comm/ble/kernel_le_client/ancs/ancs.c
@@ -2,6 +2,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include "ancs.h"
+#include "comm/ble/kernel_le_client/multi_phone.h"
 #include "ancs_app_name_storage.h"
 #include "ancs_types.h"
 #include "ancs_util.h"
@@ -94,6 +95,9 @@ typedef struct {
 } NotificationQueueNode;
 
 typedef struct ANCSClient {
+  PhoneSlot slot;
+  bool just_connected;
+  RegularTimerInfo notification_connection_delay_timer;
   ANCSClientState state;
   BLECharacteristic characteristics[NumANCSCharacteristic];
   RegularTimerInfo is_alive_timer;
@@ -107,7 +111,19 @@ typedef struct ANCSClient {
   uint8_t alive_checks_without_ns;
 } ANCSClient;
 
+static ANCSClient *s_ancs_clients[MAX_PHONE_CONNECTIONS];
 static ANCSClient *s_ancs_client;
+
+static PhoneSlot prv_slot_for_characteristic(BLECharacteristic c) {
+  for (PhoneSlot slot = 0; slot < MAX_PHONE_CONNECTIONS; slot++) {
+    ANCSClient *client = s_ancs_clients[slot];
+    if (!client) continue;
+    for (int i = 0; i < NumANCSCharacteristic; i++) {
+      if (client->characteristics[i] == c) return slot;
+    }
+  }
+  return PHONE_SLOT_INVALID;
+}
 
 // -----------------------------------------------------------------------------
 // State Machine
@@ -275,7 +291,9 @@ static void prv_reset_and_idle(void) {
   prv_reset_reassembly_context();
 }
 
-static void prv_reset_and_retry(void *unused) {
+static void prv_reset_and_retry(void *data) {
+  PhoneSlot slot = (PhoneSlot)(uintptr_t)data;
+  s_ancs_client = s_ancs_clients[slot];
   if (s_ancs_client == NULL) {
     return;
   }
@@ -326,6 +344,7 @@ static void prv_is_ancs_alive_response_timeout(void *data);
 static void prv_ancs_is_alive_schedule_next_check(void) {
   s_ancs_client->is_alive_timer = (const RegularTimerInfo) {
     .cb = prv_is_ancs_alive_cb,
+    .cb_data = (void *)(uintptr_t)s_ancs_client->slot,
   };
   regular_timer_add_multiminute_callback(&s_ancs_client->is_alive_timer,
                                          ANCS_IS_ALIVE_NEXT_CHECK_TIME_MINUTES);
@@ -334,6 +353,7 @@ static void prv_ancs_is_alive_schedule_next_check(void) {
 static void prv_ancs_is_alive_start_response_wait_timer(void) {
   s_ancs_client->is_alive_timer = (const RegularTimerInfo) {
     .cb = prv_is_ancs_alive_response_timeout,
+    .cb_data = (void *)(uintptr_t)s_ancs_client->slot,
   };
   regular_timer_add_multisecond_callback(&s_ancs_client->is_alive_timer,
                                          ANCS_IS_ALIVE_RESPONSE_WAIT_TIME_SECONDS);
@@ -390,6 +410,8 @@ static void prv_resubscribe_to_ancs(void) {
 }
 
 static void prv_is_ancs_alive_response_timeout_launcher_task_cb(void *data) {
+  PhoneSlot slot = (PhoneSlot)(uintptr_t)data;
+  s_ancs_client = s_ancs_clients[slot];
   if (!s_ancs_client) {
     return;
   }
@@ -463,6 +485,8 @@ T_STATIC void prv_check_ancs_alive(void) {
 }
 
 static void prv_is_ancs_alive_launcher_task_cb(void *data) {
+  PhoneSlot slot = (PhoneSlot)(uintptr_t)data;
+  s_ancs_client = s_ancs_clients[slot];
   if (!s_ancs_client) {
     return;
   }
@@ -480,25 +504,26 @@ static void prv_is_ancs_alive_cb(void *data) {
 // -----------------------------------------------------------------------------
 //! With iOS 8.2 the pre-existing flag seems to be broken. Don't allow notifications for a bit after
 //! reconnection so that all the "real" pre-existing notification don't come through again.
-static RegularTimerInfo s_notification_connection_delay_timer;
-static bool s_just_connected = false;
-
 static void prv_set_no_longer_just_connected(void *data) {
-  s_just_connected = false;
-  regular_timer_remove_callback(&s_notification_connection_delay_timer);
+  PhoneSlot slot = (PhoneSlot)(uintptr_t)data;
+  ANCSClient *client = s_ancs_clients[slot];
+  if (!client) return;
+  client->just_connected = false;
+  regular_timer_remove_callback(&client->notification_connection_delay_timer);
 }
 
 static void prv_start_temp_notification_connection_delay_timer(void) {
-  if (regular_timer_is_scheduled(&s_notification_connection_delay_timer)) {
-    regular_timer_remove_callback(&s_notification_connection_delay_timer);
+  if (regular_timer_is_scheduled(&s_ancs_client->notification_connection_delay_timer)) {
+    regular_timer_remove_callback(&s_ancs_client->notification_connection_delay_timer);
   }
-  s_just_connected = true;
+  s_ancs_client->just_connected = true;
 
   const int post_connection_notification_ignore_seconds = 10;
-  s_notification_connection_delay_timer = (const RegularTimerInfo) {
+  s_ancs_client->notification_connection_delay_timer = (const RegularTimerInfo) {
     .cb = prv_set_no_longer_just_connected,
+    .cb_data = (void *)(uintptr_t)s_ancs_client->slot,
   };
-  regular_timer_add_multisecond_callback(&s_notification_connection_delay_timer,
+  regular_timer_add_multisecond_callback(&s_ancs_client->notification_connection_delay_timer,
                                          post_connection_notification_ignore_seconds);
 }
 
@@ -776,7 +801,8 @@ static void prv_get_notification_attributes(uint32_t uid) {
       prv_reset_and_flush();
     } else {
       prv_set_state(ANCSClientStateRetrying);
-      evented_timer_register(ANCS_RETRY_TIME_MS, false, prv_reset_and_retry, NULL);
+      evented_timer_register(ANCS_RETRY_TIME_MS, false, prv_reset_and_retry,
+                             (void *)(uintptr_t)s_ancs_client->slot);
     }
   }
 }
@@ -831,6 +857,9 @@ static void prv_put_ancs_disconnected_event(void) {
 // Catching the subscription (CCCD write) confirmation for analytics purposes:
 void ancs_handle_subscribe(BLECharacteristic subscribed_characteristic,
                            BLESubscription subscription_type, BLEGATTError error) {
+  PhoneSlot slot = prv_slot_for_characteristic(subscribed_characteristic);
+  if (slot == PHONE_SLOT_INVALID) return;
+  s_ancs_client = s_ancs_clients[slot];
   ANCSCharacteristic characteristic_id = prv_get_id_for_characteristic(subscribed_characteristic);
   if (characteristic_id != ANCSCharacteristicNotification &&
       characteristic_id != ANCSCharacteristicData) {
@@ -850,13 +879,20 @@ void ancs_handle_subscribe(BLECharacteristic subscribed_characteristic,
   }
 }
 
-void ancs_invalidate_all_references(void) {
+void ancs_invalidate_all_references_for_slot(PhoneSlot slot) {
+  s_ancs_client = s_ancs_clients[slot];
+  if (!s_ancs_client) return;
   for (int c = 0; c < NumANCSCharacteristic; c++) {
     s_ancs_client->characteristics[c] = BLE_CHARACTERISTIC_INVALID;
   }
-
   prv_reset_and_flush();
   prv_put_ancs_disconnected_event();
+}
+
+void ancs_invalidate_all_references(void) {
+  for (PhoneSlot slot = 0; slot < MAX_PHONE_CONNECTIONS; slot++) {
+    ancs_invalidate_all_references_for_slot(slot);
+  }
 }
 
 void ancs_handle_service_removed(BLECharacteristic *characteristics, uint8_t num_characteristics) {
@@ -864,7 +900,8 @@ void ancs_handle_service_removed(BLECharacteristic *characteristics, uint8_t num
   ancs_invalidate_all_references();
 }
 
-void ancs_handle_service_discovered(BLECharacteristic *characteristics) {
+void ancs_handle_service_discovered(BLECharacteristic *characteristics, PhoneSlot slot) {
+  s_ancs_client = s_ancs_clients[slot];
   PBL_LOG_DBG("In ANCS service discovery CB");
   PBL_ASSERTN(characteristics); // should only be called if we found something!
 
@@ -895,15 +932,7 @@ void ancs_handle_service_discovered(BLECharacteristic *characteristics) {
 }
 
 bool ancs_can_handle_characteristic(BLECharacteristic characteristic) {
-  if (!s_ancs_client) {
-    return false;
-  }
-  for (int c = 0; c < NumANCSCharacteristic; ++c) {
-    if (s_ancs_client->characteristics[c] == characteristic) {
-      return true;
-    }
-  }
-  return false;
+  return prv_slot_for_characteristic(characteristic) != PHONE_SLOT_INVALID;
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -958,7 +987,7 @@ static void prv_handle_ns_notification(uint32_t length, const uint8_t *notificat
       // By skipping the pre-existing check we will re-recieve all the notifications
       // we got in the past 2 hours. To get past this ignore notifications for the first couple
       // seconds after connecting
-      if (s_just_connected && (nsnotification->event_flags & EventFlagPreExisting)) {
+      if (s_ancs_client->just_connected && (nsnotification->event_flags & EventFlagPreExisting)) {
         PBL_LOG_DBG("Ignoring notification because we just connected and PreExisting");
       } else {
         PBL_LOG_DBG("Added ANCS notification!");
@@ -996,6 +1025,9 @@ static void prv_handle_ds_notification(uint32_t length, const uint8_t *data) {
 
 void ancs_handle_read_or_notification(BLECharacteristic characteristic, const uint8_t *value,
                                       size_t value_length, BLEGATTError error) {
+  PhoneSlot slot = prv_slot_for_characteristic(characteristic);
+  if (slot == PHONE_SLOT_INVALID) return;
+  s_ancs_client = s_ancs_clients[slot];
   if (error != BLEGATTErrorSuccess) {
     PBL_LOG_ERR("Read or notification error: %d", error);
     prv_reset_due_to_bt_error();
@@ -1021,6 +1053,9 @@ void ancs_handle_read_or_notification(BLECharacteristic characteristic, const ui
 // Writing commands to the ANCS Control Point
 
 void ancs_handle_write_response(BLECharacteristic characteristic, BLEGATTError error) {
+  PhoneSlot slot = prv_slot_for_characteristic(characteristic);
+  if (slot == PHONE_SLOT_INVALID) return;
+  s_ancs_client = s_ancs_clients[slot];
   if (error == ANCS_INVALID_PARAM) {
     if (s_ancs_client->state == ANCSClientStateAliveCheck) {
       // We got a response so cancel the response wait timer and setup another check.
@@ -1083,12 +1118,17 @@ static void prv_perform_action(uint32_t notification_uid, ActionId action_id) {
 }
 
 static void prv_serialize_action(const PerformNotificationActionMsg *action_msg) {
-  if (!s_ancs_client) {
-    PBL_LOG_ERR("No ANCS client");
-    return;
+  bool any_client = false;
+  for (PhoneSlot slot = 0; slot < MAX_PHONE_CONNECTIONS; slot++) {
+    if (s_ancs_clients[slot]) {
+      s_ancs_client = s_ancs_clients[slot];
+      any_client = true;
+      prv_notif_queue_push_action(action_msg->notification_uid, action_msg->action_id);
+    }
   }
-
-  prv_notif_queue_push_action(action_msg->notification_uid, action_msg->action_id);
+  if (!any_client) {
+    PBL_LOG_ERR("No ANCS client");
+  }
 }
 
 void prv_serialize_action_launcher_task_cb(void *data) {
@@ -1116,32 +1156,43 @@ void ancs_perform_action(uint32_t notification_uid, uint8_t action_id) {
 }
 
 void ancs_handle_ios9_or_newer_detected(void) {
-  // The ANCSClient is created as soon as the gateway is connected (see kernel_le_client.c).
-  PBL_ASSERTN(s_ancs_client);
-  s_ancs_client->version = ANCSVersion_iOS9OrNewer;
+  for (PhoneSlot slot = 0; slot < MAX_PHONE_CONNECTIONS; slot++) {
+    if (s_ancs_clients[slot]) {
+      s_ancs_clients[slot]->version = ANCSVersion_iOS9OrNewer;
+    }
+  }
 }
 
 // -------------------------------------------------------------------------------------------------
 // Lifecyle
 
-void ancs_create(void) {
-  PBL_ASSERTN(s_ancs_client == NULL);
-  s_ancs_client = (ANCSClient *) kernel_zalloc_check(sizeof(ANCSClient));
+void ancs_create(PhoneSlot slot) {
+  PBL_ASSERTN(s_ancs_clients[slot] == NULL);
+  s_ancs_clients[slot] = (ANCSClient *) kernel_zalloc_check(sizeof(ANCSClient));
+  s_ancs_client = s_ancs_clients[slot];
+  s_ancs_client->slot = slot;
   buffer_init(&s_ancs_client->reassembly_ctx.buffer,
               sizeof(s_ancs_client->reassembly_ctx.buffer_storage));
-  ancs_app_name_storage_init();
+  if (slot == 0) {
+    ancs_app_name_storage_init();
+  }
 }
 
-void ancs_destroy(void) {
+void ancs_destroy(PhoneSlot slot) {
+  s_ancs_client = s_ancs_clients[slot];
   if (!s_ancs_client) {
     return;
   }
   prv_ancs_is_alive_stop_timer();
-
-  ancs_app_name_storage_deinit();
-
+  if (regular_timer_is_scheduled(&s_ancs_client->notification_connection_delay_timer)) {
+    regular_timer_remove_callback(&s_ancs_client->notification_connection_delay_timer);
+  }
+  if (slot == 0) {
+    ancs_app_name_storage_deinit();
+  }
   prv_reset_and_flush();
   kernel_free(s_ancs_client);
+  s_ancs_clients[slot] = NULL;
   s_ancs_client = NULL;
   prv_put_ancs_disconnected_event();
 }

--- a/src/fw/comm/ble/kernel_le_client/ancs/ancs.h
+++ b/src/fw/comm/ble/kernel_le_client/ancs/ancs.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "applib/bluetooth/ble_client.h"
+#include "comm/ble/kernel_le_client/multi_phone.h"
 
 //! @file ancs.h Module implementing an ANCS client.
 //! See http://bit.ly/ancs-spec for Apple's documentation of ANCS
@@ -32,17 +33,23 @@ typedef enum {
   ANCSCharacteristicInvalid = NumANCSCharacteristic,
 } ANCSCharacteristic;
 
-//! Creates the ANCS client.
+//! Creates the ANCS client for the given phone slot.
 //! Must only be called from KernelMain!
-void ancs_create(void);
+void ancs_create(PhoneSlot slot);
 
 //! Updates the BLECharacteristic references, in case new ones have been obtained after a
 //! re-discovery of the remote services.
 //! @param characteristics Matrix of characteristics references of the ANCS service(s)
+//! @param slot            Phone slot (0..MAX_PHONE_CONNECTIONS-1) owning this service
 //! @note This module only uses the first service instance, any others will be ignored.
 //! Must only be called from KernelMain!
-void ancs_handle_service_discovered(BLECharacteristic *characteristics);
+void ancs_handle_service_discovered(BLECharacteristic *characteristics, PhoneSlot slot);
 
+//! Invalidates all ANCS characteristic references for a given phone slot.
+void ancs_invalidate_all_references_for_slot(PhoneSlot slot);
+
+//! Invalidates all ANCS characteristic references across all slots.
+//! Legacy wrapper kept for callers that don't yet carry slot context.
 void ancs_invalidate_all_references(void);
 
 void ancs_handle_service_removed(BLECharacteristic *characteristics, uint8_t num_characteristics);
@@ -68,9 +75,9 @@ void ancs_handle_subscribe(BLECharacteristic characteristic,
 void ancs_handle_read_or_notification(BLECharacteristic characteristic, const uint8_t *value,
                                       size_t value_length, BLEGATTError error);
 
-//! Destroys the ANCS client.
+//! Destroys the ANCS client for the given phone slot.
 //! Must only be called from KernelMain!
-void ancs_destroy(void);
+void ancs_destroy(PhoneSlot slot);
 
 //! This function is safe to call from any task.
 void ancs_perform_action(uint32_t notification_uid, uint8_t action_id);

--- a/src/fw/comm/ble/kernel_le_client/kernel_le_client.c
+++ b/src/fw/comm/ble/kernel_le_client/kernel_le_client.c
@@ -495,7 +495,13 @@ static void prv_handle_connection_event(const PebbleBLEConnectionEvent *event) {
       ppogatt_create();
     }
 
-    gap_le_slave_reconnect_stop();
+    int active_count = 0;
+    for (PhoneSlot s = 0; s < MAX_PHONE_CONNECTIONS; s++) {
+      if (s_phone_slots[s].active) active_count++;
+    }
+    if (active_count >= MAX_PHONE_CONNECTIONS) {
+      gap_le_slave_reconnect_stop();
+    }
     gatt_client_discovery_discover_all(&device);
 
   } else {

--- a/src/fw/comm/ble/kernel_le_client/kernel_le_client.c
+++ b/src/fw/comm/ble/kernel_le_client/kernel_le_client.c
@@ -50,6 +50,10 @@ static void prv_ancs_handle_service_discovered_cb(BLECharacteristic *characteris
   ancs_handle_service_discovered(characteristics, s_discovery_slot);
 }
 
+static void prv_ppogatt_handle_service_discovered_cb(BLECharacteristic *characteristics) {
+  ppogatt_handle_service_discovered(characteristics, s_discovery_slot);
+}
+
 static PhoneSlot prv_slot_for_device(const BTDeviceInternal *device) {
   for (PhoneSlot slot = 0; slot < MAX_PHONE_CONNECTIONS; slot++) {
     if (s_phone_slots[slot].active &&
@@ -149,7 +153,7 @@ static const KernelLEClient s_clients[KernelLEClientNum] = {
     .service_uuid = &s_ppogatt_service_uuid,
     .characteristic_uuids = s_ppogatt_characteristic_uuids,
     .num_characteristics = PPoGATTCharacteristicNum,
-    .handle_service_discovered = ppogatt_handle_service_discovered,
+    .handle_service_discovered = prv_ppogatt_handle_service_discovered_cb,
     .handle_service_removed = ppogatt_handle_service_removed,
     .invalidate_all_references = ppogatt_invalidate_all_references,
     .can_handle_characteristic = ppogatt_can_handle_characteristic,
@@ -490,9 +494,9 @@ static void prv_handle_connection_event(const PebbleBLEConnectionEvent *event) {
     }
 
     ancs_create(slot);
+    ppogatt_create(slot);
     if (slot == 0) {
       ams_create();
-      ppogatt_create();
     }
 
     int active_count = 0;
@@ -508,13 +512,13 @@ static void prv_handle_connection_event(const PebbleBLEConnectionEvent *event) {
     PBL_LOG_DBG("Disconnected from Gateway!");
 
     PhoneSlot slot = prv_slot_for_device(&device);
-    if (slot == 0) {
-      ppogatt_destroy();
-      ams_destroy();
-    }
     if (slot != PHONE_SLOT_INVALID) {
+      ppogatt_destroy(slot);
       ancs_destroy(slot);
       prv_free_slot(slot);
+    }
+    if (slot == 0) {
+      ams_destroy();
     }
     app_launch_handle_disconnection();
     gap_le_slave_reconnect_start();
@@ -598,5 +602,7 @@ void kernel_le_client_deinit(void) {
 
   gap_le_slave_reconnect_stop();
   gap_le_connect_cancel_all(GAPLEClientKernel);
-  ppogatt_destroy();
+  for (PhoneSlot slot = 0; slot < MAX_PHONE_CONNECTIONS; slot++) {
+    ppogatt_destroy(slot);
+  }
 }

--- a/src/fw/comm/ble/kernel_le_client/kernel_le_client.c
+++ b/src/fw/comm/ble/kernel_le_client/kernel_le_client.c
@@ -2,6 +2,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include "kernel_le_client.h"
+#include "multi_phone.h"
 
 #include "ancs/ancs_definition.h"
 #include "ams/ams_definition.h"
@@ -33,8 +34,48 @@
 #include "comm/ble/gatt_client_subscriptions.h"
 
 #include <bluetooth/pebble_bt.h>
+#include <btutil/bt_device.h>
 
 #define MAX_SERVICE_INSTANCES (8)
+
+typedef struct {
+  bool active;
+  BTDeviceInternal device;
+} PhoneSlotInfo;
+
+static PhoneSlotInfo s_phone_slots[MAX_PHONE_CONNECTIONS];
+static PhoneSlot s_discovery_slot = PHONE_SLOT_INVALID;
+
+static void prv_ancs_handle_service_discovered_cb(BLECharacteristic *characteristics) {
+  ancs_handle_service_discovered(characteristics, s_discovery_slot);
+}
+
+static PhoneSlot prv_slot_for_device(const BTDeviceInternal *device) {
+  for (PhoneSlot slot = 0; slot < MAX_PHONE_CONNECTIONS; slot++) {
+    if (s_phone_slots[slot].active &&
+        bt_device_internal_equal(&s_phone_slots[slot].device, device)) {
+      return slot;
+    }
+  }
+  return PHONE_SLOT_INVALID;
+}
+
+static PhoneSlot prv_alloc_slot(const BTDeviceInternal *device) {
+  for (PhoneSlot slot = 0; slot < MAX_PHONE_CONNECTIONS; slot++) {
+    if (!s_phone_slots[slot].active) {
+      s_phone_slots[slot].active = true;
+      s_phone_slots[slot].device = *device;
+      return slot;
+    }
+  }
+  return PHONE_SLOT_INVALID;
+}
+
+static void prv_free_slot(PhoneSlot slot) {
+  if (slot < MAX_PHONE_CONNECTIONS) {
+    s_phone_slots[slot] = (PhoneSlotInfo){};
+  }
+}
 
 //! Array indices for the different client "classes"
 enum {
@@ -121,7 +162,7 @@ static const KernelLEClient s_clients[KernelLEClientNum] = {
     .service_uuid = &s_ancs_service_uuid,
     .characteristic_uuids = s_ancs_characteristic_uuids,
     .num_characteristics = NumANCSCharacteristic,
-    .handle_service_discovered = ancs_handle_service_discovered,
+    .handle_service_discovered = prv_ancs_handle_service_discovered_cb,
     .handle_service_removed = ancs_handle_service_removed,
     .invalidate_all_references = ancs_invalidate_all_references,
     .can_handle_characteristic = ancs_can_handle_characteristic,
@@ -206,6 +247,7 @@ static void prv_handle_all_services_invalidated(void) {
 
 static void prv_handle_services_added(
     PebbleBLEGATTClientServicesAdded *added_services, BTDeviceInternal *device) {
+  s_discovery_slot = prv_slot_for_device(device);
   // loop through the new services
   for (int s = 0; s < added_services->num_services_added; s++) {
     // get the uuid for the service
@@ -249,6 +291,7 @@ static void prv_handle_services_added(
       client->handle_service_discovered(characteristics);
     }
   }
+  s_discovery_slot = PHONE_SLOT_INVALID;
 }
 
 static void prv_handle_gatt_service_discovery_event(const PebbleBLEGATTClientServiceEvent *event) {
@@ -440,18 +483,33 @@ static void prv_handle_connection_event(const PebbleBLEConnectionEvent *event) {
   if (connected) {
     PBL_LOG_DBG("Connected to Gateway!");
 
-    ancs_create();
-    ams_create();
-    ppogatt_create();
+    PhoneSlot slot = prv_alloc_slot(&device);
+    if (slot == PHONE_SLOT_INVALID) {
+      PBL_LOG_WRN("No free phone slot for new connection");
+      return;
+    }
+
+    ancs_create(slot);
+    if (slot == 0) {
+      ams_create();
+      ppogatt_create();
+    }
 
     gap_le_slave_reconnect_stop();
     gatt_client_discovery_discover_all(&device);
 
   } else {
     PBL_LOG_DBG("Disconnected from Gateway!");
-    ppogatt_destroy();
-    ams_destroy();
-    ancs_destroy();
+
+    PhoneSlot slot = prv_slot_for_device(&device);
+    if (slot == 0) {
+      ppogatt_destroy();
+      ams_destroy();
+    }
+    if (slot != PHONE_SLOT_INVALID) {
+      ancs_destroy(slot);
+      prv_free_slot(slot);
+    }
     app_launch_handle_disconnection();
     gap_le_slave_reconnect_start();
     gatt_client_op_cleanup(GAPLEClientKernel);
@@ -498,7 +556,9 @@ static void prv_cancel_connect_gateway_bonding(BTBondingID gateway_bonding) {
 
 // -------------------------------------------------------------------------------------------------
 static void prv_cleanup_clients_kernel_main_cb(void *unused) {
-  ancs_destroy();
+  for (PhoneSlot slot = 0; slot < MAX_PHONE_CONNECTIONS; slot++) {
+    ancs_destroy(slot);
+  }
   ams_destroy();
 }
 
@@ -518,9 +578,10 @@ void kernel_le_client_init(void) {
   // Reset analytics
   ppogatt_reset_disconnect_counter();
 
-  BTBondingID gateway_bonding = bt_persistent_storage_get_ble_ancs_bonding();
-  if (gateway_bonding != BT_BONDING_ID_INVALID) {
-    prv_connect_gateway_bonding(gateway_bonding);
+  BTBondingID bondings[MAX_PHONE_CONNECTIONS];
+  int count = bt_persistent_storage_get_all_ble_ancs_bondings(bondings, MAX_PHONE_CONNECTIONS);
+  for (int i = 0; i < count; i++) {
+    prv_connect_gateway_bonding(bondings[i]);
   }
 }
 

--- a/src/fw/comm/ble/kernel_le_client/multi_phone.h
+++ b/src/fw/comm/ble/kernel_le_client/multi_phone.h
@@ -1,0 +1,12 @@
+/* SPDX-FileCopyrightText: 2024 Google LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+//! Maximum number of phones that can be simultaneously connected.
+#define MAX_PHONE_CONNECTIONS 2
+
+//! Identifies which phone slot (0 or 1) a connection occupies.
+typedef uint8_t PhoneSlot;
+
+#define PHONE_SLOT_INVALID 0xFF

--- a/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
+++ b/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
@@ -69,6 +69,7 @@ typedef struct PPoGATTClient {
   ListNode node;
   State state;
   uint8_t version;
+  PhoneSlot slot;
 
   // TODO: Save some memory and point to app metadata instead?
   Uuid app_uuid;
@@ -147,8 +148,8 @@ static uint8_t s_timer_ticks;
 
 static uint8_t s_disconnect_counter;
 
-//! Caps rediscovery on stale meta handles to once per BLE connection.
-static bool s_rediscovery_requested_this_connection;
+//! Caps rediscovery on stale meta handles to once per BLE connection, per slot.
+static bool s_rediscovery_requested[MAX_PHONE_CONNECTIONS];
 
 // -------------------------------------------------------------------------------------------------
 // Function Prototypes
@@ -360,7 +361,7 @@ static void prv_timer_callback(void *unused) {
 
 // -------------------------------------------------------------------------------------------------
 
-static PPoGATTClient *prv_create_client(TimerID timer) {
+static PPoGATTClient *prv_create_client(TimerID timer, PhoneSlot slot) {
   PPoGATTClient *client = kernel_malloc(sizeof(PPoGATTClient));
   if (!client) {
     return NULL;
@@ -369,6 +370,7 @@ static PPoGATTClient *prv_create_client(TimerID timer) {
   client->app_uuid = UUID_INVALID;
   client->rx_ack_timer = timer;
   client->created_ticks = rtc_get_ticks();
+  client->slot = slot;
   s_ppogatt_head = (PPoGATTClient *) list_prepend((ListNode *)s_ppogatt_head, &client->node);
   if (!regular_timer_is_scheduled(&s_ack_timer)) {
     s_ack_timer.cb = prv_timer_callback;
@@ -905,9 +907,9 @@ handle_retriable_error:
           PPOGATT_META_READ_RETRY_COUNT_MAX);
 
   // Cached handle may be stale; try once with fresh discovery.
-  if (!s_rediscovery_requested_this_connection) {
+  if (!s_rediscovery_requested[client->slot]) {
     PBL_LOG_INFO("Triggering GATT rediscovery for fresh PPoGATT handles");
-    s_rediscovery_requested_this_connection = true;
+    s_rediscovery_requested[client->slot] = true;
     prv_request_meta_rediscovery(client);
   }
 
@@ -920,13 +922,12 @@ handle_error:
 
 // -------------------------------------------------------------------------------------------------
 
-void ppogatt_create(void) {
+void ppogatt_create(PhoneSlot slot) {
   bt_lock();
   {
     PBL_ASSERT_TASK(PebbleTask_KernelMain);
-    PBL_ASSERTN(!s_ppogatt_head);
     s_timer_ticks = 0;
-    s_rediscovery_requested_this_connection = false;
+    s_rediscovery_requested[slot] = false;
   }
   bt_unlock();
 }
@@ -990,7 +991,22 @@ void ppogatt_invalidate_all_references(void) {
   bt_unlock();
 }
 
-void ppogatt_handle_service_discovered(BLECharacteristic *characteristics) {
+void ppogatt_invalidate_all_references_for_slot(PhoneSlot slot) {
+  bt_lock();
+  {
+    PPoGATTClient *client = s_ppogatt_head;
+    while (client) {
+      PPoGATTClient *next = (PPoGATTClient *) client->node.next;
+      if (client->slot == slot) {
+        prv_delete_client(client, true /* is_disconnected */, DeleteReason_InvalidateAllReferences);
+      }
+      client = next;
+    }
+  }
+  bt_unlock();
+}
+
+void ppogatt_handle_service_discovered(BLECharacteristic *characteristics, PhoneSlot slot) {
   PBL_LOG_INFO("PPoGATT service discovered, starting handshake");
 
   // Create timer outside of bt_lock to avoid deadlock with NimbleHost.
@@ -1002,7 +1018,7 @@ void ppogatt_handle_service_discovered(BLECharacteristic *characteristics) {
   bt_lock();
   {
     // Create new clients:
-    PPoGATTClient *client = prv_create_client(timer);
+    PPoGATTClient *client = prv_create_client(timer, slot);
     if (!client) {
       bt_unlock();
       new_timer_delete(timer);
@@ -1431,18 +1447,20 @@ unlock:
 
 // -------------------------------------------------------------------------------------------------
 
-void ppogatt_destroy(void) {
+void ppogatt_destroy(PhoneSlot slot) {
   bool self_initiated_disconnect = false;
   bt_lock();
   {
     PPoGATTClient *client = s_ppogatt_head;
     while (client) {
       PPoGATTClient *next = (PPoGATTClient *) client->node.next;
-      self_initiated_disconnect = self_initiated_disconnect || client->disconnect_requested;
-      prv_delete_client(client, true /* is_disconnected */, DeleteReason_DestroyCalled);
+      if (client->slot == slot) {
+        self_initiated_disconnect = self_initiated_disconnect || client->disconnect_requested;
+        prv_delete_client(client, true /* is_disconnected */, DeleteReason_DestroyCalled);
+      }
       client = next;
     }
-    s_rediscovery_requested_this_connection = false;
+    s_rediscovery_requested[slot] = false;
   }
   bt_unlock();
 

--- a/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.h
+++ b/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "applib/bluetooth/ble_client.h"
+#include "comm/ble/kernel_le_client/multi_phone.h"
 
 struct Transport;
 
@@ -13,9 +14,9 @@ typedef enum {
   PPoGATTCharacteristicNum
 } PPoGATTCharacteristic;
 
-void ppogatt_create(void);
+void ppogatt_create(PhoneSlot slot);
 
-void ppogatt_handle_service_discovered(BLECharacteristic *characteristics);
+void ppogatt_handle_service_discovered(BLECharacteristic *characteristics, PhoneSlot slot);
 
 bool ppogatt_can_handle_characteristic(BLECharacteristic characteristic);
 
@@ -30,6 +31,8 @@ void ppogatt_handle_service_removed(
 
 void ppogatt_invalidate_all_references(void);
 
+void ppogatt_invalidate_all_references_for_slot(PhoneSlot slot);
+
 //! Interface for kernel_le_client, to handle the event that the Bluetooth stack has space available
 //! again in its outbound queue. It will trigger the PPoGATT module to send out the next packet(s).
 void ppogatt_handle_buffer_empty(void);
@@ -42,7 +45,7 @@ void ppogatt_close(struct Transport *transport);
 
 void ppogatt_reset(struct Transport *transport);
 
-void ppogatt_destroy(void);
+void ppogatt_destroy(PhoneSlot slot);
 
 //! Interface for analytics
 void ppogatt_reset_disconnect_counter(void);

--- a/src/fw/comm/prf_stubs/ancs.c
+++ b/src/fw/comm/prf_stubs/ancs.c
@@ -2,6 +2,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include "comm/ble/kernel_le_client/ancs/ancs.h"
+#include "comm/ble/kernel_le_client/multi_phone.h"
 
 
 // -------------------------------------------------------------------------------------------------
@@ -20,7 +21,7 @@ void ancs_perform_action(uint32_t notification_uid, uint8_t action_id) {
   return;
 }
 
-void ancs_handle_service_discovered(BLECharacteristic *characteristics) {
+void ancs_handle_service_discovered(BLECharacteristic *characteristics, PhoneSlot slot) {
   return;
 }
 
@@ -33,17 +34,20 @@ void ancs_handle_subscribe(BLECharacteristic subscribed_characteristic,
   return;
 }
 
+void ancs_invalidate_all_references_for_slot(PhoneSlot slot) {
+}
+
 void ancs_invalidate_all_references(void) {
 }
 
 void ancs_handle_service_removed(BLECharacteristic *characteristics, uint8_t num_characteristics) {
 }
 
-void ancs_create(void) {
+void ancs_create(PhoneSlot slot) {
   return;
 }
 
-void ancs_destroy(void) {
+void ancs_destroy(PhoneSlot slot) {
   return;
 }
 

--- a/src/fw/services/bluetooth/bluetooth_persistent_storage_normal.c
+++ b/src/fw/services/bluetooth/bluetooth_persistent_storage_normal.c
@@ -2,6 +2,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include "pbl/services/bluetooth/bluetooth_persistent_storage.h"
+#include "comm/ble/kernel_le_client/multi_phone.h"
 #include "pbl/services/bluetooth/bluetooth_persistent_storage_debug.h"
 
 #include "comm/ble/gap_le_connect.h"
@@ -682,7 +683,7 @@ static void prv_prune_stale_ble_bondings(void) {
   };
   prv_file_each(prv_find_most_recent_ble_bonding_itr, &itr_data);
 
-  if (itr_data.ble_count <= 1 || itr_data.key_out == BT_BONDING_ID_INVALID) {
+  if (itr_data.ble_count <= MAX_PHONE_CONNECTIONS || itr_data.key_out == BT_BONDING_ID_INVALID) {
     return;
   }
 
@@ -772,10 +773,8 @@ BTBondingID bt_persistent_storage_store_ble_pairing(const SMPairingInfo *new_pai
 
   prv_call_ble_bonding_change_handlers(key, op);
 
-  // We only support a single BLE pairing at a time. Drop any previous BLE bonding so that
-  // re-pairing with a different phone (or merging a PRF pairing) replaces the old one instead of
-  // leaving it behind and forcing the user to forget it manually.
-  prv_delete_other_ble_bondings(key);
+  // Drop excess BLE bondings so the DB never exceeds MAX_PHONE_CONNECTIONS entries.
+  prv_prune_stale_ble_bondings();
 
   return key;
 }
@@ -1068,6 +1067,33 @@ BTBondingID bt_persistent_storage_get_ble_ancs_bonding(void) {
   prv_file_each(prv_get_first_ancs_bonding_itr, &first_ancs_supported_bonding_found);
 
   return first_ancs_supported_bonding_found;
+}
+
+typedef struct {
+  BTBondingID *out;
+  int max_count;
+  int count;
+} AllAncsItrData;
+
+static bool prv_collect_all_ancs_bondings_itr(SettingsFile *file, SettingsRecordInfo *info,
+                                               void *context) {
+  if (info->val_len == 0 || info->key_len != sizeof(BTBondingID)) return true;
+  AllAncsItrData *data = context;
+  if (data->count >= data->max_count) return false;
+  BTBondingID key;
+  info->get_key(file, (uint8_t *)&key, info->key_len);
+  BtPersistBondingData stored_data;
+  info->get_val(file, (uint8_t *)&stored_data, MIN((unsigned)info->val_len, sizeof(stored_data)));
+  if (stored_data.type == BtPersistBondingTypeBLE && stored_data.ble_data.supports_ancs) {
+    data->out[data->count++] = key;
+  }
+  return true;
+}
+
+int bt_persistent_storage_get_all_ble_ancs_bondings(BTBondingID *out, int max_count) {
+  AllAncsItrData data = { .out = out, .max_count = max_count, .count = 0 };
+  prv_file_each(prv_collect_all_ancs_bondings_itr, &data);
+  return data.count;
 }
 
 bool bt_persistent_storage_is_ble_ancs_bonding(BTBondingID bonding) {

--- a/src/fw/shell/prf/stubs.c
+++ b/src/fw/shell/prf/stubs.c
@@ -9,6 +9,7 @@
 
 #include "util/uuid.h"
 #include "board/board.h"
+#include "bluetooth/bluetooth_types.h"
 #include "drivers/backlight.h"
 #include "kernel/events.h"
 #include "popups/crashed_ui.h"
@@ -226,6 +227,10 @@ bool bt_persistent_storage_get_airplane_mode_enabled(void) {
 }
 
 void bt_persistent_storage_set_airplane_mode_enabled(bool *state) {
+}
+
+int bt_persistent_storage_get_all_ble_ancs_bondings(BTBondingID *out, int max_count) {
+  return 0;
 }
 
 uint32_t backlight_get_timeout_ms(void) {

--- a/tests/fw/comm/test_ancs.c
+++ b/tests/fw/comm/test_ancs.c
@@ -292,12 +292,12 @@ void test_ancs__initialize(void) {
   fake_event_init();
   fake_gatt_client_subscriptions_set_subscribe_return_value(BTErrnoOK);
 
-  ancs_create();
-  ancs_handle_service_discovered(s_characteristics);
+  ancs_create(0);
+  ancs_handle_service_discovered(s_characteristics, 0);
 }
 
 void test_ancs__cleanup(void) {
-  ancs_destroy();
+  ancs_destroy(0);
   cl_assert_equal_i(regular_timer_seconds_count(), 0);
   cl_assert_equal_i(regular_timer_minutes_count(), 0);
   regular_timer_deinit();
@@ -311,7 +311,7 @@ void test_ancs__should_fail_soft_on_subscribe_failure(void) {
   cl_assert(ancs_can_handle_characteristic(s_characteristics[ANCSCharacteristicData]));
 
   fake_gatt_client_subscriptions_set_subscribe_return_value(BTErrnoInvalidParameter);
-  ancs_handle_service_discovered(s_characteristics);
+  ancs_handle_service_discovered(s_characteristics, 0);
 
   // ANCS is left disconnected rather than crashing:
   cl_assert(!ancs_can_handle_characteristic(s_characteristics[ANCSCharacteristicData]));
@@ -484,7 +484,7 @@ void test_ancs__alive_check_disconnection(void) {
   cl_assert_equal_i(s_num_requested_notif_attributes, 1);
   // simulate a disconnection/reconnection
   ancs_handle_service_removed(s_characteristics, NumANCSCharacteristic);
-  ancs_handle_service_discovered(s_characteristics);
+  ancs_handle_service_discovered(s_characteristics, 0);
   // we should be back in the Idle state
   cl_assert_equal_i(prv_get_state(), ANCSClientStateIdle);
   // Make sure we can still receive notifications
@@ -552,12 +552,12 @@ void test_ancs__notification_parsing(void) {
 void test_ancs__disconnection(void) {
   // Simulate a disconnection/reconnection
   ancs_handle_service_removed(s_characteristics, NumANCSCharacteristic);
-  ancs_handle_service_discovered(s_characteristics);
+  ancs_handle_service_discovered(s_characteristics, 0);
   cl_assert_equal_i(fake_event_get_last().type, PEBBLE_ANCS_DISCONNECTED_EVENT);
   fake_event_clear_last();
 
   // If we unexpectedly register another session, make sure we send the event
-  ancs_handle_service_discovered(s_characteristics);
+  ancs_handle_service_discovered(s_characteristics, 0);
   cl_assert_equal_i(fake_event_get_last().type, PEBBLE_ANCS_DISCONNECTED_EVENT);
   fake_event_clear_last();
 
@@ -565,7 +565,7 @@ void test_ancs__disconnection(void) {
   cl_assert_equal_i(fake_event_get_last().type, PEBBLE_ANCS_DISCONNECTED_EVENT);
 
   // Make sure that losing BT altogether sends the event
-  ancs_destroy();
+  ancs_destroy(0);
   cl_assert_equal_i(fake_event_get_last().type, PEBBLE_ANCS_DISCONNECTED_EVENT);
   fake_event_clear_last();
 }

--- a/tests/fw/comm/test_kernel_le_client.c
+++ b/tests/fw/comm/test_kernel_le_client.c
@@ -99,10 +99,13 @@ void launcher_task_add_callback(CallbackEventCallback callback, void *data) {
   system_task_add_callback(callback, data);
 }
 
-void ppogatt_create(void) {
+void ppogatt_create(PhoneSlot slot) {
 }
 
-void ppogatt_destroy(void) {
+void ppogatt_destroy(PhoneSlot slot) {
+}
+
+void ppogatt_handle_service_discovered(BLECharacteristic *characteristics, PhoneSlot slot) {
 }
 
 void ppogatt_handle_buffer_empty(void) {

--- a/tests/fw/comm/test_kernel_le_client.c
+++ b/tests/fw/comm/test_kernel_le_client.c
@@ -21,16 +21,18 @@
 #include "stubs_rand_ptr.h"
 #include "stubs_rtc.h"
 
+#include "comm/ble/kernel_le_client/multi_phone.h"
+
 void ams_create(void) {
 }
 
 void ams_destroy(void) {
 }
 
-void ancs_create(void) {
+void ancs_create(PhoneSlot slot) {
 }
 
-void ancs_destroy(void) {
+void ancs_destroy(PhoneSlot slot) {
 }
 
 void app_launch_handle_disconnection(void) {
@@ -38,6 +40,14 @@ void app_launch_handle_disconnection(void) {
 
 BTBondingID bt_persistent_storage_get_ble_ancs_bonding(void) {
   return 1;
+}
+
+int bt_persistent_storage_get_all_ble_ancs_bondings(BTBondingID *out, int max_count) {
+  if (max_count > 0) {
+    out[0] = 1;
+    return 1;
+  }
+  return 0;
 }
 
 bool bt_persistent_storage_is_ble_ancs_bonding(BTBondingID bonding) {

--- a/tests/fw/comm/test_ppogatt.c
+++ b/tests/fw/comm/test_ppogatt.c
@@ -309,11 +309,11 @@ void test_ppogatt__initialize(void) {
   fake_gatt_client_subscriptions_init();
   regular_timer_init();
   fake_comm_session_init();
-  ppogatt_create();
+  ppogatt_create(0);
 }
 
 void test_ppogatt__cleanup(void) {
-  ppogatt_destroy();
+  ppogatt_destroy(0);
   cl_assert_equal_i(ppogatt_client_count(), 0);
   cl_assert_equal_i(regular_timer_seconds_count(), 0);
   regular_timer_deinit();
@@ -331,7 +331,7 @@ void test_ppogatt__cleanup(void) {
 
 void prv_notify_services_discovered(int num_services_to_register) {
   for (int i = 0; i < s_num_service_instances && i < num_services_to_register; i++) {
-    ppogatt_handle_service_discovered(s_characteristics[i]);
+    ppogatt_handle_service_discovered(s_characteristics[i], 0);
   }
 }
 
@@ -1114,7 +1114,7 @@ void test_ppogatt__mtu_zero_due_to_disconnection(void) {
 //! packet shouldn't be attempted to be written at all, because it will not fit and overrun the
 //! buffer.
 void test_ppogatt__mtu_zero_due_to_service_rediscovery_while_resetting(void) {
-  ppogatt_handle_service_discovered(s_characteristics[0]);
+  ppogatt_handle_service_discovered(s_characteristics[0], 0);
 
   ppogatt_handle_read_or_notification(s_characteristics[0][PPoGATTCharacteristicMeta],
                                       (const uint8_t *) &s_meta_v0_system,

--- a/third_party/nimble/syscfg/targets/nrf52/syscfg.yml
+++ b/third_party/nimble/syscfg/targets/nrf52/syscfg.yml
@@ -6,10 +6,11 @@ syscfg.vals:
     MCU_HFCLK_SOURCE: HFINT
     # Values measured to be found _okay_ when doing firmware update related
     # activites. They may need further tuning.
-    MSYS_1_BLOCK_COUNT: 35
+    MSYS_1_BLOCK_COUNT: 50
     MSYS_1_BLOCK_SIZE: 304
     BLE_SM_IO_CAP: 'BLE_HS_IO_DISPLAY_YESNO'
     BLE_SM_SC_ONLY: 1
     BLE_SM_LEGACY: 0
     BLE_SM_MITM: 1
     BLE_SM_LVL: 4
+    BLE_MAX_CONNECTIONS: 2

--- a/third_party/nimble/syscfg/targets/sf32lb52/syscfg.yml
+++ b/third_party/nimble/syscfg/targets/sf32lb52/syscfg.yml
@@ -11,3 +11,4 @@ syscfg.vals:
     # Increased to prevent ACL mbuf allocation failures during high-throughput
     # operations (e.g. FW upgrade over BLE on iOS).
     BLE_TRANSPORT_ACL_COUNT: 60
+    BLE_MAX_CONNECTIONS: 2


### PR DESCRIPTION
PebbleOS hard-codes a single phone connection throughout the BLE stack.
This series removes that assumption end-to-end, supporting any two phones
simultaneously regardless of OS.

## What changes

**`multi_phone.h`** introduces `PhoneSlot` (`uint8_t`),
`MAX_PHONE_CONNECTIONS 2`, and `PHONE_SLOT_INVALID 0xFF`.

**NimBLE** raises `BLE_MAX_CONNECTIONS` from 1 to 2 on both nrf52 and
sf32lb52 targets.

**`gap_le_advert` / `gap_le_connect`** replaces single-connection booleans
with `uint8_t` slave connection counters so advertising and reconnect logic
correctly tracks whether all slots are full.

**`ancs.c`** replaces the `s_ancs_client` singleton with
`s_ancs_clients[MAX_PHONE_CONNECTIONS]`. All entry points take a
`PhoneSlot slot` parameter. GATT characteristic events route to the
correct slot via `prv_slot_for_characteristic()`.

**`ppogatt.c`** extends the same treatment to Android: `PPoGATTClient`
gains a `slot` field, rediscovery state becomes per-slot, and
create/destroy/service-discovery all take `PhoneSlot`. Both protocols
now operate independently on separate slots.

**`kernel_le_client`** replaces the single-bonding init lookup with
`bt_persistent_storage_get_all_ble_ancs_bondings`; slot wrappers route
service discovery events to the correct protocol handler per connection.

**PRF stubs and unit tests** updated throughout.

## What this enables

- iPhone + iPhone: independent ANCS streams, one per slot
- Android + Android: independent PPoGATT sessions, one per slot
- iPhone + Android: ANCS on one slot, PPoGATT on the other

## What is not in scope

AMS (music controls) remains slot-0 only. Notification UID scoping across
two phones is a pre-existing architectural issue in notification_storage
that is independent of this change.

Note: this PR overlaps with #1513 on `gap_le_connect.c`
(`bool` to `uint8_t` counter). Happy to rebase on top of that once it
lands.

## Verification

CI green: build-firmware, build-prf, build-qemu (emery/flint/gabbro),
nix, tests. gitlint clean.