### PR TITLE
build: preprocess linker scripts with cpp, Zephyr-style

### DIFF
--- a/tools/waf/kconfig.py
+++ b/tools/waf/kconfig.py
@@ -168,6 +168,7 @@ def configure(conf):
     kconfig = conf.load_kconfig(config_path)
     for key, val in kconfig.items():
         conf.env[key] = val
+    conf.env.AUTOCONF_H = autoconf_path
     conf.env.append_unique("CFLAGS", ["-include", autoconf_path])
     conf.env.append_unique("cfg_files", [config_path])
 

--- a/tools/waf/ldscript.py
+++ b/tools/waf/ldscript.py
@@ -1,8 +1,20 @@
 # SPDX-FileCopyrightText: 2024 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-from waflib import Utils, Errors
+from waflib import Task, Utils, Errors
 from waflib.TaskGen import after, feature
+
+
+class ldscript_cpp(Task.Task):
+    """Preprocess a linker script with the C preprocessor before it's handed
+    to the linker, the same way Zephyr does. This gives linker scripts access
+    to Kconfig CONFIG_* defines (via autoconf.h), #include, #if, etc."""
+
+    run_str = (
+        "${CC} -x assembler-with-cpp -nostdinc -undef -E -P "
+        "-include ${AUTOCONF_H} ${SRC} -o ${TGT}"
+    )
+    color = "PINK"
 
 
 @after("apply_link")
@@ -26,5 +38,12 @@ def process_ldscript(self):
     for node in nodes:
         if not node:
             raise Errors.WafError("could not find %r" % self.ldscript)
+
+        if self.env.AUTOCONF_H:
+            preprocessed = node.parent.find_or_declare(node.name + ".pre")
+            tsk = self.create_task("ldscript_cpp", node, preprocessed)
+            tsk.dep_nodes.append(self.bld.bldnode.find_or_declare("autoconf.h"))
+            node = preprocessed
+
         self.link_task.env.append_value("LINKFLAGS", "-T%s" % node.abspath())
         self.link_task.dep_nodes.append(node)


### PR DESCRIPTION
## Summary
- Run every linker script handed to `process_ldscript` through the C preprocessor (`-E -P -x assembler-with-cpp -include autoconf.h`) before passing it to the linker, mirroring how Zephyr handles its linker scripts.
- This makes Kconfig `CONFIG_*` defines (and `#include`/`#if`/etc.) directly usable in linker scripts.

## Test plan
- [x] Built `qemu_flint` and `asterix` boards successfully
- [x] Verified a test `#if CONFIG_QEMU` / `#else` directive added to `fw_common.ld` resolved to the correct branch in the linked ELF (checked via `nm`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)