### PR TITLE
moddable: revert modMachineAllowKernelHeap

### DIFF
--- a/src/fw/applib/moddable/moddable.c
+++ b/src/fw/applib/moddable/moddable.c
@@ -107,11 +107,6 @@ DEFINE_SYSCALL(void, moddable_createMachine, ModdableCreationRecord *cr)
 		}
 	}
 
-	// FFI hands the app direct pointers into XS storage (string chunks, slot
-	// handles); keep the whole machine in app RAM so unprivileged dereferences
-	// don't MPU-fault.
-	modMachineAllowKernelHeap(NULL == fxBuildFFI);
-
 	xsMachine *the = modCloneMachine(&creation, NULL);
 	if (NULL == the) {
 		APP_LOG(APP_LOG_LEVEL_ERROR, "failed to allocate XS machine");


### PR DESCRIPTION
Drop the host-side modMachineAllowKernelHeap() call and drop the commit from the moddable fork.

The Moddable maintainers advised that forcing the whole machine into app RAM is not the right way to solve the FFI/kernel-heap pointer problem. Reverting here and opening an issue on their repo instead.

This temporarily re-introduces the MPU fault when an FFI machine lands in the kernel heap, so FFI is knowingly broken on real devices until an upstream fix lands.