### PR TITLE
bluetooth: add server-side GATT caching support

### DIFF
--- a/include/pbl/services/bluetooth/bluetooth_persistent_storage.h
+++ b/include/pbl/services/bluetooth/bluetooth_persistent_storage.h
@@ -91,6 +91,21 @@ BTCCCDID bt_persistent_storage_store_cccd(const BleCCCD *cccd);
 
 bool bt_persistent_storage_delete_cccd(const BTDeviceInternal *peer, uint16_t chr_val_handle);
 
+//! Stores the GATT caching peer state table (opaque driver-defined blob).
+//! Pass data=NULL to delete the record.
+void bt_persistent_storage_set_ble_gatt_caching_state(const void *data, size_t len);
+
+//! Reads the GATT caching peer state table.
+//! @return the number of bytes read; 0 if absent or larger than the buffer
+int bt_persistent_storage_get_ble_gatt_caching_state(void *data_out, size_t buf_len);
+
+//! Stores the local GATT database hash.
+void bt_persistent_storage_set_ble_gatt_db_hash(const uint8_t hash[16]);
+
+//! Reads the local GATT database hash.
+//! @return true if a hash was stored
+bool bt_persistent_storage_get_ble_gatt_db_hash(uint8_t hash_out[16]);
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 //! Local Device Info
 

--- a/src/bluetooth-fw/nimble/nimble_store.c
+++ b/src/bluetooth-fw/nimble/nimble_store.c
@@ -40,9 +40,32 @@ typedef struct {
   unsigned int skipped;
 } BleStoreCCCDFindContext;
 
+typedef struct {
+  ListNode node;
+  struct ble_store_value_csfc value_csfc;
+} BleStoreValueCSFC;
+
+typedef struct {
+  const struct ble_store_key_csfc *key;
+  unsigned int skipped;
+} BleStoreCSFCFindContext;
+
+//! Persisted layout of one GATT caching peer state record. Kept independent
+//! of the NimBLE struct so persisted data survives NimBLE layout changes.
+typedef struct PACKED {
+  uint8_t addr_type;
+  uint8_t addr[6];
+  uint8_t csfc;
+  uint8_t change_aware;
+} NimbleStoreCSFCRecord;
+
+#define CSFC_MAX_RECORDS MYNEWT_VAL(BLE_STORE_MAX_BONDS)
+
 static BleStoreValueSec *s_peer_value_secs;
 static BleStoreValueSec *s_our_value_secs;
 static BleStoreValueCCCD *s_cccds;
+static BleStoreValueCSFC *s_csfcs;
+static bool s_csfcs_loaded;
 
 static PebbleRecursiveMutex *s_store_mutex;
 
@@ -413,6 +436,200 @@ unlock:
   return ret;
 }
 
