### PR TITLE
comm/ancs: recover from a wedged notification queue

### DIFF
--- a/src/fw/comm/ble/kernel_le_client/ancs/ancs.c
+++ b/src/fw/comm/ble/kernel_le_client/ancs/ancs.c
@@ -49,6 +49,12 @@ T_STATIC void prv_check_ancs_alive(void);
 
 static void prv_perform_action(uint32_t notification_uid, ActionId action_id);
 
+static void prv_op_timeout_start(void);
+
+static void prv_op_timeout_stop(void);
+
+static void prv_op_timeout_kick(void);
+
 // -----------------------------------------------------------------------------
 // Static variables
 //
@@ -63,6 +69,10 @@ static void prv_perform_action(uint32_t notification_uid, ActionId action_id);
 // chatty apps cannot grow it without limit. Action ops are not capped — they
 // are user-initiated and rare.
 #define ANCS_NOTIF_QUEUE_MAX_DEPTH 16
+
+// Bound the wait for a Control Point response so a lost reply can't wedge the
+// in-flight queue head forever (which blocks every later notification).
+#define ANCS_OP_RESPONSE_TIMEOUT_SECONDS 10
 
 typedef struct {
   uint8_t command_id;
@@ -97,6 +107,8 @@ typedef struct ANCSClient {
   ANCSClientState state;
   BLECharacteristic characteristics[NumANCSCharacteristic];
   RegularTimerInfo is_alive_timer;
+  // Watchdog for the in-flight Control Point request.
+  RegularTimerInfo op_timeout_timer;
   ReassemblyContext reassembly_ctx;
   ANCSAttribute *attributes[NUM_FETCHED_NOTIF_ATTRIBUTES];
   NotificationQueueNode *queue;
@@ -105,6 +117,8 @@ typedef struct ANCSClient {
   // Alive-check intervals with no NS traffic; reset by any NS notification.
   // Triggers a CCCD re-subscribe at the threshold to recover silent NS.
   uint8_t alive_checks_without_ns;
+  // Consecutive non-Idle alive checks; forces recovery at the threshold.
+  uint8_t consecutive_busy_alive_checks;
 } ANCSClient;
 
 static ANCSClient *s_ancs_client;
@@ -223,10 +237,32 @@ static void prv_notif_queue_push_action(uint32_t uid, ActionId action_id) {
   prv_notif_queue_push_common(node);
 }
 
+// Evict the oldest pending attribute request to make room for a newer one.
+// Never the in-flight head or a user action. Returns true if one was freed.
+static bool prv_evict_oldest_attr_request(void) {
+  const NotificationQueueNode *in_flight =
+      (s_ancs_client->state != ANCSClientStateIdle) ? s_ancs_client->queue : NULL;
+  NotificationQueueNode *node = s_ancs_client->queue;
+  while (node) {
+    NotificationQueueNode *next = (NotificationQueueNode *)list_get_next((ListNode *)node);
+    if (node != in_flight && node->op == NotificationQueueOpGetAttributes) {
+      PBL_LOG_WRN("ANCS queue full, evicting oldest notif (uid=%"PRIu32")", node->uid);
+      list_remove((ListNode *)node, (ListNode **)&s_ancs_client->queue, NULL);
+      kernel_free(node);
+      return true;
+    }
+    node = next;
+  }
+  return false;
+}
+
 static void prv_notif_queue_push_attr_request(uint32_t uid, ANCSProperty properties) {
   if (list_count((ListNode *)s_ancs_client->queue) >= ANCS_NOTIF_QUEUE_MAX_DEPTH) {
-    PBL_LOG_WRN("ANCS queue full, dropping notif (uid=%"PRIu32")", uid);
-    return;
+    // Evict a stale entry rather than drop the fresh one.
+    if (!prv_evict_oldest_attr_request()) {
+      PBL_LOG_WRN("ANCS queue full, dropping notif (uid=%"PRIu32")", uid);
+      return;
+    }
   }
 
   NotificationQueueNode *node = kernel_malloc(sizeof(NotificationQueueNode));
@@ -267,12 +303,29 @@ static void prv_notif_queue_next(void) {
   prv_do_notif_queue_operation();
 }
 
+#if UNITTEST
+T_STATIC uint32_t prv_get_queue_depth(void) {
+  return list_count((ListNode *)s_ancs_client->queue);
+}
+
+T_STATIC bool prv_queue_contains_uid(uint32_t uid) {
+  NotificationQueueNode key = {
+    .op = NotificationQueueOpGetAttributes,
+    .uid = uid,
+  };
+  return prv_notif_queue_find(&key) != NULL;
+}
+#endif
+
 // -----------------------------------------------------------------------------
 // Reset & Error Handling
 
 static void prv_reset_and_idle(void) {
+  prv_op_timeout_stop();
   prv_set_state(ANCSClientStateIdle);
   prv_reset_reassembly_context();
+  // Back to Idle: not wedged.
+  s_ancs_client->consecutive_busy_alive_checks = 0;
 }
 
 static void prv_reset_and_retry(void *unused) {
@@ -304,11 +357,63 @@ static void prv_reset_due_to_bt_error(void) {
 }
 
 // -----------------------------------------------------------------------------
+// In-flight operation watchdog
+//
+// Drops the queue head if its Control Point response never arrives.
+
+static void prv_op_timeout_launcher_task_cb(void *unused) {
+  if (!s_ancs_client) {
+    return;
+  }
+  prv_op_timeout_stop();
+  PBL_LOG_WRN("ANCS op timed out (state=%d, uid=%"PRIu32"); dropping stuck head",
+              s_ancs_client->state,
+              s_ancs_client->queue ? s_ancs_client->queue->uid : 0);
+  // Drop the wedged head so the queue keeps draining.
+  prv_reset_and_next();
+}
+
+static void prv_op_timeout_cb(void *unused) {
+  // Hop to KernelMain; ANCS state is single-threaded there.
+  launcher_task_add_callback(prv_op_timeout_launcher_task_cb, NULL);
+}
+
+static void prv_op_timeout_stop(void) {
+  if (s_ancs_client && regular_timer_is_scheduled(&s_ancs_client->op_timeout_timer)) {
+    regular_timer_remove_callback(&s_ancs_client->op_timeout_timer);
+  }
+}
+
+static void prv_op_timeout_start(void) {
+  if (!s_ancs_client) {
+    return;
+  }
+  // Only touch .cb — reassigning the whole struct would zero list_node while it
+  // may still be linked (we can re-arm from inside the callback), corrupting the
+  // regular-timer list.
+  prv_op_timeout_stop();
+  s_ancs_client->op_timeout_timer.cb = prv_op_timeout_cb;
+  regular_timer_add_multisecond_callback(&s_ancs_client->op_timeout_timer,
+                                         ANCS_OP_RESPONSE_TIMEOUT_SECONDS);
+}
+
+static void prv_op_timeout_kick(void) {
+  // DS data is progress; refresh the window so slow reassembly isn't killed.
+  if (s_ancs_client && regular_timer_is_scheduled(&s_ancs_client->op_timeout_timer)) {
+    prv_op_timeout_start();
+  }
+}
+
+// -----------------------------------------------------------------------------
 // Is Alive Logic
 
 #define ANCS_INVALID_PARAM 0xA2
 #define ANCS_IS_ALIVE_NEXT_CHECK_TIME_MINUTES 15 // Check every 15 minutes for faster recovery
 #define ANCS_IS_ALIVE_RESPONSE_WAIT_TIME_SECONDS 5 // 5 seconds
+
+// Force a flush + resubscribe if still busy after this many alive checks
+// (a wedge the op watchdog somehow missed).
+#define ANCS_MAX_BUSY_ALIVE_CHECKS 2
 
 // Force a CCCD refresh after this many consecutive alive-check intervals
 // without any NS traffic. 6 h is short enough to recover the same day for a
@@ -462,13 +567,23 @@ T_STATIC void prv_check_ancs_alive(void) {
   }
 }
 
-static void prv_is_ancs_alive_launcher_task_cb(void *data) {
+T_STATIC void prv_is_ancs_alive_launcher_task_cb(void *data) {
   if (!s_ancs_client) {
     return;
   }
   if (s_ancs_client->state == ANCSClientStateIdle) {
+    s_ancs_client->consecutive_busy_alive_checks = 0;
     prv_check_ancs_alive();
+  } else if (++s_ancs_client->consecutive_busy_alive_checks >= ANCS_MAX_BUSY_ALIVE_CHECKS) {
+    // Wedged past the op watchdog: force recovery so we don't go silent.
+    PBL_LOG_ERR("ANCS busy for %u alive checks; forcing flush + resubscribe",
+                s_ancs_client->consecutive_busy_alive_checks);
+    s_ancs_client->consecutive_busy_alive_checks = 0;
+    prv_reset_due_to_bt_error();
+    prv_resubscribe_to_ancs();
+    prv_ancs_is_alive_schedule_next_check();
   } else {
+    // Legitimately processing; defer this round's probe.
     s_ancs_client->alive_check_pending = true;
   }
 }
@@ -734,6 +849,7 @@ static void prv_get_app_attributes(const ANCSAttribute *app_id) {
   }
 
   prv_set_state(ANCSClientStateRequestedApp);
+  prv_op_timeout_start();
 
   bool success = prv_write_control_point_request((const CPDSMessage *) request, request_size);
 
@@ -765,6 +881,8 @@ static void prv_get_notification_attributes(uint32_t uid) {
 
   bool retrying = (s_ancs_client->state == ANCSClientStateRetrying);
   prv_set_state(ANCSClientStateRequestedNotification);
+  // Arm before the write so completion/failure can cancel it.
+  prv_op_timeout_start();
 
   bool success = prv_write_control_point_request((const CPDSMessage *) request_buffer->data,
                                                  request_buffer->bytes_written);
@@ -775,6 +893,8 @@ static void prv_get_notification_attributes(uint32_t uid) {
     if (retrying) {
       prv_reset_and_flush();
     } else {
+      // Waiting on the retry timer, not a response.
+      prv_op_timeout_stop();
       prv_set_state(ANCSClientStateRetrying);
       evented_timer_register(ANCS_RETRY_TIME_MS, false, prv_reset_and_retry, NULL);
     }
@@ -986,6 +1106,9 @@ static void prv_handle_ds_notification(uint32_t length, const uint8_t *data) {
     return;
   }
 
+  // Forward progress — refresh the watchdog.
+  prv_op_timeout_kick();
+
   if (s_ancs_client->state == ANCSClientStateRequestedApp) {
     prv_handle_app_attributes_response(data, length);
   } else if (s_ancs_client->state == ANCSClientStateRequestedNotification ||
@@ -1075,6 +1198,7 @@ static void prv_perform_action(uint32_t notification_uid, ActionId action_id) {
   PBL_LOG_DBG("Taking action <%u> upon UID: %"PRIu32, action_id,
       notification_uid);
 
+  prv_op_timeout_start();
   const bool success = prv_write_control_point_request((const CPDSMessage *) &action_msg,
                                                        sizeof(action_msg));
   if (!success) {
@@ -1137,6 +1261,7 @@ void ancs_destroy(void) {
     return;
   }
   prv_ancs_is_alive_stop_timer();
+  prv_op_timeout_stop();
 
   ancs_app_name_storage_deinit();
 

--- a/tests/fw/comm/test_ancs.c
+++ b/tests/fw/comm/test_ancs.c
@@ -476,6 +476,21 @@ void test_ancs__ancs_invalid_param(void) {
 
 extern ANCSClientState prv_get_state(void);
 extern void prv_check_ancs_alive(void);
+extern uint32_t prv_get_queue_depth(void);
+extern bool prv_queue_contains_uid(uint32_t uid);
+extern void prv_is_ancs_alive_launcher_task_cb(void *data);
+
+// Send a notification whose uid the fake never answers, so the head wedges.
+static void prv_send_unanswered_notification(uint32_t uid) {
+  NSNotification ns_notification = {
+    .event_id = EventIDNotificationAdded,
+    .event_flags = 0,
+    .category_id = CategoryIDSocial,
+    .category_count = 1,
+    .uid = uid,
+  };
+  prv_fake_receiving_ns_notification(sizeof(ns_notification), (uint8_t *) &ns_notification);
+}
 
 void test_ancs__alive_check_disconnection(void) {
   prv_check_ancs_alive();
@@ -621,6 +636,72 @@ void test_ancs__reset_after_retry(void) {
   prv_send_notification((uint8_t *)&s_complete_dict);
   ancs_invalidate_all_references();
   cl_assert_equal_i(prv_get_state(), ANCSClientStateIdle);
+}
+
+// A lost DS response must not wedge the queue: the watchdog drops the stuck head.
+void test_ancs__op_timeout_recovers_wedged_head(void) {
+  // The fake never answers this uid, so the head wedges in-flight.
+  prv_send_unanswered_notification(0xD0000001);
+  cl_assert_equal_i(prv_get_state(), ANCSClientStateRequestedNotification);
+  cl_assert_equal_i(s_num_requested_notif_attributes, 1);
+
+  // Queue more behind it (distinct uids so they aren't deduped).
+  prv_send_notification((uint8_t *)&s_complete_dict);
+  prv_send_notification((uint8_t *)&s_message_size_attr_dict);
+  cl_assert_equal_i(prv_get_queue_depth(), 3);
+  cl_assert_equal_i(s_num_requested_notif_attributes, 1);
+  cl_assert_equal_i(fake_kernel_services_notifications_ancs_notifications_count(), 0);
+
+  // Watchdog fires: stuck head dropped, queue drains.
+  regular_timer_fire_seconds(1);
+
+  cl_assert_equal_i(prv_get_state(), ANCSClientStateIdle);
+  cl_assert_equal_i(prv_get_queue_depth(), 0);
+  cl_assert_equal_i(s_num_requested_notif_attributes, 3);
+  cl_assert_equal_i(fake_kernel_services_notifications_ancs_notifications_count(), 2);
+  cl_assert_equal_i(regular_timer_seconds_count(), 0);
+}
+
+// When full, evict the oldest pending request rather than drop the newest.
+void test_ancs__queue_full_evicts_oldest(void) {
+  // Wedge the head so nothing drains while we fill the queue.
+  prv_send_unanswered_notification(0xD0000002);
+  cl_assert_equal_i(prv_get_state(), ANCSClientStateRequestedNotification);
+
+  // Fill the queue (1 head + 15 pending == ANCS_NOTIF_QUEUE_MAX_DEPTH).
+  const uint32_t first_pending = 0xC0000000;
+  for (uint32_t i = 0; i < 15; i++) {
+    prv_send_unanswered_notification(first_pending + i);
+  }
+  cl_assert_equal_i(prv_get_queue_depth(), 16);
+  cl_assert(prv_queue_contains_uid(first_pending));
+
+  // One more while full: oldest evicted, newest kept, head safe.
+  const uint32_t newest = 0xB0000000;
+  prv_send_unanswered_notification(newest);
+
+  cl_assert_equal_i(prv_get_queue_depth(), 16);
+  cl_assert(prv_queue_contains_uid(newest));
+  cl_assert(!prv_queue_contains_uid(first_pending));
+  cl_assert(prv_queue_contains_uid(0xD0000002));
+}
+
+// If wedged across consecutive alive checks, escalate to flush + resubscribe.
+void test_ancs__alive_check_escalates_when_wedged(void) {
+  prv_send_unanswered_notification(0xD0000003);
+  prv_send_notification((uint8_t *)&s_complete_dict);
+  cl_assert_equal_i(prv_get_state(), ANCSClientStateRequestedNotification);
+  cl_assert_equal_i(prv_get_queue_depth(), 2);
+
+  // First busy alive check: defer, don't escalate yet.
+  prv_is_ancs_alive_launcher_task_cb(NULL);
+  cl_assert_equal_i(prv_get_state(), ANCSClientStateRequestedNotification);
+  cl_assert_equal_i(prv_get_queue_depth(), 2);
+
+  // Second consecutive busy alive check: force flush + resubscribe.
+  prv_is_ancs_alive_launcher_task_cb(NULL);
+  cl_assert_equal_i(prv_get_state(), ANCSClientStateIdle);
+  cl_assert_equal_i(prv_get_queue_depth(), 0);
 }
 
 // No Longer Supported


### PR DESCRIPTION
When a Control Point request is sent, the queue head stays in flight until its Data Source response arrives. There was no timeout on that wait, so a lost DS response — common during the GATT churn of a reconnect — left the head stuck forever. With the 16-entry queue cap, every later notification then hit "queue full" and was dropped, so notifications went silent until the user forced a BLE reconnect or rebooted. The 15-minute alive check that should recover this only ran when the state machine was Idle, so a wedged head also blocked the recovery path.

Add three layers of defense:

- An in-flight op watchdog (10s). If a GetNotificationAttributes / GetAppAttributes / PerformAction response never lands, drop the stuck head and advance so the queue keeps draining. Inbound DS chunks refresh the window so slow multi-part reassembly isn't killed mid-stream.

- Evict the oldest pending request instead of dropping the newest when the queue is full, so fresh notifications still get through during a backlog. The in-flight head and user-initiated actions are never evicted.

- Escalate in the alive check: if the client stays busy across two consecutive checks (the watchdog somehow missed it), force a flush + resubscribe rather than stay silent until reboot.

Add unit tests covering wedged-head recovery, eviction-when-full, and the alive-check escalation.

Fixes FIRM-2581