### PR TITLE
⚡️kernel: feed task-liveness watchdog every 3 s instead of every second

### DIFF
--- a/src/fw/console/pulse2.c
+++ b/src/fw/console/pulse2.c
@@ -263,7 +263,8 @@ static void prv_pulse_task_main(void *unused) {
   static RegularTimerInfo idle_watchdog_timer = {
     .cb = prv_pulse_task_idle_timer_callback
   };
-  regular_timer_add_seconds_callback(&idle_watchdog_timer);
+  // 3s check-in, same margin rationale as the other task liveness feeds.
+  regular_timer_add_multisecond_callback(&idle_watchdog_timer, 3);
 
   CobsDecodeContext frame_decode_ctx;
   cobs_streaming_decode_start(&frame_decode_ctx, s_current_rx_frame,

--- a/src/fw/kernel/event_loop.c
+++ b/src/fw/kernel/event_loop.c
@@ -593,7 +593,10 @@ void launcher_main_loop(void) {
 
     // We make this PebbleEvent static to save stack space
     static PebbleEvent e;
-    if (event_take_timeout(&e, 1000)) {
+    // The timeout exists only to refresh the watchdog bit above; events wake
+    // the loop immediately. 3s keeps ~5s of margin against the shortest (8s)
+    // hardware watchdog while letting an idle KernelMain sleep 3x longer.
+    if (event_take_timeout(&e, 3000)) {
       const PebbleTaskBitset kernel_main_task_bit = (1 << PebbleTask_KernelMain);
       const bool is_not_masked_out_from_kernel_main = !(e.task_mask & kernel_main_task_bit);
       if (is_not_masked_out_from_kernel_main) {

--- a/src/fw/main.c
+++ b/src/fw/main.c
@@ -174,8 +174,11 @@ static void watchdog_timer_callback(void* data) {
 }
 
 static void register_system_timers(void) {
+  // Liveness check-in for the timer task. The hardware watchdog allows 10s
+  // between feeds, so a 3s cadence keeps ample margin while letting the
+  // system idle three times longer between wakeups.
   static RegularTimerInfo watchdog_timer = { .list_node = { 0, 0 }, .cb = watchdog_timer_callback };
-  regular_timer_add_seconds_callback(&watchdog_timer);
+  regular_timer_add_multisecond_callback(&watchdog_timer, 3);
 }
 
 static void init_drivers(void) {

--- a/src/fw/services/system_task/service.c
+++ b/src/fw/services/system_task/service.c
@@ -115,7 +115,9 @@ void system_task_timer_init(void) {
   static RegularTimerInfo idle_watchdog_timer = {
     .cb = system_task_idle_timer_callback
   };
-  regular_timer_add_seconds_callback(&idle_watchdog_timer);
+  // 3s check-in leaves plenty of margin against the 10s hardware watchdog
+  // while cutting idle wakeups for this task by two thirds.
+  regular_timer_add_multisecond_callback(&idle_watchdog_timer, 3);
 }
 
 void system_task_watchdog_feed(void) {


### PR DESCRIPTION
> ⚡ **Power tweak** — one of a series of idle-wakeup reductions that let the SoC spend more time in deep sleep. Companion PRs: #1658 · #1659 · #1660 · #1661 · #1662 · #1663.

## What

Two related cadence changes, one per commit:

1. **Task-liveness watchdog feeds: 1 s → 3 s.** The hardware watchdog timeout is 8–10 s depending on platform; feeding the liveness bits every second is 3× more often than needed. At 3 s cadence a genuinely-hung task is still detected with ≥5 s of margin before the hardware timeout.
2. **KernelMain idle event timeout: 1 s → 3 s.** KernelMain's event loop woke every second just to check in with the watchdog; with feeds at 3 s it only needs to wake at the same cadence.

## Why

On an otherwise-idle watch these two are a steady 2 wakeups/second that serve no purpose beyond watchdog bookkeeping. This cuts them to ~0.7/s combined.

## Testing

Full unit suite passes; field-tested on SF32LB52 (Obelix) alongside the other idle-wakeup changes — no watchdog resets over multi-day soak, hang detection verified still working via a deliberately-stalled task.