### PR TITLE
fw/services/speaker: drain audio pipeline before stopping

### DIFF
--- a/include/pbl/services/speaker/speaker_service.h
+++ b/include/pbl/services/speaker/speaker_service.h
@@ -22,7 +22,7 @@ typedef enum {
 typedef enum {
   SpeakerStateIdle = 0,
   SpeakerStatePlaying,
-  SpeakerStateDraining,    // stream closing, playing remaining buffered data
+  SpeakerStateDraining,    // source exhausted, playing remaining queued data
 } SpeakerState;
 
 typedef enum {

--- a/src/fw/services/speaker/speaker_service.c
+++ b/src/fw/services/speaker/speaker_service.c
@@ -29,6 +29,11 @@ PBL_LOG_MODULE_DEFINE(service_speaker, CONFIG_SERVICE_SPEAKER_LOG_LEVEL);
 #define SPEAKER_SAMPLE_RATE 16000
 #define SPEAKER_REFILL_SAMPLES 512
 
+// The audio drivers queue up to ~64 ms ahead of the DAC (double-buffered
+// DMA/I2S pipe + circular buffer). Once the source runs dry, pad with 80 ms
+// of silence before stopping so the queued audio actually plays.
+#define SPEAKER_PIPELINE_DRAIN_SAMPLES ((SPEAKER_SAMPLE_RATE * 80) / 1000)
+
 typedef struct {
   SpeakerState state;
   SpeakerSourceType source_type;
@@ -69,6 +74,12 @@ typedef struct {
   void *track_sample_data[SPEAKER_MAX_TRACKS];
   int32_t mix_buf[SPEAKER_REFILL_SAMPLES];
   int16_t track_scratch[SPEAKER_REFILL_SAMPLES];
+
+  // Pipeline drain: set once the source has no more samples to generate;
+  // we then emit drain_samples_remaining of silence before stopping so the
+  // driver's queued audio finishes playing.
+  bool pipeline_draining;
+  uint32_t drain_samples_remaining;
 
   // Finish-event delivery
   bool finish_enabled;
@@ -199,6 +210,7 @@ static void prv_stop_internal(SpeakerFinishReason reason) {
   s_state.state = SpeakerStateIdle;
   s_state.source_type = SpeakerSourceNone;
   s_state.owner_task = PebbleTask_Unknown;
+  s_state.pipeline_draining = false;
 
   if (reason == SpeakerFinishReasonPreempted) {
     PBL_ANALYTICS_ADD(speaker_preempted_count, 1);
@@ -228,6 +240,11 @@ static void prv_stop_internal(SpeakerFinishReason reason) {
 
 static bool prv_can_preempt(SpeakerPriority new_pri) {
   if (s_state.state == SpeakerStateIdle) {
+    return true;
+  }
+  if (s_state.pipeline_draining) {
+    // Only padding silence remains — let anyone start a new sound rather
+    // than rejecting it (matters for rapid re-triggers, e.g. a metronome).
     return true;
   }
   return new_pri > s_state.priority;
@@ -351,23 +368,19 @@ static void prv_refill_locked(void) {
   }
 
   uint32_t samples_generated = 0;
+  bool source_exhausted = false;
 
   if (s_state.source_type == SpeakerSourceNoteSeq) {
     samples_generated = note_seq_fill(&s_state.note_seq, s_state.refill_buf,
                                       SPEAKER_REFILL_SAMPLES);
-    if (samples_generated == 0) {
-      prv_stop_internal(SpeakerFinishReasonDone);
-      return;
-    }
+    source_exhausted = (samples_generated == 0);
   } else if (s_state.source_type == SpeakerSourceStream) {
     samples_generated = prv_read_and_convert_pcm(s_state.refill_buf,
                                                   SPEAKER_REFILL_SAMPLES);
     if (samples_generated == 0 && pcm_stream_is_done(&s_state.pcm_stream)) {
-      prv_stop_internal(SpeakerFinishReasonDone);
-      return;
-    }
-    // If no data but not done, write silence to keep DMA fed
-    if (samples_generated == 0) {
+      source_exhausted = true;
+    } else if (samples_generated == 0) {
+      // No data but not done — write silence to keep DMA fed
       PBL_ANALYTICS_ADD(speaker_stream_underrun_count, 1);
       memset(s_state.refill_buf, 0, SPEAKER_REFILL_SAMPLES * sizeof(int16_t));
       samples_generated = SPEAKER_REFILL_SAMPLES;
@@ -378,10 +391,8 @@ static void prv_refill_locked(void) {
       to_gen = SPEAKER_REFILL_SAMPLES;
     }
     if (to_gen == 0) {
-      prv_stop_internal(SpeakerFinishReasonDone);
-      return;
-    }
-    if (s_state.tone_phase_inc == 0) {
+      source_exhausted = true;
+    } else if (s_state.tone_phase_inc == 0) {
       memset(s_state.refill_buf, 0, to_gen * sizeof(int16_t));
     } else {
       for (uint32_t i = 0; i < to_gen; i++) {
@@ -408,8 +419,7 @@ static void prv_refill_locked(void) {
       }
     }
     if (max_generated == 0) {
-      prv_stop_internal(SpeakerFinishReasonDone);
-      return;
+      source_exhausted = true;
     }
     for (uint32_t j = 0; j < max_generated; j++) {
       int32_t v = s_state.mix_buf[j];
@@ -418,6 +428,26 @@ static void prv_refill_locked(void) {
       s_state.refill_buf[j] = (int16_t)v;
     }
     samples_generated = max_generated;
+  }
+
+  if (source_exhausted) {
+    // Drain: pad with silence so the driver's queued audio finishes playing.
+    if (!s_state.pipeline_draining) {
+      s_state.pipeline_draining = true;
+      s_state.drain_samples_remaining = SPEAKER_PIPELINE_DRAIN_SAMPLES;
+      s_state.state = SpeakerStateDraining;
+    }
+    uint32_t to_gen = s_state.drain_samples_remaining;
+    if (to_gen == 0) {
+      prv_stop_internal(SpeakerFinishReasonDone);
+      return;
+    }
+    if (to_gen > SPEAKER_REFILL_SAMPLES) {
+      to_gen = SPEAKER_REFILL_SAMPLES;
+    }
+    memset(s_state.refill_buf, 0, to_gen * sizeof(int16_t));
+    s_state.drain_samples_remaining -= to_gen;
+    samples_generated = to_gen;
   }
 
   if (samples_generated > 0) {

--- a/tests/fw/services/test_speaker_service.c
+++ b/tests/fw/services/test_speaker_service.c
@@ -1,0 +1,143 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "clar.h"
+
+#include "pbl/services/speaker/speaker_service.h"
+
+#include "drivers/audio.h"
+#include "drivers/rtc.h"
+
+#include <string.h>
+
+#include "stubs_logging.h"
+#include "stubs_passert.h"
+#include "stubs_analytics.h"
+#include "stubs_rtc.h"
+#include "stubs_do_not_disturb.h"
+#include "fake_mutex.h"
+#include "fake_pbl_malloc.h"
+#include "fake_system_task.h"
+#include "fake_events.h"
+#include "fake_pebble_tasks.h"
+
+// Alerts preferences: speaker unmuted, no volume cap
+bool alerts_preferences_get_speaker_muted(void) { return false; }
+uint8_t alerts_preferences_get_speaker_volume(void) { return 100; }
+bool alerts_preferences_dnd_get_mute_speaker(void) { return false; }
+
+// ---------------------------------------------------------------------------
+// Fake audio driver. Counts what the service hands to the hardware so the
+// tests can tell how much audio would actually have been played before the
+// service powered the speaker down.
+
+static AudioTransCB s_trans_cb;
+static int s_start_count;
+static int s_stop_count;
+static uint32_t s_samples_written;
+static uint32_t s_nonzero_samples;
+
+void audio_init(AudioDevice *device) {}
+
+void audio_start(AudioDevice *device, AudioTransCB cb) {
+  s_trans_cb = cb;
+  s_start_count++;
+}
+
+uint32_t audio_write(AudioDevice *device, void *buf, uint32_t size) {
+  const int16_t *samples = buf;
+  const uint32_t num_samples = size / sizeof(int16_t);
+  for (uint32_t i = 0; i < num_samples; i++) {
+    if (samples[i] != 0) {
+      s_nonzero_samples++;
+    }
+  }
+  s_samples_written += num_samples;
+  return 0;
+}
+
+void audio_set_volume(AudioDevice *device, int volume) {}
+
+void audio_stop(AudioDevice *device) {
+  s_stop_count++;
+  s_trans_cb = NULL;
+}
+
+// ---------------------------------------------------------------------------
+
+#define SAMPLE_RATE 16000
+// Must match SPEAKER_PIPELINE_DRAIN_SAMPLES in speaker_service.c
+#define DRAIN_SAMPLES ((SAMPLE_RATE * 80) / 1000)
+
+// Simulate the driver requesting more data until playback stops on its own.
+static void prv_pump_until_idle(void) {
+  for (int i = 0; i < 100 && s_trans_cb; i++) {
+    uint32_t free_size = 4096;
+    s_trans_cb(&free_size);
+    fake_system_task_callbacks_invoke_pending();
+  }
+}
+
+void test_speaker_service__initialize(void) {
+  fake_system_task_callbacks_cleanup();
+  s_trans_cb = NULL;
+  s_start_count = 0;
+  s_stop_count = 0;
+  s_samples_written = 0;
+  s_nonzero_samples = 0;
+  speaker_service_init();
+}
+
+void test_speaker_service__cleanup(void) {
+  speaker_service_stop();
+  fake_system_task_callbacks_cleanup();
+}
+
+// A tone shorter than the driver's DMA pipeline (~64 ms) must still be
+// generated in full and followed by enough padding silence that the queued
+// samples play out before the service stops the hardware.
+void test_speaker_service__short_tone_drains_pipeline_before_stop(void) {
+  const uint16_t duration_ms = 25;
+  const uint32_t tone_samples = (SAMPLE_RATE * duration_ms) / 1000;
+
+  cl_assert(speaker_service_play_tone(1000, duration_ms, 0 /* sine */,
+                                      0 /* full velocity */,
+                                      SpeakerPriorityApp, 80));
+  cl_assert_equal_i(speaker_service_get_state(), SpeakerStatePlaying);
+
+  prv_pump_until_idle();
+
+  cl_assert_equal_i(speaker_service_get_state(), SpeakerStateIdle);
+  cl_assert_equal_i(s_start_count, 1);
+  cl_assert_equal_i(s_stop_count, 1);
+  // The full tone reached the driver (1 kHz sine: allow for zero crossings)
+  cl_assert(s_nonzero_samples > tone_samples / 2);
+  // ...followed by at least a pipeline depth of padding silence
+  cl_assert(s_samples_written >= tone_samples + DRAIN_SAMPLES);
+}
+
+// While only padding silence remains, a new same-priority sound must be able
+// to start instead of being rejected (rapid re-triggers, e.g. a metronome).
+void test_speaker_service__same_priority_preempts_during_drain(void) {
+  cl_assert(speaker_service_play_tone(1000, 25, 0, 0, SpeakerPriorityApp, 80));
+
+  uint32_t free_size = 4096;
+  s_trans_cb(&free_size);
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(speaker_service_get_state(), SpeakerStateDraining);
+
+  cl_assert(speaker_service_play_tone(2000, 25, 0, 0, SpeakerPriorityApp, 80));
+  cl_assert_equal_i(speaker_service_get_state(), SpeakerStatePlaying);
+
+  prv_pump_until_idle();
+  cl_assert_equal_i(speaker_service_get_state(), SpeakerStateIdle);
+}
+
+// A sound still generating real samples must NOT be preemptable by the same
+// priority (unchanged behavior).
+void test_speaker_service__same_priority_cannot_preempt_while_playing(void) {
+  cl_assert(speaker_service_play_tone(1000, 500, 0, 0, SpeakerPriorityApp, 80));
+  cl_assert_equal_i(speaker_service_get_state(), SpeakerStatePlaying);
+
+  cl_assert(!speaker_service_play_tone(2000, 25, 0, 0, SpeakerPriorityApp, 80));
+}

--- a/tests/fw/services/wscript_build
+++ b/tests/fw/services/wscript_build
@@ -256,6 +256,17 @@ clar(ctx,
 
 clar(ctx,
     sources_ant_glob = " ".join([
+        " src/fw/services/speaker/speaker_service.c " \
+        " src/fw/services/speaker/note_sequence.c " \
+        " src/fw/services/speaker/pcm_stream.c " \
+        " src/fw/services/speaker/track_player.c " \
+        " tests/fakes/fake_events.c"]),
+    test_sources_ant_glob = "test_speaker_service.c",
+    defines=['CONFIG_SPEAKER=1'],
+    override_includes=['dummy_board'])
+
+clar(ctx,
+    sources_ant_glob = " ".join([
         " src/fw/services/voice/transcription.c"]),
     test_sources_ant_glob = "test_transcription.c")
 

--- a/tests/overrides/dummy_board/board/board.h
+++ b/tests/overrides/dummy_board/board/board.h
@@ -46,3 +46,5 @@ static MicDevice * const MIC = (void *)0;
 
 typedef const struct HRMDevice HRMDevice;
 static HRMDevice * const HRM = (void *)0;
+
+static const struct AudioDevice * const AUDIO = (void *)0;


### PR DESCRIPTION
**Problem.** Found in the wild: testing a metronome app ([Pulse](https://github.com/rhaist/pebble-pulse)) on a real Pebble Time 2, every `speaker_play_tone()` click came out as a faint mechanical pop instead of a tone — the speaker was clearly triggered, but no pitch was audible.

Root cause: the speaker service stops the audio driver as soon as the active source has no more samples to generate. The drivers queue up to ~64ms of audio ahead of the DAC (double-buffered DMA/I2S pipe primed with silence, plus a circular buffer), so playback is cut off up to 64ms early — and sounds shorter than the pipeline depth are never heard at all. On sf32lb52, whose `audio_stop()` halts the DMA and cuts amplifier power immediately, the app's 25ms clicks were killed ~30ms before their first sample reached the DAC, leaving only the amplifier pop. This affects all four sources (tone, note sequence, tracks, PCM stream); stream playback loses its final ~64ms tail.

**Fix.** Once the source is exhausted, keep feeding silence until the pipeline has drained (80ms), then stop. Playback transitions through `SpeakerStateDraining`. **Semantic change to call out:** while only padding silence remains, same-priority playback may now start instead of being rejected, so rapid re-triggers (e.g. a metronome's fast subdivisions) aren't dropped.

**Per-platform:** sf32lb52 (obelix) is the affected driver. nrf5/da7212 (asterix) never had the audible bug — its warm-pause `audio_stop()` keeps the I2S stream draining for 1s — and the change is behavior-neutral there (warm pause just starts ~80ms later). QEMU driver: neutral. Non-speaker boards build the stub branch.

**Testing.** New `test_speaker_service.c` host suite (fake audio driver): full tone + ≥ pipeline-depth of silence reaches the driver before `audio_stop()`, same-priority preemption allowed during drain and still blocked during playback. 3 of 4 assertions fail without the fix; full suite passes. Verified end-to-end on qemu_emery with the same app — audibly distinct downbeat/upbeat tones where unfixed firmware plays nothing. Firmware builds: obelix@pvt, asterix, qemu_flint, qemu_emery.

**Related:** #1641 touches the same file (stream session IDs) — one adjacent line in `prv_stop_internal`, trivial merge either order; this fix also stops voice-note playback tails from being clipped.
