### PR TITLE
bluetooth: Reverse PPOG v2

### DIFF
--- a/include/bluetooth/bt_driver_ppog_reversed.h
+++ b/include/bluetooth/bt_driver_ppog_reversed.h
@@ -1,0 +1,47 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include <bluetooth/bluetooth_types.h>
+
+#include <stdint.h>
+
+//! @file Kernel <-> BT driver API for the "reversed PPoG" GATT service: the
+//! watch hosts the service and the phone is the GATT client. Outbound bytes
+//! leave via notifications on the data-notify characteristic; inbound bytes
+//! arrive as write-without-response writes on the data-write characteristic.
+
+//! All bt_driver_cb_ppog_reversed_* callbacks are invoked from NimBLE host-task
+//! callbacks (no bt_lock held). The kernel-side implementations defer the
+//! actual work to KernelBG to avoid stacking on top of NimBLE's already-deep
+//! frames — running the PPoG state machine + bt_lock acquisition + further
+//! NimBLE calls from this task can overflow the 5000-byte host stack.
+
+//! Driver -> kernel: the phone enabled notifications on the data-notify
+//! characteristic.
+extern void bt_driver_cb_ppog_reversed_subscribed(const BTDeviceInternal *device,
+                                                  uint16_t conn_handle);
+
+//! Driver -> kernel: the phone disabled notifications or disconnected.
+extern void bt_driver_cb_ppog_reversed_unsubscribed(uint16_t conn_handle);
+
+//! Driver -> kernel: the phone wrote a PPoG packet to the data-write
+//! characteristic. Ownership of @p buf transfers to the kernel, which frees it
+//! after the deferred handler runs. @p buf must have been allocated with
+//! kernel_malloc / kernel_zalloc.
+extern void bt_driver_cb_ppog_reversed_data_written(uint16_t conn_handle,
+                                                    uint8_t *buf, uint16_t len);
+
+//! Driver -> kernel: a previously-queued notification finished transmitting,
+//! freeing host buffers. The kernel drains any backlog accumulated while we
+//! were getting BLE_HS_ENOMEM.
+extern void bt_driver_cb_ppog_reversed_notify_tx_complete(void);
+
+//! Kernel -> driver: send a PPoG packet to the phone as a notification on the
+//! reversed PPoG data-notify characteristic.
+//! @return BTErrnoOK on success, BTErrnoNotEnoughResources if NimBLE is out of
+//! mbufs (caller should wait for bt_driver_cb_ppog_reversed_notify_tx_complete
+//! and retry), BTErrnoInvalidState if no subscription is active.
+BTErrno bt_driver_ppog_reversed_notify(uint16_t conn_handle,
+                                       const uint8_t *buf, uint16_t len);

--- a/include/bluetooth/pebble_bt.h
+++ b/include/bluetooth/pebble_bt.h
@@ -20,13 +20,24 @@
 #define PEBBLE_BT_PPOGATT_DATA_CHARACTERISTIC_UUID_32BIT (0x10000001)
 #define PEBBLE_BT_PPOGATT_META_CHARACTERISTIC_UUID_32BIT (0x10000002)
 
-//! The Service UUID of the "Pebble Protocol over GATT" (PPoGATT) service that the watch
-//! publishes to operate as a Server instead of it's normal client role. This allows certain
-//! sad Android phones to communicate with the watch
-#define PEBBLE_BT_PPOGATT_WATCH_SERVER_SERVICE_UUID_32BIT             (0x30000003)
-#define PEBBLE_BT_PPOGATT_WATCH_SERVER_DATA_CHARACTERISTIC_UUID_32BIT (0x30000004)
-#define PEBBLE_BT_PPOGATT_WATCH_SERVER_META_CHARACTERISTIC_UUID_32BIT (0x30000005)
-#define PEBBLE_BT_PPOGATT_WATCH_SERVER_DATA_WR_CHARACTERISTIC_UUID_32BIT (0x30000006)
+//! V1: shipped on Pebble 2 / silk (Dialog DA1468x). The phone is the GATT
+//! client; the watch hosts these characteristics and emulates the legacy
+//! phone-as-server PPoGATT to the rest of the firmware. No meta
+//! characteristic — the phone assumes protocol v0 and sends the first
+//! ResetRequest itself. Reserved here so new allocations don't collide.
+#define PEBBLE_BT_PPOGATT_WATCH_SERVER_V1_SERVICE_UUID_32BIT             (0x30000003)
+#define PEBBLE_BT_PPOGATT_WATCH_SERVER_V1_DATA_CHARACTERISTIC_UUID_32BIT (0x30000004)
+#define PEBBLE_BT_PPOGATT_WATCH_SERVER_V1_META_CHARACTERISTIC_UUID_32BIT (0x30000005)
+#define PEBBLE_BT_PPOGATT_WATCH_SERVER_V1_DATA_WR_CHARACTERISTIC_UUID_32BIT (0x30000006)
+
+//! V2: reversed PPoGATT for NimBLE-based watches (asterix / SiFli). Phone is
+//! the GATT client. Differs from V1 in that the watch sends the first
+//! ResetRequest after the phone subscribes; version is taken from the
+//! ResetRequest payload (no separate meta characteristic — 0x40000002 is
+//! reserved here in case a future revision wants one).
+#define PEBBLE_BT_PPOGATT_WATCH_SERVER_SERVICE_UUID_32BIT             (0x40000000)
+#define PEBBLE_BT_PPOGATT_WATCH_SERVER_DATA_CHARACTERISTIC_UUID_32BIT (0x40000001)
+#define PEBBLE_BT_PPOGATT_WATCH_SERVER_DATA_WR_CHARACTERISTIC_UUID_32BIT (0x40000003)
 
 //! The Service UUID of the "Pebble App Launch" service.
 //! This UUID needs to be expanded using the Pebble Base UUID (@see pebble_bt_uuid_expand)

