### PR TITLE
⚡️ power: reduce idle draw from ALS, touch, and stationary polling

### DIFF
--- a/src/fw/drivers/touch/cst816/cst816.c
+++ b/src/fw/drivers/touch/cst816/cst816.c
@@ -61,7 +61,7 @@ PBL_LOG_MODULE_DEFINE(driver_touch_cst816, CONFIG_DRIVER_TOUCH_LOG_LEVEL);
 
 /* Workaround: the CST816 occasionally wedges and stops asserting its INT line.
  * If no touch activity is seen between two watchdog checks, hard-reset it. */
-#define CST816_WATCHDOG_PERIOD_MIN    30
+#define CST816_WATCHDOG_PERIOD_MIN    60
 
 /* The chip stays awake for 2s after a wake; an interrupt seen >=2s after the
  * previous one therefore marks a fresh sleep->awake transition. */

--- a/src/fw/services/light/service.c
+++ b/src/fw/services/light/service.c
@@ -119,7 +119,7 @@ static uint32_t s_total_on_time_ms; // Total backlight on time tracked internall
 //! that follows the press within the TTL) skip the ~200 ms I2C poll.
 static uint32_t s_als_cached_level;
 static RtcTicks s_als_cached_ticks;  // 0 = invalid
-#define ALS_CACHE_TTL_TICKS (RTC_TICKS_HZ)  // 1 second
+#define ALS_CACHE_TTL_OFF_TICKS (5 * RTC_TICKS_HZ)
 
 //! Event-gated continuous ALS:
 //!
@@ -185,7 +185,8 @@ static uint32_t prv_get_als_level(void) {
   RtcTicks now = rtc_get_ticks();
   const bool cache_valid =
       s_als_cached_ticks != 0 &&
-      (s_current_brightness > 0 || (now - s_als_cached_ticks) < ALS_CACHE_TTL_TICKS);
+      (s_current_brightness > 0 ||
+       (now - s_als_cached_ticks) < ALS_CACHE_TTL_OFF_TICKS);
   if (cache_valid) {
     return s_als_cached_level;
   }

--- a/src/fw/services/stationary/service.c
+++ b/src/fw/services/stationary/service.c
@@ -245,7 +245,7 @@ static void prv_exit_disabled_state(void) {
 #if DEBUG_STATIONARY
   regular_timer_add_seconds_callback(&s_accel_stationary_timer_info);
 #else
-  regular_timer_add_minutes_callback(&s_accel_stationary_timer_info);
+  regular_timer_add_multiminute_callback(&s_accel_stationary_timer_info, 2);
 #endif
   s_current_state = StationaryStateAwake;
 }


### PR DESCRIPTION
Three small idle-power reductions:

- ALS: extend the cached ambient-light level TTL from 1 s to 5 s while the backlight is off, skipping the ~200 ms I2C poll on rapid wake-check sequences.
- CST816 touch: the wedge-detection watchdog only needs to catch a controller that stopped asserting INT; check every 60 min instead of every 30 min.
- Stationary service: poll for the stationary transition every 2 min instead of every minute; entry into stationary mode is already delayed well beyond that.



(cherry picked from commit 8a32da38e670d0fb39081009fd1230be04c5032b)