### PR TITLE
applib: align glyph baseline across base and extension fonts

### DIFF
--- a/src/fw/applib/graphics/text_render.c
+++ b/src/fw/applib/graphics/text_render.c
@@ -66,10 +66,17 @@ void render_glyph(GContext* const ctx, const uint32_t codepoint, FontInfo* const
   // Bitfiddle the metrics data:
   GRect glyph_metrics = get_glyph_rect(glyph);
 
+  // Align to the font's common baseline. A FontInfo's base and extension
+  // sub-fonts can be rasterized at different heights; without this, glyphs
+  // drawn from the shorter sub-font float off the shared baseline on a
+  // mixed-script line. No-op (0) for single-font text. See
+  // text_resources_get_glyph_baseline_offset().
+  const int16_t baseline_offset = text_resources_get_glyph_baseline_offset(font, codepoint);
+
   // Calculate the box that we intend to draw to the screen, in screen coordinates
   GRect glyph_target = {
     .origin = { .x = cursor.origin.x + glyph_metrics.origin.x,
-                .y = cursor.origin.y + glyph_metrics.origin.y },
+                .y = cursor.origin.y + glyph_metrics.origin.y + baseline_offset },
     .size = { .w = glyph_metrics.size.w,
               .h = glyph_metrics.size.h }
   };

