### PR TITLE
fw: build remaining src/fw directories from wscript_build

### DIFF
--- a/src/fw/debug/wscript_build
+++ b/src/fw/debug/wscript_build
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+bld.objects(
+    name='debug',
+    source=bld.path.ant_glob('*.c'),
+    use=['fw_includes', 'pblibc_includes'],
+)
+
+# vim:filetype=python

--- a/src/fw/flash_region/wscript_build
+++ b/src/fw/flash_region/wscript_build
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+bld.objects(
+    name='flash_region',
+    source=bld.path.ant_glob('*.c'),
+    use=['fw_includes', 'pblibc_includes'],
+)
+
+# vim:filetype=python

--- a/src/fw/kernel/wscript_build
+++ b/src/fw/kernel/wscript_build
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+bld.objects(
+    name='kernel',
+    source=bld.path.ant_glob('**/*.c'),
+    use=['fw_includes', 'pblibc_includes'],
+)
+
+# vim:filetype=python

--- a/src/fw/popups/wscript_build
+++ b/src/fw/popups/wscript_build
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+if bld.env.VARIANT == 'prf':
+    # Recovery only needs the BT pairing UI.
+    source = ['bluetooth_pairing_ui.c']
+else:
+    excl = [] if bld.env.CONFIG_HRM else ['ble_hrm/**']
+    source = bld.path.ant_glob('**/*.c', excl=excl)
+
+bld.objects(
+    name='popups',
+    source=source,
+    use=['fw_includes', 'pblibc_includes'],
+)
+
+# vim:filetype=python

--- a/src/fw/process_management/wscript_build
+++ b/src/fw/process_management/wscript_build
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+excl = []
+if bld.env.VARIANT == 'prf':
+    excl += ['app_custom_icon.c', 'app_menu_data_source.c']
+
+bld.objects(
+    name='process_management',
+    source=bld.path.ant_glob('*.c', excl=excl),
+    use=['fw_includes', 'pblibc_includes'],
+)
+
+# vim:filetype=python

--- a/src/fw/process_state/wscript_build
+++ b/src/fw/process_state/wscript_build
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+bld.objects(
+    name='process_state',
+    source=bld.path.ant_glob('**/*.c'),
+    use=['fw_includes', 'pblibc_includes', 'tinymt32'],
+)
+
+# vim:filetype=python

--- a/src/fw/resource/wscript_build
+++ b/src/fw/resource/wscript_build
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+excl = []
+if bld.env.VARIANT == 'prf':
+    excl += ['resource_storage_file.c']
+
+bld.objects(
+    name='resource',
+    source=bld.path.ant_glob('*.c', excl=excl),
+    use=['fw_includes', 'pblibc_includes'],
+)
+
+# vim:filetype=python

--- a/src/fw/shell/wscript_build
+++ b/src/fw/shell/wscript_build
@@ -182,4 +182,10 @@ bld(rule=generate_apps_table,
     target=[registry, app_enum],
     vars=['DEFINES'])
 
+bld.objects(
+    name='shell',
+    source=bld.path.ant_glob('*.c') + bld.path.ant_glob('%s/**/*.c' % shell_name),
+    use=['fw_includes', 'pblibc_includes'],
+)
+
 # vim:filetype=python

--- a/src/fw/syscall/wscript_build
+++ b/src/fw/syscall/wscript_build
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+bld.objects(
+    name='syscall',
+    source=bld.path.ant_glob('*.c'),
+    use=['fw_includes', 'pblibc_includes'],
+)
+
+# vim:filetype=python

--- a/src/fw/system/wscript_build
+++ b/src/fw/system/wscript_build
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+bld.objects(
+    name='system',
+    source=bld.path.ant_glob('*.c'),
+    use=['fw_includes', 'pblibc_includes'],
+)
+
+# vim:filetype=python

--- a/src/fw/util/wscript_build
+++ b/src/fw/util/wscript_build
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+bld.objects(
+    name='util',
+    source=bld.path.ant_glob('**/*.c'),
+    use=['fw_includes', 'pblibc_includes', 'tinymt32'],
+)
+
+# vim:filetype=python

--- a/src/fw/wscript
+++ b/src/fw/wscript
@@ -255,11 +255,22 @@ def _link_firmware(bld, sources):
             'bt_driver',
             'comm',
             'console',
+            'debug',
             'drivers',
+            'flash_region',
             'freertos',
             'fw_services',
             'gcc',
