### PR TITLE
services/vibe_pattern: scope app-cleanup clear to app-owned vibes

### DIFF
--- a/include/pbl/services/vibe_pattern.h
+++ b/include/pbl/services/vibe_pattern.h
@@ -7,6 +7,16 @@
 #include <stdint.h>
 #include <time.h>
 
+//! Source that started a vibe pattern, so cancels can be scoped to their owner
+//! (e.g. a notification dismiss must not stop an alarm vibe).
+typedef enum VibePatternOwner {
+  VibePatternOwner_Other = 0,   // default for untagged kernel vibes
+  VibePatternOwner_App,         // any app/worker vibe; cleared on app cleanup
+  VibePatternOwner_Notification,
+  VibePatternOwner_PhoneCall,
+  VibePatternOwner_Alarm,
+} VibePatternOwner;
+
 void vibes_init();
 
 int32_t vibes_get_vibe_strength(void);
@@ -14,3 +24,10 @@ int32_t vibes_get_default_vibe_strength(void);
 void vibes_set_default_vibe_strength(int32_t vibe_strength_default);
 
 void vibe_service_set_enabled(bool enable);
+
+//! Tag the next triggered pattern's owner (consumed when it starts). Kernel/modal
+//! callers set this before vibing; app vibes default to VibePatternOwner_App.
+void vibe_pattern_set_owner(VibePatternOwner owner);
+
+//! Clear the active pattern only if it is owned by `owner`; no-op otherwise.
+void vibe_pattern_clear_for_owner(VibePatternOwner owner);

--- a/src/fw/process_management/app_manager.c
+++ b/src/fw/process_management/app_manager.c
@@ -42,6 +42,7 @@
 #endif
 #include "pbl/services/app_inbox_service.h"
 #include "pbl/services/app_outbox_service.h"
+#include "pbl/services/vibe_pattern.h"
 #ifndef CONFIG_RECOVERY_FW
 #include "pbl/services/speaker/speaker_service.h"
 #endif
