### PR TITLE
fw/drivers/imu/lsm6dso: harden against INT1/FIFO stream stalls

### DIFF
--- a/src/fw/board/boards/board_asterix.c
+++ b/src/fw/board/boards/board_asterix.c
@@ -191,6 +191,10 @@ static const LSM6DSOConfig s_lsm6dso_config = {
         .channel = 7,
         .gpio_pin = NRF_GPIO_PIN_MAP(1, 13),
     },
+    .int1_in = {
+        .gpio = NRF5_GPIO_RESOURCE_EXISTS,
+        .gpio_pin = NRF_GPIO_PIN_MAP(1, 13),
+    },
     .axis_map = {
         [AXIS_X] = 1,
         [AXIS_Y] = 0,

--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -355,6 +355,10 @@ static const LSM6DSOConfig s_lsm6dso_config = {
       .peripheral = hwp_gpio1,
       .gpio_pin = 38,
     },
+    .int1_in = {
+      .gpio = hwp_gpio1,
+      .gpio_pin = 38,
+    },
 #ifdef CONFIG_IS_BIGBOARD
     .axis_map = {
         [AXIS_X] = 0,

--- a/src/fw/drivers/gpio/nrf5.c
+++ b/src/fw/drivers/gpio/nrf5.c
@@ -10,6 +10,10 @@ void gpio_input_init(const InputConfig *pin_config) {
   nrf_gpio_pin_dir_set(pin_config->gpio_pin, NRF_GPIO_PIN_DIR_INPUT);
 }
 
+bool gpio_input_read(const InputConfig *input_cfg) {
+  return nrf_gpio_pin_read(input_cfg->gpio_pin) != 0U;
+}
+
 void gpio_output_init(const OutputConfig *pin_config, GPIOOType_TypeDef otype) {
   if (otype == GPIO_OType_OD)
     WTF;

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -32,10 +32,12 @@ PBL_LOG_MODULE_DEFINE(driver_accel_lsm6dso, CONFIG_DRIVER_IMU_LOG_LEVEL);
 //   be changed depending on the sampling interval configuration. Value is NOT
 //   adjusted automatically when ODR changes, so it is possible to notice
 //   sensitivity changes when changing sampling interval.
-// - Like the LIS2DW12, INT1 can be left HIGH on FIFO overruns; a watchdog timer
-//   re-arms the FIFO if no samples have been read within the expected time
-//   window (FIFO reads are tracked instead of INT1 edges, which shake events
-//   would keep feeding).
+// - INT1 mixes level (FIFO threshold) and latched (wake-up) sources on a
+//   rising-edge EXTI, and (like the LIS2DW12) FIFO overruns can leave the pad
+//   latched HIGH, so edges can be lost. The work handler re-checks the pad
+//   level after servicing, and a watchdog timer recovers the stream if no
+//   FIFO samples have been read within the expected time window (FIFO reads
+//   are tracked instead of INT1 edges, which shake events would keep feeding).
 
 // Time to wait after reset (us)
 #define LSM6DSO_RESET_TIME_US 5
@@ -361,7 +363,9 @@ static void prv_lsm6dso_drain_fifo(void) {
 
 static void prv_lsm6dso_recover(void);
 
-static void prv_lsm6dso_int1_work_handler(void) {
+//! Single INT1 servicing pass; returns true if any INT source was handled.
+//! fifo_progress is set when FIFO data was consumed (samples or overrun).
+static bool prv_lsm6dso_service_int1(bool *fifo_progress) {
   bool ret;
   uint8_t val;
   bool action_taken = false;
@@ -378,7 +382,7 @@ static void prv_lsm6dso_int1_work_handler(void) {
     ret = prv_lsm6dso_read(LSM6DSO_FIFO_STATUS2, &val, 1);
     if (!ret) {
       PBL_LOG_ERR("Could not read FIFO_STATUS2 register");
-      return;
+      return false;
     }
 
     if ((val & LSM6DSO_FIFO_STATUS2_FIFO_OVR_IA) != 0U) {
@@ -388,7 +392,7 @@ static void prv_lsm6dso_int1_work_handler(void) {
 
       if (!prv_lsm6dso_read(LSM6DSO_FIFO_STATUS1, &status1, 1)) {
         PBL_LOG_ERR("Could not read FIFO_STATUS1 register");
-        return;
+        return false;
       }
 
       samples = (((uint16_t)(val & LSM6DSO_FIFO_STATUS2_DIFF_HI_MASK)) << 8U) | status1;
@@ -400,7 +404,7 @@ static void prv_lsm6dso_int1_work_handler(void) {
         if (!prv_lsm6dso_read(LSM6DSO_FIFO_DATA_OUT_TAG, LSM6DSO->state->raw_sample_buf,
                               samples * LSM6DSO_FIFO_WORD_SIZE_BYTES)) {
           PBL_LOG_ERR("Failed to read samples");
-          return;
+          return false;
         }
         timestamp_us = prv_get_curr_system_time_us();
         LSM6DSO->state->last_fifo_read_tick = rtc_get_ticks();
@@ -412,7 +416,7 @@ static void prv_lsm6dso_int1_work_handler(void) {
     ret = prv_lsm6dso_read(LSM6DSO_ALL_INT_SRC, &val, 1);
     if (!ret) {
       PBL_LOG_ERR("Could not read ALL_INT_SRC register");
-      return;
+      return false;
     }
 
     shake = (val & LSM6DSO_ALL_INT_SRC_WU_IA) != 0U;
@@ -422,25 +426,54 @@ static void prv_lsm6dso_int1_work_handler(void) {
     PBL_LOG_WRN("FIFO overrun detected, recovering");
     prv_lsm6dso_recover();
     action_taken = true;
+    *fifo_progress = true;
   } else if (samples > 0U) {
     prv_lsm6dso_process_samples(samples, timestamp_us);
     action_taken = true;
+    *fifo_progress = true;
   }
 
   if (shake) {
-    PBL_LOG_DBG("Shake detected");
-    // TODO: provide more info about the shake (axis, direction, etc.) or
-    // refactor shake to be non-dimensional
-    accel_cb_shake_detected(AXIS_Z, 0);
+    // WU_IA stays set while the wake-up condition persists (LIR), so only
+    // dispatch on its assertion to avoid flooding events
+    if (!LSM6DSO->state->wu_active) {
+      PBL_LOG_DBG("Shake detected");
+      // TODO: provide more info about the shake (axis, direction, etc.) or
+      // refactor shake to be non-dimensional
+      accel_cb_shake_detected(AXIS_Z, 0);
+    }
     action_taken = true;
   }
+  LSM6DSO->state->wu_active = shake;
 
   if (!action_taken) {
     PBL_LOG_WRN("INT1 triggered but no action taken");
   }
+
+  return action_taken;
+}
+
+static void prv_lsm6dso_int1_work_handler(void) {
+  bool fifo_progress = false;
+  bool action_taken = prv_lsm6dso_service_int1(&fifo_progress);
+
+  // Sources asserting while the pad is high produce no new edge: requeue on
+  // FIFO progress, recover when nothing was serviced (stuck pad). A pad held
+  // by a persistent wake-up condition is left to the stall watchdog.
+  if (!gpio_input_read(&LSM6DSO->int1_in)) {
+    return;
+  }
+
+  if (fifo_progress) {
+    accel_offload_work(prv_lsm6dso_int1_work_handler);
+  } else if (!action_taken) {
+    prv_lsm6dso_recover();
+  }
 }
 
 static void prv_lsm6dso_int1_irq_handler(bool *should_context_switch) {
+  // A rising edge proves the pad was low, i.e. the wake-up source deasserted
+  LSM6DSO->state->wu_active = false;
   accel_offload_work_from_isr(prv_lsm6dso_int1_work_handler, should_context_switch);
 }
 
@@ -579,6 +612,7 @@ static void prv_lsm6dso_recover(void) {
     return;
   }
 
+  LSM6DSO->state->wu_active = false;
   LSM6DSO->state->last_fifo_read_tick = rtc_get_ticks();
 }
 
@@ -894,6 +928,7 @@ void accel_enable_shake_detection(bool on) {
   }
 
   LSM6DSO->state->shake_detection_enabled = on;
+  LSM6DSO->state->wu_active = false;
 
   PBL_LOG_DBG("%s shake detection", on ? "Enabled" : "Disabled");
 }

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -626,8 +626,12 @@ static uint32_t prv_stall_threshold_ms(void) {
              LSM6DSO_STALL_MIN_MS);
 }
 
+//! Shared by the INT1 watchdog and the accel_peek staleness trigger;
+//! re-validates the stall at execution time.
 static void prv_stall_check_work_cb(void) {
   uint32_t ms_since_last_read;
+
+  LSM6DSO->state->recovery_pending = false;
 
   // Sampling may have stopped between scheduling and execution
   if (LSM6DSO->state->num_samples == 0U) {
@@ -794,6 +798,9 @@ void accel_set_num_samples(uint32_t num_samples) {
   // Disable all INT1 before changing FIFO threshold
   prv_configure_int1(false, false);
 
+  // Config change invalidates any queued stall check; re-arm the peek trigger
+  LSM6DSO->state->recovery_pending = false;
+
   // Salvage queued samples
   if (LSM6DSO->state->num_samples > 0U) {
     prv_lsm6dso_drain_fifo();
@@ -848,6 +855,13 @@ int accel_peek(AccelDriverSample *data) {
 
   // If sampling is active, return the last obtained sample
   if (LSM6DSO->state->num_samples > 0U) {
+    // Self-heal: a stalled stream would otherwise freeze peek data forever
+    if (!LSM6DSO->state->recovery_pending &&
+        (prv_ms_since_last_fifo_read() >= prv_stall_threshold_ms())) {
+      LSM6DSO->state->recovery_pending = true;
+      accel_offload_work(prv_stall_check_work_cb);
+    }
+
     if (!LSM6DSO->state->last_sample_valid) {
       return E_ERROR;
     }

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -333,6 +333,34 @@ static bool prv_lsm6dso_enable_fifo(uint16_t num_samples) {
   return true;
 }
 
+//! Salvage and dispatch any samples queued in the FIFO
+static void prv_lsm6dso_drain_fifo(void) {
+  uint8_t status[2];
+  uint16_t samples;
+
+  if (!prv_lsm6dso_read(LSM6DSO_FIFO_STATUS1, status, 2)) {
+    PBL_LOG_ERR("Could not read FIFO_STATUS registers");
+    return;
+  }
+
+  samples = (((uint16_t)(status[1] & LSM6DSO_FIFO_STATUS2_DIFF_HI_MASK)) << 8U) | status[0];
+  samples = MIN(samples, LSM6DSO_FIFO_SIZE);
+  if (samples == 0U) {
+    return;
+  }
+
+  if (!prv_lsm6dso_read(LSM6DSO_FIFO_DATA_OUT_TAG, LSM6DSO->state->raw_sample_buf,
+                        samples * LSM6DSO_FIFO_WORD_SIZE_BYTES)) {
+    PBL_LOG_ERR("Failed to read samples");
+    return;
+  }
+
+  prv_lsm6dso_process_samples(samples, prv_get_curr_system_time_us());
+  LSM6DSO->state->last_fifo_read_tick = rtc_get_ticks();
+}
+
+static void prv_lsm6dso_recover(void);
+
 static void prv_lsm6dso_int1_work_handler(void) {
   bool ret;
   uint8_t val;
@@ -391,8 +419,8 @@ static void prv_lsm6dso_int1_work_handler(void) {
   }
 
   if (fifo_overrun) {
-    PBL_LOG_WRN("FIFO overrun detected, re-arming");
-    prv_lsm6dso_enable_fifo(LSM6DSO->state->num_samples);
+    PBL_LOG_WRN("FIFO overrun detected, recovering");
+    prv_lsm6dso_recover();
     action_taken = true;
   } else if (samples > 0U) {
     prv_lsm6dso_process_samples(samples, timestamp_us);
@@ -510,6 +538,50 @@ static bool prv_configure_int1(bool shake_detection_enabled, bool fifo_enabled) 
   return true;
 }
 
+//! Recover a dead INT1/FIFO stream by re-asserting ODR, FIFO and INT routing.
+//! Routing is quiesced first so a latched-high pad produces a fresh edge.
+static void prv_lsm6dso_recover(void) {
+  uint8_t val;
+
+  LSM6DSO->state->num_recoveries++;
+  PBL_LOG_WRN("Recovering accel stream (count %" PRIu32 ")",
+          LSM6DSO->state->num_recoveries);
+
+  if (!prv_configure_int1(false, false)) {
+    return;
+  }
+
+  // Salvage queued samples
+  if (LSM6DSO->state->num_samples > 0U) {
+    prv_lsm6dso_drain_fifo();
+  }
+
+  // Clear any latched function INT source while routing is quiesced
+  if (!prv_lsm6dso_read(LSM6DSO_ALL_INT_SRC, &val, 1)) {
+    PBL_LOG_ERR("Could not read ALL_INT_SRC register");
+    return;
+  }
+
+  if (!prv_configure_odr(LSM6DSO->state->sampling_interval_us,
+                         LSM6DSO->state->shake_detection_enabled)) {
+    PBL_LOG_ERR("Could not configure ODR");
+    return;
+  }
+
+  if (LSM6DSO->state->num_samples > 0U) {
+    if (!prv_lsm6dso_enable_fifo(LSM6DSO->state->num_samples)) {
+      return;
+    }
+  }
+
+  if (!prv_configure_int1(LSM6DSO->state->shake_detection_enabled,
+                          LSM6DSO->state->num_samples > 0U)) {
+    return;
+  }
+
+  LSM6DSO->state->last_fifo_read_tick = rtc_get_ticks();
+}
+
 static uint32_t prv_ms_since_last_fifo_read(void) {
   RtcTicks ticks = rtc_get_ticks() - LSM6DSO->state->last_fifo_read_tick;
   return (uint32_t)((ticks * 1000) / RTC_TICKS_HZ);
@@ -521,8 +593,6 @@ static uint32_t prv_stall_threshold_ms(void) {
 }
 
 static void prv_stall_check_work_cb(void) {
-  bool ret;
-  uint8_t val;
   uint32_t ms_since_last_read;
 
   // Sampling may have stopped between scheduling and execution
@@ -536,21 +606,7 @@ static void prv_stall_check_work_cb(void) {
   }
 
   PBL_LOG_WRN("FIFO stream stalled for %" PRIu32 " ms", ms_since_last_read);
-
-  // Re-enable FIFO, and clear any event INT source
-  ret = prv_lsm6dso_enable_fifo(LSM6DSO->state->num_samples);
-  if (!ret) {
-    PBL_LOG_ERR("Failed to re-enable FIFO");
-    return;
-  }
-
-  ret = prv_lsm6dso_read(LSM6DSO_ALL_INT_SRC, &val, 1);
-  if (!ret) {
-    PBL_LOG_ERR("Could not read ALL_INT_SRC register");
-    return;
-  }
-
-  LSM6DSO->state->last_fifo_read_tick = rtc_get_ticks();
+  prv_lsm6dso_recover();
 }
 
 static void prv_int1_wdt_cb(void *data) {

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -794,6 +794,11 @@ void accel_set_num_samples(uint32_t num_samples) {
   // Disable all INT1 before changing FIFO threshold
   prv_configure_int1(false, false);
 
+  // Salvage queued samples
+  if (LSM6DSO->state->num_samples > 0U) {
+    prv_lsm6dso_drain_fifo();
+  }
+
   if (num_samples == 0U) {
     // Bypass FIFO (disable)
     val = LSM6DSO_FIFO_CTRL4_MODE_BYPASS;
@@ -803,8 +808,6 @@ void accel_set_num_samples(uint32_t num_samples) {
 
     regular_timer_remove_callback(&LSM6DSO->state->int1_wdt_timer);
   } else {
-    // FIXME: we should ideally drain the FIFO here to not discard existing samples
-
     // Configure FIFO in continuous mode with threshold
     ret = prv_lsm6dso_enable_fifo((uint16_t)num_samples);
     if (!ret) {

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -33,8 +33,9 @@ PBL_LOG_MODULE_DEFINE(driver_accel_lsm6dso, CONFIG_DRIVER_IMU_LOG_LEVEL);
 //   adjusted automatically when ODR changes, so it is possible to notice
 //   sensitivity changes when changing sampling interval.
 // - Like the LIS2DW12, INT1 can be left HIGH on FIFO overruns; a watchdog timer
-//   re-arms the FIFO if no INT1 event is detected within the expected time
-//   window based on the ODR and FIFO threshold.
+//   re-arms the FIFO if no samples have been read within the expected time
+//   window (FIFO reads are tracked instead of INT1 edges, which shake events
+//   would keep feeding).
 
 // Time to wait after reset (us)
 #define LSM6DSO_RESET_TIME_US 5
@@ -42,6 +43,11 @@ PBL_LOG_MODULE_DEFINE(driver_accel_lsm6dso, CONFIG_DRIVER_IMU_LOG_LEVEL);
 // DRDY polling parameters for accel_peek single-shot mode
 #define LSM6DSO_DRDY_POLL_DELAY_MS   (5)   /* ms between data-ready polls */
 #define LSM6DSO_DRDY_POLL_TIMEOUT_MS (100) /* max wait (~5x 20ms at 52Hz ODR) */
+
+// FIFO threshold periods without a FIFO read before the stream is considered
+// stalled (>1x to tolerate scheduling jitter), and threshold lower bound
+#define LSM6DSO_STALL_MARGIN 2U
+#define LSM6DSO_STALL_MIN_MS 1000U
 
 // Scale range for 16-bit two's complement samples
 #define LSM6DSO_S16_SCALE_RANGE (1U << (16U - 1U))
@@ -369,6 +375,7 @@ static void prv_lsm6dso_int1_work_handler(void) {
           return;
         }
         timestamp_us = prv_get_curr_system_time_us();
+        LSM6DSO->state->last_fifo_read_tick = rtc_get_ticks();
       }
     }
   }
@@ -406,7 +413,6 @@ static void prv_lsm6dso_int1_work_handler(void) {
 }
 
 static void prv_lsm6dso_int1_irq_handler(bool *should_context_switch) {
-  LSM6DSO->state->last_int1_tick = rtc_get_ticks();
   accel_offload_work_from_isr(prv_lsm6dso_int1_work_handler, should_context_switch);
 }
 
@@ -504,34 +510,51 @@ static bool prv_configure_int1(bool shake_detection_enabled, bool fifo_enabled) 
   return true;
 }
 
-static void prv_int1_wdt_work_cb(void) {
-  RtcTicks now_tick = rtc_get_ticks();
-  RtcTicks ticks_since_last_int1 = now_tick - LSM6DSO->state->last_int1_tick;
-  uint32_t ms_since_last_int1 = (ticks_since_last_int1 * 1000) / RTC_TICKS_HZ;
+static uint32_t prv_ms_since_last_fifo_read(void) {
+  RtcTicks ticks = rtc_get_ticks() - LSM6DSO->state->last_fifo_read_tick;
+  return (uint32_t)((ticks * 1000) / RTC_TICKS_HZ);
+}
 
-  if (ms_since_last_int1 >= LSM6DSO->state->int1_period_ms) {
-    bool ret;
-    uint8_t val;
+static uint32_t prv_stall_threshold_ms(void) {
+  return MAX(LSM6DSO_STALL_MARGIN * LSM6DSO->state->int1_period_ms,
+             LSM6DSO_STALL_MIN_MS);
+}
 
-    PBL_LOG_WRN("INT1 not received in %" PRIu32 " ms", ms_since_last_int1);
+static void prv_stall_check_work_cb(void) {
+  bool ret;
+  uint8_t val;
+  uint32_t ms_since_last_read;
 
-    // Re-enable FIFO, and clear any event INT source
-    ret = prv_lsm6dso_enable_fifo(LSM6DSO->state->num_samples);
-    if (!ret) {
-      PBL_LOG_ERR("Failed to re-enable FIFO");
-      return;
-    }
-
-    ret = prv_lsm6dso_read(LSM6DSO_ALL_INT_SRC, &val, 1);
-    if (!ret) {
-      PBL_LOG_ERR("Could not read ALL_INT_SRC register");
-      return;
-    }
+  // Sampling may have stopped between scheduling and execution
+  if (LSM6DSO->state->num_samples == 0U) {
+    return;
   }
+
+  ms_since_last_read = prv_ms_since_last_fifo_read();
+  if (ms_since_last_read < prv_stall_threshold_ms()) {
+    return;
+  }
+
+  PBL_LOG_WRN("FIFO stream stalled for %" PRIu32 " ms", ms_since_last_read);
+
+  // Re-enable FIFO, and clear any event INT source
+  ret = prv_lsm6dso_enable_fifo(LSM6DSO->state->num_samples);
+  if (!ret) {
+    PBL_LOG_ERR("Failed to re-enable FIFO");
+    return;
+  }
+
+  ret = prv_lsm6dso_read(LSM6DSO_ALL_INT_SRC, &val, 1);
+  if (!ret) {
+    PBL_LOG_ERR("Could not read ALL_INT_SRC register");
+    return;
+  }
+
+  LSM6DSO->state->last_fifo_read_tick = rtc_get_ticks();
 }
 
 static void prv_int1_wdt_cb(void *data) {
-  accel_offload_work(prv_int1_wdt_work_cb);
+  accel_offload_work(prv_stall_check_work_cb);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -700,7 +723,7 @@ void accel_set_num_samples(uint32_t num_samples) {
     }
 
     LSM6DSO->state->last_sample_valid = false;
-    LSM6DSO->state->last_int1_tick = rtc_get_ticks();
+    LSM6DSO->state->last_fifo_read_tick = rtc_get_ticks();
     LSM6DSO->state->int1_period_ms = (LSM6DSO->state->sampling_interval_us * num_samples) / 1000;
     regular_timer_add_multisecond_callback(&LSM6DSO->state->int1_wdt_timer,
                                            DIVIDE_CEIL(LSM6DSO->state->int1_period_ms, 1000UL));

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -937,6 +937,16 @@ void accel_enable_shake_detection(bool on) {
     return;
   }
 
+  if (on) {
+    uint8_t val;
+
+    // WU_IA may be latched from a previous enablement or an ODR startup
+    // transient; clear it so a phantom shake is not dispatched on enable
+    if (!prv_lsm6dso_read(LSM6DSO_ALL_INT_SRC, &val, 1)) {
+      PBL_LOG_ERR("Could not read ALL_INT_SRC register");
+    }
+  }
+
   // Configure INT1
   ret = prv_configure_int1(on, LSM6DSO->state->num_samples > 0U);
   if (!ret) {

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.h
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.h
@@ -28,7 +28,7 @@ typedef struct LSM6DSOState {
   uint16_t num_samples;
   uint8_t raw_sample_buf[LSM6DSO_FIFO_SIZE * LSM6DSO_FIFO_WORD_SIZE_BYTES];
   RegularTimerInfo int1_wdt_timer;
-  RtcTicks last_int1_tick;
+  RtcTicks last_fifo_read_tick;
   uint32_t int1_period_ms;
   uint32_t num_recoveries;
   uint8_t wk_ths_curr;

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.h
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.h
@@ -34,6 +34,7 @@ typedef struct LSM6DSOState {
   uint8_t wk_ths_curr;
   AccelDriverSample last_sample;
   bool last_sample_valid;
+  bool recovery_pending;
   bool wu_active;
 } LSM6DSOState;
 

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.h
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.h
@@ -34,6 +34,7 @@ typedef struct LSM6DSOState {
   uint8_t wk_ths_curr;
   AccelDriverSample last_sample;
   bool last_sample_valid;
+  bool wu_active;
 } LSM6DSOState;
 
 typedef struct LSM6DSOConfig {
@@ -43,6 +44,8 @@ typedef struct LSM6DSOConfig {
   I2CSlavePort i2c;
   //! INT1 EXTI configuration
   ExtiConfig int1;
+  //! INT1 input configuration (to read back the pad level)
+  InputConfig int1_in;
   //! Axis mapping (0: X, 1: Y, 2: Z)
   uint8_t axis_map[3];
   //! Axis direction (1 upside, -1 downside)


### PR DESCRIPTION
## Summary

Ports the INT1/FIFO stream stall hardening from the lis2dw12 driver (#1701) to the lsm6dso driver (obelix, asterix), which inherited the same structure and therefore the same failure modes: INT1 mixes level-based (FIFO watermark) and latched (wake-up, LIR) sources on a rising-edge EXTI, the watchdog timed INT1 edges (which shake events keep feeding while the FIFO stream is dead), and the recovery only rewrote the FIFO configuration, which does not release a latched-high pad.

## Changes

Mirrors #1701 commit by commit:

1. **Watchdog tracks successful FIFO reads** instead of INT1 edges (2x threshold-period margin, 1 s floor).
2. **Recovery quiesces INT routing first**, salvages queued samples, clears latched sources while quiesced, then re-asserts ODR/FIFO/INT routing.
3. **Pad-level recheck after each servicing pass** (new `int1_in` config on obelix/asterix): requeue on FIFO progress, recover on a stuck pad. Shake dispatched only on WU assertion to avoid event floods under continuous motion.
4. **Drain the FIFO on subscriber reconfiguration** (resolves existing FIXME).
5. **accel_peek self-heals stale cached data**.
6. **Clear stale WU_IA before enabling shake detection** (phantom shake guard; note the pre-latched window is narrower on this part since the wake-up engine is gated by TAP_CFG2, enabled together with the routing).

Additionally adds `gpio_input_read()` to the nrf5 gpio driver (asterix), which only had init/output functions.

## Testing

- Validated on-device on obelix: normal shake/steps behavior, no event floods, no recovery logs during normal wear.
- `obelix@pvt` and `asterix` builds clean.
- Validated on-device on asterix as well (exercises the new nrf5 `gpio_input_read`).

Related: FIRM-2490, FIRM-1626, FIRM-1812

🤖 Generated with [Claude Code](https://claude.com/claude-code)
