### PR TITLE
fw/shell: enable timeline peek watchface fit on getafix

### DIFF
--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -19,8 +19,7 @@
 #include "shell/system_theme.h"
 #include "pbl/util/uuid.h"
 
-#if defined(CONFIG_APP_SCALING) && \
-    (defined(CONFIG_BOARD_OBELIX) || defined(CONFIG_BOARD_QEMU_EMERY))
+#if defined(CONFIG_APP_SCALING)
 #define TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED 1
 #else
 #define TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED 0


### PR DESCRIPTION
## Summary
- The Quick View **Unsupported Faces** setting (Overlay / Shift up / Squish up) was gated to `CONFIG_BOARD_OBELIX` and `CONFIG_BOARD_QEMU_EMERY` only, so it never appeared on getafix even though the board has `CONFIG_APP_SCALING=y` and the compositor support is round-display aware.
- Gate `TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED` purely on `CONFIG_APP_SCALING`: the boards enabling it (obelix, getafix, qemu_emery, qemu_gabbro) are exactly the intended set, and future app-scaling boards pick the setting up automatically.

Fixes [FIRM-3391](https://linear.app/core-dev/issue/FIRM-3391/timeline-quick-view-with-moto-maker-watchface-looks-weird) (cluster: FIRM-3326/3327 — unsupported faces on getafix currently always overlay, with no way to pick squish/shift).

Companion app change adding the `timelineQuickViewWatchfaceFit` pref to the phone UI is in a separate CoreApp PR.

## Test plan
- Built `qemu_gabbro` (getafix platform) and verified in the emulator: Settings → Timeline now shows **Unsupported Faces** between Quick View and Timing, submenu offers Overlay/Shift up/Squish up, and the selection persists.
- `getafix@dvt` build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)