### PR TITLE
applib: keep digit runs left-to-right when reversing RTL text

### DIFF
--- a/src/fw/applib/graphics/rtl_support.c
+++ b/src/fw/applib/graphics/rtl_support.c
@@ -61,6 +61,22 @@ bool utf8_contains_arabic(const utf8_t *start, const utf8_t *end) {
   return false;
 }
 
+// Weak-LTR digits: Western (0x30-0x39, as used in Arabic, Hebrew and other RTL
+// text) and Arabic-Indic (0x0660-0x0669, 0x06F0-0x06F9). Inside an RTL run
+// these keep their left-to-right order; reversing them with the run would turn
+// a number such as 2026 into 6202.
+static bool prv_codepoint_is_digit(Codepoint cp) {
+  return (cp >= 0x30 && cp <= 0x39) ||
+         (cp >= 0x0660 && cp <= 0x0669) ||
+         (cp >= 0x06F0 && cp <= 0x06F9);
+}
+
+// Separators that stay inside a numeric run when flanked by digits, so a time
+// or date such as 12:34 or 2026/06/22 keeps its left-to-right group order.
+static bool prv_codepoint_is_numeric_separator(Codepoint cp) {
+  return cp == ':' || cp == '/' || cp == '.' || cp == ',';
+}
+
 size_t utf8_reverse_for_rtl(const utf8_t *src, size_t src_len,
                             utf8_t *dest, size_t dest_size) {
   if (src == NULL || dest == NULL || src_len == 0 || dest_size == 0) {
@@ -101,6 +117,59 @@ size_t utf8_reverse_for_rtl(const utf8_t *src, size_t src_len,
     Codepoint cp = utf8_peek_codepoint((utf8_t *)cp_start, &next);
     if (cp == 0 || next == NULL || next > reverse_ptr) {
       break;
+    }
+
+    if (prv_codepoint_is_digit(cp)) {
+      // Weak-LTR: emit a contiguous digit run in logical (left-to-right)
+      // order instead of reversing it.
+      const utf8_t *run_start = cp_start;
+      while (run_start > src) {
+        const utf8_t *prev_start = run_start - 1;
+        while (prev_start > src && ((*prev_start & 0xC0) == 0x80)) {
+          prev_start--;
+        }
+        utf8_t *prev_next = NULL;
+        Codepoint prev_cp = utf8_peek_codepoint((utf8_t *)prev_start, &prev_next);
+        if (prev_cp == 0 || prev_next == NULL) {
+          break;
+        }
+        if (prv_codepoint_is_digit(prev_cp)) {
+          run_start = prev_start;
+          continue;
+        }
+        // A separator joins the run only between two digits. run_start already
+        // points at a digit (so the separator is followed by one); require a
+        // digit before it too, then pull both into the run in one step.
+        if (prv_codepoint_is_numeric_separator(prev_cp) && prev_start > src) {
+          const utf8_t *before = prev_start - 1;
+          while (before > src && ((*before & 0xC0) == 0x80)) {
+            before--;
+          }
+          utf8_t *before_next = NULL;
+          Codepoint before_cp = utf8_peek_codepoint((utf8_t *)before, &before_next);
+          if (before_cp != 0 && before_next != NULL && prv_codepoint_is_digit(before_cp)) {
+            run_start = before;
+            continue;
+          }
+        }
+        break;
+      }
+
+      const utf8_t *fwd = run_start;
+      while (fwd < reverse_ptr) {
+        utf8_t *fwd_next = NULL;
+        Codepoint dcp = utf8_peek_codepoint((utf8_t *)fwd, &fwd_next);
+        if (dcp == 0 || fwd_next == NULL || dest_offset + 4 >= dest_size) {
+          break;
+        }
+        size_t n = utf8_encode_codepoint(dcp, dest + dest_offset);
+        if (n != 0) {
+          dest_offset += n;
+        }
+        fwd = fwd_next;
+      }
+      reverse_ptr = run_start;
+      continue;
     }
 
     // Make sure we have room for at least 4 bytes + null terminator

--- a/tests/fw/test_rtl_support.c
+++ b/tests/fw/test_rtl_support.c
@@ -1,0 +1,122 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "applib/graphics/rtl_support.h"
+#include "applib/graphics/utf8.h"
+
+#include "clar.h"
+
+#include <string.h>
+
+///////////////////////////////////////////////////////////
+// Stubs
+
+#include "stubs_logging.h"
+#include "stubs_passert.h"
+
+///////////////////////////////////////////////////////////
+// Helpers
+
+// Reverse `in` for RTL, decode the result into `cps`, return codepoint count.
+static size_t prv_reverse(const char *in, Codepoint *cps, size_t max) {
+  utf8_t out[128];
+  size_t len = utf8_reverse_for_rtl((const utf8_t *)in, strlen(in), out, sizeof(out) - 1);
+  out[len] = '\0';
+  size_t count = 0;
+  utf8_t *ptr = out;
+  while (*ptr != '\0' && count < max) {
+    utf8_t *next = NULL;
+    Codepoint cp = utf8_peek_codepoint(ptr, &next);
+    if (cp == 0 || next == NULL) {
+      break;
+    }
+    cps[count++] = cp;
+    ptr = next;
+  }
+  return count;
+}
+
+void test_rtl_support__initialize(void) {}
+void test_rtl_support__cleanup(void) {}
+
+///////////////////////////////////////////////////////////
+// Tests
+
+// Pure Arabic letters reverse to visual order: "ابج" -> ج ب ا.
+void test_rtl_support__reverses_letters(void) {
+  Codepoint cps[8];
+  size_t n = prv_reverse("\xD8\xA7\xD8\xA8\xD8\xAC", cps, 8);  // Alef Beh Jeem
+  cl_assert_equal_i(n, 3);
+  cl_assert_equal_i(cps[0], 0x062C);  // Jeem
+  cl_assert_equal_i(cps[1], 0x0628);  // Beh
+  cl_assert_equal_i(cps[2], 0x0627);  // Alef
+}
+
+// Arabic-Indic digit runs keep left-to-right order (weak-LTR), not mirrored.
+void test_rtl_support__arabic_indic_digits_preserved(void) {
+  Codepoint cps[8];
+  size_t n = prv_reverse("\xD9\xA2\xD9\xA0\xD9\xA2\xD9\xA6", cps, 8);  // ٢٠٢٦
+  cl_assert_equal_i(n, 4);
+  cl_assert_equal_i(cps[0], 0x0662);  // ٢
+  cl_assert_equal_i(cps[1], 0x0660);  // ٠
+  cl_assert_equal_i(cps[2], 0x0662);  // ٢
+  cl_assert_equal_i(cps[3], 0x0666);  // ٦
+}
+
+// Western digits are weak-LTR too.
+void test_rtl_support__western_digits_preserved(void) {
+  Codepoint cps[8];
+  size_t n = prv_reverse("123", cps, 8);
+  cl_assert_equal_i(n, 3);
+  cl_assert_equal_i(cps[0], '1');
+  cl_assert_equal_i(cps[1], '2');
+  cl_assert_equal_i(cps[2], '3');
+}
+
+// A digit run embedded in Arabic: letters reverse, the number stays in order.
+// "ا٢٣" -> the digit run ٢٣ is emitted first (it ends up left of the letter),
+// in logical order, then the Alef.
+void test_rtl_support__digits_in_arabic(void) {
+  Codepoint cps[8];
+  size_t n = prv_reverse("\xD8\xA7\xD9\xA2\xD9\xA3", cps, 8);  // Alef ٢ ٣
+  cl_assert_equal_i(n, 3);
+  cl_assert_equal_i(cps[0], 0x0662);  // ٢
+  cl_assert_equal_i(cps[1], 0x0663);  // ٣
+  cl_assert_equal_i(cps[2], 0x0627);  // Alef
+}
+
+// A date keeps its slash-separated groups in order: the separators travel with
+// the numeric run rather than reversing the groups (٢٠٢٦/٠٦/٢٢, not ٢٢/٠٦/٢٠٢٦).
+void test_rtl_support__date_separators_preserved(void) {
+  Codepoint cps[16];
+  size_t n = prv_reverse("\xD9\xA2\xD9\xA0\xD9\xA2\xD9\xA6/\xD9\xA0\xD9\xA6/"
+                         "\xD9\xA2\xD9\xA2", cps, 16);  // ٢٠٢٦/٠٦/٢٢
+  cl_assert_equal_i(n, 10);
+  const Codepoint expect[] = {0x0662, 0x0660, 0x0662, 0x0666, '/',
+                              0x0660, 0x0666, '/', 0x0662, 0x0662};
+  for (size_t i = 0; i < n; i++) {
+    cl_assert_equal_i(cps[i], expect[i]);
+  }
+}
+
+// A time keeps its colon-separated groups in order (١٢:٣٤, not ٣٤:١٢).
+void test_rtl_support__time_separators_preserved(void) {
+  Codepoint cps[8];
+  size_t n = prv_reverse("\xD9\xA1\xD9\xA2:\xD9\xA3\xD9\xA4", cps, 8);  // ١٢:٣٤
+  cl_assert_equal_i(n, 5);
+  const Codepoint expect[] = {0x0661, 0x0662, ':', 0x0663, 0x0664};
+  for (size_t i = 0; i < n; i++) {
+    cl_assert_equal_i(cps[i], expect[i]);
+  }
+}
+
+// A separator only joins the run between two digits. Here "/" has a letter on
+// one side, so it is not part of the number and reverses normally: ا/٢ -> ٢ / ا.
+void test_rtl_support__separator_needs_two_digits(void) {
+  Codepoint cps[8];
+  size_t n = prv_reverse("\xD8\xA7/\xD9\xA2", cps, 8);  // Alef / ٢
+  cl_assert_equal_i(n, 3);
+  cl_assert_equal_i(cps[0], 0x0662);  // ٢
+  cl_assert_equal_i(cps[1], '/');
+  cl_assert_equal_i(cps[2], 0x0627);  // Alef
+}

--- a/tests/fw/wscript_build
+++ b/tests/fw/wscript_build
@@ -43,6 +43,12 @@ clar(ctx,
     test_sources_ant_glob = "test_codepoint.c")
 
 clar(ctx,
+    sources_ant_glob = "src/fw/applib/graphics/rtl_support.c" \
+        " src/fw/applib/graphics/utf8.c" \
+        " src/fw/applib/fonts/codepoint.c",
+    test_sources_ant_glob = "test_rtl_support.c")
+
+clar(ctx,
     sources_ant_glob = "src/fw/applib/graphics/utf8.c" \
         " src/fw/applib/graphics/framebuffer.c" \
         " src/fw/applib/graphics/gtypes.c" \


### PR DESCRIPTION
 ## What

`utf8_reverse_for_rtl()` mirrored every codepoint in an RTL run, including digits. Numbers are weak left-to-right, so a year like ٢٠٢٦ came out reversed as ٦٢٠٢.    Treat Western (0–9), Arabic-Indic (U+0660–0669), and Extended Arabic-Indic   (U+06F0–06F9) digits as weak-LTR: emit a contiguous digit run in logical order while still reversing the surrounding RTL text.


## Before / After

<img width="600" height="404" alt="cmp_arabicindic" src="https://github.com/user-attachments/assets/e18bce92-1f1a-434e-a2a6-99991c6d4099" />


## Test

`tests/fw/test_rtl_support.c`: Arabic-Indic ٢٠٢٦ preserved, Western digits preserved, digits embedded in Arabic. `./pbl test` passes.