### PR TITLE
applib: add read-only MusicService now-playing API

### DIFF
--- a/src/fw/applib/music_service.c
+++ b/src/fw/applib/music_service.c
@@ -1,0 +1,94 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "music_service.h"
+#include "music_service_private.h"
+
+#include "event_service_client.h"
+#include "kernel/events.h"
+#include "syscall/syscall.h"
+#include "system/passert.h"
+
+#include "process_state/app_state/app_state.h"
+#include "process_state/worker_state/worker_state.h"
+
+
+// ----------------------------------------------------------------------------------------------------
+static MusicServiceState* prv_get_state(PebbleTask task) {
+  if (task == PebbleTask_Unknown) {
+    task = pebble_task_get_current();
+  }
+
+  if (task == PebbleTask_App) {
+    return app_state_get_music_service_state();
+  } else if (task == PebbleTask_Worker) {
+    return worker_state_get_music_service_state();
+  } else {
+    WTF;
+  }
+}
+
+
+static void do_handle(PebbleEvent *e, void *context) {
+  MusicServiceState *state = prv_get_state(PebbleTask_Unknown);
+  PBL_ASSERTN(state->handler != NULL);
+  switch (e->media.type) {
+    case PebbleMediaEventTypeNowPlayingChanged:
+    case PebbleMediaEventTypeServerConnected:
+    case PebbleMediaEventTypeServerDisconnected:
+      state->handler(MusicServiceEventNowPlayingChanged);
+      break;
+    case PebbleMediaEventTypePlaybackStateChanged:
+      state->handler(MusicServiceEventPlaybackStateChanged);
+      break;
+    default:
+      // Volume / track position changes are not exposed through this API
+      break;
+  }
+}
+
+bool music_service_has_now_playing(void) {
+  return sys_music_has_now_playing();
+}
+
+void music_service_get_now_playing(char *title, char *artist, char *album) {
+  sys_music_get_now_playing(title, artist, album);
+}
+
+MusicServicePlaybackState music_service_get_playback_state(void) {
+  switch (sys_music_get_playback_state()) {
+    case MusicPlayStatePlaying:
+      return MusicServicePlaybackStatePlaying;
+    case MusicPlayStatePaused:
+      return MusicServicePlaybackStatePaused;
+    case MusicPlayStateForwarding:
+      return MusicServicePlaybackStateForwarding;
+    case MusicPlayStateRewinding:
+      return MusicServicePlaybackStateRewinding;
+    case MusicPlayStateUnknown:
+    case MusicPlayStateInvalid:
+    default:
+      return MusicServicePlaybackStateUnknown;
+  }
+}
+
+void music_service_subscribe(MusicServiceEventHandler handler) {
+  MusicServiceState *state = prv_get_state(PebbleTask_Unknown);
+  state->handler = handler;
+  event_service_client_subscribe(&state->mss_info);
+}
+
+void music_service_unsubscribe(void) {
+  MusicServiceState *state = prv_get_state(PebbleTask_Unknown);
+  event_service_client_unsubscribe(&state->mss_info);
+  state->handler = NULL;
+}
+
+void music_service_state_init(MusicServiceState *state) {
+  *state = (MusicServiceState) {
+    .mss_info = {
+      .type = PEBBLE_MEDIA_EVENT,
+      .handler = &do_handle,
+    },
+  };
+}

