### PR TITLE
services/bluetooth: fix CCCD deletion using uninitialized key

### DIFF
--- a/src/fw/services/bluetooth/bluetooth_persistent_storage_normal.c
+++ b/src/fw/services/bluetooth/bluetooth_persistent_storage_normal.c
@@ -1288,6 +1288,7 @@ bool bt_persistent_storage_delete_cccd(const BTDeviceInternal *peer, uint16_t ch
     return false;
   }
 
+  cccd_id = itr_data.id;
   if (prv_file_set(&cccd_id, sizeof(cccd_id), NULL, 0) == GapBondingFileSetFail) {
     return false;
   }


### PR DESCRIPTION
bt_persistent_storage_delete_cccd() looked up the CCCD id for the given peer and characteristic but then deleted the record keyed by the uninitialized cccd_id local instead, so the intended record survived and whatever record the garbage id happened to match could be deleted instead.