### PR TITLE
⚡️regular_timer: arm for the next due callback instead of ticking at 1 Hz

### DIFF
--- a/src/fw/services/regular_timer/service.c
+++ b/src/fw/services/regular_timer/service.c
@@ -3,14 +3,18 @@
 
 #include "pbl/services/regular_timer.h"
 
+#include "drivers/rtc.h"
 #include "pbl/os/mutex.h"
 #include "pbl/services/new_timer/new_timer.h"
 #include "system/logging.h"
 #include "system/passert.h"
+#include "pbl/util/math.h"
+#include "util/time/time.h"
 
 #include "FreeRTOS.h"
 #include "portmacro.h"
 
+#include <stdint.h>
 #include <time.h>
 
 PBL_LOG_MODULE_DEFINE(service_regular_timer, CONFIG_SERVICE_REGULAR_TIMER_LOG_LEVEL);
@@ -18,19 +22,28 @@ PBL_LOG_MODULE_DEFINE(service_regular_timer, CONFIG_SERVICE_REGULAR_TIMER_LOG_LE
 //! Don't let users modify the list while callbacks are occurring.
 static PebbleMutex * s_callback_list_semaphore = 0;
 
-//! The timer we use
+//! The timer we use. One-shot, re-armed after every pass for the next due
+//! callback instead of ticking at a fixed 1 Hz: multisecond callbacks are
+//! credited with the elapsed seconds when the timer fires, so the wakeup
+//! cadence collapses to the soonest-due callback (or the next minute boundary
+//! for the minutes list) with no behavior change for the callbacks themselves.
 static TimerID s_timer_id = TIMER_INVALID_ID;
 
 static ListNode s_seconds_callbacks;
 static ListNode s_minutes_callbacks;
 
+//! Tick-time (monotonic, sleep-compensated) of the last processing pass,
+//! kept aligned to whole elapsed seconds so fractional remainders carry over
+//! instead of accumulating drift.
+static RtcTicks s_last_run_ticks;
+
 // Set to 90 seconds because we do eventually drift. Make it in the middle of a minute so we can
 // be sure that it isn't due to drifting.
 #define MISSING_MINUTE_CB_LOG_THRESHOLD_S 90
 static time_t s_last_minute_fire_ts; // uses
-static int s_last_minute_fired = -1; // Track which minute we last fired on
+static time_t s_last_minute_fired = -1; // Epoch-minute (utc / 60) we last fired on
 
-
+static void timer_callback(void* data);
 
 // -------------------------------------------------------------------------------------------
 // Passed to list_find() to determine if a callback is already registered or not
@@ -39,13 +52,72 @@ static bool prv_callback_registered_filter(ListNode *found_node, void *data) {
 }
 
 // -------------------------------------------------------------------------------------------
-static void do_callbacks(ListNode* list) {
+//! Seconds until the next seconds-list callback is due, or UINT32_MAX when
+//! the list is empty. Assumes the callback list mutex is held.
+static uint32_t prv_seconds_list_next_due(void) {
+  uint32_t next = UINT32_MAX;
+
+  for (ListNode* iter = list_get_next(&s_seconds_callbacks); iter != NULL;
+       iter = list_get_next(iter)) {
+    const RegularTimerInfo* reg_timer = (const RegularTimerInfo*) iter;
+    next = MIN(next, MAX(reg_timer->private_count, 1));
+  }
+
+  return next;
+}
+
+// -------------------------------------------------------------------------------------------
+//! (Re-)arm the timer for the next due callback. Assumes the callback list
+//! mutex is held.
+//!
+//! Seconds-list deadlines are armed on the tick-clock grid anchored at
+//! s_last_run_ticks — the same clock elapsed seconds are credited on — so a
+//! fire can never land short of the seconds it is meant to credit. The
+//! minutes list fires on wall-minute changes, so its deadline aims just past
+//! the next wall-minute boundary; the wall and tick clocks are independent
+//! oscillators on some boards, so an early landing is possible there and
+//! costs one extra pass (the re-arm below then aims at the same boundary).
+static void prv_arm_timer(void) {
+  uint64_t delay_ms = UINT64_MAX;
+
+  const uint32_t next_s = prv_seconds_list_next_due();
+  if (next_s != UINT32_MAX) {
+    const RtcTicks now_ticks = rtc_get_ticks();
+    const RtcTicks target_ticks = s_last_run_ticks + (RtcTicks)next_s * RTC_TICKS_HZ;
+    const RtcTicks delta = (target_ticks > now_ticks) ? (target_ticks - now_ticks) : 0;
+    // Round up, +2ms bias: land past the grid point, never before it.
+    delay_ms = (delta * 1000U + RTC_TICKS_HZ - 1) / RTC_TICKS_HZ + 2U;
+  }
+
+  if (list_get_next(&s_minutes_callbacks) != NULL) {
+    time_t seconds;
+    uint16_t milliseconds;
+    rtc_get_time_ms(&seconds, &milliseconds);
+    const uint32_t to_boundary_s =
+        SECONDS_PER_MINUTE - (uint32_t)(seconds % SECONDS_PER_MINUTE);
+    delay_ms = MIN(delay_ms, ((uint64_t)to_boundary_s * 1000U) - milliseconds + 2U);
+  }
+
+  if (delay_ms == UINT64_MAX) {
+    new_timer_stop(s_timer_id);
+    return;
+  }
+
+  new_timer_start(s_timer_id, (uint32_t)MAX(delay_ms, 1U), timer_callback, NULL, 0 /*flags*/);
+}
+
+// -------------------------------------------------------------------------------------------
+//! Run due callbacks on a list after crediting elapsed whole seconds against
+//! multisecond countdowns. For the minutes list, elapsed is always 1: minute
+//! callbacks are credited per detected minute change, exactly as before.
+static void do_callbacks(ListNode* list, uint32_t elapsed) {
   mutex_lock(s_callback_list_semaphore);
 
   for (ListNode* iter = list_get_next(list); iter != 0; ) {
     RegularTimerInfo* reg_timer = (RegularTimerInfo*) iter;
 
-    if (--reg_timer->private_count == 0) {
+    reg_timer->private_count -= MIN(elapsed, reg_timer->private_count);
+    if (reg_timer->private_count == 0) {
       reg_timer->private_count = reg_timer->private_reset_count;
 
       // Release the mutex while we execute the callback
@@ -75,24 +147,31 @@ static void do_callbacks(ListNode* list) {
 
 // -------------------------------------------------------------------------------------------
 static void timer_callback(void* data) {
-  (void) data;
+  // Whole seconds since the last pass, measured on the monotonic tick clock so
+  // wall-clock changes can't stall or double-credit the countdowns. The
+  // fractional remainder stays in s_last_run_ticks for the next pass.
+  const RtcTicks now_ticks = rtc_get_ticks();
+  uint32_t elapsed = (uint32_t)((now_ticks - s_last_run_ticks) / RTC_TICKS_HZ);
+  if (elapsed > 0) {
+    s_last_run_ticks += (RtcTicks)elapsed * RTC_TICKS_HZ;
+    do_callbacks(&s_seconds_callbacks, elapsed);
+  }
 
-  do_callbacks(&s_seconds_callbacks);
+  // Fire minute callbacks when the minute changes (not just when tm_sec == 0).
+  // This prevents missing callbacks when the RTC adjusts. Timezone and DST
+  // offsets are whole minutes, so the UTC epoch-minute boundary is the local
+  // one too.
+  const time_t t = rtc_get_time();
+  const time_t cur_minute = t / SECONDS_PER_MINUTE;
 
-  time_t t = rtc_get_time();
-  struct tm time;
-  localtime_r(&t, &time);
-
-  // Fire minute callbacks when the minute changes (not just when tm_sec == 0)
-  // This prevents missing callbacks when RTC adjusts
   bool should_fire_minute = false;
   if (s_last_minute_fired == -1) {
     // First run - initialize but don't fire
-    s_last_minute_fired = time.tm_min;
-  } else if (s_last_minute_fired != time.tm_min) {
+    s_last_minute_fired = cur_minute;
+  } else if (s_last_minute_fired != cur_minute) {
     // Minute changed - fire callback
     should_fire_minute = true;
-    s_last_minute_fired = time.tm_min;
+    s_last_minute_fired = cur_minute;
   }
 
   if (should_fire_minute) {
@@ -104,18 +183,12 @@ static void timer_callback(void* data) {
     }
     s_last_minute_fire_ts = now_ts;
 
-    do_callbacks(&s_minutes_callbacks);
+    do_callbacks(&s_minutes_callbacks, 1);
   }
-}
 
-// -------------------------------------------------------------------------------------------
-//! Used only once when we first start up. This should be really close to the 0ms point.
-static void timer_callback_initializing(void* data) {
-  // FIXME: FreeRTOS timers are subject to skew if something else is running on the millisecond.
-  // We'll need to continously adjust our timer period in really annoying ways.
-  new_timer_start(s_timer_id, 1000, timer_callback, NULL, TIMER_START_FLAG_REPEATING);
-
-  timer_callback(data);
+  mutex_lock(s_callback_list_semaphore);
+  prv_arm_timer();
+  mutex_unlock(s_callback_list_semaphore);
 }
 
 // --------------------------------------------------------------------------------------------
@@ -124,12 +197,9 @@ void regular_timer_init(void) {
 
   s_callback_list_semaphore = mutex_create();
 
-  time_t seconds;
-  uint16_t milliseconds;
-  rtc_get_time_ms(&seconds, &milliseconds);
+  s_last_run_ticks = rtc_get_ticks();
   s_timer_id = new_timer_create();
-  bool success = new_timer_start(s_timer_id, 1000-milliseconds, timer_callback_initializing, NULL, 0 /*flags*/);
-  PBL_ASSERTN(success);
+  // Armed lazily: the first registered callback arms the timer.
 }
 
 // -------------------------------------------------------------------------------------------
@@ -138,8 +208,20 @@ void regular_timer_add_multisecond_callback(RegularTimerInfo* cb, uint16_t secon
 
   mutex_lock(s_callback_list_semaphore);
 
+  if ((list_get_next(&s_seconds_callbacks) == NULL) &&
+      (list_get_next(&s_minutes_callbacks) == NULL)) {
+    // Timer idle: the anchor is stale and no countdown depends on it.
+    s_last_run_ticks = rtc_get_ticks();
+  }
+
+  // Seconds elapsed since the last crediting pass get credited to every
+  // countdown at the next fire; pad the new countdown so it still waits the
+  // full requested interval.
+  const uint32_t uncredited =
+      (uint32_t)((rtc_get_ticks() - s_last_run_ticks) / RTC_TICKS_HZ);
+
   cb->private_reset_count = seconds;
-  cb->private_count = seconds;
+  cb->private_count = (uint16_t)MIN((uint32_t)seconds + uncredited, UINT16_MAX);
 
   // Only add to the list if not already registered
   if (!list_find(&s_seconds_callbacks, prv_callback_registered_filter, &cb->list_node)) {
@@ -152,6 +234,8 @@ void regular_timer_add_multisecond_callback(RegularTimerInfo* cb, uint16_t secon
     // If it is marked for deletion, remove the deletion flag
     cb->pending_delete = false;
   }
+
+  prv_arm_timer();
 
   mutex_unlock(s_callback_list_semaphore);
 }
@@ -181,6 +265,8 @@ void regular_timer_add_multiminute_callback(RegularTimerInfo* cb, uint16_t minut
     // If it is marked for deletion, remove the deletion flag
     cb->pending_delete = false;
   }
+
+  prv_arm_timer();
 
   mutex_unlock(s_callback_list_semaphore);
 }
@@ -229,6 +315,7 @@ bool regular_timer_remove_callback(RegularTimerInfo* cb) {
     } else {
       list_remove(&cb->list_node, NULL, NULL);
       timer_removed = true;
+      prv_arm_timer();
     }
   }
 
@@ -260,7 +347,7 @@ static void prv_fire_callbacks(ListNode *list, uint16_t mod) {
   }
   mutex_unlock(s_callback_list_semaphore);
 
-  do_callbacks(list);
+  do_callbacks(list, 1);
 }
 
 void regular_timer_fire_seconds(uint8_t secs) {


### PR DESCRIPTION
> ⚡ **Power tweak** — one of a series of idle-wakeup reductions that let the SoC spend more time in deep sleep. Companion PRs: #1658 · #1659 · #1660 · #1661 · #1662 · #1663.

The service woke the system every second even when nothing was due: minute callbacks only need a wakeup at the minute boundary, and multisecond callbacks only at their next deadline. Replace the 1 Hz repeating timer with a one-shot armed for the soonest-due callback.

Elapsed whole seconds are credited against multisecond countdowns at each fire, measured on the monotonic tick clock so wall-clock changes can't stall or double-credit them. Seconds-list deadlines are armed on that same tick-clock grid, anchored at the last crediting pass, so a fire can never land short of the seconds it is meant to credit; on boards where the hardware RTC and the tick clock are independent oscillators (e.g. SF32LB52), arming against wall boundaries instead would drift and cause double-wakes. The minutes list fires on wall-minute changes, so its deadline aims just past the next wall-minute boundary; an early landing there costs one extra pass. New registrations are padded by the elapsed-but-uncredited seconds so they wait their full interval, and the anchor is re-based when the timer was idle.

On an idle watch this removes the perpetual 1 Hz wakeup, leaving the minute boundary as the only recurring deadline.