### PR TITLE
third_party/hal_sifli: pull latest HAL

### DIFF
--- a/soc/sf32lb/sf32lb52x/freertos.c
+++ b/soc/sf32lb/sf32lb52x/freertos.c
@@ -302,10 +302,9 @@ bool vPortEnableTimer() {
   HAL_RCC_HCPU_ClockSelect(RCC_CLK_MOD_HP_TICK, RCC_CLK_TICK_HXT48);
   // delay to avoid systick config failure (undocumented silicon issue)
   HAL_Delay_us(200);
-  MODIFY_REG(hwp_hpsys_rcc->CFGR, HPSYS_RCC_CFGR_TICKDIV_Msk,
-             MAKE_REG_VAL(25, HPSYS_RCC_CFGR_TICKDIV_Msk, HPSYS_RCC_CFGR_TICKDIV_Pos));
+  HAL_RCC_HCPU_SetTickDiv(25);
   HAL_SYSTICK_Config(1920000 / RTC_TICKS_HZ);
-  HAL_SYSTICK_CLKSourceConfig(SYSTICK_CLKSOURCE_HCLK_DIV8);
+  HAL_SYSTICK_CLKSourceConfig(SYSTICK_CLKSOURCE_TICK_CLK);
 
   SysTick->CTRL |= (SysTick_CTRL_ENABLE_Msk | SysTick_CTRL_TICKINT_Msk);
 

--- a/src/fw/drivers/sf32lb52/qspi.c
+++ b/src/fw/drivers/sf32lb52/qspi.c
@@ -317,7 +317,7 @@ status_t qspi_flash_security_register_is_locked(QSPIFlash *dev, uint32_t addr, b
 
   /* OPT operation are synchronous, one match means all matched. */
   portENTER_CRITICAL();
-  opt_val = HAL_QSPI_GET_OTP_LB(hflash, addr);
+  opt_val = HAL_QSPI_GET_OTP_LB(hflash);
   portEXIT_CRITICAL();
 
   if (opt_val == 0xff) {

--- a/third_party/hal_sifli/sf32lb52/ipc_os_port.h
+++ b/third_party/hal_sifli/sf32lb52/ipc_os_port.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "bf0_hal.h"
+
 void vPortEnterCritical(void);
 void vPortExitCritical(void);
 
@@ -17,3 +19,11 @@ static inline void os_interrupt_enable(int mask) {
 
 #define os_interrupt_enter()
 #define os_interrupt_exit()
+
+#define os_interrupt_start(irq_number, priority, sub_priority) \
+  do {                                                         \
+    HAL_NVIC_SetPriority(irq_number, priority, sub_priority);  \
+    HAL_NVIC_EnableIRQ(irq_number);                            \
+  } while (0)
+
+#define os_interrupt_stop(irq_number) HAL_NVIC_DisableIRQ(irq_number)

--- a/third_party/hal_sifli/wscript_build
+++ b/third_party/hal_sifli/wscript_build
@@ -167,7 +167,7 @@ if bld.env.CONFIG_HAL_SIFLI_SF32LB52:
         micro_sources += [
             'SiFli-SDK/drivers/cmsis/sf32lb52x/bf0_lcpu_init.c',
             'SiFli-SDK/drivers/cmsis/sf32lb52x/lcpu_patch.c',
-            'SiFli-SDK/drivers/cmsis/sf32lb52x/lcpu_patch_rev_b.c',
+            '../nonfree/pebbleos-nonfree/sf32lb52/lcpu_patch_rev_b.c',
             'SiFli-SDK/drivers/cmsis/sf32lb52x/bt_rf_fulcal.c',
             'sf32lb52/lcpu_config.c',
         ]


### PR DESCRIPTION
## Summary

Retry of the April HAL update (`2e843a0af`, reverted in `acdab3ac0`): moves the SiFli-SDK submodule to the tip of the `pebbleos` branch (`bfee83c7a`, ~880 commits over the current merge-base), which is the exact same target as the reverted attempt — the branch has not moved since.

- The GPIO SET/CLR write-only and MPI OTP FIFO-clear fixes carried on the previous rebased pointer are already merged in the updated branch, so nothing is lost.
- Companion changes for HAL API updates:
  - `HAL_QSPI_GET_OTP_LB()` no longer takes an address argument
  - SYSTICK setup now uses `HAL_RCC_HCPU_SetTickDiv()` and `SYSTICK_CLKSOURCE_TICK_CLK`
  - `ipc_os_port.h` provides `os_interrupt_start()/os_interrupt_stop()`, now required by `ipc_hw.c`
- Also re-applies the LCPU patch switch (`821f9c8de`, reverted in `81a171114`): the LCPU ROM patch is built from pebbleos-nonfree instead of the SiFli-SDK copy. The nonfree submodule already contains the updated patch.

## Testing

- Built `obelix@pvt` and `getafix@dvt2` (normal variant) successfully.
- Needs on-device validation before merge, given the original update was reverted for runtime issues.

Fixes FIRM-1741

🤖 Generated with [Claude Code](https://claude.com/claude-code)