### PR TITLE
resources/asterix: restore builtin flag on large PDCS files

### DIFF
--- a/resources/normal/asterix/resource_map.json
+++ b/resources/normal/asterix/resource_map.json
@@ -13,7 +13,8 @@
     {
       "type": "raw",
       "name": "NO_EVENTS_LARGE",
-      "file": "normal/snowy/images/Pebble_80x80_No_events.pdc"
+      "file": "normal/snowy/images/Pebble_80x80_No_events.pdc",
+      "builtin": true
     },
     {
       "type": "raw",
@@ -55,7 +56,8 @@
     {
       "type": "raw",
       "name": "RESULT_MUTE_LARGE",
-      "file": "normal/snowy/images/animated_pdcs/Pebble_80x80_Mute.pdc"
+      "file": "normal/snowy/images/animated_pdcs/Pebble_80x80_Mute.pdc",
+      "builtin": true
     },
     {
       "type": "raw",


### PR DESCRIPTION
Originally removed due to space constraints that no longer exist (jerryscript engine)
Fixes FIRM-2808