### PR TITLE
soc/sf32lb52x: replace force deepwfi command with force wfi

### DIFF
--- a/src/fw/console/prompt_commands.h
+++ b/src/fw/console/prompt_commands.h
@@ -288,7 +288,7 @@ extern void command_analytics_heartbeat(void);
 extern void command_console_disable_rx(const char *seconds_str);
 
 #ifdef CONFIG_SOC_SF32LB52
-extern void command_force_deepwfi(const char *arg);
+extern void command_force_wfi(const char *arg);
 #endif
 
 #if !defined(CONFIG_RELEASE) && defined(CONFIG_DISPLAY_JDI_SF32LB)
@@ -624,7 +624,7 @@ static const Command s_prompt_commands[] = {
   { "vibe", command_vibe_ctl, 1 },
   { "console disable rx", command_console_disable_rx, 1 },
 #ifdef CONFIG_SOC_SF32LB52
-  { "force deepwfi", command_force_deepwfi, 1 },
+  { "force wfi", command_force_wfi, 1 },
 #endif
 #if !defined(CONFIG_RELEASE) && defined(CONFIG_DISPLAY_JDI_SF32LB)
   { "display drop_complete", command_display_drop_complete, 0 },

--- a/src/fw/soc/sf32lb/sf32lb52x/freertos.c
+++ b/src/fw/soc/sf32lb/sf32lb52x/freertos.c
@@ -44,7 +44,7 @@ static RtcTicks s_analytics_deepwfi_ticks;
 static RtcTicks s_analytics_deepsleep_ticks;
 static RtcTicks s_last_ticks;
 static uint32_t s_analytics_ipc_not_idle_count;
-static bool s_force_deepwfi;
+static bool s_force_wfi;
 
 //! Early wake-up ticks (to avoid over-sleeping due to wake-up latency)
 static const uint32_t EARLY_WAKEUP_TICKS = 4;
@@ -198,9 +198,14 @@ void vPortSuppressTicksAndSleep(TickType_t xExpectedIdleTime) {
   if (eTaskConfirmSleepModeStatus() != eAbortSleep) {
     SocSf32lbSleepLevel max_level = soc_sf32lb_sleep_max_level();
 
-    // Deep sleep needs a minimum idle window; the debug flag forces deep WFI.
-    if (xExpectedIdleTime < MIN_DEEPSLEEP_TICKS || s_force_deepwfi) {
+    // Deep sleep needs a minimum idle window.
+    if (xExpectedIdleTime < MIN_DEEPSLEEP_TICKS) {
       max_level = MIN(max_level, SOC_SF32LB_DEEPWFI);
+    }
+
+    // The debug flag forces plain WFI (deep WFI and deep sleep disabled).
+    if (s_force_wfi) {
+      max_level = MIN(max_level, SOC_SF32LB_WFI);
     }
 
     switch (max_level) {
@@ -376,13 +381,13 @@ void dump_current_runtime_stats(void) {
   prompt_send_response(buf);
 }
 
-void command_force_deepwfi(const char *arg) {
+void command_force_wfi(const char *arg) {
   if (arg[0] == '1') {
-    s_force_deepwfi = true;
-    prompt_send_response("Deep WFI forced ON (deep sleep disabled)");
+    s_force_wfi = true;
+    prompt_send_response("WFI forced ON (deep WFI and deep sleep disabled)");
   } else {
-    s_force_deepwfi = false;
-    prompt_send_response("Deep WFI forced OFF (deep sleep allowed)");
+    s_force_wfi = false;
+    prompt_send_response("WFI forced OFF (deep WFI and deep sleep allowed)");
   }
 }
 


### PR DESCRIPTION
## Summary

Replaces the `force deepwfi` debug console command with `force wfi`, which caps the sleep level at plain WFI — disabling both deep WFI and deep sleep. Useful for debugging issues that only reproduce with the lighter sleep level.

## Changes

- Renamed `s_force_deepwfi` → `s_force_wfi` and split the sleep-level capping logic so the flag now caps to `SOC_SF32LB_WFI` instead of `SOC_SF32LB_DEEPWFI`.
- The minimum-idle-window check still independently caps to deep WFI.
- Renamed the console command `command_force_deepwfi` → `command_force_wfi` (`force wfi`) with updated response strings.

## Usage

- `force wfi 1` — force plain WFI on
- `force wfi 0` — restore normal sleep behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)