### PR TITLE
drivers/backlight: don't assert on AW2016 I2C failures

### DIFF
--- a/src/fw/drivers/backlight/Kconfig
+++ b/src/fw/drivers/backlight/Kconfig
@@ -43,4 +43,8 @@ config BACKLIGHT_QEMU_COLOR
     help
       Enable support for RGB backlight colors in the QEMU backlight driver.
   
+module = DRIVER_BACKLIGHT
+module-str = Backlight
+source "src/fw/Kconfig.template.log_level"
+
 endif # BACKLIGHT

--- a/src/fw/drivers/backlight/aw2016.c
+++ b/src/fw/drivers/backlight/aw2016.c
@@ -5,7 +5,9 @@
 
 #include "board/board.h"
 #include "drivers/i2c.h"
-#include "system/passert.h"
+#include "system/logging.h"
+
+PBL_LOG_MODULE_DEFINE(driver_backlight_aw2016, CONFIG_DRIVER_BACKLIGHT_LOG_LEVEL);
 
 #define AW2016_REG_RSTR 0x00U
 #define AW2016_REG_RSTR_CHIP_ID 0x09U
@@ -75,17 +77,22 @@ static bool prv_configure_registers(void) {
 }
 
 void backlight_init(void) {
-  uint8_t value;
+  uint8_t value = 0;
   bool ret;
 
+  // A wedged AW2016 or I2C bus must not be fatal here: asserting on boot bricks
+  // the watch into a recovery/factory-reset loop. A dead backlight is preferable.
   ret = prv_read_register(AW2016_REG_RSTR, &value);
-  PBL_ASSERTN(ret && (value == AW2016_REG_RSTR_CHIP_ID));
+  if (!ret || (value != AW2016_REG_RSTR_CHIP_ID)) {
+    PBL_LOG_ERR("AW2016 not detected (i2c_ok=%d id=0x%02x); backlight disabled", ret, value);
+    return;
+  }
 
   ret = prv_write_register(AW2016_REG_RSTR, AW2016_REG_RSTR_RST);
-  PBL_ASSERTN(ret);
-
-  ret = prv_write_register(AW2016_REG_GCR1, AW2016_REG_GCR1_CHGDIS_DIS);
-  PBL_ASSERTN(ret);
+  ret &= prv_write_register(AW2016_REG_GCR1, AW2016_REG_GCR1_CHGDIS_DIS);
+  if (!ret) {
+    PBL_LOG_ERR("AW2016 init write failed (i2c)");
+  }
 }
 
 void backlight_set_brightness(uint8_t brightness) {
@@ -105,13 +112,18 @@ void backlight_set_brightness(uint8_t brightness) {
   if (brightness == 0U) {
     ret = prv_write_register(AW2016_REG_GCR1,
                              AW2016_REG_GCR1_CHGDIS_DIS | AW2016_REG_GCR1_CHIPEN_DIS);
-    PBL_ASSERTN(ret);
+    if (!ret) {
+      PBL_LOG_ERR("AW2016 disable failed (i2c)");
+    }
   } else {
     if (previous_brightness == 0U) {
       ret = prv_write_register(AW2016_REG_GCR1,
                                AW2016_REG_GCR1_CHGDIS_DIS | AW2016_REG_GCR1_CHIPEN_EN);
       ret &= prv_configure_registers();
-      PBL_ASSERTN(ret);
+      if (!ret) {
+        PBL_LOG_ERR("AW2016 enable failed (i2c)");
+        return;
+      }
     }
 
     backlight_set_color(s_rgb_current_color);
@@ -130,7 +142,10 @@ void backlight_set_color(uint32_t rgb_color) {
   ret &= prv_write_register(AW2016_REG_PWM2, green);
   ret &= prv_write_register(AW2016_REG_PWM3, blue);
 
-  PBL_ASSERTN(ret);
+  if (!ret) {
+    PBL_LOG_ERR("AW2016 set color failed (i2c)");
+    return;
+  }
 
   s_rgb_current_color = rgb_color;
 }
@@ -149,7 +164,10 @@ void backlight_refresh(void) {
   ret = prv_write_register(AW2016_REG_GCR1,
                            AW2016_REG_GCR1_CHGDIS_DIS | AW2016_REG_GCR1_CHIPEN_EN);
   ret &= prv_configure_registers();
-  PBL_ASSERTN(ret);
+  if (!ret) {
+    PBL_LOG_ERR("AW2016 refresh failed (i2c)");
+    return;
+  }
 
   backlight_set_color(s_rgb_current_color);
 }


### PR DESCRIPTION
A transient I2C NACK/bus error to the AW2016 LED controller, or a wedged chip on boot, would trip PBL_ASSERTN and crash the OS. On boot this is especially harmful: backlight_init() asserts on the chip-ID read, so a stuck chip/bus bricks the watch into a recovery/factory-reset loop that reinstalling firmware does not clear.

Degrade gracefully instead: log a warning and continue at each I2C call site. A dark or stale backlight is preferable to a reboot, and boot now survives an unresponsive chip. Software state is still updated to the intended values so backlight_refresh() keeps retrying once the bus recovers.

Fixes FIRM-2514