### PR TITLE
services/alarms: fix user snooze delay on smart alarms

### DIFF
--- a/src/fw/services/alarms/alarm.c
+++ b/src/fw/services/alarms/alarm.c
@@ -125,6 +125,10 @@ static bool s_most_recent_alarm_recorded;
 static TimerID s_snooze_timer_id = TIMER_INVALID_ID;
 static uint16_t s_snooze_delay_m = DEFAULT_SNOOZE_DELAY_M;
 
+//! Whether the pending snooze timer was armed by an explicit user snooze rather
+//! than the smart alarm's internal sleep poll.
+static bool s_user_snoozed;
+
 //! Number of times the most recent alarm was automatically smart snoozed.
 //! Used to determine an expired smart alarm avoiding issues with midnight rollover and DST.
 static int s_smart_snooze_counter;
@@ -390,6 +394,7 @@ static bool prv_record_alarm_op(AlarmId id, AlarmConfig *config, void *context) 
 // ----------------------------------------------------------------------------------------------
 static void prv_clear_snooze_timer(void) {
   new_timer_stop(s_snooze_timer_id);
+  s_user_snoozed = false;
 }
 
 // ----------------------------------------------------------------------------------------------
@@ -398,9 +403,13 @@ static void prv_process_most_recent_alarm(void) {
   // Only processes the most recent alarm since it modifies the alarm config
   AlarmConfig *config = s_most_recent_alarm_id != ALARM_INVALID_ID ? &s_most_recent_alarm_config :
                                                                      NULL;
+  const bool user_snoozed = s_user_snoozed;
+  s_user_snoozed = false;
   bool trigger = true;
   const bool is_smart = (config && config->is_smart);
-  if (is_smart) {
+  // A user snooze must fire after exactly the configured delay; only the smart
+  // alarm's internal sleep poll may re-evaluate the sleep state and re-snooze.
+  if (is_smart && !user_snoozed) {
     trigger = prv_should_smart_alarm_trigger(config);
     if (!trigger) {
       // Not triggering an event, increment to signify elapsed time and snooze
@@ -1013,6 +1022,8 @@ static void prv_snooze_alarm(int snooze_delay_s) {
 // ----------------------------------------------------------------------------------------------
 void alarm_set_snooze_alarm(void) {
   prv_snooze_alarm(s_snooze_delay_m * SECONDS_PER_MINUTE);
+  // Set after prv_snooze_alarm(): clearing the previous timer resets the flag.
+  s_user_snoozed = true;
 }
 
 // ----------------------------------------------------------------------------------------------

--- a/tests/fw/test_alarm_smart.c
+++ b/tests/fw/test_alarm_smart.c
@@ -246,6 +246,37 @@ void test_alarm_smart__trigger_at_timeout(void) {
   cl_assert_equal_i(s_last_timeline_item_added->header.timestamp, rtc_get_time());
 }
 
+void test_alarm_smart__user_snooze_fires_after_delay(void) {
+  AlarmId id;
+  id = alarm_create(&(AlarmInfo) { .hour = 10, .minute = 30, .kind = ALARM_KIND_EVERYDAY, .is_smart = true });
+  prv_assert_alarm_config(id, 10, 30, false, ALARM_KIND_EVERYDAY, s_every_day_schedule);
+
+  // Awake, so the smart alarm fires immediately at T-30min
+  s_sleep_state = ActivitySleepStateAwake;
+  s_sleep_state_seconds = 0;
+  s_last_vmc = 0;
+  prv_set_time(s_current_day, 10, 0);
+  cron_service_wakeup();
+  cl_assert_equal_i(s_num_alarms_fired, 1);
+  cl_assert_equal_i(s_num_alarm_events_put, 1);
+
+  // The user snoozes the firing alarm, then looks asleep again
+  alarm_set_snooze_alarm();
+  s_sleep_state = ActivitySleepStateRestfulSleep;
+  s_last_vmc = 0;
+
+  // The snooze timer must re-fire the alarm event, not re-enter the sleep poll
+  prv_set_time(s_current_day, 10, alarm_get_snooze_delay());
+  stub_new_timer_invoke(1);
+  cl_assert_equal_i(s_num_alarm_events_put, 2);
+
+  // Snoozing again keeps working the same way
+  alarm_set_snooze_alarm();
+  prv_set_time(s_current_day, 10, 2 * alarm_get_snooze_delay());
+  stub_new_timer_invoke(1);
+  cl_assert_equal_i(s_num_alarm_events_put, 3);
+}
+
 void test_alarm_smart__across_midnight_boundary(void) {
   prv_set_time(s_sunday, 22, 0);
 


### PR DESCRIPTION
## Problem

Snoozing a firing smart alarm does not come back after the configured snooze delay. "Snooze for 10 minutes" instead turns into an open-ended loop that only re-fires the alarm once the watch decides the user has exited sleep, or after the smart-poll cap.

## Root cause

User snoozes (`alarm_set_snooze_alarm()`) and the smart alarm's internal 1-minute sleep poll share the same snooze timer (`s_snooze_timer_id`), with no state distinguishing who armed it. When the timer expires, `prv_process_most_recent_alarm()` sees `config->is_smart` and unconditionally routes through `prv_should_smart_alarm_trigger()`: if the user still looks asleep (RestfulSleep/LightSleep with VMC 0), it re-snoozes for `SMART_ALARM_SNOOZE_DELAY_S` (60 s) instead of firing — so a user snooze of a smart alarm degenerates into the sleep-poll loop.

## Fix

Track whether the pending snooze timer was armed by an explicit user snooze (`s_user_snoozed`). On expiry the flag is consumed and, when set, the sleep gate is bypassed so the alarm event fires after exactly the configured delay. The flag is set after `prv_snooze_alarm()` (which clears the previous timer) and reset in `prv_clear_snooze_timer()`, so every snooze-lifecycle teardown (dismiss, disable, delete, new alarm fire, clock-change force trigger) clears it. Regular (non-smart) alarms are unaffected.

## Test plan

- New regression test `test_alarm_smart__user_snooze_fires_after_delay`: smart alarm fires, user snoozes, sleep state stays RestfulSleep with VMC 0 — the snooze timer expiry must put the alarm event (twice, to cover repeated snoozes). Fails on unfixed code (`1 NOT == 2`, log shows `Snoozing for 10 minutes` → `Snoozing for 1 minutes`), passes with the fix.
- `./waf test -M '.*alarm.*'`: 4/4 suites pass (test_alarm, test_alarm_smart, test_alarm_layout_obelix, test_alarm_layout_gabbro).
- Firmware build: `./waf configure --board obelix@pvt && ./waf build` succeeds.

Fixes FIRM-3127

🤖 Generated with [Claude Code](https://claude.com/claude-code)
