### PR TITLE
apps/prf/mfg_test_aging: pre-discharge phase + minute-granularity discharge

### DIFF
--- a/src/fw/apps/prf/mfg_test_aging.c
+++ b/src/fw/apps/prf/mfg_test_aging.c
@@ -28,6 +28,7 @@
 #include "pbl/services/light.h"
 #include "pbl/services/idle_watchdog.h"
 #include "system/logging.h"
+#include "util/time/time.h"
 
 #include <stdio.h>
 
@@ -363,7 +364,7 @@ static void prv_run_component_display(AppData *data) {
             comp_detail);
 }
 
-static void prv_handle_second_tick(struct tm *tick_time, TimeUnits units_changed) {
+static void prv_handle_tick(struct tm *tick_time, TimeUnits units_changed) {
   AppData *data = app_state_get_user_data();
 
   switch (data->state) {
@@ -575,6 +576,9 @@ static void prv_handle_second_tick(struct tm *tick_time, TimeUnits units_changed
         backlight_set_color(0xFFFFFF);
 #endif
         light_enable(true);
+        // The screen only needs occasional refreshes while discharging, so
+        // tick once a minute to cut wake-ups and the test's own power draw.
+        tick_timer_service_subscribe(MINUTE_UNIT, prv_handle_tick);
         break;
       }
 
@@ -601,7 +605,8 @@ static void prv_handle_second_tick(struct tm *tick_time, TimeUnits units_changed
     }
 
     case AgingStateDischarging: {
-      data->phase_elapsed_sec++;
+      // This phase ticks once a minute (see the Idle->Discharge transition).
+      data->phase_elapsed_sec += SECONDS_PER_MINUTE;
 
       BatteryConstants bc;
       battery_get_constants(&bc);
@@ -732,7 +737,7 @@ static void prv_handle_init(void) {
                                                            GTextAlignmentLeft));
   layer_add_child(window_layer, &status->layer);
 
-  tick_timer_service_subscribe(SECOND_UNIT, prv_handle_second_tick);
+  tick_timer_service_subscribe(SECOND_UNIT, prv_handle_tick);
 
   app_window_stack_push(window, true);
 }

--- a/src/fw/apps/prf/mfg_test_aging.c
+++ b/src/fw/apps/prf/mfg_test_aging.c
@@ -52,6 +52,11 @@
 // Adjust here if the target ever changes.
 #define DISCHARGE_TARGET_PERCENT 65
 
+// Pre-discharge phase parameters — if the battery arrives too full, drain it
+// to a known starting level before the charge+cycle phase.
+#define PRE_DISCHARGE_THRESHOLD_PERCENT 85
+#define PRE_DISCHARGE_TARGET_PERCENT 70
+
 #ifdef CONFIG_SPEAKER
 static const int16_t sine_wave_4k[] = {
   0, 32767, 0, -32768, 0, 32767, 0, -32768,
@@ -60,7 +65,9 @@ static const int16_t sine_wave_4k[] = {
 #endif
 
 typedef enum {
-  AgingStateWaitPlug = 0,
+  AgingStateInit = 0,
+  AgingStatePreDischarge,
+  AgingStateWaitPlug,
   AgingStateChargingAndCycling,
   AgingStateWaitUnplug,
   AgingStateIdle,
@@ -360,6 +367,82 @@ static void prv_handle_second_tick(struct tm *tick_time, TimeUnits units_changed
   AppData *data = app_state_get_user_data();
 
   switch (data->state) {
+    case AgingStateInit: {
+      // Decide on the first tick whether the battery needs to be drained to a
+      // known level before charging. Reading the battery here keeps all the
+      // battery accesses in the tick handler.
+      BatteryChargeState cs = battery_get_charge_state();
+      if (cs.charge_percent > PRE_DISCHARGE_THRESHOLD_PERCENT) {
+        data->state = AgingStatePreDischarge;
+        data->phase_elapsed_sec = 0;
+#ifdef CONFIG_BACKLIGHT_HAS_COLOR
+        data->saved_backlight_color = backlight_get_color();
+        backlight_set_color(0xFFFFFF);
+#endif
+        light_enable(true);
+        sniprintf(data->status_string, sizeof(data->status_string),
+                  "PRE-DISCHARGE\nStarting...");
+      } else {
+        data->state = AgingStateWaitPlug;
+      }
+      break;
+    }
+
+    case AgingStatePreDischarge: {
+      BatteryConstants bc;
+      battery_get_constants(&bc);
+      BatteryChargeState cs = battery_get_charge_state();
+
+      // The battery can only drain while unplugged: prompt the operator to
+      // unplug instead of spinning here charging the cell. Don't count this
+      // wait against the drain time.
+      if (cs.is_plugged) {
+        light_enable(false);
+#ifdef CONFIG_BACKLIGHT_HAS_COLOR
+        backlight_set_color(data->saved_backlight_color);
+#endif
+        sniprintf(data->status_string, sizeof(data->status_string),
+                  "PRE-DISCHARGE\n\nUnplug watch\nto drain to %d%%",
+                  PRE_DISCHARGE_TARGET_PERCENT);
+        break;
+      }
+
+      data->phase_elapsed_sec++;
+
+      // Resume draining with backlight on (it may have been turned off above
+      // while plugged).
+#ifdef CONFIG_BACKLIGHT_HAS_COLOR
+      backlight_set_color(0xFFFFFF);
+#endif
+      light_enable(true);
+
+      if (cs.charge_percent <= PRE_DISCHARGE_TARGET_PERCENT) {
+        light_enable(false);
+#ifdef CONFIG_BACKLIGHT_HAS_COLOR
+        backlight_set_color(data->saved_backlight_color);
+#endif
+        data->state = AgingStateWaitPlug;
+        data->phase_elapsed_sec = 0;
+        break;
+      }
+
+      char time_str[16];
+      prv_format_time(time_str, sizeof(time_str), data->phase_elapsed_sec);
+
+      int8_t temp_c = (int8_t)(bc.t_mc / 1000);
+      uint8_t temp_c_frac = ((bc.t_mc > 0 ? bc.t_mc : -bc.t_mc) % 1000) / 10;
+
+      sniprintf(data->status_string, sizeof(data->status_string),
+                "PRE-DISCHARGE\nTime: %s\n\n"
+                "%" PRId32 "mV %" PRIu8 "%%\n"
+                "%" PRId8 ".%02" PRIu8 "C\n\n"
+                "Target: %d%%",
+                time_str, bc.v_mv, cs.charge_percent,
+                temp_c, temp_c_frac,
+                PRE_DISCHARGE_TARGET_PERCENT);
+      break;
+    }
+
     case AgingStateWaitPlug: {
       BatteryChargeState cs = battery_get_charge_state();
       if (cs.is_plugged) {
@@ -580,7 +663,7 @@ static void prv_handle_second_tick(struct tm *tick_time, TimeUnits units_changed
 static void prv_back_click_handler(ClickRecognizerRef recognizer, void *context) {
   AppData *data = app_state_get_user_data();
 
-  if (data->state == AgingStateDischarging) {
+  if (data->state == AgingStateDischarging || data->state == AgingStatePreDischarge) {
     light_enable(false);
 #ifdef CONFIG_BACKLIGHT_HAS_COLOR
     backlight_set_color(data->saved_backlight_color);
@@ -606,7 +689,7 @@ static void prv_config_provider(void *context) {
 static void prv_handle_init(void) {
   AppData *data = app_malloc_check(sizeof(AppData));
   *data = (AppData){
-    .state = AgingStateWaitPlug,
+    .state = AgingStateInit,
 #ifdef CONFIG_SPEAKER
     .audio_playing = false,
 #endif


### PR DESCRIPTION
## Summary

Two changes to the MFG aging test (`src/fw/apps/prf/mfg_test_aging.c`):

1. **Add a pre-discharge phase.** If the battery arrives above 85% when the aging test starts, it is drained down to 70% (backlight on to draw current) before the charge+cycle phase, so every unit begins the test from a comparable, not-fully-charged level. When the battery is already at or below the threshold, this phase is skipped and the test proceeds straight to the usual `WaitPlug → charge+cycle → idle → discharge` flow.

   The battery can only drain while unplugged, so if the watch is plugged in during pre-discharge the phase turns the backlight off and prompts the operator to unplug (`Unplug watch to drain to 70%`) rather than spinning while the cell charges. The drain timer is paused during this wait and only counts actual draining time. The back button restores the backlight when exiting mid-pre-discharge.

2. **Update the screen once a minute while discharging.** When the idle phase transitions into the final discharge, the tick subscription switches from `SECOND_UNIT` to `MINUTE_UNIT`, cutting wake-ups and the test's own power draw to improve the discharge measurement. Earlier phases keep second-granularity ticks for prompt plug/unplug detection. (Idea ported from the v4.9.142-cosonic branch.)

## Test plan

- Builds clean: `./pbl configure --board getafix@dvt2 --variant=prf -DCONFIG_MFG=y -DCONFIG_LOG_HASHED=n && ./pbl build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)