### PR TITLE
fw: fix alarms being silent in low power (Watch Only) mode

### DIFF
--- a/src/fw/popups/alarm_popup.c
+++ b/src/fw/popups/alarm_popup.c
@@ -13,6 +13,7 @@
 #include "kernel/pbl_malloc.h"
 #include "kernel/ui/modals/modal_manager.h"
 #include "resource/resource_ids.auto.h"
+#include "system/logging.h"
 #include "pbl/services/clock.h"
 #include "pbl/services/i18n/i18n.h"
 #include "pbl/services/light.h"
@@ -215,7 +216,11 @@ static void prv_vibe_kernel_main_cb(void *callback_context) {
     if (s_alarm_popup_data->vibe_count < s_alarm_popup_data->max_vibes) {
       s_alarm_popup_data->vibe_count++;
       vibes_cancel();
-      vibe_score_do_vibe(s_alarm_popup_data->vibe_score);
+      if (s_alarm_popup_data->vibe_score) {
+        vibe_score_do_vibe(s_alarm_popup_data->vibe_score);
+      } else {
+        vibes_long_pulse();
+      }
 #ifdef CONFIG_SPEAKER
       if (s_alarm_popup_data->sound_active &&
           s_alarm_popup_data->sound_driven_by_vibe_timer) {
@@ -241,17 +246,28 @@ static void prv_vibe(void *unused) {
 
 static void prv_start_vibes(void) {
   s_alarm_popup_data->vibe_count = 0;
-  unsigned int vibe_repeat_interval_ms = TINTIN_VIBE_REPEAT_INTERVAL_MS;
   if (low_power_is_active()) {
     s_alarm_popup_data->vibe_score = vibe_client_get_score(VibeClient_AlarmsLPM);
   } else {
     s_alarm_popup_data->vibe_score = vibe_client_get_score(VibeClient_Alarms);
   }
-  if (!s_alarm_popup_data->vibe_score) {
-    return;
+  unsigned int vibe_repeat_interval_ms = 0;
+  if (s_alarm_popup_data->vibe_score) {
+    vibe_repeat_interval_ms = vibe_score_get_duration_ms(s_alarm_popup_data->vibe_score) +
+        vibe_score_get_repeat_delay_ms(s_alarm_popup_data->vibe_score);
   }
-  vibe_repeat_interval_ms = vibe_score_get_duration_ms(s_alarm_popup_data->vibe_score) +
-      vibe_score_get_repeat_delay_ms(s_alarm_popup_data->vibe_score);
+  if (vibe_repeat_interval_ms == 0) {
+    // Missing (e.g. resource load failure under memory pressure) or empty
+    // score: an alarm must never be silent, so pulse on a fixed cadence.
+    PBL_LOG_WRN("No usable alarm vibe score; falling back to fixed pulse");
+    if (s_alarm_popup_data->vibe_score) {
+      vibe_score_destroy(s_alarm_popup_data->vibe_score);
+      s_alarm_popup_data->vibe_score = NULL;
+    }
+    vibe_repeat_interval_ms = low_power_is_active()
+        ? (SECONDS_PER_MINUTE * MS_PER_SECOND / TINTIN_LPM_VIBES_PER_MINUTE)
+        : TINTIN_VIBE_REPEAT_INTERVAL_MS;
+  }
   s_alarm_popup_data->max_vibes = DIVIDE_CEIL(VIBE_DURATION, vibe_repeat_interval_ms);
   s_alarm_popup_data->vibe_timer = new_timer_create();
   prv_vibe(NULL);
@@ -359,7 +375,10 @@ void alarm_popup_push_window(PebbleAlarmClockEvent *event) {
   }
 #ifdef CONFIG_SPEAKER
   if (have_info) {
-    prv_start_sound(alarm_id, vibe_on);
+    // The paired-tone piggyback assumes the timer runs at the score's cycle
+    // length; in fallback-pulse mode (score == NULL) it doesn't, so let the
+    // sound loop on its own.
+    prv_start_sound(alarm_id, vibe_on && (s_alarm_popup_data->vibe_score != NULL));
   }
 #endif
 

--- a/src/fw/services/vibes/vibe_score.c
+++ b/src/fw/services/vibes/vibe_score.c
@@ -14,7 +14,10 @@
 
 PBL_LOG_MODULE_DECLARE(service_vibes, CONFIG_SERVICE_VIBES_LOG_LEVEL);
 
-#define VIBE_SCORE_MAX_REPEAT_DELAY_MS (10000) // matches MAX_VIBE_DURATION_MS in vibe_pattern
+// The repeat delay is a passive wait between score playbacks (it never becomes
+// a hardware vibe step), so it is not bound by MAX_VIBE_DURATION_MS in
+// vibe_pattern. The LPM alarm score uses 50s. Keep in sync with json2vibe.py.
+#define VIBE_SCORE_MAX_REPEAT_DELAY_MS (60000)
 
 static VibeNote *prv_vibe_score_get_note_list(GenericAttribute *notes_attribute) {
   return (VibeNote *)notes_attribute->data;

--- a/tests/fw/services/test_vibe_score.c
+++ b/tests/fw/services/test_vibe_score.c
@@ -132,6 +132,68 @@ void test_vibe_score__repeat_delay_is_valid(void) {
   vibe_score_destroy(score);
 }
 
+void test_vibe_score__repeat_delay_lpm_alarm_is_valid(void) {
+  // 50s repeat delay, as used by the LPM alarm score
+  uint8_t buffer[] = {
+      'V', 'I', 'B', 'E', // FourCC
+      1, 0, // version
+      0, 0, 0, 0, // reserved bytes
+      23, 0, // attr_list_size
+      3, // GenericAttributeList.num_attributes
+      VibeAttributeId_Notes,
+      8, 0, // GenericAttribute.length
+      15, 0, // VibeNote.vibe_duration_ms
+      9, // VibeNote.brake_duration_ms
+      100, // VibeNote.strength
+      100, 0, // VibeNote.vibe_duration_ms
+      0, // VibeNote.brake_duration_ms
+      0, // VibeNote.strength
+      VibeAttributeId_Pattern,
+      3, 0, // GenericAttribute.length
+      0,
+      1,
+      0,
+      VibeAttributeId_RepeatDelay,
+      2, 0, // GenericAttribute.length (2 bytes for a uint16)
+      0x50, 0xC3 // repeat_delay value (50000)
+  };
+  s_resource_buffer = buffer;
+  s_resource_buffer_size = sizeof(buffer);
+  VibeScore *score = vibe_score_create_with_resource_system(0, 0);
+  cl_assert(score);
+  cl_assert_equal_i(vibe_score_get_repeat_delay_ms(score), 50000);
+  vibe_score_destroy(score);
+}
+
+void test_vibe_score__repeat_delay_too_long_is_invalid(void) {
+  uint8_t buffer[] = {
+      'V', 'I', 'B', 'E', // FourCC
+      1, 0, // version
+      0, 0, 0, 0, // reserved bytes
+      23, 0, // attr_list_size
+      3, // GenericAttributeList.num_attributes
+      VibeAttributeId_Notes,
+      8, 0, // GenericAttribute.length
+      15, 0, // VibeNote.vibe_duration_ms
+      9, // VibeNote.brake_duration_ms
+      100, // VibeNote.strength
+      100, 0, // VibeNote.vibe_duration_ms
+      0, // VibeNote.brake_duration_ms
+      0, // VibeNote.strength
+      VibeAttributeId_Pattern,
+      3, 0, // GenericAttribute.length
+      0,
+      1,
+      0,
+      VibeAttributeId_RepeatDelay,
+      2, 0, // GenericAttribute.length (2 bytes for a uint16)
+      0x61, 0xEA // repeat_delay value (60001, above the cap)
+  };
+  s_resource_buffer = buffer;
+  s_resource_buffer_size = sizeof(buffer);
+  cl_assert(vibe_score_create_with_resource_system(0, 0) == NULL);
+}
+
 void test_vibe_score__test_get_duration_ms(void) {
   uint8_t buffer[] = {
       'V', 'I', 'B', 'E', // FourCC

--- a/tools/json2vibe.py
+++ b/tools/json2vibe.py
@@ -67,6 +67,16 @@ def serialize(json_data):
     CURRENT_VERSION = 1
     NEGATIVE_VIBE_STRENGTH_MAX = -100
     POSITIVE_VIBE_STRENGTH_MAX = 100
+    # Keep in sync with VIBE_SCORE_MAX_REPEAT_DELAY_MS in vibe_score.c; the
+    # firmware refuses to load scores exceeding it.
+    MAX_REPEAT_DELAY_MS = 60000
+
+    if not 0 <= json_data.get("repeat_delay_ms", 0) <= MAX_REPEAT_DELAY_MS:
+        raise ValueError(
+            '"repeat_delay_ms" {} out of bounds. Values between 0 and {} only.'.format(
+                json_data["repeat_delay_ms"], MAX_REPEAT_DELAY_MS
+            )
+        )
 
     for note in json_data["notes"]:
         if not (


### PR DESCRIPTION
## Summary

Alarms in low power ("Watch Only") mode fire visually but never vibrate. The root cause is deterministic and affects every board on every release to date: `alarm_lpm.json` declares a 50s `repeat_delay_ms`, but `vibe_score_validate()` rejects any repeat delay above 10s, so `RESOURCE_ID_VIBE_SCORE_ALARM_LPM` never loads. `vibe_client_get_score()` returns NULL (`Got a null VibeScore resource!` in field logs) and `alarm_popup.c` bailed out silently — no vibration, and since the vibe timer also drives the 10-minute auto-dismiss, the popup stayed up indefinitely.

The 10s cap claimed to match `MAX_VIBE_DURATION_MS`, but that constant clamps individual hardware vibe steps; the score repeat delay is a passive software wait between playbacks and never reaches the hardware queue.

Two commits:

1. **fw/services/vibes: allow vibe score repeat delays up to 60s** — raises the validation cap so the LPM score (10×500ms pulses, 50s rest ≈ 10 vibes/minute, matching the intent documented by the previously-dead `TINTIN_LPM_VIBES_PER_MINUTE` constant) loads again. Adds a matching range check to `json2vibe.py` so an out-of-range score fails the build instead of shipping unloadable, plus unit tests (50000 valid, 60001 rejected).
2. **fw/popups/alarm: never let a missing vibe score silence the alarm** — if the score still fails to load (e.g. under memory pressure, cf. the FIRM-3035 OOM cluster), fall back to a plain long pulse on a fixed cadence (1s normal / 6s LPM) with a warning log, keeping the vibe timer — and therefore auto-dismiss — alive.

## Verification

Driven end-to-end in QEMU (qemu_emery), observing vibration via the QEMU vibe protocol and simulating LPM by setting `s_low_power_active` through gdb (QEMU's battery monitor never enters LPM naturally):

- **Stock main, LPM alarm**: popup shows, `Got a null VibeScore resource!` logged, zero vibration events, no auto-dismiss — reproduces the field report exactly.
- **Fixed, LPM alarm**: LPM score loads cleanly and plays the designed cadence — 10×500ms pulses, then 50s rest, next burst exactly 60s after the first.
- **Fixed, gdb forcing the score load to return NULL** (normal and LPM): fallback warning logged, steady pulses at 1s / 6s cadence respectively.
- `./pbl test -M ".*vibe_score.*"` passes; normal-mode alarm vibes unchanged.

Fixes FIRM-3413

🤖 Generated with [Claude Code](https://claude.com/claude-code)