### PR TITLE
applib: fix stack overflow when rendering Hebrew notifications

### DIFF
--- a/src/fw/applib/graphics/rtl_support.c
+++ b/src/fw/applib/graphics/rtl_support.c
@@ -8,9 +8,8 @@
 
 #include <string.h>
 
-// Maximum number of codepoints we can handle in a single reversal
-// Keep small for stack safety on embedded systems (32 codepoints * 4 bytes = 128 bytes)
-// 32 is sufficient for all real Hebrew words including long morphological forms
+// Maximum number of codepoints we can handle in a single reversal.
+// 32 is sufficient for real Hebrew words including long morphological forms.
 #define MAX_RTL_CODEPOINTS 32
 
 bool utf8_contains_rtl(const utf8_t *start, const utf8_t *end) {
@@ -68,10 +67,8 @@ size_t utf8_reverse_for_rtl(const utf8_t *src, size_t src_len,
     return 0;
   }
 
-  // First pass: collect all codepoints into an array
-  Codepoint codepoints[MAX_RTL_CODEPOINTS];
+  // First pass: find the end of the bounded input we will reverse.
   size_t num_codepoints = 0;
-
   utf8_t *ptr = (utf8_t *)src;
   const utf8_t *end = src + src_len;
 
@@ -81,19 +78,30 @@ size_t utf8_reverse_for_rtl(const utf8_t *src, size_t src_len,
     if (cp == 0 || next == NULL) {
       break;
     }
-    codepoints[num_codepoints++] = cp;
     ptr = next;
+    num_codepoints++;
   }
 
   if (num_codepoints == 0) {
     return 0;
   }
 
-  // Second pass: write codepoints in reverse order to destination
+  const utf8_t *reverse_ptr = ptr;
   size_t dest_offset = 0;
 
-  for (size_t i = num_codepoints; i > 0; i--) {
-    Codepoint cp = codepoints[i - 1];
+  // Second pass: walk backward over UTF-8 sequence starts and write each
+  // codepoint to the destination. This avoids a stack array in the render path.
+  while (reverse_ptr > src) {
+    const utf8_t *cp_start = reverse_ptr - 1;
+    while (cp_start > src && ((*cp_start & 0xC0) == 0x80)) {
+      cp_start--;
+    }
+
+    utf8_t *next = NULL;
+    Codepoint cp = utf8_peek_codepoint((utf8_t *)cp_start, &next);
+    if (cp == 0 || next == NULL || next > reverse_ptr) {
+      break;
+    }
 
     // Make sure we have room for at least 4 bytes + null terminator
     if (dest_offset + 4 >= dest_size) {
@@ -102,9 +110,11 @@ size_t utf8_reverse_for_rtl(const utf8_t *src, size_t src_len,
 
     size_t bytes_written = utf8_encode_codepoint(cp, dest + dest_offset);
     if (bytes_written == 0) {
-      continue; // Skip invalid codepoints
+      reverse_ptr = cp_start;
+      continue;
     }
     dest_offset += bytes_written;
+    reverse_ptr = cp_start;
   }
 
   // Null-terminate if we have space

--- a/src/fw/applib/graphics/text_layout.c
+++ b/src/fw/applib/graphics/text_layout.c
@@ -752,6 +752,8 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
     // Pass 3: Render segments in (possibly reordered) visual order
     int walked_width_px = 0;
     utf8_t *last_visited_char = NULL;
+    utf8_t rtl_buffer[128];
+    const size_t rtl_buffer_size = sizeof(rtl_buffer);
 
     for (int seg_idx = 0; seg_idx < num_segments; seg_idx++) {
       BiDiSegment *seg = &segments[seg_idx];
@@ -761,27 +763,32 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
         // Shape, reverse, render. Buffers sized to fit any single line on
         // 200-260 px displays; shaping expands Arabic basic-block (2 UTF-8
         // bytes) to presentation forms (3 bytes).
-        utf8_t shaped_buffer[128];
-        utf8_t rtl_buffer[128];
-        const utf8_t *to_render = seg->start;
         size_t render_len = seg_len;
+        size_t reversed_len = 0;
 
-        if (render_len > sizeof(rtl_buffer) - 4) {
-          render_len = sizeof(rtl_buffer) - 4;
+        if (render_len > rtl_buffer_size - 4) {
+          render_len = rtl_buffer_size - 4;
         }
 
         if (utf8_contains_arabic(seg->start, seg->end)) {
-          size_t shaped_len = arabic_shape_text(seg->start, render_len,
-                                                shaped_buffer, sizeof(shaped_buffer) - 1);
-          if (shaped_len > 0) {
-            shaped_buffer[shaped_len] = '\0';
-            to_render = shaped_buffer;
-            render_len = shaped_len;
+          utf8_t *shaped_buffer = applib_malloc(rtl_buffer_size);
+          if (shaped_buffer) {
+            size_t shaped_len = arabic_shape_text(seg->start, render_len,
+                                                  shaped_buffer, rtl_buffer_size - 1);
+            if (shaped_len > 0) {
+              shaped_buffer[shaped_len] = '\0';
+              reversed_len = utf8_reverse_for_rtl(shaped_buffer, shaped_len,
+                                                  rtl_buffer, rtl_buffer_size - 1);
+            }
+            applib_free(shaped_buffer);
           }
         }
 
-        size_t reversed_len = utf8_reverse_for_rtl(to_render, render_len,
-                                                    rtl_buffer, sizeof(rtl_buffer) - 1);
+        if (reversed_len == 0) {
+          reversed_len = utf8_reverse_for_rtl(seg->start, render_len,
+                                              rtl_buffer, rtl_buffer_size - 1);
+        }
+
         if (reversed_len > 0) {
           rtl_buffer[reversed_len] = '\0';
 


### PR DESCRIPTION
## Summary

This fixes a watch crash in the RTL text rendering path. When a notification contains Hebrew in the sender/author field, or in one of the available responses shown after pressing Select, text rendering can overflow the stack and crash the watch.

The crash comes from the Hebrew/RTL rendering path keeping several 128-byte scratch buffers on the render stack. This change keeps a single RTL output buffer on the stack, walks UTF-8 sequence starts backward instead of storing decoded codepoints in another stack array, and allocates the Arabic shaping scratch buffer only when Arabic shaping is actually needed. Hebrew rendering keeps the same visual behavior while using less stack.

## Testing

- Tested in QEMU
- Tested on physical Pebble 2 hardware
- Verified Hebrew notification author and response text no longer crash the watch
- gitlint --commits origin/main..HEAD
- git diff --check origin/main..HEAD