--- a/src/bluetooth-fw/nimble/advert.c
+++ b/src/bluetooth-fw/nimble/advert.c
@@ -15,6 +15,7 @@
 #include <pbl/util/math.h>
 
 #include "nimble_type_conversions.h"
+#include "ppog_reversed_service.h"
 
 PBL_LOG_MODULE_DECLARE(bt, CONFIG_BT_LOG_LEVEL);
 
@@ -251,6 +252,7 @@ static void prv_handle_subscription_event(struct ble_gap_event *event) {
             event->subscribe.conn_handle, event->subscribe.attr_handle,
             event->subscribe.prev_notify, event->subscribe.cur_notify,
             event->subscribe.prev_indicate, event->subscribe.cur_indicate);
+  ppog_reversed_service_handle_subscribe_event(event);
 }
 
 static void prv_handle_notification_rx_event(struct ble_gap_event *event) {
@@ -279,6 +281,7 @@ static void prv_handle_notification_tx_event(struct ble_gap_event *event) {
             event->notify_tx.status,
             event->notify_tx.attr_handle,
             event->notify_tx.indication);
+  ppog_reversed_service_handle_notify_tx_event(event);
 }
 
 static int prv_handle_repeat_pairing_event(struct ble_gap_event *event) {

--- a/src/bluetooth-fw/nimble/init.c
+++ b/src/bluetooth-fw/nimble/init.c
@@ -28,6 +28,7 @@ PBL_LOG_MODULE_DEFINE(bt, CONFIG_BT_LOG_LEVEL);
 static const uint32_t s_bt_stack_start_stop_timeout_ms = 10000;
 
 extern void pebble_pairing_service_init(void);
+extern void ppog_reversed_service_init(void);
 extern void nimble_discover_init(void);
 
 #if NIMBLE_CFG_CONTROLLER
@@ -145,6 +146,7 @@ bool bt_driver_start(BTDriverConfig *config) {
   ble_svc_dis_init();
   pebble_pairing_service_init();
   ble_svc_bas_init();
+  ppog_reversed_service_init();
 
 #ifdef CONFIG_GH3X2X_TUNING_SERVICE_ENABLED
   gh3x2x_tuning_service_init();

--- a/src/bluetooth-fw/nimble/ppog_reversed_service.c
+++ b/src/bluetooth-fw/nimble/ppog_reversed_service.c
@@ -1,0 +1,147 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "ppog_reversed_service.h"
+
+#include <bluetooth/bt_driver_ppog_reversed.h>
+#include <bluetooth/pebble_bt.h>
+#include <host/ble_gatt.h>
+#include <host/ble_hs.h>
+#include <host/ble_uuid.h>
+#include <kernel/pbl_malloc.h>
+#include <os/os_mbuf.h>
+#include <system/logging.h>
+#include <system/passert.h>
+#include <util/uuid.h>
+
+#include "nimble_type_conversions.h"
+
+PBL_LOG_MODULE_DECLARE(bt, CONFIG_BT_LOG_LEVEL);
+
+static uint16_t s_data_notify_handle;
+static uint16_t s_data_write_handle;
+
+static int prv_access_data_notify(uint16_t conn_handle, uint16_t attr_handle,
+                                  struct ble_gatt_access_ctxt *ctxt, void *arg) {
+  // Notify-only — refuse explicit reads.
+  return BLE_ATT_ERR_READ_NOT_PERMITTED;
+}
+
+static int prv_access_data_write(uint16_t conn_handle, uint16_t attr_handle,
+                                 struct ble_gatt_access_ctxt *ctxt, void *arg) {
+  if (ctxt->op != BLE_GATT_ACCESS_OP_WRITE_CHR) {
+    return BLE_ATT_ERR_UNLIKELY;
+  }
+  // Heap-allocate (not stack — this runs on the 5000-byte NimBLE host task) and
+  // hand ownership to the kernel callback, which will free it after the
+  // KernelBG handler runs.
+  const uint16_t pkt_len = OS_MBUF_PKTLEN(ctxt->om);
+  if (pkt_len == 0) {
+    return 0;
+  }
+  uint8_t *buf = kernel_malloc(pkt_len);
+  if (!buf) {
+    return BLE_ATT_ERR_INSUFFICIENT_RES;
+  }
+  uint16_t out_len = 0;
+  int rc = ble_hs_mbuf_to_flat(ctxt->om, buf, pkt_len, &out_len);
+  if (rc != 0) {
+    PBL_LOG_ERR("Reversed PPoG write flatten failed: 0x%04x", (uint16_t) rc);
+    kernel_free(buf);
+    return BLE_ATT_ERR_UNLIKELY;
+  }
+  bt_driver_cb_ppog_reversed_data_written(conn_handle, buf, out_len);
+  return 0;
+}
+
+static const struct ble_gatt_svc_def s_ppog_reversed_svc[] = {
+    {
+        .type = BLE_GATT_SVC_TYPE_PRIMARY,
+        .uuid = BLE_UUID128_DECLARE(BLE_UUID_SWIZZLE(
+            PEBBLE_BT_UUID_EXPAND(PEBBLE_BT_PPOGATT_WATCH_SERVER_SERVICE_UUID_32BIT))),
+        .characteristics =
+            (struct ble_gatt_chr_def[]){
+                {
+                    .uuid = BLE_UUID128_DECLARE(BLE_UUID_SWIZZLE(PEBBLE_BT_UUID_EXPAND(
+                        PEBBLE_BT_PPOGATT_WATCH_SERVER_DATA_CHARACTERISTIC_UUID_32BIT))),
+                    .access_cb = prv_access_data_notify,
+                    .flags = BLE_GATT_CHR_F_NOTIFY,
+                    .val_handle = &s_data_notify_handle,
+                },
+                {
+                    .uuid = BLE_UUID128_DECLARE(BLE_UUID_SWIZZLE(PEBBLE_BT_UUID_EXPAND(
+                        PEBBLE_BT_PPOGATT_WATCH_SERVER_DATA_WR_CHARACTERISTIC_UUID_32BIT))),
+                    .access_cb = prv_access_data_write,
+                    .flags = BLE_GATT_CHR_F_WRITE_NO_RSP,
+                    .val_handle = &s_data_write_handle,
+                },
+                {
+                    0,
+                },
+            },
+    },
+    {
+        0,
+    },
+};
+
+void ppog_reversed_service_init(void) {
+  int rc = ble_gatts_count_cfg(s_ppog_reversed_svc);
+  PBL_ASSERTN(rc == 0);
+  rc = ble_gatts_add_svcs(s_ppog_reversed_svc);
+  PBL_ASSERTN(rc == 0);
+}
+
+void ppog_reversed_service_handle_subscribe_event(struct ble_gap_event *event) {
+  if (event->subscribe.attr_handle != s_data_notify_handle) {
+    return;
+  }
+  if (event->subscribe.cur_notify == event->subscribe.prev_notify) {
+    return;
+  }
+  if (event->subscribe.cur_notify) {
+    struct ble_gap_conn_desc desc;
+    if (ble_gap_conn_find(event->subscribe.conn_handle, &desc) != 0) {
+      PBL_LOG_ERR("Reversed PPoG subscribe: no conn descriptor for handle %u",
+                  event->subscribe.conn_handle);
+      return;
+    }
+    BTDeviceInternal device;
+    nimble_addr_to_pebble_device(&desc.peer_id_addr, &device);
+    bt_driver_cb_ppog_reversed_subscribed(&device, event->subscribe.conn_handle);
+  } else {
+    bt_driver_cb_ppog_reversed_unsubscribed(event->subscribe.conn_handle);
+  }
+}
+
+void ppog_reversed_service_handle_notify_tx_event(struct ble_gap_event *event) {
+  if (event->notify_tx.attr_handle != s_data_notify_handle) {
+    return;
+  }
+  // Successful TX frees buffer space; let the kernel drain any backlog.
+  if (event->notify_tx.status == 0 || event->notify_tx.status == BLE_HS_EDONE) {
+    bt_driver_cb_ppog_reversed_notify_tx_complete();
+  }
+}
+
+BTErrno bt_driver_ppog_reversed_notify(uint16_t conn_handle,
+                                       const uint8_t *buf, uint16_t len) {
+  struct os_mbuf *om = ble_hs_mbuf_from_flat(buf, len);
+  if (!om) {
+    return BTErrnoNotEnoughResources;
+  }
+  int rc = ble_gatts_notify_custom(conn_handle, s_data_notify_handle, om);
+  // ble_gatts_notify_custom always consumes the mbuf on enqueue. On error, it
+  // also frees it (NimBLE handles ownership internally).
+  switch (rc) {
+    case 0:
+      return BTErrnoOK;
+    case BLE_HS_ENOMEM:
+      return BTErrnoNotEnoughResources;
+    case BLE_HS_ENOTCONN:
+      return BTErrnoInvalidState;
+    default:
+      PBL_LOG_ERR("ble_gatts_notify_custom failed: 0x%04x", (uint16_t) rc);
+      return (BTErrno)(BTErrnoInternalErrorBegin + rc);
+  }
+}

--- a/src/bluetooth-fw/nimble/ppog_reversed_service.h
+++ b/src/bluetooth-fw/nimble/ppog_reversed_service.h
@@ -1,0 +1,18 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include <host/ble_gap.h>
+
+void ppog_reversed_service_init(void);
+
+//! Called from the advert.c GAP event dispatcher on BLE_GAP_EVENT_SUBSCRIBE.
+//! Forwards CCCD changes on our notify characteristic to the kernel-side PPoG
+//! state machine.
+void ppog_reversed_service_handle_subscribe_event(struct ble_gap_event *event);
+
+//! Called from the advert.c GAP event dispatcher on BLE_GAP_EVENT_NOTIFY_TX
+//! when a previously-queued notification finished sending — used to drain any
+//! tx backlog accumulated under BLE_HS_ENOMEM.
+void ppog_reversed_service_handle_notify_tx_event(struct ble_gap_event *event);

--- a/src/bluetooth-fw/qemu/gatt_client_operations.c
+++ b/src/bluetooth-fw/qemu/gatt_client_operations.c
@@ -1,6 +1,7 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include <bluetooth/bt_driver_ppog_reversed.h>
 #include <bluetooth/gatt.h>
 
 #include <pbl/btutil/bt_device.h>
@@ -24,4 +25,8 @@ BTErrno bt_driver_gatt_read(GAPLEConnection *connection,
                             uint16_t att_handle,
                             void *context) {
   return 0;
+}
+
+BTErrno bt_driver_ppog_reversed_notify(uint16_t conn_handle, const uint8_t *buf, uint16_t len) {
+  return BTErrnoInvalidState;
 }

--- a/src/bluetooth-fw/stub/gatt_client_operations.c
+++ b/src/bluetooth-fw/stub/gatt_client_operations.c
@@ -1,6 +1,7 @@
 /* SPDX-FileCopyrightText: 2024 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include <bluetooth/bt_driver_ppog_reversed.h>
 #include <bluetooth/gatt.h>
 
 #include <pbl/btutil/bt_device.h>
@@ -24,4 +25,8 @@ BTErrno bt_driver_gatt_read(GAPLEConnection *connection,
                             uint16_t att_handle,
                             void *context) {
   return 0;
+}
+
+BTErrno bt_driver_ppog_reversed_notify(uint16_t conn_handle, const uint8_t *buf, uint16_t len) {
+  return BTErrnoInvalidState;
 }

--- a/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
+++ b/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
@@ -8,6 +8,7 @@
 #include "comm/ble/gatt_client_operations.h"
 #include "comm/bt_lock.h"
 
+#include <bluetooth/bt_driver_ppog_reversed.h>
 #include <bluetooth/gatt.h>
 
 #include "kernel/pbl_malloc.h"
@@ -35,7 +36,11 @@ typedef enum {
   StateDisconnectedReadingMeta,
   StateDisconnectedAwaitingMetaRetry,
   StateDisconnectedSubscribingData,
-  // StateConnectedClosedAwaitingResetRequest, // Server-only state
+  //! Reversed PPoG (server) state: waiting for the phone to send the first
+  //! ResetRequest. Entered after the phone subscribes to our notify char; the
+  //! incoming ResetRequest will transition us to RemoteInitiatedReset and
+  //! send the ResetComplete back via prv_handle_reset_request.
+  StateConnectedClosedAwaitingResetRequest,
   StateConnectedClosedAwaitingResetCompleteSelfInitiatedReset,
   StateConnectedClosedAwaitingResetCompleteSelfInitiatedResetStalled,
   StateConnectedClosedAwaitingResetCompleteRemoteInitiatedReset,
@@ -69,6 +74,7 @@ typedef struct PPoGATTClient {
   ListNode node;
   State state;
   uint8_t version;
+  PPoGATTRole role;
 
   // TODO: Save some memory and point to app metadata instead?
   Uuid app_uuid;
@@ -77,6 +83,12 @@ typedef struct PPoGATTClient {
     BLECharacteristic meta;
     BLECharacteristic data;
   } characteristics;
+
+  //! State for the reversed role (watch hosts the GATT service).
+  struct {
+    uint16_t conn_handle;
+    GAPLEConnection *connection;
+  } rev;
 
   //! Stuffs that deals with inbound data
   struct {
@@ -120,6 +132,16 @@ typedef struct PPoGATTClient {
 
   bool disconnect_requested; //! True if the client requested a disconnect
 
+  //! Re-entry guard for prv_send_next_packets. The function temporarily drops
+  //! bt_lock around NimBLE calls, during which other tasks (e.g. KernelMain
+  //! processing comm_session_send_next scheduled by comm_session_open) can
+  //! re-enter prv_send_next_packets and observe an inconsistent state — most
+  //! visibly, re-send a pending reset/ack packet that hasn't been finalized
+  //! yet. If a re-entrant call hits the guard, schedule a send_next via
+  //! comm_session so the queued data still gets flushed after the outer call
+  //! exits.
+  bool send_in_progress;
+
   TimerID rx_ack_timer;   //! Timer to ensure Acks for data are dispatched regularly
 
   //! Whether the PPoGATT server transports "System", "App" or "Hybrid" PP sessions.
@@ -149,6 +171,10 @@ static uint8_t s_disconnect_counter;
 
 //! Caps rediscovery on stale meta handles to once per BLE connection.
 static bool s_rediscovery_requested_this_connection;
+
+//! The connection currently using reversed PPoG, or NULL if none. Forward PPoG
+//! yields to reversed on this connection (see ppogatt_handle_service_discovered).
+static GAPLEConnection *s_reversed_active_conn;
 
 // -------------------------------------------------------------------------------------------------
 // Function Prototypes
@@ -191,12 +217,18 @@ static bool prv_client_supports_enhanced_throughput_features(const PPoGATTClient
 
 // -------------------------------------------------------------------------------------------------
 
+static GAPLEConnection *prv_get_connection(const PPoGATTClient *client) {
+  if (client->role == PPoGATTRoleReversed) {
+    return client->rev.connection;
+  }
+  return gatt_client_characteristic_get_connection(client->characteristics.meta);
+}
+
 static void prv_set_connection_responsiveness(
     Transport *transport, BtConsumer consumer, ResponseTimeState state, uint16_t max_period_secs,
     ResponsivenessGrantedHandler granted_handler) {
   PPoGATTClient *client = (PPoGATTClient *) transport;
-  const BLECharacteristic characteristic = client->characteristics.meta;
-  GAPLEConnection *connection = gatt_client_characteristic_get_connection(characteristic);
+  GAPLEConnection *connection = prv_get_connection(client);
   conn_mgr_set_ble_conn_response_time_ext(connection, consumer, state, max_period_secs,
                                           granted_handler);
 }
@@ -381,10 +413,13 @@ static PPoGATTClient *prv_create_client(TimerID timer) {
 
 static void prv_delete_client(PPoGATTClient *client, bool is_disconnected, DeleteReason reason) {
   const uint32_t elapsed_ms = (rtc_get_ticks() - client->created_ticks) * 1000 / RTC_TICKS_HZ;
-  PBL_LOG_INFO("PPoGATT client deleted: state=%u reason=%u disconnected=%u after %"PRIu32"ms",
-          client->state, reason, is_disconnected, elapsed_ms);
-  // Unsubscribe from Data characteristic:
-  if (client->state > StateDisconnectedSubscribingData && !is_disconnected) {
+  PBL_LOG_INFO("PPoGATT client deleted: role=%u state=%u reason=%u disconnected=%u after %"PRIu32"ms",
+          client->role, client->state, reason, is_disconnected, elapsed_ms);
+  // Unsubscribe from the phone's Data characteristic (forward role only — in
+  // reversed the phone subscribed to *our* notify characteristic and the
+  // disconnect/CCCD-clear path handles teardown there).
+  if (client->role == PPoGATTRoleForward &&
+      client->state > StateDisconnectedSubscribingData && !is_disconnected) {
     BLECharacteristic data_char = client->characteristics.data;
     // Release bt_lock before calling into NimBLE to avoid deadlock with ble_hs_mutex.
     bt_unlock();
@@ -394,6 +429,10 @@ static void prv_delete_client(PPoGATTClient *client, bool is_disconnected, Delet
 
   if (client->state == StateConnectedOpen) {
     comm_session_close(client->session, (CommSessionCloseReason)reason);
+  }
+
+  if (client->role == PPoGATTRoleReversed && s_reversed_active_conn == client->rev.connection) {
+    s_reversed_active_conn = NULL;
   }
 
   list_remove(&client->node, (ListNode **) &s_ppogatt_head, NULL);
@@ -440,6 +479,36 @@ static PPoGATTClient * prv_find_client_with_uuid(const Uuid *uuid) {
 
 // -------------------------------------------------------------------------------------------------
 
+static bool prv_reversed_conn_filter_callback(ListNode *found_node, void *data) {
+  const PPoGATTClient *client = (const PPoGATTClient *) found_node;
+  const uint16_t conn_handle = (uint16_t)(uintptr_t) data;
+  return (client->role == PPoGATTRoleReversed && client->rev.conn_handle == conn_handle);
+}
+
+static PPoGATTClient *prv_find_reversed_client_for_conn(uint16_t conn_handle) {
+  return (PPoGATTClient *) list_find((ListNode *) s_ppogatt_head,
+                                     prv_reversed_conn_filter_callback,
+                                     (void *)(uintptr_t) conn_handle);
+}
+
+static bool prv_connection_filter_callback(ListNode *found_node, void *data) {
+  const PPoGATTClient *client = (const PPoGATTClient *) found_node;
+  const GAPLEConnection *connection = (const GAPLEConnection *) data;
+  if (client->role == PPoGATTRoleReversed) {
+    return (client->rev.connection == connection);
+  }
+  GAPLEConnection *forward_conn =
+      gatt_client_characteristic_get_connection(client->characteristics.meta);
+  return (forward_conn == connection);
+}
+
+static PPoGATTClient *prv_find_client_for_connection(GAPLEConnection *connection) {
+  return (PPoGATTClient *) list_find((ListNode *) s_ppogatt_head,
+                                     prv_connection_filter_callback, (void *) connection);
+}
+
+// -------------------------------------------------------------------------------------------------
+
 static bool prv_client_filter_callback(ListNode *found_node, void *data) {
   return ((const PPoGATTClient *) found_node == (const PPoGATTClient *) data);
 }
@@ -452,8 +521,15 @@ static bool prv_is_client_valid(const PPoGATTClient *client) {
 // -------------------------------------------------------------------------------------------------
 
 static uint16_t prv_get_max_payload_size(const PPoGATTClient *client) {
-  const BTDeviceInternal device =
-        gatt_client_characteristic_get_device(client->characteristics.data);
+  BTDeviceInternal device;
+  if (client->role == PPoGATTRoleReversed) {
+    if (!client->rev.connection) {
+      return 0;
+    }
+    device = client->rev.connection->device;
+  } else {
+    device = gatt_client_characteristic_get_device(client->characteristics.data);
+  }
   const uint16_t mtu = gap_le_connection_get_gatt_mtu(&device);
   if (mtu < GATT_MTU_MINIMUM) {
     // Device got disconnected in the mean time
@@ -542,8 +618,7 @@ static void prv_start_reset(PPoGATTClient *client) {
     // Record the time of this disconnect request
 
     bt_lock();
-    const BLECharacteristic characteristic = client->characteristics.meta;
-    GAPLEConnection *connection = gatt_client_characteristic_get_connection(characteristic);
+    GAPLEConnection *connection = prv_get_connection(client);
     PBL_ASSERTN(connection != NULL);
     bt_unlock();
 
@@ -990,6 +1065,174 @@ void ppogatt_invalidate_all_references(void) {
   bt_unlock();
 }
 
+// -------------------------------------------------------------------------------------------------
+// Reversed PPoG (watch hosts the GATT service)
+
+static void prv_reversed_start(GAPLEConnection *connection, uint16_t conn_handle, TimerID timer) {
+  bt_lock_assert_held(true);
+
+  // If anyone (forward or reversed) is already bound to this connection, drop them — reversed wins.
+  PPoGATTClient *existing = prv_find_client_for_connection(connection);
+  if (existing) {
+    PBL_LOG_INFO("Reversed PPoG taking over from existing client (role=%u)", existing->role);
+    prv_delete_client(existing, false /* is_disconnected */, DeleteReason_DuplicateServer);
+  }
+
+  PPoGATTClient *client = prv_create_client(timer);
+  if (!client) {
+    return;
+  }
+  client->role = PPoGATTRoleReversed;
+  client->rev.conn_handle = conn_handle;
+  client->rev.connection = connection;
+  client->app_uuid = UUID_INVALID;
+  client->version = PPOGATT_MAX_VERSION;
+  client->destination = TransportDestinationHybrid;
+
+  s_reversed_active_conn = connection;
+
+  // Phone-initiated handshake: wait for the phone to send the ResetRequest.
+  // When it arrives, prv_handle_data_notification dispatches to
+  // prv_handle_reset_request, which calls prv_enter_awaiting_reset_complete
+  // with self_initiated=false — transitioning us to RemoteInitiatedReset and
+  // sending the ResetComplete back.
+  client->state = StateConnectedClosedAwaitingResetRequest;
+}
+
+void ppogatt_reversed_handle_subscribed(const BTDeviceInternal *device, uint16_t conn_handle) {
+  // new_timer_create() must be called outside bt_lock (see ppogatt_handle_service_discovered).
+  TimerID timer = new_timer_create();
+  PBL_ASSERTN(timer);
+
+  bool started = false;
+  bt_lock();
+  {
+    GAPLEConnection *connection = gap_le_connection_by_device(device);
+    if (!connection) {
+      PBL_LOG_WRN("Reversed PPoG subscribed: no connection for device");
+      goto unlock;
+    }
+    PBL_LOG_INFO("Reversed PPoG subscribed (conn_handle=%u)", conn_handle);
+    prv_reversed_start(connection, conn_handle, timer);
+    started = true;
+  }
+unlock:
+  bt_unlock();
+  if (!started) {
+    new_timer_delete(timer);
+  }
+}
+
+void ppogatt_reversed_handle_unsubscribed(uint16_t conn_handle) {
+  bt_lock();
+  {
+    PPoGATTClient *client = prv_find_reversed_client_for_conn(conn_handle);
+    if (client) {
+      PBL_LOG_INFO("Reversed PPoG unsubscribed (conn_handle=%u)", conn_handle);
+      prv_delete_client(client, false /* is_disconnected */, DeleteReason_CloseCalled);
+    }
+  }
+  bt_unlock();
+}
+
+void ppogatt_reversed_handle_data(uint16_t conn_handle, const uint8_t *buf, size_t len) {
+  bt_lock();
+  {
+    PPoGATTClient *client = prv_find_reversed_client_for_conn(conn_handle);
+    if (!client) {
+      PBL_LOG_DBG("Reversed PPoG data for unknown conn_handle=%u", conn_handle);
+      goto unlock;
+    }
+    prv_handle_data_notification(client, buf, (uint16_t) len);
+  }
+unlock:
+  bt_unlock();
+}
+
+// The bt_driver_cb_ppog_reversed_* callbacks below all defer their real work to
+// KernelBG. Running it inline would put the bt_lock + comm_session_open +
+// re-entrant NimBLE calls chain on top of NimBLE's own host-task frames, which
+// overflows the 5000-byte host stack (see PebbleTask_BTHost in init.c).
+
+typedef struct {
+  BTDeviceInternal device;
+  uint16_t conn_handle;
+} ReversedSubscribedCtx;
+
+typedef struct {
+  uint16_t conn_handle;
+} ReversedUnsubscribedCtx;
+
+typedef struct {
+  uint16_t conn_handle;
+  uint16_t len;
+  uint8_t *buf;  // owned, freed by the KernelBG cb.
+} ReversedDataCtx;
+
+static void prv_reversed_subscribed_kernelbg_cb(void *data) {
+  ReversedSubscribedCtx *ctx = (ReversedSubscribedCtx *)data;
+  ppogatt_reversed_handle_subscribed(&ctx->device, ctx->conn_handle);
+  kernel_free(ctx);
+}
+
+static void prv_reversed_unsubscribed_kernelbg_cb(void *data) {
+  ReversedUnsubscribedCtx *ctx = (ReversedUnsubscribedCtx *)data;
+  ppogatt_reversed_handle_unsubscribed(ctx->conn_handle);
+  kernel_free(ctx);
+}
+
+static void prv_reversed_data_kernelbg_cb(void *data) {
+  ReversedDataCtx *ctx = (ReversedDataCtx *)data;
+  ppogatt_reversed_handle_data(ctx->conn_handle, ctx->buf, ctx->len);
+  kernel_free(ctx->buf);
+  kernel_free(ctx);
+}
+
+static void prv_reversed_notify_tx_kernelbg_cb(void *data) {
+  ppogatt_handle_buffer_empty();
+}
+
+void bt_driver_cb_ppog_reversed_subscribed(const BTDeviceInternal *device, uint16_t conn_handle) {
+  ReversedSubscribedCtx *ctx = kernel_malloc(sizeof(*ctx));
+  if (!ctx) {
+    PBL_LOG_ERR("Reversed PPoG subscribed: out of memory");
+    return;
+  }
+  ctx->device = *device;
+  ctx->conn_handle = conn_handle;
+  system_task_add_callback(prv_reversed_subscribed_kernelbg_cb, ctx);
+}
+
+void bt_driver_cb_ppog_reversed_unsubscribed(uint16_t conn_handle) {
+  ReversedUnsubscribedCtx *ctx = kernel_malloc(sizeof(*ctx));
+  if (!ctx) {
+    PBL_LOG_ERR("Reversed PPoG unsubscribed: out of memory");
+    return;
+  }
+  ctx->conn_handle = conn_handle;
+  system_task_add_callback(prv_reversed_unsubscribed_kernelbg_cb, ctx);
+}
+
+void bt_driver_cb_ppog_reversed_data_written(uint16_t conn_handle,
+                                             uint8_t *buf, uint16_t len) {
+  ReversedDataCtx *ctx = kernel_malloc(sizeof(*ctx));
+  if (!ctx) {
+    PBL_LOG_ERR("Reversed PPoG data: out of memory");
+    kernel_free(buf);
+    return;
+  }
+  ctx->conn_handle = conn_handle;
+  ctx->len = len;
+  ctx->buf = buf;
+  system_task_add_callback(prv_reversed_data_kernelbg_cb, ctx);
+}
+
+void bt_driver_cb_ppog_reversed_notify_tx_complete(void) {
+  system_task_add_callback(prv_reversed_notify_tx_kernelbg_cb, NULL);
+}
+
+// -------------------------------------------------------------------------------------------------
+
 void ppogatt_handle_service_discovered(BLECharacteristic *characteristics) {
   PBL_LOG_INFO("PPoGATT service discovered, starting handshake");
 
@@ -1001,6 +1244,18 @@ void ppogatt_handle_service_discovered(BLECharacteristic *characteristics) {
 
   bt_lock();
   {
+    // If reversed PPoG has already opened (or is opening) a transport on this
+    // connection, ignore the discovered forward service — reversed always wins.
+    // gatt_client_characteristic_get_connection requires bt_lock held.
+    GAPLEConnection *meta_conn =
+        gatt_client_characteristic_get_connection(characteristics[PPoGATTCharacteristicMeta]);
+    if (meta_conn && s_reversed_active_conn == meta_conn) {
+      bt_unlock();
+      new_timer_delete(timer);
+      PBL_LOG_DBG("Reversed PPoG active, skipping forward");
+      return;
+    }
+
     // Create new clients:
     PPoGATTClient *client = prv_create_client(timer);
     if (!client) {
@@ -1008,6 +1263,7 @@ void ppogatt_handle_service_discovered(BLECharacteristic *characteristics) {
       new_timer_delete(timer);
       return;
     }
+    client->role = PPoGATTRoleForward;
     BLECharacteristic meta = characteristics[PPoGATTCharacteristicMeta];
     client->characteristics.meta = characteristics[PPoGATTCharacteristicMeta];
     client->characteristics.data = characteristics[PPoGATTCharacteristicData];
@@ -1290,6 +1546,18 @@ static void prv_finalize_queued_packet(PPoGATTClient *client, uint16_t payload_s
 // -------------------------------------------------------------------------------------------------
 
 static void prv_send_next_packets(PPoGATTClient *client) {
+  if (client->send_in_progress) {
+    // Another caller is already in the middle of sending — drop bt_lock around
+    // a NimBLE call and another task tried to re-enter. Returning now keeps the
+    // outer call's in-flight packet from being re-sent. Re-schedule via the
+    // session so any queued data still gets flushed once the outer call exits.
+    if (client->session) {
+      comm_session_send_next(client->session);
+    }
+    return;
+  }
+  client->send_in_progress = true;
+
   uint16_t payload_size = 0;
   const PPoGATTPacket *packet = NULL;
   PPoGATTPacket *heap_packet = NULL;
@@ -1298,6 +1566,34 @@ static void prv_send_next_packets(PPoGATTClient *client) {
   uint8_t loop_count = 0;
   while ((packet = prv_prepare_next_packet(client, &heap_packet, &payload_size))) {
     ++loop_count;
+
+    if (client->role == PPoGATTRoleReversed) {
+      const uint16_t total_len = sizeof(PPoGATTPacket) + payload_size;
+      const bool lock_was_held = bt_lock_is_held();
+      if (lock_was_held) {
+        bt_unlock();
+      }
+      const BTErrno e = bt_driver_ppog_reversed_notify(client->rev.conn_handle,
+                                                       (const uint8_t *) packet, total_len);
+      if (lock_was_held) {
+        bt_lock();
+      }
+      if (e == BTErrnoNotEnoughResources) {
+        // Wait for the next BLE_GAP_EVENT_NOTIFY_TX (see ppogatt_handle_buffer_empty).
+        break;
+      } else if (e != BTErrnoOK) {
+        PBL_LOG_ERR("Reversed PPoG notify failed %i", e);
+        break;
+      }
+      prv_finalize_queued_packet(client, payload_size);
+
+      const uint8_t max_loop_count = 10;
+      if (loop_count > max_loop_count) {
+        prv_send_next_packets_async(client);
+        break;
+      }
+      continue;
+    }
 
     // Get the connection and handle while holding bt_lock
     GAPLEConnection *connection;
@@ -1374,6 +1670,8 @@ static void prv_send_next_packets(PPoGATTClient *client) {
   }
 
   kernel_free(heap_packet);
+
+  client->send_in_progress = false;
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt_internal.h
+++ b/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt_internal.h
@@ -37,6 +37,13 @@
 #define PPOGATT_META_READ_RETRY_DELAY_MS (500)
 
 typedef enum {
+  //! Watch is the GATT client; phone hosts the PPoG service.
+  PPoGATTRoleForward,
+  //! Watch hosts the PPoG service; phone is the GATT client.
+  PPoGATTRoleReversed,
+} PPoGATTRole;
+
+typedef enum {
   PPoGATTPacketTypeData = 0x0,
   PPoGATTPacketTypeAck = 0x1,
   PPoGATTPacketTypeResetRequest = 0x2,

--- a/tests/fw/comm/test_ppogatt.c
+++ b/tests/fw/comm/test_ppogatt.c
@@ -53,6 +53,10 @@ GAPLEConnection *gap_le_connection_get_gateway(void) {
   return NULL;
 }
 
+GAPLEConnection *gap_le_connection_by_device(const BTDeviceInternal *device) {
+  return NULL;
+}
+
 GAPLEConnection *gatt_client_characteristic_get_connection(BLECharacteristic characteristic_ref) {
   return NULL;
 }
@@ -69,6 +73,12 @@ uint16_t gatt_client_characteristic_get_handle_and_connection(
 BTErrno bt_driver_gatt_write_without_response(GAPLEConnection *connection, const uint8_t *value,
                                               size_t value_length, uint16_t att_handle) {
   cl_fail("unexpected call: bt_lock is never held in this test");
+  return BTErrnoOK;
+}
+
+// Reversed PPoG only fires from a reversed-role client, which this test never creates.
+BTErrno bt_driver_ppog_reversed_notify(uint16_t conn_handle, const uint8_t *buf, uint16_t len) {
+  cl_fail("unexpected call: no reversed client in this test");
   return BTErrnoOK;
 }
 


### PR DESCRIPTION
Adds reversed-ppog, so that the phone can subscribe to the watch's ppog service, instead of the other way around.

Reasoning:
- This is simpler and will fix a class of bugs we see in the field where the watch either can't find the phone's ppog service, or 
doesn't realize that it needs to resubscribe on iOS because the link never dropped kept alive by ANCS). Also may fix some bugs on weird android devices.
- In the future it would enable us to use AccessorySetupKit on iOS (which is currently pre-requisite to new Accessory Notifications framework), which is not allowed while while running a GATT server on the phone.

Changes:
- Add new reversed-ppog GATT service on the watch. This uses a different UUID from previous reversed-ppog service (only supported on Pebble 2) which worked differently.
- Phone app will subscribe to this service if it exists, otherwise it will open a GATT server with "normal" ppog service.
- Watch will ignore phone ppog service if the phone subscribes to reversed service (i.e. reversed has priority, and is intended to be the primary connection path going forward).

Implementation notes:
- We drop the meta characteristic. This was required to distinguish between the Pebble app's service and 3rd-party app services on iOS, but that is not longer an issue when the watch is hosting.
- The phone is expected to send the initial reset request after subscribing to reversed ppog. This makes it clear that the phone initiates the connection (and never needs to wait for the watch, which is what caused a lot of problems previously).

Remaining issues:
- Both iOS and Android cache the watch's GATT services, and will return a stale list to the mobile app until the device is repaired. That means the phone app not see this new service initially (given that we expect users to pair in PRF which will not have the new service). This is OK for now - the existing ppog mechanism will continue to work. We should follow up by potentially implementing the 0x2B2A hash characteristic which nimble doesn't support yet (both phone OSs should trigger a full discovery refresh if this changes).

Testing:
- Tested on iOS and Android; works in both normal and reversed mode, depending on whether the app can see the new reversed service or not. Tried pairing in PRF -> update to FW with this service (continues to use normal ppog, unless I force-refresh the GATT cache on android in which case it uses new reversed service). Tried pairing to device running this service: works using new reversed mode. Mobile app changes to follow.