### PR TITLE
ci: resolve rebase action from the merge ref

### DIFF
--- a/.github/actions/rebase/action.yml
+++ b/.github/actions/rebase/action.yml
@@ -1,9 +1,10 @@
 name: Rebase onto target branch
 description: >
-  Rebase the checked-out PR branch onto the current target branch so CI
-  runs against up-to-date code. Fails if the rebase does not apply
+  Check out the PR head and rebase it onto the current target branch so
+  CI runs against up-to-date code. Fails if the rebase does not apply
   cleanly. No-op on non-PR events. Requires a full checkout
-  (fetch-depth: 0) of the PR head SHA.
+  (fetch-depth: 0) of the default (merge) ref, so this action resolves
+  from the merged tree regardless of the PR branch contents.
 
 inputs:
   submodules:
@@ -20,6 +21,7 @@ runs:
       shell: bash
       env:
         SUBMODULES: ${{ inputs.submodules }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
         if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
           echo "Not a pull request, skipping rebase."
@@ -30,6 +32,8 @@ runs:
         git config --global user.name "PebbleOS CI"
 
         rm -rf .git/rebase-apply .git/rebase-merge
+
+        git checkout --force "${HEAD_SHA}"
 
         if ! git rebase "origin/${GITHUB_BASE_REF}"; then
           git rebase --abort || true

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -59,7 +59,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           submodules: true
 

--- a/.github/workflows/build-prf.yml
+++ b/.github/workflows/build-prf.yml
@@ -60,7 +60,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           submodules: true
 

--- a/.github/workflows/build-qemu-sdkshell.yml
+++ b/.github/workflows/build-qemu-sdkshell.yml
@@ -52,7 +52,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           submodules: true
 

--- a/.github/workflows/build-qemu.yml
+++ b/.github/workflows/build-qemu.yml
@@ -52,7 +52,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           submodules: true
 

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -10,7 +10,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Rebase onto target branch
@@ -28,7 +27,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Rebase onto target branch
@@ -68,7 +66,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Rebase onto target branch

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -42,7 +42,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           submodules: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           submodules: true
 


### PR DESCRIPTION
Workflows checked out the PR head SHA before resolving the local rebase action, so PR branches created before the action existed were missing it from the workspace and every job failed at action resolution.

Check out the default merge ref instead, which always contains the current merged copy of the action, and let the action itself switch to the PR head before rebasing. The head SHA is always fetchable since it is a parent of the merge commit and the checkout is full depth. If the PR conflicts with its base, the merge ref does not exist and checkout fails, which surfaces the same rebase-locally error one step earlier.

Compared to pinning a remote `coredevices/pebbleos/.github/actions/rebase@<sha>` reference (#1722), this keeps the in-tree action live: future edits to it take effect through the merge ref without having to bump a pinned SHA across every workflow.

Validation:
- gitlint --commits HEAD~1..HEAD
- parsed all workflow and action YAML files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXM9QU4HXCYWPuRX2HwuyW