### PR TITLE
⚡️ tick_timer: broadcast at minute granularity when no second subscribers

### DIFF
--- a/include/pbl/services/tick_timer.h
+++ b/include/pbl/services/tick_timer.h
@@ -5,5 +5,13 @@
 
 #include "kernel/pebble_tasks.h"
 
+#include <stdbool.h>
+
 void tick_timer_add_subscriber(PebbleTask task);
 void tick_timer_remove_subscriber(PebbleTask task);
+
+//! @internal
+//! Report whether \a task needs second-resolution ticks. When no task needs
+//! seconds, the tick event is only broadcast when the minute changes so that
+//! minute-granularity subscribers don't wake the app/worker tasks every second.
+void tick_timer_set_seconds_subscribed(PebbleTask task, bool needs_seconds);

--- a/src/fw/applib/tick_timer_service.c
+++ b/src/fw/applib/tick_timer_service.c
@@ -91,6 +91,13 @@ void tick_timer_service_subscribe(TimeUnits tick_units, TickHandler handler) {
   state->tick_units = tick_units;
   state->first_tick = true;
   event_service_client_subscribe(&state->tick_service_info);
+  // Tell the kernel whether we need second-resolution ticks so it can fall back
+  // to minute-granularity broadcasts (and let this task sleep) when we don't.
+  const bool needs_seconds = (tick_units & SECOND_UNIT) != 0;
+  if (needs_seconds != state->seconds_subscribed) {
+    state->seconds_subscribed = needs_seconds;
+    sys_tick_timer_set_seconds_subscribed(needs_seconds);
+  }
   if (pebble_task_get_current() == PebbleTask_App && sys_app_is_watchface()) {
     PBL_ANALYTICS_SET_UNSIGNED(app_tick_timer_second_subscribed,
                                (tick_units & SECOND_UNIT) ? 1 : 0);
@@ -102,6 +109,10 @@ void tick_timer_service_unsubscribe(void) {
   TickTimerServiceState *state = prv_get_state(PebbleTask_Unknown);
   event_service_client_unsubscribe(&state->tick_service_info);
   state->handler = NULL;
+  if (state->seconds_subscribed) {
+    state->seconds_subscribed = false;
+    sys_tick_timer_set_seconds_subscribed(false);
+  }
   if (pebble_task_get_current() == PebbleTask_App && sys_app_is_watchface()) {
     PBL_ANALYTICS_SET_UNSIGNED(app_tick_timer_second_subscribed, 0);
   }

--- a/src/fw/applib/tick_timer_service_private.h
+++ b/src/fw/applib/tick_timer_service_private.h
@@ -12,6 +12,8 @@ typedef struct __attribute__((packed)) TickTimerServiceState {
   struct tm last_time;
   bool first_tick;
   bool last_is_24h;
+  //! Whether this task has told the kernel it needs second-resolution ticks.
+  bool seconds_subscribed;
 
   EventServiceInfo tick_service_info;
 } TickTimerServiceState;

--- a/src/fw/services/tick_timer/service.c
+++ b/src/fw/services/tick_timer/service.c
@@ -9,18 +9,43 @@
 #include "process_management/app_manager.h"
 #include "system/logging.h"
 #include "system/passert.h"
+#include "util/time/time.h"
 
 PBL_LOG_MODULE_DEFINE(service_tick_timer, CONFIG_SERVICE_TICK_TIMER_LOG_LEVEL);
 
 static uint16_t s_num_subscribers;
 
-static void timer_tick_event_publisher(void* data) {
+// Per-task flag for whether that task needs second-resolution ticks, plus the
+// running count of tasks that do. When nobody needs seconds we only broadcast
+// the tick when the minute changes, so minute-granularity subscribers (the
+// common watchface, the status bar) let the app/worker tasks stay asleep for
+// the rest of the minute. The 1 Hz regular timer still fires (it also feeds the
+// watchdogs), but we skip event_put() on the in-between seconds.
+static bool s_task_needs_seconds[NumPebbleTask];
+static uint16_t s_seconds_subscribers;
+
+//! Epoch seconds of the most recently broadcast tick, used to detect minute
+//! rollover in a way that tolerates regular-timer drift.
+static time_t s_last_published;
+
+static void prv_publish_tick(time_t now) {
+  s_last_published = now;
   PebbleEvent e = {
     .type = PEBBLE_TICK_EVENT,
-    .clock_tick.tick_time = rtc_get_time(),
+    .clock_tick.tick_time = now,
   };
-
   event_put(&e);
+}
+
+static void timer_tick_event_publisher(void* data) {
+  const time_t now = rtc_get_time();
+  if (s_seconds_subscribers == 0 &&
+      (now / SECONDS_PER_MINUTE) == (s_last_published / SECONDS_PER_MINUTE)) {
+    // No second-resolution subscribers and still within the same minute as the
+    // last tick: nothing for minute-granularity subscribers to do.
+    return;
+  }
+  prv_publish_tick(now);
 }
 
 static RegularTimerInfo s_tick_timer_info = {
@@ -33,13 +58,32 @@ void tick_timer_add_subscriber(PebbleTask task) {
     PBL_LOG_DBG("starting tick timer");
     regular_timer_add_seconds_callback(&s_tick_timer_info);
   }
+  // Give the new subscriber a prompt baseline tick instead of making it wait up
+  // to a full minute for the next boundary.
+  prv_publish_tick(rtc_get_time());
 }
 
 void tick_timer_remove_subscriber(PebbleTask task) {
   PBL_ASSERTN(s_num_subscribers > 0);
+  // Drop any second-resolution request this task still held.
+  tick_timer_set_seconds_subscribed(task, false);
   --s_num_subscribers;
   if (s_num_subscribers == 0) {
     PBL_LOG_DBG("stopping tick timer");
     regular_timer_remove_callback(&s_tick_timer_info);
+  }
+}
+
+void tick_timer_set_seconds_subscribed(PebbleTask task, bool needs_seconds) {
+  PBL_ASSERTN(task < NumPebbleTask);
+  if (s_task_needs_seconds[task] == needs_seconds) {
+    return;
+  }
+  s_task_needs_seconds[task] = needs_seconds;
+  if (needs_seconds) {
+    ++s_seconds_subscribers;
+  } else {
+    PBL_ASSERTN(s_seconds_subscribers > 0);
+    --s_seconds_subscribers;
   }
 }

--- a/src/fw/syscall/services_syscalls.c
+++ b/src/fw/syscall/services_syscalls.c
@@ -3,7 +3,9 @@
 
 #include "syscall/syscall_internal.h"
 
+#include "kernel/pebble_tasks.h"
 #include "pbl/services/alarms/alarm.h"
+#include "pbl/services/tick_timer.h"
 
 DEFINE_SYSCALL(bool, sys_alarm_get_next_enabled, time_t *timestamp_out) {
   if (PRIVILEGE_WAS_ELEVATED) {
@@ -18,4 +20,8 @@ DEFINE_SYSCALL(bool, sys_hrm_manager_is_hrm_present) {
 #else
   return false;
 #endif
+}
+
+DEFINE_SYSCALL(void, sys_tick_timer_set_seconds_subscribed, bool needs_seconds) {
+  tick_timer_set_seconds_subscribed(pebble_task_get_current(), needs_seconds);
 }

--- a/src/fw/syscall/syscall.h
+++ b/src/fw/syscall/syscall.h
@@ -48,6 +48,9 @@ struct tm* sys_localtime_r(const time_t *timep, struct tm *result);
 void sys_copy_timezone_abbr(char* timezone_abbr, time_t time);
 time_t sys_time_start_of_today(void);
 
+//! Report whether the calling task needs second-resolution clock ticks.
+void sys_tick_timer_set_seconds_subscribed(bool needs_seconds);
+
 
 void sys_evented_timer_consume(TimerID timer_id, EventedTimerCallback* out_cb, void** out_cb_data);
 


### PR DESCRIPTION
> ⚡ **Power tweak** — one of a series of idle-wakeup reductions that let the SoC spend more time in deep sleep. Companion PRs: #1658 · #1659 · #1660 · #1661 · #1662 · #1663.

The kernel tick publisher posted PEBBLE_TICK_EVENT every second whenever anything subscribed, waking the app/worker tasks 60 times a minute even when the only subscribers (a typical watchface, the status bar) just want minute updates. The 1 Hz regular timer wake itself is unavoidable since it also feeds the watchdogs, but the event broadcast that wakes the other tasks is not.

Track, per task, whether a subscriber needs second resolution. When none do, only broadcast the tick when the minute actually changes (drift tolerant), so the app/worker tasks can stay asleep the rest of the minute and the SoC spends more time in deep sleep. Second-resolution watchfaces (stopwatch, seconds display) report their need through a new syscall and keep getting per-second ticks. A prompt baseline tick is published when a subscriber is added so initial draw is not delayed to the next minute.