### PR TITLE
fw/services/timeline: dismiss all notifications, not just the first

### DIFF
--- a/src/fw/services/timeline/timeline.c
+++ b/src/fw/services/timeline/timeline.c
@@ -23,6 +23,7 @@
 #include "pbl/services/blob_db/pin_db.h"
 #include "pbl/services/blob_db/reminder_db.h"
 #include "pbl/services/notifications/notification_storage.h"
+#include "pbl/services/notifications/notifications.h"
 #include "pbl/services/phone_call_util.h"
 #include "pbl/services/timeline/actions_endpoint.h"
 #include "system/logging.h"
@@ -755,6 +756,10 @@ static void prv_perform_ancs_negative_action(const TimelineItem *item,
     }
     prv_put_notification_action_result(&item->header.id, i18n_get(msg_i18n, &i18n_key), res_id,
                                        ActionResultTypeSuccess);
+  } else {
+    // Bulk mode suppresses the per-item dialog, but we must still remove the notification from the
+    // UI ourselves; the phone only echoes a removal for notifications still in its center.
+    notifications_handle_notification_removed((Uuid *)&item->header.id);
   }
 }
 

--- a/tests/fw/services/blob_db/test_timeline.c
+++ b/tests/fw/services/blob_db/test_timeline.c
@@ -106,6 +106,10 @@ void notifications_handle_notification_acted_upon(Uuid *notification_id) {
   return;
 }
 
+void notifications_handle_notification_removed(Uuid *notification_id) {
+  return;
+}
+
 // Data
 /////////////////////////
 static TimelineItem s_items[] = {

--- a/tests/fw/services/timeline/test_timeline_model.c
+++ b/tests/fw/services/timeline/test_timeline_model.c
@@ -99,6 +99,10 @@ void notifications_handle_notification_acted_upon(Uuid *notification_id) {
   return;
 }
 
+void notifications_handle_notification_removed(Uuid *notification_id) {
+  return;
+}
+
 // Data
 /////////////////////////
 static TimelineItem s_items[] = {

--- a/tests/fw/test_timeline_api.c
+++ b/tests/fw/test_timeline_api.c
@@ -100,6 +100,10 @@ void notifications_handle_notification_acted_upon(Uuid *notification_id) {
   return;
 }
 
+void notifications_handle_notification_removed(Uuid *notification_id) {
+  return;
+}
+
 // Setup
 /////////////////////////
 


### PR DESCRIPTION
## Problem

Holding **Select** in the notification window is the advertised "dismiss all" gesture (its first-use tutorial says *"Quickly dismiss all notifications by holding the Select button"*). For iOS/ANCS notifications in the **notification history app**, it only ever removed the **first** notification — so users who scrolled to a specific notification and held Select saw the first one vanish while their selection stayed (FIRM-2495, 100% repro).

## Root cause

A notification is removed from the UI only when an `ActionResultTypeSuccess` ("Dismissed") event fires. `timeline_actions_dismiss_all` enables ANCS **bulk mode** after the first dismiss, and `prv_perform_ancs_negative_action` **suppresses that event while bulk mode is on**, relying on the phone to echo back an ANCS removal instead. That echo never comes for history notifications already cleared from the iPhone's Notification Center, so only the first (non-bulk) notification — the one driving the single result dialog — was removed.

## Fix

In the bulk branch of `prv_perform_ancs_negative_action`, remove the notification from the UI locally via `notifications_handle_notification_removed`, so the whole batch is cleared while still showing a single result dialog. The modal popup path is unchanged (it ignores `NotificationRemoved` while frozen, then closes on completion).

## Testing

- Firmware builds for `obelix@pvt`.
- `./pbl test` passes (incl. `test_timeline`, `test_timeline_model`). Added the matching `notifications_handle_notification_removed` stub to the three tests that compile `timeline.c` with local notification stubs.

Fixes FIRM-2495

🤖 Generated with [Claude Code](https://claude.com/claude-code)