### PR TITLE
services/notifications: fire DND update when prefs synced from phone

### DIFF
--- a/include/pbl/services/notifications/do_not_disturb.h
+++ b/include/pbl/services/notifications/do_not_disturb.h
@@ -76,6 +76,10 @@ void do_not_disturb_init(void);
 
 void do_not_disturb_handle_clock_change(void);
 
+//! Handle a DND state preference (manual/smart/schedule) written via phone settings sync.
+//! Re-evaluates the DND state so the change fires the usual event and schedule timer update.
+void do_not_disturb_handle_pref_synced(void);
+
 void do_not_disturb_handle_calendar_event(PebbleCalendarEvent *e);
 
 void do_not_disturb_manual_toggle_with_dialog(void);

--- a/src/fw/services/notifications/alerts_preferences.c
+++ b/src/fw/services/notifications/alerts_preferences.c
@@ -650,6 +650,21 @@ void alerts_preferences_unlock(void) {
   mutex_unlock(s_mutex);
 }
 
+//! Keys that feed do_not_disturb_is_active() or the DND schedule timer
+static bool prv_is_dnd_state_key(const char *key) {
+  if (strcmp(key, PREF_KEY_DND_MANUALLY_ENABLED) == 0 ||
+      strcmp(key, PREF_KEY_DND_SMART_ENABLED) == 0) {
+    return true;
+  }
+  for (int i = 0; i < NumDNDSchedules; i++) {
+    if (strcmp(key, s_dnd_schedule_keys[i].schedule_pref_key) == 0 ||
+        strcmp(key, s_dnd_schedule_keys[i].enabled_pref_key) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void alerts_preferences_handle_blob_db_event(PebbleBlobDBEvent *event) {
   if (event->type != BlobDBEventTypeInsert) {
     return;
@@ -720,8 +735,12 @@ done:
   settings_file_close(&file);
   mutex_unlock(s_mutex);
 
-  // Notify UI that a preference changed so it can refresh
   if (matched_key) {
+    // DND state keys are reloaded behind the DND service's back; kick it so the
+    // change re-arms the schedule timer and fires PEBBLE_DO_NOT_DISTURB_EVENT.
+    if (prv_is_dnd_state_key(matched_key)) {
+      do_not_disturb_handle_pref_synced();
+    }
     PebbleEvent pref_event = {
       .type = PEBBLE_PREF_CHANGE_EVENT,
       .pref_change = {

--- a/src/fw/services/notifications/do_not_disturb.c
+++ b/src/fw/services/notifications/do_not_disturb.c
@@ -321,6 +321,10 @@ void do_not_disturb_handle_clock_change(void) {
   prv_try_update_schedule_mode_callback(false);
 }
 
+void do_not_disturb_handle_pref_synced(void) {
+  prv_try_update_schedule_mode_callback(false);
+}
+
 void do_not_disturb_handle_calendar_event(PebbleCalendarEvent *e) {
   prv_do_update();
 }

--- a/tests/fw/services/test_do_not_disturb.c
+++ b/tests/fw/services/test_do_not_disturb.c
@@ -58,7 +58,9 @@ bool system_task_add_callback(SystemTaskEventCallback cb, void *data) {
 }
 
 void event_put(PebbleEvent* event) {
-  s_num_dnd_events_put++;
+  if (event->type == PEBBLE_DO_NOT_DISTURB_EVENT) {
+    s_num_dnd_events_put++;
+  }
 }
 
 // Thursday, March 12, 2015, 00:00 UTC
@@ -182,6 +184,37 @@ void test_do_not_disturb__manually_enable(void) {
   cl_assert(enabled == true);
   prv_assert_manually_dnd_setting_val(true);
   cl_assert_equal_i(s_num_dnd_events_put, 3);
+}
+
+//! Simulate the phone writing a pref through settings sync: the record lands in the
+//! settings file first, then the BlobDB insert event is handed to alerts_preferences.
+static void prv_sync_bool_pref_from_phone(const char *key, bool value) {
+  SettingsFile file;
+  cl_must_pass(settings_file_open(&file, "notifpref", 1024));
+  cl_must_pass(settings_file_set(&file, key, strlen(key), &value, sizeof(value)));
+  settings_file_close(&file);
+
+  PebbleBlobDBEvent event = {
+    .type = BlobDBEventTypeInsert,
+    .key = (uint8_t *)key,
+    .key_len = strlen(key),
+  };
+  alerts_preferences_handle_blob_db_event(&event);
+}
+
+void test_do_not_disturb__manual_pref_synced_from_phone(void) {
+  cl_assert(do_not_disturb_is_active() == false);
+  s_num_dnd_events_put = 0;
+
+  prv_sync_bool_pref_from_phone(PREF_KEY_DND_MANUALLY_ENABLED, true);
+  cl_assert(do_not_disturb_is_manually_enabled() == true);
+  cl_assert(do_not_disturb_is_active() == true);
+  cl_assert_equal_i(s_num_dnd_events_put, 1);
+
+  prv_sync_bool_pref_from_phone(PREF_KEY_DND_MANUALLY_ENABLED, false);
+  cl_assert(do_not_disturb_is_manually_enabled() == false);
+  cl_assert(do_not_disturb_is_active() == false);
+  cl_assert_equal_i(s_num_dnd_events_put, 2);
 }
 
 void test_do_not_disturb__manually_enable_active(void) {

--- a/tests/fw/test_alerts.c
+++ b/tests/fw/test_alerts.c
@@ -34,6 +34,10 @@ void do_not_disturb_init(void) {
   return;
 }
 
+void do_not_disturb_handle_pref_synced(void) {
+  return;
+}
+
 void vibe_intensity_init(void) {
   return;
 }

--- a/tests/stubs/stubs_do_not_disturb.h
+++ b/tests/stubs/stubs_do_not_disturb.h
@@ -15,3 +15,5 @@ void WEAK do_not_disturb_init(void) {}
 void WEAK do_not_disturb_manual_toggle_with_dialog(void) {}
 
 void WEAK do_not_disturb_toggle_manually_enabled(ManualDNDFirstUseSource source) {}
+
+void WEAK do_not_disturb_handle_pref_synced(void) {}


### PR DESCRIPTION
Settings sync writes from the phone reload dndManuallyEnabled, dndSmartEnabled and the DND schedule prefs directly into alerts_preferences, bypassing the do_not_disturb service. Quiet Time would silently (de)activate: no PEBBLE_DO_NOT_DISTURB_EVENT was fired, so UI indicators never updated, and schedule changes did not re-arm the schedule timer. A stale dndManuallyEnabled=true pushed by the phone could leave the watch stuck in Quiet Time (suppressing the shake-to-light backlight) with no visible indication.

Kick the do_not_disturb service when one of its state prefs is reloaded from a BlobDB insert so it re-evaluates state, fires the event, and re-arms the schedule timer.

Fixes FIRM-3372