### PR TITLE
Localize backlight & ambient-sensor state subtitles

### DIFF
--- a/resources/normal/base/lang/ca_ES/tintin.po
+++ b/resources/normal/base/lang/ca_ES/tintin.po
@@ -4427,3 +4427,13 @@ msgstr "Desactivat"
 msgctxt "AlarmSound"
 msgid "Off"
 msgstr "Desactivat"
+
+#: ../src/fw/apps/system/settings/display.c:346
+msgctxt "DeviceState"
+msgid "On"
+msgstr "Activat"
+
+#: ../src/fw/apps/system/settings/display.c:352
+msgctxt "DeviceState"
+msgid "Off"
+msgstr "Desactivat"

--- a/resources/normal/base/lang/de_DE/tintin.po
+++ b/resources/normal/base/lang/de_DE/tintin.po
@@ -4403,3 +4403,13 @@ msgstr "Aus"
 msgctxt "AlarmSound"
 msgid "Off"
 msgstr "Aus"
+
+#: ../src/fw/apps/system/settings/display.c:346
+msgctxt "DeviceState"
+msgid "On"
+msgstr "An"
+
+#: ../src/fw/apps/system/settings/display.c:352
+msgctxt "DeviceState"
+msgid "Off"
+msgstr "Aus"

--- a/resources/normal/base/lang/en_TW/tintin.po
+++ b/resources/normal/base/lang/en_TW/tintin.po
@@ -3247,3 +3247,13 @@ msgstr "Off"
 msgctxt "AlarmSound"
 msgid "Off"
 msgstr "Off"
+
+#: ../src/fw/apps/system/settings/display.c:346
+msgctxt "DeviceState"
+msgid "On"
+msgstr "On"
+
+#: ../src/fw/apps/system/settings/display.c:352
+msgctxt "DeviceState"
+msgid "Off"
+msgstr "Off"

--- a/resources/normal/base/lang/es_ES/tintin.po
+++ b/resources/normal/base/lang/es_ES/tintin.po
@@ -4426,3 +4426,13 @@ msgstr "Off"
 msgctxt "AlarmSound"
 msgid "Off"
 msgstr "Off"
+
+#: ../src/fw/apps/system/settings/display.c:346
+msgctxt "DeviceState"
+msgid "On"
+msgstr "On"
+
+#: ../src/fw/apps/system/settings/display.c:352
+msgctxt "DeviceState"
+msgid "Off"
+msgstr "Off"

--- a/resources/normal/base/lang/fr_FR/tintin.po
+++ b/resources/normal/base/lang/fr_FR/tintin.po
@@ -4443,3 +4443,13 @@ msgstr "Désactivé"
 msgctxt "AlarmSound"
 msgid "Off"
 msgstr "Désactivé"
+
+#: ../src/fw/apps/system/settings/display.c:346
+msgctxt "DeviceState"
+msgid "On"
+msgstr "Activé"
+
+#: ../src/fw/apps/system/settings/display.c:352
+msgctxt "DeviceState"
+msgid "Off"
+msgstr "Désactivé"

--- a/resources/normal/base/lang/it_IT/tintin.po
+++ b/resources/normal/base/lang/it_IT/tintin.po
@@ -4000,3 +4000,13 @@ msgstr "Off"
 msgctxt "AlarmSound"
 msgid "Off"
 msgstr "Off"
+
+#: ../src/fw/apps/system/settings/display.c:346
+msgctxt "DeviceState"
+msgid "On"
+msgstr "On"
+
+#: ../src/fw/apps/system/settings/display.c:352
+msgctxt "DeviceState"
+msgid "Off"
+msgstr "Off"

--- a/resources/normal/base/lang/nl_NL/tintin.po
+++ b/resources/normal/base/lang/nl_NL/tintin.po
@@ -3481,3 +3481,13 @@ msgstr "Uit"
 msgctxt "AlarmSound"
 msgid "Off"
 msgstr "Uit"
+
+#: ../src/fw/apps/system/settings/display.c:346
+msgctxt "DeviceState"
+msgid "On"
+msgstr "On"
+
+#: ../src/fw/apps/system/settings/display.c:352
+msgctxt "DeviceState"
+msgid "Off"
+msgstr "Uit"

--- a/resources/normal/base/lang/pl_PL/tintin.po
+++ b/resources/normal/base/lang/pl_PL/tintin.po
@@ -3268,3 +3268,21 @@ msgstr "Wył."
 msgctxt "AlarmSound"
 msgid "Off"
 msgstr "Wył."
+
+#: ../src/fw/apps/system/settings/display.c:343
+msgid "On - %d%%"
+msgstr "Włączone - %d%%"
+
+#: ../src/fw/apps/system/settings/display.c:370
+msgid "On (%d)"
+msgstr "Włączone (%d)"
+
+#: ../src/fw/apps/system/settings/display.c:346
+msgctxt "DeviceState"
+msgid "On"
+msgstr "Włączone"
+
+#: ../src/fw/apps/system/settings/display.c:352
+msgctxt "DeviceState"
+msgid "Off"
+msgstr "Wyłączone"

