### PR TITLE
fw/drivers/rtc: bound RSF sync wait in rtc_get_time_ms

### DIFF
--- a/src/fw/drivers/rtc/sf32lb.c
+++ b/src/fw/drivers/rtc/sf32lb.c
@@ -283,13 +283,28 @@ void rtc_set_time(time_t time) {
   prv_rtc_set_time_no_cal_reset(time);
 }
 
+// RSF sync completes within a few RTC clock cycles (~0.5 ms at RC10K); a
+// wedged low-power domain can leave it stuck low forever, so bound the wait
+// well above the genuine sync time (~40-200 ms depending on HCLK).
+#define RTC_RSF_SYNC_MAX_SPINS 1000000UL
+
 void rtc_get_time_ms(time_t* out_seconds, uint16_t* out_ms) {
   RTC_DateTypeDef rtc_date;
   RTC_TimeTypeDef rtc_time;
 
   if (s_initialized) {
+    uint32_t spins = 0;
     while((RTC_Handler.Instance->ISR & RTC_ISR_RSF) == (uint32_t)RESET) {
       // Wait for RTC registers to synchronize
+      if (++spins > RTC_RSF_SYNC_MAX_SPINS) {
+        static bool s_rsf_timeout_logged = false;
+        if (!s_rsf_timeout_logged) {
+          // Set before logging: PBL_LOG timestamps re-enter rtc_get_time_ms
+          s_rsf_timeout_logged = true;
+          PBL_LOG_ERR("RSF sync timeout, reading stale RTC shadow registers");
+        }
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
The wait for RTC shadow-register synchronization spun forever if RSF never set. On FIRM-3403 a wedged low-power domain left RSF stuck low, so rtc_get_time_ms hung the system task and tripped the task watchdog ("stuck task" reboot 9 s after boot on v4.23.0).

Bound the wait at 1M iterations (~40-200 ms depending on HCLK, vs ~0.5 ms genuine sync time) and fall back to the last-synced shadow values, degrading to stale time instead of a watchdog reboot loop. The timeout is logged once; the guard flag is set before logging because PBL_LOG timestamps re-enter rtc_get_time_ms.

Related to FIRM-3403.