### PR TITLE
waftools/gettext: skip git-based POT-Creation-Date

### DIFF
--- a/waftools/gettext.py
+++ b/waftools/gettext.py
@@ -27,10 +27,16 @@ def configure(conf):
     )
     conf.find_program("msgcat")
 
+    # gettext >=0.22 shells out to git for a reproducible POT-Creation-Date,
+    # which warns per-source-file on out-of-tree build paths. Skip it when the
+    # installed xgettext supports --no-git.
+    help_text = conf.cmd_and_log(conf.env.XGETTEXT + ["--help"])
+    conf.env.XGETTEXT_NO_GIT = ["--no-git"] if "--no-git" in help_text else []
+
 
 class xgettext(Task.Task):
     run_str = (
-        "${XGETTEXT} -c/ -k --from-code=UTF-8 --language=C "
+        "${XGETTEXT} ${XGETTEXT_NO_GIT} -c/ -k --from-code=UTF-8 --language=C "
         + " ".join("--keyword=" + word for word in GETTEXT_KEYWORDS)
         + " -o ${TGT[0].abspath()} ${SRC}"
     )


### PR DESCRIPTION
## Problem

Builds print a flood (~1000 lines) of warnings like:

```
vc-mtime: git ls-files returned an unexpected file name: ../src/fw/util/shared/...
vc-mtime: git diff returned an unexpected file name: src/fw/...
```

These come from **GNU gettext (≥0.22)**, not from waf or PebbleOS code. `xgettext` shells out to git (via gnulib's `vc-mtime` module) to compute a reproducible `POT-Creation-Date`, running `git ls-files -c -o -t -z`, `git diff`, and `git log` over every scanned source file. With gettext 0.26 + git 2.54 the `vc-mtime` parser rejects the file names git reports back and warns once per file before falling back to filesystem mtimes.

It's harmless (the `.pot` is still produced correctly) but extremely noisy.

## Fix

Pass `--no-git` to `xgettext` so it never invokes git. The flag is **detected at configure time** (`xgettext --help` probe → `XGETTEXT_NO_GIT`), so toolchains predating it (gettext <0.22) keep building unchanged.

The only behavioral change: the `.pot` `POT-Creation-Date` uses wall-clock time instead of a git commit time. These `.pot` files are build intermediates and never reach the firmware image.

## Verification

- Reconfigured `obelix@pvt` → `XGETTEXT_NO_GIT = ['--no-git']`.
- Forced `fw.pot` to regenerate → **0 `vc-mtime` warnings** (was 1026), build succeeds, `.pot` header intact (369 strings extracted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)