### PR TITLE
fw/services/accel_manager: ignore vibe-induced shake/tap events

### DIFF
--- a/include/pbl/services/vibe_pattern.h
+++ b/include/pbl/services/vibe_pattern.h
@@ -20,6 +20,12 @@ typedef enum VibePatternOwner {
 void vibes_init();
 
 int32_t vibes_get_vibe_strength(void);
+
+//! Milliseconds since the motor was last active (on, or the moment it turned
+//! off). UINT32_MAX if it has not run this boot. Used to suppress
+//! vibration-induced false shake/tap detections.
+uint32_t vibes_get_time_since_last_vibe_ms(void);
+
 int32_t vibes_get_default_vibe_strength(void);
 void vibes_set_default_vibe_strength(int32_t vibe_strength_default);
 

--- a/src/fw/services/accel_manager/service.c
+++ b/src/fw/services/accel_manager/service.c
@@ -14,6 +14,7 @@
 #include "pbl/services/event_service.h"
 #include "pbl/services/system_task.h"
 #include "pbl/services/imu/units.h"
+#include "pbl/services/vibe_pattern.h"
 #include "syscall/syscall.h"
 #include "syscall/syscall_internal.h"
 #include "system/logging.h"
@@ -845,8 +846,28 @@ void accel_cb_new_samples(AccelRawBatch const *batch) {
   prv_dispatch_data(true /* post_event */);
 }
 
+// Motor spin-down plus hardware shake-detection latency after the last vibe
+// pulse during which a "shake" is almost certainly the motor, not the user.
+// Also bridges the brief off-gaps between segments of a multi-pulse pattern.
+#define ACCEL_VIBE_SHAKE_HOLDOFF_MS (500)
+
+// The vibe motor mechanically trips the accel's hardware wake-up/tap
+// interrupt. Ignore shake/tap events while the motor is on or just after it
+// stopped so a vibrating notification doesn't self-trigger a shake action.
+static bool prv_shake_caused_by_vibe(void) {
+  if (vibes_get_vibe_strength() != VIBE_STRENGTH_OFF) {
+    return true;
+  }
+  return vibes_get_time_since_last_vibe_ms() < ACCEL_VIBE_SHAKE_HOLDOFF_MS;
+}
+
 void accel_cb_shake_detected(IMUCoordinateAxis axis, int32_t direction) {
   if (!s_enabled) {
+    return;
+  }
+
+  if (prv_shake_caused_by_vibe()) {
+    PBL_LOG_DBG("Ignoring vibe-induced shake");
     return;
   }
 
@@ -876,6 +897,11 @@ void accel_cb_shake_detected(IMUCoordinateAxis axis, int32_t direction) {
 
 void accel_cb_double_tap_detected(IMUCoordinateAxis axis, int32_t direction) {
   if (!s_enabled) {
+    return;
+  }
+
+  if (prv_shake_caused_by_vibe()) {
+    PBL_LOG_DBG("Ignoring vibe-induced tap");
     return;
   }
 

--- a/src/fw/services/vibe_pattern/service.c
+++ b/src/fw/services/vibe_pattern/service.c
@@ -168,6 +168,9 @@ static RtcTicks s_pattern_start_ticks = 0;
 static uint64_t s_pattern_deadline_ms = 0;
 // s_vibe_strength is the current vibration strength setting of the motor
 static int32_t s_vibe_strength = VIBE_STRENGTH_OFF;
+// Tick at which the motor was last active (turned on or last transitioned off).
+// Used to suppress vibration-induced false shake/tap detections. 0 = never.
+static RtcTicks s_last_vibe_active_tick = 0;
 // s_vibe_strength_default is the vibrations trength of the motor used when one is not specified
 // explicitly, and can be changed in the notification vibration strength setting.
 static int32_t s_vibe_strength_default = VIBE_STRENGTH_MAX;
@@ -236,6 +239,7 @@ static void prv_vibes_set_vibe_strength(int32_t new_strength) {
   if (new_strength != VIBE_STRENGTH_OFF) {
     vibe_set_strength(new_strength);
     vibe_ctl(true /* on */);
+    s_last_vibe_active_tick = rtc_get_ticks();
     if (s_vibe_strength == VIBE_STRENGTH_OFF) {
       // Transitioning from off to on
       PBL_ANALYTICS_TIMER_START(vibrator_on_time_ms);
@@ -244,7 +248,9 @@ static void prv_vibes_set_vibe_strength(int32_t new_strength) {
   } else {
     vibe_ctl(false /* on */);
     if (s_vibe_strength != VIBE_STRENGTH_OFF) {
-      // Transitioning from on to off
+      // Transitioning from on to off; stamp the end so the shake holdoff runs
+      // from when the motor actually stopped.
+      s_last_vibe_active_tick = rtc_get_ticks();
       PBL_ANALYTICS_TIMER_STOP(vibrator_on_time_ms);
       prv_vibe_history_end_event();
     }
@@ -324,6 +330,16 @@ void vibes_set_default_vibe_strength(int32_t vibe_strength_default) {
 
 DEFINE_SYSCALL(int32_t, sys_vibe_get_vibe_strength, void) {
   return vibes_get_vibe_strength();
+}
+
+uint32_t vibes_get_time_since_last_vibe_ms(void) {
+  if (s_last_vibe_active_tick == 0) {
+    // Motor has never run this boot.
+    return UINT32_MAX;
+  }
+  RtcTicks elapsed = rtc_get_ticks() - s_last_vibe_active_tick;
+  uint64_t elapsed_ms = (uint64_t)elapsed * 1000 / RTC_TICKS_HZ;
+  return (elapsed_ms > UINT32_MAX) ? UINT32_MAX : (uint32_t)elapsed_ms;
 }
 
 bool prv_vibe_pattern_enqueue_step_raw(uint32_t duration_ms, int32_t strength) {

--- a/tests/fw/services/test_accel_manager.c
+++ b/tests/fw/services/test_accel_manager.c
@@ -44,6 +44,12 @@ void sys_vibe_history_stop_collecting(void) {}
 int32_t sys_vibe_get_vibe_strength(void) {
   return 0;
 }
+int32_t vibes_get_vibe_strength(void) {
+  return 0;
+}
+uint32_t vibes_get_time_since_last_vibe_ms(void) {
+  return UINT32_MAX;
+}
 void accel_set_shake_sensitivity_high(bool sensitivity_high) {}
 void accel_set_shake_sensitivity_percent(uint8_t percent) {}
 bool shell_prefs_get_accel_shake_log_info_enabled(void) {


### PR DESCRIPTION
## Problem

Since v4.19, an incoming notification's vibration triggers a phantom "shake"
action on the watch (e.g. motion backlight, shake-subscribed apps/watchfaces).
Reported on obelix (LSM6DSO).

## Root cause

In v4.19 shake detection moved to the accelerometer's **hardware wake-up
interrupt** (`WU_IA`). The LSM6DSO/LIS2DW12 drivers dispatch
`accel_cb_shake_detected()` on that interrupt. The vibe motor mechanically
shakes the watch and trips `WU_IA`, so the firmware reports a shake the user
never made. That shake then drives the motion backlight
(`event_loop.c`) and any shake-subscribed consumer.

## Fix

Service-layer only (no driver changes):

- **`vibe_pattern` service** tracks when the motor was last active (turned on,
  or the moment it turned off) and exposes `vibes_get_time_since_last_vibe_ms()`.
- **`accel_manager` service** drops shake/double-tap events while the motor is
  on **or** within a short spin-down window (`ACCEL_VIBE_SHAKE_HOLDOFF_MS`,
  500 ms) after the last pulse. This window covers motor spin-down + hardware
  detection latency and bridges the brief off-gaps between segments of a
  multi-pulse pattern.

A deliberate shake more than the holdoff after a vibration still registers
normally, so shake-to-backlight isn't broken — only the self-triggered false
shakes during/right-after a vibe are dropped.

Fixes FIRM-3290

## Test plan

- [x] On obelix, send a notification and confirm the vibration no longer
      triggers the motion backlight / shake action.
- [x] Confirm a deliberate shake shortly after (>500 ms) still works.
