### PR TITLE
⚡️cron: arm a one-shot timer for the next job instead of polling at 1 Hz

### DIFF
--- a/src/fw/services/cron/service.c
+++ b/src/fw/services/cron/service.c
@@ -4,10 +4,11 @@
 #include "pbl/services/cron.h"
 #include <pebbleos/cron.h>
 
+#include "drivers/rtc.h"
 #include "pbl/os/mutex.h"
-#include "system/passert.h"
-#include "pbl/services/regular_timer.h"
+#include "pbl/services/new_timer/new_timer.h"
 #include "system/logging.h"
+#include "system/passert.h"
 #include "pbl/util/math.h"
 
 PBL_LOG_MODULE_DEFINE(service_cron, CONFIG_SERVICE_CRON_LOG_LEVEL);
@@ -15,13 +16,36 @@ PBL_LOG_MODULE_DEFINE(service_cron, CONFIG_SERVICE_CRON_LOG_LEVEL);
 //! Don't let users modify the list while callbacks are occurring.
 static PebbleMutex *s_list_mutex = NULL;
 
-static void prv_timer_callback(void* data);
-static RegularTimerInfo s_regular = {
-  .cb = prv_timer_callback,
-};
-
 // List of jobs sorted from soonest to farthest.
 static ListNode *s_scheduled_jobs;
+
+static void prv_timer_callback(void* data);
+
+//! One-shot timer armed for the next job's execute time. Re-armed after every
+//! list mutation and every firing; stopped when no jobs are scheduled. Capped
+//! so that long sleeps re-check at least hourly, which keeps any tick-clock
+//! drift across sleep bounded.
+#define CRON_MAX_ARM_INTERVAL_S (60 * 60)
+static TimerID s_wakeup_timer = TIMER_INVALID_ID;
+
+//! Arm (or stop) the wakeup timer for the head job. s_list_mutex must be held.
+static void prv_arm_wakeup(void) {
+  if (s_scheduled_jobs == NULL) {
+    new_timer_stop(s_wakeup_timer);
+    return;
+  }
+  time_t now;
+  uint16_t milliseconds;
+  rtc_get_time_ms(&now, &milliseconds);
+  const time_t execute_time = ((CronJob *)s_scheduled_jobs)->cached_execute_time;
+  int32_t delta_s = (execute_time > now) ? (int32_t)(execute_time - now) : 0;
+  delta_s = MIN(delta_s, CRON_MAX_ARM_INTERVAL_S);
+  uint32_t timeout_ms = (uint32_t)delta_s * 1000U;
+  if (timeout_ms > milliseconds) {
+    timeout_ms -= milliseconds;
+  }
+  new_timer_start(s_wakeup_timer, timeout_ms, prv_timer_callback, NULL, 0 /*flags*/);
+}
 
 // -------------------------------------------------------------------------------------------
 static bool prv_is_scheduled(CronJob *job) {
@@ -49,6 +73,7 @@ static void prv_timer_callback(void* data) {
     job->cb(job, job->cb_data);
     mutex_lock(s_list_mutex);
   }
+  prv_arm_wakeup();
   mutex_unlock(s_list_mutex);
 }
 
@@ -89,7 +114,9 @@ void cron_service_init(void) {
   s_list_mutex = mutex_create();
   s_scheduled_jobs = NULL;
 
-  regular_timer_add_seconds_callback(&s_regular);
+  if (s_wakeup_timer == TIMER_INVALID_ID) {
+    s_wakeup_timer = new_timer_create();
+  }
 }
 
 // -------------------------------------------------------------------------------------------
