### PR TITLE
fw/comm/ble: fix silent GATT state wipe on failed range discovery

### DIFF
--- a/src/bluetooth-fw/nimble/gatt_client_discovery.c
+++ b/src/bluetooth-fw/nimble/gatt_client_discovery.c
@@ -448,7 +448,7 @@ static int prv_find_chr_cb(uint16_t conn_handle, const struct ble_gatt_error *er
       break;
 
     default:
-      PBL_LOG_DBG("Characteristic discovery error: %d",
+      PBL_LOG_ERR("Characteristic discovery error: %d",
                 error->status);
       if (error->status == BLE_HS_ETIMEOUT) {
         errno = BTErrnoServiceDiscoveryTimeout;

--- a/src/fw/comm/ble/gatt_client_discovery.c
+++ b/src/fw/comm/ble/gatt_client_discovery.c
@@ -350,9 +350,22 @@ void gatt_client_cleanup_discovery_jobs(GAPLEConnection *connection) {
 
 static void prv_finalize_discovery(GAPLEConnection *connection, BTErrno errno) {
   if (errno != BTErrnoOK) {
-    // Handle failure -- cleanup and dispatch event:
-    prv_free_service_nodes(connection);
-    gatt_client_subscriptions_cleanup_by_connection(connection, false /* should_unsubscribe */);
+    const DiscoveryJobQueue *job = connection->discovery_jobs;
+    const bool is_range_job =
+        (job && ((job->hdl.start != MIN_ATT_HANDLE) || (job->hdl.end != MAX_ATT_HANDLE)));
+    if (errno != BTErrnoServiceDiscoveryDatabaseChanged) {
+      PBL_LOG_ERR("GATT service discovery failed: errno=%d, range=0x%x-0x%x", errno,
+              job ? job->hdl.start : 0, job ? job->hdl.end : 0);
+    }
+    if (!is_range_job || (errno == BTErrnoServiceDiscoveryDatabaseChanged)) {
+      // Handle failure -- cleanup and dispatch event:
+      prv_free_service_nodes(connection);
+      gatt_client_subscriptions_cleanup_by_connection(connection, false /* should_unsubscribe */);
+    }
+    // A failed range job must leave services and subscriptions from earlier
+    // discoveries intact: the stale service for the range was already removed
+    // when the job was queued, so there is nothing to clean up and wiping
+    // connection-wide state would leave clients with dangling references.
   }
 
   prv_remove_current_discovery_job(connection);


### PR DESCRIPTION
Root-cause fix for an iOS connect/disconnect loop seen with mobile app 1.0.6.3 against a PRF build (follow-up to #1679, whose log fixes exposed this).

## Failure chain

The mobile app republishing its PPoGATT GATT service triggers Service Changed indications, so range rediscoveries run concurrently with PPoGATT handshake GATT traffic. One of those range jobs (0x40–0x42) fails — invisibly, because the NimBLE driver's characteristic-discovery error path logged at DBG. `prv_finalize_discovery()` then treated the failed 3-handle range scan as catastrophic:

1. Freed **all** discovered services on the connection, including the PPoGATT service the watch had just handshaken on.
2. Silently dropped **all** GATT subscription records, including the just-created PPoGATT Data subscription.
3. Emitted a ServicesAdded event with error status, which `kernel_le_client` ignores — so PPoGATT/ANCS/AMS were never told their characteristic references had become dangling.

Result: the session stayed "open" locally while every inbound notification was dropped (`No subscription found for ATT handle 61`), the responsiveness request failed (`GAP Handle not properly intialized`), and the phone disconnected ~20 s later (reason 0x213, remote user terminated). Repeat on every reconnect.

## Fix

- **bluetooth-fw/nimble**: log characteristic discovery errors at ERR, consistent with the service/descriptor paths.
- **fw/comm/ble**: only wipe connection-wide services/subscriptions for failed *full-range* discoveries and the intentional rediscover-all path (`DatabaseChanged`). A failed range job leaves state from earlier discoveries intact — the stale service for that range was already removed when the job was queued (see `gatt_service_changed_client_handle_indication`), so there is nothing to clean up. Failed jobs are now logged at ERR with errno and handle range.

## Testing

- `./pbl build` clean
- Unit suites pass: `test_gatt_client_discovery`, `test_gatt_client_subscriptions`, `test_gatt_service_changed_client/server`, `test_kernel_le_client`, `test_ppogatt_v0/v1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)