### PR TITLE
build: normalize bundle file names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,16 +62,11 @@ jobs:
       - name: Copy PRF artifacts
         run: |
           mkdir -p artifacts
-          cp build/src/fw/tintin_fw.hex \
-             artifacts/prf_${{ steps.artifact_board.outputs.NAME }}_${{github.ref_name}}.hex
-          cp build/src/fw/tintin_fw.bin \
-             artifacts/prf_${{ steps.artifact_board.outputs.NAME }}_${{github.ref_name}}.bin
-          cp build/src/fw/tintin_fw.elf \
-             artifacts/prf_${{ steps.artifact_board.outputs.NAME }}_${{github.ref_name}}.elf
-          cp build/recovery_${{ matrix.board }}_${{ github.ref_name }}.pbz \
-             artifacts/recovery_${{ steps.artifact_board.outputs.NAME }}_${{ github.ref_name }}.pbz
-          cp build/src/fw/tintin_fw_loghash_dict.json \
-             artifacts/prf_${{ steps.artifact_board.outputs.NAME }}_${{github.ref_name}}_loghash_dict.json
+          cp build/src/fw/tintin_fw.hex artifacts/prf_${{ steps.artifact_board.outputs.NAME }}_${{github.ref_name}}.hex
+          cp build/src/fw/tintin_fw.bin artifacts/prf_${{ steps.artifact_board.outputs.NAME }}_${{github.ref_name}}.bin
+          cp build/src/fw/tintin_fw.elf artifacts/prf_${{ steps.artifact_board.outputs.NAME }}_${{github.ref_name}}.elf
+          cp build/*.pbz artifacts
+          cp build/src/fw/tintin_fw_loghash_dict.json artifacts/prf_${{ steps.artifact_board.outputs.NAME }}_${{github.ref_name}}_loghash_dict.json
 
       - name: Get PRF Build ID
         id: prf_build_id
@@ -184,16 +179,11 @@ jobs:
       - name: Copy firmware artifacts
         run: |
           mkdir -p artifacts
-          cp build/src/fw/tintin_fw.hex \
-             artifacts/firmware_${{ steps.artifact_board.outputs.NAME }}_${{github.ref_name}}${{ steps.slot_suffix.outputs.SLOT_SUFFIX }}.hex
-          cp build/src/fw/tintin_fw.bin \
-             artifacts/firmware_${{ steps.artifact_board.outputs.NAME }}_${{github.ref_name}}${{ steps.slot_suffix.outputs.SLOT_SUFFIX }}.bin
-          cp build/src/fw/tintin_fw.elf \
-             artifacts/firmware_${{ steps.artifact_board.outputs.NAME }}_${{github.ref_name}}${{ steps.slot_suffix.outputs.SLOT_SUFFIX }}.elf
-          cp build/normal_${{ matrix.board }}_${{ github.ref_name }}${{ steps.slot_suffix.outputs.SLOT_SUFFIX }}.pbz \
-             artifacts/normal_${{ steps.artifact_board.outputs.NAME }}_${{ github.ref_name }}${{ steps.slot_suffix.outputs.SLOT_SUFFIX }}.pbz
-          cp build/src/fw/tintin_fw_loghash_dict.json \
-             artifacts/firmware_${{ steps.artifact_board.outputs.NAME }}_${{github.ref_name}}${{ steps.slot_suffix.outputs.SLOT_SUFFIX }}_loghash_dict.json
+          cp build/src/fw/tintin_fw.hex artifacts/firmware_${{ steps.artifact_board.outputs.NAME }}_${{github.ref_name}}${{ steps.slot_suffix.outputs.SLOT_SUFFIX }}.hex
+          cp build/src/fw/tintin_fw.bin artifacts/firmware_${{ steps.artifact_board.outputs.NAME }}_${{github.ref_name}}${{ steps.slot_suffix.outputs.SLOT_SUFFIX }}.bin
+          cp build/src/fw/tintin_fw.elf artifacts/firmware_${{ steps.artifact_board.outputs.NAME }}_${{github.ref_name}}${{ steps.slot_suffix.outputs.SLOT_SUFFIX }}.elf
+          cp build/*.pbz artifacts
+          cp build/src/fw/tintin_fw_loghash_dict.json artifacts/firmware_${{ steps.artifact_board.outputs.NAME }}_${{github.ref_name}}${{ steps.slot_suffix.outputs.SLOT_SUFFIX }}_loghash_dict.json
 
       - name: Get Build ID
         id: build_id

--- a/waftools/boards.py
+++ b/waftools/boards.py
@@ -16,6 +16,10 @@ class BoardSpec:
         self.revision = revision
         self.runners = runners or []
 
+    @property
+    def normalized(self):
+        return self.target.replace("@", "_")
+
 
 def _boards_dir(srcdir):
     return os.path.join(srcdir, "boards")

--- a/wscript
+++ b/wscript
@@ -173,6 +173,7 @@ def configure(conf):
     conf.env.BOARD = board.target
     conf.env.BOARD_NAME = board.name
     conf.env.BOARD_REVISION = board.revision
+    conf.env.BOARD_NORMALIZED = board.normalized
 
     conf.env.VARIANT = conf.options.variant
     if conf.env.VARIANT == 'prf':
@@ -502,13 +503,13 @@ def _make_bundle(ctx, fw_bin_path, fw_type='normal', board=None, resource_path=N
     import mkbundle
 
     if board is None:
-        board = ctx.env.BOARD
+        board = ctx.env.BOARD_NORMALIZED
 
     b = mkbundle.PebbleBundle()
 
     version_string, version_ts, version_commit = _get_version_info(ctx)
     slot = ctx.env.SLOT if fw_type == 'normal' and ctx.env.SLOT != -1 else None
-    out_file = ctx.get_pbz_node(fw_type, ctx.env.BOARD, version_string, slot).path_from(ctx.path)
+    out_file = ctx.get_pbz_node(fw_type, ctx.env.BOARD_NORMALIZED, version_string, slot).path_from(ctx.path)
 
     try:
         _check_firmware_image_size(ctx, fw_bin_path)


### PR DESCRIPTION
## Summary

Move bundle file name normalization from the release workflow into the
build system.

Board targets may contain `@` (e.g. `obelix@dvt`) to select a revision,
which leaked into the `.pbz` bundle file names. Previously the release
workflow worked around this by renaming the artifacts after the build.

- Revert `ci/release: normalize bundle names` (the workflow-side
  workaround).
- Add `BoardSpec.normalized` (`@` → `_`) and use it for the `.pbz`
  bundle output names, so the build system emits clean names directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)