### PR TITLE
fw/comm/ble: fix two BLE log bugs

### DIFF
--- a/src/fw/comm/ble/gap_le_connection.h
+++ b/src/fw/comm/ble/gap_le_connection.h
@@ -119,6 +119,9 @@ typedef struct GAPLEConnection {
   //! Opaque, used by gatt_client_discovery.c
   DiscoveryJobQueue *discovery_jobs;
 
+  //! Tick at which the current discovery job started, used by gatt_client_discovery.c
+  RtcTicks gatt_discovery_start_ticks;
+
   //! @see gap_le_connect_params.c
   struct {
     TimerID watchdog_timer;

--- a/src/fw/comm/ble/gatt_client_discovery.c
+++ b/src/fw/comm/ble/gatt_client_discovery.c
@@ -112,6 +112,10 @@ static BTErrno prv_run_next_job(GAPLEConnection *connection) {
   bt_lock();
 
   if (rv == BTErrnoOK) {
+    if (!connection->gatt_is_service_discovery_in_progress) {
+      // Fresh job (not a transparent watchdog retry), record the start time
+      connection->gatt_discovery_start_ticks = rtc_get_ticks();
+    }
     // if we are back here because a timeout occurred, let the
     // driver handle resetting the watchdog timer (cc2564x issue)
     connection->gatt_is_service_discovery_in_progress = true;
@@ -408,7 +412,7 @@ bool bt_driver_cb_gatt_client_discovery_complete(GAPLEConnection *connection, BT
 
     if (errno == BTErrnoOK) {
       const uint32_t discovery_ms =
-          (rtc_get_ticks() - connection->ticks_since_connection) * 1000 / RTC_TICKS_HZ;
+          (rtc_get_ticks() - connection->gatt_discovery_start_ticks) * 1000 / RTC_TICKS_HZ;
       PBL_LOG_INFO("GATT service discovery completed in %"PRIu32"ms", discovery_ms);
       // Completion of service discovery implies we are about to have more BLE
       // traffic (for example, ANCS notifications, PPoG communication). Keep the

--- a/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
+++ b/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
@@ -807,7 +807,8 @@ static void prv_handle_meta_read(PPoGATTClient *client, const uint8_t *value,
     // GATT read failed - this is retriable since the mobile app may not be ready yet
     goto handle_retriable_error;
   }
-  PBL_LOG_INFO("PPoGATT meta read success after %"PRIu32"ms, len=%zu", elapsed_ms, value_length);
+  PBL_LOG_INFO("PPoGATT meta read success after %"PRIu32"ms, len=%u", elapsed_ms,
+               (unsigned int)value_length);
   if (value_length < sizeof(PPoGATTMetaV0)) {
     goto handle_error;
   }


### PR DESCRIPTION
Two log fixes found while debugging an iOS connect/disconnect loop against a PRF build:

- **ppogatt: avoid `%zu` in meta read log** — the log dehasher cannot render the `%z` length modifier, so the "PPoGATT meta read success" line was lost from every capture (`ERROR: unsupported format character 'z'`). Use `%u` with a cast.
- **log per-job GATT discovery duration** — the discovery completion log measured time since the connection was established rather than since the discovery job started, so rediscoveries triggered by Service Changed indications reported absurd cumulative times (a ~90 ms rediscovery logged as `40567ms`). Record the start tick when a job is kicked off (preserved across transparent watchdog retries) and measure against that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)