### PR TITLE
fw/apps/alarms: restore Just Once default for new alarms

### DIFF
--- a/src/fw/apps/system/alarms/alarm_editor.c
+++ b/src/fw/apps/system/alarms/alarm_editor.c
@@ -187,7 +187,7 @@ static void prv_time_picker_complete(TimeSelectionWindowData *time_picker_window
 
   if (data->creating_alarm) {
     DayPickerResult initial = {
-      .kind = DayPickerKindEveryday,
+      .kind = DayPickerKindJustOnce,
     };
     memset(initial.custom_days, 0, sizeof(initial.custom_days));
     DayPickerConfig config = {


### PR DESCRIPTION
The day_picker refactor (7fc1a7241) inadvertently changed the default frequency for newly created alarms from Just Once to Every Day. Restore the previous behavior by initializing the day picker selection to DayPickerKindJustOnce when creating an alarm.

Fixes FIRM-3360