--- a/resources/normal/base/lang/pt_PT/tintin.po
+++ b/resources/normal/base/lang/pt_PT/tintin.po
@@ -4428,3 +4428,13 @@ msgstr "Off"
 msgctxt "AlarmSound"
 msgid "Off"
 msgstr "Off"
+
+#: ../src/fw/apps/system/settings/display.c:346
+msgctxt "DeviceState"
+msgid "On"
+msgstr "On"
+
+#: ../src/fw/apps/system/settings/display.c:352
+msgctxt "DeviceState"
+msgid "Off"
+msgstr "Off"

--- a/resources/normal/base/lang/ru_RU/tintin.po
+++ b/resources/normal/base/lang/ru_RU/tintin.po
@@ -3247,3 +3247,13 @@ msgstr "Off"
 msgctxt "AlarmSound"
 msgid "Off"
 msgstr "Off"
+
+#: ../src/fw/apps/system/settings/display.c:346
+msgctxt "DeviceState"
+msgid "On"
+msgstr "On"
+
+#: ../src/fw/apps/system/settings/display.c:352
+msgctxt "DeviceState"
+msgid "Off"
+msgstr "Off"

--- a/resources/normal/base/lang/uk-UA/tintin.po
+++ b/resources/normal/base/lang/uk-UA/tintin.po
@@ -2931,3 +2931,13 @@ msgstr "Викл"
 msgctxt "AlarmSound"
 msgid "Off"
 msgstr "Викл"
+
+#: ../src/fw/apps/system/settings/display.c:346
+msgctxt "DeviceState"
+msgid "On"
+msgstr "Вкл"
+
+#: ../src/fw/apps/system/settings/display.c:352
+msgctxt "DeviceState"
+msgid "Off"
+msgstr "Викл"

--- a/resources/normal/base/lang/zh_CN/tintin.po
+++ b/resources/normal/base/lang/zh_CN/tintin.po
@@ -3292,3 +3292,13 @@ msgstr "关"
 msgctxt "AlarmSound"
 msgid "Off"
 msgstr "关"
+
+#: ../src/fw/apps/system/settings/display.c:346
+msgctxt "DeviceState"
+msgid "On"
+msgstr "开"
+
+#: ../src/fw/apps/system/settings/display.c:352
+msgctxt "DeviceState"
+msgid "Off"
+msgstr "关"

--- a/src/fw/apps/system/settings/display.c
+++ b/src/fw/apps/system/settings/display.c
@@ -341,16 +341,16 @@ static void prv_backlight_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
         if (backlight_is_dynamic_intensity_enabled()) {
           uint8_t current_percent = light_get_current_brightness_percent();
           snprintf(data->backlight_percent_buffer, sizeof(data->backlight_percent_buffer),
-                   "On - %"PRIu8"%%", current_percent);
+                   i18n_get("On - %d%%", data), (int)current_percent);
           subtitle = data->backlight_percent_buffer;
         } else {
-          subtitle = i18n_noop("On");
+          subtitle = i18n_ctx_noop("DeviceState", "On");
         }
 #else
-        subtitle = i18n_noop("On");
+        subtitle = i18n_ctx_noop("DeviceState", "On");
 #endif
       } else {
-        subtitle = i18n_noop("Off");
+        subtitle = i18n_ctx_noop("DeviceState", "Off");
       }
       break;
     case SettingsBacklightMotionWake:
@@ -368,10 +368,10 @@ static void prv_backlight_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
       if (backlight_is_ambient_sensor_enabled()) {
         uint32_t als_value = ambient_light_get_light_level();
         snprintf(data->als_value_buffer, sizeof(data->als_value_buffer),
-                 "On (%"PRIu32")", als_value);
+                 i18n_get("On (%d)", data), (int)als_value);
         subtitle = data->als_value_buffer;
       } else {
-        subtitle = i18n_noop("Off");
+        subtitle = i18n_ctx_noop("DeviceState", "Off");
       }
       break;
 #ifdef CONFIG_DYNAMIC_BACKLIGHT


### PR DESCRIPTION
Follow-up to #1623 (now merged) — fixes two Display settings rows that were hardcoded in English for *every* language.

The **Backlight** (`"On - 50%"`) and **Ambient Sensor** (`"On (123)"`) rows built their on-state subtitles with a raw `snprintf`, so they rendered in English regardless of locale. This wraps those formats in `i18n` and splits the two rows' on/off into a `DeviceState` context so they read as full words (Polish: `Włączone`/`Wyłączone`), distinct from the `Tak`/`Nie` used for plain toggles.

Other locales get the `DeviceState` entries mapped to their existing `On`/`Off` (no regression), and can fill the `On - %d%%` / `On (%d)` formats whenever — those fall back to English (same as today) until a translator gets to them.

Now that #1623 has landed, this is down to its own two commits.

Tested on Pebble Time 2 (`obelix@pvt`).
