### PR TITLE
core_dump: capture 64K of LCPU RAM instead of 24K

### DIFF
--- a/src/fw/kernel/core_dump_private.h
+++ b/src/fw/kernel/core_dump_private.h
@@ -28,7 +28,7 @@
 // LCPU (BLE coprocessor) RAM, in the LPSYS domain outside main RAM.
 #if defined(CONFIG_SOC_SF32LB52)
 #define COREDUMP_LCPU_RAM_START (0x20400000)
-#define COREDUMP_LCPU_RAM_SIZE (24 * 1024)
+#define COREDUMP_LCPU_RAM_SIZE (64 * 1024)
 #endif
 
 // Max number of core dump images we can fit in our allocated space


### PR DESCRIPTION
## Summary

Enlarge the LPSYS RAM window dumped for LCPU (BLE coprocessor) coredumps on SF32LB52 from 24K to 64K, so more of the controller state is captured when a BLE crash triggers a coredump.

## Notes

`COREDUMP_LCPU_RAM_START` is unchanged at `0x20400000`; only `COREDUMP_LCPU_RAM_SIZE` grows. Reviewers: please confirm the LPSYS RAM region is at least 64K so the extended window stays within valid memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tw582DK2g4J7VErThtd971