### PR TITLE
Fix speaker volume mapping applying positive digital gain

### DIFF
--- a/include/pbl/services/speaker/speaker_service.h
+++ b/include/pbl/services/speaker/speaker_service.h
@@ -57,6 +57,13 @@ bool speaker_service_play_tone(uint16_t freq_hz, uint16_t duration_ms,
                                uint8_t waveform, uint8_t velocity,
                                SpeakerPriority pri, uint8_t vol);
 
+//! Play a short fixed tone at an absolute output volume, bypassing the user's
+//! speaker-volume preference, so settings UIs can preview a candidate volume
+//! before it is saved. Mute still applies.
+//! @param vol Absolute output volume (0-100)
+//! @return true if playback started
+bool speaker_service_play_volume_preview(uint8_t vol);
+
 //! Play N monophonic tracks in parallel, mixed together.
 //! Track arrays and any sample data are copied into kernel memory.
 //! @param tracks Array of tracks. For each, its notes array and (optional)

--- a/src/fw/apps/system/settings/speaker_volume_window.c
+++ b/src/fw/apps/system/settings/speaker_volume_window.c
@@ -1,0 +1,150 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "speaker_volume_window.h"
+
+#ifdef CONFIG_SPEAKER
+
+#include "menu.h"
+
+#include "applib/fonts/fonts.h"
+#include "applib/ui/ui.h"
+#include "kernel/pbl_malloc.h"
+#include "kernel/pebble_tasks.h"
+#include "kernel/ui/system_icons.h"
+#include "pbl/services/i18n/i18n.h"
+#include "pbl/services/notifications/alerts_preferences.h"
+#include "pbl/services/speaker/speaker_service.h"
+
+#include <stddef.h>
+#include <stdio.h>
+
+#define VOLUME_STEP 5
+#define BUTTON_REPEAT_INTERVAL_MS 100
+
+typedef struct SpeakerVolumeWindowData {
+  Window window;  //!< Must be first: the base layer is cast back to this struct.
+  ActionBarLayer action_bar;
+  int16_t value;
+} SpeakerVolumeWindowData;
+
+static void prv_play_preview(SpeakerVolumeWindowData *data) {
+  // Restart the preview on every step so rapid clicks aren't rejected as
+  // same-priority playback.
+  speaker_service_stop_for_task(PebbleTask_App);
+  speaker_service_set_owner_task(PebbleTask_App);
+  speaker_service_play_volume_preview((uint8_t)data->value);
+}
+
+static void prv_update_proc(Layer *layer, GContext *ctx) {
+  _Static_assert(offsetof(Window, layer) == 0, "");
+  _Static_assert(offsetof(SpeakerVolumeWindowData, window) == 0, "");
+  SpeakerVolumeWindowData *data = (SpeakerVolumeWindowData *)layer;
+
+  graphics_context_set_fill_color(ctx, GColorWhite);
+  graphics_fill_rect(ctx, &layer->bounds);
+  graphics_context_set_text_color(ctx, GColorBlack);
+
+  const int16_t x_margin = 5;
+  const GRect content = grect_inset(
+      layer->bounds, GEdgeInsets(0, ACTION_BAR_WIDTH + x_margin, 0, x_margin));
+
+  GRect title_frame = content;
+  title_frame.origin.y = PBL_IF_ROUND_ELSE(24, 16);
+  title_frame.size.h = 30;
+  graphics_draw_text(ctx, i18n_get("Volume", data),
+                     fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD), title_frame,
+                     GTextOverflowModeTrailingEllipsis, GTextAlignmentCenter, NULL);
+
+  char value_text[8];
+  snprintf(value_text, sizeof(value_text), "%d%%", (int)data->value);
+
+  GFont value_font = fonts_get_system_font(FONT_KEY_LECO_38_BOLD_NUMBERS);
+  const int16_t value_height = fonts_get_font_height(value_font);
+  GRect value_frame = content;
+  value_frame.origin.y = (layer->bounds.size.h - value_height) / 2;
+  value_frame.size.h = value_height + 4;  // slack so nothing clips
+  graphics_draw_text(ctx, value_text, value_font, value_frame,
+                     GTextOverflowModeTrailingEllipsis, GTextAlignmentCenter, NULL);
+}
+
+static void prv_set_value(SpeakerVolumeWindowData *data, int new_value) {
+  if (new_value < 0) {
+    new_value = 0;
+  } else if (new_value > 100) {
+    new_value = 100;
+  }
+  if (new_value == data->value) {
+    return;
+  }
+  data->value = (int16_t)new_value;
+  layer_mark_dirty(&data->window.layer);
+  prv_play_preview(data);
+}
+
+static void prv_up_click_handler(ClickRecognizerRef recognizer,
+                                 SpeakerVolumeWindowData *data) {
+  prv_set_value(data, data->value + VOLUME_STEP);
+}
+
+static void prv_down_click_handler(ClickRecognizerRef recognizer,
+                                   SpeakerVolumeWindowData *data) {
+  prv_set_value(data, data->value - VOLUME_STEP);
+}
+
+static void prv_select_click_handler(ClickRecognizerRef recognizer,
+                                     SpeakerVolumeWindowData *data) {
+  alerts_preferences_set_speaker_volume((uint8_t)data->value);
+  speaker_service_handle_audio_prefs_changed();
+  settings_menu_mark_dirty(SettingsMenuItemVibrations);
+  app_window_stack_remove(&data->window, true /* animated */);
+}
+
+static void prv_click_config_provider(SpeakerVolumeWindowData *data) {
+  window_single_repeating_click_subscribe(BUTTON_ID_UP, BUTTON_REPEAT_INTERVAL_MS,
+                                          (ClickHandler)prv_up_click_handler);
+  window_single_repeating_click_subscribe(BUTTON_ID_DOWN, BUTTON_REPEAT_INTERVAL_MS,
+                                          (ClickHandler)prv_down_click_handler);
+  // Multi-click setup so the action bar's inverted segment stays visible for a
+  // moment as press feedback (same work-around as NumberWindow).
+  window_multi_click_subscribe(BUTTON_ID_SELECT, 1, 2, 25, true,
+                               (ClickHandler)prv_select_click_handler);
+}
+
+static void prv_window_load(Window *window) {
+  SpeakerVolumeWindowData *data = (SpeakerVolumeWindowData *)window;
+  ActionBarLayer *action_bar = &data->action_bar;
+  action_bar_layer_init(action_bar);
+  action_bar_layer_set_context(action_bar, data);
+  action_bar_layer_set_icon(action_bar, BUTTON_ID_UP, &s_bar_icon_up_bitmap);
+  action_bar_layer_set_icon(action_bar, BUTTON_ID_DOWN, &s_bar_icon_down_bitmap);
+  action_bar_layer_set_icon(action_bar, BUTTON_ID_SELECT, &s_bar_icon_check_bitmap);
+  action_bar_layer_set_click_config_provider(
+      action_bar, (ClickConfigProvider)prv_click_config_provider);
+  action_bar_layer_add_to_window(action_bar, window);
+}
+
+static void prv_window_unload(Window *window) {
+  SpeakerVolumeWindowData *data = (SpeakerVolumeWindowData *)window;
+  // Stop any in-flight preview tone.
+  speaker_service_stop_for_task(PebbleTask_App);
+  action_bar_layer_deinit(&data->action_bar);
+  i18n_free_all(data);
+  app_free(data);
+}
+
+void speaker_volume_window_push(void) {
+  SpeakerVolumeWindowData *data = app_zalloc_check(sizeof(*data));
+  data->value = alerts_preferences_get_speaker_volume();
+
+  window_init(&data->window, WINDOW_NAME("Speaker Volume"));
+  window_set_window_handlers(&data->window, &(WindowHandlers) {
+    .load = prv_window_load,
+    .unload = prv_window_unload,
+  });
+  layer_set_update_proc(&data->window.layer, prv_update_proc);
+
+  app_window_stack_push(&data->window, true /* animated */);
+}
+
+#endif // CONFIG_SPEAKER

