### PR TITLE
fw/comm/ble: hand clients a single service instance, rotating on failure [FIRM-2018]

### DIFF
--- a/src/fw/comm/ble/kernel_le_client/kernel_le_client.c
+++ b/src/fw/comm/ble/kernel_le_client/kernel_le_client.c
@@ -205,37 +205,78 @@ static void prv_handle_all_services_invalidated(void) {
   }
 }
 
+//! Selects which instance of a duplicated service we hand to a client. Advanced
+//! by PPoGATT after a failed handshake and reset after a successful session, so
+//! that across reconnects we eventually try every instance. See
+//! prv_handle_services_added and kernel_le_client.h.
+static uint8_t s_service_instance_attempt;
+
+void kernel_le_client_reset_service_instance_attempt(void) {
+  s_service_instance_attempt = 0;
+}
+
+void kernel_le_client_advance_service_instance_attempt(void) {
+  s_service_instance_attempt++;
+}
+
 static void prv_handle_services_added(
     PebbleBLEGATTClientServicesAdded *added_services, BTDeviceInternal *device) {
-  // loop through the new services
-  for (int s = 0; s < added_services->num_services_added; s++) {
-    // get the uuid for the service
-    Uuid service_uuid = gatt_client_service_get_uuid(added_services->services[s]);
+  for (int c = 0; c < KernelLEClientNum; c++) {
+    const KernelLEClient * const client = &s_clients[c];
 
-    // are any clients looking for this uuid?
-    for (int c = 0; c < KernelLEClientNum; c++) {
-      const KernelLEClient * const client = &s_clients[c];
-
+    // Collect every complete instance of this client's service. Some peer GATT
+    // servers (notably buggy Android companions) leave a stale duplicate of a
+    // service behind -- same UUID, different handle range -- when they re-add
+    // services without removing the old one. We must hand the client exactly one
+    // instance: PPoGATT starts a handshake (meta read) per instance, and
+    // concurrent reads deadlock the shared ATT bearer when the stale instance
+    // never answers. The completeness check drops malformed/partial duplicates.
+    BLEService instances[MAX_SERVICE_INSTANCES];
+    int num_instances = 0;
+    for (int s = 0;
+         s < added_services->num_services_added && num_instances < MAX_SERVICE_INSTANCES; s++) {
+      const Uuid service_uuid = gatt_client_service_get_uuid(added_services->services[s]);
       if (!uuid_equal(&service_uuid, (const Uuid *)client->service_uuid)) {
         continue;
       }
 
-      // We have found a service that a client is looking for. Make sure the
-      // characteristics we want are present and if so notify the interested client about it
       BLECharacteristic characteristics[client->num_characteristics];
       const uint8_t num_characteristics =
           gatt_client_service_get_characteristics_matching_uuids(
               added_services->services[s], &characteristics[0], client->characteristic_uuids,
               client->num_characteristics);
-
       if (num_characteristics != client->num_characteristics) {
         PBL_LOG_ERR("Found %s, but only %u characteristics...",
                 client->debug_name, num_characteristics);
         continue;
       }
 
-      client->handle_service_discovered(characteristics);
+      instances[num_instances++] = added_services->services[s];
     }
+
+    if (num_instances == 0) {
+      continue;
+    }
+
+    // We can't tell which instance is live at discovery time, so try the newest
+    // (highest-handle) one first and rotate to the next on each reconnect after
+    // a failed handshake, cycling until the live one connects. Newest-first
+    // matches the Android re-add bug, where the server only retains a reference
+    // to the most recently added characteristics. Note: handing over a single
+    // instance also drops support for multiple concurrent instances of the same
+    // service UUID (legacy multi-app PPoGATT); the Core companion uses a single
+    // Hybrid server, so exactly one instance is expected.
+    const int chosen = num_instances - 1 - (s_service_instance_attempt % num_instances);
+    if (num_instances > 1) {
+      PBL_LOG_WRN("%d instances of %s; trying instance %d",
+              num_instances, client->debug_name, chosen);
+    }
+
+    BLECharacteristic characteristics[client->num_characteristics];
+    gatt_client_service_get_characteristics_matching_uuids(
+        instances[chosen], &characteristics[0], client->characteristic_uuids,
+        client->num_characteristics);
+    client->handle_service_discovered(characteristics);
   }
 }
 

--- a/src/fw/comm/ble/kernel_le_client/kernel_le_client.h
+++ b/src/fw/comm/ble/kernel_le_client/kernel_le_client.h
@@ -16,6 +16,14 @@ void kernel_le_client_handle_bonding_change(BTBondingID bonding, BtPersistBondin
 
 void kernel_le_client_handle_event(const PebbleEvent *event);
 
+//! When a peer exposes more than one instance of a service (e.g. a buggy
+//! companion that left a stale duplicate behind), we hand the client a single
+//! instance and rotate which one across reconnects until a handshake succeeds.
+//! PPoGATT calls these to drive that rotation: reset on a successful session,
+//! advance after a failed handshake attempt. See prv_handle_services_added.
+void kernel_le_client_reset_service_instance_attempt(void);
+void kernel_le_client_advance_service_instance_attempt(void);
+
 void kernel_le_client_init(void);
 
 void kernel_le_client_deinit(void);

--- a/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
+++ b/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
@@ -6,6 +6,7 @@
 
 #include "comm/ble/gap_le_connection.h"
 #include "comm/ble/gatt_client_operations.h"
+#include "comm/ble/kernel_le_client/kernel_le_client.h"
 #include "comm/bt_lock.h"
 
 #include <bluetooth/gatt.h>
@@ -383,6 +384,12 @@ static void prv_delete_client(PPoGATTClient *client, bool is_disconnected, Delet
   const uint32_t elapsed_ms = (rtc_get_ticks() - client->created_ticks) * 1000 / RTC_TICKS_HZ;
   PBL_LOG_INFO("PPoGATT client deleted: state=%u reason=%u disconnected=%u after %"PRIu32"ms",
           client->state, reason, is_disconnected, elapsed_ms);
+
+  // The handshake never completed for this instance. If the peer is exposing a
+  // stale duplicate, advance so the next reconnect tries a different instance.
+  if (client->state != StateConnectedOpen) {
+    kernel_le_client_advance_service_instance_attempt();
+  }
   // Unsubscribe from Data characteristic:
   if (client->state > StateDisconnectedSubscribingData && !is_disconnected) {
     BLECharacteristic data_char = client->characteristics.data;
@@ -599,6 +606,9 @@ static void prv_handle_reset_complete(PPoGATTClient *client, const PPoGATTPacket
   }
   client->state = StateConnectedOpen;
   client->session = session;
+
+  // Handshake succeeded: stop rotating through duplicate service instances.
+  kernel_le_client_reset_service_instance_attempt();
 
   if (prv_client_supports_enhanced_throughput_features(client)) {
     if (payload_length < sizeof(PPoGATTResetCompleteClientIDPayloadV1)) {

--- a/tests/fw/comm/test_kernel_le_client.c
+++ b/tests/fw/comm/test_kernel_le_client.c
@@ -117,6 +117,10 @@ typedef enum {
   TestServiceInstanceComplete = 1,
   TestServiceInstanceIncomplete = 2,
   TestServiceInstanceUnsupported = 3,
+  // A second complete instance of the same service UUID, as a duplicate-leaving
+  // peer would expose. Listed after TestServiceInstanceComplete so it is the
+  // "newest" (highest-handle) instance.
+  TestServiceInstanceCompleteB = 4,
 } TestServiceInstance;
 
 static BLEService s_service_handles[] = {
@@ -130,12 +134,15 @@ typedef enum {
   TestCharacteristicInstanceCompleteTwo = 12,
   TestCharacteristicInstanceIncompleteOne = 21,
   TestCharacteristicInstanceUnsupported = 33,
+  TestCharacteristicInstanceCompleteBOne = 41,
+  TestCharacteristicInstanceCompleteBTwo = 42,
 } TestCharacteristicInstance;
 
 Uuid gatt_client_service_get_uuid(BLEService service_ref) {
   switch (service_ref) {
     case TestServiceInstanceComplete:
     case TestServiceInstanceIncomplete:
+    case TestServiceInstanceCompleteB:
       return s_test_service_uuid;
 
     case TestServiceInstanceUnsupported:
@@ -157,6 +164,10 @@ uint8_t gatt_client_service_get_characteristics_matching_uuids(BLEService servic
     case TestServiceInstanceIncomplete:
       characteristics_out[0] = TestCharacteristicInstanceIncompleteOne;
       return 1;
+    case TestServiceInstanceCompleteB:
+      characteristics_out[0] = TestCharacteristicInstanceCompleteBOne;
+      characteristics_out[1] = TestCharacteristicInstanceCompleteBTwo;
+      return 2;
     case TestCharacteristicInstanceUnsupported:
       characteristics_out[0] = TestCharacteristicInstanceUnsupported;
       return 1;
@@ -174,8 +185,10 @@ void gatt_client_consume_read_response(uintptr_t object_ref,
 }
 
 static int s_services_discovered_count;
+static BLECharacteristic s_last_discovered_first_char;
 void test_client_handle_service_discovered(BLECharacteristic *characteristics) {
   ++s_services_discovered_count;
+  s_last_discovered_first_char = characteristics[0];
 }
 
 void test_client_invalidate_all_references(void) {
@@ -276,6 +289,61 @@ void test_kernel_le_client__service_added(void) {
   cl_assert_equal_i(s_services_discovered_count, 1);
 
   kernel_free(info);
+}
+
+static void prv_fire_services_added(const BLEService *services, uint8_t count) {
+  PebbleBLEGATTClientServiceEventInfo *info =
+      kernel_malloc(sizeof(PebbleBLEGATTClientServiceEventInfo) + (count * sizeof(BLEService)));
+
+  *info = (PebbleBLEGATTClientServiceEventInfo) {
+    .status = BTErrnoOK,
+    .type = PebbleServicesAdded,
+    .device = s_test_device,
+  };
+  info->services_added_data.num_services_added = count;
+  memcpy(info->services_added_data.services, services, count * sizeof(BLEService));
+
+  PebbleEvent e = (PebbleEvent) {
+    .type = PEBBLE_BLE_GATT_CLIENT_EVENT,
+    .bluetooth.le.gatt_client_service = {
+      .info = info,
+      .subtype = PebbleBLEGATTClientEventTypeServiceChange,
+    },
+  };
+
+  kernel_le_client_handle_event(&e);
+
+  kernel_free(info);
+}
+
+void test_kernel_le_client__duplicate_service_instance_rotates(void) {
+  // A peer exposing two complete instances of the same service UUID, newest last.
+  const BLEService services[] = {
+    TestServiceInstanceComplete,   // older instance, first characteristic == 11
+    TestServiceInstanceCompleteB,  // newest instance, first characteristic == 41
+  };
+
+  kernel_le_client_reset_service_instance_attempt();
+
+  // Exactly one instance is handed over, and the first attempt uses the newest.
+  s_services_discovered_count = 0;
+  prv_fire_services_added(services, ARRAY_LENGTH(services));
+  cl_assert_equal_i(s_services_discovered_count, 1);
+  cl_assert_equal_i(s_last_discovered_first_char, TestCharacteristicInstanceCompleteBOne);
+
+  // After a failed handshake, the next attempt rotates to the other instance.
+  kernel_le_client_advance_service_instance_attempt();
+  s_services_discovered_count = 0;
+  prv_fire_services_added(services, ARRAY_LENGTH(services));
+  cl_assert_equal_i(s_services_discovered_count, 1);
+  cl_assert_equal_i(s_last_discovered_first_char, TestCharacteristicInstanceCompleteOne);
+
+  // A successful handshake resets the rotation back to the newest instance.
+  kernel_le_client_reset_service_instance_attempt();
+  s_services_discovered_count = 0;
+  prv_fire_services_added(services, ARRAY_LENGTH(services));
+  cl_assert_equal_i(s_services_discovered_count, 1);
+  cl_assert_equal_i(s_last_discovered_first_char, TestCharacteristicInstanceCompleteBOne);
 }
 
 // FIXME: PBL-27751: Improve test coverage of kernel_le_client.c

--- a/tests/fw/comm/test_ppogatt.c
+++ b/tests/fw/comm/test_ppogatt.c
@@ -90,6 +90,12 @@ void launcher_task_add_callback(void (*callback)(void *data), void *data) {
   callback(data);
 }
 
+void kernel_le_client_reset_service_instance_attempt(void) {
+}
+
+void kernel_le_client_advance_service_instance_attempt(void) {
+}
+
 // Helpers
 ///////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Some peer GATT servers (notably buggy Android companions) leave a stale duplicate of a service behind -- same UUID, different handle range -- when they re-add services without removing the old one. PPoGATT then started a handshake (meta read) per instance, and the concurrent reads deadlocked the single ATT bearer when the stale instance never answered, so the whole connection failed. With two PPoGATT instances the meta read failed with ENOTCONN once the phone gave up and disconnected; with one it succeeded.

Hand each kernel LE client exactly one instance: collect every instance that exposes all required characteristics, and try the newest (highest-handle) one first. We can't tell which instance is live at discovery time, so PPoGATT advances the selection after a failed handshake and resets it on a successful session; across reconnects this cycles through the complete instances until the live one connects. Newest-first matches the Android re-add bug, where the server only retains a reference to the most recently added characteristics.

This drops support for multiple concurrent instances of the same service UUID (legacy multi-app PPoGATT); the Core companion uses a single Hybrid server.