--- a/src/fw/applib/music_service.h
+++ b/src/fw/applib/music_service.h
@@ -1,0 +1,81 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include <stdbool.h>
+
+//! @addtogroup Foundation
+//! @{
+//!   @addtogroup EventService
+//!   @{
+//!     @addtogroup MusicService
+//!
+//! \brief Read-only access to the now-playing music metadata
+//!
+//! The MusicService API lets watchfaces and apps read the now-playing music
+//! metadata (track title, artist and album) and playback state that the
+//! connected phone reports to the watch. It is the same data shown by the
+//! built-in Music app. This API is read-only: it does not provide any
+//! playback control.
+//! @{
+
+//! Required size in bytes, including the null terminator, of each buffer
+//! passed to \ref music_service_get_now_playing().
+#define MUSIC_SERVICE_BUFFER_LENGTH 64
+
+//! Playback state of the connected music player
+typedef enum {
+  //! The playback state is not known
+  MusicServicePlaybackStateUnknown = 0,
+  //! The player is playing
+  MusicServicePlaybackStatePlaying,
+  //! The player is paused
+  MusicServicePlaybackStatePaused,
+  //! The player is fast-forwarding
+  MusicServicePlaybackStateForwarding,
+  //! The player is rewinding
+  MusicServicePlaybackStateRewinding,
+} MusicServicePlaybackState;
+
+//! Type of music service event
+typedef enum {
+  //! The now-playing metadata (title, artist or album) changed. Also emitted
+  //! when a music server connects or disconnects, since the metadata is
+  //! (re)set at those points.
+  MusicServiceEventNowPlayingChanged = 0,
+  //! The playback state changed
+  MusicServiceEventPlaybackStateChanged,
+} MusicServiceEventType;
+
+//! Callback type for music service events
+//! @param event_type The type of event that occurred
+typedef void (*MusicServiceEventHandler)(MusicServiceEventType event_type);
+
+//! @return True if now-playing metadata is currently available.
+bool music_service_has_now_playing(void);
+
+//! Copy the current now-playing metadata into the provided buffers. Each
+//! buffer must be at least \ref MUSIC_SERVICE_BUFFER_LENGTH bytes; fields
+//! longer than the buffer are truncated. Fields that are unknown are set to
+//! the empty string.
+//! @param title Buffer to receive the track title. Must not be NULL.
+//! @param artist Buffer to receive the artist name. Must not be NULL.
+//! @param album Buffer to receive the album name. Must not be NULL.
+void music_service_get_now_playing(char *title, char *artist, char *album);
+
+//! @return The current playback state of the connected music player.
+MusicServicePlaybackState music_service_get_playback_state(void);
+
+//! Subscribe to the music event service. Once subscribed, the handler gets
+//! called whenever the now-playing metadata or playback state changes.
+//! @param handler A callback to be executed on music service events
+void music_service_subscribe(MusicServiceEventHandler handler);
+
+//! Unsubscribe from the music event service. Once unsubscribed, the
+//! previously registered handler will no longer be called.
+void music_service_unsubscribe(void);
+
+//!     @} // end addtogroup MusicService
+//!   @} // end addtogroup EventService
+//! @} // end addtogroup Foundation

--- a/src/fw/applib/music_service_private.h
+++ b/src/fw/applib/music_service_private.h
@@ -1,0 +1,15 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include "event_service_client.h"
+#include "music_service.h"
+
+typedef struct __attribute__((packed)) MusicServiceState {
+  MusicServiceEventHandler handler;
+
+  EventServiceInfo mss_info;
+} MusicServiceState;
+
+void music_service_state_init(MusicServiceState *state);

--- a/src/fw/kernel/kernel_applib_state.c
+++ b/src/fw/kernel/kernel_applib_state.c
@@ -151,6 +151,12 @@ BatteryStateServiceState* kernel_applib_get_battery_state_service_state(void) {
   return &s_battery_state_service_state;
 }
 
