### PR TITLE
fw/comm/ble/ams: tolerate extra PlaybackInfo CSV fields

### DIFF
--- a/src/fw/comm/ble/kernel_le_client/ams/ams.c
+++ b/src/fw/comm/ble/kernel_le_client/ams/ams.c
@@ -301,6 +301,13 @@ static MusicPlayState prv_music_playstate_for_ams_playback_state(int32_t ams_pla
 
 static bool prv_handle_player_playback_info_value(const char *value, uint32_t value_length,
                                                   uint32_t idx, void *context) {
+  // Non-Apple AMS servers can format the floats with a comma decimal separator
+  // (e.g. "1,00"), yielding extra CSV fields. Stop parsing instead of
+  // asserting; the caller rejects the update based on the field count.
+  if (idx > AMSPlaybackInfoIdxElapsedTime) {
+    return false /* should_continue */;
+  }
+
   // Default to -1 for playback state, or 0 otherwise, in case "value" is an empty string:
   // This will cause the playback state to be set to MusicPlayStateUnknown.
   int32_t value_out = (idx == AMSPlaybackInfoIdxState) ? -1 : 0;

--- a/tests/fw/comm/test_ams.c
+++ b/tests/fw/comm/test_ams.c
@@ -558,6 +558,38 @@ void test_ams__receive_incomplete_csv_list_player_playback_info_update(void) {
   prv_assert_initial_playback_state();
 }
 
+void test_ams__receive_trailing_comma_player_playback_info_update(void) {
+  prv_connect_ams();
+
+  // Receive: paused, 100% playback rate, elapsed time 2.0s, trailing comma
+  // adding an empty 4th field.
+  // 0000  00 01 00 30 2c 31 2c 32  2e 30 2c   ...0,1,2 .0,
+  uint8_t trailing_comma_playback_info_update[] = {
+    0x00, 0x01, 0x00, 0x30, 0x2c, 0x31, 0x2c, 0x32,
+    0x2e, 0x30, 0x2c,
+  };
+  prv_receive_entity_update(trailing_comma_playback_info_update,
+                            sizeof(trailing_comma_playback_info_update));
+
+  prv_assert_initial_playback_state();
+}
+
+void test_ams__receive_comma_decimal_player_playback_info_update(void) {
+  prv_connect_ams();
+
+  // Receive: paused, "1,00" rate, "-0,00" elapsed time — floats formatted with
+  // a comma decimal separator, as sent by some non-Apple AMS servers.
+  // 0000  00 01 00 30 2c 31 2c 30  30 2c 2d 30 2c 30 30   ...0,1,0 0,-0,00
+  uint8_t comma_decimal_playback_info_update[] = {
+    0x00, 0x01, 0x00, 0x30, 0x2c, 0x31, 0x2c, 0x30,
+    0x30, 0x2c, 0x2d, 0x30, 0x2c, 0x30, 0x30,
+  };
+  prv_receive_entity_update(comma_decimal_playback_info_update,
+                            sizeof(comma_decimal_playback_info_update));
+
+  prv_assert_initial_playback_state();
+}
+
 void test_ams__receive_malformed_player_volume_update(void) {
   prv_connect_ams();
 


### PR DESCRIPTION
## Summary

Some non-Apple AMS servers format the PlaybackInfo floats with a comma decimal separator — e.g. `0,1,00,-0,00` (state 0, rate "1,00", elapsed "-0,00") from a de_DE Android phone. `ams_util_csv_parse` splits on every comma, so the per-field callback gets called with `idx >= 3`: an out-of-bounds read of `multiplier[idx]`, then the `default: WTF` assert.

The user impact is severe (FIRM-3441): with music playing, the phone re-sends the poisoned value seconds after every reconnect, so the watch crash-loops. Three crashes with under 15 minutes of uptime each trip the bootloader's strike counter and it falls back to PRF, which invalidates both firmware slots — the user has to fully reinstall the firmware every day and otherwise sits on the factory QR code screen. Any comma-decimal locale (de, fr, es, it, …) reproduces this. Verified end-to-end against the FIRM-3441 coredump, watch logs, and pblboot strike logic.

Fix: bound-check the field index at the top of the callback and stop parsing instead of asserting. This removes both the OOB read and the assert; the existing `num_results == 3` check then rejects the malformed update, so valid peers are unaffected.

## Tests

- New: trailing-comma payload (`0,1,2.0,` — empty 4th field short-circuits the parse and deterministically hit the `WTF` before this fix; verified red pre-fix, green post-fix)
- New: the exact comma-decimal payload from the FIRM-3441 coredump (`0,1,00,-0,00`)
- `./waf test -M '.*test_ams.*'` passes; `obelix@pvt` firmware builds clean

Fixes FIRM-3228, FIRM-2706, FIRM-3441

🤖 Generated with [Claude Code](https://claude.com/claude-code)