### PR TITLE
fw/drivers/imu/lsm6dso: retry INT1 servicing before stream recovery

### DIFF
--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -459,7 +459,22 @@ static void prv_lsm6dso_int1_work_handler(void) {
 
   if (fifo_progress) {
     accel_offload_work(prv_lsm6dso_int1_work_handler);
-  } else if (!action_taken) {
+    return;
+  }
+
+  if (action_taken) {
+    return;
+  }
+
+  // A source asserting between the status reads and the pad re-check is
+  // indistinguishable from a stuck pad, and recovering would discard it.
+  // Retry the servicing pass once (a latched wake-up or a fresh FIFO
+  // threshold is visible on re-read) and only recover if the pad is still
+  // high with nothing serviced.
+  action_taken = prv_lsm6dso_service_int1(&fifo_progress);
+  if (fifo_progress) {
+    accel_offload_work(prv_lsm6dso_int1_work_handler);
+  } else if (!action_taken && gpio_input_read(&LSM6DSO->int1_in)) {
     prv_lsm6dso_recover();
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1729. Field logs on hardened firmware show stream recoveries clustering during sustained motion (up to 7 in 23 minutes), each preceded by an `INT1 triggered but no action taken` warning at the same timestamp.

Root cause: the stuck-pad heuristic (`!action_taken && pad high` → recover) cannot distinguish a genuinely stuck pad from a wake-up/FIFO source asserting in the window between the status register reads and the `gpio_input_read` pad re-check. When the race is hit, a healthy stream gets re-initialized and the wake-up event that raced the check is silently discarded (recovery clears `ALL_INT_SRC` without dispatching a shake).

Since INT2 is not routed on these boards, the mixed level/latched single-pad design stays — this closes the race in software instead: retry the servicing pass once before recovering. A racing wake-up is latched (LIR) and a FIFO threshold is level, so both are visible on re-read and get serviced normally. Recovery now only triggers when two consecutive passes find nothing with the pad still high — a genuinely stuck pad.

The pad-deassert-latency false positive is also covered: by the time the retry finishes its register reads, a lagging pad has settled low and no recovery fires.

## Testing

- Built for obelix@pvt, compiles clean.
- With the #1729 diagnostics, field captures should show the `Discarded latched INT sources` warning with WU_IA (0x20) disappear, and recovery counts drop to near zero outside genuine stalls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgAszMS3XMYZRNopN9RUtP