### PR TITLE
ci: rebase PR branches onto target branch before running

### DIFF
--- a/.github/actions/rebase/action.yml
+++ b/.github/actions/rebase/action.yml
@@ -1,0 +1,46 @@
+name: Rebase onto target branch
+description: >
+  Rebase the checked-out PR branch onto the current target branch so CI
+  runs against up-to-date code. Fails if the rebase does not apply
+  cleanly. No-op on non-PR events. Requires a full checkout
+  (fetch-depth: 0) of the PR head SHA.
+
+inputs:
+  submodules:
+    description: >
+      Update submodules after the rebase. Same semantics as
+      actions/checkout: 'false', 'true' or 'recursive'.
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Rebase onto target branch
+      shell: bash
+      env:
+        SUBMODULES: ${{ inputs.submodules }}
+      run: |
+        if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
+          echo "Not a pull request, skipping rebase."
+          exit 0
+        fi
+
+        git config --global user.email "ci@repebble.com"
+        git config --global user.name "PebbleOS CI"
+
+        rm -rf .git/rebase-apply .git/rebase-merge
+
+        if ! git rebase "origin/${GITHUB_BASE_REF}"; then
+          git rebase --abort || true
+          echo "::error::Cannot rebase onto ${GITHUB_BASE_REF}. Rebase your branch locally, resolve conflicts and push again."
+          exit 1
+        fi
+
+        if [ "${SUBMODULES}" = "recursive" ]; then
+          git submodule update --init --recursive
+        elif [ "${SUBMODULES}" = "true" ]; then
+          git submodule update --init
+        fi
+
+        git log --oneline -10

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           filters: |
             src:
+              - '.github/actions/**'
               - '.github/workflows/build-firmware.yml'
               - 'boards/**'
               - 'platform/**'
@@ -58,7 +59,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          submodules: true
+
+      - name: Rebase onto target branch
+        uses: ./.github/actions/rebase
+        with:
           submodules: true
 
       - name: Install Python dependencies

--- a/.github/workflows/build-prf.yml
+++ b/.github/workflows/build-prf.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           filters: |
             src:
+              - '.github/actions/**'
               - '.github/workflows/build-prf.yml'
               - 'boards/**'
               - 'platform/**'
@@ -59,7 +60,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          submodules: true
+
+      - name: Rebase onto target branch
+        uses: ./.github/actions/rebase
+        with:
           submodules: true
 
       - name: Install Python dependencies

--- a/.github/workflows/build-qemu-sdkshell.yml
+++ b/.github/workflows/build-qemu-sdkshell.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           filters: |
             src:
+              - '.github/actions/**'
               - '.github/workflows/build-qemu-sdkshell.yml'
               - 'platform/**'
               - 'resources/**'
@@ -51,7 +52,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          submodules: true
+
+      - name: Rebase onto target branch
+        uses: ./.github/actions/rebase
+        with:
           submodules: true
 
       - name: Install Python dependencies

--- a/.github/workflows/build-qemu.yml
+++ b/.github/workflows/build-qemu.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           filters: |
             src:
+              - '.github/actions/**'
               - '.github/workflows/build-qemu.yml'
               - 'platform/**'
               - 'resources/**'
@@ -51,7 +52,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          submodules: true
+
+      - name: Rebase onto target branch
+        uses: ./.github/actions/rebase
+        with:
           submodules: true
 
       - name: Install Python dependencies

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -13,11 +13,14 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      - name: Rebase onto target branch
+        uses: ./.github/actions/rebase
+
       - name: Install GitLint
         run: pip install gitlint
 
       - name: Run GitLint
-        run: gitlint --commits "${{ github.event.pull_request.base.sha }}..HEAD"
+        run: gitlint --commits "origin/${GITHUB_BASE_REF}..HEAD"
 
   ruff:
     runs-on: ubuntu-24.04
@@ -28,12 +31,15 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      - name: Rebase onto target branch
+        uses: ./.github/actions/rebase
+
       - name: Install ruff
         run: pip install ruff
 
       - name: Run ruff format check
         run: |
-          base="${{ github.event.pull_request.base.sha }}"
+          base="origin/${GITHUB_BASE_REF}"
 
           # collect submodule paths to skip
           submodules=$(git config --file .gitmodules --get-regexp '\.path$' \
@@ -65,9 +71,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      - name: Rebase onto target branch
+        uses: ./.github/actions/rebase
+
       - name: Check SPDX license headers
         run: |
-          base="${{ github.event.pull_request.base.sha }}"
+          base="origin/${GITHUB_BASE_REF}"
           failed_files=()
 
           # collect submodule paths to skip

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           filters: |
             src:
+              - '.github/actions/**'
               - '.github/workflows/nix.yml'
               - 'flake.nix'
               - 'flake.lock'
@@ -41,7 +42,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          submodules: true
+
+      - name: Rebase onto target branch
+        uses: ./.github/actions/rebase
+        with:
           submodules: true
 
       - name: Install Nix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           filters: |
             src:
+              - '.github/actions/**'
               - '.github/workflows/test.yml'
               - 'platform/**'
               - 'resources/**'
@@ -49,7 +50,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          submodules: true
+
+      - name: Rebase onto target branch
+        uses: ./.github/actions/rebase
+        with:
           submodules: true
 
       - name: Install Python dependencies


### PR DESCRIPTION
## Summary

- Check out the PR head SHA and rebase it onto the current tip of the target branch before any CI job runs, following the approach used by Zephyr. If the rebase does not apply cleanly, CI fails immediately with an error asking the author to rebase locally.
- This replaces building GitHub's ephemeral merge commit, which only reflects the target branch at event time, so stale branches were tested against an outdated base (and conflicting PRs failed at checkout with a cryptic "unable to resolve refs/pull/N/merge" error).
- The rebase logic lives in a reusable composite action (`.github/actions/rebase`) with a checkout-style `submodules` input (default `false`, accepts `true`/`recursive`) to re-sync submodules after the rebase so gitlinks match the rebased tree.
- Compliance diff ranges now use `origin/$GITHUB_BASE_REF` instead of the event base SHA, which would include unrelated upstream commits after the rebase.

## Test plan

- YAML validated locally.
- This PR itself exercises the new path: all PR workflows should show the "Rebase onto target branch" step rebasing onto `main` before building/testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)