### PR TITLE
build: prune dead packages from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,38 +1,34 @@
+# Resource/font/image generation
 pillow
 freetype-py
-ply==3.4
-pyusb==1.3.1
-pyserial
-sh
 pypng
-pexpect
-cobs==1.0.0
 svg.path
-requests
-GitPython==1.0.1
-pyelftools
-pycryptodome
-mock
-nose
-boto
-prompt_toolkit>=0.55
-enum34
 bitarray
-pep8
 polib
-intelhex>=2.1,<3
-protobuf
-grpcio-tools
-nanopb
-kconfiglib
-meson
-ninja
-certifi
-libclang
+
+# Build system (waf) tooling
+sh<2
 packaging
 PyYAML
+kconfiglib
+intelhex>=2.1,<3
+pyelftools
+libclang
+meson
+ninja
+
+# Protobuf codegen: nanopb_generator; grpcio-tools provides protoc where
+# there is no system protoc (e.g. brew setups)
+nanopb
+grpcio-tools
+
+# Device communication / debugging
+pyserial
+pexpect
+cobs
+prompt_toolkit>=3
+requests
 libpebble2>=0.0.16
-pathlib
 
 -e tools/libs/pebble-commander
 -e tools/libs/pulse2

--- a/tools/generate_native_sdk/extract_comments.py
+++ b/tools/generate_native_sdk/extract_comments.py
@@ -122,11 +122,9 @@ def test_handle_macro():
 
     scan_file_content_for_defines(test_input, defines)
 
-    from nose.tools import eq_
-
-    eq_(defines[0].comment, "//! This is a documented MACRO")
-    eq_(defines[1].comment, "//! This is a documented define")
-    eq_(defines[2].comment, "//! This is a multiline\n//! documented define.")
+    assert defines[0].comment == "//! This is a documented MACRO"
+    assert defines[1].comment == "//! This is a documented define"
+    assert defines[2].comment == "//! This is a multiline\n//! documented define."
     assert defines[3].comment is None
 
 


### PR DESCRIPTION
Removes twelve packages with no remaining users in the tree: `ply`, `pyusb`, `GitPython`, `pycryptodome`, `mock`, `nose`, `boto`, `enum34`, `pep8`, `protobuf` (transitive dep of nanopb), `certifi` (transitive dep of requests), and `pathlib`.

Several are Python-2-era relics: `pathlib`/`enum34` are stdlib backports that can shadow the standard library, `nose` cannot even be imported on Python ≥ 3.12 (its only user was an inline self-test in `extract_comments.py`, now plain asserts), and the `GitPython==1.0.1` pin predated the CVE-2022-24439 fix.

Also:
- **Pin `sh<2`** — the waf tooling uses the sh 1.x API; a fresh `pip install` today resolves sh 2.x, which has breaking API changes. This can break new-contributor setups right now.
- Raise `prompt_toolkit` floor to the 3.x line actually in use; unpin `cobs` (pulse2's own dependency is unpinned); group the file by purpose.
- `grpcio-tools` looks unused but supplies `protoc` for nanopb on brew setups (nix provides protoc separately) — kept with a comment.

Verified with a completely fresh venv: `pip install -r requirements.txt` succeeds (72 packages, sh resolves to 1.14.3), then `./pbl configure --board qemu_emery && ./pbl build` both pass. requirements.txt is installed by 8 CI workflow jobs, so this also slims every CI run. No flake.nix change needed (it just installs this file).