### PR TITLE
fw/shell: discard synced watchface fit pref on unsupported boards

### DIFF
--- a/src/fw/services/blob_db/settings_blob_db.c
+++ b/src/fw/services/blob_db/settings_blob_db.c
@@ -10,6 +10,7 @@
 #include "pbl/services/comm_session/session.h"
 #include "pbl/services/notifications/alerts_preferences_private.h"
 #include "pbl/services/settings/settings_file.h"
+#include "shell/prefs.h"
 #include "shell/prefs_private.h"
 #include "system/logging.h"
 #include "system/passert.h"
@@ -94,7 +95,9 @@ static const char *s_syncable_settings[] = {
   // Timeline preferences
   "timelineQuickViewEnabled",
   "timelineQuickViewBeforeTimeMin",
+#if TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
   "timelineQuickViewWatchfaceFit",
+#endif
   "timelineSettingsOpened",
 
   // Activity preferences

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -955,6 +955,21 @@ void shell_prefs_init(void) {
   prv_convert_deprecated_dynamic_intensity_key(&file);
 #endif
 
+#if !TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED
+  {
+    // Discard any watchface-fit pref synced from a watch model that supports it.
+    // Check both key forms: locally-written keys include the null terminator,
+    // phone-originated BlobDB writes may not.
+    static const char *const fit_key = "timelineQuickViewWatchfaceFit";
+    for (size_t key_len = strlen(fit_key); key_len <= strlen(fit_key) + 1; key_len++) {
+      if (settings_file_get_len(&file, fit_key, key_len) > 0) {
+        PBL_LOG_INFO("Discarding unsupported pref: %s", fit_key);
+        settings_file_delete(&file, fit_key, key_len);
+      }
+    }
+  }
+#endif
+
   // Init state for each pref from our backing store
   uint32_t num_entries = ARRAY_LENGTH(s_prefs_table);
   const PrefsTableEntry *entry = s_prefs_table;


### PR DESCRIPTION
## Summary
Users who set Quick View **Squish up**/**Shift up** on an obelix and then connect a getafix get the `timelineQuickViewWatchfaceFit` pref pushed to the getafix by the phone's settings sync: the settings BlobDB whitelist accepted the key on **every** board, so the record was stored on watches with no watchface-fit support.

- Reject `timelineQuickViewWatchfaceFit` at the settings BlobDB whitelist on boards without `TIMELINE_PEEK_WATCHFACE_FIT_SUPPORTED` (watch logs `Rejecting non-whitelisted setting`, phone gets an error response).
- Delete any record already stored by earlier firmware during `shell_prefs_init` — upgrading to a build with this fix discards the stale pref on first boot (`Discarding unsupported pref`, INFO so it shows in support log captures).

Watchface-fit behavior on supported boards (obelix, qemu_emery) is unchanged.

Fixes [FIRM-3391](https://linear.app/core-dev/issue/FIRM-3391/timeline-quick-view-with-moto-maker-watchface-looks-weird)

## Test plan
On qemu_gabbro (getafix platform):
1. Booted pre-fix firmware, inserted `timelineQuickViewWatchfaceFit=1` into the Settings BlobDB (0x0C) from a fake phone → `Success`, record stored (reproduces the obelix→getafix sync poisoning).
2. Booted fixed firmware on the same flash → first boot logs `Discarding unsupported pref: timelineQuickViewWatchfaceFit` and tombstones the record.
3. Re-inserted on fixed firmware → rejected with `Rejecting non-whitelisted setting: timelineQuickViewWatchfaceFit`.
4. `getafix@dvt` and `qemu_emery` both build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)