### PR TITLE
fw/drivers/imu/lis2dw12: harden against INT1/FIFO stream stalls

### DIFF
--- a/src/fw/board/boards/board_getafix.c
+++ b/src/fw/board/boards/board_getafix.c
@@ -291,6 +291,10 @@ static const LIS2DW12Config s_lis2dw12_config = {
       .peripheral = hwp_gpio1,
       .gpio_pin = 26,
     },
+    .int1_in = {
+      .gpio = hwp_gpio1,
+      .gpio_pin = 26,
+    },
     .axis_map = {
         [AXIS_X] = 0,
         [AXIS_Y] = 1,

--- a/src/fw/drivers/imu/lis2dw12/lis2dw12.c
+++ b/src/fw/drivers/imu/lis2dw12/lis2dw12.c
@@ -30,9 +30,9 @@ PBL_LOG_MODULE_DEFINE(driver_accel_lis2dw12, CONFIG_DRIVER_IMU_LOG_LEVEL);
 //   possible to notice sensitivity changes when changing sampling interval.
 // - For some reason (needs more investigation), INT1 is sometimes left HIGH
 //   due to FIFO overruns, and without edge change, we cannot detect such
-//   events. To mitigate this, there is a watchdog timer that re-arms FIFO
-//   if no INT1 event is detected within the expected time window based on the
-//   ODR and FIFO threshold.
+//   events. To mitigate this, a watchdog timer re-arms FIFO if no samples
+//   have been read within the expected time window (FIFO reads are tracked
+//   instead of INT1 edges, which shake events would keep feeding).
 
 // Time to wait after reset (us)
 #define LIS2DW12_RESET_TIME_US 5
@@ -40,6 +40,11 @@ PBL_LOG_MODULE_DEFINE(driver_accel_lis2dw12, CONFIG_DRIVER_IMU_LOG_LEVEL);
 // DRDY polling parameters for accel_peek single-shot mode
 #define LIS2DW12_DRDY_POLL_DELAY_MS   (5)   /* ms between data-ready polls */
 #define LIS2DW12_DRDY_POLL_TIMEOUT_MS (100) /* max wait (~5x 20ms at 50Hz ODR) */
+
+// FIFO threshold periods without a FIFO read before the stream is considered
+// stalled (>1x to tolerate scheduling jitter), and threshold lower bound
+#define LIS2DW12_STALL_MARGIN 2U
+#define LIS2DW12_STALL_MIN_MS 1000U
 
 // Scale range when in 12-bit mode (low-power mode 1)
 #define LIS2DW12_S12_SCALE_RANGE (1U << (12U - 1U))
@@ -298,6 +303,7 @@ static void prv_lis2dw12_int1_work_handler(void) {
           return;
         }
         timestamp_us = prv_get_curr_system_time_us();
+        LIS2DW12->state->last_fifo_read_tick = rtc_get_ticks();
       }
     }
   }
@@ -335,7 +341,6 @@ static void prv_lis2dw12_int1_work_handler(void) {
 }
 
 static void prv_lis2dw12_int1_irq_handler(bool *should_context_switch) {
-  LIS2DW12->state->last_int1_tick = rtc_get_ticks();
   accel_offload_work_from_isr(prv_lis2dw12_int1_work_handler, should_context_switch);
 }
 
@@ -432,34 +437,51 @@ static bool prv_configure_int1(bool shake_detection_enabled, bool fifo_enabled) 
   return true;
 }
 
