### PR TITLE
pfs: recover from corrupt file headers instead of failing opens

### DIFF
--- a/src/fw/services/filesystem/pfs.c
+++ b/src/fw/services/filesystem/pfs.c
@@ -453,12 +453,15 @@ static status_t write_pg_header(PageHeader *hdr, uint16_t pg) {
   return (S_SUCCESS);
 }
 
+static status_t unlink_flash_file(uint16_t page);
+
 // note: the goal here is to do as few flash reads as possible
 // while scanning the flash to find a given file.
 static status_t locate_flash_file(const char *name, uint16_t *page) {
   const int file_namelen_offset = FILEHEADER_OFFSET +
       offsetof(FileHeader, file_namelen);
   uint8_t namelen = strlen(name);
+  uint16_t corrupt_pg = INVALID_PAGE;
 
   for (uint16_t pg = 0; pg < s_pfs_page_count; pg++) {
     PageHeader pg_hdr;
@@ -482,7 +485,17 @@ static status_t locate_flash_file(const char *name, uint16_t *page) {
 
         if (read_header(pg, &pg_hdr, &file_hdr) == HdrCrcCorrupt) {
           PBL_LOG_WRN("CRC corrupt for page %d", pg);
+          if (corrupt_pg == INVALID_PAGE) {
+            corrupt_pg = pg;
+          }
           continue;
+        }
+
+        if (corrupt_pg != INVALID_PAGE) {
+          // A valid copy exists, so the corrupt match is a stale leftover:
+          // unlink it so it no longer shadows scans and can be reclaimed.
+          PBL_LOG_WRN("Unlinking stale corrupt copy of '%s' (page %u)", name, corrupt_pg);
+          unlink_flash_file(corrupt_pg);
         }
 
         *page = pg;

--- a/src/fw/services/filesystem/pfs.c
+++ b/src/fw/services/filesystem/pfs.c
@@ -1744,9 +1744,13 @@ static NOINLINE bool file_found_in_cache(const char *name, uint8_t op_flags, int
       // make sure the header is not corrupted
       PageHeader pg_hdr;
       FileHeader file_hdr;
-      if ((res = read_header(file->start_page, &pg_hdr, &file_hdr)) !=
-          PageAndFileHdrValid) {
-        mark_fd_free(fd); // file has been corrupted so clear fd
+      if (read_header(file->start_page, &pg_hdr, &file_hdr) != PageAndFileHdrValid) {
+        // Evict the entry and fall back to the flash scan (res stays >= 0 so
+        // the caller reuses this fd slot): the check may have hit a transient
+        // read glitch, and the scan can still find a valid copy.
+        PBL_LOG_WRN("Cached header check failed for '%s' (page %u), rescanning",
+                    name, file->start_page);
+        mark_fd_free(fd);
         goto cleanup;
       }
     }

--- a/tests/fw/services/test_pfs.c
+++ b/tests/fw/services/test_pfs.c
@@ -994,3 +994,31 @@ void test_pfs__doesnt_give_out_fd_zero(void) {
     cl_assert(fd > 0);
   }
 }
+
+// PageHeader field offsets/masks, mirroring the layout in pfs.c, so the tests
+// can corrupt and inspect raw page headers.
+#define PAGE_HDR_FLAGS_OFFSET   3
+#define PAGE_HDR_CRC_OFFSET     24
+#define PAGE_HDR_FLAG_DELETED   (1 << 1)
+
+static void prv_corrupt_page_hdr_crc(uint16_t page) {
+  const uint32_t bad_crc = 0;
+  ftl_write((uint8_t *)&bad_crc, sizeof(bad_crc),
+            ((uint32_t)page * PFS_SECTOR_SIZE) + PAGE_HDR_CRC_OFFSET);
+}
+
+// A failed header check on a cached fd must fall back to the flash scan
+// instead of failing the open with the raw header status (E_ERROR).
+void test_pfs__corrupt_cached_header_falls_back_to_scan(void) {
+  int fd = pfs_open(TEST_FILE_A_NAME, OP_FLAG_READ, 0, 0);
+  cl_assert(fd >= 0);
+  uint16_t start_page = test_get_file_start_page(fd);
+  pfs_close(fd);
+
+  prv_corrupt_page_hdr_crc(start_page);
+
+  // The cached-header check fails, the scan finds no valid copy, and the
+  // read-only open reports the file as missing.
+  fd = pfs_open(TEST_FILE_A_NAME, OP_FLAG_READ, 0, 0);
+  cl_assert_equal_i(fd, E_DOES_NOT_EXIST);
+}

--- a/tests/fw/services/test_pfs.c
+++ b/tests/fw/services/test_pfs.c
@@ -1022,3 +1022,44 @@ void test_pfs__corrupt_cached_header_falls_back_to_scan(void) {
   fd = pfs_open(TEST_FILE_A_NAME, OP_FLAG_READ, 0, 0);
   cl_assert_equal_i(fd, E_DOES_NOT_EXIST);
 }
+
+// A corrupt page which still matches a file name must get unlinked once a
+// scan finds a valid copy of the file, instead of shadowing scans forever.
+void test_pfs__stale_corrupt_duplicate_is_unlinked(void) {
+  const char *name = "dupfile";
+  char v1[] = "version 1";
+  int fd = pfs_open(name, OP_FLAG_WRITE, FILE_TYPE_STATIC, sizeof(v1));
+  cl_assert(fd >= 0);
+  cl_assert_equal_i(pfs_write(fd, (uint8_t *)v1, sizeof(v1)), sizeof(v1));
+  uint16_t old_page = test_get_file_start_page(fd);
+  pfs_close(fd);
+
+  prv_corrupt_page_hdr_crc(old_page);
+
+  // Re-opening for write falls back to the scan, finds no valid copy and
+  // recreates the file elsewhere.
+  char v2[] = "version 2";
+  fd = pfs_open(name, OP_FLAG_WRITE, FILE_TYPE_STATIC, sizeof(v2));
+  cl_assert(fd >= 0);
+  uint16_t new_page = test_get_file_start_page(fd);
+  cl_assert(new_page != old_page);
+  cl_assert_equal_i(pfs_write(fd, (uint8_t *)v2, sizeof(v2)), sizeof(v2));
+  pfs_close(fd);
+
+  // Simulate a reboot so the next open scans flash: it skips the corrupt
+  // page, finds the valid copy and unlinks the stale one.
+  pfs_reset_all_state();
+  pfs_init(false);
+
+  char rbuf[sizeof(v2)];
+  fd = pfs_open(name, OP_FLAG_READ, 0, 0);
+  cl_assert(fd >= 0);
+  cl_assert_equal_i(pfs_read(fd, (uint8_t *)rbuf, sizeof(rbuf)), sizeof(rbuf));
+  cl_assert(memcmp(rbuf, v2, sizeof(v2)) == 0);
+  pfs_close(fd);
+
+  uint8_t page_flags;
+  ftl_read(&page_flags, sizeof(page_flags),
+           ((uint32_t)old_page * PFS_SECTOR_SIZE) + PAGE_HDR_FLAGS_OFFSET);
+  cl_assert((~page_flags & PAGE_HDR_FLAG_DELETED) != 0);
+}


### PR DESCRIPTION
## Summary

Two robustness fixes for how PFS handles a file start page whose header no longer passes its CRC check. Both were found while debugging a boot log where a `gap_bonding_db` write failed with `-1` while a stale `CRC corrupt for page 2099` warning kept appearing on every scan.

- **Fall back to the flash scan when the fd-cache header check fails.** `pfs_open()` re-validates the cached start page header on every cache hit, and used to fail the whole open with the raw header status (`E_ERROR`) even though the copy on flash may still be valid (e.g. a transient flash read glitch). Callers like `settings_file_open()` treated this as a hard failure and lost the write. Now the cache entry is evicted and the open falls through to the scan, matching what already happened when the cached page merely stopped being flagged as a start page.

- **Unlink stale corrupt copies once a valid one is found.** A corrupt start page that still carries a matching file name (leftover from an interrupted rewrite/delete) was skipped by every scan with a warning, forever — leaking its pages and spamming the log. The scan now unlinks the corrupt match when it finds a valid copy of the same file. If no valid copy exists the page is left untouched, so a transient misread can't destroy live data. The unlink walk is bounded by the per-page `next_page` CRC8, so a corrupt chain cannot mark unrelated pages.

## Testing

- New unit tests `test_pfs__corrupt_cached_header_falls_back_to_scan` and `test_pfs__stale_corrupt_duplicate_is_unlinked`, which corrupt raw page headers on the fake flash and exercise both paths (including a simulated reboot).
- `./pbl test -M ".*pfs.*"` passes at each commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)