### PR TITLE
ci: upload all failed test images, not just diff PNGs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,8 +76,9 @@ jobs:
         uses: actions/upload-artifact@v6
         if: (!cancelled())
         with:
-          name: failed_diff_images
-          path: build/test/tests/failed/*-diff.png
+          name: failed_test_images
+          path: build/test/tests/failed/
+          if-no-files-found: ignore
 
   test-status:
     needs: [changes-test, build-test]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           report_paths: build/test/junit.xml
           annotate_only: true
+          detailed_summary: true
 
       - name: Store failed test images
         uses: actions/upload-artifact@v6

--- a/tools/waf/pebble_test.py
+++ b/tools/waf/pebble_test.py
@@ -144,7 +144,7 @@ def summary(bld):
         def strip_non_ascii(s):
             return "".join(i for i in str(s) if ord(i) < 128)
 
-        test_case = junit_xml.TestCase("all")
+        test_case = junit_xml.TestCase(node.parent.name)
         if code:
             # Include stdout and stderr if test failed:
             test_case.stdout = strip_non_ascii(stdout.decode("utf-8"))


### PR DESCRIPTION
## Summary

The **Store failed test images** step in `test.yml` globbed only `build/test/tests/failed/*-diff.png`. Diff images are generated for `GBitmapFormat8Bit` bitmaps only, so gabbro render-test failures emit just `-actual`/`-expected` images and the glob matched nothing:

> No files were found with the provided path: build/test/tests/failed/*-diff.png. No artifacts will be uploaded.

(seen in [run 28726905020](https://github.com/coredevices/PebbleOS/actions/runs/28726905020?pr=1666), where `test_workout_summary__*` / `test_workout_dialog__*` failed on gabbro).

## Change

Upload the whole `build/test/tests/failed/` directory so `-actual`/`-expected` (and `-diff`, when present) images are captured for visual review. Added `if-no-files-found: ignore` so passing runs (empty dir) don't emit a warning. Artifact renamed `failed_diff_images` → `failed_test_images` to reflect the broader contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)