### PR TITLE
fw/drivers/imu/lsm6dso: log INT source context on anomalous INT1 paths

### DIFF
--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -360,7 +360,8 @@ static void prv_lsm6dso_recover(void);
 //! fifo_progress is set when FIFO data was consumed (samples or overrun).
 static bool prv_lsm6dso_service_int1(bool *fifo_progress) {
   bool ret;
-  uint8_t val;
+  uint8_t fifo_status2 = 0U;
+  uint8_t all_int_src = 0U;
   bool action_taken = false;
   bool fifo_overrun = false;
   bool shake = false;
@@ -372,15 +373,15 @@ static bool prv_lsm6dso_service_int1(bool *fifo_progress) {
   // on these reads, so deferring it avoids stretching the gap between the FIFO
   // read and the ALL_INT_SRC read if this task gets preempted mid-handler.
   if (LSM6DSO->state->num_samples > 0U) {
-    ret = prv_lsm6dso_read(LSM6DSO_FIFO_STATUS2, &val, 1);
+    ret = prv_lsm6dso_read(LSM6DSO_FIFO_STATUS2, &fifo_status2, 1);
     if (!ret) {
       PBL_LOG_ERR("Could not read FIFO_STATUS2 register");
       return false;
     }
 
-    if ((val & LSM6DSO_FIFO_STATUS2_FIFO_OVR_IA) != 0U) {
+    if ((fifo_status2 & LSM6DSO_FIFO_STATUS2_FIFO_OVR_IA) != 0U) {
       fifo_overrun = true;
-    } else if ((val & LSM6DSO_FIFO_STATUS2_FIFO_WTM_IA) != 0U) {
+    } else if ((fifo_status2 & LSM6DSO_FIFO_STATUS2_FIFO_WTM_IA) != 0U) {
       uint8_t status1;
 
       if (!prv_lsm6dso_read(LSM6DSO_FIFO_STATUS1, &status1, 1)) {
@@ -388,7 +389,7 @@ static bool prv_lsm6dso_service_int1(bool *fifo_progress) {
         return false;
       }
 
-      samples = (((uint16_t)(val & LSM6DSO_FIFO_STATUS2_DIFF_HI_MASK)) << 8U) | status1;
+      samples = (((uint16_t)(fifo_status2 & LSM6DSO_FIFO_STATUS2_DIFF_HI_MASK)) << 8U) | status1;
       if (samples > LSM6DSO_FIFO_SIZE) {
         samples = LSM6DSO_FIFO_SIZE;
       }
@@ -406,13 +407,13 @@ static bool prv_lsm6dso_service_int1(bool *fifo_progress) {
   }
 
   if (LSM6DSO->state->shake_detection_enabled) {
-    ret = prv_lsm6dso_read(LSM6DSO_ALL_INT_SRC, &val, 1);
+    ret = prv_lsm6dso_read(LSM6DSO_ALL_INT_SRC, &all_int_src, 1);
     if (!ret) {
       PBL_LOG_ERR("Could not read ALL_INT_SRC register");
       return false;
     }
 
-    shake = (val & LSM6DSO_ALL_INT_SRC_WU_IA) != 0U;
+    shake = (all_int_src & LSM6DSO_ALL_INT_SRC_WU_IA) != 0U;
   }
 
   if (fifo_overrun) {
@@ -440,7 +441,11 @@ static bool prv_lsm6dso_service_int1(bool *fifo_progress) {
   LSM6DSO->state->wu_active = shake;
 
   if (!action_taken) {
-    PBL_LOG_WRN("INT1 triggered but no action taken");
+    // Registers not read this pass (gated on num_samples/shake state) log as 0
+    PBL_LOG_WRN("INT1 triggered but no action taken (FIFO_STATUS2 0x%02" PRIx8
+                " ALL_INT_SRC 0x%02" PRIx8 " num_samples %" PRIu16 " shake_en %d)",
+                fifo_status2, all_int_src, LSM6DSO->state->num_samples,
+                LSM6DSO->state->shake_detection_enabled);
   }
 
   return action_taken;
@@ -586,6 +591,10 @@ static void prv_lsm6dso_recover(void) {
   if (!prv_lsm6dso_read(LSM6DSO_ALL_INT_SRC, &val, 1)) {
     PBL_LOG_ERR("Could not read ALL_INT_SRC register");
     return;
+  }
+
+  if (val != 0U) {
+    PBL_LOG_WRN("Discarded latched INT sources during recovery (ALL_INT_SRC 0x%02" PRIx8 ")", val);
   }
 
   if (!prv_configure_odr(LSM6DSO->state->sampling_interval_us,


### PR DESCRIPTION
## Summary

Field logs from hardened firmware (v4.26.0 and v4.28.0, both containing the INT1 stall hardening series) still show frequent `INT1 triggered but no action taken` warnings, ~26 stream recoveries per day of active wear, with recoveries clustering in bursts (up to 7 in 23 minutes) during sustained motion.

The suspected dominant cause is a wake-up (shake) source asserting in the window between the `ALL_INT_SRC` read and the INT1 pad level re-check: the servicing pass legitimately finds nothing, reads the pad high, and trips the stuck-pad recovery — which then clears (and silently drops) the very shake event that triggered it.

This PR adds the diagnostics needed to confirm that from field captures before changing recovery behavior:

- The no-action warning now logs `FIFO_STATUS2`, `ALL_INT_SRC`, `num_samples` and shake-enable state (registers not read that pass log as 0, disambiguated by the state fields).
- Stream recovery now logs any non-zero latched INT sources it discards while routing is quiesced.

## How to read the new logs

- No-action pass with `ALL_INT_SRC 0x00`, `shake_en 1`, followed by a recovery discarding `0x20` (WU_IA) → confirms the WU-in-check-window race; the fix would be to retry the servicing pass once before recovering.
- No-action pass with all-zero context and no recovery → benign duplicate pass (pad deassert latency / double-enqueued work item).
- `FIFO_STATUS2` with WTM set while `num_samples 0` → reconfiguration race.

## Testing

- Built for obelix@pvt, compiles clean.
- Log format uses integer specifiers only (no `%s` mixed with `%x`), so dehashing is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgAszMS3XMYZRNopN9RUtP