### PR TITLE
Fix device name read corrupting GATT traffic and hammering pairing storage

### DIFF
--- a/src/bluetooth-fw/nimble/advert.c
+++ b/src/bluetooth-fw/nimble/advert.c
@@ -85,6 +85,17 @@ static void prv_handle_connection_event(struct ble_gap_event *event) {
   // If OTA address != ID address, then the address must be resolved.
   // This happens for an already paired devices.
   complete_event.is_resolved = ble_addr_cmp(&desc.peer_id_addr, &desc.peer_ota_addr) != 0;
+
+  {
+    BTDeviceAddress ota_addr, id_addr;
+    nimble_addr_to_pebble_addr(&desc.peer_ota_addr, &ota_addr);
+    nimble_addr_to_pebble_addr(&desc.peer_id_addr, &id_addr);
+    PBL_LOG_DBG("Conn compl: ota=" BT_DEVICE_ADDRESS_FMT " atype=%u",
+                BT_DEVICE_ADDRESS_XPLODE(ota_addr), desc.peer_ota_addr.type);
+    PBL_LOG_DBG("Conn compl: id=" BT_DEVICE_ADDRESS_FMT " atype=%u",
+                BT_DEVICE_ADDRESS_XPLODE(id_addr), desc.peer_id_addr.type);
+  }
+
   if (complete_event.is_resolved) {
     int rc;
     struct ble_store_key_sec key_sec;
@@ -98,6 +109,7 @@ static void prv_handle_connection_event(struct ble_gap_event *event) {
       // We can get a resolved address in case of a repeated pairing event,
       // where peer security is deleted. An identity resolved event will be
       // received later after the new pairing is completed.
+      PBL_LOG_INFO("Address resolved but no stored peer security (rc=%d)", rc);
       complete_event.is_resolved = false;
     } else {
       memcpy(complete_event.irk.data, value_sec.irk, 16);
@@ -140,6 +152,10 @@ static void prv_handle_enc_change_event(struct ble_gap_event *event) {
     PBL_LOG_ERR("prv_handle_enc_change_event: Failed to find connection descriptor");
     return;
   }
+
+  PBL_LOG_INFO("Encryption change: status=0x%04x encrypted=%u bonded=%u",
+               (uint16_t)event->enc_change.status, desc.sec_state.encrypted,
+               desc.sec_state.bonded);
 
   struct BleEncryptionChange enc_change_event = {
       .encryption_enabled = desc.sec_state.encrypted,
@@ -209,6 +225,8 @@ static void prv_handle_passkey_event(struct ble_gap_event *event) {
 }
 
 static void prv_handle_pairing_complete_event(struct ble_gap_event *event) {
+  PBL_LOG_INFO("Pairing complete: status=0x%04x", (uint16_t)event->pairing_complete.status);
+
   if (!s_pairing_in_progress) {
     return;
   }
@@ -295,6 +313,7 @@ static int prv_handle_repeat_pairing_event(struct ble_gap_event *event) {
     return ret;
   }
 
+  PBL_LOG_INFO("Repeat pairing: deleting stored peer keys and retrying");
   ble_store_util_delete_peer(&desc.peer_id_addr);
 
   return BLE_GAP_REPEAT_PAIRING_RETRY;

--- a/src/bluetooth-fw/nimble/advert.c
+++ b/src/bluetooth-fw/nimble/advert.c
@@ -10,10 +10,13 @@
 #include <comm/bt_lock.h>
 #include <host/ble_gap.h>
 #include <host/ble_hs_hci.h>
+#include <kernel/pbl_malloc.h>
+#include <os/os_mbuf.h>
 #include <system/logging.h>
 #include <system/passert.h>
 #include <pbl/util/math.h>
 
+#include "nimble_gattc_op_queue.h"
 #include "nimble_type_conversions.h"
 
 PBL_LOG_MODULE_DECLARE(bt, CONFIG_BT_LOG_LEVEL);
@@ -24,13 +27,29 @@ static bool s_pairing_in_progress;
 
 static int prv_device_name_read_event_cb(uint16_t conn_handle, const struct ble_gatt_error *error,
                                          struct ble_gatt_attr *attr, void *arg) {
-  if (error->status == 0) {
-    size_t len = MIN(attr->om->om_len, sizeof(s_device_name) - 1);
-    strncpy(s_device_name, (char *)attr->om->om_data, len);
-    s_device_name[len] = '\0';
+  if (error->status != 0) {
+    nimble_gattc_op_queue_complete();
+    return 0;
   }
 
+  size_t len = MIN(OS_MBUF_PKTLEN(attr->om), sizeof(s_device_name) - 1);
+  os_mbuf_copydata(attr->om, 0, len, s_device_name);
+  s_device_name[len] = '\0';
+
   return 0;
+}
+
+static int prv_device_name_read_op_start(void *ctx) {
+  const uint16_t conn_handle = *(uint16_t *)ctx;
+
+  int rc = ble_gattc_read_by_uuid(conn_handle, 1, UINT16_MAX,
+                                  (ble_uuid_t *)&s_device_name_chr_uuid,
+                                  prv_device_name_read_event_cb, NULL);
+  if (rc != 0) {
+    PBL_LOG_ERR("Pairing device name read failed to start (rc=0x%04x)", (uint16_t)rc);
+  }
+
+  return rc;
 }
 
 void bt_driver_advert_advertising_disable(void) {
@@ -118,9 +137,9 @@ static void prv_handle_connection_event(struct ble_gap_event *event) {
     // If the address is not resolved, pairing is gonna happen.
     // Trigger name read to have it ready for the pairing confirmation.
     memset(s_device_name, 0, sizeof(s_device_name));
-    ble_gattc_read_by_uuid(event->connect.conn_handle, 1, UINT16_MAX,
-                           (ble_uuid_t *)&s_device_name_chr_uuid, prv_device_name_read_event_cb,
-                           NULL);
+    uint16_t *conn_handle = kernel_malloc_check(sizeof(*conn_handle));
+    *conn_handle = event->connect.conn_handle;
+    nimble_gattc_op_queue_push(prv_device_name_read_op_start, conn_handle);
   }
 
   nimble_conn_params_to_pebble(&desc, &complete_event.conn_params);

--- a/src/bluetooth-fw/nimble/gap_le_device_name.c
+++ b/src/bluetooth-fw/nimble/gap_le_device_name.c
@@ -18,6 +18,9 @@ const ble_uuid16_t device_name_chr_uuid = BLE_UUID16_INIT(GAP_DEVICE_NAME_CHR);
 
 static int prv_device_name_read_event_cb(uint16_t conn_handle, const struct ble_gatt_error *error,
                                          struct ble_gatt_attr *attr, void *arg) {
+  bool changed;
+  GAPLEConnection *connection = (GAPLEConnection *)arg;
+
   if (error->status != 0) {
     if (error->status != BLE_HS_EDONE) {
       PBL_LOG_ERR("prv_device_name_read_event_cb error=%d",
@@ -26,18 +29,30 @@ static int prv_device_name_read_event_cb(uint16_t conn_handle, const struct ble_
     return 0;
   }
 
+  PBL_LOG_DBG("Device name read cb: conn=%u handle=%u len=%u", conn_handle, attr->handle,
+              attr->om->om_len);
+
   char *device_name = kernel_zalloc_check(attr->om->om_len + 1);
   strncpy(device_name, (char *)attr->om->om_data, attr->om->om_len);
 
   bt_lock();
 
-  GAPLEConnection *connection = (GAPLEConnection *)arg;
-  if (connection->device_name) {
-    kernel_free(connection->device_name);
+  changed = (connection->device_name == NULL) || strcmp(connection->device_name, device_name) != 0;
+  if (changed) {
+    if (connection->device_name) {
+      kernel_free(connection->device_name);
+    }
+    connection->device_name = device_name;
   }
-  connection->device_name = device_name;
 
   bt_unlock();
+
+  if (!changed) {
+    // Same name as before: don't re-persist it (each store rewrites the
+    // pairing storage and fires bonding change handlers).
+    kernel_free(device_name);
+    return 0;
+  }
 
   BTDeviceAddress *addr = kernel_zalloc_check(sizeof(BTDeviceAddress));
   *addr = connection->device.address;

--- a/src/bluetooth-fw/nimble/gap_le_device_name.c
+++ b/src/bluetooth-fw/nimble/gap_le_device_name.c
@@ -4,10 +4,14 @@
 #include <bluetooth/gap_le_device_name.h>
 #include <comm/bt_lock.h>
 #include <host/ble_gatt.h>
+#include <host/ble_hs.h>
 #include <host/ble_uuid.h>
+#include <kernel/pbl_malloc.h>
+#include <os/os_mbuf.h>
 #include <pbl/services/system_task.h>
 #include <system/logging.h>
 
+#include "nimble_gattc_op_queue.h"
 #include "nimble_type_conversions.h"
 
 PBL_LOG_MODULE_DECLARE(bt, CONFIG_BT_LOG_LEVEL);
@@ -18,24 +22,40 @@ const ble_uuid16_t device_name_chr_uuid = BLE_UUID16_INIT(GAP_DEVICE_NAME_CHR);
 
 static int prv_device_name_read_event_cb(uint16_t conn_handle, const struct ble_gatt_error *error,
                                          struct ble_gatt_attr *attr, void *arg) {
-  bool changed;
-  GAPLEConnection *connection = (GAPLEConnection *)arg;
+  const BTDeviceInternal *device = arg;
 
   if (error->status != 0) {
     if (error->status != BLE_HS_EDONE) {
       PBL_LOG_ERR("prv_device_name_read_event_cb error=%d",
                 error->status);
     }
+    // Frees arg (the op context); must be the last use of it
+    nimble_gattc_op_queue_complete();
     return 0;
   }
 
-  PBL_LOG_DBG("Device name read cb: conn=%u handle=%u len=%u", conn_handle, attr->handle,
-              attr->om->om_len);
+  const uint16_t name_len = OS_MBUF_PKTLEN(attr->om);
 
-  char *device_name = kernel_zalloc_check(attr->om->om_len + 1);
-  strncpy(device_name, (char *)attr->om->om_data, attr->om->om_len);
+  PBL_LOG_DBG("Device name read cb: conn=%u handle=%u len=%u", conn_handle, attr->handle,
+              name_len);
+
+  char *device_name = kernel_zalloc_check(name_len + 1);
+  if (ble_hs_mbuf_to_flat(attr->om, device_name, name_len, NULL) != 0) {
+    kernel_free(device_name);
+    return 0;
+  }
+
+  bool changed;
+  BTDeviceAddress addr_copy;
 
   bt_lock();
+
+  GAPLEConnection *connection = gap_le_connection_by_device(device);
+  if (connection == NULL) {
+    bt_unlock();
+    kernel_free(device_name);
+    return 0;
+  }
 
   changed = (connection->device_name == NULL) || strcmp(connection->device_name, device_name) != 0;
   if (changed) {
@@ -44,6 +64,7 @@ static int prv_device_name_read_event_cb(uint16_t conn_handle, const struct ble_
     }
     connection->device_name = device_name;
   }
+  addr_copy = connection->device.address;
 
   bt_unlock();
 
@@ -55,39 +76,44 @@ static int prv_device_name_read_event_cb(uint16_t conn_handle, const struct ble_
   }
 
   BTDeviceAddress *addr = kernel_zalloc_check(sizeof(BTDeviceAddress));
-  *addr = connection->device.address;
+  *addr = addr_copy;
   system_task_add_callback(bt_driver_store_device_name_kernelbg_cb, addr);
 
   return 0;
 }
 
-static void prv_gap_le_device_name_request(GAPLEConnection *connection) {
+static int prv_device_name_read_op_start(void *ctx) {
+  const BTDeviceInternal *device = ctx;
   uint16_t conn_handle;
-  if (!pebble_device_to_nimble_conn_handle(&connection->device, &conn_handle)) {
-    PBL_LOG_ERR("prv_gap_le_device_name_request: Failed to find connection handle");
-    return;
+
+  if (!pebble_device_to_nimble_conn_handle(device, &conn_handle)) {
+    PBL_LOG_WRN("Device name read: connection is gone");
+    return BLE_HS_ENOTCONN;
   }
 
+  PBL_LOG_DBG("Device name read request: conn=%u", conn_handle);
+
   int rc = ble_gattc_read_by_uuid(conn_handle, 1, UINT16_MAX, (ble_uuid_t *)&device_name_chr_uuid,
-                                  prv_device_name_read_event_cb, (void *)connection);
+                                  prv_device_name_read_event_cb, ctx);
   if (rc != 0) {
-    PBL_LOG_ERR("prv_gap_le_device_name_request ble_gattc_read_by_uuid rc=0x%04x", (uint16_t)rc);
+    PBL_LOG_ERR("prv_device_name_read_op_start ble_gattc_read_by_uuid rc=0x%04x", (uint16_t)rc);
   }
+
+  return rc;
+}
+
+void bt_driver_gap_le_device_name_request(const BTDeviceInternal *device) {
+  BTDeviceInternal *ctx = kernel_zalloc_check(sizeof(*ctx));
+  *ctx = *device;
+  nimble_gattc_op_queue_push(prv_device_name_read_op_start, ctx);
 }
 
 static void prv_request_device_name_cb(GAPLEConnection *connection, void *data) {
-    prv_gap_le_device_name_request(connection);
-  }
-
-void bt_driver_gap_le_device_name_request(const BTDeviceInternal *device) {
-  GAPLEConnection *connection = gap_le_connection_by_device(device);
-  if (connection == NULL) {
-    PBL_LOG_ERR("bt_driver_gap_le_device_name_request gap_le_connection_by_device returned NULL");
-    return;
-  }
-  prv_gap_le_device_name_request(connection);
+  bt_driver_gap_le_device_name_request(&connection->device);
 }
 
 void bt_driver_gap_le_device_name_request_all(void) {
+  bt_lock();
   gap_le_connection_for_each(prv_request_device_name_cb, NULL);
+  bt_unlock();
 }

--- a/src/bluetooth-fw/nimble/gatt_client_discovery.c
+++ b/src/bluetooth-fw/nimble/gatt_client_discovery.c
@@ -2,6 +2,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include <bluetooth/gatt.h>
+#include <comm/bt_lock.h>
 #include <host/ble_hs.h>
 #include <system/logging.h>
 #include <pbl/util/math.h>
@@ -11,6 +12,7 @@
 #include <FreeRTOS.h>
 #include <semphr.h>
 
+#include "nimble_gattc_op_queue.h"
 #include "nimble_type_conversions.h"
 
 PBL_LOG_MODULE_DECLARE(bt, CONFIG_BT_LOG_LEVEL);
@@ -18,6 +20,13 @@ PBL_LOG_MODULE_DECLARE(bt, CONFIG_BT_LOG_LEVEL);
 static bool s_discovery_in_progress;
 static bool s_stop_discovery_requested;
 static SemaphoreHandle_t s_discovery_stopped;
+
+//! Marks the end of a discovery run, letting the next queued GATT client
+//! procedure start. Every terminal path of the discovery chain must end here.
+static void prv_discovery_finished(void) {
+  s_discovery_in_progress = false;
+  nimble_gattc_op_queue_complete();
+}
 
 // -------------------------------------------------------------------------------------------------
 // Gatt Client Discovery API calls
@@ -322,7 +331,7 @@ static int prv_find_dsc_cb(uint16_t conn_handle, const struct ble_gatt_error *er
 
   if (s_stop_discovery_requested) {
     xSemaphoreGive(s_discovery_stopped);
-    s_discovery_in_progress = false;
+    prv_discovery_finished();
     prv_free_discovery_context(context);
     return BLE_HS_EDONE;
   }
@@ -368,7 +377,7 @@ static int prv_find_dsc_cb(uint16_t conn_handle, const struct ble_gatt_error *er
 
         if (context->current_service == NULL) {
           // we're done!
-          s_discovery_in_progress = false;
+          prv_discovery_finished();
           prv_convert_service_and_notify_os(conn_handle, context);
         }
       }
@@ -386,7 +395,7 @@ static int prv_find_dsc_cb(uint16_t conn_handle, const struct ble_gatt_error *er
         errno = BTErrnoInternalErrorBegin + error->status;
       }
 
-      s_discovery_in_progress = false;
+      prv_discovery_finished();
       bt_driver_cb_gatt_client_discovery_complete(context->connection, errno);
       prv_free_discovery_context(context);
       break;
@@ -402,7 +411,7 @@ static int prv_find_chr_cb(uint16_t conn_handle, const struct ble_gatt_error *er
 
   if (s_stop_discovery_requested) {
     xSemaphoreGive(s_discovery_stopped);
-    s_discovery_in_progress = false;
+    prv_discovery_finished();
     prv_free_discovery_context(context);
     return BLE_HS_EDONE;
   }
@@ -440,7 +449,7 @@ static int prv_find_chr_cb(uint16_t conn_handle, const struct ble_gatt_error *er
           prv_discover_next_dscs(conn_handle, context);
         } else {
           // No characteristics found, discovery complete
-          s_discovery_in_progress = false;
+          prv_discovery_finished();
           prv_convert_service_and_notify_os(conn_handle, context);
         }
       }
@@ -458,7 +467,7 @@ static int prv_find_chr_cb(uint16_t conn_handle, const struct ble_gatt_error *er
         errno = BTErrnoInternalErrorBegin + error->status;
       }
 
-      s_discovery_in_progress = false;
+      prv_discovery_finished();
       bt_driver_cb_gatt_client_discovery_complete(context->connection, errno);
       prv_free_discovery_context(context);
       break;
@@ -474,7 +483,7 @@ static int prv_find_inc_svc_cb(uint16_t conn_handle, const struct ble_gatt_error
 
   if (s_stop_discovery_requested) {
     xSemaphoreGive(s_discovery_stopped);
-    s_discovery_in_progress = false;
+    prv_discovery_finished();
     prv_free_discovery_context(context);
     return BLE_HS_EDONE;
   }
@@ -505,7 +514,7 @@ static int prv_find_inc_svc_cb(uint16_t conn_handle, const struct ble_gatt_error
         prv_discover_next_chrs(conn_handle, context);
       } else {
         // no services found
-        s_discovery_in_progress = false;
+        prv_discovery_finished();
         bt_driver_cb_gatt_client_discovery_complete(context->connection, BTErrnoOK);
         prv_free_discovery_context(context);
       }
@@ -522,7 +531,7 @@ static int prv_find_inc_svc_cb(uint16_t conn_handle, const struct ble_gatt_error
         errno = BTErrnoInternalErrorBegin + error->status;
       }
 
-      s_discovery_in_progress = false;
+      prv_discovery_finished();
       bt_driver_cb_gatt_client_discovery_complete(context->connection, errno);
       prv_free_discovery_context(context);
       break;
@@ -534,8 +543,7 @@ void nimble_discover_init(void) {
   s_discovery_stopped = xSemaphoreCreateBinary();
 }
 
-BTErrno bt_driver_gatt_start_discovery_range(const GAPLEConnection *connection,
-                                             const ATTHandleRange *data) {
+static BTErrno prv_start_discovery(const GAPLEConnection *connection, const ATTHandleRange *data) {
   uint16_t conn_handle;
   if (!pebble_device_to_nimble_conn_handle(&connection->device, &conn_handle)) {
     return BTErrnoInvalidState;
@@ -547,11 +555,53 @@ BTErrno bt_driver_gatt_start_discovery_range(const GAPLEConnection *connection,
 
   int rc = ble_gattc_disc_all_svcs(conn_handle, prv_find_inc_svc_cb, (void *)context);
   if (rc != 0) {
+    prv_free_discovery_context(context);
     return BTErrnoInternalErrorBegin + rc;
   }
 
   s_discovery_in_progress = true;
   s_stop_discovery_requested = false;
+
+  return BTErrnoOK;
+}
+
+typedef struct {
+  GAPLEConnection *connection;
+  ATTHandleRange range;
+} DiscoveryOp;
+
+static int prv_discovery_op_start(void *ctx) {
+  DiscoveryOp *op = ctx;
+
+  bt_lock();
+  const bool valid = gap_le_connection_is_valid(op->connection);
+  bt_unlock();
+
+  BTErrno err = valid ? prv_start_discovery(op->connection, &op->range) : BTErrnoInvalidState;
+  if (err == BTErrnoOK) {
+    return 0;
+  }
+
+  PBL_LOG_WRN("Failed to start discovery (errno=%d)", err);
+  if (valid) {
+    // The firmware was told the start succeeded (see
+    // bt_driver_gatt_start_discovery_range); report the failure through the
+    // completion callback so it can finalize.
+    bt_driver_cb_gatt_client_discovery_complete(op->connection, err);
+  }
+  return -1;
+}
+
+BTErrno bt_driver_gatt_start_discovery_range(const GAPLEConnection *connection,
+                                             const ATTHandleRange *data) {
+  DiscoveryOp *op = kernel_zalloc_check(sizeof(*op));
+  op->connection = (GAPLEConnection *)connection;
+  op->range = *data;
+
+  // Queued so it never runs concurrently with another GATT client procedure
+  // (e.g. a device name read). Start errors are reported through
+  // bt_driver_cb_gatt_client_discovery_complete.
+  nimble_gattc_op_queue_push(prv_discovery_op_start, op);
 
   return BTErrnoOK;
 }

--- a/src/bluetooth-fw/nimble/init.c
+++ b/src/bluetooth-fw/nimble/init.c
@@ -30,6 +30,7 @@ static const uint32_t s_bt_stack_start_stop_timeout_ms = 10000;
 extern void pebble_pairing_service_init(void);
 extern void ppog_reversed_service_init(void);
 extern void nimble_discover_init(void);
+extern void nimble_gattc_op_queue_init(void);
 
 #if NIMBLE_CFG_CONTROLLER
 static TaskHandle_t s_ll_task_handle;
@@ -85,6 +86,7 @@ void bt_driver_init(void) {
   s_host_stopped = xSemaphoreCreateBinary();
 
   nimble_discover_init();
+  nimble_gattc_op_queue_init();
 
   nimble_port_init();
   nimble_store_init();

--- a/src/bluetooth-fw/nimble/nimble_gattc_op_queue.c
+++ b/src/bluetooth-fw/nimble/nimble_gattc_op_queue.c
@@ -1,0 +1,94 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "nimble_gattc_op_queue.h"
+
+#include <comm/bt_lock.h>
+#include <kernel/pbl_malloc.h>
+#include <pbl/services/system_task.h>
+#include <pbl/util/list.h>
+
+typedef struct {
+  ListNode node;
+  NimbleGattClientOpStartFn start;
+  void *ctx;
+} GattClientOp;
+
+//! All state is guarded by bt_lock. The head of s_ops is the running op when
+//! s_op_running is set.
+static ListNode *s_ops;
+static bool s_op_running;
+static bool s_kick_scheduled;
+
+static void prv_run_cb(void *unused);
+
+static void prv_kick_locked(void) {
+  if (s_op_running || s_kick_scheduled || (s_ops == NULL)) {
+    return;
+  }
+  s_kick_scheduled = true;
+  system_task_add_callback(prv_run_cb, NULL);
+}
+
+static void prv_pop_locked(void) {
+  GattClientOp *op = (GattClientOp *)s_ops;
+  list_remove(&op->node, &s_ops, NULL);
+  kernel_free(op->ctx);
+  kernel_free(op);
+}
+
+static void prv_run_cb(void *unused) {
+  bt_lock();
+  s_kick_scheduled = false;
+  while (!s_op_running && (s_ops != NULL)) {
+    GattClientOp *op = (GattClientOp *)s_ops;
+    s_op_running = true;
+    bt_unlock();
+    // The op may complete (even fail) before start returns, so op must not be
+    // touched after a successful start.
+    const int rc = op->start(op->ctx);
+    bt_lock();
+    if (rc == 0) {
+      break;
+    }
+    // Failed to start: drop it and try the next one
+    s_op_running = false;
+    prv_pop_locked();
+  }
+  bt_unlock();
+}
+
+void nimble_gattc_op_queue_push(NimbleGattClientOpStartFn start, void *ctx) {
+  GattClientOp *op = kernel_zalloc_check(sizeof(*op));
+  list_init(&op->node);
+  op->start = start;
+  op->ctx = ctx;
+
+  bt_lock();
+  if (s_ops == NULL) {
+    s_ops = &op->node;
+  } else {
+    list_append(s_ops, &op->node);
+  }
+  prv_kick_locked();
+  bt_unlock();
+}
+
+void nimble_gattc_op_queue_complete(void) {
+  bt_lock();
+  if (s_op_running) {
+    s_op_running = false;
+    prv_pop_locked();
+    prv_kick_locked();
+  }
+  bt_unlock();
+}
+
+void nimble_gattc_op_queue_init(void) {
+  bt_lock();
+  while (s_ops != NULL) {
+    prv_pop_locked();
+  }
+  s_op_running = false;
+  bt_unlock();
+}

--- a/src/bluetooth-fw/nimble/nimble_gattc_op_queue.h
+++ b/src/bluetooth-fw/nimble/nimble_gattc_op_queue.h
@@ -1,0 +1,32 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+//! Serializes GATT client procedures.
+//!
+//! NimBLE runs GATT client procedures concurrently and dispatches incoming ATT
+//! responses to the first pending procedure that consumes that response
+//! opcode. Two concurrent procedures consuming the same opcode (e.g.
+//! characteristic discovery and a read-by-UUID, which both consume ATT Read By
+//! Type responses) get responses cross-delivered, corrupting both. This queue
+//! guarantees only one GATT client procedure runs at a time.
+//!
+//! Ops are started from KernelBG, so pushing is safe from any context,
+//! including with bt_lock held.
+
+//! Starts the operation. Called from KernelBG without bt_lock held. Returns 0
+//! if the operation was started, in which case its completion path must call
+//! nimble_gattc_op_queue_complete() exactly once. On a non-zero return the op
+//! is dropped and the next one runs; error reporting is the starter's
+//! responsibility.
+typedef int (*NimbleGattClientOpStartFn)(void *ctx);
+
+//! Enqueues an operation. ctx must be heap-allocated (or NULL); it is
+//! kernel_free()'d when the op completes, fails to start, or is dropped.
+void nimble_gattc_op_queue_push(NimbleGattClientOpStartFn start, void *ctx);
+
+//! Signals completion of the running operation and kicks the next one.
+void nimble_gattc_op_queue_complete(void);
+
+void nimble_gattc_op_queue_init(void);

--- a/src/bluetooth-fw/nimble/nimble_store.c
+++ b/src/bluetooth-fw/nimble/nimble_store.c
@@ -235,8 +235,18 @@ static void prv_handle_sec_written_cb(void *data) {
 
 static int prv_nimble_store_write_sec(const int obj_type,
                                       const struct ble_store_value_sec *value_sec) {
+  BTDeviceAddress addr;
+
+  nimble_addr_to_pebble_addr(&value_sec->peer_addr, &addr);
+  PBL_LOG_INFO("SEC write: obj=%d addr=" BT_DEVICE_ADDRESS_FMT, obj_type,
+               BT_DEVICE_ADDRESS_XPLODE(addr));
+  PBL_LOG_INFO("SEC write: atype=%u ltk=%u irk=%u csrk=%u sc=%u auth=%u ksz=%u",
+               value_sec->peer_addr.type, value_sec->ltk_present, value_sec->irk_present,
+               value_sec->csrk_present, value_sec->sc, value_sec->authenticated,
+               value_sec->key_size);
+
   if (value_sec->key_size != KEY_SIZE || value_sec->csrk_present) {
-    PBL_LOG_ERR("Unsupported security parameters");
+    PBL_LOG_ERR("Unsupported security parameters, dropping bonding keys");
     return BLE_HS_ENOTSUP;
   }
 
@@ -275,6 +285,8 @@ static int prv_nimble_store_delete_sec(int obj_type, const struct ble_store_key_
   kernel_free(s);
 
   nimble_addr_to_pebble_device(&key_sec->peer_addr, &device);
+  PBL_LOG_INFO("SEC delete: obj=%d addr=" BT_DEVICE_ADDRESS_FMT, obj_type,
+               BT_DEVICE_ADDRESS_XPLODE(device.address));
   bt_persistent_storage_delete_ble_pairing_by_addr(&device);
 
   return 0;
@@ -542,6 +554,14 @@ static void prv_convert_bonding_local_to_store_val(const BleBonding *bonding,
 void bt_driver_handle_host_added_bonding(const BleBonding *bonding) {
   struct ble_store_value_sec value_sec;
 
+  PBL_LOG_INFO("Host added bonding: addr=" BT_DEVICE_ADDRESS_FMT " random=%u",
+               BT_DEVICE_ADDRESS_XPLODE(bonding->pairing_info.identity.address),
+               bonding->pairing_info.identity.is_random_address);
+  PBL_LOG_INFO("Host added bonding: remote_enc=%u local_enc=%u irk=%u",
+               bonding->pairing_info.is_remote_encryption_info_valid,
+               bonding->pairing_info.is_local_encryption_info_valid,
+               bonding->pairing_info.is_remote_identity_info_valid);
+
   prv_convert_bonding_remote_to_store_val(bonding, &value_sec);
   prv_nimble_store_upsert_sec(BLE_STORE_OBJ_TYPE_PEER_SEC, &value_sec);
 
@@ -552,6 +572,10 @@ void bt_driver_handle_host_added_bonding(const BleBonding *bonding) {
 void bt_driver_handle_host_removed_bonding(const BleBonding *bonding) {
   BleStoreValueSec *s_sec;
   struct ble_store_key_sec key_sec;
+
+  PBL_LOG_INFO("Host removed bonding: addr=" BT_DEVICE_ADDRESS_FMT " random=%u",
+               BT_DEVICE_ADDRESS_XPLODE(bonding->pairing_info.identity.address),
+               bonding->pairing_info.identity.is_random_address);
 
   key_sec.idx = 0;
   pebble_device_to_nimble_addr(&bonding->pairing_info.identity, &key_sec.peer_addr);

--- a/src/fw/comm/ble/gap_le_connect.c
+++ b/src/fw/comm/ble/gap_le_connect.c
@@ -599,7 +599,8 @@ void bt_driver_handle_le_encryption_change_event(const BleEncryptionChange *even
   connection->is_encrypted = true;
 
   if (!local_is_master) {
-    PBL_LOG_INFO("LE encryption change: encrypted");
+    // The driver already logs encryption changes (status/encrypted/bonded)
+    PBL_LOG_DBG("LE encryption change: encrypted");
     bluetooth_analytics_handle_encryption_change();
     bt_driver_pebble_pairing_service_handle_status_change(connection);
   }

--- a/src/fw/comm/ble/gap_le_connect.c
+++ b/src/fw/comm/ble/gap_le_connect.c
@@ -856,10 +856,12 @@ static BTErrno prv_register_intent(struct RegisterIntentRequest *request,
   if (request->is_bonding_based) {
     const GAPLEConnection *connection = gap_le_connection_find_by_irk(&request->bonding.irk);
     if (!connection) {
-      if (sm_is_pairing_info_irk_not_used(&request->bonding.irk)) {
-        PBL_LOG_DBG("register_intent: IRK not used, searching by addr");
-        connection = gap_le_connection_by_device(&request->bonding.device);
-      }
+      // The connection may not have an IRK yet: right after pairing, the
+      // bonding change handlers (which get here) can run before the driver
+      // delivers the IRK update. The connection address has already been
+      // updated to the identity address by then, so match by address too.
+      PBL_LOG_DBG("register_intent: no IRK match, searching by addr");
+      connection = gap_le_connection_by_device(&request->bonding.device);
     }
     if (connection) {
       is_already_connected = true;

--- a/src/fw/services/bluetooth/bluetooth_persistent_storage_prf.c
+++ b/src/fw/services/bluetooth/bluetooth_persistent_storage_prf.c
@@ -113,11 +113,20 @@ BTBondingID bt_persistent_storage_store_ble_pairing(const SMPairingInfo *new_pai
 bool bt_persistent_storage_update_ble_device_name(BTBondingID bonding, const char *device_name) {
   // A device name has come in, update the name of our currently paired device
   SMPairingInfo data = {};
+  char existing_name[BT_DEVICE_NAME_BUFFER_SIZE] = {};
   bool requires_address_pinning = false;
   uint8_t flags = 0;
-  if (!shared_prf_storage_get_ble_pairing_data(&data, NULL, &requires_address_pinning, &flags)) {
+  if (!shared_prf_storage_get_ble_pairing_data(&data, existing_name, &requires_address_pinning,
+                                               &flags)) {
     PBL_LOG_ERR("Tried to store device name, but pairing no longer around.");
     return false;
+  }
+
+  if (strncmp(existing_name, device_name, BT_DEVICE_NAME_BUFFER_SIZE) == 0) {
+    // Unchanged: skip the flash rewrite and bonding change handlers. Returning
+    // true means the caller may still emit a name-updated event; that's
+    // harmless (the stored name is correct).
+    return true;
   }
   // In PRF, only the gateway should get paired, so default to "true":
   return (BT_BONDING_ID_INVALID !=

--- a/src/fw/services/bluetooth/bluetooth_persistent_storage_prf.c
+++ b/src/fw/services/bluetooth/bluetooth_persistent_storage_prf.c
@@ -46,6 +46,13 @@ static BTBondingID prv_bt_persistent_storage_store_ble_pairing(
     const SMPairingInfo *new_pairing_info, bool is_gateway, bool requires_address_pinning,
     uint8_t flags, const char *device_name, BtPersistBondingOp op) {
   if (new_pairing_info && is_gateway) {
+    PBL_LOG_INFO("Storing BLE pairing: addr=" BT_DEVICE_ADDRESS_FMT " random=%u",
+                 BT_DEVICE_ADDRESS_XPLODE(new_pairing_info->identity.address),
+                 new_pairing_info->identity.is_random_address);
+    PBL_LOG_INFO("Storing BLE pairing: irk=%u remote_enc=%u local_enc=%u",
+                 new_pairing_info->is_remote_identity_info_valid,
+                 new_pairing_info->is_remote_encryption_info_valid,
+                 new_pairing_info->is_local_encryption_info_valid);
     shared_prf_storage_store_ble_pairing_data(new_pairing_info, device_name,
                                               requires_address_pinning,
                                               flags);
@@ -53,6 +60,7 @@ static BTBondingID prv_bt_persistent_storage_store_ble_pairing(
     return BLE_BONDING_ID;
   }
 
+  PBL_LOG_WRN("BLE pairing not stored (gateway=%u)", is_gateway);
   return BT_BONDING_ID_INVALID;
 }
 
@@ -132,6 +140,7 @@ static void prv_remove_ble_bonding_from_bt_driver(void) {
 }
 
 void bt_persistent_storage_delete_ble_pairing_by_id(BTBondingID bonding) {
+  PBL_LOG_INFO("Deleting stored BLE pairing");
   prv_remove_ble_bonding_from_bt_driver();
   shared_prf_storage_erase_ble_pairing_data();
   prv_call_ble_bonding_change_handlers(bonding, BtPersistBondingOpWillDelete);
@@ -200,6 +209,7 @@ void bt_persistent_storage_register_existing_ble_bondings(void) {
   BleBonding bonding = {};
   uint8_t flags;
   if (!shared_prf_storage_get_ble_pairing_data(&bonding.pairing_info, NULL, NULL, &flags)) {
+    PBL_LOG_INFO("No existing BLE bonding to register");
     return;
   }
   bonding.is_gateway = true;

--- a/src/fw/services/bluetooth/bonding.c
+++ b/src/fw/services/bluetooth/bonding.c
@@ -66,6 +66,7 @@ void bt_driver_cb_handle_create_bonding(const BleBonding *bonding,
                                                                    should_pin_address,
                                                                    flags);
   if (bonding_id == BT_BONDING_ID_INVALID) {
+    PBL_LOG_ERR("Failed to persist new bonding");
     return;
   }
 


### PR DESCRIPTION
## Summary

Debugging a "phone pairs but then fails to (re)connect" issue on PRF surfaced a GATT client concurrency defect in the NimBLE driver, a pairing-storage write amplification problem, a bonding/intent registration race that left a freshly paired phone without a session, and a lack of observability in the bonding storage chain.

### The main bug: concurrent GATT client procedures cross-deliver responses

NimBLE runs GATT client procedures concurrently and dispatches incoming ATT responses to the first pending procedure that consumes that response opcode (`ble_gattc_rx_read_type_elem_entries`). Two concurrent procedures consuming the same opcode get their responses cross-delivered, corrupting both. Observed as the GAP device name read (read-by-UUID) racing characteristic discovery — both consume ATT Read By Type responses:

- the "device name" ended up containing raw characteristic declaration bytes (observed: 5-byte 16-bit and 19-byte 128-bit char declarations), rendering as a blank name on the PRF getting-started screen
- discovery/PPoGATT received the other half of the cross-delivery: meta protocol errors, session failures, and phone reconnect loops

Fix: a driver-level FIFO of GATT client operations (`nimble_gattc_op_queue`) so only one procedure ever runs at a time — the next op starts when the previous op's terminal callback fires. Ops start from KernelBG, which makes pushing safe from any context, including with `bt_lock` held (NimBLE calls under `bt_lock` deadlock against the host task, see 3d5009dd0). Service discovery, the GAP device name read and the pairing-confirmation name read all go through the queue. This serializes both directions of the race by construction and covers any future GATT client procedure as well.

While at it, the device name read callback now resolves the connection by address under `bt_lock` instead of trusting a raw `GAPLEConnection` pointer, names are copied with `ble_hs_mbuf_to_flat()` so chained mbufs don't truncate them, discovery start errors are reported through the completion callback (start is now asynchronous), and a discovery context leak on failed `ble_gattc_disc_all_svcs` is fixed.

### The amplifier: unconditional pairing re-persist on every name read

Every completed name read re-persisted the full pairing: the nimble driver unconditionally scheduled the store callback and the PRF backend unconditionally rewrote the pairing blob to SPRF flash (a sector write) and re-fired the bonding change handlers. Combined with the bug above this produced flash writes at connection-interval rate (~20 Hz observed). Now both layers no-op when the name is unchanged.

### Pairing a different phone got stuck: intent registration racing the IRK update

After pairing completes, the driver persists our and the peer's keys through two separate launcher-task callbacks. The first one creates the bonding, whose `DidAdd` handler re-registers the kernel gateway intent; the second one delivers the peer IRK to the connection. `prv_register_intent()` looked the live connection up by IRK only (the by-address fallback was gated on the bonding having no IRK), so it missed, the intent was registered as not connected, and the ConnectedAndEncrypted event that kicks off the kernel LE clients (PPoGATT, service discovery) was never emitted. The second key store is treated as a re-pair (`DidChange`), which the kernel client ignores — so switching phones got stuck after pairing until the phone reconnected.

Fix: fall back to matching by address whenever the IRK lookup misses; the connection address is already updated to the identity address by the time the bonding change handlers run.

### Observability

The bonding storage chain had several silent failure points (rejected key writes, failed persists, untraced deletes). Added logging for security material writes/deletes (presence flags only, never key data), bonding sync add/remove, PRF pairing store/delete/restore, encryption change and pairing completion status. The pre-existing FW "LE encryption change: encrypted" log is demoted to DBG since the driver-level encryption change log supersedes it.

## Testing

- Reproduced the original failure on obelix PRF (pair → disconnect from phone → reconnect): before, blank name + `Meta protocol error: 0xdc` + reconnect loop; after, name shows correctly and reconnection works.
- Reproduced the phone-switch stall on obelix PRF (pair phone A → disconnect → pair phone B): before, pairing completed but no session/discovery until reconnect; after, the session comes up right after pairing.
- Each commit builds standalone (obelix@pvt PRF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
