### PR TITLE
services/notifications: fix cross-heap free in storage compression

### DIFF
--- a/src/fw/services/notifications/notification_storage.c
+++ b/src/fw/services/notifications/notification_storage.c
@@ -476,7 +476,9 @@ static bool prv_rewrite_iter_next(NotificationIterState *iter_state) {
   }
 
   if (iter_state->header.common.status & TimelineItemStatusDeleted) {
-    return true;
+    // Deleted entries are not read into iter_state->notification; skip the payload so the next
+    // iteration reads a record header, not payload bytes
+    return pfs_seek(iter_state->fd, iter_state->header.payload_length, FSeekCur) >= 0;
   }
   return prv_get_notification(&iter_state->notification, &iter_state->header, iter_state->fd);
 }
@@ -668,13 +670,23 @@ void notification_storage_rewrite(void (*iter_callback)(TimelineItem *notificati
   };
   iter_init(&iter, (IteratorCallback)prv_rewrite_iter_next, NULL, &iter_state);
 
+  int write_offset = 0;
   while (iter_next(&iter)) {
     uint8_t status = iter_state.header.common.status;
-    if (!(status & TimelineItemStatusDeleted)) {
-      iter_callback(&iter_state.notification, &iter_state.header, data);
+    if (status & TimelineItemStatusDeleted) {
+      // Drop deleted entries; iter_state.notification still holds the previous item, whose
+      // buffer has already been written and freed
+      continue;
     }
-    prv_write_notification(&iter_state.notification, &iter_state.header, new_fd);
+    iter_callback(&iter_state.notification, &iter_state.header, data);
+    int result = prv_write_notification(&iter_state.notification, &iter_state.header, new_fd);
+    timeline_item_free_allocated_buffer(&iter_state.notification);
+    if (result < 0) {
+      break;
+    }
+    write_offset += result;
   }
+  s_write_offset = write_offset;
 
   // Close the old file
   prv_file_close(fd);

--- a/src/fw/services/notifications/notification_storage.c
+++ b/src/fw/services/notifications/notification_storage.c
@@ -231,11 +231,14 @@ static bool prv_compress(size_t size_needed, int *fd) {
       char uuid_buffer[UUID_STRING_BUFFER_LENGTH];
       uuid_to_string(&iter_state.header.common.id, uuid_buffer);
       PBL_LOG_ERR("Failed to write notification %s during compression (error %d). Resetting all notifications.", uuid_buffer, result);
-      kernel_free(notification.allocated_buffer);
+      // The buffer comes from the calling task's heap (timeline_item_deserialize_item), so it
+      // must not be freed with kernel_free: compression can run on the app task, e.g. when a
+      // workout summary notification is stored while storage is full.
+      timeline_item_free_allocated_buffer(&notification);
       goto cleanup;
     }
     write_offset += result;
-    kernel_free(notification.allocated_buffer);
+    timeline_item_free_allocated_buffer(&notification);
   }
 
   s_write_offset = write_offset;

--- a/tests/fw/services/notifications/test_notification_storage.c
+++ b/tests/fw/services/notifications/test_notification_storage.c
@@ -888,3 +888,78 @@ void test_notification_storage__should_detect_corruption(void) {
   notification_storage_store(&e4);
   cl_assert_equal_b(notification_storage_get(&i4, &r), false);
 }
+
+static void prv_rewrite_bump_timestamp_callback(TimelineItem *notification,
+    SerializedTimelineItemHeader *header, void *data) {
+  int *count = data;
+  (*count)++;
+  header->common.timestamp += 42;
+  notification->header.timestamp = header->common.timestamp;
+}
+
+void test_notification_storage__rewrite_skips_deleted(void) {
+  Uuid i1;
+  uuid_generate(&i1);
+  TimelineItem e1 = {
+    .header = {
+      .id = i1,
+      .type = TimelineItemTypeNotification,
+      .status = 0,
+      .ancs_uid = 0,
+      .layout = LayoutIdGeneric,
+      .timestamp = 0x53f0dda5,
+    },
+    .attr_list = {
+      .num_attributes = ARRAY_LENGTH(attributes),
+      .attributes = attributes,
+    },
+    .action_group = {
+      .num_actions = ARRAY_LENGTH(actions),
+      .actions = actions,
+    }
+  };
+
+  TimelineItem e2 = e1;
+  Uuid i2;
+  uuid_generate(&i2);
+  e2.header.id = i2;
+
+  TimelineItem e3 = e1;
+  Uuid i3;
+  uuid_generate(&i3);
+  e3.header.id = i3;
+
+  notification_storage_store(&e1);
+  notification_storage_store(&e2);
+  notification_storage_store(&e3);
+
+  // Delete the middle notification; the rewrite must skip it and still visit e3
+  notification_storage_remove(&i2);
+
+  int count = 0;
+  notification_storage_rewrite(prv_rewrite_bump_timestamp_callback, &count);
+  cl_assert_equal_i(count, 2);
+
+  TimelineItem r;
+  e1.header.timestamp += 42;
+  cl_assert(notification_storage_get(&i1, &r));
+  compare_notifications(&e1, &r);
+  free(r.allocated_buffer);
+
+  cl_assert_equal_b(notification_storage_get(&i2, &r), false);
+
+  e3.header.timestamp += 42;
+  cl_assert(notification_storage_get(&i3, &r));
+  compare_notifications(&e3, &r);
+  free(r.allocated_buffer);
+
+  // Storage must still accept and retrieve new notifications after a rewrite
+  Uuid i4;
+  uuid_generate(&i4);
+  TimelineItem e4 = e1;
+  e4.header.id = i4;
+  notification_storage_store(&e4);
+  cl_assert(notification_storage_get(&i4, &r));
+  compare_notifications(&e4, &r);
+  free(r.allocated_buffer);
+}


### PR DESCRIPTION
## Summary

Fixes the `heap.c:275` range-assert reboot when stopping a workout (FIRM-3485; same root cause as FIRM-1925 — the earlier workout-mutex fix never addressed it), plus a follow-up fix to `notification_storage_rewrite()` found during the investigation.

### Commit 1 — cross-heap free in compression

`prv_get_notification()` fills the `TimelineItem` via `timeline_item_deserialize_item()`, which allocates `allocated_buffer` with `task_malloc_check` — i.e. from the **calling task's heap**. `prv_compress()` then freed that buffer with `kernel_free()`. Compression runs on whatever task triggers it: when the workout-summary notification is stored from the app task while notification storage is full (the FIRM-3485 logs show ~16 "Storage full: marking notification … as deleted" evictions right before the assert), an app-heap pointer is handed to the kernel heap, `heap_contains_address()` fails, and the watch reboots — losing the notification data mid-compaction.

Fix: free via `timeline_item_free_allocated_buffer()` (task-heap free that also NULLs the pointer), matching the allocation. On kernel tasks `task_free == kernel_free`, so behavior there is unchanged. All other alloc/free pairs in this file are already heap-symmetric (`kernel_malloc_check`/`kernel_free`).

### Commit 2 — leak + deleted-entry handling in `notification_storage_rewrite()`

The rewrite path (used by timezone migration) never freed the per-item buffer `prv_rewrite_iter_next()` allocates — one leak per live notification per rewrite. Freeing per iteration exposes the deleted-entry path, which was broken in two ways: the iterator didn't seek past a deleted entry's payload (the next header read got payload bytes, silently ending iteration early), and the loop still wrote a record for the deleted entry using the previous item's stale payload. Deleted entries are now skipped entirely, matching `prv_compress()`, and the bytes written are tracked so `s_write_offset` stays correct for the now-shorter file.

Includes a new unit test (`rewrite_skips_deleted`: live+deleted+live entries, mutation callback, post-rewrite store) that fails against the previous code and passes with the fix.

## Testing

- `./waf test -M ".*notification_storage.*"` — pass (incl. new `rewrite_skips_deleted` test; verified the new test fails on pre-fix code)
- `./waf configure --board obelix@pvt && ./waf build` — clean build

Fixes FIRM-3485
Refs FIRM-1925

🤖 Generated with [Claude Code](https://claude.com/claude-code)