### PR TITLE
fw/comm/ble/ppogatt: add ppog_reversed analytics metric

### DIFF
--- a/include/pbl/services/analytics/analytics.def
+++ b/include/pbl/services/analytics/analytics.def
@@ -102,6 +102,7 @@ PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(ble_disconnect_conn_term_local_count)     /
 PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(ble_disconnect_lmp_ll_rsp_tmo_count)      // 0x22
 PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(ble_disconnect_conn_establishment_count)  // 0x3e
 PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(ble_disconnect_other_count)
+PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(ppog_reversed)
 
 // Settings
 PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(settings_health_tracking_enabled)

--- a/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
+++ b/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
@@ -674,6 +674,8 @@ static void prv_handle_reset_complete(PPoGATTClient *client, const PPoGATTPacket
   client->state = StateConnectedOpen;
   client->session = session;
 
+  PBL_ANALYTICS_SET_UNSIGNED(ppog_reversed, (client->role == PPoGATTRoleReversed) ? 1 : 0);
+
   if (prv_client_supports_enhanced_throughput_features(client)) {
     if (payload_length < sizeof(PPoGATTResetCompleteClientIDPayloadV1)) {
       PBL_LOG_WRN("Unexpected PPoGatt Reset Complete Payload Size: %"PRIu16,


### PR DESCRIPTION
Adds a boolean heartbeat metric (`ppog_reversed`) that records whether the PPoG session opened during the heartbeat period used the reversed role (watch hosts the GATT service) or the forward role.

The flag is set at PPoG session open (`prv_handle_reset_complete`), the one place where the role is known — both roles report the same `CommSessionTransportType_PPoGATT`, so this cannot be derived in the generic session analytics. Since Memfault heartbeat metrics reset each heartbeat, the metric is reported for heartbeats in which a session was (re)opened and is null otherwise.

Built for asterix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)