### PR TITLE
applib: reorder bidi boundary spaces and measure Arabic ligatures

### DIFF
--- a/src/fw/applib/graphics/rtl_support.c
+++ b/src/fw/applib/graphics/rtl_support.c
@@ -77,6 +77,23 @@ static bool prv_codepoint_is_numeric_separator(Codepoint cp) {
   return cp == ':' || cp == '/' || cp == '.' || cp == ',';
 }
 
+utf8_t *rtl_segment_content_end(utf8_t *start, utf8_t *end) {
+  utf8_t *content_end = start;
+  utf8_t *scan = start;
+  while (scan < end) {
+    utf8_t *scan_next = NULL;
+    Codepoint scan_cp = utf8_peek_codepoint(scan, &scan_next);
+    if (scan_cp == 0 || scan_next == NULL) {
+      return end;
+    }
+    if (scan_cp != SPACE_CODEPOINT) {
+      content_end = scan_next;
+    }
+    scan = scan_next;
+  }
+  return content_end;
+}
+
 size_t utf8_reverse_for_rtl(const utf8_t *src, size_t src_len,
                             utf8_t *dest, size_t dest_size) {
   if (src == NULL || dest == NULL || src_len == 0 || dest_size == 0) {

--- a/src/fw/applib/graphics/rtl_support.h
+++ b/src/fw/applib/graphics/rtl_support.h
@@ -32,3 +32,12 @@ bool utf8_contains_arabic(const utf8_t *start, const utf8_t *end);
 //! @return Number of bytes written to dest (excluding null terminator), or 0 on failure
 size_t utf8_reverse_for_rtl(const utf8_t *src, size_t src_len,
                             utf8_t *dest, size_t dest_size);
+
+//! Find the end of a bidi segment's content, i.e. the position just past its
+//! last non-space codepoint (the start of any trailing spaces), or `start` if
+//! the range is all spaces. The line layout peels trailing spaces into their
+//! own neutral segment so they reorder correctly between an RTL and an LTR run.
+//! @param start Pointer to start of the segment range
+//! @param end Pointer to end of the segment range (exclusive)
+//! @return Pointer in [start, end] just past the last non-space codepoint
+utf8_t *rtl_segment_content_end(utf8_t *start, utf8_t *end);

--- a/src/fw/applib/graphics/text_layout.c
+++ b/src/fw/applib/graphics/text_layout.c
@@ -263,15 +263,25 @@ bool word_init(GContext* ctx, Word* word, const TextBoxParams* const text_box_pa
   Codepoint curr_cp = utf8_iter_state->codepoint;
   WordState state = WordStateStart;
   state = word_state_update(state, curr_cp);
+  // arabic_shape_pair() can fold this codepoint and the next into a single
+  // glyph (the Arabic Lam-Alef ligature), reporting the next one as consumed.
+  // Its advance is then already counted, so skip it on the next iteration.
+  bool skip_ligature_member = false;
 
   do {
     iter_next(&char_iter);
     Codepoint next_cp = utf8_iter_state->codepoint;
 
     if (state == WordStateGrowing || state == WordStateIdeograph) {
-      Codepoint width_cp = arabic_shape_codepoint(prev_cp, curr_cp, next_cp);
-      word->width_px += prv_codepoint_get_horizontal_advance(&ctx->font_cache,
-          text_box_params->font, width_cp);
+      if (skip_ligature_member) {
+        skip_ligature_member = false;
+      } else {
+        bool consumed_next = false;
+        Codepoint width_cp = arabic_shape_pair(prev_cp, curr_cp, next_cp, &consumed_next);
+        word->width_px += prv_codepoint_get_horizontal_advance(&ctx->font_cache,
+            text_box_params->font, width_cp);
+        skip_ligature_member = consumed_next;
+      }
     }
 
     prev_cp = curr_cp;
@@ -558,17 +568,46 @@ void render_chars_char_visitor_cb(GContext* ctx, const TextBoxParams* const text
 void update_dimensions_char_visitor_cb(GContext* ctx, const TextBoxParams* const text_box_params,
                                        Line* line, GRect cursor, const Codepoint codepoint) {
   (void) ctx;
+  (void) codepoint;
   PBL_ASSERT(cursor.origin.x >= line->origin.x, "Text cursor x=<%u> ahead of line origin x=<%u>",
       cursor.origin.x, line->origin.x);
 
-  const int glyph_width_px = prv_codepoint_get_horizontal_advance(&ctx->font_cache,
-      text_box_params->font, codepoint);
+  // Use the advance the caller already computed (the cursor width). walk_line
+  // makes it ligature-aware -- a Lam-Alef pair is one glyph -- so recomputing it
+  // per codepoint here would double-count the Alef on the measurement path.
+  const int glyph_width_px = cursor.size.w;
 
   line->width_px = (cursor.origin.x + glyph_width_px) - line->origin.x;
 
   PBL_ASSERT(line->width_px <= text_box_params->box.size.w,
       "Line <%p>: max extent=<%" PRId16 "> exceeds text_box_params width=<%" PRId16 ">",
       line, line->width_px + line->origin.x, text_box_params->box.size.w);
+}
+
+// Peek the codepoint after the one starting at `pos`, bounded by `end`. Returns
+// 0 at a line/text boundary. Lets the width pass see the next letter so a
+// Lam-Alef pair folds into one ligature advance, matching the render path.
+static Codepoint prv_peek_next_codepoint(utf8_t *pos, const utf8_t *end) {
+  if (pos == NULL) {
+    return 0;
+  }
+  utf8_t *after = NULL;
+  utf8_peek_codepoint(pos, &after);
+  if (after == NULL || (end != NULL && after >= end) || *after == '\0' || *after == '\n') {
+    return 0;
+  }
+  utf8_t *unused = NULL;
+  return utf8_peek_codepoint(after, &unused);
+}
+
+// Ligature-aware glyph advance: a Lam-Alef pair measures as the single ligature
+// glyph, like word_init and the render path. *consumed_next is set when the next
+// codepoint (the Alef) was folded in and must therefore contribute zero width.
+static int prv_shaped_glyph_advance(GContext *ctx, const TextBoxParams *text_box_params,
+                                    Codepoint prev_cp, Codepoint curr_cp, Codepoint next_cp,
+                                    bool *consumed_next) {
+  Codepoint width_cp = arabic_shape_pair(prev_cp, curr_cp, next_cp, consumed_next);
+  return prv_codepoint_get_horizontal_advance(&ctx->font_cache, text_box_params->font, width_cp);
 }
 
 //! Call char_visitor_cb on each character in the line
@@ -621,7 +660,8 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
       utf8_contains_rtl(line->start, text_box_params->utf8_bounds->end)) {
 
     // Segment descriptor for BiDi reordering
-    #define MAX_BIDI_SEGMENTS 8
+    // Headroom for splitting boundary spaces into their own neutral segments.
+    #define MAX_BIDI_SEGMENTS 16
     typedef struct {
       utf8_t *start;
       utf8_t *end;
@@ -669,6 +709,10 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
       // layout (word_init) and by the actual draw pass below — letters at
       // the line edge get truncated and a gap appears.
       Codepoint prev_seg_cp = 0;
+      // arabic_shape_pair() may combine this codepoint with the next into one
+      // Lam-Alef ligature glyph and report the next as consumed; its advance is
+      // then already counted, so skip it on the following iteration.
+      bool skip_ligature_member = false;
       while (segment_end < line_end && *segment_end != '\0' && *segment_end != '\n') {
         utf8_t *seg_next = NULL;
         Codepoint seg_cp = utf8_peek_codepoint(segment_end, &seg_next);
@@ -689,50 +733,57 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
           }
         }
 
-        // For RTL segments: don't include trailing spaces before LTR text
-        if (segment_is_rtl && seg_cp == SPACE_CODEPOINT) {
-          utf8_t *look_ptr = seg_next;
-          while (look_ptr < line_end && *look_ptr != '\0' && *look_ptr != '\n') {
-            utf8_t *look_next = NULL;
-            Codepoint look_cp = utf8_peek_codepoint(look_ptr, &look_next);
-            if (look_cp == 0 || look_next == NULL) break;
-            if (look_cp != SPACE_CODEPOINT && !codepoint_is_zero_width(look_cp) &&
-                !prv_codepoint_is_punctuation(look_cp)) {
-              if (!codepoint_is_rtl(look_cp)) {
-                goto end_segment_collect;
-              }
-              break;
-            }
-            look_ptr = look_next;
-          }
-        }
+        // Trailing spaces are kept in the run here and split out after the loop
+        // (see the trailing-space peel below) so they reorder between runs.
 
-        Codepoint next_seg_cp = 0;
-        if (seg_next < line_end && *seg_next != '\0' && *seg_next != '\n') {
-          utf8_t *peek_next = NULL;
-          next_seg_cp = utf8_peek_codepoint(seg_next, &peek_next);
-        }
-        Codepoint width_cp = arabic_shape_codepoint(prev_seg_cp, seg_cp, next_seg_cp);
-        int glyph_width = prv_codepoint_get_horizontal_advance(&ctx->font_cache,
-            text_box_params->font, width_cp);
-        if (total_width_px + segment_width_px + glyph_width + suffix_width_px > available_horiz_px) {
-          break;
+        if (skip_ligature_member) {
+          // Alef already counted in the preceding Lam-Alef ligature.
+          skip_ligature_member = false;
+        } else {
+          Codepoint next_seg_cp = 0;
+          if (seg_next < line_end && *seg_next != '\0' && *seg_next != '\n') {
+            utf8_t *peek_next = NULL;
+            next_seg_cp = utf8_peek_codepoint(seg_next, &peek_next);
+          }
+          bool consumed_next = false;
+          Codepoint width_cp = arabic_shape_pair(prev_seg_cp, seg_cp, next_seg_cp, &consumed_next);
+          int glyph_width = prv_codepoint_get_horizontal_advance(&ctx->font_cache,
+              text_box_params->font, width_cp);
+          if (total_width_px + segment_width_px + glyph_width + suffix_width_px > available_horiz_px) {
+            break;
+          }
+          segment_width_px += glyph_width;
+          skip_ligature_member = consumed_next;
         }
 
         prev_seg_cp = seg_cp;
-        segment_width_px += glyph_width;
         segment_end = seg_next;
       }
-      end_segment_collect:
-
       size_t segment_len = segment_end - segment_start;
       if (segment_len == 0) break;
 
-      segments[num_segments++] = (BiDiSegment){
-        .start = segment_start,
-        .end = segment_end,
-        .is_rtl = segment_is_rtl,
-      };
+      // Peel trailing spaces into their own neutral segment. A space between
+      // two runs is direction-neutral: if it stays inside a run it is reversed
+      // with that run and the segment reorder then carries it to the run's far
+      // edge, so the gap separating the two runs collapses. As its own segment
+      // it stays put between the runs it separates.
+      utf8_t *content_end = rtl_segment_content_end(segment_start, segment_end);
+
+      if (content_end > segment_start && content_end < segment_end) {
+        // strong-direction content, then the trailing space(s) as a neutral
+        segments[num_segments++] = (BiDiSegment){
+          .start = segment_start, .end = content_end, .is_rtl = segment_is_rtl,
+        };
+        if (num_segments < MAX_BIDI_SEGMENTS) {
+          segments[num_segments++] = (BiDiSegment){
+            .start = content_end, .end = segment_end, .is_rtl = false,
+          };
+        }
+      } else {
+        segments[num_segments++] = (BiDiSegment){
+          .start = segment_start, .end = segment_end, .is_rtl = segment_is_rtl,
+        };
+      }
       total_width_px += segment_width_px;
       ptr = segment_end;
     }
@@ -884,9 +935,16 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
     }
   }
 
+  const utf8_t *text_end =
+      (text_box_params->utf8_bounds != NULL) ? text_box_params->utf8_bounds->end : NULL;
+
   int walked_width_px = 0;
-  int next_glyph_width_px = prv_codepoint_get_horizontal_advance(&ctx->font_cache,
-      text_box_params->font, current_codepoint);
+  Codepoint prev_shaped_cp = 0;       // previous codepoint, for Arabic joining context
+  bool skip_ligature_member = false;  // current codepoint was folded into a preceding ligature
+  bool consumed_next = false;
+  Codepoint peek_cp = prv_peek_next_codepoint(utf8_iter_state->current, text_end);
+  int next_glyph_width_px = prv_shaped_glyph_advance(ctx, text_box_params, prev_shaped_cp,
+      current_codepoint, peek_cp, &consumed_next);
 
   utf8_t* last_visited_char = NULL;
 
@@ -910,6 +968,10 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
 
     last_visited_char = utf8_iter_state->current;
 
+    // Carry the ligature decision to the next iteration before advancing.
+    skip_ligature_member = consumed_next;
+    prev_shaped_cp = current_codepoint;
+
     if (!iter_next(&char_iter)) {
       break;
     }
@@ -923,8 +985,16 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
       }
     }
 
