### PR TITLE
fw/shell/normal: clamp out-of-range backlight intensity preference

### DIFF
--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -72,7 +72,11 @@ static bool s_backlight_ambient_sensor_enabled = true;
 #define PREF_KEY_BACKLIGHT_TIMEOUT_MS "lightTimeoutMs"
 static uint32_t s_backlight_timeout_ms = DEFAULT_BACKLIGHT_TIMEOUT_MS;
 #define PREF_KEY_BACKLIGHT_INTENSITY "lightIntensity"
-static uint8_t s_backlight_intensity; // default pulled from BOARD_CONFIGs in shell_prefs_init()
+// Logical 0-100% brightness; the light service scales it to the HW maximum.
+#define BACKLIGHT_INTENSITY_MIN 1U
+#define BACKLIGHT_INTENSITY_MAX 100U
+#define BACKLIGHT_INTENSITY_DEFAULT 25U  // Medium
+static uint8_t s_backlight_intensity; // default set in shell_prefs_init()
 
 #ifdef CONFIG_BACKLIGHT_HAS_COLOR
 #define PREF_KEY_BACKLIGHT_COLOR "lightColor"
@@ -336,7 +340,16 @@ static bool prv_set_s_backlight_timeout_ms(uint32_t *timeout_ms) {
   return false;
 }
 
+static bool prv_backlight_intensity_is_valid(uint8_t intensity) {
+  return intensity >= BACKLIGHT_INTENSITY_MIN && intensity <= BACKLIGHT_INTENSITY_MAX;
+}
+
 static bool prv_set_s_backlight_intensity(uint8_t *intensity) {
+  // Reject out-of-range values
+  if (!prv_backlight_intensity_is_valid(*intensity)) {
+    s_backlight_intensity = BACKLIGHT_INTENSITY_DEFAULT;
+    return false;
+  }
   s_backlight_intensity = *intensity;
   return true;
 }
@@ -824,9 +837,9 @@ static void prv_convert_deprecated_backlight_behaviour_key(SettingsFile *file) {
 // ------------------------------------------------------------------------------------
 void shell_prefs_init(void) {
 #ifdef CONFIG_QEMU
-  s_backlight_intensity = 100U; // Blinding
+  s_backlight_intensity = BACKLIGHT_INTENSITY_MAX; // Blinding
 #else
-  s_backlight_intensity = 25U; // Medium
+  s_backlight_intensity = BACKLIGHT_INTENSITY_DEFAULT; // Medium
 #endif
   s_backlight_ambient_threshold = BOARD_CONFIG.ambient_light_dark_threshold;
 #ifdef CONFIG_DYNAMIC_BACKLIGHT
@@ -860,6 +873,10 @@ void shell_prefs_init(void) {
   }
 
   settings_file_close(&file);
+  
+  if (!prv_backlight_intensity_is_valid(s_backlight_intensity)) {
+    s_backlight_intensity = BACKLIGHT_INTENSITY_DEFAULT;
+  }
   
   // Update the ambient light driver with the loaded threshold value
   ambient_light_set_dark_threshold(s_backlight_ambient_threshold);


### PR DESCRIPTION
The backlight settings row could show a nonsensical "On - 204%" when dynamic intensity was enabled. The intensity preference is a logical 0-100% value (the light service scales it to the HW maximum), and the dynamic-backlight UI prints it verbatim.

A stale or corrupt persisted value could fall outside that range. The UI setter backlight_set_intensity() asserts 1..100, but the validating handler prv_set_s_backlight_intensity() did not, and the boot loader in shell_prefs_init() copies stored bytes straight into the global without running any handler at all. Either path let an out-of-range value reach the settings display and the HW brightness scaling.

Validate the intensity in the handler (resetting to the Medium default and self-healing the backing store on sync) and clamp again after the boot load loop so an already-persisted bad value is corrected on boot.

Fixes FIRM-2841