### PR TITLE
ci: fix rebase action resolution

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -64,7 +64,7 @@ jobs:
           submodules: true
 
       - name: Rebase onto target branch
-        uses: ./.github/actions/rebase
+        uses: coredevices/pebbleos/.github/actions/rebase@9ee5c919d9d42833b1d96abe1f00da6f8cc2d8eb
         with:
           submodules: true
 

--- a/.github/workflows/build-prf.yml
+++ b/.github/workflows/build-prf.yml
@@ -65,7 +65,7 @@ jobs:
           submodules: true
 
       - name: Rebase onto target branch
-        uses: ./.github/actions/rebase
+        uses: coredevices/pebbleos/.github/actions/rebase@9ee5c919d9d42833b1d96abe1f00da6f8cc2d8eb
         with:
           submodules: true
 

--- a/.github/workflows/build-qemu-sdkshell.yml
+++ b/.github/workflows/build-qemu-sdkshell.yml
@@ -57,7 +57,7 @@ jobs:
           submodules: true
 
       - name: Rebase onto target branch
-        uses: ./.github/actions/rebase
+        uses: coredevices/pebbleos/.github/actions/rebase@9ee5c919d9d42833b1d96abe1f00da6f8cc2d8eb
         with:
           submodules: true
 

--- a/.github/workflows/build-qemu.yml
+++ b/.github/workflows/build-qemu.yml
@@ -57,7 +57,7 @@ jobs:
           submodules: true
 
       - name: Rebase onto target branch
-        uses: ./.github/actions/rebase
+        uses: coredevices/pebbleos/.github/actions/rebase@9ee5c919d9d42833b1d96abe1f00da6f8cc2d8eb
         with:
           submodules: true
 

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0
 
       - name: Rebase onto target branch
-        uses: ./.github/actions/rebase
+        uses: coredevices/pebbleos/.github/actions/rebase@9ee5c919d9d42833b1d96abe1f00da6f8cc2d8eb
 
       - name: Install GitLint
         run: pip install gitlint
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Rebase onto target branch
-        uses: ./.github/actions/rebase
+        uses: coredevices/pebbleos/.github/actions/rebase@9ee5c919d9d42833b1d96abe1f00da6f8cc2d8eb
 
       - name: Install ruff
         run: pip install ruff
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 0
 
       - name: Rebase onto target branch
-        uses: ./.github/actions/rebase
+        uses: coredevices/pebbleos/.github/actions/rebase@9ee5c919d9d42833b1d96abe1f00da6f8cc2d8eb
 
       - name: Check SPDX license headers
         run: |

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -47,7 +47,7 @@ jobs:
           submodules: true
 
       - name: Rebase onto target branch
-        uses: ./.github/actions/rebase
+        uses: coredevices/pebbleos/.github/actions/rebase@9ee5c919d9d42833b1d96abe1f00da6f8cc2d8eb
         with:
           submodules: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
           submodules: true
 
       - name: Rebase onto target branch
-        uses: ./.github/actions/rebase
+        uses: coredevices/pebbleos/.github/actions/rebase@9ee5c919d9d42833b1d96abe1f00da6f8cc2d8eb
         with:
           submodules: true
 


### PR DESCRIPTION
Older pull request branches do not contain the newly added local rebase action. Checking out the PR head therefore removes the action before GitHub Actions resolves it, causing every affected job to fail.\n\nReference the action through coredevices/pebbleos at the immutable commit that introduced it. This keeps the shared implementation available independently of the checked-out PR contents.\n\nValidation:\n- gitlint --commits HEAD~1..HEAD\n- git diff --check\n- parsed all workflow and action YAML files