### PR TITLE
⚡️clock: check DST and hourly chime once a minute

### DIFF
--- a/include/pbl/services/clock.h
+++ b/include/pbl/services/clock.h
@@ -43,6 +43,12 @@ typedef enum {
 //! Initialize clock service
 void clock_init(void);
 
+#ifndef CONFIG_RECOVERY_FW
+//! @internal
+//! Allow the hourly chime to access system resources after they are initialized.
+void clock_hourly_chime_arm(void);
+#endif
+
 //! @internal
 void clock_get_time_tm(struct tm* time_tm);
 

--- a/src/fw/main.c
+++ b/src/fw/main.c
@@ -333,6 +333,10 @@ static NOINLINE void prv_main_task_init(void) {
 
   system_resource_init();
 
+#ifndef CONFIG_RECOVERY_FW
+  clock_hourly_chime_arm();
+#endif
+
 #ifdef CONFIG_HRM
   hrm_init(HRM);
 #endif

--- a/src/fw/services/clock/service.c
+++ b/src/fw/services/clock/service.c
@@ -386,15 +386,18 @@ void clock_protocol_msg_callback(CommSession *session, const uint8_t* data, unsi
 }
 
 // TODO: Using a regular timer is pretty gross...
+//! Runs once a minute from the regular_timer minutes list. DST transitions and
+//! the top of the hour both land on minute boundaries, so minute granularity
+//! detects them at the same instant the old per-second poll did.
 T_STATIC void prv_watch_dst(void* user) {
   const bool was_dst = (bool)user;
   const bool is_dst = time_get_isdst(rtc_get_time());
-  
+
 #ifndef CONFIG_RECOVERY_FW
   if (!s_hourly_chime_armed) {
     s_hourly_chime_armed = true;
   } else if (alerts_should_vibrate_for_type(AlertOther) &&
-             (time_utc_to_local(rtc_get_time()) % SECONDS_PER_HOUR == 0)) {
+             (time_utc_to_local(rtc_get_time()) % SECONDS_PER_HOUR < SECONDS_PER_MINUTE)) {
     uint32_t vibe_id = vibe_score_info_get_resource_id(
         alerts_preferences_get_vibe_score_for_client(VibeClient_Hourly));
     VibeScore *score = vibe_score_create_with_resource_system(0, vibe_id);
@@ -442,7 +445,7 @@ void clock_init(void) {
 #ifndef CONFIG_RECOVERY_FW
   s_hourly_chime_armed = false;
 #endif
-  regular_timer_add_seconds_callback(&s_dst_checker);
+  regular_timer_add_minutes_callback(&s_dst_checker);
 }
 
 void clock_get_time_tm(struct tm* time_tm) {

--- a/src/fw/services/clock/service.c
+++ b/src/fw/services/clock/service.c
@@ -46,8 +46,9 @@ static const uint16_t protocol_time_endpoint_id = 11;
 static RegularTimerInfo s_dst_checker;
 
 #ifndef CONFIG_RECOVERY_FW
-// Armed on the first timer tick, after init has settled.
+// Armed after system resources are initialized.
 static bool s_hourly_chime_armed;
+#define HOURLY_CHIME_GRACE_PERIOD_SECONDS 5
 #endif
 
 static time_t prv_migrate_local_time_to_UTC(time_t local_time) {
@@ -394,10 +395,9 @@ T_STATIC void prv_watch_dst(void* user) {
   const bool is_dst = time_get_isdst(rtc_get_time());
 
 #ifndef CONFIG_RECOVERY_FW
-  if (!s_hourly_chime_armed) {
-    s_hourly_chime_armed = true;
-  } else if (alerts_should_vibrate_for_type(AlertOther) &&
-             (time_utc_to_local(rtc_get_time()) % SECONDS_PER_HOUR < SECONDS_PER_MINUTE)) {
+  const time_t seconds_into_hour = time_utc_to_local(rtc_get_time()) % SECONDS_PER_HOUR;
+  if (s_hourly_chime_armed && alerts_should_vibrate_for_type(AlertOther) &&
+      (seconds_into_hour < HOURLY_CHIME_GRACE_PERIOD_SECONDS)) {
     uint32_t vibe_id = vibe_score_info_get_resource_id(
         alerts_preferences_get_vibe_score_for_client(VibeClient_Hourly));
     VibeScore *score = vibe_score_create_with_resource_system(0, vibe_id);
@@ -447,6 +447,12 @@ void clock_init(void) {
 #endif
   regular_timer_add_minutes_callback(&s_dst_checker);
 }
+
+#ifndef CONFIG_RECOVERY_FW
+void clock_hourly_chime_arm(void) {
+  s_hourly_chime_armed = true;
+}
+#endif
 
 void clock_get_time_tm(struct tm* time_tm) {
   rtc_get_time_tm(time_tm);

--- a/tests/fw/services/test_clock.c
+++ b/tests/fw/services/test_clock.c
@@ -174,7 +174,7 @@ void test_clock__hourly_chime_only_on_the_hour(void) {
   prv_watch_dst((void *)false);  // arm
   cl_assert_equal_i(s_vibe_create_count, 0);
 
-  rtc_set_time(1262304000 + 42);  // not on the hour
+  rtc_set_time(1262304000 + SECONDS_PER_MINUTE + 42);  // not in the first minute of the hour
   prv_watch_dst((void *)false);
   cl_assert_equal_i(s_vibe_create_count, 0);
 

--- a/tests/fw/services/test_clock.c
+++ b/tests/fw/services/test_clock.c
@@ -137,11 +137,8 @@ void launcher_task_add_callback(void (*callback)(void *data), void *data) {
 // Tests
 ///////////////////////////
 
-// FIRM-2072: on first boot after an OTA the RTC is snapped to a timestamp that
-// is exactly on the hour, and the per-second DST timer is registered before
-// resource_init() runs. The chime must not touch the (uninitialized) resource
-// subsystem on that first tick.
-void test_clock__hourly_chime_skips_first_tick_after_boot(void) {
+// The chime must not touch resources before initialization finishes.
+void test_clock__hourly_chime_waits_for_resources_after_boot(void) {
   s_prefs_24h_style = false;
   fake_rtc_init(0, 0);
   rtc_timezone_clear();
@@ -151,12 +148,29 @@ void test_clock__hourly_chime_skips_first_tick_after_boot(void) {
   s_should_vibrate = true;
   s_vibe_create_count = 0;
 
-  // First tick after boot: must not create a vibe score even though we are
-  // exactly on the hour.
+  // A callback before resources are ready must not create a vibe score.
   prv_watch_dst((void *)false);
   cl_assert_equal_i(s_vibe_create_count, 0);
 
-  // A later tick still on the hour chimes normally.
+  // Once resources are ready, the same minute may chime normally.
+  clock_hourly_chime_arm();
+  prv_watch_dst((void *)false);
+  cl_assert_equal_i(s_vibe_create_count, 1);
+}
+
+void test_clock__hourly_chime_first_minute_boundary_after_boot(void) {
+  static const time_t hour_timestamp = 1262304000 + SECONDS_PER_HOUR;
+  s_prefs_24h_style = false;
+  fake_rtc_init(0, 0);
+  rtc_timezone_clear();
+  rtc_set_time(hour_timestamp - 20);
+  clock_init();
+
+  s_should_vibrate = true;
+  s_vibe_create_count = 0;
+  clock_hourly_chime_arm();
+
+  rtc_set_time(hour_timestamp + 1);
   prv_watch_dst((void *)false);
   cl_assert_equal_i(s_vibe_create_count, 1);
 }
@@ -171,16 +185,33 @@ void test_clock__hourly_chime_only_on_the_hour(void) {
   s_should_vibrate = true;
   s_vibe_create_count = 0;
 
-  prv_watch_dst((void *)false);  // arm
+  clock_hourly_chime_arm();
   cl_assert_equal_i(s_vibe_create_count, 0);
 
-  rtc_set_time(1262304000 + SECONDS_PER_MINUTE + 42);  // not in the first minute of the hour
+  rtc_set_time(1262304000 + SECONDS_PER_MINUTE + 42);  // not near the hour
   prv_watch_dst((void *)false);
   cl_assert_equal_i(s_vibe_create_count, 0);
 
   rtc_set_time(1262304000 + SECONDS_PER_HOUR);  // top of the hour
   prv_watch_dst((void *)false);
   cl_assert_equal_i(s_vibe_create_count, 1);
+}
+
+void test_clock__hourly_chime_ignores_clock_adjustment_into_first_minute(void) {
+  static const time_t hour_timestamp = 1262304000 + SECONDS_PER_HOUR;
+  s_prefs_24h_style = false;
+  fake_rtc_init(0, 0);
+  rtc_timezone_clear();
+  rtc_set_time(hour_timestamp - SECONDS_PER_MINUTE);
+  clock_init();
+
+  s_should_vibrate = true;
+  s_vibe_create_count = 0;
+  clock_hourly_chime_arm();
+
+  rtc_set_time(hour_timestamp + 42);
+  prv_watch_dst((void *)false);
+  cl_assert_equal_i(s_vibe_create_count, 0);
 }
 
 void test_clock__hourly_chime_respects_vibrate_setting(void) {
@@ -193,7 +224,7 @@ void test_clock__hourly_chime_respects_vibrate_setting(void) {
   s_should_vibrate = false;
   s_vibe_create_count = 0;
 
-  prv_watch_dst((void *)false);  // arm
+  clock_hourly_chime_arm();
   prv_watch_dst((void *)false);  // on the hour but vibing disabled
   cl_assert_equal_i(s_vibe_create_count, 0);
 }


### PR DESCRIPTION
The DST watcher polled every second, but DST transitions and the top of the hour both land on minute boundaries, and the regular_timer minutes list fires exactly at those boundaries. Move the callback to the minutes list and widen the chime match from an exact ==0 comparison to the first minute of the hour, which is equivalent at minute cadence and more robust to a delayed tick.

One less per-second callback on the 1 Hz housekeeping wake.



(cherry picked from commit 1f8dd4ffc8ffb08ea401276ab710b97c92bbd37d)