### PR TITLE
fw: revert flint/diorite app segment to 66 KiB

### DIFF
--- a/src/fw/process_management/app_manager.c
+++ b/src/fw/process_management/app_manager.c
@@ -201,7 +201,11 @@ void prv_dump_start_app_info(const PebbleProcessMd *app_md) {
 }
 
 #define APP_STACK_JS_SIZE (8 * 1024)
+#if defined(CONFIG_PLATFORM_EMERY) || defined(CONFIG_PLATFORM_GABBRO)
 #define APP_STACK_NORMAL_SIZE (4 * 1024)
+#else
+#define APP_STACK_NORMAL_SIZE (2 * 1024)
+#endif
 
 static size_t prv_get_app_segment_size(const PebbleProcessMd *app_md) {
   switch (process_metadata_get_app_sdk_type(app_md)) {
@@ -229,7 +233,16 @@ static size_t prv_get_app_stack_size(const PebbleProcessMd *app_md) {
     return APP_STACK_JS_SIZE;
   }
 #endif
-  return APP_STACK_NORMAL_SIZE;
+  // Only 4x/System apps get the larger stack: their segment (APP_RAM_SIZES) is
+  // sized for it. Legacy 2x/3x apps keep the historical 2 KiB stack to match
+  // their (unchanged) segment sizes.
+  switch (process_metadata_get_app_sdk_type(app_md)) {
+    case ProcessAppSDKType_Legacy2x:
+    case ProcessAppSDKType_Legacy3x:
+      return 2 * 1024;
+    default:
+      return APP_STACK_NORMAL_SIZE;
+  }
 }
 
 T_STATIC MemorySegment prv_get_app_ram_segment(void) {

--- a/src/fw/wscript
+++ b/src/fw/wscript
@@ -168,14 +168,17 @@ def _generate_memory_layout(bld):
     # (AppState) for each SDK platform, respectively.
     AppRamSize = collections.namedtuple('AppRamSize',
                                         'app_segment runtime_reserved')
+    # emery and gabbro use a 4 KiB app stack (see APP_STACK_NORMAL_SIZE); their
+    # app_segment is sized 2 KiB larger to compensate. All other platforms keep
+    # the 2 KiB stack and the historical segment sizes.
     APP_RAM_SIZES = {
-        'aplite': AppRamSize(28000, 6820),
-        'basalt': AppRamSize(68 * 1024, 30 * 1024),
-        'chalk': AppRamSize(68 * 1024, 30 * 1024),
+        'aplite': AppRamSize(25952, 6820),
+        'basalt': AppRamSize(66 * 1024, 30 * 1024),
+        'chalk': AppRamSize(66 * 1024, 30 * 1024),
         # FIXME: The runtime_reserved size could be reduced for diorite
-        'diorite': AppRamSize(68 * 1024, 30 * 1024),
+        'diorite': AppRamSize(66 * 1024, 30 * 1024),
         'emery': AppRamSize(132 * 1024, 62 * 1024),
-        'flint': AppRamSize(68 * 1024, 30 * 1024),
+        'flint': AppRamSize(66 * 1024, 30 * 1024),
         'gabbro': AppRamSize(132 * 1024, 94 * 1024),
     }
     APP_UNSUPPORTED = AppRamSize(0, 0)


### PR DESCRIPTION
Commit d2cd45a9 ("fw/process_management: double the app stack to 4 KiB") bumped app_segment for all platforms, taking flint (and diorite) to 68 KiB. Combined with the 30 KiB runtime_reserved this makes the App RAM region 98 KiB (0x18800), which the ARMv7-M MPU cannot express: a region must be n*2^k bytes with n <= 8 subregions, and 98 KiB = 2^11 * 49.

Since db56c6c4 the subregion math runs at runtime rather than at build time (tools/mpu_calc.py), so the illegal size no longer fails the build and instead trips PBL_CROAK in compute_block_layout() while booting asterix (a flint board):

  mpu_armv7m.c: MPU region cannot fit subregion alignment:
  base=0x20027800 size=0x18800

Revert flint and diorite (the ARMv7-M platforms) to 66 KiB, restoring the 96 KiB (0x18000) App RAM region that maps cleanly to 6 x 16 KiB subregions. ARMv8-M platforms program the limit register directly and are unaffected, so they keep 68 KiB.