### PR TITLE
applib/ui, settings/time: fix reboot from wrap-around onto timezone row

### DIFF
--- a/src/fw/applib/ui/menu_layer.c
+++ b/src/fw/applib/ui/menu_layer.c
@@ -135,6 +135,20 @@ static bool prv_menu_scroll_handle_wrap_around(MenuLayer *menu_layer, ClickRecog
     return false;
   }
 
+  // Honor selection_will_change, like normal scrolling does, so the wrap
+  // destination can be redirected away from non-selectable rows.
+  MenuLayerSelectionWillChangeCallback will_change_cb =
+      menu_layer->callbacks.selection_will_change;
+  if (will_change_cb) {
+    MenuIndex new_index = *wraparound_dest_index;
+    will_change_cb(menu_layer, &new_index, current_index, menu_layer->callback_context);
+    if (menu_index_compare(&new_index, &current_index) == 0) {
+      // Callback locked the selection in place; don't wrap.
+      return false;
+    }
+    *wraparound_dest_index = new_index;
+  }
+
   const bool animated = true;
   menu_layer_set_selected_index(menu_layer, *wraparound_dest_index, MenuRowAlignCenter, animated);
   if (menu_layer->scroll_vibe_on_wrap_around) {

--- a/src/fw/apps/system/settings/time.c
+++ b/src/fw/apps/system/settings/time.c
@@ -28,6 +28,7 @@
 #include "pbl/services/timezone_database.h"
 #include "shell/prefs.h"
 
+#include <stdio.h>
 #include <time.h>
 
 // 9 (TZ) continents: Africa, America, Antarctica, Asia, Atlantic, Australia,
@@ -71,33 +72,38 @@ typedef enum {
   TimeRowNum,
 } TimeRow;
 
-//! Rows that remain visible when time source is automatic (Set Time and Set Date are hidden).
-static const TimeRow s_auto_visible_rows[] = {
-  TimeRow_TimeSource,
-  TimeRow_Format,
-  TimeRow_TimezoneSource,
-  TimeRow_Timezone,
-};
+//! Set Time and Set Date are hidden when the time source is automatic;
+//! Timezone is hidden when the timezone source is automatic.
+static bool prv_row_visible(TimeRow row) {
+  switch (row) {
+    case TimeRow_SetTime:
+    case TimeRow_SetDate:
+      return clock_time_source_is_manual();
+    case TimeRow_Timezone:
+      return clock_timezone_source_is_manual();
+    default:
+      return true;
+  }
+}
 
 //! Map a visible row index to its TimeRow enum value.
-//! When time source is automatic, Set Time and Set Date rows are hidden.
 static TimeRow prv_row_for_index(uint16_t index) {
-  if (clock_time_source_is_manual()) {
-    // All rows visible
-    return (TimeRow)index;
-  }
-  // Automatic mode: map through the reduced row list
-  if (index < ARRAY_LENGTH(s_auto_visible_rows)) {
-    return s_auto_visible_rows[index];
+  for (TimeRow row = 0; row < TimeRowNum; row++) {
+    if (prv_row_visible(row) && (index-- == 0)) {
+      return row;
+    }
   }
   return TimeRowNum;
 }
 
 static uint16_t prv_visible_row_count(void) {
-  if (clock_time_source_is_manual()) {
-    return TimeRowNum;
+  uint16_t count = 0;
+  for (TimeRow row = 0; row < TimeRowNum; row++) {
+    if (prv_row_visible(row)) {
+      count++;
+    }
   }
-  return ARRAY_LENGTH(s_auto_visible_rows);
+  return count;
 }
 
 
@@ -328,12 +334,15 @@ static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
       prv_cycle_clock_style();
       break;
     case TimeRow_TimezoneSource:
-      // Time settings (automatic / manual)
+      // Toggle automatic / manual timezone; the Timezone row is shown/hidden
       prv_cycle_clock_timezone_source();
-      break;
+      settings_menu_reload_data(SettingsMenuItemDateTime);
+      return;
     case TimeRow_Timezone:
-      // Set Timezone Region
-      PBL_ASSERTN(clock_timezone_source_is_manual());
+      // Set Timezone Region; row is hidden while source is automatic
+      if (!clock_timezone_source_is_manual()) {
+        return;
+      }
       prv_continent_menu_push(data);
       break;
     default:
@@ -349,6 +358,7 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
   const char *title = NULL;
   const char *subtitle = NULL;
   char current_timezone_region[TIMEZONE_NAME_LENGTH];
+  char tz_source_buf[TIMEZONE_NAME_LENGTH + 32];
   char time_buf[TIME_STRING_TIME_LENGTH];
   char date_buf[16];
 
@@ -383,8 +393,17 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
     }
     case TimeRow_TimezoneSource: {
       title = i18n_noop("Timezone Source");
-      subtitle = clock_timezone_source_is_manual() ? i18n_noop("Manual") :
-                                                     i18n_noop("Automatic");
+      if (clock_timezone_source_is_manual()) {
+        subtitle = i18n_noop("Manual");
+      } else if (clock_is_timezone_set()) {
+        // Show the active timezone since the Timezone row is hidden
+        clock_get_timezone_region(current_timezone_region, TIMEZONE_NAME_LENGTH);
+        snprintf(tz_source_buf, sizeof(tz_source_buf), "%s (%s)",
+                 i18n_get("Automatic", data), current_timezone_region);
+        subtitle = tz_source_buf;
+      } else {
+        subtitle = i18n_noop("Automatic");
+      }
       break;
     }
     case TimeRow_Timezone: {
@@ -398,14 +417,6 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
   }
 
   menu_cell_basic_draw(ctx, cell_layer, i18n_get(title, data), i18n_get(subtitle, data), NULL);
-}
-
-static void prv_selection_will_change_cb(SettingsCallbacks *context, uint16_t *new_row,
-                                         uint16_t old_row) {
-  if (!clock_timezone_source_is_manual() &&
-      prv_row_for_index(*new_row) == TimeRow_Timezone) {
-    *new_row = old_row;
-  }
 }
 
 static uint16_t prv_num_rows_cb(SettingsCallbacks *context) {
@@ -432,7 +443,6 @@ static Window *prv_init(void) {
     .draw_row = prv_draw_row_cb,
     .select_click = prv_select_click_cb,
     .num_rows = prv_num_rows_cb,
-    .selection_will_change = prv_selection_will_change_cb,
   };
 
   prv_init_continent_and_region_names(data);

--- a/tests/fw/ui/test_menu_layer.c
+++ b/tests/fw/ui/test_menu_layer.c
@@ -327,6 +327,64 @@ void test_menu_layer__center_focused_handles_skipped_rows(void) {
   cl_assert_equal_i(4 * basic_cell_height, l.selection.y);
 }
 
+// Not declared in menu_layer.h; normally reached via the window click config
+extern void menu_up_click_handler(ClickRecognizerRef recognizer, MenuLayer *menu_layer);
+extern void menu_down_click_handler(ClickRecognizerRef recognizer, MenuLayer *menu_layer);
+
+static void prv_redirect_off_last_row(struct MenuLayer *menu_layer,
+                                      MenuIndex *new_index,
+                                      MenuIndex old_index,
+                                      void *callback_context) {
+  if (new_index->row == s_num_rows - 1) {
+    new_index->row = s_num_rows - 2;
+  }
+}
+
+void test_menu_layer__wrap_around_honors_selection_will_change(void) {
+  MenuLayer l;
+  menu_layer_init(&l, &GRect(10, 10, DISP_COLS, DISP_ROWS));
+  menu_layer_set_callbacks(&l, NULL, &(MenuLayerCallbacks) {
+    .draw_row = prv_draw_row,
+    .get_num_rows = prv_get_num_rows,
+    .selection_will_change = prv_redirect_off_last_row,
+  });
+  menu_layer_set_scroll_wrap_around(&l, true);
+  menu_layer_reload_data(&l);
+  cl_assert_equal_i(0, menu_layer_get_selected_index(&l).row);
+
+  // Wrapping up from the first row must honor the redirect away from the
+  // non-selectable last row
+  menu_up_click_handler(NULL, &l);
+  cl_assert_equal_i(s_num_rows - 2, menu_layer_get_selected_index(&l).row);
+
+  // Scrolling down from there stays put: not at the true last index, so no
+  // wrap, and normal scrolling is redirected back
+  menu_down_click_handler(NULL, &l);
+  cl_assert_equal_i(s_num_rows - 2, menu_layer_get_selected_index(&l).row);
+}
+
+static void prv_lock_selection(struct MenuLayer *menu_layer,
+                               MenuIndex *new_index,
+                               MenuIndex old_index,
+                               void *callback_context) {
+  *new_index = old_index;
+}
+
+void test_menu_layer__wrap_around_cancelled_when_selection_locked(void) {
+  MenuLayer l;
+  menu_layer_init(&l, &GRect(10, 10, DISP_COLS, DISP_ROWS));
+  menu_layer_set_callbacks(&l, NULL, &(MenuLayerCallbacks) {
+    .draw_row = prv_draw_row,
+    .get_num_rows = prv_get_num_rows,
+    .selection_will_change = prv_lock_selection,
+  });
+  menu_layer_set_scroll_wrap_around(&l, true);
+  menu_layer_reload_data(&l);
+
+  menu_up_click_handler(NULL, &l);
+  cl_assert_equal_i(0, menu_layer_get_selected_index(&l).row);
+}
+
 void test_menu_layer__center_focused_handles_skipped_rows_animated(void) {
   MenuLayer l;
   menu_layer_init(&l, &GRect(10, 10, DISP_COLS, DISP_ROWS));


### PR DESCRIPTION
## Summary

With **Menu Scrolling Wrap Around** enabled and **Timezone Source** set to **Automatic**, pressing up from the top of Settings → Date & Time wrapped the selection onto the non-selectable Timezone row; selecting it hit `PBL_ASSERTN(clock_timezone_source_is_manual())` and rebooted the watch.

Two changes:

- **applib/ui**: the menu wrap-around path called `menu_layer_set_selected_index()` directly, which skips the `selection_will_change` callback, so wrap-around could land on rows the callback would have redirected away from. The wrap destination now goes through the callback like normal scrolling, and the wrap is cancelled if the callback locks the selection in place. Covered by two new unit tests.
- **settings/time**: per @gmarull's feedback on the earlier attempt (#1543), a visible but non-selectable row is confusing — the Timezone row is now hidden entirely while the timezone source is automatic, mirroring how Set Time / Set Date are hidden for the automatic time source. The active region is still shown as the Timezone Source subtitle ("Automatic (Region)"), and the assert is replaced with a plain guard so selecting the row can never reboot the watch.

Fixes #1521

## Test plan

Verified in QEMU (qemu_emery, wrap-around pref force-enabled):

- [x] Reproduced the reboot on a pre-fix build (wrap up → disabled Timezone row → select → reboot)
- [x] Post-fix, automatic mode shows Time Source / Time Format / Timezone Source only; wrap works in both directions
- [x] Toggling Timezone Source to Manual immediately shows the Timezone row; selecting it opens the continent/region picker
- [x] Setting a region (Africa/Abidjan) and toggling back to Automatic hides the row again, no crash
- [x] `./pbl test` passes, including two new menu_layer wrap-around unit tests