--- a/src/fw/apps/system/settings/speaker_volume_window.h
+++ b/src/fw/apps/system/settings/speaker_volume_window.h
@@ -1,0 +1,8 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+//! Push the speaker volume editor window. Each volume change plays a preview
+//! tone at the candidate level; Select saves it to the alerts preferences.
+void speaker_volume_window_push(void);

--- a/src/fw/apps/system/settings/vibe_patterns.c
+++ b/src/fw/apps/system/settings/vibe_patterns.c
@@ -2,9 +2,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include "vibe_patterns.h"
+#include "speaker_volume_window.h"
 #include "window.h"
 
-#include "applib/ui/number_window.h"
 #include "applib/ui/ui.h"
 #include "kernel/pbl_malloc.h"
 #include "pbl/services/i18n/i18n.h"
@@ -175,34 +175,6 @@ static void prv_selection_changed_cb(SettingsCallbacks *context, uint16_t new_ro
   vibe_score_destroy(score);
 }
 
-#ifdef CONFIG_SPEAKER
-static void prv_volume_window_selected(NumberWindow *number_window, void *context) {
-  const int32_t value = number_window_get_value(number_window);
-  alerts_preferences_set_speaker_volume((uint8_t)value);
-  speaker_service_handle_audio_prefs_changed();
-  settings_menu_mark_dirty(SettingsMenuItemVibrations);
-  app_window_stack_remove(&number_window->window, true /* animated */);
-}
-
-static void prv_push_volume_window(SettingsVibePatternsData *data) {
-  NumberWindow *number_window = number_window_create(
-      i18n_get("Volume", data),
-      (NumberWindowCallbacks) {
-        .selected = prv_volume_window_selected,
-      },
-      data);
-  if (!number_window) {
-    return;
-  }
-  number_window_set_min(number_window, 0);
-  number_window_set_max(number_window, 100);
-  number_window_set_step_size(number_window, 5);
-  number_window_set_value(number_window,
-                          (int32_t)alerts_preferences_get_speaker_volume());
-  app_window_stack_push(&number_window->window, true /* animated */);
-}
-#endif
-
 static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
   vibes_cancel();
 