+static void prv_nimble_store_csfc_insert(const struct ble_store_value_csfc *value_csfc);
+
+//! Loads the persisted GATT caching peer state table on first use. Must be
+//! called without the store mutex held: bt_persistent_storage holds its own
+//! lock while iterating records into this store, so the storage read must not
+//! happen under the store mutex (lock ordering).
+static void prv_nimble_store_csfc_ensure_loaded(void) {
+  NimbleStoreCSFCRecord records[CSFC_MAX_RECORDS];
+  bool loaded;
+  int len;
+
+  mutex_lock_recursive(s_store_mutex);
+  loaded = s_csfcs_loaded;
+  mutex_unlock_recursive(s_store_mutex);
+
+  if (loaded) {
+    return;
+  }
+
+  len = bt_persistent_storage_get_ble_gatt_caching_state(records, sizeof(records));
+
+  mutex_lock_recursive(s_store_mutex);
+  if (!s_csfcs_loaded) {
+    s_csfcs_loaded = true;
+
+    for (int i = 0; i < len / (int)sizeof(NimbleStoreCSFCRecord); i++) {
+      struct ble_store_value_csfc value = {
+        .peer_addr = {
+          .type = records[i].addr_type,
+        },
+        .csfc = { records[i].csfc },
+        .change_aware = records[i].change_aware,
+      };
+      memcpy(value.peer_addr.val, records[i].addr, sizeof(value.peer_addr.val));
+      prv_nimble_store_csfc_insert(&value);
+    }
+  }
+  mutex_unlock_recursive(s_store_mutex);
+}
+
+//! Serializes the GATT caching peer state table. Must be called with the
+//! store mutex held; the returned length is persisted by the caller after
+//! releasing the mutex.
+static size_t prv_nimble_store_csfc_serialize(NimbleStoreCSFCRecord *records) {
+  size_t num = 0;
+
+  for (BleStoreValueCSFC *s = s_csfcs; s != NULL && num < CSFC_MAX_RECORDS;
+       s = (BleStoreValueCSFC *)list_get_next((ListNode *)s)) {
+    records[num].addr_type = s->value_csfc.peer_addr.type;
+    memcpy(records[num].addr, s->value_csfc.peer_addr.val, sizeof(records[num].addr));
+    records[num].csfc = s->value_csfc.csfc[0];
+    records[num].change_aware = s->value_csfc.change_aware;
+    num++;
+  }
+
+  return num * sizeof(NimbleStoreCSFCRecord);
+}
+
+static bool prv_nimble_store_find_csfc_cb(ListNode *node, void *data) {
+  BleStoreValueCSFC *s = (BleStoreValueCSFC *)node;
+  BleStoreCSFCFindContext *ctx = data;
+
+  if ((ble_addr_cmp(&ctx->key->peer_addr, BLE_ADDR_ANY) != 0) &&
+      (ble_addr_cmp(&s->value_csfc.peer_addr, &ctx->key->peer_addr) != 0)) {
+    return false;
+  }
+
+  if (ctx->key->idx > ctx->skipped) {
+    ctx->skipped++;
+    return false;
+  }
+
+  return true;
+}
+
+static BleStoreValueCSFC *prv_nimble_store_find_csfc(const struct ble_store_key_csfc *key_csfc) {
+  BleStoreCSFCFindContext ctx = {
+    .key = key_csfc,
+    .skipped = 0U,
+  };
+
+  return (BleStoreValueCSFC *)list_find((ListNode *)s_csfcs, prv_nimble_store_find_csfc_cb, &ctx);
+}
+
+static void prv_nimble_store_csfc_insert(const struct ble_store_value_csfc *value_csfc) {
+  struct ble_store_key_csfc key_csfc;
+  BleStoreValueCSFC *s;
+
+  ble_store_key_from_value_csfc(&key_csfc, value_csfc);
+
+  s = prv_nimble_store_find_csfc(&key_csfc);
+  if (s == NULL) {
+    s = kernel_zalloc_check(sizeof(BleStoreValueCSFC));
+    if (s_csfcs == NULL) {
+      s_csfcs = s;
+    } else {
+      list_append((ListNode *)s_csfcs, (ListNode *)s);
+    }
+  }
+
+  s->value_csfc = *value_csfc;
+}
+
+static int prv_nimble_store_read_csfc(const struct ble_store_key_csfc *key_csfc,
+                                      struct ble_store_value_csfc *value_csfc) {
+  BleStoreValueCSFC *s;
+  int ret = 0;
+
+  prv_nimble_store_csfc_ensure_loaded();
+
+  mutex_lock_recursive(s_store_mutex);
+
+  s = prv_nimble_store_find_csfc(key_csfc);
+  if (s == NULL) {
+    ret = BLE_HS_ENOENT;
+    goto unlock;
+  }
+
+  *value_csfc = s->value_csfc;
+
+unlock:
+  mutex_unlock_recursive(s_store_mutex);
+
+  return ret;
+}
+
+static int prv_nimble_store_write_csfc(const struct ble_store_value_csfc *value_csfc) {
+  NimbleStoreCSFCRecord records[CSFC_MAX_RECORDS];
+  size_t len;
+
+  prv_nimble_store_csfc_ensure_loaded();
+
+  mutex_lock_recursive(s_store_mutex);
+
+  if (list_count((ListNode *)s_csfcs) >= CSFC_MAX_RECORDS) {
+    struct ble_store_key_csfc key_csfc;
+
+    ble_store_key_from_value_csfc(&key_csfc, value_csfc);
+    if (prv_nimble_store_find_csfc(&key_csfc) == NULL) {
+      mutex_unlock_recursive(s_store_mutex);
+      return BLE_HS_ESTORE_CAP;
+    }
+  }
+
+  prv_nimble_store_csfc_insert(value_csfc);
+  len = prv_nimble_store_csfc_serialize(records);
+
+  mutex_unlock_recursive(s_store_mutex);
+
+  bt_persistent_storage_set_ble_gatt_caching_state(records, len);
+
+  return 0;
+}
+
+static int prv_nimble_store_delete_csfc(const struct ble_store_key_csfc *key_csfc) {
+  NimbleStoreCSFCRecord records[CSFC_MAX_RECORDS];
+  BleStoreValueCSFC *s;
+  size_t len;
+
+  prv_nimble_store_csfc_ensure_loaded();
+
+  mutex_lock_recursive(s_store_mutex);
+
+  s = prv_nimble_store_find_csfc(key_csfc);
+  if (s == NULL) {
+    mutex_unlock_recursive(s_store_mutex);
+    return BLE_HS_ENOENT;
+  }
+
+  list_remove((ListNode *)s, (ListNode **)&s_csfcs, NULL);
+  kernel_free(s);
+  len = prv_nimble_store_csfc_serialize(records);
+
+  mutex_unlock_recursive(s_store_mutex);
+
+  bt_persistent_storage_set_ble_gatt_caching_state(records, len);
+
+  return 0;
+}
+
+static int prv_nimble_store_read_db_hash(struct ble_store_value_db_hash *value_db_hash) {
+  if (!bt_persistent_storage_get_ble_gatt_db_hash(value_db_hash->hash)) {
+    return BLE_HS_ENOENT;
+  }
+
+  return 0;
+}
+
+static int prv_nimble_store_write_db_hash(const struct ble_store_value_db_hash *value_db_hash) {
+  bt_persistent_storage_set_ble_gatt_db_hash(value_db_hash->hash);
+
+  return 0;
+}
+
 static int prv_nimble_store_read(const int obj_type, const union ble_store_key *key,
                                  union ble_store_value *value) {
   switch (obj_type) {
@@ -421,6 +638,10 @@ static int prv_nimble_store_read(const int obj_type, const union ble_store_key *
       return prv_nimble_store_read_sec(obj_type, &key->sec, &value->sec);
     case BLE_STORE_OBJ_TYPE_CCCD:
       return prv_nimble_store_read_cccd(&key->cccd, &value->cccd);
+    case BLE_STORE_OBJ_TYPE_CSFC:
+      return prv_nimble_store_read_csfc(&key->csfc, &value->csfc);
+    case BLE_STORE_OBJ_TYPE_DB_HASH:
+      return prv_nimble_store_read_db_hash(&value->db_hash);
     default:
       return BLE_HS_ENOTSUP;
   }
@@ -433,6 +654,10 @@ static int prv_nimble_store_write(int obj_type, const union ble_store_value *val
       return prv_nimble_store_write_sec(obj_type, &val->sec);
     case BLE_STORE_OBJ_TYPE_CCCD:
       return prv_nimble_store_write_cccd(&val->cccd);
+    case BLE_STORE_OBJ_TYPE_CSFC:
+      return prv_nimble_store_write_csfc(&val->csfc);
+    case BLE_STORE_OBJ_TYPE_DB_HASH:
+      return prv_nimble_store_write_db_hash(&val->db_hash);
     default:
       return BLE_HS_ENOTSUP;
   }
@@ -445,6 +670,8 @@ static int prv_nimble_store_delete(int obj_type, const union ble_store_key *key)
       return prv_nimble_store_delete_sec(obj_type, &key->sec);
     case BLE_STORE_OBJ_TYPE_CCCD:
       return prv_nimble_store_delete_cccd(&key->cccd);
+    case BLE_STORE_OBJ_TYPE_CSFC:
+      return prv_nimble_store_delete_csfc(&key->csfc);
     default:
       return BLE_HS_ENOTSUP;
   }
@@ -500,10 +727,13 @@ void nimble_store_unload(void) {
   list_foreach((ListNode *)s_peer_value_secs, prv_store_value_free, NULL);
   list_foreach((ListNode *)s_our_value_secs, prv_store_value_free, NULL);
   list_foreach((ListNode *)s_cccds, prv_store_value_free, NULL);
+  list_foreach((ListNode *)s_csfcs, prv_store_value_free, NULL);
 
   s_peer_value_secs = NULL;
   s_our_value_secs = NULL;
   s_cccds = NULL;
+  s_csfcs = NULL;
+  s_csfcs_loaded = false;
 
   mutex_unlock_recursive(s_store_mutex);
 }

--- a/src/fw/services/bluetooth/bluetooth_persistent_storage_normal.c
+++ b/src/fw/services/bluetooth/bluetooth_persistent_storage_normal.c
@@ -108,6 +108,10 @@ static const char AIRPLANE_MODE_KEY[] = "AIRPLANE_MODE";
 static const char SYSTEM_CAPABILITIES_KEY[] = "SYSTEM_CAPABILITIES";
 //! This key is used to access the BLE address that can be used for address pinning.
 static const char BLE_PINNED_ADDRESS_KEY[] = "BLE_PINNED_ADDRESS";
+//! This key is used to access the GATT caching peer state table (opaque driver blob)
+static const char BLE_GATT_CACHING_STATE_KEY[] = "BLE_GATT_CACHING";
+//! This key is used to access the local GATT database hash
+static const char BLE_GATT_DB_HASH_KEY[] = "BLE_GATT_DB_HASH";
 
 static uint8_t s_bt_persistent_storage_updates = 0;
 
@@ -1299,6 +1303,23 @@ bool bt_persistent_storage_delete_cccd(const BTDeviceInternal *peer, uint16_t ch
   }
 
   return true;
+}
+
+void bt_persistent_storage_set_ble_gatt_caching_state(const void *data, size_t len) {
+  prv_file_set(BLE_GATT_CACHING_STATE_KEY, sizeof(BLE_GATT_CACHING_STATE_KEY), data, len);
+}
+
+int bt_persistent_storage_get_ble_gatt_caching_state(void *data_out, size_t buf_len) {
+  return prv_file_get(BLE_GATT_CACHING_STATE_KEY, sizeof(BLE_GATT_CACHING_STATE_KEY), data_out,
+                      buf_len);
+}
+
+void bt_persistent_storage_set_ble_gatt_db_hash(const uint8_t hash[16]) {
+  prv_file_set(BLE_GATT_DB_HASH_KEY, sizeof(BLE_GATT_DB_HASH_KEY), hash, 16);
+}
+
+bool bt_persistent_storage_get_ble_gatt_db_hash(uint8_t hash_out[16]) {
+  return prv_file_get(BLE_GATT_DB_HASH_KEY, sizeof(BLE_GATT_DB_HASH_KEY), hash_out, 16) == 16;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/fw/services/bluetooth/bluetooth_persistent_storage_prf.c
+++ b/src/fw/services/bluetooth/bluetooth_persistent_storage_prf.c
@@ -236,6 +236,20 @@ bool bt_persistent_storage_delete_cccd(const BTDeviceInternal *peer, uint16_t ch
   return true;
 }
 
+// PRF does not support persistent GATT caching state either
+
+void bt_persistent_storage_set_ble_gatt_caching_state(const void *data, size_t len) {}
+
+int bt_persistent_storage_get_ble_gatt_caching_state(void *data_out, size_t buf_len) {
+  return 0;
+}
+
+void bt_persistent_storage_set_ble_gatt_db_hash(const uint8_t hash[16]) {}
+
+bool bt_persistent_storage_get_ble_gatt_db_hash(uint8_t hash_out[16]) {
+  return false;
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 //! Local Device Info
 

--- a/third_party/nimble/port/include/nrf52/syscfg/syscfg.h
+++ b/third_party/nimble/port/include/nrf52/syscfg/syscfg.h
@@ -27,7 +27,7 @@
 
 /*** Repository @apache-mynewt-nimble info */
 #ifndef MYNEWT_VAL_REPO_HASH_APACHE_MYNEWT_NIMBLE
-#define MYNEWT_VAL_REPO_HASH_APACHE_MYNEWT_NIMBLE "a7a156f28954819e158b62dd613008f22f9cf73b"
+#define MYNEWT_VAL_REPO_HASH_APACHE_MYNEWT_NIMBLE "53e266cea1d00aaf584532865877836d1eb60719"
 #endif
 
 #ifndef MYNEWT_VAL_REPO_VERSION_APACHE_MYNEWT_NIMBLE
@@ -45,7 +45,7 @@
 
 /*** Repository @syscfg info */
 #ifndef MYNEWT_VAL_REPO_HASH_SYSCFG
-#define MYNEWT_VAL_REPO_HASH_SYSCFG "e383a491b7c5897735a9e09ffd4ff68f3bf0ab40-dirty"
+#define MYNEWT_VAL_REPO_HASH_SYSCFG "cec598b52d94d500687b9ffd3517e9cefcddfc2e-dirty"
 #endif
 
 #ifndef MYNEWT_VAL_REPO_VERSION_SYSCFG
@@ -1865,6 +1865,11 @@
 
 #ifndef MYNEWT_VAL_BLE_GAP_MAX_PENDING_CONN_PARAM_UPDATE
 #define MYNEWT_VAL_BLE_GAP_MAX_PENDING_CONN_PARAM_UPDATE (1)
+#endif
+
+/* Overridden by targets/nrf52 (defined by @apache-mynewt-nimble/nimble/host) */
+#ifndef MYNEWT_VAL_BLE_GATT_CACHING
+#define MYNEWT_VAL_BLE_GATT_CACHING (1)
 #endif
 
 #ifndef MYNEWT_VAL_BLE_GATT_DISC_ALL_CHRS

--- a/third_party/nimble/port/include/sf32lb52/syscfg/syscfg.h
+++ b/third_party/nimble/port/include/sf32lb52/syscfg/syscfg.h
@@ -27,7 +27,7 @@
 
 /*** Repository @apache-mynewt-nimble info */
 #ifndef MYNEWT_VAL_REPO_HASH_APACHE_MYNEWT_NIMBLE
-#define MYNEWT_VAL_REPO_HASH_APACHE_MYNEWT_NIMBLE "a7a156f28954819e158b62dd613008f22f9cf73b"
+#define MYNEWT_VAL_REPO_HASH_APACHE_MYNEWT_NIMBLE "53e266cea1d00aaf584532865877836d1eb60719"
 #endif
 
 #ifndef MYNEWT_VAL_REPO_VERSION_APACHE_MYNEWT_NIMBLE
@@ -45,7 +45,7 @@
 
 /*** Repository @syscfg info */
 #ifndef MYNEWT_VAL_REPO_HASH_SYSCFG
-#define MYNEWT_VAL_REPO_HASH_SYSCFG "e383a491b7c5897735a9e09ffd4ff68f3bf0ab40-dirty"
+#define MYNEWT_VAL_REPO_HASH_SYSCFG "cec598b52d94d500687b9ffd3517e9cefcddfc2e-dirty"
 #endif
 
 #ifndef MYNEWT_VAL_REPO_VERSION_SYSCFG
@@ -926,6 +926,11 @@
 
 #ifndef MYNEWT_VAL_BLE_GAP_MAX_PENDING_CONN_PARAM_UPDATE
 #define MYNEWT_VAL_BLE_GAP_MAX_PENDING_CONN_PARAM_UPDATE (1)
+#endif
+
+/* Overridden by targets/sf32lb52 (defined by @apache-mynewt-nimble/nimble/host) */
+#ifndef MYNEWT_VAL_BLE_GATT_CACHING
+#define MYNEWT_VAL_BLE_GATT_CACHING (1)
 #endif
 
 #ifndef MYNEWT_VAL_BLE_GATT_DISC_ALL_CHRS

--- a/third_party/nimble/syscfg/targets/nrf52/syscfg.yml
+++ b/third_party/nimble/syscfg/targets/nrf52/syscfg.yml
@@ -13,3 +13,4 @@ syscfg.vals:
     BLE_SM_LEGACY: 0
     BLE_SM_MITM: 1
     BLE_SM_LVL: 4
+    BLE_GATT_CACHING: 1

--- a/third_party/nimble/syscfg/targets/sf32lb52/syscfg.yml
+++ b/third_party/nimble/syscfg/targets/sf32lb52/syscfg.yml
@@ -8,6 +8,7 @@ syscfg.vals:
     BLE_SM_LEGACY: 0
     BLE_SM_MITM: 1
     BLE_SM_LVL: 4
+    BLE_GATT_CACHING: 1
     # Increased to prevent ACL mbuf allocation failures during high-throughput
     # operations (e.g. FW upgrade over BLE on iOS).
     BLE_TRANSPORT_ACL_COUNT: 60


### PR DESCRIPTION
Stacked on #1705 (the first two commits — Mbed TLS + NimBLE upstream master migration — belong to that PR; only the last three commits are new here). Will be rebased once #1705 merges.

Add server-side GATT caching (Core spec v5.4, Vol 3, Part G, 2.5.2 and 7.3):

- `third_party/nimble`: move the submodule to the `gatt-hash-new` branch, which carries the GATT caching series on top of upstream master (Database Hash characteristic 0x2B2A, CSFC/database hash store object types, Database Out Of Sync ATT error, robust caching state machine), and enable `BLE_GATT_CACHING` for both SoC targets.
- `services/bluetooth`: new persistent storage record for GATT caching state.
- `bluetooth-fw/nimble`: handle the new store object types in the NimBLE store glue. Per-bonded-peer Client Supported Features and change-aware state are kept in a RAM list, serialized into the new storage record, and lazily loaded on first access.

With this, a bonded phone that enabled robust caching gets a Database Out Of Sync ATT error when it operates on stale attribute handles after a firmware update changed the GATT database, instead of silently misbehaving, and clients can detect database changes deterministically by reading the hash on reconnection. Awareness state survives reboots on both sides.

The NimBLE series is intended to be submitted to apache/mynewt-nimble; the submodule branch keeps it rebased on upstream master for that purpose.

Build-verified on asterix and obelix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)