### PR TITLE
fw/services/process_management: allow unaligned relocation table offsets

### DIFF
--- a/src/fw/services/process_management/process_loader_storage.c
+++ b/src/fw/services/process_management/process_loader_storage.c
@@ -97,13 +97,6 @@ static bool prv_validate_process_info(const PebbleProcessInfo *info,
     return false;
   }
 
-  if ((info->num_reloc_entries != 0) &&
-      !prv_offset_is_word_aligned(image_size)) {
-    PBL_LOG_WRN("Invalid app relocation table offset alignment: image=%zu",
-                image_size);
-    return false;
-  }
-
   if (!prv_offset_is_halfword_aligned(info->offset) ||
       !prv_offset_range_fits(info->offset, sizeof(uint16_t), image_size) ||
       (info->offset < header_size)) {
@@ -154,12 +147,15 @@ static bool prv_apply_relocations(const PebbleProcessInfo *info,
                                   MemorySegment *destination) {
   // Relocation entries point to uint32_t slots in the loaded image
   // Slot values are still relative to the app image
-  uint32_t *reloc_array = prv_offset_to_address(destination, info->load_size);
+  // Legacy SDK apps can have a non-word-aligned image size, which places the
+  // table itself at an unaligned offset, so entries must be read bytewise
+  uint8_t *reloc_table = prv_offset_to_address(destination, info->load_size);
 
   for (uint32_t i = 0; i < info->num_reloc_entries; ++i) {
     // A target has to land on a word boundary inside the image and past the header,
     // otherwise the write below is an out of bounds write in a privileged context
-    const uint32_t reloc_offset = reloc_array[i];
+    uint32_t reloc_offset;
+    memcpy(&reloc_offset, &reloc_table[i * sizeof(uint32_t)], sizeof(reloc_offset));
     if (!prv_offset_is_word_aligned(reloc_offset) ||
         !prv_offset_range_fits(reloc_offset, sizeof(uint32_t), info->load_size) ||
         (reloc_offset < sizeof(PebbleProcessInfo))) {
@@ -184,7 +180,7 @@ static bool prv_apply_relocations(const PebbleProcessInfo *info,
 
   // The reloc table is loaded over the start of .bss, so we have to restore the zeros the app expects
   if (info->num_reloc_entries != 0) {
-    memset(reloc_array, 0, info->num_reloc_entries * sizeof(uint32_t));
+    memset(reloc_table, 0, info->num_reloc_entries * sizeof(uint32_t));
   }
   return true;
 }


### PR DESCRIPTION
## Summary

Fixes [FIRM-3396](https://linear.app/core-dev/issue/FIRM-3396): third-party **Timer** (and any legacy SDK app whose binary image size is not a multiple of 4) fails to launch on v4.24.0+ with:

```
Invalid app relocation table offset alignment: image=18110
app_manager.c:315> Tried to launch an invalid app in bank 1!
app_manager.c:629> Failed to start app <Timer>! Restarting launcher
```

The relocation-data validation added in 68b30e60 requires `load_size` to be word-aligned because the relocation table starts at that offset and was read as a `uint32_t` array. Legacy SDK apps routinely have non-word-aligned image sizes — the store Timer PBW (`c64aae42-b822-4d6d-995b-bc7c38e843f4`) has `load_size % 4 == 2` on **all** of its platform binaries (aplite/basalt/chalk), so it is rejected on every watch. These apps loaded fine before the hardening (unaligned `LDR` is legal on Cortex-M).

## Fix

Drop the alignment requirement on the table *start* and read the entries bytewise (`memcpy`). All security-relevant validation from 68b30e60 is unchanged: relocation targets must still be word-aligned, in-bounds, and past the header; relocated values must stay within the app image; all size/overflow checks remain.

## Verification

On `qemu_emery` with the actual store Timer PBW:
- **Before**: launch rejected with the exact log lines from the field report, launcher restarts.
- **After**: app launches; setting a timer works (UI increments, end-time computed), confirming relocations are applied correctly.
- `./pbl test -M '.*app_manager.*'` passes (no unit test compiles the loader itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)