### PR TITLE
applib: shape Arabic Lam-Alef ligature

### DIFF
--- a/src/fw/applib/graphics/arabic_shaping.c
+++ b/src/fw/applib/graphics/arabic_shaping.c
@@ -249,6 +249,50 @@ Codepoint arabic_shape_codepoint(Codepoint prev_cp, Codepoint curr_cp, Codepoint
   return prv_get_shaped_codepoint(entry, form);
 }
 
+// Lam-Alef mandatory ligatures: Lam (0x0644) followed by an Alef variant
+// collapses to a single glyph. Only isolated and final forms exist (Alef
+// never joins to a following letter).
+typedef struct {
+  uint16_t alef;        // second member of the pair
+  uint16_t isolated;    // ligature isolated form
+  uint16_t final_form;  // ligature final form (preceding letter joins)
+} LamAlefLigature;
+
+static const LamAlefLigature s_lam_alef[] = {
+  { 0x0622, 0xFEF5, 0xFEF6 },  // Lam + Alef with Madda
+  { 0x0623, 0xFEF7, 0xFEF8 },  // Lam + Alef with Hamza above
+  { 0x0625, 0xFEF9, 0xFEFA },  // Lam + Alef with Hamza below
+  { 0x0627, 0xFEFB, 0xFEFC },  // Lam + plain Alef
+};
+
+static const LamAlefLigature *prv_find_lam_alef(Codepoint curr, Codepoint next) {
+  if (curr != 0x0644) {
+    return NULL;
+  }
+  for (size_t i = 0; i < sizeof(s_lam_alef) / sizeof(s_lam_alef[0]); i++) {
+    if (s_lam_alef[i].alef == next) {
+      return &s_lam_alef[i];
+    }
+  }
+  return NULL;
+}
+
+Codepoint arabic_shape_pair(Codepoint prev_cp, Codepoint curr_cp, Codepoint next_cp,
+                            bool *consumed_next) {
+  *consumed_next = false;
+
+  // Lam-Alef ligature: curr (Lam) + next (an Alef variant) becomes one glyph.
+  const LamAlefLigature *lig = prv_find_lam_alef(curr_cp, next_cp);
+  if (lig != NULL) {
+    const ArabicShapingEntry *prev_entry = prv_find_shaping_entry(prev_cp);
+    bool prev_connects = (prev_entry != NULL) && prv_connects_left(prev_entry);
+    *consumed_next = true;
+    return prev_connects ? lig->final_form : lig->isolated;
+  }
+
+  return arabic_shape_codepoint(prev_cp, curr_cp, next_cp);
+}
+
 size_t arabic_shape_text(const utf8_t *src, size_t src_len,
                          utf8_t *dest, size_t dest_size) {
   if (src == NULL || dest == NULL || src_len == 0 || dest_size == 0) {
@@ -281,8 +325,15 @@ size_t arabic_shape_text(const utf8_t *src, size_t src_len,
 
   for (size_t i = 0; i < num_codepoints; i++) {
     Codepoint prev_cp = (i > 0) ? codepoints[i - 1] : 0;
+    Codepoint curr_cp = codepoints[i];
     Codepoint next_cp = (i + 1 < num_codepoints) ? codepoints[i + 1] : 0;
-    Codepoint shaped_cp = arabic_shape_codepoint(prev_cp, codepoints[i], next_cp);
+
+    // Lam-Alef collapses two codepoints into one ligature glyph.
+    bool consumed_next = false;
+    Codepoint shaped_cp = arabic_shape_pair(prev_cp, curr_cp, next_cp, &consumed_next);
+    if (consumed_next) {
+      i++;  // skip the Alef
+    }
 
     // Encode the shaped codepoint to UTF-8
     // Ensure we have room for at least 4 bytes (max UTF-8 length)

--- a/src/fw/applib/graphics/arabic_shaping.h
+++ b/src/fw/applib/graphics/arabic_shaping.h
@@ -35,6 +35,13 @@ bool arabic_is_shapeable(Codepoint cp);
 //! width computation matches what is actually drawn.
 Codepoint arabic_shape_codepoint(Codepoint prev_cp, Codepoint curr_cp, Codepoint next_cp);
 
+//! Shape `curr_cp`, resolving a Lam-Alef ligature when `curr_cp` (Lam) is
+//! followed by `next_cp` (an Alef variant): returns the single ligature glyph
+//! and sets `*consumed_next` to true so the caller skips `next_cp`. Otherwise
+//! behaves like arabic_shape_codepoint() and leaves `*consumed_next` false.
+Codepoint arabic_shape_pair(Codepoint prev_cp, Codepoint curr_cp, Codepoint next_cp,
+                            bool *consumed_next);
+
 //! Shape Arabic text by converting basic Arabic letters to their
 //! contextual presentation forms based on position in words.
 //!

--- a/tests/fw/test_arabic_shaping.c
+++ b/tests/fw/test_arabic_shaping.c
@@ -1,0 +1,103 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "applib/graphics/arabic_shaping.h"
+#include "applib/graphics/utf8.h"
+
+#include "clar.h"
+
+#include <string.h>
+
+///////////////////////////////////////////////////////////
+// Stubs
+
+#include "stubs_logging.h"
+#include "stubs_passert.h"
+
+///////////////////////////////////////////////////////////
+// Helpers
+
+// Shape `in`, decode the result into `cps`, return the codepoint count.
+static size_t prv_shape(const char *in, Codepoint *cps, size_t max) {
+  utf8_t out[128];
+  size_t len = arabic_shape_text((const utf8_t *)in, strlen(in), out, sizeof(out) - 1);
+  out[len] = '\0';
+  size_t count = 0;
+  utf8_t *ptr = out;
+  while (*ptr != '\0' && count < max) {
+    utf8_t *next = NULL;
+    Codepoint cp = utf8_peek_codepoint(ptr, &next);
+    if (cp == 0 || next == NULL) {
+      break;
+    }
+    cps[count++] = cp;
+    ptr = next;
+  }
+  return count;
+}
+
+void test_arabic_shaping__initialize(void) {}
+void test_arabic_shaping__cleanup(void) {}
+
+///////////////////////////////////////////////////////////
+// Tests
+
+// "لا" = Lam (U+0644) + Alef (U+0627) -> isolated Lam-Alef ligature U+FEFB.
+void test_arabic_shaping__lam_alef_isolated(void) {
+  Codepoint cps[8];
+  size_t n = prv_shape("\xD9\x84\xD8\xA7", cps, 8);
+  cl_assert_equal_i(n, 1);
+  cl_assert_equal_i(cps[0], 0xFEFB);
+}
+
+// "بلا" = Beh + Lam + Alef. Beh joins forward, so the ligature takes its
+// final form U+FEFC, preceded by Beh in initial form U+FE91.
+void test_arabic_shaping__lam_alef_final_after_connector(void) {
+  Codepoint cps[8];
+  size_t n = prv_shape("\xD8\xA8\xD9\x84\xD8\xA7", cps, 8);
+  cl_assert_equal_i(n, 2);
+  cl_assert_equal_i(cps[0], 0xFE91);  // Beh initial
+  cl_assert_equal_i(cps[1], 0xFEFC);  // Lam-Alef final ligature
+}
+
+// "سلام" = Seen Lam Alef Meem -> Seen initial, Lam-Alef final ligature, Meem
+// isolated (Alef does not join forward). Four input letters, three glyphs.
+void test_arabic_shaping__salaam_has_ligature(void) {
+  Codepoint cps[8];
+  size_t n = prv_shape("\xD8\xB3\xD9\x84\xD8\xA7\xD9\x85", cps, 8);
+  cl_assert_equal_i(n, 3);
+  cl_assert_equal_i(cps[0], 0xFEB3);  // Seen initial
+  cl_assert_equal_i(cps[1], 0xFEFC);  // Lam-Alef final
+  cl_assert_equal_i(cps[2], 0xFEE1);  // Meem isolated
+}
+
+// Alef with Hamza above (U+0623) maps to its own ligature pair (U+FEF7/FEF8).
+void test_arabic_shaping__lam_alef_hamza_variant(void) {
+  Codepoint cps[8];
+  size_t n = prv_shape("\xD9\x84\xD8\xA3", cps, 8);  // Lam + Alef-Hamza-above
+  cl_assert_equal_i(n, 1);
+  cl_assert_equal_i(cps[0], 0xFEF7);
+}
+
+// Non-Arabic text passes through untouched.
+void test_arabic_shaping__ascii_passthrough(void) {
+  Codepoint cps[8];
+  size_t n = prv_shape("Hi", cps, 8);
+  cl_assert_equal_i(n, 2);
+  cl_assert_equal_i(cps[0], 'H');
+  cl_assert_equal_i(cps[1], 'i');
+}
+
+// arabic_shape_pair: Lam + Alef returns the ligature and flags the Alef
+// consumed; anything else behaves like arabic_shape_codepoint with no consume.
+void test_arabic_shaping__shape_pair_consumes_alef(void) {
+  bool consumed = false;
+  Codepoint cp = arabic_shape_pair(0, 0x0644 /* Lam */, 0x0627 /* Alef */, &consumed);
+  cl_assert_equal_i(cp, 0xFEFB);  // isolated Lam-Alef
+  cl_assert(consumed);
+
+  consumed = true;  // ensure it gets cleared
+  cp = arabic_shape_pair(0, 0x0628 /* Beh */, 0x0644 /* Lam */, &consumed);
+  cl_assert(!consumed);
+  cl_assert_equal_i(cp, arabic_shape_codepoint(0, 0x0628, 0x0644));
+}

--- a/tests/fw/wscript_build
+++ b/tests/fw/wscript_build
@@ -49,6 +49,11 @@ clar(ctx,
     test_sources_ant_glob = "test_rtl_support.c")
 
 clar(ctx,
+    sources_ant_glob = "src/fw/applib/graphics/arabic_shaping.c" \
+        " src/fw/applib/graphics/utf8.c",
+    test_sources_ant_glob = "test_arabic_shaping.c")
+
+clar(ctx,
     sources_ant_glob = "src/fw/applib/graphics/utf8.c" \
         " src/fw/applib/graphics/framebuffer.c" \
         " src/fw/applib/graphics/gtypes.c" \


### PR DESCRIPTION
## What

Arabic requires the Lam–Alef sequence (ل + ا) to render as a single mandatory ligature. The shaper picked a contextual form one codepoint at a time, so a Lam followed by an Alef stayed two separate glyphs, and words like السلام came out malformed.

Add `arabic_shape_pair()`: when the current codepoint is Lam and the next is an Alef form (ا أ إ آ), emit the Lam–Alef presentation form — isolated   (`U+FEF5/FEF7/FEF9/FEFB`) or final (`U+FEF6/FEF8/FEFA/FEFC`), chosen by whether the preceding letter connects — and report the Alef as consumed.   Every other codepoint falls through to the existing per-codepoint shaper, so this is a no-op outside Lam–Alef.

## Before / After

Emulator notification, السلام عليكم. Before: the Lam–Alef in السلام is split into two glyphs. After: it forms the correct ligature.

![Lam-Alef ligature before/after](https://github.com/user-attachments/assets/3d392412-0ec4-433e-b2be-83de09755db2)

## Test

`tests/fw/test_arabic_shaping.c` adds: isolated Lam–Alef, the ligature inside a word (السلام), and that the pair shaper consumes the Alef.   `./pbl test` passes.