-static void prv_int1_wdt_work_cb(void) {
-  RtcTicks now_tick = rtc_get_ticks();
-  RtcTicks ticks_since_last_int1 = now_tick - LIS2DW12->state->last_int1_tick;
-  uint32_t ms_since_last_int1 = (ticks_since_last_int1 * 1000) / RTC_TICKS_HZ;
+static uint32_t prv_ms_since_last_fifo_read(void) {
+  RtcTicks ticks = rtc_get_ticks() - LIS2DW12->state->last_fifo_read_tick;
+  return (uint32_t)((ticks * 1000) / RTC_TICKS_HZ);
+}
 
-  if (ms_since_last_int1 >= LIS2DW12->state->int1_period_ms) {
-    bool ret;
-    uint8_t val;
+static uint32_t prv_stall_threshold_ms(void) {
+  return MAX(LIS2DW12_STALL_MARGIN * LIS2DW12->state->int1_period_ms,
+             LIS2DW12_STALL_MIN_MS);
+}
 
-    PBL_LOG_WRN("INT1 not received in %" PRIu32 " ms", ms_since_last_int1);
+static void prv_stall_check_work_cb(void) {
+  bool ret;
+  uint8_t val;
+  uint32_t ms_since_last_read;
 
-    // Re-enable FIFO, and clear any event INT source
-    ret = prv_lis2dw12_enable_fifo(LIS2DW12->state->num_samples);
-    if (!ret) {
-      PBL_LOG_ERR("Failed to re-enable FIFO");
-      return;
-    }
-
-    ret = prv_lis2dw12_read(LIS2DW12_ALL_INT_SRC, &val, 1);
-    if (!ret) {
-      PBL_LOG_ERR("Could not read ALL_INT_SRC register");
-      return;
-    }
+  // Sampling may have stopped between scheduling and execution
+  if (LIS2DW12->state->num_samples == 0U) {
+    return;
   }
+
+  ms_since_last_read = prv_ms_since_last_fifo_read();
+  if (ms_since_last_read < prv_stall_threshold_ms()) {
+    return;
+  }
+
+  PBL_LOG_WRN("FIFO stream stalled for %" PRIu32 " ms", ms_since_last_read);
+
+  // Re-enable FIFO, and clear any event INT source
+  ret = prv_lis2dw12_enable_fifo(LIS2DW12->state->num_samples);
+  if (!ret) {
+    PBL_LOG_ERR("Failed to re-enable FIFO");
+    return;
+  }
+
+  ret = prv_lis2dw12_read(LIS2DW12_ALL_INT_SRC, &val, 1);
+  if (!ret) {
+    PBL_LOG_ERR("Could not read ALL_INT_SRC register");
+    return;
+  }
+
+  LIS2DW12->state->last_fifo_read_tick = rtc_get_ticks();
 }
 
 static void prv_int1_wdt_cb(void *data) {
-  accel_offload_work(prv_int1_wdt_work_cb);
+  accel_offload_work(prv_stall_check_work_cb);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -637,7 +659,7 @@ void accel_set_num_samples(uint32_t num_samples) {
     }
 
     LIS2DW12->state->last_sample_valid = false;
-    LIS2DW12->state->last_int1_tick = rtc_get_ticks();
+    LIS2DW12->state->last_fifo_read_tick = rtc_get_ticks();
     LIS2DW12->state->int1_period_ms = (LIS2DW12->state->sampling_interval_us * num_samples) / 1000;
     regular_timer_add_multisecond_callback(&LIS2DW12->state->int1_wdt_timer,
                                            DIVIDE_CEIL(LIS2DW12->state->int1_period_ms, 1000UL));

--- a/src/fw/drivers/imu/lis2dw12/lis2dw12.c
+++ b/src/fw/drivers/imu/lis2dw12/lis2dw12.c
@@ -887,6 +887,16 @@ void accel_enable_shake_detection(bool on) {
     return;
   }
 
+  if (on) {
+    uint8_t val;
+
+    // WU_IA latches even while unrouted (e.g. on ODR startup transients);
+    // clear it so a phantom shake is not dispatched on enable
+    if (!prv_lis2dw12_read(LIS2DW12_ALL_INT_SRC, &val, 1)) {
+      PBL_LOG_ERR("Could not read ALL_INT_SRC register");
+    }
+  }
+
   // Configure INT1
   ret = prv_configure_int1(on, LIS2DW12->state->num_samples > 0U);
   if (!ret) {

--- a/src/fw/drivers/imu/lis2dw12/lis2dw12.c
+++ b/src/fw/drivers/imu/lis2dw12/lis2dw12.c
@@ -729,6 +729,11 @@ void accel_set_num_samples(uint32_t num_samples) {
   // Disable all INT1 before changing FIFO threshold
   prv_configure_int1(false, false);
 
+  // Salvage queued samples
+  if (LIS2DW12->state->num_samples > 0U) {
+    prv_lis2dw12_drain_fifo();
+  }
+
   if (num_samples == 0U) {
     // Bypass FIFO (disable)
     val = LIS2DW12_FIFO_CTRL_FIFO_MODE_BYPASS;
@@ -738,8 +743,6 @@ void accel_set_num_samples(uint32_t num_samples) {
 
     regular_timer_remove_callback(&LIS2DW12->state->int1_wdt_timer);
   } else {
-    // FIXME: we should ideally drain the FIFO here to not discard existing samples
-
     // Configure FIFO in CONT mode with threshold
     ret = prv_lis2dw12_enable_fifo((uint8_t)num_samples);
     if (!ret) {

--- a/src/fw/drivers/imu/lis2dw12/lis2dw12.c
+++ b/src/fw/drivers/imu/lis2dw12/lis2dw12.c
@@ -272,6 +272,33 @@ static bool prv_lis2dw12_enable_fifo(uint8_t num_samples) {
   return true;
 }
 
+//! Salvage and dispatch any samples queued in the FIFO
+static void prv_lis2dw12_drain_fifo(void) {
+  uint8_t val;
+  uint8_t samples;
+
+  if (!prv_lis2dw12_read(LIS2DW12_FIFO_SAMPLES, &val, 1)) {
+    PBL_LOG_ERR("Could not read FIFO_SAMPLES register");
+    return;
+  }
+
+  samples = MIN(LIS2DW12_FIFO_SAMPLES_DIFF_GET(val), LIS2DW12_FIFO_SIZE);
+  if (samples == 0U) {
+    return;
+  }
+
+  if (!prv_lis2dw12_read(LIS2DW12_OUT_X_L, LIS2DW12->state->raw_sample_buf,
+                         samples * LIS2DW12_SAMPLE_SIZE_BYTES)) {
+    PBL_LOG_ERR("Failed to read samples");
+    return;
+  }
+
+  prv_lis2dw12_process_samples(samples, prv_get_curr_system_time_us());
+  LIS2DW12->state->last_fifo_read_tick = rtc_get_ticks();
+}
+
+static void prv_lis2dw12_recover(void);
+
 static void prv_lis2dw12_int1_work_handler(void) {
   bool ret;
   uint8_t val;
@@ -319,8 +346,8 @@ static void prv_lis2dw12_int1_work_handler(void) {
   }
 
   if (fifo_overrun) {
-    PBL_LOG_WRN("FIFO overrun detected, re-arming");
-    prv_lis2dw12_enable_fifo(LIS2DW12->state->num_samples);
+    PBL_LOG_WRN("FIFO overrun detected, recovering");
+    prv_lis2dw12_recover();
     action_taken = true;
   } else if (samples > 0U) {
     prv_lis2dw12_process_samples(samples, timestamp_us);
@@ -437,6 +464,50 @@ static bool prv_configure_int1(bool shake_detection_enabled, bool fifo_enabled) 
   return true;
 }
 
+//! Recover a dead INT1/FIFO stream by re-asserting ODR, FIFO and INT routing.
+//! Routing is quiesced first so a latched-high pad produces a fresh edge.
+static void prv_lis2dw12_recover(void) {
+  uint8_t val;
+
+  LIS2DW12->state->num_recoveries++;
+  PBL_LOG_WRN("Recovering accel stream (count %" PRIu32 ")",
+          LIS2DW12->state->num_recoveries);
+
+  if (!prv_configure_int1(false, false)) {
+    return;
+  }
+
+  // Salvage queued samples
+  if (LIS2DW12->state->num_samples > 0U) {
+    prv_lis2dw12_drain_fifo();
+  }
+
+  // Clear any latched function INT source while routing is quiesced
+  if (!prv_lis2dw12_read(LIS2DW12_ALL_INT_SRC, &val, 1)) {
+    PBL_LOG_ERR("Could not read ALL_INT_SRC register");
+    return;
+  }
+
+  if (!prv_configure_odr(LIS2DW12->state->sampling_interval_us,
+                         LIS2DW12->state->shake_detection_enabled)) {
+    PBL_LOG_ERR("Could not configure ODR");
+    return;
+  }
+
+  if (LIS2DW12->state->num_samples > 0U) {
+    if (!prv_lis2dw12_enable_fifo(LIS2DW12->state->num_samples)) {
+      return;
+    }
+  }
+
+  if (!prv_configure_int1(LIS2DW12->state->shake_detection_enabled,
+                          LIS2DW12->state->num_samples > 0U)) {
+    return;
+  }
+
+  LIS2DW12->state->last_fifo_read_tick = rtc_get_ticks();
+}
+
 static uint32_t prv_ms_since_last_fifo_read(void) {
   RtcTicks ticks = rtc_get_ticks() - LIS2DW12->state->last_fifo_read_tick;
   return (uint32_t)((ticks * 1000) / RTC_TICKS_HZ);
@@ -448,8 +519,6 @@ static uint32_t prv_stall_threshold_ms(void) {
 }
 
 static void prv_stall_check_work_cb(void) {
-  bool ret;
-  uint8_t val;
   uint32_t ms_since_last_read;
 
   // Sampling may have stopped between scheduling and execution
@@ -463,21 +532,7 @@ static void prv_stall_check_work_cb(void) {
   }
 
   PBL_LOG_WRN("FIFO stream stalled for %" PRIu32 " ms", ms_since_last_read);
-
-  // Re-enable FIFO, and clear any event INT source
-  ret = prv_lis2dw12_enable_fifo(LIS2DW12->state->num_samples);
-  if (!ret) {
-    PBL_LOG_ERR("Failed to re-enable FIFO");
-    return;
-  }
-
-  ret = prv_lis2dw12_read(LIS2DW12_ALL_INT_SRC, &val, 1);
-  if (!ret) {
-    PBL_LOG_ERR("Could not read ALL_INT_SRC register");
-    return;
-  }
-
-  LIS2DW12->state->last_fifo_read_tick = rtc_get_ticks();
+  prv_lis2dw12_recover();
 }
 
 static void prv_int1_wdt_cb(void *data) {

--- a/src/fw/drivers/imu/lis2dw12/lis2dw12.c
+++ b/src/fw/drivers/imu/lis2dw12/lis2dw12.c
@@ -28,11 +28,13 @@ PBL_LOG_MODULE_DEFINE(driver_accel_lis2dw12, CONFIG_DRIVER_IMU_LOG_LEVEL);
 //   be changed depending on the sampling interval configuration. Value is NOT
 //   adjusted automatically when ODR changes (we just have 2 bits...), so it is
 //   possible to notice sensitivity changes when changing sampling interval.
-// - For some reason (needs more investigation), INT1 is sometimes left HIGH
-//   due to FIFO overruns, and without edge change, we cannot detect such
-//   events. To mitigate this, a watchdog timer re-arms FIFO if no samples
-//   have been read within the expected time window (FIFO reads are tracked
-//   instead of INT1 edges, which shake events would keep feeding).
+// - INT1 mixes level (FIFO threshold) and latched (wake-up) sources on a
+//   rising-edge EXTI, and FIFO overruns sometimes leave the pad latched HIGH
+//   (needs more investigation), so edges can be lost. The work handler
+//   re-checks the pad level after servicing, and a watchdog timer recovers
+//   the stream if no FIFO samples have been read within the expected time
+//   window (FIFO reads are tracked instead of INT1 edges, which shake events
+//   would keep feeding).
 
 // Time to wait after reset (us)
 #define LIS2DW12_RESET_TIME_US 5
@@ -299,7 +301,9 @@ static void prv_lis2dw12_drain_fifo(void) {
 
 static void prv_lis2dw12_recover(void);
 
-static void prv_lis2dw12_int1_work_handler(void) {
+//! Single INT1 servicing pass; returns true if any INT source was handled.
+//! fifo_progress is set when FIFO data was consumed (samples or overrun).
+static bool prv_lis2dw12_service_int1(bool *fifo_progress) {
   bool ret;
   uint8_t val;
   bool action_taken = false;
@@ -316,7 +320,7 @@ static void prv_lis2dw12_int1_work_handler(void) {
     ret = prv_lis2dw12_read(LIS2DW12_FIFO_SAMPLES, &val, 1);
     if (!ret) {
       PBL_LOG_ERR("Could not read FIFO_SAMPLES register");
-      return;
+      return false;
     }
 
     if ((val & LIS2DW12_FIFO_SAMPLES_FIFO_OVR) != 0U) {
@@ -327,7 +331,7 @@ static void prv_lis2dw12_int1_work_handler(void) {
         if (!prv_lis2dw12_read(LIS2DW12_OUT_X_L, LIS2DW12->state->raw_sample_buf,
                                samples * LIS2DW12_SAMPLE_SIZE_BYTES)) {
           PBL_LOG_ERR("Failed to read samples");
-          return;
+          return false;
         }
         timestamp_us = prv_get_curr_system_time_us();
         LIS2DW12->state->last_fifo_read_tick = rtc_get_ticks();
@@ -339,7 +343,7 @@ static void prv_lis2dw12_int1_work_handler(void) {
     ret = prv_lis2dw12_read(LIS2DW12_ALL_INT_SRC, &val, 1);
     if (!ret) {
       PBL_LOG_ERR("Could not read ALL_INT_SRC register");
-      return;
+      return false;
     }
 
     shake = (val & LIS2DW12_ALL_INT_SRC_WU_IA) != 0U;
@@ -349,25 +353,54 @@ static void prv_lis2dw12_int1_work_handler(void) {
     PBL_LOG_WRN("FIFO overrun detected, recovering");
     prv_lis2dw12_recover();
     action_taken = true;
+    *fifo_progress = true;
   } else if (samples > 0U) {
     prv_lis2dw12_process_samples(samples, timestamp_us);
     action_taken = true;
+    *fifo_progress = true;
   }
 
   if (shake) {
-    PBL_LOG_DBG("Shake detected");
-    // TODO: provide more info about the shake (axis, direction, etc.) or
-    // refactor shake to be non-dimensional
-    accel_cb_shake_detected(AXIS_Z, 0);
+    // WU_IA stays set while the wake-up condition persists (LIR), so only
+    // dispatch on its assertion to avoid flooding events
+    if (!LIS2DW12->state->wu_active) {
+      PBL_LOG_DBG("Shake detected");
+      // TODO: provide more info about the shake (axis, direction, etc.) or
+      // refactor shake to be non-dimensional
+      accel_cb_shake_detected(AXIS_Z, 0);
+    }
     action_taken = true;
   }
+  LIS2DW12->state->wu_active = shake;
 
   if (!action_taken) {
     PBL_LOG_WRN("INT1 triggered but no action taken");
   }
+
+  return action_taken;
+}
+
+static void prv_lis2dw12_int1_work_handler(void) {
+  bool fifo_progress = false;
+  bool action_taken = prv_lis2dw12_service_int1(&fifo_progress);
+
+  // Sources asserting while the pad is high produce no new edge: requeue on
+  // FIFO progress, recover when nothing was serviced (stuck pad). A pad held
+  // by a persistent wake-up condition is left to the stall watchdog.
+  if (!gpio_input_read(&LIS2DW12->int1_in)) {
+    return;
+  }
+
+  if (fifo_progress) {
+    accel_offload_work(prv_lis2dw12_int1_work_handler);
+  } else if (!action_taken) {
+    prv_lis2dw12_recover();
+  }
 }
 
 static void prv_lis2dw12_int1_irq_handler(bool *should_context_switch) {
+  // A rising edge proves the pad was low, i.e. the wake-up source deasserted
+  LIS2DW12->state->wu_active = false;
   accel_offload_work_from_isr(prv_lis2dw12_int1_work_handler, should_context_switch);
 }
 
@@ -505,6 +538,7 @@ static void prv_lis2dw12_recover(void) {
     return;
   }
 
+  LIS2DW12->state->wu_active = false;
   LIS2DW12->state->last_fifo_read_tick = rtc_get_ticks();
 }
 
@@ -844,6 +878,7 @@ void accel_enable_shake_detection(bool on) {
   }
 
   LIS2DW12->state->shake_detection_enabled = on;
+  LIS2DW12->state->wu_active = false;
 
   PBL_LOG_DBG("%s shake detection", on ? "Enabled" : "Disabled");
 }

--- a/src/fw/drivers/imu/lis2dw12/lis2dw12.c
+++ b/src/fw/drivers/imu/lis2dw12/lis2dw12.c
@@ -552,8 +552,12 @@ static uint32_t prv_stall_threshold_ms(void) {
              LIS2DW12_STALL_MIN_MS);
 }
 
+//! Shared by the INT1 watchdog and the accel_peek staleness trigger;
+//! re-validates the stall at execution time.
 static void prv_stall_check_work_cb(void) {
   uint32_t ms_since_last_read;
+
+  LIS2DW12->state->recovery_pending = false;
 
   // Sampling may have stopped between scheduling and execution
   if (LIS2DW12->state->num_samples == 0U) {
@@ -729,6 +733,9 @@ void accel_set_num_samples(uint32_t num_samples) {
   // Disable all INT1 before changing FIFO threshold
   prv_configure_int1(false, false);
 
+  // Config change invalidates any queued stall check; re-arm the peek trigger
+  LIS2DW12->state->recovery_pending = false;
+
   // Salvage queued samples
   if (LIS2DW12->state->num_samples > 0U) {
     prv_lis2dw12_drain_fifo();
@@ -784,6 +791,13 @@ int accel_peek(AccelDriverSample *data) {
 
   // If sampling is active, return the last obtained sample
   if (LIS2DW12->state->num_samples > 0U) {
+    // Self-heal: a stalled stream would otherwise freeze peek data forever
+    if (!LIS2DW12->state->recovery_pending &&
+        (prv_ms_since_last_fifo_read() >= prv_stall_threshold_ms())) {
+      LIS2DW12->state->recovery_pending = true;
+      accel_offload_work(prv_stall_check_work_cb);
+    }
+
     if (!LIS2DW12->state->last_sample_valid) {
       return E_ERROR;
     }

--- a/src/fw/drivers/imu/lis2dw12/lis2dw12.h
+++ b/src/fw/drivers/imu/lis2dw12/lis2dw12.h
@@ -22,7 +22,7 @@ typedef struct LIS2DW12State {
   uint8_t num_samples;
   uint8_t raw_sample_buf[LIS2DW12_FIFO_SIZE * LIS2DW12_SAMPLE_SIZE_BYTES];
   RegularTimerInfo int1_wdt_timer;
-  RtcTicks last_int1_tick;
+  RtcTicks last_fifo_read_tick;
   uint32_t int1_period_ms;
   uint32_t num_recoveries;
   uint8_t wk_ths_curr;

--- a/src/fw/drivers/imu/lis2dw12/lis2dw12.h
+++ b/src/fw/drivers/imu/lis2dw12/lis2dw12.h
@@ -28,6 +28,7 @@ typedef struct LIS2DW12State {
   uint8_t wk_ths_curr;
   AccelDriverSample last_sample;
   bool last_sample_valid;
+  bool recovery_pending;
   bool wu_active;
 } LIS2DW12State;
 

--- a/src/fw/drivers/imu/lis2dw12/lis2dw12.h
+++ b/src/fw/drivers/imu/lis2dw12/lis2dw12.h
@@ -28,6 +28,7 @@ typedef struct LIS2DW12State {
   uint8_t wk_ths_curr;
   AccelDriverSample last_sample;
   bool last_sample_valid;
+  bool wu_active;
 } LIS2DW12State;
 
 typedef struct LIS2DW12Config {
@@ -37,6 +38,8 @@ typedef struct LIS2DW12Config {
   I2CSlavePort i2c;
   //! INT1 EXTI configuration
   ExtiConfig int1;
+  //! INT1 input configuration (to read back the pad level)
+  InputConfig int1_in;
   //! Axis mapping (0: X, 1: Y, 2: Z)
   uint8_t axis_map[3];
   //! Axis direction (1 upside, -1 downside)


### PR DESCRIPTION
## Summary

Reworked take on #1484 (thanks @jplexer — root-cause analysis and several changes carried over, rebased onto the rewritten driver on `main`), addressing accel stream stalls on lis2dw12 boards where the FIFO/INT1 stream silently dies until an accel session is recreated (health toggle).

Root cause: INT1 mixes level-based (FIFO threshold) and latched (wake-up, LIR) sources on a rising-edge EXTI. A source asserting while the pad is already high produces no new edge, and FIFO overruns sometimes leave the pad latched HIGH. The old watchdog timed INT1 *edges*, which shake events kept feeding, so a dead FIFO stream was never detected while the watch was moving; its recovery only rewrote FIFO_CTRL, which does not release a latched pad.

## Changes

1. **Watchdog tracks successful FIFO reads** instead of INT1 edges, with a 2x threshold-period margin and a 1 s floor.
2. **Recovery quiesces INT routing first** (forces a latched pad low so re-enabling produces a fresh edge), salvages queued samples, clears latched sources while quiesced, then re-asserts ODR/FIFO/INT routing. Shared by the watchdog and the FIFO overrun path.
3. **Pad-level recheck after each servicing pass** (new `int1_in` board config): requeue when FIFO work remains (no edge will come), recover when the pad is high with nothing serviced (stuck pad). Closes the lost-edge race deterministically; the watchdog becomes a pure backstop. Shake is dispatched only on WU assertion (WU_IA stays set under LIR while motion persists — dispatching per pass floods events).
4. **Drain the FIFO on subscriber reconfiguration** instead of discarding queued samples (resolves existing FIXME).
5. **accel_peek self-heals stale cached data** by queueing the stall check, breaking the stall's self-masking of peek consumers.
6. **Clear stale WU_IA before enabling shake detection** — ODR startup transients latch a spurious wake-up while WU is unrouted, which dispatched a phantom shake at boot.

Related: FIRM-2490, FIRM-3208, FIRM-1626, FIRM-1812

## Testing

- Validated on getafix_dvt2 on-device: no phantom shake at boot, one shake event per gesture (no event floods under continuous motion), steps/FIFO stream healthy, no recovery logs during normal wear.
- `getafix@dvt2` normal build clean.
- Not yet re-run on this branch: #1484's fault-injection test (killing INT routing/FIFO mode/ODR behind the driver's back) — worth repeating before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)