@@ -108,6 +135,7 @@ time_t cron_job_schedule(CronJob *job) {
   PBL_LOG_DBG("Cron job scheduled for %ld (%+ld)", job->cached_execute_time,
           (job->cached_execute_time - now));
 
+  prv_arm_wakeup();
   mutex_unlock(s_list_mutex);
 
   return job->cached_execute_time;
@@ -135,6 +163,7 @@ time_t cron_job_schedule_after(CronJob *job, CronJob *new_job) {
   list_insert_after(&job->list_node, &new_job->list_node);
   PBL_LOG_DBG("Cron job scheduled for %ld", job->cached_execute_time);
 
+  prv_arm_wakeup();
   mutex_unlock(s_list_mutex);
 
   return job->cached_execute_time;
@@ -160,6 +189,7 @@ bool cron_job_unschedule(CronJob *job) {
   if (prv_is_scheduled(job)) {
     list_remove(&job->list_node, &s_scheduled_jobs, NULL);
     removed = true;
+    prv_arm_wakeup();
   }
 
   mutex_unlock(s_list_mutex);
@@ -181,6 +211,7 @@ void cron_clear_all_jobs(void) {
     list_remove(&job->list_node, NULL, NULL);
   }
   s_scheduled_jobs = NULL;
+  prv_arm_wakeup();
 
   mutex_unlock(s_list_mutex);
 }
@@ -191,7 +222,7 @@ void cron_service_deinit(void) {
   mutex_destroy(s_list_mutex);
   s_list_mutex = NULL;
 
-  regular_timer_remove_callback(&s_regular);
+  new_timer_stop(s_wakeup_timer);
 }
 
 uint32_t cron_service_get_job_count(void) {

--- a/tests/fw/services/test_cron.c
+++ b/tests/fw/services/test_cron.c
@@ -4,6 +4,7 @@
 #include "clar.h"
 
 #include "pbl/services/cron.h"
+#include "pbl/services/new_timer/new_timer.h"
 #include "pbl/util/size.h"
 
 #include <pebbleos/cron.h>
@@ -11,8 +12,23 @@
 #include "stubs_logging.h"
 #include "stubs_mutex.h"
 #include "stubs_passert.h"
-#include "stubs_regular_timer.h"
 #include "fake_rtc.h"
+
+static uint32_t s_timer_timeout_ms;
+
+TimerID new_timer_create(void) {
+  return 1;
+}
+
+bool new_timer_start(TimerID timer, uint32_t timeout_ms, NewTimerCallback cb, void *cb_data,
+                     uint32_t flags) {
+  s_timer_timeout_ms = timeout_ms;
+  return true;
+}
+
+bool new_timer_stop(TimerID timer) {
+  return true;
+}
 
 // Tests
 ///////////////////////////////////////////////////////////
@@ -36,6 +52,7 @@ static const TimezoneInfo s_timezone_gmt = {
 };
 
 void test_cron__initialize(void) {
+  s_timer_timeout_ms = 0;
   cron_service_init();
 }
 
@@ -64,6 +81,24 @@ static void prv_clock_change(int32_t time_diff, int32_t gmt_diff, bool dst_trans
   g_timezone.tm_gmtoff += gmt_diff;
   time_util_update_timezone(&g_timezone);
   cron_service_handle_clock_change(&set_time_info);
+}
+
+void test_cron__timer_aligned_to_execute_second(void) {
+  CronJob job = {
+    .cb = prv_cron_callback,
+    .minute = 45,
+    .hour = CRON_HOUR_ANY,
+    .mday = CRON_MDAY_ANY,
+    .month = CRON_MONTH_ANY,
+  };
+  prv_set_rtc(s_2015_nov12_123456_gmt, &s_timezone_gmt);
+  fake_rtc_increment_time_ms(750);
+
+  const time_t execute_time = cron_job_schedule(&job);
+
+  cl_assert_equal_i(execute_time, 1447332300);
+  cl_assert_equal_i(s_timer_timeout_ms, 603250);
+  cl_assert(cron_job_unschedule(&job));
 }
 
 void test_cron__time_change_basic(void) {


### PR DESCRIPTION
> ⚡ **Power tweak** — one of a series of idle-wakeup reductions that let the SoC spend more time in deep sleep. Companion PRs: #1658 · #1659 · #1660 · #1661 · #1662 · #1663.

The cron service registered a per-second regular_timer callback that locked the job-list mutex and compared the head job's execute time against the clock 86400 times a day, almost always concluding there was nothing to do. Cron already knows exactly when the next job is due, so arm a one-shot new_timer for that instant instead and re-arm on every list mutation (schedule, schedule_after, unschedule, clear) and firing.

Job execution semantics are unchanged: callbacks still run on the timer task at the same second they used to, offset_seconds resolution is preserved, and cron_service_handle_clock_change() still runs due jobs and now re-arms for the new head. The armed interval is capped at one hour so any tick-clock drift across long sleeps stays bounded.

(cherry picked from commit 90a67da23149275b8cf746706e04744e321f6c7c)