--- a/src/fw/applib/graphics/text_render.c
+++ b/src/fw/applib/graphics/text_render.c
@@ -71,7 +71,8 @@ void render_glyph(GContext* const ctx, const uint32_t codepoint, FontInfo* const
   // drawn from the shorter sub-font float off the shared baseline on a
   // mixed-script line. No-op (0) for single-font text. See
   // text_resources_get_glyph_baseline_offset().
-  const int16_t baseline_offset = text_resources_get_glyph_baseline_offset(font, codepoint);
+  const int16_t baseline_offset =
+      text_resources_get_glyph_baseline_offset(&ctx->font_cache, font, codepoint);
 
   // Calculate the box that we intend to draw to the screen, in screen coordinates
   GRect glyph_target = {

--- a/src/fw/applib/graphics/text_resources.c
+++ b/src/fw/applib/graphics/text_resources.c
@@ -586,21 +586,6 @@ bool text_resources_init_font(ResAppNum app_num, uint32_t font_resource,
   return true;
 }
 
-int16_t text_resources_get_glyph_baseline_offset(const FontInfo *font_info, Codepoint codepoint) {
-  // Baseline alignment only applies to extended fonts, which pair a base and an
-  // extension sub-font of possibly different heights on the same line. A
-  // non-extended FontInfo has a single sub-font, so there is nothing to align.
-  if (!font_info->extended) {
-    return 0;
-  }
-  // Each sub-font anchors its glyph baselines at its own max_height. Shift a
-  // glyph down by the difference between the FontInfo's overall height (the
-  // tallest sub-font) and the height of the sub-font this codepoint is drawn
-  // from, so the base and extension scripts share one baseline.
-  const FontResource *res = prv_font_res_for_codepoint(codepoint, font_info);
-  return (int16_t)font_info->max_height - (int16_t)res->md.max_height;
-}
-
 // Leaf glyph lookup against a single font. This NEVER consults the fallback font, which is what
 // structurally bounds the fallback to depth 1: the fallback font is looked up with this helper, so
 // it can never trigger a further fallback and no recursion or cycle is possible.
@@ -611,8 +596,13 @@ static const GlyphData *prv_get_glyph_in_font(FontCache *font_cache, Codepoint c
   return prv_get_glyph_metadata_from_spi(codepoint, font_cache, font_res, need_bitmap);
 }
 
+// When source_out is non-NULL it receives the FontResource that actually
+// supplied the returned glyph -- the primary sub-font, the system fallback, or
+// the wildcard's sub-font -- which is not always the one nominally mapped from
+// the requested codepoint. Baseline alignment needs the real source.
 static const GlyphData *prv_get_glyph(FontCache *font_cache, Codepoint codepoint,
-                                      FontInfo *font_info, bool need_bitmap) {
+                                      FontInfo *font_info, bool need_bitmap,
+                                      const FontResource **source_out) {
   if (!font_info->loaded) {
     sys_font_reload_font(font_info);
   }
@@ -620,6 +610,9 @@ static const GlyphData *prv_get_glyph(FontCache *font_cache, Codepoint codepoint
   // (a) Requested codepoint in the primary font.
   const GlyphData *data = prv_get_glyph_in_font(font_cache, codepoint, font_info, need_bitmap);
   if (data) {
+    if (source_out) {
+      *source_out = prv_font_res_for_codepoint(codepoint, font_info);
+    }
     return data;
   }
 
@@ -637,6 +630,9 @@ static const GlyphData *prv_get_glyph(FontCache *font_cache, Codepoint codepoint
     }
     data = prv_get_glyph_in_font(font_cache, codepoint, fallback, need_bitmap);
     if (data) {
+      if (source_out) {
+        *source_out = prv_font_res_for_codepoint(codepoint, fallback);
+      }
       return data;
     }
   }
@@ -650,6 +646,9 @@ static const GlyphData *prv_get_glyph(FontCache *font_cache, Codepoint codepoint
   for (unsigned int i = 0; i < ARRAY_LENGTH(substitutes); i++) {
     data = prv_get_glyph_in_font(font_cache, substitutes[i], font_info, need_bitmap);
     if (data) {
+      if (source_out) {
+        *source_out = prv_font_res_for_codepoint(substitutes[i], font_info);
+      }
       return data;
     }
   }
@@ -660,7 +659,7 @@ static const GlyphData *prv_get_glyph(FontCache *font_cache, Codepoint codepoint
 int8_t text_resources_get_glyph_horiz_advance(FontCache *font_cache, const Codepoint codepoint,
                                               FontInfo *font_info) {
   // Metadata only: measuring must not pay the deep bitmap load; render pre-loads it in walk_line().
-  const GlyphData *g = prv_get_glyph(font_cache, codepoint, font_info, false /* need_bitmap */);
+  const GlyphData *g = prv_get_glyph(font_cache, codepoint, font_info, false /* need_bitmap */, NULL);
   if (!g) {
     return 0;
   }
@@ -669,5 +668,26 @@ int8_t text_resources_get_glyph_horiz_advance(FontCache *font_cache, const Codep
 
 const GlyphData *text_resources_get_glyph(FontCache *font_cache, const Codepoint codepoint,
                                           FontInfo *font_info) {
-  return prv_get_glyph(font_cache, codepoint, font_info, true /* need_bitmap */);
+  return prv_get_glyph(font_cache, codepoint, font_info, true /* need_bitmap */, NULL);
+}
+
+int16_t text_resources_get_glyph_baseline_offset(FontCache *font_cache, FontInfo *font_info,
+                                                 Codepoint codepoint) {
+  // Baseline alignment only applies to extended fonts, which pair a base and an
+  // extension sub-font of possibly different heights on the same line. A
+  // non-extended FontInfo has a single sub-font, so there is nothing to align.
+  if (!font_info->extended) {
+    return 0;
+  }
+  // Resolve the glyph the way the renderer will (metadata only) so the offset
+  // is based on the sub-font that actually supplies it -- including the system
+  // fallback or the wildcard box -- not the nominal sub-font for the codepoint.
+  // Each sub-font anchors its baselines at its own max_height, so shift a glyph
+  // down by the FontInfo height (the tallest sub-font) minus its source height.
+  const FontResource *source = NULL;
+  prv_get_glyph(font_cache, codepoint, font_info, false /* need_bitmap */, &source);
+  if (source == NULL) {
+    return 0;
+  }
+  return (int16_t)font_info->max_height - (int16_t)source->md.max_height;
 }

--- a/src/fw/applib/graphics/text_resources.c
+++ b/src/fw/applib/graphics/text_resources.c
@@ -586,6 +586,21 @@ bool text_resources_init_font(ResAppNum app_num, uint32_t font_resource,
   return true;
 }
 
+int16_t text_resources_get_glyph_baseline_offset(const FontInfo *font_info, Codepoint codepoint) {
+  // Baseline alignment only applies to extended fonts, which pair a base and an
+  // extension sub-font of possibly different heights on the same line. A
+  // non-extended FontInfo has a single sub-font, so there is nothing to align.
+  if (!font_info->extended) {
+    return 0;
+  }
+  // Each sub-font anchors its glyph baselines at its own max_height. Shift a
+  // glyph down by the difference between the FontInfo's overall height (the
+  // tallest sub-font) and the height of the sub-font this codepoint is drawn
+  // from, so the base and extension scripts share one baseline.
+  const FontResource *res = prv_font_res_for_codepoint(codepoint, font_info);
+  return (int16_t)font_info->max_height - (int16_t)res->md.max_height;
+}
+
 // Leaf glyph lookup against a single font. This NEVER consults the fallback font, which is what
 // structurally bounds the fallback to depth 1: the fallback font is looked up with this helper, so
 // it can never trigger a further fallback and no recursion or cycle is possible.

--- a/src/fw/applib/graphics/text_resources.h
+++ b/src/fw/applib/graphics/text_resources.h
@@ -117,9 +117,13 @@ int8_t text_resources_get_glyph_horiz_advance(FontCache *font_cache, Codepoint c
 //! can be rasterized at different heights; glyph baselines are anchored to their
 //! own sub-font's height, so without this a line mixing the two sub-fonts (any
 //! base script plus an extension such as Arabic, Hebrew or CJK) renders with
-//! mismatched baselines. Returns 0 for single-font (non-extended) FontInfos and
-//! for glyphs drawn from the tallest sub-font.
-int16_t text_resources_get_glyph_baseline_offset(const FontInfo *font_info, Codepoint codepoint);
+//! mismatched baselines. The glyph is resolved exactly as text_resources_get_glyph()
+//! resolves it, so the offset follows the sub-font that actually supplies the
+//! glyph (including the system fallback or the wildcard box), not just the
+//! nominal sub-font for the codepoint. Returns 0 for single-font (non-extended)
+//! FontInfos and for glyphs drawn from the tallest sub-font.
+int16_t text_resources_get_glyph_baseline_offset(FontCache *font_cache, FontInfo *font_info,
+                                                 Codepoint codepoint);
 
 //! Initialize a FontInfo struct with resource contents
 //! A FontInfo contains references to up to *two* font resources: a "base" font and an "extension".

--- a/src/fw/applib/graphics/text_resources.h
+++ b/src/fw/applib/graphics/text_resources.h
@@ -112,6 +112,15 @@ const GlyphData *text_resources_get_glyph(FontCache *font_cache, Codepoint codep
 int8_t text_resources_get_glyph_horiz_advance(FontCache *font_cache, Codepoint codepoint,
                                               FontInfo *font_info);
 
+//! Vertical offset (in pixels) to add when drawing this codepoint's glyph so it
+//! sits on the font's common baseline. A FontInfo's base and extension sub-fonts
+//! can be rasterized at different heights; glyph baselines are anchored to their
+//! own sub-font's height, so without this a line mixing the two sub-fonts (any
+//! base script plus an extension such as Arabic, Hebrew or CJK) renders with
+//! mismatched baselines. Returns 0 for single-font (non-extended) FontInfos and
+//! for glyphs drawn from the tallest sub-font.
+int16_t text_resources_get_glyph_baseline_offset(const FontInfo *font_info, Codepoint codepoint);
+
 //! Initialize a FontInfo struct with resource contents
 //! A FontInfo contains references to up to *two* font resources: a "base" font and an "extension".
 //! The base font is part of the system resources pack and contains latin characters and emoji

--- a/tests/fw/applib/test_text_render.c
+++ b/tests/fw/applib/test_text_render.c
@@ -22,7 +22,8 @@ void graphics_context_mark_dirty_rect(GContext* ctx, GRect rect) {}
 const GlyphData* text_resources_get_glyph(FontCache* font_cache, const Codepoint codepoint,
                                           FontInfo* fontinfo) { return NULL; }
 
-int16_t text_resources_get_glyph_baseline_offset(const FontInfo *font_info, Codepoint codepoint) {
+int16_t text_resources_get_glyph_baseline_offset(FontCache *font_cache, FontInfo *font_info,
+                                                 Codepoint codepoint) {
   return 0;
 }
 

--- a/tests/fw/applib/test_text_render.c
+++ b/tests/fw/applib/test_text_render.c
@@ -22,6 +22,10 @@ void graphics_context_mark_dirty_rect(GContext* ctx, GRect rect) {}
 const GlyphData* text_resources_get_glyph(FontCache* font_cache, const Codepoint codepoint,
                                           FontInfo* fontinfo) { return NULL; }
 
+int16_t text_resources_get_glyph_baseline_offset(const FontInfo *font_info, Codepoint codepoint) {
+  return 0;
+}
+
 
 extern int32_t prv_convert_1bit_addr_to_8bit_x(GBitmap *dest_bitmap, uint32_t *block_addr,
                                                int32_t y_offset);

--- a/tests/fw/applib/test_text_resources.c
+++ b/tests/fw/applib/test_text_resources.c
@@ -232,13 +232,23 @@ void test_text_resources__baseline_offset(void) {
                                      &s_font_info));
   cl_assert(s_font_info.extended);
 
-  // Latin resolves to the base sub-font, CJK to the extension. Each glyph's
-  // baseline offset is the FontInfo height minus its source sub-font's height.
-  int16_t latin_off = text_resources_get_glyph_baseline_offset(&s_font_info, 'a');
-  int16_t cjk_off = text_resources_get_glyph_baseline_offset(&s_font_info, 0x4E50 /* 乐 */);
+  // The offset follows the sub-font that actually supplies the glyph. 'a' is
+  // drawn from the base, 乐 from the extension; each shifts by the FontInfo
+  // height minus its own source sub-font's height.
+  int16_t latin_off = text_resources_get_glyph_baseline_offset(&s_font_cache, &s_font_info, 'a');
+  int16_t cjk_off =
+      text_resources_get_glyph_baseline_offset(&s_font_cache, &s_font_info, 0x4E50 /* 乐 */);
 
   cl_assert_equal_i(latin_off, s_font_info.max_height - s_font_info.base.md.max_height);
   cl_assert_equal_i(cjk_off, s_font_info.max_height - s_font_info.extension.md.max_height);
+
+  // 袈 is absent from the extension, so it renders as the wildcard box, which
+  // resolves to the extension sub-font here. The offset must match the sub-font
+  // the glyph actually came from, not be derived blindly from the requested
+  // (CJK) codepoint -- they differ once a glyph falls back to another sub-font.
+  int16_t missing_off =
+      text_resources_get_glyph_baseline_offset(&s_font_cache, &s_font_info, 0x8888 /* 袈 */);
+  cl_assert_equal_i(missing_off, s_font_info.max_height - s_font_info.extension.md.max_height);
 
   // Offsets are never negative and the tallest sub-font is the unshifted anchor.
   cl_assert(latin_off >= 0);
@@ -256,9 +266,11 @@ void test_text_resources__baseline_offset_non_extended(void) {
   cl_assert(text_resources_init_font(0, RESOURCE_ID_GOTHIC_18, 0 /* no extension */, &font_info));
   cl_assert(!font_info.extended);
 
-  cl_assert_equal_i(text_resources_get_glyph_baseline_offset(&font_info, 'a'), 0);
-  cl_assert_equal_i(text_resources_get_glyph_baseline_offset(&font_info, 0x4E50 /* 乐 */), 0);
-  cl_assert_equal_i(text_resources_get_glyph_baseline_offset(&font_info, 0x0644 /* lam */), 0);
+  cl_assert_equal_i(text_resources_get_glyph_baseline_offset(&s_font_cache, &font_info, 'a'), 0);
+  cl_assert_equal_i(
+      text_resources_get_glyph_baseline_offset(&s_font_cache, &font_info, 0x4E50 /* 乐 */), 0);
+  cl_assert_equal_i(
+      text_resources_get_glyph_baseline_offset(&s_font_cache, &font_info, 0x0644 /* lam */), 0);
 }
 
 void test_text_resources__test_emoji_font(void) {

--- a/tests/fw/applib/test_text_resources.c
+++ b/tests/fw/applib/test_text_resources.c
@@ -227,6 +227,40 @@ void test_text_resources__extended_font(void) {
   cl_assert_equal_m(chinese_wildcard_bytes, glyph->data, glyph_size_bytes);
 }
 
+void test_text_resources__baseline_offset(void) {
+  cl_assert(text_resources_init_font(0, RESOURCE_ID_GOTHIC_18, RESOURCE_ID_GOTHIC_18_EXTENDED,
+                                     &s_font_info));
+  cl_assert(s_font_info.extended);
+
+  // Latin resolves to the base sub-font, CJK to the extension. Each glyph's
+  // baseline offset is the FontInfo height minus its source sub-font's height.
+  int16_t latin_off = text_resources_get_glyph_baseline_offset(&s_font_info, 'a');
+  int16_t cjk_off = text_resources_get_glyph_baseline_offset(&s_font_info, 0x4E50 /* 乐 */);
+
+  cl_assert_equal_i(latin_off, s_font_info.max_height - s_font_info.base.md.max_height);
+  cl_assert_equal_i(cjk_off, s_font_info.max_height - s_font_info.extension.md.max_height);
+
+  // Offsets are never negative and the tallest sub-font is the unshifted anchor.
+  cl_assert(latin_off >= 0);
+  cl_assert(cjk_off >= 0);
+  cl_assert(latin_off == 0 || cjk_off == 0);
+}
+
+void test_text_resources__baseline_offset_non_extended(void) {
+  // A font with no extension has a single sub-font: nothing to align, so the
+  // offset must always be zero regardless of codepoint. This guards every
+  // non-extended font (system and custom fonts, all languages) from being
+  // vertically shifted.
+  FontInfo font_info;
+  memset(&font_info, 0, sizeof(font_info));
+  cl_assert(text_resources_init_font(0, RESOURCE_ID_GOTHIC_18, 0 /* no extension */, &font_info));
+  cl_assert(!font_info.extended);
+
+  cl_assert_equal_i(text_resources_get_glyph_baseline_offset(&font_info, 'a'), 0);
+  cl_assert_equal_i(text_resources_get_glyph_baseline_offset(&font_info, 0x4E50 /* 乐 */), 0);
+  cl_assert_equal_i(text_resources_get_glyph_baseline_offset(&font_info, 0x0644 /* lam */), 0);
+}
+
 void test_text_resources__test_emoji_font(void) {
   const uint8_t phone_bytes[] = {0xfe, 0x81, 0x81, 0x3c, 0x66, 0x42, 0xc3, 0xe7, 0xff, 0x00, 0x00, 0x00};
 


### PR DESCRIPTION
## What

A `FontInfo` can pair a base sub-font with a taller or shorter extension   (language-pack) sub-font. Each sub-font anchors glyph baselines at its own   max_height, so on a mixed-script line, glyphs from the shorter sub-font floated off the shared baseline — Latin sat lower than Arabic on one line.
  
Add a per-glyph baseline offset (FontInfo height − sub-font height) so each glyph lands on the common baseline. No-op for single-font text (guarded on   `font_info->extended`).


## Before / After

<img width="600" height="404" alt="cmp_mixedscript" src="https://github.com/user-attachments/assets/20035461-2cb2-424c-8f5c-4ed002658b61" />


## Test

`tests/fw/applib/test_text_resources.c`: baseline offset for extended and non-extended fonts. `./pbl test` passes.