### PR TITLE
fw/comm_session: drain receiver one message per callback

### DIFF
--- a/src/fw/services/comm_session/default_kernel_receiver.c
+++ b/src/fw/services/comm_session/default_kernel_receiver.c
@@ -49,11 +49,10 @@ typedef struct {
   uint8_t payload[];
 } DefaultReceiverImpl;
 
-//! Pending receiver lists: completed messages are appended here instead of each
-//! getting their own system_task/launcher_task callback. A single callback is
-//! scheduled per list and drains all entries when it fires. This prevents the
-//! system task queue from overflowing when many Pebble Protocol messages arrive
-//! in rapid succession (e.g. after BT reconnect).
+//! Pending receiver lists. One callback per list is in flight at a time; it
+//! handles one message and reschedules until empty. Coalescing bounds the
+//! system task queue; one-per-callback keeps a slow handler from starving the
+//! task watchdog.
 static SingleListNode *s_pending_bg_head;
 static bool s_bg_callback_pending;
 
@@ -113,30 +112,50 @@ static void prv_append_to_pending_list(DefaultReceiverImpl *impl,
   }
 }
 
-static void prv_drain_pending_list(SingleListNode **head,
-                                   bool *callback_pending) {
-  // Snapshot and detach the list so new items that arrive while we are
-  // processing do not extend the current batch indefinitely.
-  SingleListNode *list = *head;
-  *head = NULL;
-  *callback_pending = false;
-
-  while (list) {
-    DefaultReceiverImpl *impl = (DefaultReceiverImpl *)list;
-    list = slist_get_next(list);
+//! Handle one pending message; returns true if more remain. One per callback
+//! so a slow handler (e.g. data logging blocking ~500ms per send) can't starve
+//! the watchdog: the draining task feeds it between callbacks.
+static bool prv_drain_one_pending(SingleListNode **head) {
+  DefaultReceiverImpl *impl = (DefaultReceiverImpl *)*head;
+  if (impl) {
+    *head = slist_get_next(&impl->node);
     PBL_ASSERTN(impl->handler_scheduled && impl->session);
     impl->endpoint->handler(impl->session, impl->payload, impl->total_payload_size);
     prv_wipe_receiver_data(impl);
     kernel_free(impl);
   }
+  return (*head != NULL);
 }
 
 static void prv_default_kernel_receiver_bg_cb(void *data) {
-  prv_drain_pending_list(&s_pending_bg_head, &s_bg_callback_pending);
+  if (prv_drain_one_pending(&s_pending_bg_head)) {
+    // Reschedule rather than loop so the watchdog gets fed between handlers.
+    system_task_add_callback(prv_default_kernel_receiver_bg_cb, NULL);
+    return;
+  }
+
+  s_bg_callback_pending = false;
+
+  // finish() runs on another task; re-check so a message appended during the
+  // window above isn't stranded.
+  if (s_pending_bg_head) {
+    s_bg_callback_pending = true;
+    system_task_add_callback(prv_default_kernel_receiver_bg_cb, NULL);
+  }
 }
 
 static void prv_default_kernel_receiver_main_cb(void *data) {
-  prv_drain_pending_list(&s_pending_main_head, &s_main_callback_pending);
+  if (prv_drain_one_pending(&s_pending_main_head)) {
+    launcher_task_add_callback(prv_default_kernel_receiver_main_cb, NULL);
+    return;
+  }
+
+  s_main_callback_pending = false;
+
+  if (s_pending_main_head) {
+    s_main_callback_pending = true;
+    launcher_task_add_callback(prv_default_kernel_receiver_main_cb, NULL);
+  }
 }
 
 static void prv_default_kernel_receiver_finish(Receiver *receiver) {

--- a/tests/fw/services/comm_session/test_default_kernel_receiver.c
+++ b/tests/fw/services/comm_session/test_default_kernel_receiver.c
@@ -202,8 +202,8 @@ void test_default_kernel_receiver__prepare_write_finish_multiple_sessions(void) 
 
 //! It's possible the same session can receiver multiple messages before any
 //! are processed on kernel BG. Make sure they do not interfere with one
-//! another. With coalesced callbacks, a single system_task callback drains
-//! all pending messages in order.
+//! another. Coalesced messages are drained one-per-callback (chained) and
+//! delivered in arrival order.
 void test_default_kernel_receiver__same_session_batched(void) {
   const int batch_num = 10;
   char data = 'a';
@@ -222,8 +222,8 @@ void test_default_kernel_receiver__same_session_batched(void) {
 
   prv_assert_no_handler_calls();
 
-  // All 10 messages are coalesced into a single system_task callback.
-  // Skip per-handler expected_data assertion; verify order via recording.
+  // One message per callback, but invoke_pending() loops over the reschedules,
+  // so all 10 are delivered. Verify order via recording.
   s_skip_data_assert = true;
   fake_system_task_callbacks_invoke_pending();
   cl_assert_equal_i(s_handler_call_count[HandlerA], batch_num);
@@ -235,6 +235,38 @@ void test_default_kernel_receiver__same_session_batched(void) {
     cl_assert_equal_i(s_recorded_lens[i], 1);
   }
 
+  cl_assert_equal_i(fake_pbl_malloc_num_net_allocs(), 0);
+}
+
+//! A coalesced batch must drain one message per callback so a slow handler
+//! can't starve the watchdog. Verify each callback handles exactly one.
+void test_default_kernel_receiver__batch_drains_one_per_callback(void) {
+  const int batch_num = 5;
+  char data = 'a';
+  for (int i = 0; i < batch_num; i++) {
+    Receiver *receiver = g_default_kernel_receiver_implementation.prepare(
+        FAKE_COMM_SESSION, &s_endpoints[0], 1);
+    cl_assert(receiver != NULL);
+    g_default_kernel_receiver_implementation.write(receiver, (uint8_t *)&data, 1);
+    g_default_kernel_receiver_implementation.finish(receiver);
+    data += 1;
+  }
+
+  prv_assert_no_handler_calls();
+  s_skip_data_assert = true;
+
+  // The flood coalesces into a single pending callback.
+  cl_assert_equal_i(fake_system_task_count_callbacks(), 1);
+
+  // Each invocation runs one handler and chains the next callback.
+  for (int i = 0; i < batch_num; i++) {
+    cl_assert_equal_i(s_handler_call_count[HandlerA], i);
+    fake_system_task_callbacks_invoke(1);
+    cl_assert_equal_i(s_handler_call_count[HandlerA], i + 1);
+  }
+
+  // Nothing left to do once the batch is drained.
+  cl_assert_equal_i(fake_system_task_count_callbacks(), 0);
   cl_assert_equal_i(fake_pbl_malloc_num_net_allocs(), 0);
 }
 


### PR DESCRIPTION
Fixes FIRM-2903