+            'kernel',
             'mfg',
+            'popups',
+            'process_management',
+            'process_state',
+            'resource',
+            'shell',
+            'syscall',
+            'system',
+            'util',
             'proto_schemas',
             'libbtutil',
             'libos',
@@ -322,28 +333,8 @@ def _link_firmware(bld, sources):
 
 
 def _build_recovery(bld):
-    source_dirs = ['process_management',
-                   'process_state/**',
-                   'debug',
-                   'flash_region',
-                   'graphics',
-                   'kernel/**',
-                   'resource',
-                   'syscall',
-                   'system',
-                   'shell',
-                   'shell/prf/**',
-                   'util/**']
-
-    excludes = ['process_management/app_custom_icon.c',
-                'process_management/app_menu_data_source.c',
-                'resource/resource_storage_file.c']
-
-    sources = sum([bld.path.ant_glob('%s/*.c' % d, excl=excludes) for d in source_dirs], [])
-    sources.extend(bld.path.ant_glob('*.c'))
+    sources = bld.path.ant_glob('*.c')
     sources.extend(bld.path.ant_glob('*.[sS]'))
-
-    sources.append(bld.path.make_node('popups/bluetooth_pairing_ui.c'))
 
     sources.append(bld.path.get_bld().make_node('builtin_resources.auto.c'))
 
@@ -360,32 +351,14 @@ def _build_normal(bld):
 
     bld.DYNAMIC_RESOURCES.append(tzdata_bin)
 
-    source_dirs = ['process_management',
-                   'process_state/**',
-                   'debug',
-                   'flash_region',
-                   'graphics',
-                   'kernel/**',
-                   'launcher/**',
-                   'popups/**',
-                   'resource',
-                   'syscall',
-                   'system',
-                   'shell',
-                   'shell/sdk/**' if bld.env.CONFIG_SHELL_SDK else 'shell/normal/**',
-                   'util/**']
-
-    excludes = []
-
-    if not bld.env.CONFIG_HRM:
-        excludes.append('popups/ble_hrm/**')
-
-    sources = sum([bld.path.ant_glob('%s/*.c' % d, excl=excludes) for d in source_dirs], [])
-    sources.extend(bld.path.ant_glob('*.c'))
+    sources = bld.path.ant_glob('*.c')
     sources.extend(bld.path.ant_glob('*.[sS]'))
 
+    # Collect translatable strings from the firmware-core sources. apps,
+    # services and applib have their own .pot targets (merged below).
     gettexts = []
-    gettexts.extend(sources)
+    gettexts.extend(bld.path.ant_glob('**/*.c',
+                                      excl=['apps/**', 'services/**', 'applib/**']))
     gettexts.extend(bld.path.ant_glob('**/*.h'))
     gettexts.extend(bld.path.ant_glob('**/*.def'))
 
@@ -452,6 +425,16 @@ def build(bld):
     bld.recurse('mfg')
     bld.recurse('comm')
     bld.recurse('console')
+    bld.recurse('debug')
+    bld.recurse('flash_region')
+    bld.recurse('kernel')
+    bld.recurse('popups')
+    bld.recurse('process_management')
+    bld.recurse('process_state')
+    bld.recurse('resource')
+    bld.recurse('syscall')
+    bld.recurse('system')
+    bld.recurse('util')
     bld.recurse('apps/core')
 
     if bld.env.VARIANT == 'prf':


### PR DESCRIPTION
Migrate the last globbed firmware directories out of the source_dirs lists in _build_recovery/_build_normal into per-directory wscript_build objects targets, matching the convention already used by board, comm, console, mfg and the apps subtrees:

  debug, flash_region, kernel, popups, process_management, process_state,
  resource, syscall, system, util, and shell (whose wscript_build now
  also builds its sources alongside the app-registry generation).

Variant/feature selection that lived in the source globs moves into the respective wscript_build: process_management/resource drop their recovery-only files, popups builds just the BT pairing UI for recovery (and drops ble_hrm without CONFIG_HRM), and shell picks its prf/sdk/normal subdirectory. util/process_state pull tinymt32 includes.

The empty graphics/ and launcher/ globs are dropped. The firmware-core .pot extraction now globs the tree (minus apps/services/applib, which have their own .pot) so i18n coverage is unchanged. Only the firmware's own top-level *.c remain listed directly in src/fw/wscript.

No functional change: every board/variant links an identical symbol set.