### PR TITLE
shell/prefs: make backlight presets available on all platforms

### DIFF
--- a/src/fw/apps/system/settings/display.c
+++ b/src/fw/apps/system/settings/display.c
@@ -246,6 +246,7 @@ static void prv_dynamic_mode_menu_push(SettingsBacklightData *data) {
       title, OptionMenuContentType_SingleLine, index, &callbacks,
       ARRAY_LENGTH(s_dynamic_mode_labels), true /* icons_enabled */, s_dynamic_mode_labels, data);
 }
+#endif
 
 // Backlight Preset Settings
 /////////////////////////////
@@ -279,7 +280,6 @@ static void prv_preset_menu_push(SettingsDisplayData *data) {
       ARRAY_LENGTH(s_backlight_preset_labels), true /* icons_enabled */,
       s_backlight_preset_labels, data);
 }
-#endif
 
 // Legacy App Mode Settings (Obelix only)
 /////////////////////////////
@@ -536,11 +536,7 @@ static void prv_backlight_submenu_push(void) {
     .hide = prv_backlight_hide_cb,
   };
 
-#ifdef CONFIG_DYNAMIC_BACKLIGHT
   const char *title = i18n_noop("Backlight Settings");
-#else
-  const char *title = i18n_noop("Backlight");
-#endif
   Window *window = settings_window_create_with_title(SettingsMenuItemDisplay,
                                                      title, &data->callbacks);
   app_window_stack_push(window, true /* animated */);
