### PR TITLE
fw/apps/prf/mfg_touch: backport follow-the-line test from main

### DIFF
--- a/src/fw/apps/prf/mfg_touch.c
+++ b/src/fw/apps/prf/mfg_touch.c
@@ -4,119 +4,331 @@
 
 #include "applib/app.h"
 #include "applib/graphics/graphics.h"
+#include "applib/graphics/text.h"
 #include "applib/ui/app_window_stack.h"
+#include "applib/ui/text_layer.h"
 #include "applib/ui/window.h"
 #include "kernel/event_loop.h"
 #include "kernel/pbl_malloc.h"
-#include "mfg/mfg_mode/mfg_factory_mode.h"
-#include "mfg/results_ui.h"
-#include "process_management/app_manager.h"
 #include "process_management/pebble_process_md.h"
 #include "process_state/app_state/app_state.h"
 #include "services/common/light.h"
 #include "services/common/touch/touch.h"
 #include "services/common/touch/touch_event.h"
 #include "services/common/touch/touch_client.h"
-#include "util/trig.h"
-
-#if PBL_ROUND
-#define CIRCLE_ROWS (5)
-#define CIRCLE_COLS (5)
-#else
-#define RECTR_ROW (5)
-#define RECTR_COL (4)
-#endif
+#include "system/logging.h"
+#include "util/math.h"
 
 #define TOUCH_SUPPORT_DEBUG    0
 
+// Boustrophedon (snake) grid on both display shapes. On round displays each
+// row only spans the chord of the circle at its height, so rows near the top
+// and bottom hold fewer columns and only the middle runs full width.
+#define GRID_ROWS (5)
+#define GRID_COLS (5)
+#define GRID_SPACING_X (PBL_DISPLAY_WIDTH / GRID_COLS)
+#define GRID_SPACING_Y (PBL_DISPLAY_HEIGHT / GRID_ROWS)
+#define MAX_DOTS (GRID_ROWS * GRID_COLS)
+// Wall lines sit halfway between lanes: allow deviations right up to them
+#define PATH_TOLERANCE_PX (GRID_SPACING_X / 2)
+#if PBL_ROUND
+// Keep dots this far inside the circle edge, where touch gets unreliable
+#define ROUND_EDGE_INSET_PX (12)
+#endif
+
+#define DOT_RADIUS_PX (4)
+#define DOT_CAPTURE_RADIUS_PX (14)
+// Segments ahead of the current one a sample may match, so a fast drag with
+// sparse samples cannot stall progress at a skipped dot. Kept well below the
+// ring/row separation so a stroke cannot tunnel to another path section.
+#define PATH_LOOKAHEAD_SEGMENTS (3)
+#define TRACE_MIN_DIST_PX (3)
+#define MAX_TRACE_POINTS (640)
+
 typedef struct {
   Window window;
-  uint32_t touch_mark;
   EventServiceInfo event_info;
+  GPoint dots[MAX_DOTS];
+  uint8_t num_dots;
 #if PBL_ROUND
-  GPoint circle_centers[CIRCLE_ROWS * CIRCLE_COLS];
-  uint16_t circle_radius;
-  uint8_t num_circles;
-#else
-  GRect rectr[RECTR_ROW * RECTR_COL];
-  uint16_t rectr_radius;
-  uint16_t rectr_corners_index;
+  GPoint wall_start[GRID_ROWS - 1];
+  GPoint wall_end[GRID_ROWS - 1];
 #endif
+  GPoint trace[MAX_TRACE_POINTS];
+  uint16_t trace_len;
+  uint8_t next_dot;
+  bool tracking;
+  TextLayer status;
+  bool test_complete;
 } AppData;
