### PR TITLE
build: encode boot priority in pblboot firmware header

### DIFF
--- a/tools/waf/pblboot.py
+++ b/tools/waf/pblboot.py
@@ -4,6 +4,7 @@
 
 import argparse
 import datetime
+import re
 import struct
 import zlib
 
@@ -12,8 +13,45 @@ from intelhex import IntelHex
 
 MAGIC = 0x96F3B83D
 
+# Boot priority bands (bits 63..56 of the header priority field, formerly a
+# plain build timestamp). The bootloader boots the valid slot with the highest
+# 64-bit value, so bands order as: dev > release > legacy timestamp.
+# 0x02-0x7f and 0x81-0xff are reserved for future schemes/overrides.
+PRIORITY_BAND_RELEASE = 0x01
+PRIORITY_BAND_DEV = 0x80
 
-def _insert_header_hex(fin, fout, offset):
+_RELEASE_TAG_RE = re.compile(r"^v(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-(?:beta|rc)\d+)?$")
+
+
+def boot_priority(tag=None, commit_timestamp=None):
+    """Compute the boot priority stamped into the pblboot header.
+
+    Exact release tags (vX[.Y[.Z]], optionally -betaN/-rcN) encode the version
+    in the high bits with the commit timestamp as tie-break, so the bootloader
+    always picks the highest version regardless of build order. Anything else
+    is a dev build: a higher band with the build wall-clock time, so the most
+    recently built dev image always boots.
+    """
+    m = _RELEASE_TAG_RE.match(tag) if tag else None
+    if m:
+        major, minor, patch = (int(x) if x else 0 for x in m.groups())
+        if max(major, minor, patch) > 0xFF:
+            raise ValueError(f"version components must fit in 8 bits: {tag}")
+        if commit_timestamp is None:
+            raise ValueError(f"commit timestamp required for release tag: {tag}")
+        return (
+            (PRIORITY_BAND_RELEASE << 56)
+            | (major << 48)
+            | (minor << 40)
+            | (patch << 32)
+            | (commit_timestamp & 0xFFFFFFFF)
+        )
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return (PRIORITY_BAND_DEV << 56) | (int(now.timestamp()) & 0xFFFFFFFF)
+
+
+def _insert_header_hex(fin, fout, offset, priority):
     # Load the hex file
     ih = IntelHex(fin)
 
@@ -23,10 +61,8 @@ def _insert_header_hex(fin, fout, offset):
 
     # Prepare the header
     crc = zlib.crc32(content)
-    now = datetime.datetime.now(datetime.timezone.utc)
-    timestamp = int(now.timestamp())
 
-    fwdesc = struct.pack("<LLQLLL", MAGIC, 28, timestamp, offset, len(content), crc)
+    fwdesc = struct.pack("<LLQLLL", MAGIC, 28, priority, offset, len(content), crc)
 
     # Create new IntelHex object for output
     out_ih = IntelHex()
@@ -49,17 +85,15 @@ def _insert_header_hex(fin, fout, offset):
     out_ih.write_hex_file(fout)
 
 
-def _insert_header_bin(fin, fout, offset):
+def _insert_header_bin(fin, fout, offset, priority):
     # Read the input binary file
     with open(fin, "rb") as f:
         content = f.read()
 
     # Prepare the header
     crc = zlib.crc32(content)
-    now = datetime.datetime.now(datetime.timezone.utc)
-    timestamp = int(now.timestamp())
 
-    fwdesc = struct.pack("<LLQLLL", MAGIC, 28, timestamp, offset, len(content), crc)
+    fwdesc = struct.pack("<LLQLLL", MAGIC, 28, priority, offset, len(content), crc)
 
     # Write output binary file
     with open(fout, "wb") as f:
@@ -68,19 +102,29 @@ def _insert_header_bin(fin, fout, offset):
         f.write(content)
 
 
+def _env_priority(bld):
+    if bld.env.PBLBOOT_PRIORITY:
+        return int(bld.env.PBLBOOT_PRIORITY)
+    return boot_priority()
+
+
 def insert_header_hex(task):
+    bld = task.generator.bld
     _insert_header_hex(
         task.inputs[0].abspath(),
         task.outputs[0].abspath(),
-        task.generator.bld.env.FIRMWARE_OFFSET,
+        bld.env.FIRMWARE_OFFSET,
+        _env_priority(bld),
     )
 
 
 def insert_header_bin(task):
