### PR TITLE
services/battery: sample nRF battery state every minute

### DIFF
--- a/src/fw/services/battery/nrf_fuel_gauge/battery_state.c
+++ b/src/fw/services/battery/nrf_fuel_gauge/battery_state.c
@@ -40,7 +40,7 @@ PBL_LOG_MODULE_DECLARE(service_battery, CONFIG_SERVICE_BATTERY_LOG_LEVEL);
 #define RECONNECTION_DELAY_MS (1 * 1000)
 // TODO: Adjust sample rate based on activity periods once we have good
 // power consumption profiles
-#define BATTERY_SAMPLE_RATE_S 1
+#define BATTERY_SAMPLE_RATE_MIN 1
 
 #define LOG_MIN_SEC 30
 
@@ -526,7 +526,7 @@ void battery_state_init(void) {
   static RegularTimerInfo battery_regular_timer = {
     .cb = prv_callback_from_regular_timer
   };
-  regular_timer_add_multisecond_callback(&battery_regular_timer, BATTERY_SAMPLE_RATE_S);
+  regular_timer_add_multiminute_callback(&battery_regular_timer, BATTERY_SAMPLE_RATE_MIN);
 
   s_analytics_last_voltage_mv = s_last_voltage_mv;
   s_analytics_last_cpct = s_last_soc_cpct;


### PR DESCRIPTION
The nRF fuel gauge battery state was sampled every second via a multisecond regular timer. Switch to a per-minute regular timer to reduce wakeups and power consumption; on-demand updates (force update, USB connection events) are unchanged.

Note that we need to confirm we do not loose precision.