### PR TITLE
fw/board/obelix: disable LIS2DW12 ADDR pull-up on reset

### DIFF
--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -9,6 +9,7 @@
 #include "drivers/sf32lb52/debounced_button_definitions.h"
 #include "drivers/hrm/gh3x2x.h"
 #include "system/passert.h"
+#include "kernel/util/delay.h"
 
 #include "bf0_hal.h"
 
@@ -667,6 +668,15 @@ void board_init(void) {
   // (0x21) SOFT_RESET (bit 6) restores the part to its powered-down defaults.
   i2c_use((I2CSlavePort *)&s_i2c_lis2dw12);
   i2c_write_register((I2CSlavePort *)&s_i2c_lis2dw12, 0x21, (1U << 6U));
+#if defined(CONFIG_BOARD_OBELIX_DVT) || defined(CONFIG_BOARD_OBELIX_BB2)
+  // These revisions require the LIS2DW12 internal ADDR pull-up to be disabled.
+  // Register 0x17 (undocumented, provided by FAE) bit 6 disconnects it.
+  delay_us(5);  // wait for the soft-reset to complete
+  uint8_t undoc;
+  if (i2c_read_register((I2CSlavePort *)&s_i2c_lis2dw12, 0x17, &undoc)) {
+    i2c_write_register((I2CSlavePort *)&s_i2c_lis2dw12, 0x17, undoc | (1U << 6U));
+  }
+#endif
   i2c_release((I2CSlavePort *)&s_i2c_lis2dw12);
 
   mic_init(MIC);


### PR DESCRIPTION
## Summary

The obelix DVT/BB2 boards require the LIS2DW12 internal ADDR pull-up to be disabled. This was previously handled by the LIS2DW12 driver via `CONFIG_ACCEL_LIS2DW12_DISABLE_ADDR_PULLUP`, but that driver was dropped when obelix switched to the LSM6DSO (`1418904a8`).

`board_init()` still soft-resets the leftover LIS2DW12 so a firmware upgrade doesn't leave it powered on — but the soft-reset restores defaults, re-enabling the pull-up. This hardcodes the pull-up disable back into the board reset path.

## Details

For DVT/BB2 only (the revisions that had the config), after the soft-reset:
- `delay_us(5)` to let the reset settle (matches the driver's `LIS2DW12_RESET_TIME_US`)
- read-modify-write undocumented register `0x17`, bit 6, to disconnect the ADDR pull-up

getafix is unaffected — it still uses the LIS2DW12 driver directly, so its `DISABLE_ADDR_PULLUP` fix is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)