### PR TITLE
boards/obelix: soft-reset legacy LIS2DW12 at boot

### DIFF
--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -381,6 +381,17 @@ static const LSM6DSOConfig s_lsm6dso_config = {
 
 const LSM6DSOConfig *const LSM6DSO = &s_lsm6dso_config;
 
+// Legacy LIS2DW12 (replaced by the LSM6DSO). Kept only to soft-reset the part
+// at boot, since a firmware upgrade may leave it powered on existing devices.
+static const I2CSlavePort s_i2c_lis2dw12 = {
+    .bus = &s_i2c_bus_2,
+#if defined(CONFIG_BOARD_OBELIX_DVT) || defined(CONFIG_BOARD_OBELIX_BB2)
+    .address = 0x18,
+#else
+    .address = 0x19,
+#endif
+};
+
 static const I2CSlavePort s_i2c_mmc5603nj = {
     .bus = &s_i2c_bus_2,
     .address = 0x30,
@@ -651,6 +662,12 @@ void board_init(void) {
   i2c_init(I2C2_BUS);
   i2c_init(I2C3_BUS);
   i2c_init(I2C4_BUS);
+
+  // Soft-reset the legacy LIS2DW12 in case an upgrade left it powered on. CTRL2
+  // (0x21) SOFT_RESET (bit 6) restores the part to its powered-down defaults.
+  i2c_use((I2CSlavePort *)&s_i2c_lis2dw12);
+  i2c_write_register((I2CSlavePort *)&s_i2c_lis2dw12, 0x21, (1U << 6U));
+  i2c_release((I2CSlavePort *)&s_i2c_lis2dw12);
 
   mic_init(MIC);
   audio_init(AUDIO);


### PR DESCRIPTION
## Summary

The obelix boards switched from the LIS2DW12 to the LSM6DSO, but a firmware upgrade can leave the LIS2DW12 powered on existing devices, where it keeps drawing current and driving its interrupt line.

This adds a soft reset of the legacy part in `board_init`:
- Re-introduces a minimal `I2CSlavePort` for the LIS2DW12 on I2C2, with the original per-revision address (`0x18` for DVT/BB2, `0x19` otherwise).
- After the I2C buses are brought up, writes `CTRL2` (`0x21`) `SOFT_RESET` (bit 6), returning the part to its powered-down defaults.

The write NAKs harmlessly on devices that never had the LIS2DW12, so it's safe across all obelix revisions.

## Test plan

- `board_obelix.c` compiles cleanly for `obelix@pvt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)