### PR TITLE
fw/put_bytes: scope BLE slowdown to the raw storage erase

### DIFF
--- a/src/fw/services/put_bytes/put_bytes.c
+++ b/src/fw/services/put_bytes/put_bytes.c
@@ -313,7 +313,7 @@ static bool prv_init_put_job_queue_if_necessary(void) {
 
 static void prv_set_responsiveness(ResponseTimeState state, uint16_t timeout_secs) {
   comm_session_set_responsiveness(comm_session_get_system_session(),
-                                  BtConsumerPpPutBytes, ResponseTimeMin, timeout_secs);
+                                  BtConsumerPpPutBytes, state, timeout_secs);
 }
 
 static void prv_send_nack_from_system_task(void *data) {

--- a/src/fw/services/put_bytes/put_bytes_storage_raw.c
+++ b/src/fw/services/put_bytes/put_bytes_storage_raw.c
@@ -122,13 +122,6 @@ bool pb_storage_raw_init(PutBytesStorage *storage, PutBytesObjectType object_typ
 
   storage->current_offset = layout->start_offset;
 
-  // Reduce BLE activity for the duration of raw flash operations to help prevent stack overflow
-  // in NimbleHost task. Flash operations block and concurrent BLE mbuf handling can cause deep
-  // call stacks. Using ResponseTimeMiddle reduces the frequency of BLE events while still
-  // maintaining reasonable transfer speeds.
-  comm_session_set_responsiveness(comm_session_get_system_session(),
-                                  BtConsumerPpPutBytes, ResponseTimeMiddle, 0);
-
   // This erase operation will take awhile, so disable the task watchdog for the current task
   // while we're doing this.
   bool previous_system_task_watchdog_state = task_watchdog_mask_get(PebbleTask_KernelBackground);
@@ -137,10 +130,21 @@ bool pb_storage_raw_init(PutBytesStorage *storage, PutBytesObjectType object_typ
   }
 
   if (append_offset == 0) {
+    // Reduce BLE activity while the blocking erase runs, to lower stack pressure on the
+    // NimbleHost task. Scoped to the erase only: this shares BtConsumerPpPutBytes with the
+    // ResponseTimeMin request held during chunk streaming, so leaving it in place would cancel
+    // the fast connection interval.
+    comm_session_set_responsiveness(comm_session_get_system_session(), BtConsumerPpPutBytes,
+                                    ResponseTimeMiddle, MIN_LATENCY_MODE_TIMEOUT_PUT_BYTES_SECS);
+
     // By erasing the entire region we make it more likely for 'pb_storage_raw_get_status' to
     // recover the correct location.
     flash_region_erase_optimal_range(layout->start_address, layout->start_address,
         layout->end_address, layout->end_address);
+
+    // Restore the fast interval so the init ACK isn't delayed by the slow connection parameters.
+    comm_session_set_responsiveness(comm_session_get_system_session(), BtConsumerPpPutBytes,
+                                    ResponseTimeMin, MIN_LATENCY_MODE_TIMEOUT_PUT_BYTES_SECS);
   } else {
     // Some data we want has already been written, just continue from last valid location!
     storage->current_offset += append_offset;


### PR DESCRIPTION
## Summary

During a firmware update, the BLE connection interval bounced Min → Middle → Max → Min at every raw PutBytes object boundary (firmware object, then system resources), leaving the multi-second slot erase and its init ACK running at up to 180 ms effective interval (45 ms interval, slave latency 3). Watch log signature:

```
bt_conn_mgr.c:188:LE: Requesting state <Middle> for 0 secs, due to <PpPutBytes>
bt_conn_mgr.c:188:LE: Requesting state <Max> for 0 secs, due to <None>
bt:Connection parameters updated: itvl=45 ms, latency=3, spvn timeout=6000 ms
bt_conn_mgr.c:188:LE: Requesting state <Min> for 60 secs, due to <PpPutBytes>
bt:Connection parameters updated: itvl=15 ms, latency=0, spvn timeout=6000 ms
```

Root cause: `pb_storage_raw_init()` requested `ResponseTimeMiddle` with `max_period_secs=0` (added in 6d679bc73 to reduce NimbleHost stack pressure during blocking flash ops). Two problems:

- `0` is not "run forever" (`MAX_PERIOD_RUN_FOREVER` is `0xFFFF`): it creates an already-expired request, which the `bt_conn_mgr` watchdog deletes ~1 s later, dropping the connection to `ResponseTimeMax` (due to `<None>`).
- It shares `BtConsumerPpPutBytes` with the `ResponseTimeMin` request refreshed by `prv_receiver_finish()` during chunk streaming, so it cancelled the fast interval at every object init.

## Fix

- Request `ResponseTimeMiddle` only for the duration of the blocking erase (bounded timeout as a safety net), and restore `ResponseTimeMin` right after, so the init ACK goes out at the fast interval and the streaming request is never cancelled. The resume path (`append_offset != 0`, no erase) no longer touches responsiveness.
- `prv_set_responsiveness()` in `put_bytes.c` now honors its `state` argument instead of hardcoding `ResponseTimeMin` (latent bug, all current callers pass Min).

The NimbleHost stack overflow that motivated 6d679bc73 remains covered by its +1000 B stack size increase.

This costs ~5–10 s per object boundary on obelix updates; it is not the dominant cost of the slow transfer reported in FIRM-3431 (that is the phone's serial one-chunk-per-ack PutBytes flow, tracked separately).

Fixes FIRM-3431

## Testing

- Full firmware build for `obelix@pvt` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)