### PR TITLE
fw/linker: show static kernel RAM usage in the memory report

### DIFF
--- a/src/fw/linker/sections/kernel-ram.ld
+++ b/src/fw/linker/sections/kernel-ram.ld
@@ -64,8 +64,9 @@
     } >REGION_KERNEL_STACKS
     __kernel_bg_stack_size__ = . - __kernel_bg_stack_start__;
 
+    /* The heap gets whatever is left. Keep the section empty so the memory
+       usage report shows static usage only. */
     .kernel_heap (NOLOAD) : {
         _heap_start = .;
-        . = ORIGIN(REGION_KERNEL_HEAP) + LENGTH(REGION_KERNEL_HEAP);
-        _heap_end = .;
     } >REGION_KERNEL_HEAP
+    _heap_end = ORIGIN(REGION_KERNEL_HEAP) + LENGTH(REGION_KERNEL_HEAP);


### PR DESCRIPTION
The `.kernel_heap` section used to advance the location counter to the end of `KERNEL_RAM`, so the linker's `--print-memory-usage` report always showed the region as 100% used, hiding how much RAM is actually consumed statically.

Keep the section empty and assign `_heap_end` outside of it instead: the report now shows only the statically allocated portion (data, bss and kernel stacks), with the remainder implicitly available as kernel heap. The `_heap_start`/`_heap_end` symbols are unchanged, so the runtime heap is identical.

Before (getafix):
```
      KERNEL_RAM:        273 KB       273 KB    100.00%
```

After:
```
      KERNEL_RAM:        186 KB       273 KB     68.13%
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)