### PR TITLE
drivers/gpio: remove speed setting from GPIO API

### DIFF
--- a/src/fw/board/board_qemu.h
+++ b/src/fw/board/board_qemu.h
@@ -48,12 +48,6 @@ typedef enum {
   GPIO_PuPd_DOWN,
 } GPIOPuPd_TypeDef;
 
-typedef enum {
-  GPIO_Speed_2MHz,
-  GPIO_Speed_50MHz,
-  GPIO_Speed_200MHz
-} GPIOSpeed_TypeDef;
-
 typedef struct {
   void *const peripheral;
   const uint32_t gpio_pin;

--- a/src/fw/board/board_sf32lb52.h
+++ b/src/fw/board/board_sf32lb52.h
@@ -45,12 +45,6 @@ typedef enum {
   GPIO_PuPd_DOWN,
 } GPIOPuPd_TypeDef;
 
-typedef enum {
-  GPIO_Speed_2MHz,
-  GPIO_Speed_50MHz,
-  GPIO_Speed_200MHz
-} GPIOSpeed_TypeDef;
-
 typedef struct {
   GPIO_TypeDef* const peripheral; ///< One of GPIOX. For example, GPIOA.
   const uint32_t gpio_pin; ///< One of GPIO_Pin_X.

--- a/src/fw/drivers/backlight/aw9364e.c
+++ b/src/fw/drivers/backlight/aw9364e.c
@@ -22,7 +22,7 @@
 #define AW9364E_OFF_TIME_US 2600U
 
 void backlight_init(void) {
-  gpio_output_init(&AW9364E.gpio, GPIO_OType_PP, GPIO_Speed_2MHz);
+  gpio_output_init(&AW9364E.gpio, GPIO_OType_PP);
 }
 
 void backlight_set_brightness(uint8_t brightness) {

--- a/src/fw/drivers/backlight/pwm.c
+++ b/src/fw/drivers/backlight/pwm.c
@@ -15,7 +15,7 @@ static const uint32_t PWM_OUTPUT_FREQUENCY_HZ = 256;
 
 void backlight_init(void) {
   if (BACKLIGHT_PWM.ctl.gpio != NULL) {
-    gpio_output_init(&BACKLIGHT_PWM.ctl, GPIO_OType_PP, GPIO_Speed_2MHz);
+    gpio_output_init(&BACKLIGHT_PWM.ctl, GPIO_OType_PP);
     gpio_output_set(&BACKLIGHT_PWM.ctl, false);
   }
 

--- a/src/fw/drivers/display/sf32lb/display_jdi.c
+++ b/src/fw/drivers/display/sf32lb/display_jdi.c
@@ -128,23 +128,23 @@ static void prv_power_cycle(void){
   // allowing for a clean power cycle.
 
   cfg.gpio_pin = DISPLAY->pinmux.b1.pad - PAD_PA00;
-  gpio_output_init(&cfg, GPIO_OType_PP, GPIO_Speed_2MHz);
+  gpio_output_init(&cfg, GPIO_OType_PP);
   gpio_output_set(&cfg, false);
 
   cfg.gpio_pin = DISPLAY->pinmux.vck.pad - PAD_PA00;
-  gpio_output_init(&cfg, GPIO_OType_PP, GPIO_Speed_2MHz);
+  gpio_output_init(&cfg, GPIO_OType_PP);
   gpio_output_set(&cfg, false);
 
   cfg.gpio_pin = DISPLAY->pinmux.xrst.pad - PAD_PA00;
-  gpio_output_init(&cfg, GPIO_OType_PP, GPIO_Speed_2MHz);
+  gpio_output_init(&cfg, GPIO_OType_PP);
   gpio_output_set(&cfg, false);
 
   cfg.gpio_pin = DISPLAY->pinmux.hck.pad - PAD_PA00;
-  gpio_output_init(&cfg, GPIO_OType_PP, GPIO_Speed_2MHz);
+  gpio_output_init(&cfg, GPIO_OType_PP);
   gpio_output_set(&cfg, false);
 
   cfg.gpio_pin = DISPLAY->pinmux.r2.pad - PAD_PA00;
-  gpio_output_init(&cfg, GPIO_OType_PP, GPIO_Speed_2MHz);
+  gpio_output_init(&cfg, GPIO_OType_PP);
   gpio_output_set(&cfg, false);
 
   gpio_output_set(&DISPLAY->vddp, false);
@@ -355,8 +355,8 @@ void display_init(void) {
 
   DisplayJDIState *state = DISPLAY->state;
 
-  gpio_output_init(&DISPLAY->vddp, GPIO_OType_PP, GPIO_Speed_2MHz);
-  gpio_output_init(&DISPLAY->vlcd, GPIO_OType_PP, GPIO_Speed_2MHz);
+  gpio_output_init(&DISPLAY->vddp, GPIO_OType_PP);
+  gpio_output_init(&DISPLAY->vlcd, GPIO_OType_PP);
 
   prv_power_cycle();
 

--- a/src/fw/drivers/display/sharp_ls013b7dh01/sharp_ls013b7dh01_nrf5.c
+++ b/src/fw/drivers/display/sharp_ls013b7dh01/sharp_ls013b7dh01_nrf5.c
@@ -148,10 +148,10 @@ void display_init(void) {
   nrfx_err_t err = nrfx_spim_init(&BOARD_CONFIG_DISPLAY.spi, &config, prv_spim_evt_handler, NULL);
   PBL_ASSERTN(err == NRFX_SUCCESS);
 
-  gpio_output_init(&BOARD_CONFIG_DISPLAY.cs, GPIO_OType_PP, GPIO_Speed_50MHz);
+  gpio_output_init(&BOARD_CONFIG_DISPLAY.cs, GPIO_OType_PP);
 
-  gpio_output_init(&BOARD_CONFIG_DISPLAY.on_ctrl, (GPIOOType_TypeDef)BOARD_CONFIG_DISPLAY.on_ctrl_otype,
-                   GPIO_Speed_50MHz);
+  gpio_output_init(&BOARD_CONFIG_DISPLAY.on_ctrl,
+                   (GPIOOType_TypeDef)BOARD_CONFIG_DISPLAY.on_ctrl_otype);
   gpio_output_set(&BOARD_CONFIG_DISPLAY.on_ctrl, true);
 
   prv_extcomin_init();

--- a/src/fw/drivers/gpio.h
+++ b/src/fw/drivers/gpio.h
@@ -47,12 +47,6 @@ void gpio_output_init(const OutputConfig *pin_config, GPIOOType_TypeDef otype);
 //! is true, and drives it low if pin_config.active_high is false.
 void gpio_output_set(const OutputConfig *pin_config, bool asserted);
 
-//! Configure all GPIOs in the system to optimize for power consumption.
-//! At poweron most GPIOs can be configured as analog inputs instead of the
-//! default digital input. This allows digital filtering logic to be shut down,
-//! saving quite a bit of power.
-void gpio_init_all(void);
-
 //! Configure gpios as inputs (suitable for things like exti lines)
 void gpio_input_init(const InputConfig *input_cfg);
 

--- a/src/fw/drivers/gpio.h
+++ b/src/fw/drivers/gpio.h
@@ -55,6 +55,3 @@ void gpio_input_init_pull_up_down(const InputConfig *input_cfg, GPIOPuPd_TypeDef
 
 //! @return bool the current state of the GPIO pin
 bool gpio_input_read(const InputConfig *input_cfg);
-
-//! Configure gpios as analog inputs. Useful for unused GPIOs as this is their lowest power state.
-void gpio_analog_init(const InputConfig *input_cfg);

--- a/src/fw/drivers/gpio.h
+++ b/src/fw/drivers/gpio.h
@@ -23,18 +23,6 @@ typedef enum {
 
 #endif
 
-#ifdef CONFIG_SOC_NRF52
-
-void gpio_use(uint32_t pin);
-void gpio_release(uint32_t pin);
-
-#else
-
-void gpio_use(GPIO_TypeDef* GPIOx);
-void gpio_release(GPIO_TypeDef* GPIOx);
-
-#endif
-
 //! Initialize a GPIO as an output.
 //!
 //! @param pin_config the BOARD_CONFIG pin configuration struct

--- a/src/fw/drivers/gpio.h
+++ b/src/fw/drivers/gpio.h
@@ -47,34 +47,6 @@ void gpio_output_init(const OutputConfig *pin_config, GPIOOType_TypeDef otype);
 //! is true, and drives it low if pin_config.active_high is false.
 void gpio_output_set(const OutputConfig *pin_config, bool asserted);
 
-#ifndef CONFIG_SOC_NRF52
-
-//! Configure a GPIO alternate function.
-//!
-//! @param pin_config the BOARD_CONFIG pin configuration struct
-//! @param otype the output type of the pin (GPIO_OType_PP or GPIO_OType_OD)
-//! @param pupd pull-up or pull-down configuration
-void gpio_af_init(const AfConfig *af_config, GPIOOType_TypeDef otype,
-                  GPIOPuPd_TypeDef pupd);
-
-//! Configure a GPIO alternate function pin to minimize power consumption.
-//!
-//! Once a pin has been configured for low power, it is no longer
-//! connected to its alternate function. \ref gpio_af_init will need to
-//! be called again on the pin in order to configure it in alternate
-//! function mode again.
-void gpio_af_configure_low_power(const AfConfig *af_config);
-
-//! Configure a GPIO alternate function pin to drive a constant output.
-//!
-//! Once a pin has been configured as a fixed output, it is no longer
-//! connected to its alternate function. \ref gpio_af_init will need to
-//! be called again on the pin in order to configure it in alternate
-//! function mode again.
-void gpio_af_configure_fixed_output(const AfConfig *af_config, bool asserted);
-
-#endif
-
 //! Configure all GPIOs in the system to optimize for power consumption.
 //! At poweron most GPIOs can be configured as analog inputs instead of the
 //! default digital input. This allows digital filtering logic to be shut down,

--- a/src/fw/drivers/gpio.h
+++ b/src/fw/drivers/gpio.h
@@ -21,12 +21,6 @@ typedef enum {
   GPIO_PuPd_DOWN,
 } GPIOPuPd_TypeDef;
 
-typedef enum {
-  GPIO_Speed_2MHz,
-  GPIO_Speed_50MHz,
-  GPIO_Speed_200MHz
-} GPIOSpeed_TypeDef;
-
 #endif
 
 #ifdef CONFIG_SOC_NRF52
@@ -45,11 +39,7 @@ void gpio_release(GPIO_TypeDef* GPIOx);
 //!
 //! @param pin_config the BOARD_CONFIG pin configuration struct
 //! @param otype the output type of the pin (GPIO_OType_PP or GPIO_OType_OD)
-//! @param speed the output slew rate
-//! @note The slew rate should be set as low as possible for the
-//!       pin function to minimize ringing and RF interference.
-void gpio_output_init(const OutputConfig *pin_config, GPIOOType_TypeDef otype,
-                      GPIOSpeed_TypeDef speed);
+void gpio_output_init(const OutputConfig *pin_config, GPIOOType_TypeDef otype);
 
 //! Assert or deassert the output pin.
 //!
@@ -63,12 +53,9 @@ void gpio_output_set(const OutputConfig *pin_config, bool asserted);
 //!
 //! @param pin_config the BOARD_CONFIG pin configuration struct
 //! @param otype the output type of the pin (GPIO_OType_PP or GPIO_OType_OD)
-//! @param speed the output slew rate
 //! @param pupd pull-up or pull-down configuration
-//! @note The slew rate should be set as low as possible for the
-//!       pin function to minimize ringing and RF interference.
 void gpio_af_init(const AfConfig *af_config, GPIOOType_TypeDef otype,
-                  GPIOSpeed_TypeDef speed, GPIOPuPd_TypeDef pupd);
+                  GPIOPuPd_TypeDef pupd);
 
 //! Configure a GPIO alternate function pin to minimize power consumption.
 //!

--- a/src/fw/drivers/gpio/nrf5.c
+++ b/src/fw/drivers/gpio/nrf5.c
@@ -10,12 +10,10 @@ void gpio_input_init(const InputConfig *pin_config) {
   nrf_gpio_pin_dir_set(pin_config->gpio_pin, NRF_GPIO_PIN_DIR_INPUT);
 }
 
-void gpio_output_init(const OutputConfig *pin_config, GPIOOType_TypeDef otype,
-                      GPIOSpeed_TypeDef speed) {
+void gpio_output_init(const OutputConfig *pin_config, GPIOOType_TypeDef otype) {
   if (otype == GPIO_OType_OD)
     WTF;
 
-  /* XXX: speed */
   nrf_gpio_cfg(pin_config->gpio_pin, NRF_GPIO_PIN_DIR_OUTPUT, NRF_GPIO_PIN_INPUT_DISCONNECT, NRF_GPIO_PIN_NOPULL, NRF_GPIO_PIN_S0S1, NRF_GPIO_PIN_NOSENSE);
 }
 

--- a/src/fw/drivers/gpio/sf32lb.c
+++ b/src/fw/drivers/gpio/sf32lb.c
@@ -34,9 +34,7 @@ void gpio_release(GPIO_TypeDef *GPIOx) {
   portEXIT_CRITICAL();
 }
 
-void gpio_output_init(const OutputConfig *pin_config, GPIOOType_TypeDef otype,
-                      GPIOSpeed_TypeDef speed) {
-  (void)speed;
+void gpio_output_init(const OutputConfig *pin_config, GPIOOType_TypeDef otype) {
   gpio_use(pin_config->gpio);
   GPIO_InitTypeDef GPIO_InitStruct;
   GPIO_InitStruct.Pin = pin_config->gpio_pin;

--- a/src/fw/drivers/gpio/sf32lb.c
+++ b/src/fw/drivers/gpio/sf32lb.c
@@ -9,34 +9,11 @@
 
 #include <stdint.h>
 
-static RCC_MODULE_TYPE prv_get_gpio_rcc_module(GPIO_TypeDef *GPIOx) {
-  if (GPIOx == hwp_gpio1) {
-    return RCC_MOD_GPIO1;
-  } else if (GPIOx == hwp_gpio2) {
-    return RCC_MOD_GPIO2;
-  } else {
-    WTF;
-  }
-  return 0;
-}
-
-void gpio_use(GPIO_TypeDef *GPIOx) {
-  RCC_MODULE_TYPE rcc_module = prv_get_gpio_rcc_module(GPIOx);
-  portENTER_CRITICAL();
-  HAL_RCC_EnableModule(rcc_module);
-  portEXIT_CRITICAL();
-}
-
-void gpio_release(GPIO_TypeDef *GPIOx) {
-  RCC_MODULE_TYPE rcc_module = prv_get_gpio_rcc_module(GPIOx);
-  portENTER_CRITICAL();
-  HAL_RCC_DisableModule(rcc_module);
-  portEXIT_CRITICAL();
-}
-
 void gpio_output_init(const OutputConfig *pin_config, GPIOOType_TypeDef otype) {
-  gpio_use(pin_config->gpio);
   GPIO_InitTypeDef GPIO_InitStruct;
+
+  HAL_RCC_EnableModule(RCC_MOD_GPIO1);
+
   GPIO_InitStruct.Pin = pin_config->gpio_pin;
   if (otype == GPIO_OType_OD) {
     GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_OD;
@@ -56,8 +33,10 @@ void gpio_input_init(const InputConfig *input_cfg) {
 }
 
 void gpio_input_init_pull_up_down(const InputConfig *input_cfg, GPIOPuPd_TypeDef pupd) {
-  gpio_use(input_cfg->gpio);
   GPIO_InitTypeDef GPIO_InitStruct;
+
+  HAL_RCC_EnableModule(RCC_MOD_GPIO1);
+
   GPIO_InitStruct.Pin = input_cfg->gpio_pin;
   GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
   GPIO_InitStruct.Pull = GPIO_NOPULL;

--- a/src/fw/drivers/qemu/qemu_gpio_hal.c
+++ b/src/fw/drivers/qemu/qemu_gpio_hal.c
@@ -21,11 +21,9 @@ void gpio_release(GPIO_TypeDef *gpios) {
   (void)gpios;
 }
 
-void gpio_output_init(const OutputConfig *pin_config, GPIOOType_TypeDef otype,
-                      GPIOSpeed_TypeDef speed) {
+void gpio_output_init(const OutputConfig *pin_config, GPIOOType_TypeDef otype) {
   (void)pin_config;
   (void)otype;
-  (void)speed;
 }
 
 void gpio_output_set(const OutputConfig *pin_config, bool asserted) {
@@ -43,10 +41,9 @@ void gpio_output_set(const OutputConfig *pin_config, bool asserted) {
 }
 
 void gpio_af_init(const AfConfig *af_config, GPIOOType_TypeDef otype,
-                  GPIOSpeed_TypeDef speed, GPIOPuPd_TypeDef pupd) {
+                  GPIOPuPd_TypeDef pupd) {
   (void)af_config;
   (void)otype;
-  (void)speed;
   (void)pupd;
 }
 

--- a/src/fw/drivers/qemu/qemu_gpio_hal.c
+++ b/src/fw/drivers/qemu/qemu_gpio_hal.c
@@ -56,7 +56,3 @@ bool gpio_input_read(const InputConfig *input_cfg) {
   uint32_t state = REG32(QEMU_GPIO_BASE + GPIO_STATE);
   return (state & (1U << input_cfg->gpio_pin)) != 0;
 }
-
-void gpio_analog_init(const InputConfig *input_cfg) {
-  (void)input_cfg;
-}

--- a/src/fw/drivers/qemu/qemu_gpio_hal.c
+++ b/src/fw/drivers/qemu/qemu_gpio_hal.c
@@ -40,22 +40,6 @@ void gpio_output_set(const OutputConfig *pin_config, bool asserted) {
   REG32(QEMU_GPIO_BASE + GPIO_OUTPUT) = output;
 }
 
-void gpio_af_init(const AfConfig *af_config, GPIOOType_TypeDef otype,
-                  GPIOPuPd_TypeDef pupd) {
-  (void)af_config;
-  (void)otype;
-  (void)pupd;
-}
-
-void gpio_af_configure_low_power(const AfConfig *af_config) {
-  (void)af_config;
-}
-
-void gpio_af_configure_fixed_output(const AfConfig *af_config, bool asserted) {
-  (void)af_config;
-  (void)asserted;
-}
-
 void gpio_init_all(void) {
   // Nothing to configure for QEMU
 }

--- a/src/fw/drivers/qemu/qemu_gpio_hal.c
+++ b/src/fw/drivers/qemu/qemu_gpio_hal.c
@@ -13,14 +13,6 @@
 #define GPIO_STATE   0x00  // r: bit per button
 #define GPIO_OUTPUT  0x04  // w: output state bits
 
-void gpio_use(GPIO_TypeDef *gpios) {
-  (void)gpios;
-}
-
-void gpio_release(GPIO_TypeDef *gpios) {
-  (void)gpios;
-}
-
 void gpio_output_init(const OutputConfig *pin_config, GPIOOType_TypeDef otype) {
   (void)pin_config;
   (void)otype;

--- a/src/fw/drivers/qemu/qemu_gpio_hal.c
+++ b/src/fw/drivers/qemu/qemu_gpio_hal.c
@@ -40,10 +40,6 @@ void gpio_output_set(const OutputConfig *pin_config, bool asserted) {
   REG32(QEMU_GPIO_BASE + GPIO_OUTPUT) = output;
 }
 
-void gpio_init_all(void) {
-  // Nothing to configure for QEMU
-}
-
 void gpio_input_init(const InputConfig *input_cfg) {
   (void)input_cfg;
 }

--- a/src/fw/drivers/speaker/sf32lb52/audio.c
+++ b/src/fw/drivers/speaker/sf32lb52/audio.c
@@ -10,7 +10,7 @@
 #define PA_POWER_DELAY_TIME      (200) /* us */
 
 void audio_init(AudioDevice* audio_device) {
-    gpio_output_init(&audio_device->pa_ctrl, GPIO_OType_PP, GPIO_Speed_2MHz);
+    gpio_output_init(&audio_device->pa_ctrl, GPIO_OType_PP);
     gpio_output_set(&audio_device->pa_ctrl, false);
     delay_us(PA_POWER_DELAY_TIME*10);
     audec_init(audio_device);

--- a/src/fw/drivers/stubs/gpio.c
+++ b/src/fw/drivers/stubs/gpio.c
@@ -1,12 +1,5 @@
 #include "drivers/gpio.h"
 
-void gpio_use(GPIO_TypeDef* GPIOx) {
-
-}
-
-void gpio_release(GPIO_TypeDef* GPIOx) {
-}
-
 void gpio_output_init(const OutputConfig *pin_config, GPIOOType_TypeDef otype) {
 }
 

--- a/src/fw/drivers/stubs/gpio.c
+++ b/src/fw/drivers/stubs/gpio.c
@@ -24,6 +24,3 @@ bool gpio_input_read(const InputConfig *input_config) {
 
   return false;
 }
-
-void gpio_analog_init(const InputConfig *input_config) {
-}

--- a/src/fw/drivers/stubs/gpio.c
+++ b/src/fw/drivers/stubs/gpio.c
@@ -7,15 +7,14 @@ void gpio_use(GPIO_TypeDef* GPIOx) {
 void gpio_release(GPIO_TypeDef* GPIOx) {
 }
 
-void gpio_output_init(const OutputConfig *pin_config, GPIOOType_TypeDef otype,
-                      GPIOSpeed_TypeDef speed) {
+void gpio_output_init(const OutputConfig *pin_config, GPIOOType_TypeDef otype) {
 }
 
 void gpio_output_set(const OutputConfig *pin_config, bool asserted) {
 }
 
 void gpio_af_init(const AfConfig *af_config, GPIOOType_TypeDef otype,
-                  GPIOSpeed_TypeDef speed, GPIOPuPd_TypeDef pupd) {
+                  GPIOPuPd_TypeDef pupd) {
 }
 
 void gpio_af_configure_low_power(const AfConfig *af_config) {

--- a/src/fw/drivers/stubs/gpio.c
+++ b/src/fw/drivers/stubs/gpio.c
@@ -13,16 +13,6 @@ void gpio_output_init(const OutputConfig *pin_config, GPIOOType_TypeDef otype) {
 void gpio_output_set(const OutputConfig *pin_config, bool asserted) {
 }
 
-void gpio_af_init(const AfConfig *af_config, GPIOOType_TypeDef otype,
-                  GPIOPuPd_TypeDef pupd) {
-}
-
-void gpio_af_configure_low_power(const AfConfig *af_config) {
-}
-
-void gpio_af_configure_fixed_output(const AfConfig *af_config, bool asserted) {
-}
-
 void gpio_input_init(const InputConfig *input_config) {
 }
 

--- a/src/fw/drivers/touch/cst816/cst816.c
+++ b/src/fw/drivers/touch/cst816/cst816.c
@@ -221,7 +221,7 @@ void touch_sensor_init(void) {
   s_i2c_lock = mutex_create();
 
 #ifndef RESET_PIN_CTRLBY_NPM1300
-  gpio_output_init(&CST816->reset, GPIO_OType_PP, GPIO_Speed_2MHz);
+  gpio_output_init(&CST816->reset, GPIO_OType_PP);
 #endif
 
   cst816_hw_reset();

--- a/src/fw/drivers/vibe/vibe.c
+++ b/src/fw/drivers/vibe/vibe.c
@@ -61,7 +61,7 @@ void vibe_init(void) {
   periph_config_acquire_lock();
 
   if (BOARD_CONFIG_VIBE.options & ActuatorOptions_Ctl) {
-    gpio_output_init(&BOARD_CONFIG_VIBE.ctl, GPIO_OType_PP, GPIO_Speed_2MHz);
+    gpio_output_init(&BOARD_CONFIG_VIBE.ctl, GPIO_OType_PP);
     gpio_output_set(&BOARD_CONFIG_VIBE.ctl, false);
     s_initialized = true;
   }

--- a/src/fw/drivers/vibe/vibe_aw86225.c
+++ b/src/fw/drivers/vibe/vibe_aw86225.c
@@ -317,7 +317,7 @@ void vibe_init(void) {
     s_drive_frequency_hz = AW86225->lra_frequency_hz;
   }
 
-  gpio_output_init(&BOARD_CONFIG_VIBE.ctl, GPIO_OType_PP, GPIO_Speed_2MHz);
+  gpio_output_init(&BOARD_CONFIG_VIBE.ctl, GPIO_OType_PP);
 
   gpio_output_set(&BOARD_CONFIG_VIBE.ctl, true);
   psleep(AW862XX_PWR_OFF_TIME);

--- a/src/fw/drivers/vibe/vibe_aw8623x.c
+++ b/src/fw/drivers/vibe/vibe_aw8623x.c
@@ -82,7 +82,7 @@ void vibe_init(void) {
   bool ret;
   uint8_t val;
 
-  gpio_output_init(&BOARD_CONFIG_VIBE.ctl, GPIO_OType_PP, GPIO_Speed_2MHz);
+  gpio_output_init(&BOARD_CONFIG_VIBE.ctl, GPIO_OType_PP);
 
   gpio_output_set(&BOARD_CONFIG_VIBE.ctl, true);
   psleep(AW8623X_PWR_OFF_TIME_MS);

--- a/src/fw/drivers/vibe/vibe_drv2604.c
+++ b/src/fw/drivers/vibe/vibe_drv2604.c
@@ -72,7 +72,7 @@ static bool prv_write_register(uint8_t register_address, uint8_t datum) {
 }
 
 void vibe_init(void) {
-  gpio_output_init(&BOARD_CONFIG_VIBE.ctl, GPIO_OType_PP, GPIO_Speed_2MHz);
+  gpio_output_init(&BOARD_CONFIG_VIBE.ctl, GPIO_OType_PP);
   gpio_output_set(&BOARD_CONFIG_VIBE.ctl, true);
   uint8_t rv;
   bool found = prv_read_register(DRV2604_STATUS, &rv);

--- a/src/fw/main.c
+++ b/src/fw/main.c
@@ -128,37 +128,6 @@ static void print_splash_screen(void)
   PBL_LOG_ALWAYS(" ");
 }
 
-#ifdef DUMP_GPIO_CFG_STATE
-static void dump_gpio_configuration_state(void) {
-  char name[2] = { 0 };
-  name[0] = 'A'; // GPIO Port A
-
-  GPIO_TypeDef *gpio_pin;
-
-  for (uint32_t gpio_addr = (uint32_t)GPIOA; gpio_addr <= (uint32_t)GPIOI;
-       gpio_addr += 0x400) {
-    gpio_pin = (GPIO_TypeDef *)gpio_addr;
-
-    gpio_use(gpio_pin);
-    uint32_t mode = gpio_pin->MODER;
-    gpio_release(gpio_pin);
-
-    uint16_t pin_cfg_mask = 0;
-    char buf[80];
-    for (int pin = 0; pin < 16; pin++) {
-      if ((mode & GPIO_MODER_MODER0) != GPIO_Mode_AN) {
-        pin_cfg_mask |= (0x1 << pin);
-      }
-      mode >>= 2;
-    }
-
-    dbgserial_putstr_fmt(buf, sizeof(buf), "Non Analog P%s cfg: 0x%"PRIx16,
-      name, (int)pin_cfg_mask);
-    name[0]++;
-  }
-}
-#endif /* DUMP_GPIO_CFG_STATE */
-
 int main(void) {
   soc_early_init();
 
@@ -425,11 +394,6 @@ static NOINLINE void prv_main_task_init(void) {
   // Initialize button driver at the last moment to prevent "system on" button press from
   // entering the kernel event queue.
   debounced_button_init();
-
-#ifdef DUMP_GPIO_CFG_STATE
-  // at this point everything should be configured!
-  dump_gpio_configuration_state();
-#endif
 
   task_watchdog_resume();
 }

--- a/tests/overrides/fpc_pinstrap_board/board/board.h
+++ b/tests/overrides/fpc_pinstrap_board/board/board.h
@@ -19,8 +19,6 @@ typedef enum {
   GPIO_OType_OD
 } GPIOOType_TypeDef;
 
-typedef void* GPIOSpeed_TypeDef;
-
 typedef enum {
   GPIO_PuPd_NOPULL,
   GPIO_PuPd_UP,


### PR DESCRIPTION
The slew rate parameter (GPIOSpeed_TypeDef) was never used by any GPIO driver implementation (nRF52, SF32LB, QEMU, stubs all ignored it). Drop the GPIOSpeed_TypeDef enum and the speed argument from gpio_output_init() and gpio_af_init(), and update all call sites accordingly.