+
+static void prv_complete_test(AppData *data) {
+  data->test_complete = true;
+
+  text_layer_set_background_color(&data->status, GColorWhite);
+  text_layer_set_text(&data->status, "PASS!");
+  layer_mark_dirty(&data->window.layer);
+}
+
+static uint32_t prv_dist_sq(GPoint a, GPoint b) {
+  int32_t dx = a.x - b.x;
+  int32_t dy = a.y - b.y;
+  return dx * dx + dy * dy;
+}
+
+static uint32_t prv_dist_sq_to_segment(GPoint p, GPoint a, GPoint b) {
+  int32_t abx = b.x - a.x;
+  int32_t aby = b.y - a.y;
+  int32_t apx = p.x - a.x;
+  int32_t apy = p.y - a.y;
+  int32_t len_sq = abx * abx + aby * aby;
+  int32_t t_num = apx * abx + apy * aby;
+  int32_t cx = 0;
+  int32_t cy = 0;
+
+  if (len_sq > 0 && t_num >= len_sq) {
+    cx = abx;
+    cy = aby;
+  } else if (len_sq > 0 && t_num > 0) {
+    cx = (abx * t_num) / len_sq;
+    cy = (aby * t_num) / len_sq;
+  }
+
+  int32_t dx = apx - cx;
+  int32_t dy = apy - cy;
+  return dx * dx + dy * dy;
+}
+
+static void prv_reset_stroke(AppData *data) {
+  // Keep the trace on screen so the operator can see where the stroke went
+  // wrong; it is discarded when a new stroke starts
+  data->next_dot = 0;
+  data->tracking = false;
+}
+
+static void prv_trace_append(AppData *data, GPoint p) {
+  if (data->trace_len == MAX_TRACE_POINTS) {
+    return;
+  }
+  if (data->trace_len > 0 &&
+      prv_dist_sq(p, data->trace[data->trace_len - 1]) <
+          TRACE_MIN_DIST_PX * TRACE_MIN_DIST_PX) {
+    return;
+  }
+  data->trace[data->trace_len++] = p;
+}
+
+//! Draw the snake polyline guide path in the current stroke color/width
+static void prv_draw_guide_path(GContext *ctx, AppData *data) {
+  for (uint8_t i = 0; i < data->num_dots - 1; i++) {
+    graphics_draw_line(ctx, data->dots[i], data->dots[i + 1]);
+  }
+}
+
+//! Draw a single maze-style wall between each pair of adjacent lanes, with a
+//! gap where the path crosses over
+static void prv_draw_walls(GContext *ctx, AppData *data) {
+#if PBL_ROUND
+  for (uint8_t k = 0; k < GRID_ROWS - 1; k++) {
+    graphics_draw_line(ctx, data->wall_start[k], data->wall_end[k]);
+  }
+#else
+  for (uint8_t k = 1; k < GRID_ROWS; k++) {
+    int16_t y = GRID_SPACING_Y / 2 + (k - 1) * GRID_SPACING_Y + GRID_SPACING_Y / 2;
+    if (k % 2 == 1) {
+      // Rows connect on the right: wall spans from the left edge
+      graphics_draw_line(ctx, GPoint(0, y),
+                         GPoint(PBL_DISPLAY_WIDTH - GRID_SPACING_X, y));
+    } else {
+      graphics_draw_line(ctx, GPoint(GRID_SPACING_X, y),
+                         GPoint(PBL_DISPLAY_WIDTH - 1, y));
+    }
+  }
+#endif
+}
 
 static void prv_update_proc(struct Layer *layer, GContext* ctx) {
   AppData *data = app_state_get_user_data();
 
-#if PBL_ROUND
-  for (uint8_t i=0; i < data->num_circles; i++) {
-    if (data->touch_mark & (1 << i)) {
-      graphics_context_set_fill_color(ctx, GColorGreen);
-      graphics_fill_circle(ctx, data->circle_centers[i], data->circle_radius);
-    }
+  // This update proc replaces the default window one: clear the background
+  // ourselves so stale trace pixels do not linger
+  graphics_context_set_fill_color(ctx, GColorWhite);
+  graphics_fill_rect(ctx, &layer->bounds);
+
+  // Keep frames cheap: touch samples arrive faster than antialiased arcs
+  // can be rendered, which would back up the app event queue
+  graphics_context_set_antialiased(ctx, false);
+
+  graphics_context_set_stroke_width(ctx, 3);
+
+  graphics_context_set_stroke_color(ctx, GColorMelon);
+  prv_draw_walls(ctx, data);
+
+  graphics_context_set_stroke_color(ctx, GColorLightGray);
+  prv_draw_guide_path(ctx, data);
+
+  for (uint8_t i = 0; i < data->num_dots; i++) {
+    graphics_context_set_fill_color(ctx, i < data->next_dot ? GColorGreen : GColorBlack);
+    graphics_fill_circle(ctx, data->dots[i], DOT_RADIUS_PX);
   }
-#else
-  for (uint8_t i=0; i<RECTR_ROW * RECTR_COL; i++) {
-    if (data->touch_mark & (1 << i)) {
-      graphics_context_set_fill_color(ctx, GColorGreen);
-      graphics_fill_round_rect(ctx, &data->rectr[i], data->rectr_radius, GCornersAll);
-    }
+
+  graphics_context_set_stroke_color(ctx, GColorBlack);
+  for (uint16_t i = 1; i < data->trace_len; i++) {
+    graphics_draw_line(ctx, data->trace[i - 1], data->trace[i]);
   }
-#endif
 }
 
-static void prv_touch_envent_handler(const TouchEvent *event, void *context) {
+static void prv_touch_event_handler(const TouchEvent *event, void *context) {
   AppData *data = app_state_get_user_data();
-  uint16_t x = event->start_pos.x;
-  uint16_t y = event->start_pos.y;
 
-  int16_t offset_x = event->diff_pos.x;
-  int16_t offset_y = event->diff_pos.y;
+  if (data->test_complete) {
+    return;
+  }
 
-  uint8_t touch_id;
+  if (event->type == TouchEvent_PressureUpdate) {
+    return;
+  }
 
-#if PBL_ROUND
-  // Find the closest circle to the touch point
-  int16_t touch_x = x + offset_x;
-  int16_t touch_y = y + offset_y;
-  uint32_t min_dist_sq = 0xFFFFFFFF;
-  touch_id = 0;
+  GPoint p = gpoint_add(event->start_pos, event->diff_pos);
 
-  for (uint8_t i = 0; i < data->num_circles; i++) {
-    int16_t dx = touch_x - data->circle_centers[i].x;
-    int16_t dy = touch_y - data->circle_centers[i].y;
-    uint32_t dist_sq = dx * dx + dy * dy;
-    if (dist_sq < min_dist_sq) {
-      min_dist_sq = dist_sq;
-      touch_id = i;
+#if TOUCH_SUPPORT_DEBUG
+  PBL_LOG_INFO("type:%d x:%d y:%d", event->type, p.x, p.y);
+#endif
+
+  if (event->type == TouchEvent_Liftoff) {
+    // The path must be completed in a single stroke
+    prv_reset_stroke(data);
+    layer_mark_dirty(&data->window.layer);
+    return;
+  }
+
+  if (!data->tracking) {
+    // Stroke starts anywhere within the corridor mouth around the first dot
+    if (prv_dist_sq(p, data->dots[0]) <=
+        PATH_TOLERANCE_PX * PATH_TOLERANCE_PX) {
+      data->trace_len = 0;
+      data->tracking = true;
+      data->next_dot = 1;
+      prv_trace_append(data, p);
+      layer_mark_dirty(&data->window.layer);
+    }
+    return;
+  }
+
+  // Match the sample against the nearest guide segment, from the previous
+  // one up to a small lookahead past the current one
+  uint32_t best_dist_sq = UINT32_MAX;
+  uint8_t best_end = data->next_dot;
+  uint8_t first_end = (data->next_dot >= 2) ? data->next_dot - 1 : data->next_dot;
+  for (uint8_t end = first_end;
+       end < data->num_dots && end <= data->next_dot + PATH_LOOKAHEAD_SEGMENTS; end++) {
+    uint32_t dist_sq = prv_dist_sq_to_segment(p, data->dots[end - 1], data->dots[end]);
+    if (dist_sq < best_dist_sq) {
+      best_dist_sq = dist_sq;
+      best_end = end;
     }
   }
-#else
-  uint8_t ind_x = (x+offset_x)/data->rectr[0].size.w;
-  if (ind_x > RECTR_COL-1) ind_x = RECTR_COL-1;
-  uint8_t ind_y = (y+offset_y)/data->rectr[0].size.h;
-  if (ind_y > RECTR_ROW-1) ind_y = RECTR_ROW-1;
-  touch_id = ind_x * RECTR_ROW + ind_y;
-#endif
 
-  data->touch_mark |= 1<<touch_id;
-#if TOUCH_SUPPORT_DEBUG
-  PBL_LOG_INFO("start_x:%d start_y:%d off_x:%d off_y:%d", x, y, offset_x, offset_y);
-  PBL_LOG_INFO("x:%d y:%d id:%d", (x+offset_x), (y+offset_y), touch_id);
-#endif
-  layer_mark_dirty(&data->window.layer);
+  if (best_dist_sq > PATH_TOLERANCE_PX * PATH_TOLERANCE_PX) {
+    // Off the corridor (finger slip or distorted coordinates): reset stroke
+    prv_reset_stroke(data);
+    layer_mark_dirty(&data->window.layer);
+    return;
+  }
+
+  // A sample on segment (best_end - 1 -> best_end) means all prior dots
+  // were passed; the endpoint itself is captured within its radius
+  uint8_t prev_next_dot = data->next_dot;
+  uint16_t prev_trace_len = data->trace_len;
+  if (best_end > data->next_dot) {
+    data->next_dot = best_end;
+  }
+  while (data->next_dot < data->num_dots &&
+         prv_dist_sq(p, data->dots[data->next_dot]) <=
+             DOT_CAPTURE_RADIUS_PX * DOT_CAPTURE_RADIUS_PX) {
+    data->next_dot++;
+  }
+
+  prv_trace_append(data, p);
+  // Only request a redraw when something visible changed
+  if (data->next_dot != prev_next_dot || data->trace_len != prev_trace_len) {
+    layer_mark_dirty(&data->window.layer);
+  }
+
+  if (data->next_dot == data->num_dots) {
+    prv_complete_test(data);
+  }
 }
 
 static void prv_handle_touch_event(PebbleEvent *e, void *context) {
-  AppData *data = app_state_get_user_data();
-
   if (e->type == PEBBLE_TOUCH_EVENT) {
-    PebbleTouchEvent *touch = &e->touch;
-    touch_dispatch_touch_events(touch->touch_idx, prv_touch_envent_handler, context);
+    touch_dispatch_touch_events(e->touch.touch_idx, prv_touch_event_handler, context);
   }
+}
+
+static void prv_init_dots(AppData *data) {
+#if PBL_ROUND
+  const GPoint center = GPoint(PBL_DISPLAY_WIDTH / 2, PBL_DISPLAY_HEIGHT / 2);
+  const int32_t radius = MIN(PBL_DISPLAY_WIDTH, PBL_DISPLAY_HEIGHT) / 2;
+  const int32_t dot_radius = radius - ROUND_EDGE_INSET_PX;
+
+  data->num_dots = 0;
+  for (uint8_t row = 0; row < GRID_ROWS; row++) {
+    int32_t y = GRID_SPACING_Y / 2 + row * GRID_SPACING_Y;
+    int32_t dy = y - center.y;
+    int32_t half_width = integer_sqrt(dot_radius * dot_radius - dy * dy);
+    // As many columns as the chord fits at the nominal spacing, at least the
+    // two chord ends
+    uint8_t cols = CLIP(1 + (2 * half_width) / GRID_SPACING_X, 2, GRID_COLS);
+    uint8_t first = data->num_dots;
+
+    for (uint8_t col = 0; col < cols; col++) {
+      uint8_t eff_col = (row % 2 == 0) ? col : cols - 1 - col;
+      data->dots[data->num_dots].x =
+          center.x - half_width + (2 * half_width * eff_col) / (cols - 1);
+      data->dots[data->num_dots].y = y;
+      data->num_dots++;
+    }
+
+    if (row > 0) {
+      // Wall on the row boundary spans its chord, leaving a gap around the
+      // connector between the two rows
+      int16_t wall_y = row * GRID_SPACING_Y;
+      int32_t wall_dy = wall_y - center.y;
+      int32_t wall_half = integer_sqrt(radius * radius - wall_dy * wall_dy);
+      GPoint prev_end = data->dots[first - 1];
+      GPoint row_start = data->dots[first];
+      if (row % 2 == 1) {
+        // Rows connect on the right: wall spans from the left chord end
+        int16_t gate_x = MIN(prev_end.x, row_start.x) - PATH_TOLERANCE_PX;
+        data->wall_start[row - 1] = GPoint(center.x - wall_half, wall_y);
+        data->wall_end[row - 1] = GPoint(gate_x, wall_y);
+      } else {
+        int16_t gate_x = MAX(prev_end.x, row_start.x) + PATH_TOLERANCE_PX;
+        data->wall_start[row - 1] = GPoint(gate_x, wall_y);
+        data->wall_end[row - 1] = GPoint(center.x + wall_half, wall_y);
+      }
+    }
+  }
+#else
+  int16_t spacing_x = PBL_DISPLAY_WIDTH / GRID_COLS;
+  int16_t spacing_y = PBL_DISPLAY_HEIGHT / GRID_ROWS;
+
+  // Boustrophedon (snake) ordering: even rows left-to-right, odd rows right-to-left
+  for (uint8_t row = 0; row < GRID_ROWS; row++) {
+    for (uint8_t col = 0; col < GRID_COLS; col++) {
+      uint8_t eff_col = (row % 2 == 0) ? col : GRID_COLS - 1 - col;
+      data->dots[row * GRID_COLS + col].x = spacing_x / 2 + eff_col * spacing_x;
+      data->dots[row * GRID_COLS + col].y = spacing_y / 2 + row * spacing_y;
+    }
+  }
+  data->num_dots = GRID_ROWS * GRID_COLS;
+#endif
 }
 
 static void prv_handle_init(void) {
   AppData *data = app_malloc_check(sizeof(AppData));
+  *data = (AppData) {};
 
   app_state_set_user_data(data);
 
@@ -126,76 +338,18 @@ static void prv_handle_init(void) {
   Layer *layer = window_get_root_layer(window);
   layer_set_update_proc(layer, prv_update_proc);
   app_window_stack_push(window, true /* Animated */);
-  GContext* context = app_state_get_graphics_context();
 
-#if PBL_ROUND
-  // Create honeycomb-like pattern with circles that touch but don't overlap
-  uint16_t display_radius = PBL_DISPLAY_WIDTH / 2;
-
-  // Calculate circle radius to fit 5 circles across the diameter
-  // Spacing: circles just touch, so horizontal spacing = 2 * radius
-  // For 5 circles across: 5 * (2 * radius) should fit in display width
-  data->circle_radius = PBL_DISPLAY_WIDTH / 10;
-
-  // For honeycomb packing, vertical spacing is 2 * radius * sqrt(3)/2 ≈ 1.732 * radius
-  // We'll approximate sqrt(3)/2 ≈ 0.866 using integer math: 866/1000
-  int16_t vertical_spacing = (data->circle_radius * 1732) / 1000;
-  int16_t horizontal_spacing = 2 * data->circle_radius;
-
-  // Calculate grid offset to center the pattern
-  int16_t grid_width = (CIRCLE_COLS - 1) * horizontal_spacing;
-  int16_t grid_height = (CIRCLE_ROWS - 1) * vertical_spacing;
-  int16_t start_x = (PBL_DISPLAY_WIDTH - grid_width) / 2;
-  int16_t start_y = (PBL_DISPLAY_HEIGHT - grid_height) / 2;
-
-  data->num_circles = 0;
-
-  // Create a honeycomb pattern: odd rows are offset by radius
-  for (uint8_t row = 0; row < CIRCLE_ROWS; row++) {
-    for (uint8_t col = 0; col < CIRCLE_COLS; col++) {
-      int16_t x = start_x + col * horizontal_spacing;
-      int16_t y = start_y + row * vertical_spacing;
-
-      // Offset odd rows to create honeycomb pattern
-      if (row % 2 == 1) {
-        x += data->circle_radius;
-      }
-
-      // Only add circles that are within the display radius
-      int16_t dx = x - PBL_DISPLAY_WIDTH / 2;
-      int16_t dy = y - PBL_DISPLAY_HEIGHT / 2;
-      uint32_t dist_sq = dx * dx + dy * dy;
-      uint32_t max_dist_sq = (display_radius - data->circle_radius) * (display_radius - data->circle_radius);
-
-      if (dist_sq <= max_dist_sq && data->num_circles < CIRCLE_ROWS * CIRCLE_COLS) {
-        data->circle_centers[data->num_circles].x = x;
-        data->circle_centers[data->num_circles].y = y;
-        data->num_circles++;
-      }
-    }
-  }
-
-  // Draw the circle outlines
-  graphics_context_set_stroke_color(context, GColorBlack);
-  for (uint8_t i = 0; i < data->num_circles; i++) {
-    graphics_draw_circle(context, data->circle_centers[i], data->circle_radius);
-  }
-#else
-  //draw rectrs
-  data->rectr_radius = 5;
-  data->rectr_corners_index = GCornersAll;
-  for (uint8_t x=0; x<RECTR_COL; x++) {
-    for (uint8_t y=0; y<RECTR_ROW; y++) {
-      data->rectr[RECTR_ROW * x + y].origin.x = (PBL_DISPLAY_WIDTH/RECTR_COL) * x;
-      data->rectr[RECTR_ROW * x + y].origin.y = (PBL_DISPLAY_HEIGHT/RECTR_ROW) * y;
-      data->rectr[RECTR_ROW * x + y].size.w = PBL_DISPLAY_WIDTH/RECTR_COL;
-      data->rectr[RECTR_ROW * x + y].size.h = PBL_DISPLAY_HEIGHT/RECTR_ROW;
-      graphics_context_set_stroke_color(context, GColorBlack);
-      graphics_draw_round_rect(context, &data->rectr[RECTR_ROW * x + y], data->rectr_radius);
-    }
-  }
-#endif
+  prv_init_dots(data);
   layer_mark_dirty(&data->window.layer);
+
+  TextLayer *status = &data->status;
+  // Centered overlay; kept small so it covers as little of the path as possible
+  text_layer_init(status,
+                  &GRect(PBL_DISPLAY_WIDTH / 2 - 34, PBL_DISPLAY_HEIGHT / 2 - 20, 68, 40));
+  text_layer_set_font(status, fonts_get_system_font(FONT_KEY_GOTHIC_24));
+  text_layer_set_text_alignment(status, GTextAlignmentCenter);
+  text_layer_set_background_color(status, GColorClear);
+  layer_add_child(&window->layer, &status->layer);
 
   data->event_info = (EventServiceInfo) {
     .type = PEBBLE_TOUCH_EVENT,


### PR DESCRIPTION
Backport of the follow-the-line MFG touch test from main (e4cf8f3d8, 41de90451) to the v4.9.142 branch, adapted to this branch's touch event service API.

Intentionally left out relative to main: result reporting, the timed pass/fail and the window auto-close. The test shows PASS! once the path is completed and stays open until the operator exits.

Build-tested (`--mfg`, `build_prf`) on getafix_dvt (rect path) and obelix_dvt (round path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)