+// -----------------------------------------------------------------------------------------------------------
+MusicServiceState* kernel_applib_get_music_service_state(void) {
+  static MusicServiceState s_music_service_state;
+  return &s_music_service_state;
+}
+
 Layer** kernel_applib_get_layer_tree_stack(void) {
   static Layer* layer_tree_stack[LAYER_TREE_STACK_SIZE];
   return layer_tree_stack;
@@ -161,6 +167,7 @@ void kernel_applib_init(void) {
   s_log_state_mutex = mutex_create_recursive();
   connection_service_state_init(kernel_applib_get_connection_service_state());
   battery_state_service_state_init(kernel_applib_get_battery_state_service_state());
+  music_service_state_init(kernel_applib_get_music_service_state());
 }
 
 

--- a/src/fw/kernel/kernel_applib_state.h
+++ b/src/fw/kernel/kernel_applib_state.h
@@ -11,6 +11,7 @@
 #include "applib/compass_service_private.h"
 #include "applib/battery_state_service.h"
 #include "applib/battery_state_service_private.h"
+#include "applib/music_service_private.h"
 #include "applib/connection_service.h"
 #include "applib/connection_service_private.h"
 
@@ -33,6 +34,8 @@ TouchServiceState *kernel_applib_get_touch_service_state(void);
 ConnectionServiceState* kernel_applib_get_connection_service_state(void);
 
 BatteryStateServiceState* kernel_applib_get_battery_state_service_state(void);
+
+MusicServiceState* kernel_applib_get_music_service_state(void);
 
 struct Layer;
 typedef struct Layer Layer;

--- a/src/fw/process_management/pebble_process_info.h
+++ b/src/fw/process_management/pebble_process_info.h
@@ -168,9 +168,10 @@ typedef enum {
 // sdk.major:0x5 .minor:0x64 -- Add kModdableCreationFlagDebug (rev 103)
 // sdk.major:0x5 .minor:0x65 -- Expose speaker playback limits (rev 104)
 // sdk.major:0x5 .minor:0x66 -- Expose alarm service (alarm_service_peek_next) to apps (rev 105)
+// sdk.major:0x5 .minor:0x67 -- Expose read-only music now-playing metadata to apps (rev 106)
 
 #define PROCESS_INFO_CURRENT_SDK_VERSION_MAJOR 0x5
-#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x66
+#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x67
 
 // The first SDK to ship with 2.x APIs
 #define PROCESS_INFO_FIRST_2X_SDK_VERSION_MAJOR 0x4

--- a/src/fw/process_state/app_state/app_state.c
+++ b/src/fw/process_state/app_state/app_state.c
@@ -71,6 +71,8 @@ typedef struct {
 
   BatteryStateServiceState battery_state_service_state;
 
+  MusicServiceState music_service_state;
+
   BacklightServiceState backlight_service_state;
 
   TickTimerServiceState tick_timer_service_state;
@@ -202,6 +204,8 @@ NOINLINE void app_state_init(void) {
 
   battery_state_service_state_init(app_state_get_battery_state_service_state());
 
+  music_service_state_init(app_state_get_music_service_state());
+
   backlight_service_state_init(app_state_get_backlight_service_state());
 
   connection_service_state_init(app_state_get_connection_service_state());
@@ -315,6 +319,10 @@ LogState *app_state_get_log_state(void) {
 
 BatteryStateServiceState *app_state_get_battery_state_service_state(void) {
   return &s_app_state_ptr->battery_state_service_state;
+}
+
+MusicServiceState *app_state_get_music_service_state(void) {
+  return &s_app_state_ptr->music_service_state;
 }
 
 BacklightServiceState *app_state_get_backlight_service_state(void) {

--- a/src/fw/process_state/app_state/app_state.h
+++ b/src/fw/process_state/app_state/app_state.h
@@ -12,6 +12,7 @@
 #include "applib/backlight_service_private.h"
 #include "applib/battery_state_service.h"
 #include "applib/battery_state_service_private.h"
+#include "applib/music_service_private.h"
 #include "applib/bluetooth/ble_app_support.h"
 #include "applib/compass_service_private.h"
 #include "applib/connection_service.h"
@@ -116,6 +117,8 @@ PluginServiceState *app_state_get_plugin_service(void);
 LogState *app_state_get_log_state(void);
 
 BatteryStateServiceState *app_state_get_battery_state_service_state(void);
+
+MusicServiceState *app_state_get_music_service_state(void);
 
 BacklightServiceState *app_state_get_backlight_service_state(void);
 

--- a/src/fw/process_state/worker_state/worker_state.c
+++ b/src/fw/process_state/worker_state/worker_state.c
@@ -31,6 +31,8 @@ typedef struct {
 
   BatteryStateServiceState battery_state_service_state;
 
+  MusicServiceState music_service_state;
+
   BacklightServiceState backlight_service_state;
 
   TickTimerServiceState tick_timer_service_state;
@@ -56,6 +58,8 @@ void worker_state_init(void) {
   plugin_service_state_init(worker_state_get_plugin_service());
 
   battery_state_service_state_init(worker_state_get_battery_state_service_state());
+
+  music_service_state_init(worker_state_get_music_service_state());
 
   backlight_service_state_init(worker_state_get_backlight_service_state());
 
@@ -109,6 +113,10 @@ LogState *worker_state_get_log_state(void) {
 
 BatteryStateServiceState *worker_state_get_battery_state_service_state(void) {
   return &s_worker_state_ptr->battery_state_service_state;
+}
+
+MusicServiceState *worker_state_get_music_service_state(void) {
+  return &s_worker_state_ptr->music_service_state;
 }
 
 BacklightServiceState *worker_state_get_backlight_service_state(void) {

--- a/src/fw/process_state/worker_state/worker_state.h
+++ b/src/fw/process_state/worker_state/worker_state.h
@@ -12,6 +12,7 @@
 #include "applib/backlight_service_private.h"
 #include "applib/battery_state_service.h"
 #include "applib/battery_state_service_private.h"
+#include "applib/music_service_private.h"
 #include "applib/connection_service.h"
 #include "applib/connection_service_private.h"
 #include "applib/health_service.h"
@@ -48,6 +49,8 @@ PluginServiceState *worker_state_get_plugin_service(void);
 LogState *worker_state_get_log_state(void);
 
 BatteryStateServiceState *worker_state_get_battery_state_service_state(void);
+
+MusicServiceState *worker_state_get_music_service_state(void);
 
 BacklightServiceState *worker_state_get_backlight_service_state(void);
 

--- a/src/fw/syscall/services_syscalls.c
+++ b/src/fw/syscall/services_syscalls.c
@@ -4,6 +4,7 @@
 #include "syscall/syscall_internal.h"
 
 #include "pbl/services/alarms/alarm.h"
+#include "pbl/services/music.h"
 
 DEFINE_SYSCALL(bool, sys_alarm_get_next_enabled, time_t *timestamp_out) {
   if (PRIVILEGE_WAS_ELEVATED) {
@@ -17,5 +18,36 @@ DEFINE_SYSCALL(bool, sys_hrm_manager_is_hrm_present) {
   return true;
 #else
   return false;
+#endif
+}
+
+DEFINE_SYSCALL(bool, sys_music_has_now_playing) {
+#ifdef CONFIG_SERVICE_MUSIC
+  return music_has_now_playing();
+#else
+  return false;
+#endif
+}
+
+DEFINE_SYSCALL(void, sys_music_get_now_playing, char *title, char *artist, char *album) {
+  if (PRIVILEGE_WAS_ELEVATED) {
+    syscall_assert_userspace_buffer(title, MUSIC_BUFFER_LENGTH);
+    syscall_assert_userspace_buffer(artist, MUSIC_BUFFER_LENGTH);
+    syscall_assert_userspace_buffer(album, MUSIC_BUFFER_LENGTH);
+  }
+#ifdef CONFIG_SERVICE_MUSIC
+  music_get_now_playing(title, artist, album);
+#else
+  title[0] = '\0';
+  artist[0] = '\0';
+  album[0] = '\0';
+#endif
+}
+
+DEFINE_SYSCALL(MusicPlayState, sys_music_get_playback_state) {
+#ifdef CONFIG_SERVICE_MUSIC
+  return music_get_playback_state();
+#else
+  return MusicPlayStateUnknown;
 #endif
 }

--- a/src/fw/syscall/syscall.h
+++ b/src/fw/syscall/syscall.h
@@ -28,6 +28,7 @@
 #include "pbl/services/comm_session/session.h"
 #include "pbl/services/evented_timer.h"
 #include "pbl/services/activity/activity.h"
+#include "pbl/services/music.h"
 #include "pbl/services/app_glances/app_glance_service.h"
 
 #include "process_management/pebble_process_info.h"
@@ -315,3 +316,13 @@ bool sys_do_not_disturb_is_active(void);
 //! @param timestamp_out Set to the UTC time of the next enabled alarm.
 //! @return True if at least one enabled alarm is scheduled.
 bool sys_alarm_get_next_enabled(time_t *timestamp_out);
+
+//! @return True if now-playing music metadata is available.
+bool sys_music_has_now_playing(void);
+
+//! Copy the now-playing metadata into the given buffers, each of which must
+//! be at least MUSIC_BUFFER_LENGTH bytes and must not be NULL.
+void sys_music_get_now_playing(char *title, char *artist, char *album);
+
+//! @return The current music playback state.
+MusicPlayState sys_music_get_playback_state(void);

--- a/tools/generate_native_sdk/exported_symbols.json
+++ b/tools/generate_native_sdk/exported_symbols.json
@@ -4,7 +4,7 @@
               "You should also make sure you are obeying our API design guidelines:",
               "https://pebbletechnology.atlassian.net/wiki/display/DEV/SDK+API+Design+Guidelines"
             ],
-  "revision" : "105",
+  "revision" : "106",
   "version" : "2.0",
   "files": [
     "fw/drivers/ambient_light.h",
@@ -31,6 +31,7 @@
     "fw/applib/app_worker.h",
     "fw/applib/backlight_service.h",
     "fw/applib/battery_state_service.h",
+    "fw/applib/music_service.h",
     "fw/applib/bluetooth/ble_ad_parse.h",
     "fw/applib/bluetooth/ble_central.h",
     "fw/applib/bluetooth/ble_characteristic.h",
@@ -434,6 +435,50 @@
                   "type": "function",
                   "name": "battery_state_service_peek",
                   "addedRevision": "0"
+                }
+              ]
+            }, {
+              "type": "group",
+              "name": "MusicService",
+              "appOnly": true,
+              "addedRevision": "106",
+              "exports": [
+                {
+                  "type": "define",
+                  "name": "MUSIC_SERVICE_BUFFER_LENGTH",
+                  "addedRevision": "106"
+                }, {
+                  "type": "type",
+                  "name": "MusicServicePlaybackState",
+                  "addedRevision": "106"
+                }, {
+                  "type": "type",
+                  "name": "MusicServiceEventType",
+                  "addedRevision": "106"
+                }, {
+                  "type": "type",
+                  "name": "MusicServiceEventHandler",
+                  "addedRevision": "106"
+                }, {
+                  "type": "function",
+                  "name": "music_service_has_now_playing",
+                  "addedRevision": "106"
+                }, {
+                  "type": "function",
+                  "name": "music_service_get_now_playing",
+                  "addedRevision": "106"
+                }, {
+                  "type": "function",
+                  "name": "music_service_get_playback_state",
+                  "addedRevision": "106"
+                }, {
+                  "type": "function",
+                  "name": "music_service_subscribe",
+                  "addedRevision": "106"
+                }, {
+                  "type": "function",
+                  "name": "music_service_unsubscribe",
+                  "addedRevision": "106"
                 }
               ]
             }, {


### PR DESCRIPTION
## Summary

Implements #1459: exposes **read-only** now-playing music metadata to third-party apps and watchfaces through a new `MusicService` applib API.

The data already lives in the firmware's music service (fed by AMS on iOS and the Pebble Protocol music endpoint on Android) and is consumed by the built-in Music app; this PR only adds the app-facing surface. **No playback control is exposed** — scope is deliberately limited to reading metadata, per the discussion in #1459 (control was previously declined in #1079).

## API

```c
#define MUSIC_SERVICE_BUFFER_LENGTH 64

bool music_service_has_now_playing(void);
void music_service_get_now_playing(char *title, char *artist, char *album);
MusicServicePlaybackState music_service_get_playback_state(void);
void music_service_subscribe(MusicServiceEventHandler handler);
void music_service_unsubscribe(void);
```

Events (`MusicServiceEventNowPlayingChanged`, `MusicServiceEventPlaybackStateChanged`) ride the existing `PEBBLE_MEDIA_EVENT` — server connect/disconnect maps to `NowPlayingChanged` since metadata is (re)set at those points. Volume and track-position changes are not exposed.

## Design

Follows the `battery_state_service` pattern exactly:
- applib wrapper + `event_service_client` subscription, with per-process `MusicServiceState` slots (app, worker, kernel)
- new syscalls (`sys_music_has_now_playing`, `sys_music_get_now_playing`, `sys_music_get_playback_state`) with userspace buffer validation; stubbed when `SERVICE_MUSIC` is not configured
- registered in `exported_symbols.json` as rev 106 with the matching `PROCESS_INFO_CURRENT_SDK_VERSION_MINOR` bump (0x67), per the documented three-step procedure

## Testing

Verified end-to-end on `qemu_flint`:
1. Built the firmware and the generated native SDK from this branch
2. Compiled a test watchapp against the generated SDK using the new API (peek + subscribe)
3. Injected now-playing metadata over the Pebble Protocol music endpoint (`MusicControlUpdateCurrentTrack` + `MusicControlUpdatePlayStateInfo`, phone claiming Android)
4. The built-in Music app and its launcher glance showed the injected track (service-level sanity check)
5. The test app displayed the correct title/artist and `PLAYING` state, updating live via the event subscription; before injection it correctly showed the empty state through the same code path

`gitlint` passes on both commits.

Fixes #1459

🤖 Generated with [Claude Code](https://claude.com/claude-code)