### PR TITLE
sdk: expose speaker playback limits to app SDK

### DIFF
--- a/include/pbl/services/speaker/limits.h
+++ b/include/pbl/services/speaker/limits.h
@@ -1,0 +1,14 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+//! Maximum number of notes in a single speaker_play_notes() call.
+#define SPEAKER_MAX_NOTES 256
+
+//! Maximum number of parallel tracks in a single speaker_play_tracks() call.
+#define SPEAKER_MAX_TRACKS 4
+
+//! Maximum total sample-data bytes across all tracks in one speaker_play_tracks()
+//! call.
+#define SPEAKER_MAX_SAMPLE_BYTES_TOTAL (16 * 1024)

--- a/include/pbl/services/speaker/speaker_service.h
+++ b/include/pbl/services/speaker/speaker_service.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "pbl/services/speaker/limits.h"
 #include "pbl/services/speaker/note_sequence.h"
 #include "pbl/services/speaker/speaker_finish_reason.h"
 #include "pbl/services/speaker/speaker_pcm_format.h"
@@ -71,12 +72,6 @@ bool speaker_service_play_tracks(const SpeakerTrack *tracks, uint32_t num_tracks
 //! Ask the service to post PEBBLE_SPEAKER_EVENT with the finish reason to the
 //! given task whenever playback ends.
 void speaker_service_register_finish(PebbleTask task);
-
-//! Max number of parallel tracks for polyphony.
-#define SPEAKER_MAX_TRACKS 4
-
-//! Max total sample-data bytes per speaker_service_play_tracks call.
-#define SPEAKER_MAX_SAMPLE_BYTES_TOTAL (16 * 1024)
 
 //! Open a PCM stream for writing.
 //! @param pri Priority level

--- a/src/fw/applib/ui/speaker.h
+++ b/src/fw/applib/ui/speaker.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "pbl/services/speaker/limits.h"
 #include "pbl/services/speaker/note_sequence.h"
 #include "pbl/services/speaker/speaker_finish_reason.h"
 #include "pbl/services/speaker/speaker_pcm_format.h"
@@ -40,14 +41,14 @@ typedef void (*SpeakerFinishedCallback)(SpeakerFinishReason reason, void *ctx);
 
 //! Play a sequence of notes on the speaker.
 //! @param notes Array of SpeakerNote structs defining the melody
-//! @param num_notes Number of notes in the array
+//! @param num_notes Number of notes in the array (max SPEAKER_MAX_NOTES)
 //! @param volume Playback volume (0-100)
 //! @return true if playback started successfully
 bool speaker_play_notes(const SpeakerNote *notes, uint32_t num_notes, uint8_t volume);
 
 //! Play N monophonic tracks in parallel, mixed (polyphony).
 //! @param tracks Array of track descriptors (notes + optional sample).
-//! @param num_tracks Number of tracks. Must be >= 1 and <= 4.
+//! @param num_tracks Number of tracks. Must be >= 1 and <= SPEAKER_MAX_TRACKS.
 //! @param volume Playback volume (0-100).
 //! @return true if playback started successfully.
 bool speaker_play_tracks(const SpeakerTrack *tracks, uint32_t num_tracks, uint8_t volume);

--- a/src/fw/process_management/pebble_process_info.h
+++ b/src/fw/process_management/pebble_process_info.h
@@ -166,9 +166,10 @@ typedef enum {
 // sdk.major:0x5 .minor:0x62 -- Add backlight_service_subscribe/unsubscribe for backlight on/off events (rev 101)
 // sdk.major:0x5 .minor:0x63 -- Export launch_button() (rev 102)
 // sdk.major:0x5 .minor:0x64 -- Add kModdableCreationFlagDebug (rev 103)
+// sdk.major:0x5 .minor:0x65 -- Expose speaker playback limits (rev 104)
 
 #define PROCESS_INFO_CURRENT_SDK_VERSION_MAJOR 0x5
-#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x64
+#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x65
 
 // The first SDK to ship with 2.x APIs
 #define PROCESS_INFO_FIRST_2X_SDK_VERSION_MAJOR 0x4

--- a/src/fw/syscall/syscall_speaker.c
+++ b/src/fw/syscall/syscall_speaker.c
@@ -7,11 +7,11 @@
 #include "kernel/pebble_tasks.h"
 #include "pbl/services/speaker/speaker_pcm_format.h"
 #include "pbl/services/speaker/speaker_service.h"
+#include "pbl/services/speaker/limits.h"
 #include "pbl/services/speaker/note_sequence.h"
 #include "pbl/services/speaker/track.h"
 #include "system/passert.h"
 
-#define SPEAKER_MAX_NOTES 256
 #define SPEAKER_MAX_STREAM_WRITE 8192
 
 DEFINE_SYSCALL(bool, sys_speaker_play_note_seq, const SpeakerNote *notes,

--- a/tools/generate_native_sdk/exported_symbols.json
+++ b/tools/generate_native_sdk/exported_symbols.json
@@ -4,7 +4,7 @@
               "You should also make sure you are obeying our API design guidelines:",
               "https://pebbletechnology.atlassian.net/wiki/display/DEV/SDK+API+Design+Guidelines"
             ],
-  "revision" : "103",
+  "revision" : "104",
   "version" : "2.0",
   "files": [
     "fw/drivers/ambient_light.h",
@@ -114,6 +114,7 @@
     "fw/applib/ui/ui.h",
     "fw/applib/ui/vibes.h",
     "fw/applib/ui/speaker.h",
+    "include/pbl/services/speaker/limits.h",
     "include/pbl/services/speaker/note_sequence.h",
     "include/pbl/services/speaker/speaker_finish_reason.h",
     "include/pbl/services/speaker/speaker_pcm_format.h",
@@ -4575,6 +4576,18 @@
             }, {
               "type": "type",
               "name": "SpeakerTrack"
+            }, {
+              "type": "define",
+              "name": "SPEAKER_MAX_NOTES",
+              "addedRevision": "104"
+            }, {
+              "type": "define",
+              "name": "SPEAKER_MAX_TRACKS",
+              "addedRevision": "104"
+            }, {
+              "type": "define",
+              "name": "SPEAKER_MAX_SAMPLE_BYTES_TOTAL",
+              "addedRevision": "104"
             }, {
               "type": "function",
               "name": "speaker_play_notes",


### PR DESCRIPTION
## Summary
- Add `include/pbl/services/speaker/limits.h` with `SPEAKER_MAX_NOTES`, `SPEAKER_MAX_TRACKS`, and `SPEAKER_MAX_SAMPLE_BYTES_TOTAL`.
- Export all three constants in the native SDK at revision 104.
- Document the limits in `speaker.h` and use the shared header from firmware syscall/service code.

Fixes #1221

## Test plan
- [ ] `./pbl build` on an Obelix board with `CONFIG_SPEAKER`
- [ ] Verify generated `sdk/include/pebble.h` defines all three `SPEAKER_MAX_*` symbols
- [ ] Build a test app that references `SPEAKER_MAX_NOTES` / `SPEAKER_MAX_TRACKS` against the new SDK