@@ -551,9 +547,7 @@ static void prv_backlight_submenu_push(void) {
 
 enum SettingsDisplayItem {
   SettingsDisplayBacklight,
-#ifdef CONFIG_DYNAMIC_BACKLIGHT
   SettingsDisplayBacklightSettings,
-#endif
 #ifdef CONFIG_TOUCH
   SettingsDisplayTouch,
 #endif
@@ -568,13 +562,11 @@ enum SettingsDisplayItem {
 };
 
 static bool prv_display_item_is_visible(uint16_t item) {
-#ifdef CONFIG_DYNAMIC_BACKLIGHT
   // The full backlight submenu only shows for the Advanced backlight mode;
   // the presets cover everything it contains.
   if (item == SettingsDisplayBacklightSettings) {
     return backlight_get_preset() == BacklightPreset_Advanced;
   }
-#endif
   return true;
 }
 
@@ -595,17 +587,11 @@ static uint16_t prv_display_item_from_row(uint16_t row) {
 static void prv_display_select_click_cb(SettingsCallbacks *context, uint16_t row) {
   switch (prv_display_item_from_row(row)) {
     case SettingsDisplayBacklight:
-#ifdef CONFIG_DYNAMIC_BACKLIGHT
       prv_preset_menu_push((SettingsDisplayData *)context);
-#else
-      prv_backlight_submenu_push();
-#endif
       break;
-#ifdef CONFIG_DYNAMIC_BACKLIGHT
     case SettingsDisplayBacklightSettings:
       prv_backlight_submenu_push();
       break;
-#endif
 #ifdef CONFIG_TOUCH
     case SettingsDisplayTouch:
       touch_set_globally_enabled(!touch_is_globally_enabled());
@@ -639,16 +625,12 @@ static void prv_display_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
   switch (prv_display_item_from_row(row)) {
     case SettingsDisplayBacklight:
       title = i18n_noop("Backlight");
-#ifdef CONFIG_DYNAMIC_BACKLIGHT
       subtitle = backlight_is_enabled() ? s_backlight_preset_labels[backlight_get_preset()]
                                         : i18n_ctx_noop("DeviceState", "Off");
-#endif
       break;
-#ifdef CONFIG_DYNAMIC_BACKLIGHT
     case SettingsDisplayBacklightSettings:
       title = i18n_noop("Backlight Settings");
       break;
-#endif
 #ifdef CONFIG_TOUCH
     case SettingsDisplayTouch:
       title = i18n_noop("Touch");

--- a/src/fw/services/blob_db/settings_blob_db.c
+++ b/src/fw/services/blob_db/settings_blob_db.c
@@ -66,8 +66,8 @@ static const char *s_syncable_settings[] = {
   "lightAmbientThreshold",
 #ifdef CONFIG_DYNAMIC_BACKLIGHT
   "lightDynamicMode",
-  "lightPreset",
 #endif
+  "lightPreset",
 #ifdef CONFIG_BACKLIGHT_HAS_COLOR
   "lightColor",
 #endif

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -101,6 +101,12 @@ static uint8_t s_motion_sensitivity = 55; // Default to Medium
 #define PREF_KEY_BACKLIGHT_DYNAMIC_MODE "lightDynamicMode"
 static uint8_t s_backlight_dynamic_mode = BacklightDynamicMode_Standard;
 
+// Removed prefs; the key defines survive only so migration can convert/scrub
+// stored values.
+#define PREF_KEY_BACKLIGHT_DYNAMIC_INTENSITY_DEPRECATED "lightDynamicIntensity"
+#define PREF_KEY_DYNAMIC_BACKLIGHT_MIN_THRESHOLD "dynBacklightMinThreshold"
+#endif
+
 #define PREF_KEY_BACKLIGHT_PRESET "lightPreset"
 static uint8_t s_backlight_preset = BacklightPreset_Standard;
 
@@ -108,7 +114,9 @@ static uint8_t s_backlight_preset = BacklightPreset_Standard;
 // the underlying settings untouched.
 typedef struct BacklightPresetSettings {
   bool ambient_sensor_enabled;
+#ifdef CONFIG_DYNAMIC_BACKLIGHT
   BacklightDynamicMode dynamic_mode;
+#endif
   uint8_t intensity;
   uint32_t timeout_ms;
   bool motion_enabled;
@@ -118,7 +126,9 @@ typedef struct BacklightPresetSettings {
 static const BacklightPresetSettings s_backlight_preset_settings[] = {
   [BacklightPreset_MaxBrightness] = {
     .ambient_sensor_enabled = true,
+#ifdef CONFIG_DYNAMIC_BACKLIGHT
     .dynamic_mode = BacklightDynamicMode_Off,
+#endif
     .intensity = BACKLIGHT_INTENSITY_MAX,
     .timeout_ms = 5000,
     .motion_enabled = true,
@@ -126,7 +136,9 @@ static const BacklightPresetSettings s_backlight_preset_settings[] = {
   },
   [BacklightPreset_Standard] = {
     .ambient_sensor_enabled = true,
+#ifdef CONFIG_DYNAMIC_BACKLIGHT
     .dynamic_mode = BacklightDynamicMode_Standard,
+#endif
     .intensity = BACKLIGHT_INTENSITY_HIGH,
     .timeout_ms = DEFAULT_BACKLIGHT_TIMEOUT_MS,
     .motion_enabled = true,
@@ -134,19 +146,15 @@ static const BacklightPresetSettings s_backlight_preset_settings[] = {
   },
   [BacklightPreset_BatterySaver] = {
     .ambient_sensor_enabled = true,
+#ifdef CONFIG_DYNAMIC_BACKLIGHT
     .dynamic_mode = BacklightDynamicMode_Dim,
+#endif
     .intensity = BACKLIGHT_INTENSITY_MEDIUM,
     .timeout_ms = DEFAULT_BACKLIGHT_TIMEOUT_MS,
     .motion_enabled = true,
     .touch_wake = BacklightTouchWake_DoubleTap,
   },
 };
-
-// Removed prefs; the key defines survive only so migration can convert/scrub
-// stored values.
-#define PREF_KEY_BACKLIGHT_DYNAMIC_INTENSITY_DEPRECATED "lightDynamicIntensity"
-#define PREF_KEY_DYNAMIC_BACKLIGHT_MIN_THRESHOLD "dynBacklightMinThreshold"
-#endif
 
 #ifdef CONFIG_ORIENTATION_MANAGER
 #define PREF_KEY_DISPLAY_ORIENTATION_LEFT_HANDED "displayOrientationLeftHanded"
@@ -446,6 +454,7 @@ static bool prv_set_s_backlight_dynamic_mode(uint8_t *mode) {
   s_backlight_dynamic_mode = *mode;
   return true;
 }
+#endif
 
 static bool prv_set_s_backlight_preset(uint8_t *preset) {
   if (*preset >= BacklightPresetCount) {
@@ -455,7 +464,6 @@ static bool prv_set_s_backlight_preset(uint8_t *preset) {
   s_backlight_preset = *preset;
   return true;
 }
-#endif
 
 static bool prv_set_s_motion_sensitivity(uint8_t *sensitivity) {
   // Clamp sensitivity to 0-100 range
@@ -921,11 +929,9 @@ static void prv_pref_set(const char* key, const void *value, size_t val_len);
 void shell_prefs_init(void) {
 #ifdef CONFIG_QEMU
   s_backlight_intensity = BACKLIGHT_INTENSITY_MAX; // Blinding
-#elif defined(CONFIG_DYNAMIC_BACKLIGHT)
+#else
   // Match the Standard preset so fresh devices report Mode: Standard.
   s_backlight_intensity = s_backlight_preset_settings[BacklightPreset_Standard].intensity;
-#else
-  s_backlight_intensity = BACKLIGHT_INTENSITY_DEFAULT; // Medium
 #endif
   s_backlight_ambient_threshold = BOARD_CONFIG.ambient_light_dark_threshold;
 #ifdef CONFIG_BACKLIGHT_HAS_COLOR
@@ -964,12 +970,10 @@ void shell_prefs_init(void) {
     s_backlight_intensity = BACKLIGHT_INTENSITY_DEFAULT;
   }
 
-#ifdef CONFIG_DYNAMIC_BACKLIGHT
   // The boot load above bypasses the validating setters, so clamp here.
   if (s_backlight_preset >= BacklightPresetCount) {
     s_backlight_preset = BacklightPreset_Advanced;
   }
-#endif
 
 #if defined(CONFIG_AMBIENT_LIGHT_W1160)
   // One-time: the W1160 scale rework left old-scale ambient thresholds far below
@@ -1346,6 +1350,7 @@ void backlight_set_dynamic_mode(BacklightDynamicMode mode) {
 bool backlight_is_dynamic_intensity_enabled(void) {
   return s_backlight_dynamic_mode != BacklightDynamicMode_Off;
 }
+#endif
 
 BacklightPreset backlight_get_preset(void) {
   const uint8_t preset = s_backlight_preset;
@@ -1356,7 +1361,9 @@ BacklightPreset backlight_get_preset(void) {
   // they can drift independently (e.g. via phone sync).
   const BacklightPresetSettings *settings = &s_backlight_preset_settings[preset];
   if ((s_backlight_ambient_sensor_enabled != settings->ambient_sensor_enabled) ||
+#ifdef CONFIG_DYNAMIC_BACKLIGHT
       (s_backlight_dynamic_mode != settings->dynamic_mode) ||
+#endif
       (s_backlight_intensity != settings->intensity) ||
       (s_backlight_timeout_ms != settings->timeout_ms) ||
       (s_backlight_motion_enabled != settings->motion_enabled) ||
@@ -1377,13 +1384,14 @@ void backlight_set_preset(BacklightPreset preset) {
   }
   const BacklightPresetSettings *settings = &s_backlight_preset_settings[preset];
   backlight_set_ambient_sensor_enabled(settings->ambient_sensor_enabled);
+#ifdef CONFIG_DYNAMIC_BACKLIGHT
   backlight_set_dynamic_mode(settings->dynamic_mode);
+#endif
   backlight_set_intensity(settings->intensity);
   backlight_set_timeout_ms(settings->timeout_ms);
   backlight_set_motion_enabled(settings->motion_enabled);
   backlight_set_touch_wake(settings->touch_wake);
 }
-#endif
 
 uint8_t shell_prefs_get_motion_sensitivity(void) {
   return s_motion_sensitivity;

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -17,8 +17,8 @@
   PREFS_MACRO(PREF_KEY_MOTION_SENSITIVITY, s_motion_sensitivity)
 #ifdef CONFIG_DYNAMIC_BACKLIGHT
   PREFS_MACRO(PREF_KEY_BACKLIGHT_DYNAMIC_MODE, s_backlight_dynamic_mode)
-  PREFS_MACRO(PREF_KEY_BACKLIGHT_PRESET, s_backlight_preset)
 #endif
+  PREFS_MACRO(PREF_KEY_BACKLIGHT_PRESET, s_backlight_preset)
   PREFS_MACRO(PREF_KEY_BACKLIGHT_AMBIENT_THRESHOLD, s_backlight_ambient_threshold)
   PREFS_MACRO(PREF_KEY_STATIONARY, s_stationary_mode_enabled)
   PREFS_MACRO(PREF_KEY_DEFAULT_WORKER, s_default_worker)

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -127,11 +127,13 @@ BacklightDynamicMode backlight_get_dynamic_mode(void);
 void backlight_set_dynamic_mode(BacklightDynamicMode mode);
 // Convenience: mode != Off
 bool backlight_is_dynamic_intensity_enabled(void);
+#endif
 
-// Backlight presets bundle the ambient sensor, dynamic mode and intensity
-// settings into one user-facing mode; Advanced exposes the three settings
-// individually. A stored preset only reports as active while the underlying
-// settings still match its values, otherwise Advanced is reported.
+// Backlight presets bundle the ambient sensor, dynamic mode (where dynamic
+// backlight is available) and intensity settings into one user-facing mode;
+// Advanced exposes the settings individually. A stored preset only reports
+// as active while the underlying settings still match its values, otherwise
+// Advanced is reported.
 typedef enum BacklightPreset {
   BacklightPreset_MaxBrightness = 0,
   BacklightPreset_Standard = 1,
@@ -142,7 +144,6 @@ typedef enum BacklightPreset {
 
 BacklightPreset backlight_get_preset(void);
 void backlight_set_preset(BacklightPreset preset);
-#endif
 
 // Motion sensitivity for accelerometer shake detection (0-100, lower = less sensitive)
 // Only available on platforms with LSM6DSO (Asterix, Obelix)


### PR DESCRIPTION
The Max Brightness / Standard / Battery Saver / Advanced backlight presets were gated behind CONFIG_DYNAMIC_BACKLIGHT, so only obelix and getafix had them. Make the presets unconditional and gate only the dynamic-backlight pieces (dynamic mode in the preset table, its Settings row and the brightness-percent subtitle), so asterix and the QEMU boards get the same preset UI minus the dynamic settings.

The fresh-device intensity default now always matches the Standard preset so new devices report Mode: Standard, and the lightPreset key is persisted and phone-synced on every platform.