### PR TITLE
fw/graphics: fix tiny, top-aligned emoji at the largest text size

### DIFF
--- a/src/fw/applib/fonts/fonts.c
+++ b/src/fw/applib/fonts/fonts.c
@@ -104,7 +104,7 @@ static const struct {
   const char *key_name;
   uint8_t height;
 } s_emoji_fonts[] = {
-    // Keep this sorted in descending order
+    // Keep this sorted in descending order: lookup returns the first entry that fits
   { FONT_KEY_GOTHIC_28_EMOJI, 28 },
   { FONT_KEY_GOTHIC_24_EMOJI, 24 },
   { FONT_KEY_GOTHIC_18_EMOJI, 18 },
@@ -112,12 +112,16 @@ static const struct {
 };
 
 FontInfo *fonts_get_system_emoji_font_for_size(unsigned int font_height) {
+  // Pick the largest emoji font that still fits the requested height, skipping any that fails
+  // to load so a smaller one can still be used
   for (uint32_t i = 0; i < ARRAY_LENGTH(s_emoji_fonts); i++) {
-    if (font_height == s_emoji_fonts[i].height) {
-      return sys_font_get_system_font(s_emoji_fonts[i].key_name);
+    if (s_emoji_fonts[i].height <= font_height) {
+      FontInfo *font = sys_font_get_system_font(s_emoji_fonts[i].key_name);
+      if (font) {
+        return font;
+      }
     }
   }
-  // Didn't find a suitable emoji font
   return NULL;
 }
 #endif

--- a/src/fw/applib/fonts/fonts.h
+++ b/src/fw/applib/fonts/fonts.h
@@ -38,6 +38,9 @@ GFont fonts_get_fallback_font(void);
 //! @note This may load a font from the flash peripheral into RAM.
 GFont fonts_get_system_font(const char *font_key);
 
+//! @internal
+//! Gets the largest loadable system emoji font whose height is <= font_size.
+//! @return NULL if no such font could be loaded.
 GFont fonts_get_system_emoji_font_for_size(unsigned int font_size);
 
 //! Loads a custom font.

--- a/src/fw/applib/graphics/text_layout.c
+++ b/src/fw/applib/graphics/text_layout.c
@@ -903,7 +903,7 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
             cursor.origin.x += walked_width_px;
 
             if (!codepoint_is_zero_width(rcp)) {
-              text_resources_get_glyph(&ctx->font_cache, rcp, text_box_params->font);
+              text_resources_get_glyph(&ctx->font_cache, rcp, text_box_params->font, NULL);
               render_glyph(ctx, rcp, text_box_params->font, cursor);
             }
 
@@ -949,7 +949,7 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
             cursor.origin.x += walked_width_px;
 
             if (!codepoint_is_zero_width(draw_cp)) {
-              text_resources_get_glyph(&ctx->font_cache, draw_cp, text_box_params->font);
+              text_resources_get_glyph(&ctx->font_cache, draw_cp, text_box_params->font, NULL);
               render_glyph(ctx, draw_cp, text_box_params->font, cursor);
             }
 
@@ -977,7 +977,8 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
         .size.h = fonts_get_font_height(text_box_params->font)
       };
       cursor.origin.x += walked_width_px;
-      text_resources_get_glyph(&ctx->font_cache, line->suffix_codepoint, text_box_params->font);
+      text_resources_get_glyph(&ctx->font_cache, line->suffix_codepoint, text_box_params->font,
+                               NULL);
       render_glyph(ctx, line->suffix_codepoint, text_box_params->font, cursor);
     }
 
@@ -1030,7 +1031,7 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
       if (is_render && !codepoint_is_zero_width(current_draw_cp) &&
           !codepoint_is_unicode_space(current_draw_cp)) {
         // Pre-load here so the deeper render_glyph() is a cache hit, not a deep flash read.
-        text_resources_get_glyph(&ctx->font_cache, current_draw_cp, text_box_params->font);
+        text_resources_get_glyph(&ctx->font_cache, current_draw_cp, text_box_params->font, NULL);
       }
 
       char_visitor_cb(ctx, text_box_params, line, cursor, current_draw_cp);
