### PR TITLE
battery: show percent while charging

### DIFF
--- a/src/fw/shell/normal/battery_ui.c
+++ b/src/fw/shell/normal/battery_ui.c
@@ -34,6 +34,10 @@ typedef struct {
   ResourceId warning_icon;
 } BatteryWarningDisplayData;
 
+typedef struct {
+  uint8_t percent;
+} BatteryChargingDisplayData;
+
 // UI Callbacks
 ///////////////////////
 
@@ -53,8 +57,11 @@ static void prv_update_ui_fully_charged(Dialog *dialog, void *ignored) {
   dialog_set_icon(dialog, RESOURCE_ID_BATTERY_ICON_FULL_LARGE);
 }
 
-static void prv_update_ui_charging(Dialog *dialog, void *ignored) {
-  dialog_set_text(dialog, i18n_get("Charging", dialog));
+static void prv_update_ui_charging(Dialog *dialog, void *context) {
+  BatteryChargingDisplayData *data = context;
+  char text[32];
+  snprintf(text, sizeof(text), "%s\n%u%%", i18n_get("Charging", dialog), data->percent);
+  dialog_set_text(dialog, text);
   dialog_set_background_color(dialog, GColorLightGray);
   dialog_set_icon(dialog, RESOURCE_ID_BATTERY_ICON_CHARGING_LARGE);
 }
@@ -137,12 +144,15 @@ static void prv_display_modal(WindowStack *stack, DialogUpdateFn update_fn, void
 // Public API
 ////////////////////
 
-void battery_ui_display_plugged(void) {
+void battery_ui_display_plugged(uint8_t percent) {
   // If we're plugged in for charging, we want to alert the user of this,
   // but we don't want to overlay ourselves over anything they may have
   // on the screen at the moment.
   WindowStack *stack = modal_manager_get_window_stack(ModalPriorityGeneric);
-  prv_display_modal(stack, prv_update_ui_charging, NULL);
+  BatteryChargingDisplayData display_data = {
+    .percent = percent,
+  };
+  prv_display_modal(stack, prv_update_ui_charging, &display_data);
 }
 
 void battery_ui_display_fully_charged(void) {

--- a/src/fw/shell/normal/battery_ui.h
+++ b/src/fw/shell/normal/battery_ui.h
@@ -23,7 +23,7 @@ void battery_ui_handle_state_change_event(PreciseBatteryChargeState new_state);
 void battery_ui_handle_shut_down(void);
 
 //! Show the 'battery charging' modal dialog
-void battery_ui_display_plugged(void);
+void battery_ui_display_plugged(uint8_t percent);
 
 //! Show the 'battery charged' modal dialog
 void battery_ui_display_fully_charged(void);

--- a/src/fw/shell/normal/battery_ui_fsm.c
+++ b/src/fw/shell/normal/battery_ui_fsm.c
@@ -184,7 +184,8 @@ static void prv_display_plugged(void *data) {
   if (!do_not_disturb_is_active()) {
     vibes_short_pulse();
   }
-  battery_ui_display_plugged();
+  const uint8_t percent = ratio32_to_percent(((PreciseBatteryChargeState *)data)->charge_percent);
+  battery_ui_display_plugged(percent);
 }
 
 static void prv_dismiss_plugged(void) {

--- a/tests/fw/shell/normal/test_battery_ui_fsm.c
+++ b/tests/fw/shell/normal/test_battery_ui_fsm.c
@@ -83,9 +83,10 @@ void app_manager_close_current_app(bool gracefully) {
   s_critical = false;
 }
 
-void battery_ui_display_plugged(void) {
+void battery_ui_display_plugged(uint8_t percent) {
   s_modal_onscreen = true;
   s_modal_charging = true;
+  s_modal_percent = percent;
 }
 
 void battery_ui_display_fully_charged(void) {


### PR DESCRIPTION
Add the current battery percentage to charging dialogs while keeping fully charged messages percentage-free.
Emery:
<img width="200" height="228" alt="qemu_emery_charging_42 copy" src="https://github.com/user-attachments/assets/9958ee9d-a8a1-4a0a-b1de-2fc1e5d166e1" /> <img width="200" height="228" alt="qemu_emery_fully_charged copy" src="https://github.com/user-attachments/assets/81d937c3-6a1a-41d7-99a0-0283d2df2214" />
Flint: 
<img width="144" height="168" alt="qemu_flint_charging_42" src="https://github.com/user-attachments/assets/4093c61a-6336-4c2a-bbc2-2a501ea6206e" /><img width="144" height="168" alt="qemu_flint_fully_charged" src="https://github.com/user-attachments/assets/72c2203a-c32c-4a34-992a-12bc8f57096b" />
Gabbro: 
<img width="260" height="260" alt="qemu_gabbro_charging_42" src="https://github.com/user-attachments/assets/8e119071-c9ee-4a76-8135-370461036a0d" /><img width="260" height="260" alt="qemu_gabbro_fully_charged" src="https://github.com/user-attachments/assets/7135753b-decb-4f06-9607-2a5a1b48f999" />
