### PR TITLE
applib/text_layout: pre-load glyph bitmaps in RTL rendering path

### DIFF
--- a/src/fw/applib/graphics/text_layout.c
+++ b/src/fw/applib/graphics/text_layout.c
@@ -803,6 +803,7 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
             cursor.origin.x += walked_width_px;
 
             if (!codepoint_is_zero_width(rcp)) {
+              text_resources_get_glyph(&ctx->font_cache, rcp, text_box_params->font);
               render_glyph(ctx, rcp, text_box_params->font, cursor);
             }
 
@@ -830,6 +831,7 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
           cursor.origin.x += walked_width_px;
 
           if (!codepoint_is_zero_width(scp)) {
+            text_resources_get_glyph(&ctx->font_cache, scp, text_box_params->font);
             render_glyph(ctx, scp, text_box_params->font, cursor);
           }
 
@@ -852,6 +854,7 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
         .size.h = fonts_get_font_height(text_box_params->font)
       };
       cursor.origin.x += walked_width_px;
+      text_resources_get_glyph(&ctx->font_cache, line->suffix_codepoint, text_box_params->font);
       render_glyph(ctx, line->suffix_codepoint, text_box_params->font, cursor);
     }
 


### PR DESCRIPTION
## Summary

- The BiDi (RTL) rendering path in `walk_line()` was missing glyph bitmap pre-loading before `render_glyph()` calls, unlike the standard LTR path which pre-loads via `text_resources_get_glyph()` to ensure cache hits
- Without pre-loading, the RTL path triggers the full flash I/O call chain (`text_resources_get_glyph → prv_load_glyph_bitmap → sys_resource_load_range`) from deep in the stack, on top of 256 bytes of RTL shaping/reversal buffers already allocated on the stack
- This contributes to KernelMain stack overflows during notification text rendering (FIRM-2575/FIRM-2643 crash family)
- Adds `text_resources_get_glyph()` pre-load calls before every `render_glyph()` in the BiDi rendering block — for RTL segments, LTR segments within mixed text, and the trailing suffix glyph

Fixes FIRM-2643
Fixes FIRM-2575

## Test plan

- [ ] Verify text rendering with RTL text (Arabic, Hebrew) in notifications
- [ ] Verify text rendering with mixed LTR/RTL text
- [ ] Verify no regression in standard LTR notification rendering
- [ ] Monitor KernelMain stack high-water mark during notification rendering with RTL content

🤖 Generated with [Claude Code](https://claude.com/claude-code)