@@ -1115,7 +1116,8 @@ utf8_t* walk_line(GContext* ctx, Line* line, const TextBoxParams* const text_box
     cursor.origin.x += walked_width_px;
     if (char_visitor_cb) {
       if (is_render) {
-        text_resources_get_glyph(&ctx->font_cache, line->suffix_codepoint, text_box_params->font);
+        text_resources_get_glyph(&ctx->font_cache, line->suffix_codepoint, text_box_params->font,
+                                 NULL);
       }
       char_visitor_cb(ctx, text_box_params, line, cursor, line->suffix_codepoint);
     }

--- a/src/fw/applib/graphics/text_render.c
+++ b/src/fw/applib/graphics/text_render.c
@@ -60,11 +60,16 @@ void render_glyph(GContext* const ctx, const uint32_t codepoint, FontInfo* const
     return;
   }
 
-  const GlyphData* glyph = text_resources_get_glyph(&ctx->font_cache, codepoint, font);
+  int16_t baseline_adjust = 0;
+  const GlyphData* glyph = text_resources_get_glyph(&ctx->font_cache, codepoint, font,
+                                                    &baseline_adjust);
 
   PBL_ASSERTN(glyph);
   // Bitfiddle the metrics data:
   GRect glyph_metrics = get_glyph_rect(glyph);
+  // Sit a substituted glyph on the primary font's baseline. Must happen before the target and
+  // clipping rects are derived from it.
+  glyph_metrics.origin.y += baseline_adjust;
 
   // Calculate the box that we intend to draw to the screen, in screen coordinates
   GRect glyph_target = {

--- a/src/fw/applib/graphics/text_resources.c
+++ b/src/fw/applib/graphics/text_resources.c
@@ -533,24 +533,34 @@ static bool prv_load_font_res(ResAppNum app_num, uint32_t resource_id, FontResou
   return true;
 }
 
+// @param owner_out if non-NULL, receives the FontInfo owning the returned resource. It is a font
+// other than font_info only when the emoji font takes over.
 static const FontResource *prv_font_res_for_codepoint(Codepoint codepoint,
-                                                      const FontInfo *font_info) {
+                                                      const FontInfo *font_info,
+                                                      const FontInfo **owner_out) {
+  const FontInfo *owner = font_info;
+  const FontResource *font_res = &font_info->base;
+
   if (!codepoint_is_latin(codepoint) &&
       !codepoint_is_emoji(codepoint) &&
       !codepoint_is_special(codepoint) &&
       font_info->extended) {
     // Latin & emoji codepoints are in base, others are in extension
-    return (&font_info->extension);
+    font_res = &font_info->extension;
   } else if (codepoint_is_emoji(codepoint) &&
              font_info->base.app_num == SYSTEM_APP) {
-    // Assuming we are using base
-    FontInfo *emoji_font = fonts_get_system_emoji_font_for_size(font_info->max_height);
+    // Size against the base: that is the baseline emoji glyphs get aligned to when drawn
+    FontInfo *emoji_font = fonts_get_system_emoji_font_for_size(font_info->base.md.max_height);
     if (emoji_font) {
-      return &emoji_font->base;
+      owner = emoji_font;
+      font_res = &emoji_font->base;
     }
   }
 
-  return (&font_info->base);
+  if (owner_out) {
+    *owner_out = owner;
+  }
+  return font_res;
 }
 
 static void prv_resource_changed_callback(void *data) {
@@ -589,22 +599,44 @@ bool text_resources_init_font(ResAppNum app_num, uint32_t font_resource,
 // Leaf glyph lookup against a single font. This NEVER consults the fallback font, which is what
 // structurally bounds the fallback to depth 1: the fallback font is looked up with this helper, so
 // it can never trigger a further fallback and no recursion or cycle is possible.
+// @param owner_out if non-NULL, receives the FontInfo the glyph was looked up in
 static const GlyphData *prv_get_glyph_in_font(FontCache *font_cache, Codepoint codepoint,
-                                              FontInfo *font_info, bool need_bitmap) {
-  const FontResource *font_res = prv_font_res_for_codepoint(codepoint, font_info);
+                                              FontInfo *font_info, bool need_bitmap,
+                                              const FontInfo **owner_out) {
+  const FontResource *font_res = prv_font_res_for_codepoint(codepoint, font_info, owner_out);
   prv_check_font_cache(font_cache, font_res);
   return prv_get_glyph_metadata_from_spi(codepoint, font_cache, font_res, need_bitmap);
 }
 
+// A substitute font bakes top_offset against its own baseline (== base max_height for PBF), so
+// drop its glyphs onto ours. Our own base/extension are already aligned; never shift up.
+static int16_t prv_baseline_adjust(const FontInfo *font_info, const FontInfo *owner) {
+  if (owner == NULL || owner == font_info) {
+    return 0;
+  }
+  return MAX(0, (int16_t)font_info->base.md.max_height - (int16_t)owner->base.md.max_height);
+}
+
 static const GlyphData *prv_get_glyph(FontCache *font_cache, Codepoint codepoint,
-                                      FontInfo *font_info, bool need_bitmap) {
+                                      FontInfo *font_info, bool need_bitmap,
+                                      int16_t *baseline_adjust_out) {
+  if (baseline_adjust_out) {
+    *baseline_adjust_out = 0;
+  }
+
   if (!font_info->loaded) {
     sys_font_reload_font(font_info);
   }
 
+  const FontInfo *owner = NULL;
+
   // (a) Requested codepoint in the primary font.
-  const GlyphData *data = prv_get_glyph_in_font(font_cache, codepoint, font_info, need_bitmap);
+  const GlyphData *data = prv_get_glyph_in_font(font_cache, codepoint, font_info, need_bitmap,
+                                                &owner);
   if (data) {
+    if (baseline_adjust_out) {
+      *baseline_adjust_out = prv_baseline_adjust(font_info, owner);
+    }
     return data;
   }
 
@@ -620,8 +652,12 @@ static const GlyphData *prv_get_glyph(FontCache *font_cache, Codepoint codepoint
     if (!fallback->loaded) {
       sys_font_reload_font(fallback);
     }
-    data = prv_get_glyph_in_font(font_cache, codepoint, fallback, need_bitmap);
+    data = prv_get_glyph_in_font(font_cache, codepoint, fallback, need_bitmap, &owner);
     if (data) {
+      // Baseline is still the caller's font, not the fallback's
+      if (baseline_adjust_out) {
+        *baseline_adjust_out = prv_baseline_adjust(font_info, owner);
+      }
       return data;
     }
   }
@@ -633,8 +669,11 @@ static const GlyphData *prv_get_glyph(FontCache *font_cache, Codepoint codepoint
   //     missing-glyph box is the correct indicator.
   const Codepoint substitutes[] = { font_info->base.md.wildcard_codepoint, ' ' };
   for (unsigned int i = 0; i < ARRAY_LENGTH(substitutes); i++) {
-    data = prv_get_glyph_in_font(font_cache, substitutes[i], font_info, need_bitmap);
+    data = prv_get_glyph_in_font(font_cache, substitutes[i], font_info, need_bitmap, &owner);
     if (data) {
+      if (baseline_adjust_out) {
+        *baseline_adjust_out = prv_baseline_adjust(font_info, owner);
+      }
       return data;
     }
   }
@@ -645,7 +684,8 @@ static const GlyphData *prv_get_glyph(FontCache *font_cache, Codepoint codepoint
 int8_t text_resources_get_glyph_horiz_advance(FontCache *font_cache, const Codepoint codepoint,
                                               FontInfo *font_info) {
   // Metadata only: measuring must not pay the deep bitmap load; render pre-loads it in walk_line().
-  const GlyphData *g = prv_get_glyph(font_cache, codepoint, font_info, false /* need_bitmap */);
+  const GlyphData *g = prv_get_glyph(font_cache, codepoint, font_info, false /* need_bitmap */,
+                                     NULL);
   if (!g) {
     return 0;
   }
@@ -653,6 +693,7 @@ int8_t text_resources_get_glyph_horiz_advance(FontCache *font_cache, const Codep
 }
 
 const GlyphData *text_resources_get_glyph(FontCache *font_cache, const Codepoint codepoint,
-                                          FontInfo *font_info) {
-  return prv_get_glyph(font_cache, codepoint, font_info, true /* need_bitmap */);
+                                          FontInfo *font_info, int16_t *baseline_adjust_out) {
+  return prv_get_glyph(font_cache, codepoint, font_info, true /* need_bitmap */,
+                       baseline_adjust_out);
 }

--- a/src/fw/applib/graphics/text_resources.h
+++ b/src/fw/applib/graphics/text_resources.h
@@ -106,8 +106,10 @@ typedef struct FontCache {
   const FontResource *cached_font;
 } FontCache;
 
+//! @param baseline_adjust_out optional: pixels to add to the glyph's top_offset when drawing,
+//! non-zero only when another font (emoji or system fallback) supplied the glyph
 const GlyphData *text_resources_get_glyph(FontCache *font_cache, Codepoint codepoint,
-                                          FontInfo *font_info);
+                                          FontInfo *font_info, int16_t *baseline_adjust_out);
 
 int8_t text_resources_get_glyph_horiz_advance(FontCache *font_cache, Codepoint codepoint,
                                               FontInfo *font_info);

--- a/tests/fw/applib/test_text_render.c
+++ b/tests/fw/applib/test_text_render.c
@@ -20,7 +20,8 @@ GBitmap* graphics_context_get_bitmap(GContext* ctx) { return NULL; }
 void graphics_context_mark_dirty_rect(GContext* ctx, GRect rect) {}
 
 const GlyphData* text_resources_get_glyph(FontCache* font_cache, const Codepoint codepoint,
-                                          FontInfo* fontinfo) { return NULL; }
+                                          FontInfo* fontinfo,
+                                          int16_t *baseline_adjust_out) { return NULL; }
 
 
 extern int32_t prv_convert_1bit_addr_to_8bit_x(GBitmap *dest_bitmap, uint32_t *block_addr,

--- a/tests/fw/applib/test_text_resources.c
+++ b/tests/fw/applib/test_text_resources.c
@@ -43,6 +43,8 @@ static FontInfo s_font_info;
 // lives in test_text_resources_font_stub.c so it resolves at link time without colliding with the
 // in-TU stub.
 extern FontInfo *s_test_fallback_font;
+// Installed emoji font, returned for any named font key (NULL = none, the default).
+extern FontInfo *s_test_emoji_font;
 
 #define FONT_COMPRESSION_FIXTURE_PATH "font_compression"
 
@@ -64,6 +66,7 @@ void test_text_resources__initialize(void) {
   memset(&s_font_info, 0, sizeof(s_font_info));
   memset(&s_font_cache, 0, sizeof(s_font_cache));
   s_test_fallback_font = NULL;
+  s_test_emoji_font = NULL;
 
   FontCache *font_cache = &s_font_cache;
   memset(font_cache->cache_keys, 0, sizeof(font_cache->cache_keys));
@@ -129,15 +132,15 @@ void test_text_resources__get_glyph_multiple(void) {
   uint8_t glyph_size_bytes;
   const GlyphData *glyph;
 
-  glyph = text_resources_get_glyph(&s_font_cache, 'a', &s_font_info);
+  glyph = text_resources_get_glyph(&s_font_cache, 'a', &s_font_info, NULL);
   glyph_size_bytes = glyph_get_size_bytes(glyph);
   cl_assert_equal_m(a_glyph_data_bytes, glyph->data, glyph_size_bytes);
 
-  glyph = text_resources_get_glyph(&s_font_cache, 'b', &s_font_info);
+  glyph = text_resources_get_glyph(&s_font_cache, 'b', &s_font_info, NULL);
   glyph_size_bytes = glyph_get_size_bytes(glyph);
   cl_assert_equal_m(b_glyph_data_bytes, glyph->data, glyph_size_bytes);
 
-  glyph = text_resources_get_glyph(&s_font_cache, 'c', &s_font_info);
+  glyph = text_resources_get_glyph(&s_font_cache, 'c', &s_font_info, NULL);
   glyph_size_bytes = glyph_get_size_bytes(glyph);
   cl_assert_equal_m(c_glyph_data_bytes, glyph->data, glyph_size_bytes);
 }
@@ -163,7 +166,7 @@ void test_text_resources__test_backup_wildcard(void) {
       text_resources_get_glyph_horiz_advance(&s_font_cache, WILDCARD_CODEPOINT, &s_font_info));
 
   const GlyphData *glyph = text_resources_get_glyph(&s_font_cache,
-                                                    WILDCARD_CODEPOINT, &s_font_info);
+                                                    WILDCARD_CODEPOINT, &s_font_info, NULL);
   cl_assert_equal_i(glyph->header.width_px, 5);
   cl_assert_equal_i(glyph->header.height_px, 12);
   uint8_t glyph_size_bytes = glyph_get_size_bytes(glyph);
@@ -185,7 +188,7 @@ void test_text_resources__test_gothic_wildcard(void) {
 
   const GlyphData *glyph = text_resources_get_glyph(&s_font_cache,
                                                     WILDCARD_CODEPOINT,
-                                                    &s_font_info);
+                                                    &s_font_info, NULL);
   cl_assert_equal_i(glyph->header.width_px, 7);
   cl_assert_equal_i(glyph->header.height_px, 15);
   uint8_t glyph_size_bytes = glyph_get_size_bytes(glyph);
@@ -209,18 +212,18 @@ void test_text_resources__extended_font(void) {
   uint8_t glyph_size_bytes;
   const GlyphData *glyph;
 
-  glyph = text_resources_get_glyph(&s_font_cache, 'a', &s_font_info);
+  glyph = text_resources_get_glyph(&s_font_cache, 'a', &s_font_info, NULL);
   cl_assert(glyph != NULL);
   glyph_size_bytes = glyph_get_size_bytes(glyph);
   cl_assert_equal_m(a_glyph_data_bytes, glyph->data, glyph_size_bytes);
 
-  glyph = text_resources_get_glyph(&s_font_cache, 0x4E50 /* 乐 */, &s_font_info);
+  glyph = text_resources_get_glyph(&s_font_cache, 0x4E50 /* 乐 */, &s_font_info, NULL);
   // the chinese pbpack contains the letter 你, it should succeed
   cl_assert(glyph != NULL);
   glyph_size_bytes = glyph_get_size_bytes(glyph);
   cl_assert_equal_m(chinese_glyph_data_bytes, glyph->data, glyph_size_bytes);
 
-  glyph = text_resources_get_glyph(&s_font_cache, 0x8888 /* 袈 */, &s_font_info);
+  glyph = text_resources_get_glyph(&s_font_cache, 0x8888 /* 袈 */, &s_font_info, NULL);
   // the chinese pbpack does not contain the letter 袈, it should return the wildcard
   cl_assert(glyph != NULL);
   glyph_size_bytes = glyph_get_size_bytes(glyph);
@@ -237,7 +240,7 @@ void test_text_resources__test_emoji_font(void) {
   const GlyphData *glyph;
 
   const Codepoint PHONE_CODEPOINT = 0x260E;
-  glyph = text_resources_get_glyph(&s_font_cache, PHONE_CODEPOINT, &s_font_info);
+  glyph = text_resources_get_glyph(&s_font_cache, PHONE_CODEPOINT, &s_font_info, NULL);
   cl_assert(glyph != NULL);
   glyph_size_bytes = glyph_get_size_bytes(glyph);
   cl_assert_equal_m(phone_bytes, glyph->data, glyph_size_bytes);
@@ -253,7 +256,7 @@ void DISABLED_test_text_resources__test_emoji_fallback(void) {
   const GlyphData *glyph;
 
   const Codepoint PHONE_CODEPOINT = 0x260E;
-  glyph = text_resources_get_glyph(&s_font_cache, PHONE_CODEPOINT, &s_font_info);
+  glyph = text_resources_get_glyph(&s_font_cache, PHONE_CODEPOINT, &s_font_info, NULL);
   cl_assert(glyph != NULL);
   glyph_size_bytes = glyph_get_size_bytes(glyph);
   cl_assert_equal_m(phone_bytes, glyph->data, glyph_size_bytes);
@@ -273,7 +276,7 @@ void test_text_resources__per_glyph_fallback(void) {
   // Baseline with no fallback: 0x4E50 misses -> gothic wildcard, NOT the CJK glyph.
   const uint8_t gothic_wildcard[] = {0xff, 0x60, 0x30, 0x18, 0x0c, 0x06, 0x83, 0xc1,
                                      0x60, 0x30, 0x18, 0x0c, 0xfe, 0x01};
-  const GlyphData *g0 = text_resources_get_glyph(&s_font_cache, 0x4E50, &s_font_info);
+  const GlyphData *g0 = text_resources_get_glyph(&s_font_cache, 0x4E50, &s_font_info, NULL);
   cl_assert(g0 != NULL);
   cl_assert_equal_m(gothic_wildcard, g0->data, glyph_get_size_bytes(g0));
 
@@ -292,9 +295,87 @@ void test_text_resources__per_glyph_fallback(void) {
   const uint8_t cjk_bytes[] = {0x00, 0x0C, 0xE2, 0x01, 0x0F, 0x80, 0x30, 0x40, 0x08, 0x10, 0x04,
                                0x08, 0x82, 0xFC, 0xFF, 0x80, 0x00, 0x44, 0x00, 0x26, 0x01, 0x11,
                                0x41, 0x08, 0x11, 0x84, 0x04, 0x82, 0xC0, 0x01, 0x40, 0x00};
-  const GlyphData *g1 = text_resources_get_glyph(&s_font_cache, 0x4E50, &s_font_info);
+  const GlyphData *g1 = text_resources_get_glyph(&s_font_cache, 0x4E50, &s_font_info, NULL);
   cl_assert(g1 != NULL);
   cl_assert_equal_m(cjk_bytes, g1->data, glyph_get_size_bytes(g1));  // real fallback glyph
+}
+
+// A glyph served by the system fallback font reports a positive baseline adjust, so the renderer
+// can drop it onto the primary font's baseline instead of the fallback font's.
+void test_text_resources__baseline_adjust_for_fallback_font(void) {
+  // primary: gothic 24, no extension -> lacks CJK 0x4E50
+  cl_assert(text_resources_init_font(0, RESOURCE_ID_GOTHIC_24, 0, &s_font_info));
+
+  // A glyph from the primary font itself needs no adjust.
+  int16_t adjust = -1;
+  const GlyphData *g0 = text_resources_get_glyph(&s_font_cache, 'a', &s_font_info, &adjust);
+  cl_assert(g0 != NULL);
+  cl_assert_equal_i(adjust, 0);
+
+  // Install a shorter fallback (gothic 18 + extended) that carries 0x4E50.
+  static FontInfo s_fallback;
+  memset(&s_fallback, 0, sizeof(s_fallback));
+  cl_assert(text_resources_init_font(0, RESOURCE_ID_GOTHIC_18,
+                                     RESOURCE_ID_GOTHIC_18_EXTENDED, &s_fallback));
+  s_test_fallback_font = &s_fallback;
+
+  // Fresh cache so the primary negative-cache entry does not short-circuit.
+  memset(&s_font_cache, 0, sizeof(s_font_cache));
+  keyed_circular_cache_init(&s_font_cache.line_cache, s_font_cache.cache_keys,
+                            s_font_cache.cache_data, sizeof(LineCacheData), LINE_CACHE_SIZE);
+
+  // The reference is the fallback font's own baseline, i.e. its BASE resource height.
+  const int16_t expected = (int16_t)s_font_info.base.md.max_height -
+                           (int16_t)s_fallback.base.md.max_height;
+  cl_assert(expected > 0);  // premise: the fallback really is shorter
+
+  adjust = -1;
+  const GlyphData *g1 = text_resources_get_glyph(&s_font_cache, 0x4E50, &s_font_info, &adjust);
+  cl_assert(g1 != NULL);
+  cl_assert_equal_i(adjust, expected);
+}
+
+// Regression: an extension is part of the SAME font and its glyph offsets are already baked
+// against that font's base baseline, so a short extension (as shipped for ar_SA, where a 36px
+// font carries a 20px-tall extension) must never be pushed down.
+void test_text_resources__baseline_adjust_zero_for_own_extension(void) {
+  // gothic 36 base with a much shorter extension, mimicking the ar_SA font pack
+  cl_assert(text_resources_init_font(0, RESOURCE_ID_GOTHIC_36,
+                                     RESOURCE_ID_GOTHIC_18_EXTENDED, &s_font_info));
+  cl_assert(s_font_info.extended);
+  // premise: the extension really is shorter than the base
+  cl_assert(s_font_info.extension.md.max_height < s_font_info.base.md.max_height);
+
+  // Compare against the extension's own glyph bytes, so a wildcard from the base cannot pass.
+  const uint8_t cjk_bytes[] = {0x00, 0x0C, 0xE2, 0x01, 0x0F, 0x80, 0x30, 0x40, 0x08, 0x10, 0x04,
+                               0x08, 0x82, 0xFC, 0xFF, 0x80, 0x00, 0x44, 0x00, 0x26, 0x01, 0x11,
+                               0x41, 0x08, 0x11, 0x84, 0x04, 0x82, 0xC0, 0x01, 0x40, 0x00};
+  int16_t adjust = -1;
+  const GlyphData *g = text_resources_get_glyph(&s_font_cache, 0x4E50, &s_font_info, &adjust);
+  cl_assert(g != NULL);
+  cl_assert_equal_m(cjk_bytes, g->data, glyph_get_size_bytes(g));
+  cl_assert_equal_i(adjust, 0);
+}
+
+// The case this all exists for: a 36px font has no emoji font of its own size, so the 28px one
+// takes over and its glyphs must be dropped 8px to reach the 36px baseline.
+void test_text_resources__baseline_adjust_for_emoji_font(void) {
+  cl_assert(text_resources_init_font(0, RESOURCE_ID_GOTHIC_36, 0, &s_font_info));
+  cl_assert_equal_i(s_font_info.base.md.max_height, 36);
+
+  // fonts_get_system_emoji_font_for_size(36) picks the 28px emoji font, which this stub serves.
+  static FontInfo s_emoji;
+  memset(&s_emoji, 0, sizeof(s_emoji));
+  cl_assert(text_resources_init_font(0, RESOURCE_ID_GOTHIC_28_EMOJI, 0, &s_emoji));
+  cl_assert_equal_i(s_emoji.base.md.max_height, 28);
+  s_test_emoji_font = &s_emoji;
+
+  const Codepoint PHONE_CODEPOINT = 0x260E;
+  int16_t adjust = -1;
+  const GlyphData *g = text_resources_get_glyph(&s_font_cache, PHONE_CODEPOINT, &s_font_info,
+                                                &adjust);
+  cl_assert(g != NULL);
+  cl_assert_equal_i(adjust, 8);  // 36px primary baseline - 28px emoji font baseline
 }
 
 // A codepoint present in the primary font is served by the primary font; the fallback is not
@@ -308,7 +389,7 @@ void test_text_resources__fallback_not_used_when_present(void) {
   keyed_circular_cache_init(&s_font_cache.line_cache, s_font_cache.cache_keys,
                             s_font_cache.cache_data, sizeof(LineCacheData), LINE_CACHE_SIZE);
 
-  const GlyphData *primary_g = text_resources_get_glyph(&s_font_cache, 'a', &s_font_info);
+  const GlyphData *primary_g = text_resources_get_glyph(&s_font_cache, 'a', &s_font_info, NULL);
   cl_assert(primary_g != NULL);
   uint8_t primary_size = glyph_get_size_bytes(primary_g);
 
@@ -330,7 +411,7 @@ void test_text_resources__fallback_not_used_when_present(void) {
   keyed_circular_cache_init(&s_font_cache.line_cache, s_font_cache.cache_keys,
                             s_font_cache.cache_data, sizeof(LineCacheData), LINE_CACHE_SIZE);
 
-  const GlyphData *fallback_g = text_resources_get_glyph(&s_font_cache, 'a', &s_fallback);
+  const GlyphData *fallback_g = text_resources_get_glyph(&s_font_cache, 'a', &s_fallback, NULL);
   cl_assert(fallback_g != NULL);
   uint8_t fallback_size = glyph_get_size_bytes(fallback_g);
 
@@ -350,7 +431,7 @@ void test_text_resources__fallback_not_used_when_present(void) {
   keyed_circular_cache_init(&s_font_cache.line_cache, s_font_cache.cache_keys,
                             s_font_cache.cache_data, sizeof(LineCacheData), LINE_CACHE_SIZE);
 
-  const GlyphData *result_g = text_resources_get_glyph(&s_font_cache, 'a', &s_font_info);
+  const GlyphData *result_g = text_resources_get_glyph(&s_font_cache, 'a', &s_font_info, NULL);
   cl_assert(result_g != NULL);
   cl_assert_equal_i(glyph_get_size_bytes(result_g), primary_size);
   cl_assert_equal_m(primary_bytes, result_g->data, primary_size);
@@ -364,7 +445,7 @@ void test_text_resources__fallback_self_reference(void) {
 
   const uint8_t gothic_wildcard[] = {0xff, 0x60, 0x30, 0x18, 0x0c, 0x06, 0x83, 0xc1,
                                      0x60, 0x30, 0x18, 0x0c, 0xfe, 0x01};
-  const GlyphData *g = text_resources_get_glyph(&s_font_cache, 0x4E50, &s_font_info);
+  const GlyphData *g = text_resources_get_glyph(&s_font_cache, 0x4E50, &s_font_info, NULL);
   cl_assert(g != NULL);                 // returns primary wildcard, no hang
   cl_assert_equal_m(gothic_wildcard, g->data, glyph_get_size_bytes(g));
 }
@@ -380,7 +461,8 @@ void test_text_resources__fallback_miss_yields_primary_wildcard(void) {
 
   const uint8_t gothic_wildcard[] = {0xff, 0x60, 0x30, 0x18, 0x0c, 0x06, 0x83, 0xc1,
                                      0x60, 0x30, 0x18, 0x0c, 0xfe, 0x01};
-  const GlyphData *g = text_resources_get_glyph(&s_font_cache, 0x8888 /* absent */, &s_font_info);
+  const GlyphData *g = text_resources_get_glyph(&s_font_cache, 0x8888 /* absent */, &s_font_info,
+                                                NULL);
   cl_assert(g != NULL);
   cl_assert_equal_m(gothic_wildcard, g->data, glyph_get_size_bytes(g));
 }
@@ -440,13 +522,14 @@ void test_text_resources__test_glyph_decompression(void) {
     for (unsigned codepoint = codepoint_range[index].start;
          codepoint <= codepoint_range[index].end; ++codepoint) {
 
-      const GlyphData *glyph = text_resources_get_glyph(&s_font_cache, codepoint, &s_font_info);
+      const GlyphData *glyph = text_resources_get_glyph(&s_font_cache, codepoint, &s_font_info,
+                                                        NULL);
       cl_assert(glyph);
 
       unsigned glyph_size = sizeof(GlyphHeaderData) + glyph_get_size_bytes(glyph);
       memcpy(glyph_buffer, glyph->data, glyph_size);
 
-      glyph = text_resources_get_glyph(&s_font_cache, codepoint, &font_info_compressed);
+      glyph = text_resources_get_glyph(&s_font_cache, codepoint, &font_info_compressed, NULL);
       cl_assert(glyph);
 
       cl_assert_equal_m(glyph->data, glyph_buffer, glyph_size);

--- a/tests/fw/applib/test_text_resources_font_stub.c
+++ b/tests/fw/applib/test_text_resources_font_stub.c
@@ -11,9 +11,14 @@
 
 FontInfo *s_test_fallback_font;
 
+// The only named keys the code under test asks for are the system emoji fonts, requested through
+// fonts_get_system_emoji_font_for_size(); a test installs one by pointing s_test_emoji_font at its
+// own FontInfo.
+FontInfo *s_test_emoji_font;
+
 GFont sys_font_get_system_font(const char *key) {
   if (key == NULL) {
     return s_test_fallback_font;
   }
-  return NULL;
+  return s_test_emoji_font;
 }

--- a/tests/stubs/stubs_text_resources.h
+++ b/tests/stubs/stubs_text_resources.h
@@ -31,7 +31,11 @@ int8_t text_resources_get_glyph_height(FontCache* font_cache, Codepoint codepoin
   return 10;
 }
 
-const GlyphData *text_resources_get_glyph(FontCache* font_cache, Codepoint codepoint, FontInfo* fontinfo) {
+const GlyphData *text_resources_get_glyph(FontCache* font_cache, Codepoint codepoint,
+                                          FontInfo* fontinfo, int16_t *baseline_adjust_out) {
+  if (baseline_adjust_out) {
+    *baseline_adjust_out = 0;
+  }
   return NULL;
 }
 


### PR DESCRIPTION
On boards where the "Larger" text size maps to GOTHIC_36 (display height >= 200, e.g. obelix), emoji in notifications come out tiny and stuck to the top of the line. Medium size is unaffected.

| Large, before | Medium (unaffected) | Large, after |
|---|---|---|
| <img width="200" alt="large text size, before: tiny top-aligned emoji" src="https://github.com/user-attachments/assets/4e5906c2-f9bd-44dd-8438-141afe7aa88c" /> | <img width="200" alt="medium text size: emoji renders correctly" src="https://github.com/user-attachments/assets/7b5d45a0-b8cd-4b36-abbe-faf98d62665c" /> | <img width="200" alt="large text size, after: emoji on the baseline" src="https://github.com/user-attachments/assets/bb6f6c29-3901-469c-a88f-99e052e27242" /> |

What happens: there is no EMOJI_36 resource, and `fonts_get_system_emoji_font_for_size()` requires an exact height match, so a 36px font gets no emoji font at all. The lookup then falls through to GOTHIC_36.pbf, which only has the ~98 legacy emoji, so any modern emoji ends up being served by the built-in 14px fallback font. Since `render_glyph()` places glyphs at `cursor.y + top_offset_px`, and top_offset is baked against the source font's own baseline, a 14px glyph on a 36px line lands ~22px too high.

Two commits:

1. fw/fonts: emoji font selection picks the largest emoji font that fits (<= requested height) instead of exact match, so 36px text uses EMOJI_28.

2. fw/graphics: glyphs served by a different font (emoji font or the system fallback) get shifted down onto the primary font's baseline at draw time. The shift is keyed on the owning FontInfo, not the resource, so a language pack's own extension is never shifted — extensions already bake their offsets against the base font's baseline while recording a smaller max_height in the PBF header (the shipped ar_SA pack does exactly that, with pixelHeight 12..20 against bases 14..36; shifting by resource height would have moved Arabic text down by up to 16px). Details in the commit message.

Nothing is written into the glyph cache, layout/line heights and horizontal advance are unchanged, and no resources or applib struct layouts are touched.

Tested: `./pbl build` (obelix) and the full `./pbl test` suite pass; each commit builds on its own. Added three unit tests in test_text_resources.c covering the emoji substitution (36 -> 28 -> adjust 8), the system fallback path, and a regression guard that a font's own extension yields adjust 0 (the ar_SA case). Verified on a real watch that emoji now sit on the baseline at the largest text size.

Not touched here: GOTHIC_36.pbf itself has '#' (U+0023) baked with top_offset 6 where the rest of the font uses 14, so '#' floats above the baseline at this size. That's an asset defect (GOTHIC_36_BOLD and all other sizes are fine) and needs a font asset fix, not a renderer change — done separately in #1768.
