### PR TITLE
fw/services/activity: keep short sleep cycles inside a fragmented night

### DIFF
--- a/src/fw/services/activity/kraepelin/kraepelin_algorithm.c
+++ b/src/fw/services/activity/kraepelin/kraepelin_algorithm.c
@@ -124,6 +124,8 @@ typedef struct {
 
 // ----------------------------------------------------------------------------------------
 // Sleep detection structures
+// Max number of deep sleep sessions per sleep session
+#define KALG_MAX_DEEP_SLEEP_SESSIONS 8
 // The data for each minute that we use for computing sleep
 typedef struct {
   uint16_t vmc;
@@ -138,6 +140,12 @@ typedef struct {
   uint32_t vmc_sum;
   uint16_t consecutive_sleep_minutes;
   uint16_t consecutive_awake_minutes;
+  // Contribution of the current run of awake minutes to the totals above. Reset when
+  // sleep resumes, so (total - tail) gives the slept portion of the cycle, excluding the
+  // movement that ends it -- vmc_clip alone cannot keep that movement from dominating the
+  // averages of a short cycle.
+  uint16_t num_non_zero_tail;
+  uint32_t vmc_sum_tail;
 } KAlgSleepActivityStats;
 
 typedef struct {
@@ -149,6 +157,21 @@ typedef struct {
   KAlgSleepActivityStats current_stats;
   KAlgOngoingSleepStats summary_stats;
   time_t last_sample_utc;
+
+  // End time of the last accepted or pending sleep cycle. Used to detect short cycles
+  // that continue an ongoing night. KALG_START_TIME_NONE if no cycle yet.
+  time_t last_cycle_end_utc;
+
+  // A short cycle that closely followed the previous cycle, held back until we know
+  // whether more sleep follows it (see KAlgSleepParams). start_utc is
+  // KALG_START_TIME_NONE when there is no pending cycle.
+  struct {
+    time_t start_utc;
+    uint16_t len_m;
+    uint8_t num_deep;
+    uint16_t deep_start_delta_sec[KALG_MAX_DEEP_SLEEP_SESSIONS];
+    uint16_t deep_len_m[KALG_MAX_DEEP_SLEEP_SESSIONS];
+  } pending_cycle;
 } KAlgSleepActivityState;
 
 // Params used for sleep detection
@@ -190,6 +213,15 @@ typedef struct {
   // We only start checking the percent of active minutes and average VMC when the sleep cycle
   // is at least this long
   uint16_t min_sleep_len_for_active_pct_check;
+
+  // A cycle shorter than min_sleep_cycle_len_minutes is still accepted when it slept at
+  // least min_adjacent_cycle_len_m, started within max_adjacent_cycle_gap_m of the previous
+  // cycle's end, AND more sleep follows it within the same gap: it is the middle of a night
+  // that briefly fragmented, not noise. Requiring sleep on both sides keeps post-wake
+  // stillness (dozing, reading in bed) from extending the night. Such cycles must still
+  // pass the not-worn checks.
+  uint16_t max_adjacent_cycle_gap_m;
+  uint16_t min_adjacent_cycle_len_m;
 } KAlgSleepParams;
 
 
@@ -211,6 +243,9 @@ static const KAlgSleepParams KALG_SLEEP_PARAMS = {
   .max_avg_vmc = 250,  // Increased significantly for asterix
   .vmc_clip = 1000,
   .min_sleep_len_for_active_pct_check = 39,
+
+  .max_adjacent_cycle_gap_m = 30,
+  .min_adjacent_cycle_len_m = 20,
 };
 #else
 static const KAlgSleepParams KALG_SLEEP_PARAMS = {
@@ -229,6 +264,9 @@ static const KAlgSleepParams KALG_SLEEP_PARAMS = {
   .max_avg_vmc = 180,
   .vmc_clip = 1000,
   .min_sleep_len_for_active_pct_check = 39,
+
+  .max_adjacent_cycle_gap_m = 30,
+  .min_adjacent_cycle_len_m = 20,
 };
 #endif
 
@@ -236,7 +274,6 @@ static const KAlgSleepParams KALG_SLEEP_PARAMS = {
 // ----------------------------------------------------------------------------------------
 // Deep Sleep detection structures
 // State information for deep sleep detection
-#define KALG_MAX_DEEP_SLEEP_SESSIONS 8    // Max number of deep sleep sessions per sleep session
 typedef struct {
   time_t sleep_start_time;              // KALG_START_TIME_NONE if no KAlgDeepSleepAction_Start yet
   time_t deep_start_time;               // start of current deep sleep session
@@ -1696,10 +1733,14 @@ static bool prv_sleep_activity_update_stats(KAlgState *alg_state, time_t utc_now
   bool is_sleep_minute = ((score <= params->max_sleep_minute_score) && !not_worn);
 
   // ----------------------------------------------------------------------------------
-  // Update stats
+  // Update stats. The tail counters track the contribution of the current run of awake
+  // minutes; they reset when sleep resumes, so (total - tail) gives the totals for the
+  // slept portion of the cycle, excluding the movement that ends it.
   if (is_sleep_minute) {
     state->current_stats.consecutive_sleep_minutes++;
     state->current_stats.consecutive_awake_minutes = 0;
+    state->current_stats.num_non_zero_tail = 0;
+    state->current_stats.vmc_sum_tail = 0;
   } else {
     state->current_stats.consecutive_sleep_minutes = 0;
     state->current_stats.consecutive_awake_minutes++;
@@ -1707,9 +1748,15 @@ static bool prv_sleep_activity_update_stats(KAlgState *alg_state, time_t utc_now
   if (score > params->min_valid_vmc) {
     // If there is any movememnt at all, increment the "non-zero" minutes count.
     state->current_stats.num_non_zero_minutes++;
+    if (!is_sleep_minute) {
+      state->current_stats.num_non_zero_tail++;
+    }
   }
   if (state->current_stats.start_time != KALG_START_TIME_NONE) {
     state->current_stats.vmc_sum += MIN(params->vmc_clip, vmc);
+    if (!is_sleep_minute) {
+      state->current_stats.vmc_sum_tail += MIN(params->vmc_clip, vmc);
+    }
   }
 
   state->last_sample_utc = sample_utc;
@@ -1741,6 +1788,19 @@ static void prv_sleep_activity_update_session_state(
     avg_vmc = state->current_stats.vmc_sum / minutes_since_sleep_started;
   }
 
+  // A short cycle that started soon after the previous cycle ended may be the middle of a
+  // fragmented night, held back for the sandwich test at the end of the cycle (see below).
+  // Defer the average-based rejections for it until then: the movement that is about to
+  // end the cycle skews the averages far more than it can for a full-length cycle.
+  const bool may_continue_night =
+      (state->current_stats.start_time != KALG_START_TIME_NONE)
+      && (state->last_cycle_end_utc != KALG_START_TIME_NONE)
+      && (state->current_stats.start_time >= state->last_cycle_end_utc)
+      && (state->current_stats.start_time
+          <= state->last_cycle_end_utc
+             + (params->max_adjacent_cycle_gap_m * SECONDS_PER_MINUTE))
+      && (minutes_since_sleep_started < params->min_sleep_cycle_len_minutes);
+
   // This gets set to true if we decided that the current sleep session we are in is
   // not a valid one.
   *reject_session = false;
@@ -1758,6 +1818,8 @@ static void prv_sleep_activity_update_session_state(
         - (state->current_stats.consecutive_sleep_minutes * SECONDS_PER_MINUTE);
       state->current_stats.num_non_zero_minutes = 0;
       state->current_stats.vmc_sum = 0;
+      state->current_stats.num_non_zero_tail = 0;
+      state->current_stats.vmc_sum_tail = 0;
 
       KALG_LOG_DEBUG("Detected bedtime at %s", prv_log_time(alg_state,
                                                             state->current_stats.start_time));
@@ -1798,7 +1860,7 @@ static void prv_sleep_activity_update_session_state(
       KALG_LOG_DEBUG("Cycle ended because score was too high for this minute");
 
     } else if ((minutes_since_sleep_started > params->min_sleep_len_for_active_pct_check)
-      && (pct_non_zero > params->max_active_minutes_pct)) {
+      && (pct_non_zero > params->max_active_minutes_pct) && !may_continue_night) {
       // Too high a percent of awake minutes
       // If the percentage of non-zero minutes is too high, reject this cycle.
       *sleep_end_time = sample_utc;
@@ -1807,7 +1869,7 @@ static void prv_sleep_activity_update_session_state(
                      pct_non_zero);
 
     } else if ((minutes_since_sleep_started > params->min_sleep_len_for_active_pct_check)
-      && (avg_vmc > params->max_avg_vmc)) {
+      && (avg_vmc > params->max_avg_vmc) && !may_continue_night) {
       // Too high an average VMC, reject this cycle
       // If the percentage of non-zero minutes is too high, reject this cycle.
       *sleep_end_time = sample_utc;
@@ -1825,6 +1887,84 @@ static void prv_sleep_activity_update_session_state(
                  prv_log_time(alg_state, sample_utc), score, (int8_t)is_sleep_minute,
                  state->current_stats.consecutive_sleep_minutes,
                  state->current_stats.consecutive_awake_minutes, pct_non_zero, avg_vmc);
+}
+
+
+// ------------------------------------------------------------------------------------------
+// Register the held-back short sleep cycle (see pending_cycle) and the deep sleep sessions
+// that were captured within it
+static void prv_register_pending_cycle(KAlgState *alg_state,
+                                       KAlgActivitySessionCallback sessions_cb, void *context) {
+  KAlgSleepActivityState *state = &alg_state->sleep_state;
+  PBL_LOG_DBG("Registering held-back sleep cycle of len %d, starting at %s",
+              (int)state->pending_cycle.len_m,
+              prv_log_time(alg_state, state->pending_cycle.start_utc));
+  sessions_cb(context, KAlgActivityType_Sleep, state->pending_cycle.start_utc,
+              state->pending_cycle.len_m * SECONDS_PER_MINUTE, false /*ongoing*/,
+              false /*delete*/, 0 /*steps*/, 0 /*resting_calories*/, 0 /*active_calories*/,
+              0 /*distance_mm*/);
+  for (int i = 0; i < state->pending_cycle.num_deep; i++) {
+    sessions_cb(context, KAlgActivityType_RestfulSleep,
+                state->pending_cycle.start_utc + state->pending_cycle.deep_start_delta_sec[i],
+                state->pending_cycle.deep_len_m[i] * SECONDS_PER_MINUTE, false /*ongoing*/,
+                false /*delete*/, 0 /*steps*/, 0 /*resting_calories*/, 0 /*active_calories*/,
+                0 /*distance_mm*/);
+  }
+}
+
+
+// ------------------------------------------------------------------------------------------
+// Hold back a short cycle that might be the middle of a fragmented night. Captures the deep
+// sleep sessions detected within it, since the deep sleep state machine is aborted right
+// after this.
+static void prv_stash_pending_cycle(KAlgState *alg_state, time_t sleep_end_time,
+                                    uint16_t session_len_m) {
+  KAlgSleepActivityState *state = &alg_state->sleep_state;
+  KAlgDeepSleepActivityState *deep_state = &alg_state->deep_sleep_state;
+
+  state->pending_cycle.start_utc = state->current_stats.start_time;
+  state->pending_cycle.len_m = session_len_m;
+  state->pending_cycle.num_deep = 0;
+  for (int i = 0; i < deep_state->num_sessions; i++) {
+    state->pending_cycle.deep_start_delta_sec[state->pending_cycle.num_deep] =
+        deep_state->start_delta_sec[i];
+    state->pending_cycle.deep_len_m[state->pending_cycle.num_deep] = deep_state->len_m[i];
+    state->pending_cycle.num_deep++;
+  }
+  // Include a deep sleep session still in progress, clipped to the end of the cycle
+  if ((deep_state->deep_start_time != KALG_START_TIME_NONE)
+      && (deep_state->deep_start_time < sleep_end_time)
+      && (state->pending_cycle.num_deep < KALG_MAX_DEEP_SLEEP_SESSIONS)) {
+    state->pending_cycle.deep_start_delta_sec[state->pending_cycle.num_deep] =
+        deep_state->deep_start_time - state->pending_cycle.start_utc;
+    state->pending_cycle.deep_len_m[state->pending_cycle.num_deep] =
+        (sleep_end_time - deep_state->deep_start_time) / SECONDS_PER_MINUTE;
+    state->pending_cycle.num_deep++;
+  }
+  KALG_LOG_DEBUG("Holding back short cycle of len %d at %s until more sleep follows",
+                 (int)session_len_m, prv_log_time(alg_state, state->pending_cycle.start_utc));
+}
+
+
+// ------------------------------------------------------------------------------------------
+// Resolve a held-back short cycle: register it if the current cycle is being kept and
+// started within the adjacency gap of the held-back cycle's end, then forget it either way
+static void prv_resolve_pending_cycle(KAlgState *alg_state, bool current_cycle_kept,
+                                      KAlgActivitySessionCallback sessions_cb, void *context) {
+  const KAlgSleepParams *params = &KALG_SLEEP_PARAMS;
+  KAlgSleepActivityState *state = &alg_state->sleep_state;
+
+  if (state->pending_cycle.start_utc == KALG_START_TIME_NONE) {
+    return;
+  }
+  const time_t pending_end = state->pending_cycle.start_utc
+                             + (state->pending_cycle.len_m * SECONDS_PER_MINUTE);
+  if (current_cycle_kept
+      && (state->current_stats.start_time
+          <= pending_end + (params->max_adjacent_cycle_gap_m * SECONDS_PER_MINUTE))) {
+    prv_register_pending_cycle(alg_state, sessions_cb, context);
+  }
+  state->pending_cycle.start_utc = KALG_START_TIME_NONE;
 }
 
 
@@ -1881,21 +2021,68 @@ static void prv_sleep_activity_update(KAlgState *alg_state, time_t utc_now, uint
     KALG_LOG_DEBUG("Detected wake at %s, cycle_len: %u",  prv_log_time(alg_state, sleep_end_time),
                    session_len_m);
 
-    // Reject if the session is too short
-    if (minutes_since_sleep_started < params->min_sleep_cycle_len_minutes) {
-      reject_session = true;
-      KALG_LOG_DEBUG("Cycle rejected because too short");
+    // Reject if the session is too short. A short cycle that slept a reasonable amount and
+    // started soon after the previous cycle ended may be the middle of a night that briefly
+    // fragmented: hold it back and register it only once more sleep follows it, so post-wake
+    // stillness at the end of the night is never admitted. Since the average-based checks
+    // were deferred for such a cycle (see may_continue_night above), apply them here over
+    // its slept portion, i.e. excluding the movement that ended it.
+    bool hold_back_session = false;
+    if (!reject_session
+        && (minutes_since_sleep_started < params->min_sleep_cycle_len_minutes)) {
+      const time_t last_end = state->last_cycle_end_utc;
+      bool continues_night = (last_end != KALG_START_TIME_NONE)
+          && (state->current_stats.start_time >= last_end)
+          && (state->current_stats.start_time
+              <= last_end + (params->max_adjacent_cycle_gap_m * SECONDS_PER_MINUTE))
+          && (session_len_m >= params->min_adjacent_cycle_len_m);
+      if (continues_night) {
+        unsigned slept_m = minutes_since_sleep_started;
+        if (slept_m > state->current_stats.consecutive_awake_minutes) {
+          slept_m -= state->current_stats.consecutive_awake_minutes;
+        }
+        if (slept_m > params->min_sleep_len_for_active_pct_check) {
+          const uint32_t slept_avg_vmc =
+              (state->current_stats.vmc_sum - state->current_stats.vmc_sum_tail) / slept_m;
+          const unsigned slept_pct_non_zero =
+              ((state->current_stats.num_non_zero_minutes
+                - state->current_stats.num_non_zero_tail) * 100) / slept_m;
+          if ((slept_avg_vmc > params->max_avg_vmc)
+              || (slept_pct_non_zero > params->max_active_minutes_pct)) {
+            continues_night = false;
+            KALG_LOG_DEBUG("Short cycle not held: avg vmc %"PRIu32", pct non-zero %u",
+                           slept_avg_vmc, slept_pct_non_zero);
+          }
+        }
+      }
+      if (continues_night) {
+        hold_back_session = true;
+      } else {
+        reject_session = true;
+        KALG_LOG_DEBUG("Cycle rejected because too short");
+      }
     }
 
     // Reject if we detect the watch was not worn at all during this session
     if (prv_not_worn_during_session(alg_state, state->current_stats.start_time, session_len_m,
                                     false /*ongoing*/)) {
       reject_session = true;
+      hold_back_session = false;
       KALG_LOG_DEBUG("Cycle rejected because not worn");
     }
 
-    // If we got a valid sleep cycle, add it to the totals
-    if (!reject_session) {
+    // A cycle held back earlier is registered only now that this cycle proves the night
+    // continued (no-op if it was already resolved when this cycle registered as ongoing)
+    prv_resolve_pending_cycle(alg_state, !reject_session, sessions_cb, context);
+
+    if (hold_back_session) {
+      prv_stash_pending_cycle(alg_state, sleep_end_time, session_len_m);
+      // The deep sleep sessions were captured into the pending cycle; abort the live ones
+      prv_deep_sleep_update(alg_state, sample_utc, score, KAlgDeepSleepAction_Abort,
+                            false /*ok_to_register*/, sessions_cb, context);
+      state->last_cycle_end_utc = sleep_end_time;
+
+    } else if (!reject_session) {
       PBL_LOG_DBG("Detected valid sleep cycle of len %d, starting at %s",
               session_len_m, prv_log_time(alg_state, state->current_stats.start_time));
 
@@ -1912,6 +2099,7 @@ static void prv_sleep_activity_update(KAlgState *alg_state, time_t utc_now, uint
         .uncertain_start_utc = 0,
         .sleep_len_m = session_len_m,
       };
+      state->last_cycle_end_utc = sleep_end_time;
 
     } else {
       KALG_LOG_DEBUG("Cycle rejected");
@@ -1936,6 +2124,10 @@ static void prv_sleep_activity_update(KAlgState *alg_state, time_t utc_now, uint
     // Sleep has not ended yet
     if (state->current_stats.start_time != KALG_START_TIME_NONE) {
       if (minutes_since_sleep_started >= params->min_sleep_cycle_len_minutes) {
+        // This cycle is long enough to register: it also proves any held-back short cycle
+        // was mid-night. Register that one first to keep sessions in chronological order.
+        prv_resolve_pending_cycle(alg_state, true /*current_cycle_kept*/, sessions_cb, context);
+
         // Register ongoing sleep if we are in sleep
         sessions_cb(context, KAlgActivityType_Sleep, state->current_stats.start_time,
                     minutes_since_sleep_started * SECONDS_PER_MINUTE, true /*ongoing*/,

--- a/tests/fw/services/activity/test_kraepelin_algorithm.c
+++ b/tests/fw/services/activity/test_kraepelin_algorithm.c
@@ -2208,3 +2208,202 @@ void test_kraepelin_algorithm__sleep_stats(void) {
 }
 
 
+
+
+// =============================================================================================
+// Synthetic-night tests for sleep cycles separated by brief mid-night wakes (FIRM-3473).
+//
+// A real night can fragment into cycles when the sleeper briefly stirs. Cycles shorter
+// than min_sleep_cycle_len_minutes used to be discarded outright, so genuinely slept
+// time displayed as "awake". A short cycle is now kept when it is sandwiched between
+// other sleep (starts soon after the previous cycle ended AND more sleep follows it)
+// and still passes the not-worn checks.
+
+static time_t s_synth_now;
+
+static void prv_synth_start(void) {
+  rtc_set_time(0);
+  s_synth_now = 0;
+  s_kalg_state = kernel_zalloc(kalg_state_size());
+  kalg_init(s_kalg_state, prv_stats_cb);
+  s_num_captured_sleep_sessions = 0;
+}
+
+static void prv_synth_end(void) {
+  kernel_free(s_kalg_state);
+  s_kalg_state = NULL;
+}
+
+static void prv_synth_minute(uint16_t vmc, uint8_t orientation) {
+  kalg_activities_update(s_kalg_state, s_synth_now, 0 /*steps*/, vmc, orientation,
+                         false /*definitely_not_worn*/, 0 /*rest_cals*/, 0 /*active_cals*/,
+                         0 /*distance*/, false /*shutting_down*/,
+                         prv_sleep_session_callback, NULL);
+  s_synth_now += SECONDS_PER_MINUTE;
+  rtc_set_time(s_synth_now);
+}
+
+// Worn and asleep: mostly tiny VMCs, with a small position shift (orientation change
+// plus modest movement) every ~17 minutes like a typical sleeper
+static void prv_synth_sleep(int minutes) {
+  static const uint16_t k_vmc[13] = {20, 0, 0, 45, 0, 10, 0, 90, 0, 0, 30, 0, 0};
+  static const uint8_t k_orient[5] = {0x53, 0x64, 0x75, 0x46, 0x57};
+  for (int i = 0; i < minutes; i++) {
+    int m = s_synth_now / SECONDS_PER_MINUTE;
+    uint16_t vmc = k_vmc[m % 13];
+    if ((m % 17) == 0) {
+      vmc = 45;
+    }
+    prv_synth_minute(vmc, k_orient[(m / 17) % 5]);
+  }
+}
+
+// Worn and awake: high VMC, orientation changing minute to minute
+static void prv_synth_motion(int minutes) {
+  static const uint8_t k_orient[4] = {0x41, 0x62, 0x73, 0x54};
+  for (int i = 0; i < minutes; i++) {
+    int m = s_synth_now / SECONDS_PER_MINUTE;
+    prv_synth_minute(2500 + (m % 3) * 700, k_orient[m % 4]);
+  }
+}
+
+// Not worn: dead still, flat orientation (watch on a nightstand)
+static void prv_synth_table(int minutes) {
+  for (int i = 0; i < minutes; i++) {
+    prv_synth_minute(0, 0x05);
+  }
+}
+
+static int prv_synth_count_containers(void) {
+  int count = 0;
+  for (int i = 0; i < s_num_captured_sleep_sessions; i++) {
+    if (s_captured_sleep_sessions[i].activity == KAlgActivityType_Sleep) {
+      printf("\ncontainer session: start_m: %d, len_m: %d",
+             (int)(s_captured_sleep_sessions[i].start_utc / SECONDS_PER_MINUTE),
+             (int)s_captured_sleep_sessions[i].len_m);
+      count++;
+    }
+  }
+  printf("\n");
+  return count;
+}
+
+// Returns the length of the container session starting within tolerance_m of start_m,
+// or -1 if none
+static int prv_synth_container_len_near(int start_m, int tolerance_m) {
+  for (int i = 0; i < s_num_captured_sleep_sessions; i++) {
+    if (s_captured_sleep_sessions[i].activity != KAlgActivityType_Sleep) {
+      continue;
+    }
+    int session_start_m = s_captured_sleep_sessions[i].start_utc / SECONDS_PER_MINUTE;
+    if (session_start_m >= start_m - tolerance_m && session_start_m <= start_m + tolerance_m) {
+      return s_captured_sleep_sessions[i].len_m;
+    }
+  }
+  return -1;
+}
+
+
+// ---------------------------------------------------------------------------------------
+// The FIRM-3473 night: 90 min sleep, 12 min restless, 45 min sleep, 16 min restless,
+// 150 min sleep. The middle 45-minute cycle is shorter than min_sleep_cycle_len_minutes
+// but starts a few minutes after the first cycle ended -- it is a continuation of the
+// night and must be kept.
+void test_kraepelin_algorithm__short_mid_night_cycle_kept(void) {
+  prv_synth_start();
+
+  prv_synth_motion(20);
+  prv_synth_sleep(90);     // cycle 1: accepted (>= 60 min)
+  prv_synth_motion(12);    // brief mid-night restlessness (>= 11 ends cycle 1)
+  prv_synth_sleep(45);     // cycle 2: short, adjacent -- previously discarded
+  prv_synth_motion(16);    // >= 14 ends the early-phase cycle 2
+  prv_synth_sleep(150);    // cycle 3: accepted
+  prv_synth_motion(40);
+
+  cl_assert_equal_i(prv_synth_count_containers(), 3);
+  // The short cycle is registered roughly where it was slept
+  int len_m = prv_synth_container_len_near(122, 10);
+  cl_assert(len_m >= 30);
+  cl_assert(len_m <= 50);
+
+  prv_synth_end();
+}
+
+
+// ---------------------------------------------------------------------------------------
+// Same night shape, but the "short cycle" is the watch lying flat and dead still on a
+// nightstand (FIRM-1533 / FIRM-1121 shape). The not-worn checks must still veto it.
+void test_kraepelin_algorithm__short_cycle_on_table_rejected(void) {
+  prv_synth_start();
+
+  prv_synth_motion(20);
+  prv_synth_sleep(90);
+  prv_synth_motion(12);
+  prv_synth_table(45);     // watch on nightstand: still + flat orientation
+  prv_synth_motion(16);
+  prv_synth_sleep(150);
+  prv_synth_motion(40);
+
+  cl_assert_equal_i(prv_synth_count_containers(), 2);
+  cl_assert_equal_i(prv_synth_container_len_near(122, 10), -1);
+
+  prv_synth_end();
+}
+
+
+// ---------------------------------------------------------------------------------------
+// A short cycle that does NOT closely follow accepted sleep (40 min gap) stays rejected.
+void test_kraepelin_algorithm__short_cycle_far_from_sleep_rejected(void) {
+  prv_synth_start();
+
+  prv_synth_motion(20);
+  prv_synth_sleep(90);
+  prv_synth_motion(40);    // long awake gap: the night is over
+  prv_synth_sleep(45);
+  prv_synth_motion(20);
+
+  cl_assert_equal_i(prv_synth_count_containers(), 1);
+
+  prv_synth_end();
+}
+
+
+// ---------------------------------------------------------------------------------------
+// A too-short adjacent cycle (10 min) stays rejected: adjacency does not admit noise.
+void test_kraepelin_algorithm__tiny_adjacent_cycle_rejected(void) {
+  prv_synth_start();
+
+  prv_synth_motion(20);
+  prv_synth_sleep(90);
+  prv_synth_motion(12);
+  prv_synth_sleep(10);
+  prv_synth_motion(16);
+  prv_synth_sleep(150);
+  prv_synth_motion(40);
+
+  cl_assert_equal_i(prv_synth_count_containers(), 2);
+
+  prv_synth_end();
+}
+
+
+// ---------------------------------------------------------------------------------------
+// A genuinely broken night: repeated short cycles each following the previous one. Each
+// short cycle re-anchors adjacency and is registered once the next one appears. The final
+// short cycle is never followed by more sleep, so it is (conservatively) dropped -- at the
+// end of the night a short still period is indistinguishable from post-wake dozing.
+void test_kraepelin_algorithm__chained_short_cycles_kept(void) {
+  prv_synth_start();
+
+  prv_synth_motion(20);
+  prv_synth_sleep(90);
+  for (int i = 0; i < 3; i++) {
+    prv_synth_motion(16);
+    prv_synth_sleep(35);
+  }
+  prv_synth_motion(40);
+
+  cl_assert_equal_i(prv_synth_count_containers(), 3);
+
+  prv_synth_end();
+}


### PR DESCRIPTION
Fixes FIRM-3473

## What changed

The Kraepelin sleep detector discarded any sleep cycle shorter than 60 minutes, so brief mid-night restlessness that split a night into fragments made genuinely-slept 20–59 min chunks display as "awake". Short cycles were doubly doomed: the running avg-VMC / active-pct checks include the trailing awake run, and `vmc_clip` can't stop that movement from dominating a short cycle's averages (14 clipped minutes alone push a 45-min cycle over the threshold), so they usually died before the length check even ran.

Now a short cycle is kept when it is **sandwiched inside a night**:

- Average-based rejections are deferred for a cycle that starts within 30 min of the previous cycle's end while under 60 min.
- At end-of-cycle validation, those checks re-run over the slept portion only (trailing awake run excluded). A cycle that slept ≥20 min and passes is **held back** as a pending cycle (with its deep-sleep sessions).
- The pending cycle registers only once a following cycle is kept and starts within the same 30-min gap; otherwise it is dropped. Requiring sleep on both sides keeps post-wake stillness (dozing / reading in bed) from extending the night.

## Why

Deep dive on FIRM-3473 (getafix, fw v4.27.0): overnight the firmware recorded two sleep sessions with a 71-min "awake" gap covering the disputed 3:31 AM. The logs show the algorithm *detected* sleep in that gap — including a 37-min deep-sleep run — then rejected the cycle (`Session to delete not found` at 10:59:01Z is the rejection's only trace; that warning fires exactly when a never-registered <60-min cycle is discarded). Full analysis in the Linear issue.

## How I validated

- `./waf test -M ".*kraepelin.*"` — all captured reference nights pass **unchanged** except `sleep_4`, which gains a 23-min interior cycle the old code discarded (the exact reported bug shape, on real data). The post-wake phantom-sleep guard nights (`sleep_7`, `sleep_8`, `pbl_27921`, `pbl_37734`, `watch_on_table*`) are all bit-identical to baseline.
- 5 new synthetic-night tests: mid-night short cycle kept; nightstand (flat/still) cycle still vetoed; far-gap cycle still rejected; tiny (<20 min) cycle still rejected; chained fragments kept (last fragment conservatively dropped).
- All 12 activity suites + health/sleep/alarm suites pass.
- Built and booted `qemu_emery`; firmware boots to launcher normally.
- Surveyed ~70 sleep-tracking Linear issues before designing: phantom-sleep complaints (FIRM-1533, FIRM-2500, FIRM-1121) are as common as missed-sleep ones — hence the sandwich requirement instead of a naive length relaxation, which measurably regressed labeled reference nights (+33 to +81 min phantom sleep) when tried.

## Known limitations (deliberate)

- The last short fragment of a broken night is dropped (nothing follows to prove it was sleep) — indistinguishable from post-wake dozing without HRM.
- The pending cycle registers when its follower reaches 60-min ongoing registration; a follower rejected *after* that point leaves the pending cycle registered. Undoing it would require deleting a non-ongoing session (asserts in `activity_sessions.c`) or breaking chronological session order.
- The pre-existing too-short gate still uses elapsed minutes (including the awake tail), so a ~50-min-slept cycle with an 11-min tail passes as a full cycle, as before. Left untouched for scope/regression safety.

> **Emulator-only validation.** Not yet run on hardware; the algorithm is platform-independent C exercised heavily by the host test suite, but a night of real-wrist data on getafix/obelix before release would be prudent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)