### PR TITLE
alarms: preview sounds on highlight

### DIFF
--- a/src/fw/applib/applib_malloc.json
+++ b/src/fw/applib/applib_malloc.json
@@ -64,7 +64,7 @@
         "_comment": "Only for 3.x apps"
     }, {
         "name": "ActionMenuLevel",
-        "size_3x_padding": 12,
+        "size_3x_padding": 8,
         "size_3x": 32,
         "_comment": "Only for 3.x apps"
     }, {
@@ -74,7 +74,7 @@
         "_comment": "Only for 3.x apps"
     }, {
         "name": "ActionMenuData",
-        "size_3x_padding": 90,
+        "size_3x_padding": 86,
         "size_3x": 930,
         "dependencies": ["Window", "MenuLayer", "Layer", "Layer"],
         "_comment": "Only for 3.x apps"
@@ -287,4 +287,3 @@
         "_comment": "Not exported yet (only 3.x)"
     }]
 }
-

--- a/src/fw/applib/ui/action_menu_layer.c
+++ b/src/fw/applib/ui/action_menu_layer.c
@@ -474,10 +474,18 @@ static int prv_get_menu_layer_row(ActionMenuLayer *aml, int item_index) {
   }
 }
 
+static void prv_selection_changed(ActionMenuLayer *aml) {
+  const ActionMenuItem *item = prv_get_item_for_index(aml, aml->selected_index);
+  if (item && aml->callbacks.selection_changed) {
+    aml->callbacks.selection_changed(item, aml->context);
+  }
+}
+
 T_STATIC void prv_set_selected_index(ActionMenuLayer *aml, int new_selected_index, bool animated) {
   new_selected_index = CLIP(new_selected_index, 0, aml->num_items + aml->num_short_items - 1);
+  const bool selection_changed = (new_selected_index != aml->selected_index);
 
-  if (new_selected_index != aml->selected_index) {
+  if (selection_changed) {
     // Unschedule any running item animation but don't NULL the pointer, to prevent another
     // animation from being accidentally re-scheduled.
     animation_unschedule(aml->item_animation.animation);
@@ -493,6 +501,9 @@ T_STATIC void prv_set_selected_index(ActionMenuLayer *aml, int new_selected_inde
   const int menu_layer_index = prv_get_menu_layer_row(aml, new_selected_index);
   menu_layer_set_selected_index(&aml->menu_layer, MenuIndex(0, menu_layer_index),
                                 MenuRowAlignCenter, animated);
+  if (selection_changed && new_selected_index >= aml->num_items) {
+    prv_selection_changed(aml);
+  }
 }
 
 static void prv_scroll_handler(ClickRecognizerRef recognizer, void *context) {
@@ -505,8 +516,8 @@ static void prv_scroll_handler(ClickRecognizerRef recognizer, void *context) {
 static void prv_select_handler(ClickRecognizerRef recognizer, void *context) {
   ActionMenuLayer *aml = context;
   const ActionMenuItem *item = prv_get_item_for_index(aml, aml->selected_index);
-  if (item && aml->cb) {
-    aml->cb(item, aml->context);
+  if (item && aml->callbacks.select) {
+    aml->callbacks.select(item, aml->context);
   }
 }
 
@@ -646,6 +657,7 @@ static void prv_selection_changed_cb(struct MenuLayer *menu_layer, MenuIndex new
     // Enable a new item animation to be scheduled
     prv_unschedule_item_animation(aml);
     aml->selected_index = new_index.row;
+    prv_selection_changed(aml);
   }
 }
 
@@ -739,8 +751,21 @@ void action_menu_layer_click_config_provider(ActionMenuLayer *aml) {
 void action_menu_layer_set_callback(ActionMenuLayer *aml,
                                     ActionMenuLayerCallback cb,
                                     void *context) {
-  aml->cb = cb;
+  aml->callbacks = (ActionMenuLayerCallbacks) {
+    .select = cb,
+  };
   aml->context = context;
+}
+
+void action_menu_layer_set_callbacks(ActionMenuLayer *aml,
+                                     ActionMenuLayerCallbacks callbacks,
+                                     void *context) {
+  aml->callbacks = callbacks;
+  aml->context = context;
+}
+
+void action_menu_layer_notify_selection_changed(ActionMenuLayer *aml) {
+  prv_selection_changed(aml);
 }
 
 void action_menu_layer_init(ActionMenuLayer *aml, const GRect *frame) {
@@ -752,6 +777,7 @@ void action_menu_layer_init(ActionMenuLayer *aml, const GRect *frame) {
   aml->layout_cache = (ActionMenuLayoutCache){
     .font = prv_get_item_font()
   };
+  aml->callbacks = (ActionMenuLayerCallbacks){};
   aml->layer.property_changed_proc = prv_changed_proc;
   aml->layer.update_proc = prv_update_proc;
 

--- a/src/fw/applib/ui/action_menu_layer.h
+++ b/src/fw/applib/ui/action_menu_layer.h
@@ -20,6 +20,11 @@
 typedef void (*ActionMenuLayerCallback)(const ActionMenuItem *item, void *context);
 
 typedef struct {
+  ActionMenuLayerCallback select;
+  ActionMenuLayerCallback selection_changed;
+} ActionMenuLayerCallbacks;
+
+typedef struct {
   ActionMenuAlign align;
   GFont font;
   int16_t *item_heights;
@@ -41,7 +46,7 @@ typedef struct {
   MenuLayer menu_layer;
   int selected_index;
   unsigned separator_index;
-  ActionMenuLayerCallback cb;
+  ActionMenuLayerCallbacks callbacks;
 
   const ActionMenuItem* items;
   int num_items;
@@ -61,6 +66,12 @@ ActionMenuLayer *action_menu_layer_create(GRect frame);
 void action_menu_layer_set_callback(ActionMenuLayer *aml,
                                     ActionMenuLayerCallback cb,
                                     void *context);
+
+void action_menu_layer_set_callbacks(ActionMenuLayer *aml,
+                                     ActionMenuLayerCallbacks callbacks,
+                                     void *context);
+
+void action_menu_layer_notify_selection_changed(ActionMenuLayer *aml);
 
 void action_menu_layer_set_align(ActionMenuLayer *aml,
                                  ActionMenuAlign align);

--- a/src/fw/applib/ui/action_menu_window.c
+++ b/src/fw/applib/ui/action_menu_window.c
@@ -52,11 +52,30 @@ static void prv_remove_window(Window *window) {
   window_stack_remove(window, false /* animated */);
 }
 
+static void prv_action_callback(const ActionMenuItem *item, void *context);
+static void prv_action_menu_layer_selection_changed(const ActionMenuItem *item, void *context);
+
+static void prv_invoke_level_selection_changed(ActionMenuData *data, const ActionMenuItem *item) {
+  const ActionMenuLevel *cur_level = data->view_model.cur_level;
+  if (cur_level->selection_changed) {
+    cur_level->selection_changed(item, data->config.context);
+  }
+}
+
+static void prv_set_action_menu_layer_callbacks(ActionMenuData *data,
+                                                bool enable_selection_changed) {
+  action_menu_layer_set_callbacks(&data->action_menu_layer, (ActionMenuLayerCallbacks) {
+    .select = prv_action_callback,
+    .selection_changed = enable_selection_changed ? prv_action_menu_layer_selection_changed : NULL,
+  }, data);
+}
+
 static void prv_view_model_did_change(ActionMenuData *data) {
   ActionMenuViewModel *vm = &data->view_model;
   const ActionMenuLevel *cur_level = vm->cur_level;
   GRect frame = grect_inset(data->action_menu.window.layer.frame, vm->menu_insets);
   layer_set_frame(&data->action_menu_layer.layer, &frame);
+  prv_set_action_menu_layer_callbacks(data, false);
   if (cur_level->display_mode == ActionMenuLevelDisplayModeThin) {
     action_menu_layer_set_items(&data->action_menu_layer, NULL, 0, 0, 0);
     action_menu_layer_set_short_items(&data->action_menu_layer,
@@ -68,6 +87,8 @@ static void prv_view_model_did_change(ActionMenuData *data) {
     action_menu_layer_set_items(&data->action_menu_layer, cur_level->items, cur_level->num_items,
         cur_level->default_selected_item, cur_level->separator_index);
   }
+  prv_set_action_menu_layer_callbacks(data, true);
+  action_menu_layer_notify_selection_changed(&data->action_menu_layer);
   crumbs_layer_set_level(&data->crumbs_layer, vm->num_dots);
 }
 
@@ -157,6 +178,8 @@ static void prv_set_level(ActionMenuData *data, const ActionMenuLevel *level) {
     return;
   }
 
+  prv_invoke_level_selection_changed(data, NULL);
+
   Animation *content_out = prv_create_content_out_animation(data, level);
   Animation *content_in = prv_create_content_in_animation(data, level);
 
@@ -165,8 +188,8 @@ static void prv_set_level(ActionMenuData *data, const ActionMenuLevel *level) {
 }
 
 static void prv_action_callback(const ActionMenuItem *item, void *context) {
-  ActionMenu *action_menu = context;
-  ActionMenuData *data = window_get_user_data(&action_menu->window);
+  ActionMenuData *data = context;
+  ActionMenu *action_menu = &data->action_menu;
   if (item->is_leaf && item->perform_action) {
     item->perform_action(action_menu, item, data->config.context);
     data->performed_item = item;
@@ -176,6 +199,10 @@ static void prv_action_callback(const ActionMenuItem *item, void *context) {
   } else if (item->next_level) {
     prv_set_level(data, item->next_level);
   }
+}
+
+static void prv_action_menu_layer_selection_changed(const ActionMenuItem *item, void *context) {
+  prv_invoke_level_selection_changed((ActionMenuData *)context, item);
 }
 
 static void prv_back_click_handler(ClickRecognizerRef recognizer, void *context) {
@@ -206,7 +233,7 @@ static void prv_action_window_load(Window *window) {
   // Init action menu layer
   ActionMenuLayer *action_menu_layer = &data->action_menu_layer;
   action_menu_layer_init(action_menu_layer, &GRectZero);
-  action_menu_layer_set_callback(action_menu_layer, prv_action_callback, (void *)window);
+  prv_set_action_menu_layer_callbacks(data, true);
   action_menu_layer_set_align(action_menu_layer, data->config.align);
   // Init crumbs layer
   CrumbsLayer *crumbs_layer = &data->crumbs_layer;

--- a/src/fw/applib/ui/action_menu_window_private.h
+++ b/src/fw/applib/ui/action_menu_window_private.h
@@ -64,5 +64,6 @@ struct ActionMenuLevel {
   // Double check with design before using this for another purpose.
   unsigned separator_index;
   ActionMenuLevelDisplayMode display_mode;
+  ActionMenuLayerCallback selection_changed;
   ActionMenuItem items[];
 };

--- a/src/fw/apps/system/alarms/alarm_detail.c
+++ b/src/fw/apps/system/alarms/alarm_detail.c
@@ -17,7 +17,9 @@
 #include "system/logging.h"
 
 #ifdef CONFIG_SPEAKER
+#include "popups/alarm_popup.h"
 #include "services/alarms/alarm_tones.h"
+#include "pbl/services/speaker/speaker_service.h"
 #endif
 
 #include <stdio.h>
@@ -157,6 +159,32 @@ static void prv_select_tone_handler(ActionMenu *action_menu, const ActionMenuIte
     data->alarm_editor_callback(EDITED, data->alarm_id, data->callback_context);
   }
 }
+
+static void prv_stop_sound_preview(void) {
+  speaker_service_stop_for_task(PebbleTask_App);
+}
+
+static void prv_sound_highlight_handler(const ActionMenuItem *item, void *context) {
+  (void)context;
+
+  if (!item || !item->is_leaf || item->perform_action != prv_select_tone_handler) {
+    prv_stop_sound_preview();
+    return;
+  }
+
+  const SpeakerNote *notes = NULL;
+  uint32_t count = 0;
+  alarm_tones_get((AlarmTone)(uintptr_t)item->action_data, &notes, &count);
+  if (!notes || count == 0) {
+    prv_stop_sound_preview();
+    return;
+  }
+
+  prv_stop_sound_preview();
+  speaker_service_set_owner_task(PebbleTask_App);
+  speaker_service_play_note_seq(notes, count, SpeakerPriorityApp,
+                                ALARM_SPEAKER_VOLUME);
+}
 #endif
 
 static ActionMenuLevel *prv_create_main_menu(void) {
@@ -192,10 +220,23 @@ static ActionMenuLevel *prv_create_sound_menu(ActionMenuLevel *parent_level) {
     .num_items = NUM_SOUND_MENU_ITEMS,
     .parent_level = parent_level,
     .display_mode = ActionMenuLevelDisplayModeWide,
+    .selection_changed = prv_sound_highlight_handler,
   };
   return level;
 }
 #endif
+
+static void prv_alarm_detail_menu_will_close(ActionMenu *action_menu,
+                                             const ActionMenuItem *item,
+                                             void *context) {
+  (void)action_menu;
+  (void)item;
+  (void)context;
+
+#ifdef CONFIG_SPEAKER
+  prv_stop_sound_preview();
+#endif
+}
 
 void prv_cleanup_alarm_detail_menu(ActionMenu *action_menu,
                                    const ActionMenuItem *item,
@@ -224,6 +265,7 @@ void alarm_detail_window_push(AlarmId alarm_id, AlarmInfo *alarm_info,
     .menu_config = {
       .context = data,
       .colors.background = ALARMS_APP_HIGHLIGHT_COLOR,
+      .will_close = prv_alarm_detail_menu_will_close,
       .did_close = prv_cleanup_alarm_detail_menu,
     },
   };

--- a/src/fw/popups/alarm_popup.c
+++ b/src/fw/popups/alarm_popup.c
@@ -129,10 +129,6 @@ static void prv_stop_vibes(void) {
 }
 
 #ifdef CONFIG_SPEAKER
-// Volume 60/100 is a moderate first cut; tunable, and a per-user volume
-// preference can be added in a follow-up.
-#define ALARM_SPEAKER_VOLUME 60
-
 static void prv_play_sound_loop_iteration(void) {
   speaker_service_play_note_seq(s_alarm_popup_data->sound_notes,
                                 s_alarm_popup_data->sound_count,

--- a/src/fw/popups/alarm_popup.h
+++ b/src/fw/popups/alarm_popup.h
@@ -5,4 +5,10 @@
 
 #include "kernel/events.h"
 
+#ifdef CONFIG_SPEAKER
+// Volume 60/100 is a moderate first cut; tunable, and a per-user volume
+// preference can be added in a follow-up.
+#define ALARM_SPEAKER_VOLUME 60
+#endif
+
 void alarm_popup_push_window(PebbleAlarmClockEvent* e);


### PR DESCRIPTION
Currently, there is no way to preview alarm sounds without actually setting an alarm and waiting for it to trigger.

This PR adds sound previews to the alarm sound picker. When the user opens the picker and moves between alarm tones, the currently highlighted tone plays as a preview.

Tested on PT2.