### PR TITLE
fw/services/activity: split stored-session load warning by cause

### DIFF
--- a/src/fw/services/activity/activity_sessions.c
+++ b/src/fw/services/activity/activity_sessions.c
@@ -598,8 +598,13 @@ void activity_sessions_prv_init(SettingsFile *file, time_t utc_now) {
   // Check the length first. The settings_file_get() call will not return an error if we ask
   // for less than the value size
   int stored_len = settings_file_get_len(file, &key, sizeof(key));
+  if (stored_len == 0) {
+    PBL_LOG_DBG("No stored activity sessions");
+    return;
+  }
   if (stored_len != sizeof(state->activity_sessions)) {
-    PBL_LOG_WRN("Stored activities not found or incompatible");
+    PBL_LOG_WRN("Stored activities incompatible: len %d != %d", stored_len,
+                (int)sizeof(state->activity_sessions));
     return;
   }
 

--- a/tests/fw/services/activity/test_activity.c
+++ b/tests/fw/services/activity/test_activity.c
@@ -1970,6 +1970,23 @@ void test_activity__migrate_settings_v2(void) {
   cl_assert_equal_i(settings_file_set(&file, &key, sizeof(key), &last_vmc, sizeof(last_vmc)),
                     S_SUCCESS);
 
+  // Stored sessions are not metric records; the migration must copy them verbatim
+  ActivitySession sessions[ACTIVITY_MAX_ACTIVITY_SESSIONS_COUNT] = {};
+  sessions[0] = (ActivitySession) {
+    .start_utc = rtc_get_time() - SECONDS_PER_HOUR,
+    .length_min = 42,
+    .type = ActivitySessionType_Walk,
+    .step_data = {
+      .steps = 4200,
+      .active_kcalories = 120,
+      .resting_kcalories = 80,
+      .distance_meters = 3000,
+    },
+  };
+  key = ActivitySettingsKeyStoredActivities;
+  cl_assert_equal_i(settings_file_set(&file, &key, sizeof(key), sessions, sizeof(sessions)),
+                    S_SUCCESS);
+
   settings_file_close(&file);
 
   // Initializing triggers the migration
@@ -1984,6 +2001,17 @@ void test_activity__migrate_settings_v2(void) {
   int32_t vmc;
   cl_assert(activity_get_metric(ActivityMetricLastVMC, 1, &vmc));
   cl_assert_equal_i(vmc, 1234);
+
+  // Stored sessions must come through the migration unchanged
+  uint32_t session_entries = ACTIVITY_MAX_ACTIVITY_SESSIONS_COUNT;
+  ActivitySession loaded_sessions[ACTIVITY_MAX_ACTIVITY_SESSIONS_COUNT];
+  cl_assert(activity_get_sessions(&session_entries, loaded_sessions));
+  cl_assert_equal_i(session_entries, 1);
+  cl_assert_equal_i(loaded_sessions[0].start_utc, sessions[0].start_utc);
+  cl_assert_equal_i(loaded_sessions[0].length_min, 42);
+  cl_assert_equal_i(loaded_sessions[0].type, ActivitySessionType_Walk);
+  cl_assert_equal_i(loaded_sessions[0].step_data.steps, 4200);
+  cl_assert_equal_i(loaded_sessions[0].step_data.distance_meters, 3000);
 }
 
 


### PR DESCRIPTION
## Summary

While triaging FIRM-3452 (getafix v4.28.0 BLE failures), the boot log line `Stored activities not found or incompatible` was twice misread as the v4.28.0 activity settings migration dropping stored sessions — it fires on every boot where no session record exists, which is the routine case (it appears on healthy v4.26/v4.27 boots too).

- Log the missing-record case at debug level and reserve the warning for a genuine size mismatch, printing both lengths so a real incompatibility is diagnosable from a log capture.
- Extend the v2 settings migration test to pin that stored sessions are copied through the uint32 metric migration verbatim: `ActivitySession` carries explicit `uint16_t` fields, so a verbatim copy is the correct layout-preserving behavior. Audited the remaining settings keys against the migration lists: all persisted `ActivityScalarStore` records (11 history + 6 scalar keys) are converted; StepAverages/AgeYears are genuinely `uint16_t`.

## Test plan

- `./waf test -M '.*test_activity.*'` — 4/4 suites pass, including the extended `test_activity__migrate_settings_v2`
- `./waf build` (asterix) compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)