-    next_glyph_width_px = prv_codepoint_get_horizontal_advance(&ctx->font_cache,
-        text_box_params->font, current_codepoint);
+    consumed_next = false;
+    if (skip_ligature_member) {
+      // This codepoint (the Alef) was already counted in the preceding Lam-Alef
+      // ligature, so it adds no further width.
+      next_glyph_width_px = 0;
+    } else {
+      peek_cp = prv_peek_next_codepoint(utf8_iter_state->current, text_end);
+      next_glyph_width_px = prv_shaped_glyph_advance(ctx, text_box_params, prev_shaped_cp,
+          current_codepoint, peek_cp, &consumed_next);
+    }
   }
 
   // Trim trailing whitespace
@@ -955,7 +1025,7 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
   if (line->suffix_codepoint) {
     GRect cursor = {
       .origin = line->origin,
-      .size.w = next_glyph_width_px,
+      .size.w = suffix_width_px,
       .size.h = fonts_get_font_height(text_box_params->font)
     };
     cursor.origin.x += walked_width_px;

--- a/tests/fw/test_line_layout.c
+++ b/tests/fw/test_line_layout.c
@@ -59,6 +59,34 @@ void line_reset(Line* line, utf8_t* start) {
   line->suffix_codepoint = 0;
 }
 
+// The line-width (measurement) pass must count a Lam-Alef ligature as one glyph,
+// like the render pass. "بلا" is three codepoints (Beh, Lam, Alef) but the
+// Lam-Alef collapses into one glyph, so the line is two advances wide, not
+// three. Before the measurement path was made ligature-aware it counted three,
+// inflating line width and triggering premature ellipsis on Arabic lines.
+void test_line_layout__lam_alef_width_counts_ligature_once(void) {
+  Iterator word_iter = ITERATOR_EMPTY;
+  WordIterState word_iter_state = WORD_ITER_STATE_EMPTY;
+  Line line = { 0 };
+
+  bool success = false;
+  const Utf8Bounds utf8_bounds = utf8_get_bounds(&success, "\xD8\xA8\xD9\x84\xD8\xA7");  // بلا
+  cl_assert(success);
+
+  const TextBoxParams text_box_params = (TextBoxParams) {
+    .utf8_bounds = &utf8_bounds,
+    .box = (GRect) { GPointZero, (GSize) { 5 * HORIZ_ADVANCE_PX + 1, 11 } }
+  };
+  line.max_width_px = text_box_params.box.size.w;
+  line.height_px = text_box_params.box.size.h;
+
+  word_iter_init(&word_iter, &word_iter_state, &s_ctx, &text_box_params, utf8_bounds.start);
+
+  cl_assert(line_add_word(&s_ctx, &line, &word_iter_state.current, &text_box_params));
+  // Beh + (Lam-Alef ligature) == 2 advances, not the three raw codepoints.
+  cl_assert(line.width_px == 2 * HORIZ_ADVANCE_PX);
+}
+
 void test_line_layout__test_line_add_word_no_overflow(void) {
   // Allocate mutable types
   Iterator word_iter = ITERATOR_EMPTY;

--- a/tests/fw/test_rtl_support.c
+++ b/tests/fw/test_rtl_support.c
@@ -120,3 +120,34 @@ void test_rtl_support__separator_needs_two_digits(void) {
   cl_assert_equal_i(cps[1], '/');
   cl_assert_equal_i(cps[2], 0x0627);  // Alef
 }
+
+// rtl_segment_content_end: byte offset of the trailing-space boundary.
+static size_t prv_content_len(const char *str) {
+  utf8_t *start = (utf8_t *)str;
+  utf8_t *end = start + strlen(str);
+  return (size_t)(rtl_segment_content_end(start, end) - start);
+}
+
+void test_rtl_support__content_end_no_trailing_space(void) {
+  cl_assert_equal_i(prv_content_len("abc"), 3);
+}
+
+void test_rtl_support__content_end_single_trailing_space(void) {
+  cl_assert_equal_i(prv_content_len("abc "), 3);
+}
+
+// Trailing spaces peel; interior spaces stay with content.
+void test_rtl_support__content_end_interior_vs_trailing(void) {
+  cl_assert_equal_i(prv_content_len("ab cd   "), 5);  // boundary after 'd'
+}
+
+// All-space run has no content -> boundary is the start (segment kept whole).
+void test_rtl_support__content_end_all_spaces(void) {
+  cl_assert_equal_i(prv_content_len("   "), 0);
+  cl_assert_equal_i(prv_content_len(""), 0);
+}
+
+// Boundary lands on a codepoint start, not mid-sequence. "بر " = Beh Reh SP.
+void test_rtl_support__content_end_multibyte(void) {
+  cl_assert_equal_i(prv_content_len("\xD8\xA8\xD8\xB1 "), 4);  // two 2-byte cps, then space
+}


### PR DESCRIPTION
## What

Two bidi line-layout fixes in `text_layout.c` that share the same segment-collection loop, so they ship together:

  - **Boundary spaces** — a space between an RTL and an LTR run is direction-neutral. Kept inside a run, it was reversed with that run, and the segment reorder then carried it to the run's far edge, collapsing the gap between the two runs. Peel trailing spaces into their own neutral segment so they stay put between the runs.
  - **Ligature width** — width measurement shaped each codepoint in isolation, so a Lam-Alef pair is measured as two glyphs while the renderer draws one ligature. Measure with `arabic_shape_pair()` (skipping the consumed Alef) so layout width matches what is drawn. This also covers the line/truncation measurement path (`update_dimensions`), closing the measurement gap raised on #1585.

Adds `rtl_segment_content_end()` and raises `MAX_BIDI_SEGMENTS` to 16.

## Depends on

Depends on **#1585** (`arabic_shape_pair()`). #1586 is now merged, so its digit commit is dropped and this PR has been rebased on `main`. The PR still shows #1585's commit until it merges — **please merge after #1585**, after which a rebase narrows the diff to just the `text_layout` change.

## Before / After

<img width="600" height="404" alt="cmp_rtlltr" src="https://github.com/user-attachments/assets/d4a04318-b645-4a4a-b4df-1df5a53e226e" />


## Test

`test_rtl_support` (incl. content_end) plus `test_line_layout`, `test_char_iterator`, `test_word_iterator` pass.
