### PR TITLE
applib: mirror paired brackets when reversing RTL text

### DIFF
--- a/src/fw/applib/graphics/rtl_support.c
+++ b/src/fw/applib/graphics/rtl_support.c
@@ -77,6 +77,28 @@ static bool prv_codepoint_is_numeric_separator(Codepoint cp) {
   return cp == ':' || cp == '/' || cp == '.' || cp == ',';
 }
 
+// Bidi mirrored punctuation: when an RTL run is reversed, a bracket must swap to
+// its mirror so it still opens toward the text it encloses. Without this, "(نص)"
+// reverses to ")نص(", with the parentheses pointing the wrong way. Covers the
+// Bidi_Mirrored pairs that turn up in watch text.
+static Codepoint prv_mirror_codepoint(Codepoint cp) {
+  switch (cp) {
+    case '(': return ')';
+    case ')': return '(';
+    case '[': return ']';
+    case ']': return '[';
+    case '{': return '}';
+    case '}': return '{';
+    case '<': return '>';
+    case '>': return '<';
+    case 0x00AB: return 0x00BB;  // « -> »
+    case 0x00BB: return 0x00AB;  // » -> «
+    case 0x2039: return 0x203A;  // ‹ -> ›
+    case 0x203A: return 0x2039;  // › -> ‹
+    default: return cp;
+  }
+}
+
 utf8_t *rtl_segment_content_end(utf8_t *start, utf8_t *end) {
   utf8_t *content_end = start;
   utf8_t *scan = start;
@@ -194,7 +216,7 @@ size_t utf8_reverse_for_rtl(const utf8_t *src, size_t src_len,
       break;
     }
 
-    size_t bytes_written = utf8_encode_codepoint(cp, dest + dest_offset);
+    size_t bytes_written = utf8_encode_codepoint(prv_mirror_codepoint(cp), dest + dest_offset);
     if (bytes_written == 0) {
       reverse_ptr = cp_start;
       continue;

--- a/tests/fw/test_rtl_support.c
+++ b/tests/fw/test_rtl_support.c
@@ -121,6 +121,27 @@ void test_rtl_support__separator_needs_two_digits(void) {
   cl_assert_equal_i(cps[2], 0x0627);  // Alef
 }
 
+// Bidi mirroring: brackets swap to their mirror when an RTL run is reversed, so
+// they keep opening toward the text they enclose.
+void test_rtl_support__brackets_mirror(void) {
+  Codepoint cps[8];
+
+  // "(نص)" = '(' Noon Sad ')'. Letters reverse to ص ن; the parens mirror so the
+  // pair still wraps the word: '(' ص ن ')'.
+  size_t n = prv_reverse("(\xD9\x86\xD8\xB5)", cps, 8);
+  cl_assert_equal_i(n, 4);
+  cl_assert_equal_i(cps[0], '(');
+  cl_assert_equal_i(cps[1], 0x0635);  // Sad
+  cl_assert_equal_i(cps[2], 0x0646);  // Noon
+  cl_assert_equal_i(cps[3], ')');
+
+  // A lone '(' before Alef: reversal puts it last and mirrors it to ')'.
+  n = prv_reverse("(\xD8\xA7", cps, 8);  // '(' Alef
+  cl_assert_equal_i(n, 2);
+  cl_assert_equal_i(cps[0], 0x0627);  // Alef
+  cl_assert_equal_i(cps[1], ')');
+}
+
 // rtl_segment_content_end: byte offset of the trailing-space boundary.
 static size_t prv_content_len(const char *str) {
   utf8_t *start = (utf8_t *)str;


### PR DESCRIPTION
## What

Characters with the Unicode `Bidi_Mirrored` property — `()`, `[]`, `{}`, `<>`, `«»`, `‹›` — must swap to their mirror when an RTL run is reversed, so a bracket keeps opening toward the text it encloses. `utf8_reverse_for_rtl()` reversed the codepoint order of an RTL run but emitted each bracket unchanged, so a parenthesized Arabic phrase like `(مرحبا عربي)` came out as `)مرحبا عربي(` — the parentheses pointing the wrong way.

Map each codepoint through a small mirror table where the reversal emits it. The weak-LTR digit run is left untouched (digits and numeric separators are not mirrored).

## Before / after

Notification body `(مرحبا عربي)`. Before: the parentheses point outward; after: they wrap the phrase.

<img width="936" height="592" alt="cmp_bracket" src="https://github.com/user-attachments/assets/19f63d50-b3a7-45bd-8057-6dab2be9565f" />


## Test

`brackets_mirror`: a balanced `(نص)` stays wrapped (`(` ص ن `)`), and a lone `(` before a letter comes out mirrored as `)`. `./pbl test` passes.