### PR TITLE
drivers/i2c/nrf5: write register address and data in one transfer

### DIFF
--- a/src/fw/drivers/i2c/nrf5.c
+++ b/src/fw/drivers/i2c/nrf5.c
@@ -8,12 +8,20 @@
 #include "system/passert.h"
 
 #include "FreeRTOS.h"
+#include "semphr.h"
 
 #include <nrfx.h>
+
+#include <string.h>
 
 #define I2C_IRQ_PRIORITY (0xc)
 #define I2C_NORMAL_MODE_CLOCK_SPEED_MAX   (100000)
 #define I2C_READ_WRITE_BIT    (0x01)
+
+// Register address + payload buffered for single-transfer register writes.
+// Register writes are small; a larger payload fails the transfer.
+#define I2C_REG_WRITE_BUF_SIZE 16
+static uint8_t s_reg_write_buf[NRFX_TWIM_ENABLED_COUNT][I2C_REG_WRITE_BUF_SIZE];
 
 static void prv_twim_evt_handler(nrfx_twim_evt_t const *evt, void *ctx) {
   I2CBus *bus = (I2CBus *) ctx;
@@ -62,27 +70,42 @@ void i2c_hal_init_transfer(I2CBus *bus) {
 
 void i2c_hal_start_transfer(I2CBus *bus) {
   nrfx_twim_xfer_desc_t desc;
-  
-  desc.address = bus->state->transfer.device_address >> 1;
-  if (bus->state->transfer.type == I2CTransferType_SendRegisterAddress) {
-    if (bus->state->transfer.direction == I2CTransferDirection_Read) {
+  I2CTransfer *transfer = &bus->state->transfer;
+
+  desc.address = transfer->device_address >> 1;
+  if (transfer->type == I2CTransferType_SendRegisterAddress) {
+    if (transfer->direction == I2CTransferDirection_Read) {
       desc.type = NRFX_TWIM_XFER_TXRX;
+      desc.primary_length = 1;
+      desc.p_primary_buf = &transfer->register_address;
+      desc.secondary_length = transfer->size;
+      desc.p_secondary_buf = transfer->data;
     } else {
-      desc.type = NRFX_TWIM_XFER_TXTX;
+      // Register write: send the address and data as one contiguous transfer.
+      // The two-buffer write (TXTX) sets up its data phase mid-transfer and can
+      // silently drop it depending on the calling context, so never use it.
+      if (transfer->size + 1U > I2C_REG_WRITE_BUF_SIZE) {
+        // Payload does not fit the combined-write buffer; fail the transfer.
+        bus->state->transfer_event = I2CTransferEvent_Error;
+        xSemaphoreGive(bus->state->event_semaphore);
+        return;
+      }
+      uint8_t *wbuf = s_reg_write_buf[bus->hal->twim.drv_inst_idx];
+      wbuf[0] = transfer->register_address;
+      memcpy(&wbuf[1], transfer->data, transfer->size);
+      desc.type = NRFX_TWIM_XFER_TX;
+      desc.primary_length = transfer->size + 1;
+      desc.p_primary_buf = wbuf;
+      desc.secondary_length = 0;
     }
-    desc.primary_length = 1;
-    desc.p_primary_buf = &bus->state->transfer.register_address;
-    
-    desc.secondary_length = bus->state->transfer.size;
-    desc.p_secondary_buf = bus->state->transfer.data;
   } else {
-    if (bus->state->transfer.direction == I2CTransferDirection_Read) {
+    if (transfer->direction == I2CTransferDirection_Read) {
       desc.type = NRFX_TWIM_XFER_RX;
     } else {
       desc.type = NRFX_TWIM_XFER_TX;
     }
-    desc.primary_length = bus->state->transfer.size;
-    desc.p_primary_buf = bus->state->transfer.data;
+    desc.primary_length = transfer->size;
+    desc.p_primary_buf = transfer->data;
     desc.secondary_length = 0;
   }
   


### PR DESCRIPTION
## Problem

On an nRF target (asterix), the LSM6DSO accelerometer delivered **no FIFO interrupts** (shakes worked, FIFO did not). The FIFO sat permanently full (`diff=512`) with INT1 held statically high, so no edge ever fired. The root cause is in the **nRF I²C HAL**, not the accel driver.

`i2c_write_register_block` maps to a two-buffer TWIM transfer (`NRFX_TWIM_XFER_TXTX`) that sets up its data phase *mid-transfer* — between starting the register-address byte and its completion. When issued from a preemptible/offloaded task context, that data phase is silently dropped: the device ACKs an **address-only** write and ignores it, so the register never changes while the call still returns success.

The accelerometer is the only nRF driver that writes registers from a timer/ISR-offloaded context (its FIFO-flush watchdog), so it was the only thing that tripped over this. Its bypass (`FIFO_CTRL4 = 0x00`) re-arm never landed → FIFO never flushed → INT1 stuck high → no interrupts. Reads (`TXRX`) and writes from the init/app context were unaffected, which masked the bug.

## Fix

Build the register address and data into a single contiguous buffer and issue **one `TX`**, mirroring the Zephyr nRF TWIM driver (`i2c_nrfx_twim.c`), which never uses `TXTX` and instead concatenates into a per-instance buffer. Here:

- Per-TWIM-instance scratch buffer (transfers are serialized by the bus mutex).
- Oversized payload fails the transfer (error event + semaphore release) instead of silently falling back to the broken path — equivalent to Zephyr's `-ENOSPC`.
- Reads (`TXRX`) and raw block transfers are unchanged.

The fix is entirely at the HAL layer, so all current and future nRF I²C register writes are robust; no driver changes needed.

## Test

Verified on asterix hardware: FIFO interrupts now fire, accel samples flow, no more "INT1 not received" watchdog spam. Builds clean.

Fixes FIRM-2774

🤖 Generated with [Claude Code](https://claude.com/claude-code)