### PR TITLE
services/ecompass: relax calibration gates for weak geomagnetic fields

### DIFF
--- a/src/fw/services/ecompass/correction.c
+++ b/src/fw/services/ecompass/correction.c
@@ -184,13 +184,17 @@ cleanup:
 // well). However, the greater the the threshold, the more orientations one
 // must put their watch through in order to get solution sets
 //
-// For now, select a distance metric that should work out of the box for a
-// majority of the middle of the world. However, if no solution sets are found
-// after 45s, fall back to a less aggressive threshold that will work
-// anywhere in the world.
+// For now, start with a distance metric that should work out of the box for a
+// majority of the middle of the world. In weak geomagnetic regions the samples
+// lie on a sphere too small for that metric to ever be satisfiable (e.g. in
+// the South Atlantic Anomaly, ~22 uT, the point-to-line gate at 37 uT is
+// geometrically impossible). So, each time a sample window elapses without a
+// complete point set, relax the threshold one step toward a floor that stays
+// feasible at any realistic field strength and orientation coverage.
 
 #define THRESH_MAX 370 /* 37 uT */
-#define THRESH_MIN 220 /* 22 uT */
+#define THRESH_MIN 90  /* 9 uT */
+#define THRESH_STEP 70
 
 // Note: All of the following helper routines operate on the s_samples array
 // defined above and populated by add_raw_mag_sample
@@ -280,21 +284,23 @@ static int min_max_diff(int16_t *vals, int n_vals) {
 }
 
 #define N_COMP_SAMPS 3
