### PR TITLE
fw/kernel/fault_handling: kill process on app/worker-heap OOM

### DIFF
--- a/src/fw/kernel/fault_handling.c
+++ b/src/fw/kernel/fault_handling.c
@@ -9,8 +9,11 @@
 
 #include "applib/app_logging.h"
 #include "kernel/memory_layout.h"
+#include "mcu/interrupts.h"
 #include "mcu/privilege.h"
 #include "pbl/services/system_task.h"
+#include "process_state/app_state/app_state.h"
+#include "process_state/worker_state/worker_state.h"
 #include "syscall/syscall.h"
 #include "syscall/syscall_internal.h"
 #include "system/logging.h"
@@ -157,19 +160,33 @@ NORETURN trigger_fault(RebootReasonCode reason_code, uint32_t lr) {
 }
 
 NORETURN trigger_oom_fault(size_t bytes, uint32_t lr, Heap *heap_ptr) {
-  if (mcu_state_is_privileged()) {
-      RebootReason reason = {
-        .code =  RebootReasonCode_OutOfMemory,
-        .heap_data = {
-          .heap_alloc_lr = lr,
-          .heap_ptr = (uint32_t)heap_ptr,
-        }
-      };
-      reboot_reason_set(&reason);
-      reset_due_to_software_failure();
-  } else {
+  // OOM on a process's own heap is the app's fault, not the kernel's: kill just
+  // that process even when privileged (Moddable apps run privileged inside the
+  // moddable_createMachine syscall). Only kernel-heap OOM reboots.
+  PebbleTask task = pebble_task_get_current();
+  bool process_heap_oom =
+      (task == PebbleTask_App && heap_ptr == app_state_get_heap()) ||
+      (task == PebbleTask_Worker && heap_ptr == worker_state_get_heap());
+
+  // sys_app_fault suspends this task for KernelMain to reap; only safe with the
+  // scheduler running and outside an ISR, else reboot.
+  bool can_kill_safely =
+      !mcu_state_is_isr() && (xTaskGetSchedulerState() == taskSCHEDULER_RUNNING);
+
+  if (!mcu_state_is_privileged() || (process_heap_oom && can_kill_safely)) {
     sys_app_fault(lr);
   }
+
+  // Kernel-heap OOM (or OOM on a kernel task): unrecoverable, reboot.
+  RebootReason reason = {
+    .code =  RebootReasonCode_OutOfMemory,
+    .heap_data = {
+      .heap_alloc_lr = lr,
+      .heap_ptr = (uint32_t)heap_ptr,
+    }
+  };
+  reboot_reason_set(&reason);
+  reset_due_to_software_failure();
 }
 
 void NOINLINE app_crashed(void) {


### PR DESCRIPTION
Moddable watchfaces (e.g. "Pebble Digital Classic", FIRM-2725) run their whole event loop inside the privileged `moddable_createMachine` syscall, so an app-heap OOM hits the privileged branch of `trigger_oom_fault` and reboots the whole OS — crash-looping the device into recovery + re-pair.

Fix: route by which heap ran out, not privilege. An OOM on a process's own app/worker heap kills just that process via `sys_app_fault`; only a kernel-heap OOM (or kernel-task OOM) still reboots. The kill path is gated on a safe context (not in an ISR, scheduler running). OOM-only — hardfaults still reboot.

Tested: builds for `obelix@pvt`.

Fixes FIRM-2725