### PR TITLE
drivers/speaker: throttle sf32lb52 DMA refill callbacks

### DIFF
--- a/src/fw/drivers/speaker/sf32lb52/audec.c
+++ b/src/fw/drivers/speaker/sf32lb52/audec.c
@@ -366,6 +366,7 @@ void audec_start(AudioDevice* audio_device, AudioTransCB cb) {
     AudioDeviceState* state = audio_device->state;
     AUDCODEC_HandleTypeDef *haudcodec = &state->audcodec;
     state->trans_cb = cb;
+    state->callback_pending = false;
 
     soc_sf32lb_sleep_block(SOC_SF32LB_DEEPWFI);
 
@@ -448,6 +449,7 @@ void audec_dac0_dma_irq_handler(AudioDevice* audio_device)
 
 static void prv_audio_trans_bg(void* data) {
     AudioDeviceState* state  = (AudioDeviceState*) data;
+    state->callback_pending = false;
     uint32_t free_size = circular_buffer_get_write_space_remaining(&state->circ_buffer);
     state->trans_cb(&free_size);
 }
@@ -474,10 +476,17 @@ static void prv_dma_request_processing(AudioDeviceState* state) {
     // any bytes we didn't touch were already memset() to silence.
     dcache_flush(state->queue_buf[HAL_AUDCODEC_DAC_CH0], CFG_AUDIO_PLAYBACK_PIPE_SIZE);
     uint32_t free_size = circular_buffer_get_write_space_remaining(&state->circ_buffer);
-    if(state->trans_cb && free_size >= CFG_AUDIO_PLAYBACK_PIPE_SIZE) {
+    // Only one refill callback may be in flight: this ISR fires every half
+    // buffer, and enqueueing on each one floods the system task queue when
+    // KernelBG is starved, tripping the Event Queue Full reset.
+    if(state->trans_cb && !state->callback_pending &&
+       free_size >= CFG_AUDIO_PLAYBACK_PIPE_SIZE) {
         bool system_task_switch_context = false;
-        system_task_add_callback_from_isr(prv_audio_trans_bg, (void*)state,
-            &system_task_switch_context);
+        state->callback_pending = true;
+        if (!system_task_add_callback_from_isr(prv_audio_trans_bg, (void*)state,
+                &system_task_switch_context)) {
+            state->callback_pending = false;
+        }
     }
 }
 

--- a/src/fw/drivers/speaker/sf32lb52/audio_definitions.h
+++ b/src/fw/drivers/speaker/sf32lb52/audio_definitions.h
@@ -40,6 +40,9 @@ typedef struct AudioState {
   uint8_t *circ_buffer_storage;
   CircularBuffer circ_buffer;
   AudioTransCB trans_cb;
+  //! Set while a prv_audio_trans_bg refill callback is queued on the system
+  //! task; the DMA ISR must not enqueue another until it has run.
+  volatile bool callback_pending;
   uint8_t volume;
   //! Raw (unaligned) pointer returned by kernel_malloc for the AUDCODEC DAC
   //! DMA buffer. haudcodec->buf[] is bumped up to a cache-line boundary so


### PR DESCRIPTION
## Summary

Alarms on obelix cut off ~3 s into playback with an `Event Queue Full` hard reboot (FIRM-3470, canonical FIRM-2438). The SF32LB52 AUDCODEC DMA half/full-complete ISRs enqueue a `prv_audio_trans_bg` refill callback on **every** interrupt with no in-flight tracking, so whenever KernelBG is starved (in the FIRM-3470 coredump, the DATALOAD watchface was blocking on a slow flash resource read while holding the pfs mutexes) the system task queue overflows and `handle_system_task_send_failure` deliberately reboots the watch mid-alarm.

This mirrors the guard the nrf5/da7212 driver already has (`callback_pending` + `is_running` check in `prv_maybe_request_refill_from_isr`):

- add a `callback_pending` flag to `AudioDeviceState`
- the ISR skips enqueueing while a refill callback is already queued, and rolls the flag back if `system_task_add_callback_from_isr` fails
- the callback clears the flag before invoking `trans_cb`
- `audec_start()` resets the flag so a stale value can't block refills on a new session

At most one refill callback is ever in flight, so a starved KernelBG degrades to audio underrun (silence fill, which the driver already handles) instead of a reboot.

## Testing

- `./waf configure --board obelix@pvt && ./waf build` — clean build

Fixes FIRM-3470
Refs FIRM-2438

🤖 Generated with [Claude Code](https://claude.com/claude-code)