### PR TITLE
drivers/display/sf32lb: run LCDC ISR from RAM [FIRM-1740]

### DIFF
--- a/src/fw/drivers/display/sf32lb/display_jdi.c
+++ b/src/fw/drivers/display/sf32lb/display_jdi.c
@@ -293,7 +293,6 @@ void display_jdi_irq_handler(DisplayJDIDevice *disp) {
   // coredump shows the interrupt interleaving behind the lost-EOF wedge.
   volatile DisplayIrqLogEntry *entry =
       &s_lcdc_irq_log.entries[s_lcdc_irq_log.write_count % DISPLAY_IRQ_LOG_ENTRIES];
-  entry->timestamp = (uint32_t)rtc_get_ticks();
   entry->irq_before = regs->IRQ;
   entry->jdi_par_ctrl = regs->JDI_PAR_CTRL;
   entry->status = regs->STATUS;
@@ -302,6 +301,8 @@ void display_jdi_irq_handler(DisplayJDIDevice *disp) {
   s_lcdc_eof_cb_fired = false;
   HAL_LCDC_IRQHandler(&state->hlcdc);
 
+  // After the handler: keeps rtc_get_ticks() (flash) off the reprogram path.
+  entry->timestamp = (uint32_t)rtc_get_ticks();
   entry->irq_after = regs->IRQ;
   if (s_lcdc_eof_cb_fired) {
     entry->flags |= 0x1u;

--- a/src/fw/sf32lb52_flash_fw.ld.template
+++ b/src/fw/sf32lb52_flash_fw.ld.template
@@ -54,6 +54,10 @@ SECTIONS
 
         *freertos.*.o (.text* .rodata*)
 
+        *.o (.text.LCDC1_IRQHandler)
+        *.o (.text.display_jdi_irq_handler)
+        *.o (.text.HAL_LCDC_IRQHandler)
+
         . = ALIGN(4);
         __ramfunc_end = .;
     } >KERNEL_RAM AT>FLASH


### PR DESCRIPTION
If the JDI half-frame LCDC interrupt slips past max_line, its mid- and end-of-frame interrupts merge, EOF is never sent, and the compositor wedges until the silent-loss watchdog fires.

Fix: put the reprogram path (LCDC1_IRQHandler, display_jdi_irq_handler, HAL_LCDC_IRQHandler) in .ramfunc so it runs while flash is busy.