@@ -460,7 +461,8 @@ static void prv_app_cleanup(void) {
   light_reset_user_controlled();
   light_set_system_color();
   sys_vibe_history_stop_collecting();
-  sys_vibe_pattern_clear();
+  // Clear only app-started vibes, so an app exit doesn't kill an alarm.
+  vibe_pattern_clear_for_owner(VibePatternOwner_App);
 #ifndef CONFIG_RECOVERY_FW
   speaker_service_stop_for_task(PebbleTask_App);
 #endif

--- a/src/fw/services/vibe_pattern/service.c
+++ b/src/fw/services/vibe_pattern/service.c
@@ -8,6 +8,8 @@
 #include "drivers/battery.h"
 #include "drivers/rtc.h"
 
+#include "kernel/pebble_tasks.h"
+
 #include "util/list.h"
 #include "util/math.h"
 
@@ -151,6 +153,11 @@ static const uint32_t MAX_VIBE_DURATION_MS = 10000;
 
 static int s_pattern_timer = TIMER_INVALID_ID;
 static bool s_pattern_in_progress = false;
+// Source that started the active pattern; VibePatternOwner_Other when none is live.
+static VibePatternOwner s_pattern_owner = VibePatternOwner_Other;
+// Owner to assign to the next started pattern, set by vibe_pattern_set_owner();
+// consumed (reset to _Other) when the pattern starts.
+static VibePatternOwner s_pending_owner = VibePatternOwner_Other;
 // Reference points for drift-free step scheduling. The pattern's t=0 is anchored
 // to s_pattern_start_ticks; s_pattern_deadline_ms is the (start-relative)
 // completion time of the step the timer is currently waiting on. Each step's
@@ -297,6 +304,7 @@ static void prv_timer_callback(void* data) {
     // make sure it's off
     prv_vibes_set_vibe_strength(VIBE_STRENGTH_OFF);
     s_pattern_in_progress = false;
+    s_pattern_owner = VibePatternOwner_Other;
   }
 
   mutex_unlock(s_vibe_pattern_mutex);
@@ -338,6 +346,14 @@ bool prv_vibe_pattern_enqueue_step_raw(uint32_t duration_ms, int32_t strength) {
   step->strength = strength;
 
   if (s_vibe_queue_head == NULL) {
+    // Fresh queue: take the explicitly-set owner, else default by task.
+    if (s_pending_owner != VibePatternOwner_Other) {
+      s_pattern_owner = s_pending_owner;
+    } else {
+      s_pattern_owner = (pebble_task_get_current() == PebbleTask_App)
+                            ? VibePatternOwner_App : VibePatternOwner_Other;
+    }
+    s_pending_owner = VibePatternOwner_Other;
     s_vibe_queue_head = step;
   } else {
     list_append((ListNode*)s_vibe_queue_head, (ListNode*)step);
@@ -399,8 +415,9 @@ DEFINE_SYSCALL(void, sys_vibe_pattern_trigger_start, void) {
   mutex_unlock(s_vibe_pattern_mutex);
 }
 
-DEFINE_SYSCALL(void, sys_vibe_pattern_clear, void) {
-  mutex_lock(s_vibe_pattern_mutex);
+// Stop the active pattern and drop queued steps. Caller holds s_vibe_pattern_mutex.
+static void prv_clear_pattern_locked(void) {
+  mutex_assert_held_by_curr_task(s_vibe_pattern_mutex, true);
   new_timer_stop(s_pattern_timer);
   while (s_vibe_queue_head) {
     VibePatternStep *removed_node = s_vibe_queue_head;
@@ -409,6 +426,27 @@ DEFINE_SYSCALL(void, sys_vibe_pattern_clear, void) {
   }
   prv_vibes_set_vibe_strength(VIBE_STRENGTH_OFF);
   s_pattern_in_progress = false;
+  s_pattern_owner = VibePatternOwner_Other;
+}
+
+DEFINE_SYSCALL(void, sys_vibe_pattern_clear, void) {
+  mutex_lock(s_vibe_pattern_mutex);
+  prv_clear_pattern_locked();
+  mutex_unlock(s_vibe_pattern_mutex);
+}
+
+void vibe_pattern_set_owner(VibePatternOwner owner) {
+  mutex_lock(s_vibe_pattern_mutex);
+  s_pending_owner = owner;
+  mutex_unlock(s_vibe_pattern_mutex);
+}
+
+// Clear the active pattern only if `owner` started it; no-op otherwise.
+void vibe_pattern_clear_for_owner(VibePatternOwner owner) {
+  mutex_lock(s_vibe_pattern_mutex);
+  if (s_pattern_owner == owner) {
+    prv_clear_pattern_locked();
+  }
   mutex_unlock(s_vibe_pattern_mutex);
 }
 

--- a/tests/fw/services/test_vibe.c
+++ b/tests/fw/services/test_vibe.c
@@ -263,6 +263,38 @@ void test_vibe__custom_pattern_with_amplitudes_verifies_strength(void) {
   cl_assert_equal_b(s_vibe_on, false);
 }
 
+// A vibe started on the App task defaults to VibePatternOwner_App; a clear for a
+// different owner is a no-op, and app cleanup (VibePatternOwner_App) stops it.
+void test_vibe__clear_for_owner_scopes_to_owner(void) {
+  // Start a pattern as the App task, left in progress (don't run timers).
+  stub_pebble_tasks_set_current(PebbleTask_App);
+  cl_assert(sys_vibe_pattern_enqueue_step_raw(1000, 100));
+  sys_vibe_pattern_trigger_start();
+  cl_assert_equal_b(s_vibe_on, true);
+
+  // A clear for a different owner is a no-op: the pattern keeps running.
+  vibe_pattern_clear_for_owner(VibePatternOwner_Notification);
+  cl_assert_equal_b(s_vibe_on, true);
+
+  // A clear for the owning source stops it.
+  vibe_pattern_clear_for_owner(VibePatternOwner_App);
+  cl_assert_equal_b(s_vibe_on, false);
+
+  stub_pebble_tasks_set_current(PebbleTask_KernelMain);
+}
+
+// sys_vibe_pattern_clear is unconditional regardless of owner.
+void test_vibe__clear_ignores_owner(void) {
+  stub_pebble_tasks_set_current(PebbleTask_App);
+  cl_assert(sys_vibe_pattern_enqueue_step_raw(1000, 100));
+  sys_vibe_pattern_trigger_start();
+  cl_assert_equal_b(s_vibe_on, true);
+
+  stub_pebble_tasks_set_current(PebbleTask_KernelMain);
+  sys_vibe_pattern_clear();
+  cl_assert_equal_b(s_vibe_on, false);
+}
+
 void test_vibe__custom_pattern_ramp_down(void) {
   const uint32_t durations[] = { 200, 200, 200, 200 };
   const uint32_t amplitudes[] = { 100, 75, 50, 25 };

--- a/tests/fw/test_app_manager.c
+++ b/tests/fw/test_app_manager.c
@@ -16,6 +16,7 @@
 #include "process_management/app_manager.h"
 #include "process_management/app_run_state.h"
 #include "process_management/process_manager.h"
+#include "pbl/services/vibe_pattern.h"
 #include "resource/resource_ids.auto.h"
 #include "util/heap.h"
 
@@ -297,7 +298,7 @@ void health_tracking_ui_register_app_launch(AppInstallId app_id) {
 void sys_vibe_history_stop_collecting(void) {
 }
 
-void sys_vibe_pattern_clear(void) {
+void vibe_pattern_clear_for_owner(VibePatternOwner owner) {
 }
 
 void speaker_service_stop_for_task(PebbleTask task) {


### PR DESCRIPTION
The vibe pattern engine is a global singleton with no notion of who started the active pattern. prv_app_cleanup() calls sys_vibe_pattern_clear() on every app exit, which unconditionally stops whatever is playing.

The alarm popup is a modal and starts its (Reveille) vibe from KernelMain. When the foreground app relaunches/transitions during an alarm, app cleanup clears the alarm's in-progress vibe. The alarm popup's repeat timer restarts it one cycle later (~17s for Reveille), so the user sees the vibration stop within seconds and sometimes resume on its own. The fingerprint in the captured logs is "App PP receiver already closed" immediately followed by "vibe_pattern: clear (was_in_progress=1)".

Track a VibePatternOwner for the active pattern, recorded when a fresh queue is started (app vibes default to VibePatternOwner_App). Add vibe_pattern_clear_for_owner(), which clears only when the active pattern is owned by the given source. app cleanup now clears VibePatternOwner_App, so an app exiting no longer kills a kernel/modal vibe, while still clearing vibes the app itself started. Mirrors the existing
speaker_service_stop_for_task(PebbleTask_App) call in the same path.

Fixes FIRM-2617