### PR TITLE
Fix memory-safety issues found by static analysis

### DIFF
--- a/src/fw/applib/bluetooth/ble_client.c
+++ b/src/fw/applib/bluetooth/ble_client.c
@@ -148,7 +148,9 @@ static void prv_consume_notifications(const PebbleBLEGATTClientEvent *e,
       gatt_error = BLEGATTErrorLocalInsufficientResources;
       value_length = 0;
     }
-    uintptr_t object_ref;
+    // Init: consume may return without writing object_ref (e.g. buffer already freed),
+    // and it is still handed to the app handler below.
+    uintptr_t object_ref = 0;
     // Consume, even if we didn't have enough memory, this will eat the notification and free up
     // the space in the buffer.
     const uint16_t next_value_length = sys_ble_client_consume_notification(&object_ref,

--- a/src/fw/applib/i18n.c
+++ b/src/fw/applib/i18n.c
@@ -14,6 +14,10 @@ const char *app_get_system_locale(void) {
 }
 
 void app_i18n_get(const char *locale, const char *string, char *buffer, size_t length) {
+  if (length == 0) {
+    // Nothing fits, and buffer[length - 1] below would wrap to an OOB write.
+    return;
+  }
   const char *system_locale = app_get_system_locale();
   if (strncmp(locale, system_locale, ISO_LOCALE_LENGTH) != 0) {
     strncpy(buffer, string, length);

--- a/src/fw/comm/ble/gap_le_connect.c
+++ b/src/fw/comm/ble/gap_le_connect.c
@@ -1012,6 +1012,7 @@ void gap_le_connect_handle_bonding_change(BTBondingID bonding_id, BtPersistBondi
                                               &updated_bonding.device, NULL)) {
       WTF;
     }
+    updated_bonding.id = bonding_id;
   }
 
   bt_lock();

--- a/src/fw/console/pulse2.c
+++ b/src/fw/console/pulse2.c
@@ -383,7 +383,9 @@ static void prv_assert_tx_buffer(void *buf) {
 }
 
 void pulse_handle_character(char c, bool *should_context_switch) {
-  portBASE_TYPE tmp;
+  // FromISR calls only write pdTRUE when a higher-priority task is woken; they never
+  // write pdFALSE, so tmp must start as pdFALSE to avoid a spurious context switch.
+  portBASE_TYPE tmp = pdFALSE;
   xQueueSendToBackFromISR(s_pulse_task_queue, &c, &tmp);
   xSemaphoreGiveFromISR(s_pulse_task_service_semaphore, &tmp);
   *should_context_switch = (tmp == pdTRUE);

--- a/src/fw/services/blob_db/ios_notif_pref_db.c
+++ b/src/fw/services/blob_db/ios_notif_pref_db.c
@@ -120,6 +120,11 @@ iOSNotifPrefs* ios_notif_pref_db_get_prefs(const uint8_t *app_id, int key_len) {
                                                                  &serialized_prefs);
   prv_file_close_and_unlock(&file);
 
+  if (!serialized_prefs) {
+    // Record was undersized, unreadable, or allocation failed.
+    return NULL;
+  }
+
   size_t string_alloc_size;
   uint8_t attributes_per_action[serialized_prefs->num_actions];
   bool r = attributes_actions_parse_serial_data(serialized_prefs->num_attributes,
@@ -388,6 +393,11 @@ static bool prv_print_notif_pref_db(SettingsFile *file, SettingsRecordInfo *info
 
   SerializedNotifPrefs *serialized_prefs = NULL;
   prv_get_serialized_prefs(file, (uint8_t *)app_id, info->key_len, &serialized_prefs);
+  if (!serialized_prefs) {
+    prompt_send_response("Failed to read prefs");
+    prompt_send_response("");
+    return true;
+  }
   prompt_send_response_fmt(buffer, sizeof(buffer), "Attributes: %d,  Actions: %d",
       serialized_prefs->num_attributes, serialized_prefs->num_actions);
 

--- a/src/fw/services/bluetooth/bluetooth_persistent_storage_normal.c
+++ b/src/fw/services/bluetooth/bluetooth_persistent_storage_normal.c
@@ -153,6 +153,9 @@ static void prv_update_bondings(BTBondingID id, BtPersistBondingType type) {
 //! Returns the size of the data read. If the buffer provided is too small then 0 is returned
 static int prv_file_get(const void *key, size_t key_len, void *data_out, size_t buf_len) {
   unsigned int data_len = 0;
+  // Zero the output up front so callers that ignore the return value (a 0 length on
+  // open/read failure or an oversized record) read defined zeros, not stack garbage.
+  memset(data_out, 0, buf_len);
   prv_lock();
   {
     SettingsFile fd;
@@ -335,8 +338,8 @@ static bool prv_any_pinned_ble_pairings_itr(SettingsFile *file,
   BTBondingID key;
   info->get_key(file, (uint8_t*) &key, info->key_len);
 
-  BtPersistBondingData data;
-  info->get_val(file, &data, sizeof(data));
+  BtPersistBondingData data = {};
+  info->get_val(file, &data, MIN((unsigned)info->val_len, sizeof(data)));
   if (data.ble_data.requires_address_pinning) {
     bool *has_pinned_ble_pairings = context;
     *has_pinned_ble_pairings = true;
@@ -476,9 +479,11 @@ bool prv_has_active_gateway_by_type(BtPersistBondingType desired_type) {
 static void prv_update_active_gateway_if_needed(BTBondingID bonding, BtPersistBondingOp op) {
   // Invalidate the active gateway if it is getting deleted
   if (op == BtPersistBondingOpWillDelete) {
+    // get_active_gateway leaves the out param untouched when there is no active
+    // gateway, so only compare when it reports success.
     BTBondingID current_active_gateway;
-    bt_persistent_storage_get_active_gateway(&current_active_gateway, NULL);
-    if (current_active_gateway == bonding) {
+    if (bt_persistent_storage_get_active_gateway(&current_active_gateway, NULL) &&
+        current_active_gateway == bonding) {
       bt_persistent_storage_set_active_gateway(BT_BONDING_ID_INVALID);
     }
   }

--- a/src/fw/services/filesystem/flash_translation.c
+++ b/src/fw/services/filesystem/flash_translation.c
@@ -88,9 +88,10 @@ static uint8_t prv_ftl_get_layout_version(void) {
 
 void ftl_add_region(uint32_t region_start, uint32_t region_end, bool erase_new_region) {
   // check if this region equals the next region, if so, then add next region
-  if ((region_start == s_region_list[s_next_region_idx].start) &&
-      (region_end == s_region_list[s_next_region_idx].end) &&
-      (s_next_region_idx < TOTAL_NUM_FLASH_REGIONS)) {
+  // (bounds check first: the array reads below are only valid when idx is in range)
+  if ((s_next_region_idx < TOTAL_NUM_FLASH_REGIONS) &&
+      (region_start == s_region_list[s_next_region_idx].start) &&
+      (region_end == s_region_list[s_next_region_idx].end)) {
     s_next_region_idx++;
   // failure, should never happen
   } else {

--- a/src/fw/services/filesystem/pfs.c
+++ b/src/fw/services/filesystem/pfs.c
@@ -1620,7 +1620,7 @@ void pfs_remove_files(PFSFilenameTestCallback callback) {
     if (rv >= FDAlreadyLoaded) { // the file is in the cache
       if (rv == FDBusy) {
         PBL_CROAK("Cannot delete %s, it is currently in use",
-                  s_pfs_avail_fd[fd].file.name);
+                  PFS_FD(fd).file.name);
       }
       mark_fd_free(fd);
     }
@@ -1952,7 +1952,9 @@ static status_t copy_or_recover_gc_data(int fd, GCData *gcdata, bool do_copy) {
   for (uint16_t pg = 0; pg < PFS_PAGES_PER_ERASE_SECTOR; pg++) {
     uint32_t base_addr = prv_page_to_flash_offset(sector_start_page + pg);
 
-    uint32_t data_len;
+    // Default to 0 so a failed recover-path pfs_read below skips the copy loop
+    // instead of writing an uninitialized length's worth of garbage to flash.
+    uint32_t data_len = 0;
     PageHeader hdr;
     if (do_copy) {
       // if the sector is not active we only need to copy the page header info

--- a/src/fw/services/i18n/i18n.c
+++ b/src/fw/services/i18n/i18n.c
@@ -455,6 +455,10 @@ fail:
 }
 
 void i18n_get_with_buffer(const char *msgid, char *buffer, size_t length) {
+  if (length == 0) {
+    // Nothing fits, and buffer[length - 1] below would wrap to an OOB write.
+    return;
+  }
   if (msgid == NULL || msgid[0] == 0) {
     goto fail;
   }


### PR DESCRIPTION
## Summary

A batch of memory-safety fixes surfaced by running static analysis over the firmware. All are uninitialized reads, out-of-bounds accesses, or null dereferences confirmed by reading the code and callers; each is its own atomic commit.

## How these were found

Ran **CodeChecker** driving the **Clang Static Analyzer** (with cross-translation-unit / CTU analysis) plus **clang-tidy** over the `qemu_emery` firmware build's `compile_commands.json`, scoped to `src/fw`. The raw output was ~5k reports; after filtering the systematic false-positive classes (MMIO fixed-address dereferences, register-asm `lr`/`SP` reads, container_of field-subregion artifacts) it came to ~195 unique high-severity findings. This PR fixes the subset that verification confirmed as real bugs, plus two cheap defensive hardenings. False positives were left untouched.

Reproducing locally: build with `./pbl configure --board qemu_emery --compile_commands && ./pbl build`, strip `-fvar-tracking-assignments` from the compile DB (GCC-only), then run CodeChecker with the SDK `arm-none-eabi` toolchain on PATH so it resolves the cross target/includes.

## Fixes

| Commit                      | Bug                                                                                                                                 | Severity        |
| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | --------------- |
| `comm/ble`                  | `GAPLEConnectionIntentBonding.id` never initialized before struct copy — phone re-pair corrupts intent lookups                      | phone-reachable |
| `services/filesystem` (pfs) | fd-table indexed with raw fd (≥1001) instead of `PFS_FD()`; GC-recovery writes uninitialized length on read failure                 | high / local    |
| `services/filesystem` (ftl) | `ftl_add_region` reads `s_region_list[idx]` before its bounds check                                                                 | latent          |
| `console/pulse`             | `pxHigherPriorityTaskWoken` uninitialized; FreeRTOS never writes `pdFALSE` → spurious ISR yield                                     | low             |
| `i18n`                      | `buffer[length-1]` with `length==0` wraps to a 1-byte OOB write; app-syscall reachable                                              | low             |
| `services/blob_db`          | serialized notif prefs dereferenced without null-check on the per-notification hot path (OOM/corruption)                            | low             |
| `applib/bluetooth`          | `object_ref` handed to app callback uninitialized when consume fails                                                                | low             |
| `services/bluetooth`        | three uninitialized reads of BT persistent-storage records (unchecked `prv_file_get`, active-gateway getter, unbounded record copy) | low             |

## Test plan

- [x] `./pbl build` (qemu_emery) — green
- [x] `./pbl test` — full unit suite passes
- [x] Each finding verified against code + callers before fixing; false positives excluded

Static analysis is not currently in CI — happy to follow up with a CodeQL or CodeChecker workflow if there's interest.