@@ -217,7 +189,7 @@ static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
       return;
     }
     case VibeSettingsRow_SpeakerVolume: {
-      prv_push_volume_window((SettingsVibePatternsData *)context);
+      speaker_volume_window_push();
       return;
     }
 #endif

--- a/src/fw/drivers/speaker/sf32lb52/audec.c
+++ b/src/fw/drivers/speaker/sf32lb52/audec.c
@@ -275,10 +275,13 @@ static void prv_apply_volume(AudioDevice* audio_device) {
     }
 
     HAL_AUDCODEC_Mute_DACPath(haudcodec, 0);
-    // convert to HAL decoder range (-36~54)*2
-    int volume = ((int)state->volume - 36) * 2;
-    HAL_AUDCODEC_Config_DACPath_Volume(haudcodec, 0, volume);
-    HAL_AUDCODEC_Config_DACPath_Volume(haudcodec, 1, volume);
+    // Map 1..100 to -36..0 dB in the HAL's 0.5 dB units. Never apply positive
+    // digital gain: it clips full-scale content and overdrives the speaker.
+    int atten_half_db = ((MAX_VOLUME - (int)state->volume) * 72) / MAX_VOLUME;
+    if ((HAL_AUDCODEC_Config_DACPath_Volume(haudcodec, 0, -atten_half_db) != HAL_OK) ||
+        (HAL_AUDCODEC_Config_DACPath_Volume(haudcodec, 1, -atten_half_db) != HAL_OK)) {
+        PBL_LOG_WRN("Failed to apply DAC volume (%d half-dB)", -atten_half_db);
+    }
 }
 
 static bool prv_allocate_buffers(AudioDeviceState *state) {

--- a/src/fw/popups/alarm_popup.h
+++ b/src/fw/popups/alarm_popup.h
@@ -6,9 +6,9 @@
 #include "kernel/events.h"
 
 #ifdef CONFIG_SPEAKER
-// Volume 60/100 is a moderate first cut; tunable, and a per-user volume
-// preference can be added in a follow-up.
-#define ALARM_SPEAKER_VOLUME 60
+// Full volume = 0 dB DAC gain, the loudest undistorted level; the user's
+// global speaker-volume preference scales it down from there.
+#define ALARM_SPEAKER_VOLUME 100
 #endif
 
 void alarm_popup_push_window(PebbleAlarmClockEvent* e);

--- a/src/fw/services/speaker/speaker_service.c
+++ b/src/fw/services/speaker/speaker_service.c
@@ -29,6 +29,10 @@ PBL_LOG_MODULE_DEFINE(service_speaker, CONFIG_SERVICE_SPEAKER_LOG_LEVEL);
 #define SPEAKER_SAMPLE_RATE 16000
 #define SPEAKER_REFILL_SAMPLES 512
 
+// Volume-preview tone: square, to match the perceived loudness
+#define VOLUME_PREVIEW_FREQ_HZ 660
+#define VOLUME_PREVIEW_DURATION_MS 200
+
 // The audio drivers queue up to ~64 ms ahead of the DAC (double-buffered
 // DMA/I2S pipe + circular buffer). Once the source runs dry, pad with 80 ms
 // of silence before stopping so the queued audio actually plays.
@@ -40,6 +44,7 @@ typedef struct {
   SpeakerPriority priority;
   PebbleTask owner_task;
   uint8_t volume;
+  bool volume_absolute;
 
   // Note sequence source
   NoteSequenceState note_seq;
@@ -116,6 +121,9 @@ static bool prv_is_speaker_muted(void) {
 static uint8_t prv_effective_volume(uint8_t vol) {
   if (prv_is_speaker_muted()) {
     return 0;
+  }
+  if (s_state.volume_absolute) {
+    return vol;
   }
   const uint8_t cap = alerts_preferences_get_speaker_volume();
   return (uint32_t)vol * cap / 100;
@@ -211,6 +219,7 @@ static void prv_stop_internal(SpeakerFinishReason reason) {
   s_state.source_type = SpeakerSourceNone;
   s_state.owner_task = PebbleTask_Unknown;
   s_state.pipeline_draining = false;
+  s_state.volume_absolute = false;
 
   if (reason == SpeakerFinishReasonPreempted) {
     PBL_ANALYTICS_ADD(speaker_preempted_count, 1);
@@ -507,9 +516,10 @@ bool speaker_service_play_note_seq(const SpeakerNote *notes, uint32_t num_notes,
   return true;
 }
 
-bool speaker_service_play_tone(uint16_t freq_hz, uint16_t duration_ms,
-                               uint8_t waveform, uint8_t velocity,
-                               SpeakerPriority pri, uint8_t vol) {
+static bool prv_play_tone_internal(uint16_t freq_hz, uint16_t duration_ms,
+                                   uint8_t waveform, uint8_t velocity,
+                                   SpeakerPriority pri, uint8_t vol,
+                                   bool volume_absolute) {
   mutex_lock(s_lock);
 
   if (!s_state.initialized || duration_ms == 0) {
@@ -539,12 +549,29 @@ bool speaker_service_play_tone(uint16_t freq_hz, uint16_t duration_ms,
   s_state.source_type = SpeakerSourceTone;
   s_state.priority = pri;
   s_state.volume = vol;
+  s_state.volume_absolute = volume_absolute;
 
   prv_start_audio(vol);
   prv_refill_locked();
 
   mutex_unlock(s_lock);
   return true;
+}
+
+bool speaker_service_play_tone(uint16_t freq_hz, uint16_t duration_ms,
+                               uint8_t waveform, uint8_t velocity,
+                               SpeakerPriority pri, uint8_t vol) {
+  return prv_play_tone_internal(freq_hz, duration_ms, waveform, velocity, pri, vol,
+                                false /* volume_absolute */);
+}
+
+bool speaker_service_play_volume_preview(uint8_t vol) {
+  if (vol > 100) {
+    vol = 100;
+  }
+  return prv_play_tone_internal(VOLUME_PREVIEW_FREQ_HZ, VOLUME_PREVIEW_DURATION_MS,
+                                SpeakerWaveformSquare, 0 /* velocity: full */,
+                                SpeakerPriorityApp, vol, true /* volume_absolute */);
 }
 
 bool speaker_service_play_tracks(const SpeakerTrack *tracks, uint32_t num_tracks,
@@ -814,6 +841,10 @@ bool speaker_service_play_note_seq(const SpeakerNote *notes, uint32_t num_notes,
 bool speaker_service_play_tone(uint16_t freq_hz, uint16_t duration_ms,
                                uint8_t waveform, uint8_t velocity,
                                SpeakerPriority pri, uint8_t vol) {
+  return false;
+}
+
+bool speaker_service_play_volume_preview(uint8_t vol) {
   return false;
 }
 


### PR DESCRIPTION
The SF32LB speaker driver converted the 0-100 volume scale to DAC gain as (vol - 36) * 2 half-dB, i.e. -36…+64 dB. Everything above 36 was *positive* digital gain: alarms (volume 60 → +24 dB) played as a hard-clipped, full-scale square wave - maximum loudness regardless of the volume setting - and volumes above 90 exceeded the HAL's +54 dB limit, silently failing and making 90% louder than 100%. This shipped in v4.20.0 when 0e2afbddb started re-applying the (previously inert) volume after DAC path setup, and it drives the speaker well past the level factory QC validates - likely degrading it over time.

- Map 1-100 to -36…0 dB attenuation only
- Alarms now play at volume 100 (0 dB, loudest undistorted level); the user's
  volume preference scales down from there
- New volume settings window: LECO digits, vertically centered, with a preview tone at the candidate volume on every step