### PR TITLE
Fix blank device name on PRF QR screen

### DIFF
--- a/src/fw/apps/prf/recovery_first_use/recovery_first_use.c
+++ b/src/fw/apps/prf/recovery_first_use/recovery_first_use.c
@@ -155,8 +155,14 @@ static void prv_update_name_text(RecoveryFUAppData *data) {
   } else if ((comm_session_get_system_session() != NULL) && (gap_conn != NULL)) {
     // If we have connected to a device and we have a connection to the mobile app, show the device
     // name (we are required to have a connection to mobile app to get the name).
+    data->name_text_buffer[0] = '\0';
     gap_le_connection_copy_device_name(gap_conn, data->name_text_buffer,
                                        BT_DEVICE_NAME_BUFFER_SIZE);
+    if (data->name_text_buffer[0] == '\0') {
+      // The remote name may not have been fetched yet: fall back to the local
+      // device name instead of showing a blank field.
+      bt_local_id_copy_device_name(data->name_text_buffer, false);
+    }
   } else {
     // If we aren't connected and/or don't have a session, display the name of the device
     // so it's easier for a user to figure out what they should be trying to connect to

--- a/src/fw/comm/ble/gap_le_device_name.c
+++ b/src/fw/comm/ble/gap_le_device_name.c
@@ -9,17 +9,19 @@
 #include "kernel/pbl_malloc.h"
 #include "pbl/services/bluetooth/bluetooth_persistent_storage.h"
 
-BTBondingID prv_get_bonding_id_and_name_from_address_safe(void *ctx, char* device_name) {
-  BTBondingID bonding_id = BT_BONDING_ID_INVALID;
+static bool prv_get_bonding_id_and_name_from_address_safe(void *ctx, char *device_name,
+                                                          BTBondingID *bonding_id_out) {
+  bool found = false;
   BTDeviceAddress *addr = (BTDeviceAddress *)ctx;
   GAPLEConnection *connection = gap_le_connection_by_addr(addr);
 
   bt_lock();
-  if (!gap_le_connection_is_valid(connection)) {
+  if (!gap_le_connection_is_valid(connection) || (connection->device_name == NULL)) {
     goto unlock;
   }
 
-  bonding_id = connection->bonding_id;
+  found = true;
+  *bonding_id_out = connection->bonding_id;
 
   if (device_name) {
     strncpy(device_name, connection->device_name, BT_DEVICE_NAME_BUFFER_SIZE);
@@ -28,23 +30,26 @@ BTBondingID prv_get_bonding_id_and_name_from_address_safe(void *ctx, char* devic
 
 unlock:
   bt_unlock();
-  return bonding_id;
+  return found;
 }
 
 void bt_driver_store_device_name_kernelbg_cb(void *ctx) {
   char device_name[BT_DEVICE_NAME_BUFFER_SIZE];
-  BTBondingID bonding_id = prv_get_bonding_id_and_name_from_address_safe(ctx, device_name);
+  BTBondingID bonding_id = BT_BONDING_ID_INVALID;
+  bool found = prv_get_bonding_id_and_name_from_address_safe(ctx, device_name, &bonding_id);
   kernel_free(ctx);
 
-  if (bonding_id == BT_BONDING_ID_INVALID) {
+  if (!found) {
     return;
   }
 
-  // Can't access flash when bt_lock() is held...
-  if (!bt_persistent_storage_update_ble_device_name(bonding_id, device_name)) {
-    return;
+  if (bonding_id != BT_BONDING_ID_INVALID) {
+    // Can't access flash when bt_lock() is held...
+    bt_persistent_storage_update_ble_device_name(bonding_id, device_name);
   }
 
+  // Notify listeners even if the name couldn't be persisted (e.g. not bonded
+  // yet), so the UI can pick up the freshly read name.
   PebbleEvent event = {
     .type = PEBBLE_BLE_DEVICE_NAME_UPDATED_EVENT,
   };


### PR DESCRIPTION
## Summary

The device/mobile name field on the PRF getting-started (QR) screen could render blank, or show a stale string, while a comm session was up. Two independent holes caused this:

- `gap_le_connection_copy_device_name()` leaves the output buffer untouched when the remote device name has not been fetched yet (the GATT read of GAP Device Name 0x2A00 is asynchronous), so the connected code path could draw an empty/stale buffer.
- `bt_driver_store_device_name_kernelbg_cb` only emitted `PEBBLE_BLE_DEVICE_NAME_UPDATED_EVENT` when the connection had a valid bonding and the name was persisted. In PRF a comm session can exist before a bonding is finalized, so the freshly read name was never announced and the screen stayed blank until an unrelated BT connection event repainted it.

## Changes

- `comm/ble`: always emit the device-name-updated event once a name has been read; persist to storage only when a bonding exists. Also bail out early if the connection went away before the background callback ran, instead of copying from an uninitialized name buffer.
- `fw/apps/prf/recovery_first_use`: clear the name buffer before copying and fall back to the local device name when the remote name is still unknown, matching the disconnected code path.

Net behavior: watch name → (phone connects, name read in flight) still watch name → name-updated event → phone name. No blank window at any point.

## Testing

- Full PRF build for `obelix@pvt` (nimble) compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)