+    bld = task.generator.bld
     _insert_header_bin(
         task.inputs[0].abspath(),
         task.outputs[0].abspath(),
-        task.generator.bld.env.FIRMWARE_OFFSET,
+        bld.env.FIRMWARE_OFFSET,
+        _env_priority(bld),
     )
 
 
@@ -93,9 +137,17 @@ if __name__ == "__main__":
     parser.add_argument(
         "--offset", type=int, default=512, help="Offset to apply to input file"
     )
+    parser.add_argument("--tag", help="Git tag (exact release tags encode the version)")
+    parser.add_argument(
+        "--commit-timestamp",
+        type=int,
+        help="Commit timestamp (required with a release --tag)",
+    )
     args = parser.parse_args()
 
+    priority = boot_priority(args.tag, args.commit_timestamp)
+
     if args.input.endswith(".bin"):
-        _insert_header_bin(args.input, args.output, args.offset)
+        _insert_header_bin(args.input, args.output, args.offset, priority)
     else:
-        _insert_header_hex(args.input, args.output, args.offset)
+        _insert_header_hex(args.input, args.output, args.offset, priority)

--- a/wscript
+++ b/wscript
@@ -583,6 +583,9 @@ def _link_firmware(bld, sources):
     x.env.append_value('LINKFLAGS', fw_linkflags)
 
     if bld.env.CONFIG_PBLBOOT:
+        git_revision = tools.waf.gitinfo.get_git_revision(bld)
+        bld.env.PBLBOOT_PRIORITY = str(tools.waf.pblboot.boot_priority(
+            git_revision['TAG'], int(git_revision['TIMESTAMP'])))
         nohdr_hex_node = elf_node.change_ext('.nohdr.hex')
         bld(rule=tools.waf.objcopy.objcopy_hex, source=elf_node, target=nohdr_hex_node)
         hex_node = elf_node.change_ext('.hex')


### PR DESCRIPTION
## Problem

The pblboot bootloader picks between the two firmware slots by an unsigned 64-bit compare of the header `timestamp` field, stamped with the build wall-clock time. Now that releases are cut from branches, a maintenance release (e.g. v4.19.2) can be built *after* a newer version (e.g. v4.22.0) — so when the newer version is promoted and installed into the other slot, the bootloader keeps booting the old one.

## Solution

Since the bootloader in the field cannot change, reinterpret the field as a banded **boot priority**, selected by the top byte:

| Band | Bits 63–56 | Bits 55–32 | Bits 31–0 |
|---|---|---|---|
| Legacy (already shipped) | `0x00` | 0 | build unix timestamp |
| Release | `0x01` | major / minor / patch (8 bits each) | tag commit timestamp |
| Dev | `0x80` | 0 | build wall-clock time |

- **Release** builds (exact `vX[.Y[.Z]]` tag, optionally `-betaN`/`-rcN`): a higher version always wins regardless of build order; the tag commit timestamp breaks ties within a version (beta → final promotion) and makes rebuilds of the same tag reproducible.
- **Dev** builds (anything else, including dirty trees): outrank all releases, so a freshly flashed dev image always boots with no slot invalidation required by any flash tool; among dev builds the most recently *built* one wins (wall clock, so bisecting old commits works).
- Any new-scheme value is above every legacy timestamp (< 2^32), so the first release using this scheme upgrades cleanly over the whole field.
- `0x02`–`0x7f` / `0x81`–`0xff` are reserved for future encodings and emergency overrides.

The standalone `pblboot.py` CLI gains `--tag` / `--commit-timestamp` for stamping release headers outside waf.

## Known limitations (accepted by design)

- A device running a dev image will not boot an OTA-installed release until the dev slot is invalidated (PRF entry — which already invalidates both slots — or a flash erase).
- Deliberate OTA downgrades between releases won't boot; rollback means cutting a new patch release from the old branch. After cutover, legacy-stamped artifacts must not be shipped again.

## Testing

- Ordering assertions: branch releases order by version regardless of build date; final beats beta of the same version; every new-scheme value beats legacy timestamps; dev band beats release band.
- CLI exercised end-to-end for both bands on a binary; emitted header parsed back and verified (magic, priority, offset, length, CRC, padding).
- waf rule invocation simulated with real gitinfo: current dev HEAD stamps into the dev band; missing-env fallback also yields the dev band.

Fixes FIRM-3259

🤖 Generated with [Claude Code](https://claude.com/claude-code)