### PR TITLE
clock: arm hourly chime only after vibe service init

### DIFF
--- a/include/pbl/services/clock.h
+++ b/include/pbl/services/clock.h
@@ -45,7 +45,8 @@ void clock_init(void);
 
 #ifndef CONFIG_RECOVERY_FW
 //! @internal
-//! Allow the hourly chime to access system resources after they are initialized.
+//! Arm the hourly chime once the services it uses (system resources, alerts
+//! preferences, vibe pattern service) are initialized.
 void clock_hourly_chime_arm(void);
 #endif
 

--- a/src/fw/kernel/event_loop.c
+++ b/src/fw/kernel/event_loop.c
@@ -46,6 +46,7 @@
 #include "pbl/services/analytics/analytics.h"
 #include "pbl/services/battery/battery_state.h"
 #include "pbl/services/battery/battery_monitor.h"
+#include "pbl/services/clock.h"
 #include "pbl/services/compositor/compositor.h"
 #include "pbl/services/cron.h"
 #include "pbl/services/debounced_connection_service.h"
@@ -530,6 +531,11 @@ static NOINLINE void prv_launcher_main_loop_init(void) {
   app_manager_init();
   worker_manager_init();
   vibes_init();
+#ifndef CONFIG_RECOVERY_FW
+  // The chime path uses alerts prefs and the vibe pattern service, so only
+  // arm it once vibes_init() has run; it must never fire before this point.
+  clock_hourly_chime_arm();
+#endif
   battery_monitor_init();
   evented_timer_init();
 #ifdef CONFIG_MAG

--- a/src/fw/main.c
+++ b/src/fw/main.c
@@ -333,10 +333,6 @@ static NOINLINE void prv_main_task_init(void) {
 
   system_resource_init();
 
-#ifndef CONFIG_RECOVERY_FW
-  clock_hourly_chime_arm();
-#endif
-
 #ifdef CONFIG_HRM
   hrm_init(HRM);
 #endif

--- a/src/fw/services/clock/service.c
+++ b/src/fw/services/clock/service.c
@@ -46,7 +46,7 @@ static const uint16_t protocol_time_endpoint_id = 11;
 static RegularTimerInfo s_dst_checker;
 
 #ifndef CONFIG_RECOVERY_FW
-// Armed after system resources are initialized.
+// Armed once the services the chime path uses are initialized.
 static bool s_hourly_chime_armed;
 #define HOURLY_CHIME_GRACE_PERIOD_SECONDS 5
 #endif


### PR DESCRIPTION
## Problem

087c05455 ("clock: handle minute chime edge cases") armed the hourly chime in `prv_main_task_init` right after `system_resource_init()`. That guarantees the chime can't touch uninitialized *resources*, but the chime path also uses alerts preferences and the vibe pattern service — and those come up later (`services_init()` and `prv_launcher_main_loop_init()` respectively).

On boots where `clock_init()` snaps an invalid RTC to `MIN_VALID_BOOT_TIMESTAMP` (exactly on an hour boundary), the next 1 Hz regular-timer tick sees the minute change and fires `prv_watch_dst` with `seconds_into_hour ≈ 0`, inside the 5 s chime grace window. The pre-init alerts preference defaults (`AlertMaskAllOn`, vibrate on, DND off) let the chime through. If that tick lands after the arm call — a per-boot race against init timing — the chime runs on the NewTimer task before `vibes_init()` has created `s_vibe_pattern_mutex`, so `sys_vibe_pattern_enqueue_step_raw` locks a NULL mutex: it dereferences address 0 and hands garbage to `xLightMutexLock(..., portMAX_DELAY)`, wedging (or crashing) the NewTimer task.

The task watchdog doesn't monitor `PebbleTask_NewTimers`, so the watch finishes booting with every timer-driven service dead — most visibly Bluetooth, since BLE bring-up and connection management (`gap_le_connect`, `ppogatt`, comm session timeouts) all run on new_timer. Net symptom: some devices (RTC-loss / never-synced units, plus any reboot that crosses a top-of-hour during init) boot with Bluetooth permanently down.

The pre-087c05455 code was immune by accident: consuming the first minute tick to arm meant the first tick after boot could never chime, regardless of timing.

## Fix

Move the `clock_hourly_chime_arm()` call to `prv_launcher_main_loop_init`, immediately after `vibes_init()` — the last service the chime path depends on. This keeps both fixes from 087c05455 intact:

- arming is still state-based (not consume-one-tick), so a reboot that finishes init before hh:00:05 still chimes on the hour instead of silently eating it
- the 5 s grace period against late clock corrections is untouched
- resources are still guaranteed initialized (transitively, well before `vibes_init()`)

## Testing

- `./pbl build` (getafix, normal variant) passes
- `./waf test -M '.*test_clock.*'` passes (covers boot-arming, hour-boundary, clock-adjustment, and vibrate-setting cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)