### PR TITLE
comm/ble: mitigate reconnect storms (early conn param update + advertising backoff)

### DIFF
--- a/src/fw/comm/ble/gap_le_connect_params.c
+++ b/src/fw/comm/ble/gap_le_connect_params.c
@@ -64,7 +64,11 @@
 //! See v4.2 "9.3.12 Connection Interval Timing Parameters":
 //! "The Peripheral device should not perform a Connection Parameter Update procedure
 //! within TGAP(conn_pause_peripheral = 5 seconds) after establishing a connection."
-#define REQUIRED_INIT_PAUSE_S (5)
+//! We deliberately deviate from this recommendation ("should", not "shall"): iOS
+//! creates the connection with a 720ms supervision timeout and never raises it on
+//! its own, so the link is fragile until our first update request is granted. See
+//! also the note below about Apple's relaxed handling of TGAP timings.
+#define REQUIRED_INIT_PAUSE_S (1)
 #define REQUIRED_INIT_PAUSE_TICKS (REQUIRED_INIT_PAUSE_S * RTC_TICKS_HZ)
 
 //! Try 3 times before giving up.

--- a/src/fw/comm/ble/gap_le_slave_reconnect.c
+++ b/src/fw/comm/ble/gap_le_slave_reconnect.c
@@ -12,6 +12,7 @@
 #include "system/logging.h"
 #include "comm/bt_lock.h"
 
+#include "drivers/rtc.h"
 #include "kernel/event_loop.h"
 #include "pbl/services/bluetooth/bluetooth_persistent_storage.h"
 #include "pbl/services/regular_timer.h"
@@ -30,6 +31,28 @@ typedef enum {
   ReconnectType_Plain, // Advertising for reconnection with empty payload
   ReconnectType_BleHrm // Advertising for reconnection with HRM payload
 } ReconnectType;
+
+//! When the master reconnects and drops repeatedly (e.g. supervision timeouts
+//! in bad RF conditions), skip the initial short-interval advertising term to
+//! bound the radio duty cycle. The window resets after
+//! RECONNECT_CHURN_WINDOW_SECS, so during sustained churn one attempt per
+//! window still gets the fast short-interval burst.
+#define RECONNECT_CHURN_WINDOW_SECS (60)
+#define RECONNECT_CHURN_THRESHOLD (3)
+
+//! bt_lock() needs to be taken before accessing these variables.
+static RtcTicks s_churn_window_start_ticks;
+static uint32_t s_churn_count;
+
+static bool prv_should_skip_short_interval(void) {
+  const RtcTicks now = rtc_get_ticks();
+  if ((now - s_churn_window_start_ticks) > (RECONNECT_CHURN_WINDOW_SECS * RTC_TICKS_HZ)) {
+    s_churn_window_start_ticks = now;
+    s_churn_count = 0;
+  }
+  ++s_churn_count;
+  return (s_churn_count > RECONNECT_CHURN_THRESHOLD);
+}
 
 // -----------------------------------------------------------------------------
 //! Static, internal helper functions
@@ -124,8 +147,17 @@ static void prv_evaluate(ReconnectType prev_type) {
         },
     };
 
+    const GAPLEAdvertisingJobTerm *terms = advert_terms;
+    uint8_t num_terms = ARRAY_LENGTH(advert_terms);
+    // HRM reconnection is user-initiated and time-bounded, don't back it off.
+    if (!use_hrm_payload && prv_should_skip_short_interval()) {
+      PBL_LOG_WRN("Reconnect churn: advertising at long interval only");
+      terms = &advert_terms[1];
+      num_terms = 1;
+    }
+
     s_reconnect_advert_job = gap_le_advert_schedule(
-        ad, advert_terms, sizeof(advert_terms) / sizeof(GAPLEAdvertisingJobTerm),
+        ad, terms, num_terms,
         prv_advert_job_unscheduled_callback, NULL, GAPLEAdvertisingJobTagReconnection);
 
     if (use_hrm_payload) {


### PR DESCRIPTION
## Context

Analysis of FIRM-3330 (getafix, iOS) showed severe BLE reconnect storms: 204 connect/disconnect cycles in ~20h, with 184 connections dying of supervision timeout (0x208) in under 10 seconds (median lifetime: 1s). The root cause is RF/link-level (both sides report timeouts), but the firmware makes each drop far more expensive than it needs to be. This PR contains two independent mitigations:

## 1. Request connection parameter update sooner after connect

iOS creates connections with a **720ms supervision timeout** and never raises it on its own. We waited the full TGAP(conn_pause_peripheral) = 5s before requesting parameters, so the link spent its first 5 seconds fragile — any RF fade killed it. In the FIRM-3330 logs, connections that survived to the parameter update (6s supervision timeout) stayed up for minutes-to-hours; ones that didn't died in seconds and immediately re-triggered the storm cycle.

The pause is shortened to 1s. The 5s value is a spec recommendation ("should", not "shall"), and Apple has confirmed relaxed handling of TGAP timings (see the pre-existing comment in `gap_le_connect_params.c` re the 30s Tgap timeout). If the early request is lost, the existing watchdog retry path (5s) still applies.

## 2. Back off reconnect advertising during connection churn

Every disconnection restarts reconnect advertising with a 30s short-interval (20ms) burst. During the worst storm phase in FIRM-3330 (~130 cycles in 70 minutes) that burst ran essentially continuously, together with the full post-connect machinery each bounce triggers.

Now, after 3 plain-reconnect advertising starts within a 60s window, subsequent jobs skip the short-interval term and advertise at the long interval (~1s) only. The window reset means one attempt per minute still gets the fast burst, so reconnection latency recovers as soon as the churn stops. BLE HRM reconnection advertising (user-initiated, time-bounded) is not affected.

## Testing

- Built for `getafix@dvt` and `asterix` (normal variant).
- Log analysis based on the July 19 bundle attached to [FIRM-3330](https://linear.app/core-dev/issue/FIRM-3330).

Related to FIRM-3330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)