+
+// stash several of the most recent calibration results. The idea here is if
+// we get multiple readings in a row close to one another than we have locked
+// onto a good set of solutions
+static int16_t s_calib_idx = 0;
+static int16_t s_calib_val[N_AXIS][N_COMP_SAMPS];
+static int s_saved_sample_match = 0;
+
 static MagCalStatus check_correction_value(int16_t *solution,
     int16_t *saved_solution) {
   const int max_delta_thresh = 50;
 
-  // stash several of the most recent calibration results. The idea here is if
-  // we get multiple readings in a row close to one another than we have locked
-  // onto a good set of solutions
-  static int16_t calib_idx = 0;
-  static int16_t calib_val[N_AXIS][N_COMP_SAMPS];
-  calib_val[0][calib_idx % 3] = solution[0];
-  calib_val[1][calib_idx % 3] = solution[1];
-  calib_val[2][calib_idx % 3] = solution[2];
-  calib_idx++;
+  s_calib_val[0][s_calib_idx % 3] = solution[0];
+  s_calib_val[1][s_calib_idx % 3] = solution[1];
+  s_calib_val[2][s_calib_idx % 3] = solution[2];
+  s_calib_idx++;
 
-  static int saved_sample_match = 0;
   int x_delta, y_delta, z_delta;
 
   // is the new solution close to what we already have saved?
@@ -304,10 +310,10 @@ static MagCalStatus check_correction_value(int16_t *solution,
     z_delta = ABS(saved_solution[2] - solution[2]);
     if ((x_delta < max_delta_thresh) && (y_delta < max_delta_thresh) &&
         (z_delta < max_delta_thresh)) {
-      saved_sample_match++;
-      if (saved_sample_match == 3) {
-        saved_sample_match = 0;
-        calib_idx = 0;
+      s_saved_sample_match++;
+      if (s_saved_sample_match == 3) {
+        s_saved_sample_match = 0;
+        s_calib_idx = 0;
         PBL_LOG_DBG("Persisting previous values!");
         return (MagCalStatusSavedSampleMatch); // locked
       }
@@ -315,20 +321,20 @@ static MagCalStatus check_correction_value(int16_t *solution,
   }
 
   // do we have several solutions in a row that are close to one another
-  if (calib_idx >= N_COMP_SAMPS) {
-    x_delta = min_max_diff(calib_val[0], 3);
-    y_delta = min_max_diff(calib_val[1], 3);
-    z_delta = min_max_diff(calib_val[2], 3);
+  if (s_calib_idx >= N_COMP_SAMPS) {
+    x_delta = min_max_diff(s_calib_val[0], 3);
+    y_delta = min_max_diff(s_calib_val[1], 3);
+    z_delta = min_max_diff(s_calib_val[2], 3);
     if ((x_delta < max_delta_thresh) && (y_delta < max_delta_thresh) &&
         (z_delta < max_delta_thresh)) {
       int corrs[N_AXIS] = { 0 };
       for (int i = 0; i < N_AXIS; i++) {
         for (int j = 0; j < N_COMP_SAMPS; j++) {
-          corrs[i] += calib_val[i][j];
+          corrs[i] += s_calib_val[i][j];
         }
         solution[i] = corrs[i] / N_COMP_SAMPS;
       }
-      calib_idx = 0;
+      s_calib_idx = 0;
       return (MagCalStatusNewLockedSolutionAvail);
     }
   }
@@ -337,28 +343,28 @@ static MagCalStatus check_correction_value(int16_t *solution,
 }
 
 static int s_sample_idx = 0;
-static int s_no_fit_strikes = 0;
 static int s_samples_collected_for_fit = 0;
+static int32_t s_thresh = THRESH_MAX;
 
 void ecomp_corr_reset(void) {
-    s_no_fit_strikes = 0;
     s_samples_collected_for_fit = 0;
     s_sample_idx = 0;
+    s_thresh = THRESH_MAX;
+    s_calib_idx = 0;
+    s_saved_sample_match = 0;
 }
 
 MagCalStatus ecomp_corr_add_raw_mag_sample(int16_t *sample,
     int16_t *saved_corr, int16_t *solution) {
-  static int thresh = THRESH_MAX;
   s_samples_collected_for_fit++;
 
-  // if we haven't gotten good samples points in 15s @ 20Hz (60s @ 5Hz)
+  // no complete point set in 15s @ 20Hz (60s @ 5Hz): relax the gates so
+  // calibration stays feasible in weak fields regardless of motion pattern
   if (s_samples_collected_for_fit > 300) {
-    if (s_sample_idx >= 2) { // there was some kind of motion
-      s_no_fit_strikes++;
-    }
-    if (s_no_fit_strikes == 2) {
-      PBL_LOG_INFO("Lowering magnetometer distance threshold");
-      thresh = THRESH_MIN;
+    if (s_thresh > THRESH_MIN) {
+      s_thresh = MAX(s_thresh - THRESH_STEP, THRESH_MIN);
+      PBL_LOG_DBG("Lowering magnetometer distance threshold to %d",
+          (int)s_thresh);
     }
 
     s_samples_collected_for_fit = 0;
@@ -370,15 +376,15 @@ MagCalStatus ecomp_corr_add_raw_mag_sample(int16_t *sample,
   s_samples[s_sample_idx][2] = sample[2];
 
   if (s_sample_idx == 1) {
-    if (!pt_to_pt_dist_under_thresh(0, 1, thresh)) {
+    if (!pt_to_pt_dist_under_thresh(0, 1, s_thresh)) {
       return (MagCalStatusNoSolution);
     }
   } else if (s_sample_idx == 2) {
-    if (!pt_to_line_dist_under_thresh(0, 1, 2, thresh)) {
+    if (!pt_to_line_dist_under_thresh(0, 1, 2, s_thresh)) {
       return (MagCalStatusNoSolution);
     }
   } else if (s_sample_idx == 3) {
-    if (!pt_to_plane_dist_under_thresh(0, 1, 2, 3, thresh)) {
+    if (!pt_to_plane_dist_under_thresh(0, 1, 2, 3, s_thresh)) {
       return (MagCalStatusNoSolution);
     }
   }

--- a/tests/fw/services/test_compass_cal.c
+++ b/tests/fw/services/test_compass_cal.c
@@ -99,6 +99,8 @@ static void solution_and_estimate_match(int16_t *solution, int16_t *correction) 
 void test_compass_cal__sphere_fit(void) {
   int num_entries = sizeof(s_sample_data) / sizeof(SampleData);
 
+  ecomp_corr_reset();
+
   int16_t solution[3];
   int rv;
   for (int i = 0; i < num_entries; i++) {
@@ -124,6 +126,208 @@ void test_compass_cal__sphere_fit(void) {
   }
 }
 
-  
+//////////////////////////////////////////////////////////////////////////////
+// Synthetic motion helpers
+//
+// Raw samples lie on a sphere whose radius is the local field strength
+// (1 count = 0.1 uT) centered on the hard-iron offset. Watch motion is
+// emulated by interpolating between waypoint directions, mimicking the
+// tilt coaching of the calibration UI, plus MMC5603NJ-level noise.
 
-  
+static uint32_t s_rand_state;
+
+static int prv_noise(void) {
+  // deterministic pseudo-noise in [-3, 3]
+  s_rand_state = s_rand_state * 1103515245u + 12345u;
+  return (int)((s_rand_state >> 16) % 7) - 3;
+}
+
+typedef struct {
+  const int16_t *center;
+  int32_t radius; // 0 = keep interpolated point (coplanar path)
+  const int32_t (*waypoints)[3];
+  int n_waypoints;
+  int steps_per_leg;
+  int leg;
+  int step;
+} MotionSim;
+
+static void prv_next_sample(MotionSim *sim, int16_t *sample) {
+  const int32_t *a = sim->waypoints[sim->leg % sim->n_waypoints];
+  const int32_t *b = sim->waypoints[(sim->leg + 1) % sim->n_waypoints];
+
+  int32_t v[3];
+  for (int i = 0; i < 3; i++) {
+    v[i] = a[i] + ((b[i] - a[i]) * sim->step) / sim->steps_per_leg;
+  }
+
+  if (sim->radius != 0) {
+    // project the interpolated point back onto the sphere
+    int32_t norm = integer_sqrt((int64_t)v[0] * v[0] + (int64_t)v[1] * v[1] +
+        (int64_t)v[2] * v[2]);
+    for (int i = 0; i < 3; i++) {
+      v[i] = (v[i] * sim->radius) / norm;
+    }
+  }
+
+  for (int i = 0; i < 3; i++) {
+    sample[i] = sim->center[i] + v[i] + prv_noise();
+  }
+
+  if (++sim->step >= sim->steps_per_leg) {
+    sim->step = 0;
+    sim->leg++;
+  }
+}
+
+// Directions within a 50 degree cap around +z on a radius-228 sphere
+// (~22.8 uT, South Atlantic Anomaly level). Max pairwise chord is ~349,
+// below the strict 370 point-to-point gate.
+static const int32_t s_weak_waypoints[][3] = {
+  {    0,    0, 228 }, // pole
+  {  175,    0, 147 }, // rim, azimuth 0
+  {  -87,  151, 147 }, // rim, azimuth 120
+  {    0,    0, 228 },
+  {  -87, -151, 147 }, // rim, azimuth 240
+  {   87,  151, 147 }, // rim, azimuth 60
+  {    0,    0, 228 },
+  { -175,    0, 147 }, // rim, azimuth 180
+  {   87, -151, 147 }, // rim, azimuth 300
+};
+
+// Directions within a 70 degree cap around +z on a radius-470 sphere (47 uT)
+static const int32_t s_normal_waypoints[][3] = {
+  {    0,    0, 470 }, // pole
+  {  442,    0, 161 }, // rim, azimuth 0
+  { -221,  383, 161 }, // rim, azimuth 120
+  {    0,    0, 470 },
+  { -221, -383, 161 }, // rim, azimuth 240
+  {  221,  383, 161 }, // rim, azimuth 60
+  {    0,    0, 470 },
+  { -442,    0, 161 }, // rim, azimuth 180
+  {  221, -383, 161 }, // rim, azimuth 300
+};
+
+// Coplanar ring (z = 147 slice of the weak-field sphere)
+static const int32_t s_ring_waypoints[][3] = {
+  {  175,    0, 147 },
+  {   87,  151, 147 },
+  {  -87,  151, 147 },
+  { -175,    0, 147 },
+  {  -87, -151, 147 },
+  {   87, -151, 147 },
+};
+
+// In a weak geomagnetic field all samples sit on a sphere of radius ~228, so
+// the historical fixed gates were unsatisfiable: point-to-point > 370 needs
+// ~108 degrees of tilt separation and point-to-line > 370 is geometrically
+// impossible at this radius (max ~ R + sqrt(R^2 - 185^2) < 370). The old
+// fallback never triggered without a point-to-point pass, so calibration
+// never completed. Progressive relaxation must converge here.
+void test_compass_cal__weak_field_converges(void) {
+  static const int16_t center[3] = { -1250, 830, 1980 };
+
+  ecomp_corr_reset();
+  s_rand_state = 0x12345678;
+
+  MotionSim sim = {
+    .center = center,
+    .radius = 228,
+    .waypoints = s_weak_waypoints,
+    .n_waypoints = sizeof(s_weak_waypoints) / sizeof(s_weak_waypoints[0]),
+    .steps_per_leg = 12,
+  };
+
+  int16_t solution[3] = { 0 };
+  int locked_at = -1;
+  for (int n = 0; n < 6000; n++) {
+    int16_t sample[3];
+    prv_next_sample(&sim, sample);
+    int rv = ecomp_corr_add_raw_mag_sample(sample, NULL, solution);
+    if (n < 300) {
+      // the first window still runs the strict gates: no solution possible,
+      // which is what the old fixed-threshold code produced indefinitely
+      cl_assert_equal_i(rv, MagCalStatusNoSolution);
+    }
+    if (rv == MagCalStatusNewLockedSolutionAvail) {
+      locked_at = n;
+      break;
+    }
+  }
+
+  cl_assert(locked_at > 0);
+  for (int i = 0; i < 3; i++) {
+    cl_assert(ABS(solution[i] - center[i]) <= 30);
+  }
+}
+
+// In a normal field the strict gates are satisfiable and calibration must
+// still lock quickly, before any threshold relaxation kicks in
+void test_compass_cal__normal_field_converges_quickly(void) {
+  static const int16_t center[3] = { 2400, -1700, -900 };
+
+  ecomp_corr_reset();
+  s_rand_state = 0x87654321;
+
+  MotionSim sim = {
+    .center = center,
+    .radius = 470,
+    .waypoints = s_normal_waypoints,
+    .n_waypoints = sizeof(s_normal_waypoints) / sizeof(s_normal_waypoints[0]),
+    .steps_per_leg = 12,
+  };
+
+  int16_t solution[3] = { 0 };
+  int locked_at = -1;
+  for (int n = 0; n < 1200; n++) {
+    int16_t sample[3];
+    prv_next_sample(&sim, sample);
+    int rv = ecomp_corr_add_raw_mag_sample(sample, NULL, solution);
+    if (rv == MagCalStatusNewLockedSolutionAvail) {
+      locked_at = n;
+      break;
+    }
+  }
+
+  cl_assert(locked_at > 0);
+  cl_assert(locked_at < 300); // locked within the first (strict) window
+  for (int i = 0; i < 3; i++) {
+    cl_assert(ABS(solution[i] - center[i]) <= 20);
+  }
+}
+
+// Degenerate inputs must never produce a solution, even once the threshold
+// has relaxed to its floor
+void test_compass_cal__degenerate_sets_rejected(void) {
+  static const int16_t center[3] = { -1250, 830, 1980 };
+
+  // stationary watch: spread is pure sensor noise
+  ecomp_corr_reset();
+  s_rand_state = 0xdeadbeef;
+  int16_t solution[3];
+  for (int n = 0; n < 2000; n++) {
+    int16_t sample[3] = {
+      (int16_t)(810 + prv_noise()),
+      (int16_t)(-455 + prv_noise()),
+      (int16_t)(620 + prv_noise()),
+    };
+    int rv = ecomp_corr_add_raw_mag_sample(sample, NULL, solution);
+    cl_assert_equal_i(rv, MagCalStatusNoSolution);
+  }
+
+  // near-coplanar motion: point-to-plane gate must reject the fourth point
+  ecomp_corr_reset();
+  MotionSim sim = {
+    .center = center,
+    .radius = 0, // stay in the ring plane
+    .waypoints = s_ring_waypoints,
+    .n_waypoints = sizeof(s_ring_waypoints) / sizeof(s_ring_waypoints[0]),
+    .steps_per_leg = 12,
+  };
+  for (int n = 0; n < 3000; n++) {
+    int16_t sample[3];
+    prv_next_sample(&sim, sample);
+    int rv = ecomp_corr_add_raw_mag_sample(sample, NULL, solution);
+    cl_assert_equal_i(rv, MagCalStatusNoSolution);
+  }
+}


### PR DESCRIPTION
## Problem

Compass calibration never completes in weak geomagnetic field regions. The reporter (Buenos Aires, inside the South Atlantic Anomaly, ~22 uT) tilted the watch for 7 minutes without the calibration circle ever filling; the logs show the solver produced zero solutions over the whole session (no "Mag Corr" and no threshold-lowering lines).

## Root cause (geometric)

The sphere-fit solver only accepts a four-point sample set when point-to-point, point-to-line and point-to-plane spreads all exceed an absolute threshold of 370 (37 uT). But all samples lie on a sphere whose radius R is the local field strength (1 count = 0.1 uT), so in Buenos Aires R ~= 228:

- point-to-point > 370 requires ~108 degrees of orientation change, more than the calibration UI's tilt coaching produces;
- point-to-line > 370 is geometrically **impossible**: its maximum is R + sqrt(R^2 - 185^2), which is < 370 for any R < ~231.

The only fallback (to 220) was armed exclusively by two 300-sample windows in which the point-to-point gate had already passed - the very gate weak fields can't satisfy - so the threshold never dropped and calibration was permanently starved.

## Fix

Replace the strike-based fallback with deterministic progressive relaxation: every 300-sample window (15 s at 20 Hz) that ends without a complete point set steps the threshold down by 70, to a floor of 90 (9 uT). The floor keeps all three gates satisfiable at ~20 uT with realistic <= 90 degree orientation coverage. `ecomp_corr_reset()` now also restores the strict threshold and clears the fit-consistency history, so every calibration session starts strict.

Safe in normal fields because:
- the strict 370 threshold is still tried first and only relaxes after demonstrated failure to fit (in a ~47 uT field the synthetic-motion test locks in ~6 s, entirely under the strict gates);
- a lock still requires three consecutive fits consistent within 50 counts, which rejects noisy solutions from small-spread sets;
- degenerate (stationary or coplanar) input still never produces a solution, even at the threshold floor.

## Test plan

Extended `tests/fw/services/test_compass_cal.c` with a synthetic motion generator (points on a sphere of radius R around a hard-iron offset, waypoint interpolation mimicking the UI tilt coaching, MMC5603NJ-level noise):

- **weak_field_converges**: R = 228 (22.8 uT), 50-degree cap coverage (max chord ~349 < 370, so the old gates provably never fire - the test asserts the entire first strict window yields no solution). New code locks at sample 1603 (~80 s at 20 Hz, within the 2-minute fast-sampling window) and recovers the offset within 2 counts.
- **normal_field_converges_quickly**: R = 470 (47 uT) locks at sample 119, inside the first strict window (no relaxation), offset recovered within 3 counts.
- **degenerate_sets_rejected**: stationary (noise-only) and coplanar-ring input never produce a solution across thousands of samples, even after the threshold reaches its floor.
- existing `sphere_fit` regression test unchanged and passing.

`./waf test -M '.*compass.*'`: 1/1 suites, all 4 tests pass. Firmware builds cleanly for obelix@pvt (normal variant).

Fixes FIRM-3087

🤖 Generated with [Claude Code](https://claude.com/claude-code)
