### PR TITLE
applib: treat Arabic diacritics as transparent for cursive joining

### DIFF
--- a/src/fw/applib/graphics/arabic_shaping.c
+++ b/src/fw/applib/graphics/arabic_shaping.c
@@ -293,6 +293,16 @@ Codepoint arabic_shape_pair(Codepoint prev_cp, Codepoint curr_cp, Codepoint next
   return arabic_shape_codepoint(prev_cp, curr_cp, next_cp);
 }
 
+bool arabic_is_transparent(Codepoint cp) {
+  return (cp >= 0x0610 && cp <= 0x061A) ||
+         (cp >= 0x064B && cp <= 0x065F) ||
+         (cp == 0x0670) ||
+         (cp >= 0x06D6 && cp <= 0x06DC) ||
+         (cp >= 0x06DF && cp <= 0x06E4) ||
+         (cp >= 0x06E7 && cp <= 0x06E8) ||
+         (cp >= 0x06EA && cp <= 0x06ED);
+}
+
 size_t arabic_shape_text(const utf8_t *src, size_t src_len,
                          utf8_t *dest, size_t dest_size) {
   if (src == NULL || dest == NULL || src_len == 0 || dest_size == 0) {
@@ -324,28 +334,54 @@ size_t arabic_shape_text(const utf8_t *src, size_t src_len,
   size_t dest_offset = 0;
 
   for (size_t i = 0; i < num_codepoints; i++) {
-    Codepoint prev_cp = (i > 0) ? codepoints[i - 1] : 0;
     Codepoint curr_cp = codepoints[i];
-    Codepoint next_cp = (i + 1 < num_codepoints) ? codepoints[i + 1] : 0;
 
-    // Lam-Alef collapses two codepoints into one ligature glyph.
-    bool consumed_next = false;
-    Codepoint shaped_cp = arabic_shape_pair(prev_cp, curr_cp, next_cp, &consumed_next);
-    if (consumed_next) {
-      i++;  // skip the Alef
+    // Skip transparent marks so a diacritic between two letters does not break
+    // their join.
+    Codepoint prev_cp = 0;
+    for (size_t j = i; j > 0; j--) {
+      if (!arabic_is_transparent(codepoints[j - 1])) {
+        prev_cp = codepoints[j - 1];
+        break;
+      }
+    }
+    Codepoint next_cp = 0;
+    size_t next_idx = num_codepoints;
+    for (size_t j = i + 1; j < num_codepoints; j++) {
+      if (!arabic_is_transparent(codepoints[j])) {
+        next_cp = codepoints[j];
+        next_idx = j;
+        break;
+      }
     }
 
-    // Encode the shaped codepoint to UTF-8
-    // Ensure we have room for at least 4 bytes (max UTF-8 length)
+    // Lam-Alef collapses two letters into one ligature glyph.
+    bool consumed_next = false;
+    Codepoint shaped_cp = arabic_shape_pair(prev_cp, curr_cp, next_cp, &consumed_next);
+
+    // Encode the shaped codepoint to UTF-8. Ensure room for at least 4 bytes.
     if (dest_offset + 4 >= dest_size) {
       break;
     }
-
     size_t bytes_written = utf8_encode_codepoint(shaped_cp, dest + dest_offset);
-    if (bytes_written == 0) {
-      continue;
+    if (bytes_written != 0) {
+      dest_offset += bytes_written;
     }
-    dest_offset += bytes_written;
+
+    if (consumed_next) {
+      // Emit any marks between the pair so they stay on the ligature, then skip
+      // the consumed Alef.
+      for (size_t j = i + 1; j < next_idx; j++) {
+        if (dest_offset + 4 >= dest_size) {
+          break;
+        }
+        size_t n = utf8_encode_codepoint(codepoints[j], dest + dest_offset);
+        if (n != 0) {
+          dest_offset += n;
+        }
+      }
+      i = next_idx;
+    }
   }
 
   // Null-terminate if we have space

--- a/src/fw/applib/graphics/arabic_shaping.h
+++ b/src/fw/applib/graphics/arabic_shaping.h
@@ -23,6 +23,12 @@ typedef enum {
 //! @return true if the codepoint is a shapeable Arabic letter
 bool arabic_is_shapeable(Codepoint cp);
 
+//! Check if a codepoint is a transparent Arabic combining mark (harakat etc.).
+//! These marks sit on a base letter and must be skipped when picking the
+//! previous/next letter for cursive joining, so the layout/measurement path
+//! shapes the same forms the renderer draws.
+bool arabic_is_transparent(Codepoint cp);
+
 //! Shape a single Arabic codepoint based on its neighbors.
 //!
 //! Returns the contextual presentation form for `curr_cp` given the

--- a/src/fw/applib/graphics/text_layout.c
+++ b/src/fw/applib/graphics/text_layout.c
@@ -230,6 +230,8 @@ WordState word_state_update(WordState state, Codepoint codepoint) {
 
 //! @return true if init to new word, false otherwise (ie end of text)
 //! @note assumes 'start' is not NULL, but does not assume 'start' is valid start of word
+static Codepoint prv_peek_next_letter(utf8_t *pos, const utf8_t *end);
+
 bool word_init(GContext* ctx, Word* word, const TextBoxParams* const text_box_params, utf8_t* start) {
   word->width_px = 0;
 
@@ -263,28 +265,41 @@ bool word_init(GContext* ctx, Word* word, const TextBoxParams* const text_box_pa
   Codepoint curr_cp = utf8_iter_state->codepoint;
   WordState state = WordStateStart;
   state = word_state_update(state, curr_cp);
-  // arabic_shape_pair() can fold this codepoint and the next into a single
-  // glyph (the Arabic Lam-Alef ligature), reporting the next one as consumed.
-  // Its advance is then already counted, so skip it on the next iteration.
+  // arabic_shape_pair() can fold a Lam and the next Alef into one ligature glyph
+  // and report the Alef as consumed; its advance is then already counted, so the
+  // Alef is skipped later. Marks (harakat) are transparent: they keep their own
+  // width but are stepped over when picking joining context, like the renderer.
   bool skip_ligature_member = false;
+  const utf8_t *bounds_end =
+      (text_box_params->utf8_bounds != NULL) ? text_box_params->utf8_bounds->end : NULL;
 
   do {
+    utf8_t *curr_pos = utf8_iter_state->current;
     iter_next(&char_iter);
     Codepoint next_cp = utf8_iter_state->codepoint;
 
     if (state == WordStateGrowing || state == WordStateIdeograph) {
-      if (skip_ligature_member) {
+      if (skip_ligature_member && !arabic_is_transparent(curr_cp)) {
+        // The Alef folded into the preceding Lam-Alef ligature.
         skip_ligature_member = false;
+      } else if (arabic_is_transparent(curr_cp)) {
+        // A mark keeps its own width but is not reshaped.
+        word->width_px += prv_codepoint_get_horizontal_advance(&ctx->font_cache,
+            text_box_params->font, curr_cp);
       } else {
+        Codepoint shape_next =
+            arabic_is_transparent(next_cp) ? prv_peek_next_letter(curr_pos, bounds_end) : next_cp;
         bool consumed_next = false;
-        Codepoint width_cp = arabic_shape_pair(prev_cp, curr_cp, next_cp, &consumed_next);
+        Codepoint width_cp = arabic_shape_pair(prev_cp, curr_cp, shape_next, &consumed_next);
         word->width_px += prv_codepoint_get_horizontal_advance(&ctx->font_cache,
             text_box_params->font, width_cp);
         skip_ligature_member = consumed_next;
       }
     }
 
-    prev_cp = curr_cp;
+    if (!arabic_is_transparent(curr_cp)) {
+      prev_cp = curr_cp;
+    }
     curr_cp = next_cp;
     state = word_state_update(state, curr_cp);
   } while (state != WordStateEnd);
@@ -584,20 +599,28 @@ void update_dimensions_char_visitor_cb(GContext* ctx, const TextBoxParams* const
       line, line->width_px + line->origin.x, text_box_params->box.size.w);
 }
 
-// Peek the codepoint after the one starting at `pos`, bounded by `end`. Returns
-// 0 at a line/text boundary. Lets the width pass see the next letter so a
-// Lam-Alef pair folds into one ligature advance, matching the render path.
-static Codepoint prv_peek_next_codepoint(utf8_t *pos, const utf8_t *end) {
+// Peek the next letter after the one at `pos`, skipping transparent Arabic marks
+// and bounded by `end`. Returns 0 at a line/text boundary. Lets the width pass
+// fold a Lam-Alef (even across an intervening harakat) into one ligature advance
+// and pick the same joining context the renderer shapes with.
+static Codepoint prv_peek_next_letter(utf8_t *pos, const utf8_t *end) {
   if (pos == NULL) {
     return 0;
   }
   utf8_t *after = NULL;
   utf8_peek_codepoint(pos, &after);
-  if (after == NULL || (end != NULL && after >= end) || *after == '\0' || *after == '\n') {
-    return 0;
+  while (after != NULL && (end == NULL || after < end) && *after != '\0' && *after != '\n') {
+    utf8_t *next = NULL;
+    Codepoint cp = utf8_peek_codepoint(after, &next);
+    if (cp == 0 || next == NULL) {
+      break;
+    }
+    if (!arabic_is_transparent(cp)) {
+      return cp;
+    }
+    after = next;
   }
-  utf8_t *unused = NULL;
-  return utf8_peek_codepoint(after, &unused);
+  return 0;
 }
 
 // Ligature-aware glyph advance: a Lam-Alef pair measures as the single ligature
@@ -736,27 +759,31 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
         // Trailing spaces are kept in the run here and split out after the loop
         // (see the trailing-space peel below) so they reorder between runs.
 
-        if (skip_ligature_member) {
+        if (skip_ligature_member && !arabic_is_transparent(seg_cp)) {
           // Alef already counted in the preceding Lam-Alef ligature.
           skip_ligature_member = false;
         } else {
-          Codepoint next_seg_cp = 0;
-          if (seg_next < line_end && *seg_next != '\0' && *seg_next != '\n') {
-            utf8_t *peek_next = NULL;
-            next_seg_cp = utf8_peek_codepoint(seg_next, &peek_next);
+          Codepoint width_cp;
+          if (arabic_is_transparent(seg_cp)) {
+            // A mark keeps its own width but is not reshaped.
+            width_cp = seg_cp;
+          } else {
+            Codepoint next_seg_cp = prv_peek_next_letter(segment_end, line_end);
+            bool consumed_next = false;
+            width_cp = arabic_shape_pair(prev_seg_cp, seg_cp, next_seg_cp, &consumed_next);
+            skip_ligature_member = consumed_next;
           }
-          bool consumed_next = false;
-          Codepoint width_cp = arabic_shape_pair(prev_seg_cp, seg_cp, next_seg_cp, &consumed_next);
           int glyph_width = prv_codepoint_get_horizontal_advance(&ctx->font_cache,
               text_box_params->font, width_cp);
           if (total_width_px + segment_width_px + glyph_width + suffix_width_px > available_horiz_px) {
             break;
           }
           segment_width_px += glyph_width;
-          skip_ligature_member = consumed_next;
         }
 
-        prev_seg_cp = seg_cp;
+        if (!arabic_is_transparent(seg_cp)) {
+          prev_seg_cp = seg_cp;
+        }
         segment_end = seg_next;
       }
       size_t segment_len = segment_end - segment_start;
@@ -942,7 +969,7 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
   Codepoint prev_shaped_cp = 0;       // previous codepoint, for Arabic joining context
   bool skip_ligature_member = false;  // current codepoint was folded into a preceding ligature
   bool consumed_next = false;
-  Codepoint peek_cp = prv_peek_next_codepoint(utf8_iter_state->current, text_end);
+  Codepoint peek_cp = prv_peek_next_letter(utf8_iter_state->current, text_end);
   int next_glyph_width_px = prv_shaped_glyph_advance(ctx, text_box_params, prev_shaped_cp,
       current_codepoint, peek_cp, &consumed_next);
 
@@ -968,9 +995,14 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
 
     last_visited_char = utf8_iter_state->current;
 
-    // Carry the ligature decision to the next iteration before advancing.
-    skip_ligature_member = consumed_next;
-    prev_shaped_cp = current_codepoint;
+    // Carry the ligature decision before advancing. Marks (harakat) keep their
+    // width but do not break joining context, so they leave prev/skip untouched.
+    if (consumed_next) {
+      skip_ligature_member = true;
+    }
+    if (!arabic_is_transparent(current_codepoint)) {
+      prev_shaped_cp = current_codepoint;
+    }
 
     if (!iter_next(&char_iter)) {
       break;
@@ -986,12 +1018,16 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
     }
 
     consumed_next = false;
-    if (skip_ligature_member) {
-      // This codepoint (the Alef) was already counted in the preceding Lam-Alef
-      // ligature, so it adds no further width.
+    if (skip_ligature_member && !arabic_is_transparent(current_codepoint)) {
+      // The Alef folded into the preceding Lam-Alef ligature adds no width.
       next_glyph_width_px = 0;
+      skip_ligature_member = false;
+    } else if (arabic_is_transparent(current_codepoint)) {
+      // A mark keeps its own width but is not reshaped.
+      next_glyph_width_px = prv_codepoint_get_horizontal_advance(&ctx->font_cache,
+          text_box_params->font, current_codepoint);
     } else {
-      peek_cp = prv_peek_next_codepoint(utf8_iter_state->current, text_end);
+      peek_cp = prv_peek_next_letter(utf8_iter_state->current, text_end);
       next_glyph_width_px = prv_shaped_glyph_advance(ctx, text_box_params, prev_shaped_cp,
           current_codepoint, peek_cp, &consumed_next);
     }

--- a/tests/fw/test_arabic_shaping.c
+++ b/tests/fw/test_arabic_shaping.c
@@ -71,6 +71,18 @@ void test_arabic_shaping__salaam_has_ligature(void) {
   cl_assert_equal_i(cps[2], 0xFEE1);  // Meem isolated
 }
 
+// "مكمّلات" = Meem Kaf Meem shadda Lam Alef Teh. The shadda is transparent for
+// joining, so the Meem stays medial and the Lam-Alef keeps its final form
+// U+FEFC, not isolated U+FEFB.
+void test_arabic_shaping__diacritic_transparent_join(void) {
+  Codepoint cps[12];
+  size_t n = prv_shape("\xD9\x85\xD9\x83\xD9\x85\xD9\x91\xD9\x84\xD8\xA7\xD8\xAA", cps, 12);
+  cl_assert_equal_i(n, 6);            // seven letters, Lam-Alef ligates into one
+  cl_assert_equal_i(cps[2], 0xFEE4);  // Meem medial (joins forward through the shadda)
+  cl_assert_equal_i(cps[3], 0x0651);  // shadda preserved, in place
+  cl_assert_equal_i(cps[4], 0xFEFC);  // Lam-Alef final (connected), not isolated FEFB
+}
+
 // Alef with Hamza above (U+0623) maps to its own ligature pair (U+FEF7/FEF8).
 void test_arabic_shaping__lam_alef_hamza_variant(void) {
   Codepoint cps[8];

--- a/tests/fw/test_line_layout.c
+++ b/tests/fw/test_line_layout.c
@@ -87,6 +87,33 @@ void test_line_layout__lam_alef_width_counts_ligature_once(void) {
   cl_assert(line.width_px == 2 * HORIZ_ADVANCE_PX);
 }
 
+// A harakat is transparent for the width pass too: the Lam-Alef ligates across
+// the mark, matching the renderer. "بلَا" (Beh Lam FATHA Alef) is four codepoints
+// but measures three advances -- Beh + (Lam-Alef ligature) + the fatha -- not
+// four. Without transparent-aware measurement the mark broke the ligature.
+void test_line_layout__lam_alef_width_transparent_to_harakat(void) {
+  Iterator word_iter = ITERATOR_EMPTY;
+  WordIterState word_iter_state = WORD_ITER_STATE_EMPTY;
+  Line line = { 0 };
+
+  bool success = false;
+  const Utf8Bounds utf8_bounds =
+      utf8_get_bounds(&success, "\xD8\xA8\xD9\x84\xD9\x8E\xD8\xA7");  // بلَا
+  cl_assert(success);
+
+  const TextBoxParams text_box_params = (TextBoxParams) {
+    .utf8_bounds = &utf8_bounds,
+    .box = (GRect) { GPointZero, (GSize) { 6 * HORIZ_ADVANCE_PX + 1, 11 } }
+  };
+  line.max_width_px = text_box_params.box.size.w;
+  line.height_px = text_box_params.box.size.h;
+
+  word_iter_init(&word_iter, &word_iter_state, &s_ctx, &text_box_params, utf8_bounds.start);
+
+  cl_assert(line_add_word(&s_ctx, &line, &word_iter_state.current, &text_box_params));
+  cl_assert(line.width_px == 3 * HORIZ_ADVANCE_PX);
+}
+
 void test_line_layout__test_line_add_word_no_overflow(void) {
   // Allocate mutable types
   Iterator word_iter = ITERATOR_EMPTY;


### PR DESCRIPTION
## What

Arabic combining marks (harakat — fatha, damma, kasra, shadda, sukun…) sit on a base letter and must not break the cursive connection between the letters around them. `arabic_shape_text` used each codepoint's immediate neighbours as the joining context, so a mark between two letters shaped them as if disconnected — e.g. a shadda before a Lam-Alef left the ligature isolated instead of joined. Vocalized words fragmented.

Skip transparent marks (U+0610–061A, U+064B–065F, U+0670, U+06D6–06ED) when choosing the previous/next letter for shaping, and carry any mark consumed inside a Lam-Alef pair through to the output.

## Before / after

Notification `ثَلَاثَة بِلَا مُلَاحَظَات` (fatha / kasra / damma). Before: words fragment where the marks break the joins; after: they connect.

<img width="636" height="410" alt="cmp_nsm" src="https://github.com/user-attachments/assets/7a9346c7-f0b6-4255-8819-e7d5b516c811" />


## Test

`diacritic_transparent_join`: a shadda between Meem and Lam-Alef keeps the Meem medial and the ligature final (U+FEFC), not isolated (U+FEFB). `./pbl test` passes.