### PR TITLE
fw/services/activity: fire sleep summary notification once per sleep window

### DIFF
--- a/include/pbl/services/activity/activity_private.h
+++ b/include/pbl/services/activity/activity_private.h
@@ -449,6 +449,10 @@ bool activity_test_reset(bool reset_settings, bool tracking_on,
 // Load in the stored activities from our settings file
 void activity_sessions_prv_init(SettingsFile *file, time_t utc_now);
 
+// Get the start of the sleep-day window (the ACTIVITY_LAST_SLEEP_MINUTE_OF_DAY local-time
+// cutoff) that now_utc belongs to
+time_t activity_sessions_prv_get_sleep_window_start_utc(time_t now_utc);
+
 // Get the UTC time bounds for the current day
 void activity_sessions_prv_get_sleep_bounds_utc(time_t now_utc, time_t *enter_utc,
                                                 time_t *exit_utc);

--- a/src/fw/services/activity/activity_insights.c
+++ b/src/fw/services/activity/activity_insights.c
@@ -48,6 +48,11 @@ PBL_LOG_MODULE_DECLARE(service_activity, CONFIG_SERVICE_ACTIVITY_LOG_LEVEL);
 #define NUM_COPY_VARIANTS 5
 #define VARIANT_RANDOM (-1)
 
+// The sleep summary notification only fires when the sleep exit lands within this local
+// time-of-day window ([min, max)). The timeline pin is updated regardless.
+#define SLEEP_SUMMARY_NOTIF_WAKE_MINUTE_MIN (4 * MINUTES_PER_HOUR)
+#define SLEEP_SUMMARY_NOTIF_WAKE_MINUTE_MAX (18 * MINUTES_PER_HOUR)
+
 typedef struct NotificationConfig {
   time_t notif_time;
   ActivitySession *session;
@@ -128,6 +133,10 @@ typedef struct SleepPinState {
   int active_minutes;
   bool removed;
   bool notified;
+  // Start of the sleep-day window this state belongs to. The summary notification fires at
+  // most once per window, no matter how often the sleep bounds change within it.
+  // Note: must stay the last field so older persisted states fail to restore cleanly.
+  time_t window_utc;
 } SleepPinState;
 static SleepPinState s_sleep_pin_state;
 
@@ -1002,6 +1011,16 @@ static void prv_do_sleep_notification(time_t now_utc, time_t sleep_exit_utc,
     return;
   }
 
+  // Only notify when the sleep exit lands at a plausible local wake-up time. Skipping does
+  // not consume this window's notification, so a real morning wake-up still notifies.
+  const int exit_minute_of_day = time_util_get_minute_of_day(sleep_exit_utc);
+  if (exit_minute_of_day < SLEEP_SUMMARY_NOTIF_WAKE_MINUTE_MIN ||
+      exit_minute_of_day >= SLEEP_SUMMARY_NOTIF_WAKE_MINUTE_MAX) {
+    INSIGHTS_LOG_DEBUG("Not notifying sleep pin - exit outside wake window (%d)",
+                       exit_minute_of_day);
+    return;
+  }
+
   // Notify about the pin after a certain amount of time
   const time_t since_exited = now_utc - sleep_exit_utc;
   if (since_exited < s_sleep_summary_settings.summary.sleep.trigger_notif_seconds) {
@@ -1056,17 +1075,20 @@ static void prv_do_sleep_summary(time_t now_utc) {
     return;
   }
 
-  // If we have a new sleep_enter_utc, we must have started a new day so invalidate the
-  // old sleep pin state
-  if (sleep_enter_utc != s_sleep_pin_state.first_enter_utc
+  // The pin state is keyed to the sleep-day window: only a new window invalidates it.
+  // Bounds changes within one window (merged sessions, evening extensions) update the pin
+  // below without re-arming the notification.
+  const time_t window_utc = activity_sessions_prv_get_sleep_window_start_utc(now_utc);
+  if (window_utc != s_sleep_pin_state.window_utc
       || now_utc < s_sleep_pin_state.last_triggered_utc) {
     // Checking "now_utc < s_sleep_pin_state.last_triggered_utc" catches cases where
     // the activity_test integration test might have created a pin in the future (because it
     // mucks with the real time clock)
-    INSIGHTS_LOG_DEBUG("Starting pin for new day");
+    INSIGHTS_LOG_DEBUG("Starting pin for new sleep window");
     s_sleep_pin_state = (SleepPinState) {
       .uuid = UUID_INVALID,
       .first_enter_utc = sleep_enter_utc,
+      .window_utc = window_utc,
     };
   }
 
@@ -1084,16 +1106,18 @@ static void prv_do_sleep_summary(time_t now_utc) {
   int32_t sleep_total_seconds = 0;
   activity_get_metric(ActivityMetricSleepTotalSeconds, 1, &sleep_total_seconds);
 
-  // If this is a session we've already created a pin for, send the notification for it now if
-  // we haven't already.
-  if (sleep_exit_utc <= s_sleep_pin_state.last_triggered_utc) {
+  // If the bounds haven't changed since we last pushed the pin, send the notification for it
+  // now if we haven't already.
+  if (sleep_exit_utc <= s_sleep_pin_state.last_triggered_utc
+      && sleep_enter_utc == s_sleep_pin_state.first_enter_utc) {
     // Notify about the sleep pin
     prv_do_sleep_notification(now_utc, sleep_exit_utc, sleep_total_seconds);
     INSIGHTS_LOG_DEBUG("Not adding sleep pin - already checked session %ld", sleep_exit_utc);
     return;
   }
 
-  // Insert or update the pin
+  // Insert or update the pin. This intentionally leaves "notified" untouched: within one
+  // sleep window the notification fires at most once, however often the bounds extend.
   INSIGHTS_LOG_DEBUG("Adding sleep pin");
   prv_push_sleep_summary_pin(now_utc, sleep_exit_utc, sleep_enter_seconds, sleep_exit_seconds,
                              sleep_total_seconds, s_sleep_stats.mean,
@@ -1101,8 +1125,8 @@ static void prv_do_sleep_summary(time_t now_utc) {
 
   // Update sleep pin state
   s_sleep_pin_state.last_triggered_utc = sleep_exit_utc;
+  s_sleep_pin_state.first_enter_utc = sleep_enter_utc;
   s_sleep_pin_state.active_minutes = 0;
-  s_sleep_pin_state.notified = false;
 
   prv_save_state(ActivitySettingsKeyInsightSleepSummaryState, &s_sleep_pin_state,
                  sizeof(s_sleep_pin_state));
@@ -2014,6 +2038,14 @@ void activity_insights_init(time_t now_utc) {
                       &s_session_pin_state.start_utc,
                       sizeof(s_session_pin_state.start_utc));
     activity_private_settings_close(file);
+  }
+
+  // A restored sleep pin state always has a valid window. If it doesn't (fresh boot, factory
+  // reset or a state layout change), treat the in-progress window as already notified so the
+  // next bounds recalculation can't re-notify for sleep the user already saw.
+  if (s_sleep_pin_state.window_utc == 0) {
+    s_sleep_pin_state.window_utc = activity_sessions_prv_get_sleep_window_start_utc(now_utc);
+    s_sleep_pin_state.notified = true;
   }
 
   INSIGHTS_LOG_DEBUG("Last sleep reward state: %ld",

--- a/src/fw/services/activity/activity_insights.c
+++ b/src/fw/services/activity/activity_insights.c
@@ -322,7 +322,7 @@ static bool prv_save_state(ActivitySettingsKey key, void *val, size_t val_len) {
 static void prv_build_notification_attr_list(AttributeList *attr_list, const char *body,
                                              uint32_t icon, ActivityInsightType insight_type,
                                              ActivitySessionType activity_type) {
-  attribute_list_add_uint32(attr_list, AttributeIdIconTiny, icon);
+  attribute_list_add_resource_id(attr_list, AttributeIdIconTiny, icon);
   attribute_list_add_cstring(attr_list, AttributeIdBody, body);
   attribute_list_add_uint8(attr_list, AttributeIdBgColor, GColorOrangeARGB8);
   attribute_list_add_uint8(attr_list, AttributeIdHealthInsightType, insight_type);

--- a/src/fw/services/activity/activity_sessions.c
+++ b/src/fw/services/activity/activity_sessions.c
@@ -456,22 +456,25 @@ unlock:
 
 
 // --------------------------------------------------------------------------------------------
-void activity_sessions_prv_get_sleep_bounds_utc(time_t now_utc, time_t *enter_utc,
-                                                time_t *exit_utc) {
-  // Get useful UTC times
+time_t activity_sessions_prv_get_sleep_window_start_utc(time_t now_utc) {
   time_t start_of_today_utc = time_util_get_midnight_of(now_utc);
   int minute_of_day = time_util_get_minute_of_day(now_utc);
   int last_sleep_second_of_day = ACTIVITY_LAST_SLEEP_MINUTE_OF_DAY * SECONDS_PER_MINUTE;
 
-  int first_sleep_utc;
   if (minute_of_day < ACTIVITY_LAST_SLEEP_MINUTE_OF_DAY) {
     // It is before the ACTIVITY_LAST_SLEEP_MINUTE_OF_DAY (currently 9pm) cutoff, so use
-    // the previou day's cutoff
-    first_sleep_utc = start_of_today_utc - (SECONDS_PER_DAY - last_sleep_second_of_day);
+    // the previous day's cutoff
+    return start_of_today_utc - (SECONDS_PER_DAY - last_sleep_second_of_day);
   } else {
     // It is after 9pm, so use the 9pm cutoff
-    first_sleep_utc = start_of_today_utc + last_sleep_second_of_day;
+    return start_of_today_utc + last_sleep_second_of_day;
   }
+}
+
+// --------------------------------------------------------------------------------------------
+void activity_sessions_prv_get_sleep_bounds_utc(time_t now_utc, time_t *enter_utc,
+                                                time_t *exit_utc) {
+  time_t first_sleep_utc = activity_sessions_prv_get_sleep_window_start_utc(now_utc);
 
   // Compute stats for today
   ActivitySleepStats stats;

--- a/tests/fw/services/activity/test_activity_insights.c
+++ b/tests/fw/services/activity/test_activity_insights.c
@@ -118,6 +118,18 @@ static void prv_update_sleep_metrics(void) {
 }
 
 
+time_t activity_sessions_prv_get_sleep_window_start_utc(time_t now_utc) {
+  time_t start_of_today_utc = time_util_get_midnight_of(now_utc);
+  int minute_of_day = time_util_get_minute_of_day(now_utc);
+  int last_sleep_second_of_day = ACTIVITY_LAST_SLEEP_MINUTE_OF_DAY * SECONDS_PER_MINUTE;
+
+  if (minute_of_day < ACTIVITY_LAST_SLEEP_MINUTE_OF_DAY) {
+    return start_of_today_utc - (SECONDS_PER_DAY - last_sleep_second_of_day);
+  }
+  return start_of_today_utc + last_sleep_second_of_day;
+}
+
+
 void activity_sessions_prv_get_sleep_bounds_utc(time_t now_utc, time_t *enter_utc, time_t *exit_utc) {
   ActivitySession activity_sessions[MAX_ACTIVITY_SESSIONS];
   uint32_t num_sessions = MAX_ACTIVITY_SESSIONS;
@@ -910,4 +922,153 @@ void test_activity_insights__walk_session_power_cycle(void) {
   rtc_set_time(rtc_get_time() + 2 * SECONDS_PER_HOUR);
   activity_insights_process_minute_data(rtc_get_time());
   cl_assert_equal_i(s_data.notifs_shown, 2);
+}
+
+// ---------------------------------------------------------------------------------------
+// Helpers for the sleep summary notification tests
+static void prv_use_utc_timezone(void) {
+  static TimezoneInfo tz = {
+    .tm_gmtoff = 0,
+  };
+  time_util_update_timezone(&tz);
+  prv_set_time(&s_init_time_tm);
+}
+
+// ---------------------------------------------------------------------------------------
+// Within one sleep window (9pm-to-9pm local) the summary notification fires at most once,
+// even when a later (false) sleep session extends the day's sleep bounds. The pin still
+// updates silently.
+void test_activity_insights__sleep_summary_no_renotify_same_window(void) {
+  prv_use_utc_timezone();
+  prv_set_sleep_history_avg();
+
+  // Init at Thursday 10:00am, then advance to 11:30pm - past the 9pm cutoff, so Thursday
+  // night's sleep window has started
+  activity_insights_init(rtc_get_time());
+  rtc_set_time(rtc_get_time() + 13 * SECONDS_PER_HOUR + 30 * SECONDS_PER_MINUTE);
+
+  // Sleep 10pm-11pm, awake at 11:30pm: pushes tonight's pin, no notification yet
+  prv_add_sleep_session(22, 1);
+  s_data.metric_history[ActivityMetricSleepState][0] = ActivitySleepStateAwake;
+  s_data.metric_history[ActivityMetricSleepStateSeconds][0] = 30 * SECONDS_PER_MINUTE;
+  activity_insights_process_sleep_data(rtc_get_time());
+  cl_assert_equal_i(s_data.pins_added, 1);
+  Uuid orig_id = s_last_timeline_id;
+  cl_assert_equal_i(fake_kernel_services_notifications_ancs_notifications_count(), 0);
+
+  // Advance past midnight, sleep midnight-7am, awake at 7:05am Friday - same sleep window
+  rtc_set_time(rtc_get_time() + 30 * SECONDS_PER_MINUTE);
+  activity_insights_recalculate_stats();
+  rtc_set_time(rtc_get_time() + 7 * SECONDS_PER_HOUR + 5 * SECONDS_PER_MINUTE);
+  prv_add_sleep_session(1, 7);
+  activity_insights_process_sleep_data(rtc_get_time());
+  cl_assert_equal_i(s_data.pins_added, 2);
+  cl_assert(uuid_equal(&orig_id, &s_last_timeline_id));
+
+  // Be active for a couple of minutes, then pass the 30 minute post-wake mark: the summary
+  // notification fires exactly once
+  s_data.steps_per_minute = 80;
+  prv_minute_update(2);
+  rtc_set_time(rtc_get_time() + 28 * SECONDS_PER_MINUTE);
+  activity_insights_process_sleep_data(rtc_get_time());
+  cl_assert_equal_i(fake_kernel_services_notifications_ancs_notifications_count(), 1);
+
+  // Same window, hours later: a false sleep session 4:30pm-5:30pm extends the bounds. The
+  // pin updates in place but no second notification may fire.
+  rtc_set_time(rtc_get_time() + 10 * SECONDS_PER_HOUR + 25 * SECONDS_PER_MINUTE);
+  prv_add_sleep_session(9.5, 1);
+  activity_insights_process_sleep_data(rtc_get_time());
+  cl_assert_equal_i(s_data.pins_added, 3);
+  cl_assert(uuid_equal(&orig_id, &s_last_timeline_id));
+
+  // Stay active past the 30 minute post-exit mark - still only one notification
+  prv_minute_update(2);
+  activity_insights_process_sleep_data(rtc_get_time());
+  cl_assert_equal_i(fake_kernel_services_notifications_ancs_notifications_count(), 1);
+}
+
+// ---------------------------------------------------------------------------------------
+// A new sleep window (past the 9pm cutoff) resets the notification guard: the next night's
+// sleep notifies again
+void test_activity_insights__sleep_summary_notify_next_window(void) {
+  prv_use_utc_timezone();
+  prv_set_sleep_history_avg();
+
+  activity_insights_init(rtc_get_time());
+  rtc_set_time(rtc_get_time() + 13 * SECONDS_PER_HOUR + 30 * SECONDS_PER_MINUTE);
+
+  s_data.metric_history[ActivityMetricSleepState][0] = ActivitySleepStateAwake;
+  s_data.metric_history[ActivityMetricSleepStateSeconds][0] = 30 * SECONDS_PER_MINUTE;
+
+  // Night 1: sleep 10pm-11pm Thursday and midnight-7am Friday, notification at 7:35am
+  prv_add_sleep_session(22, 1);
+  activity_insights_process_sleep_data(rtc_get_time());
+  rtc_set_time(rtc_get_time() + 30 * SECONDS_PER_MINUTE);
+  activity_insights_recalculate_stats();
+  rtc_set_time(rtc_get_time() + 7 * SECONDS_PER_HOUR + 5 * SECONDS_PER_MINUTE);
+  prv_add_sleep_session(1, 7);
+  activity_insights_process_sleep_data(rtc_get_time());
+  s_data.steps_per_minute = 80;
+  prv_minute_update(2);
+  rtc_set_time(rtc_get_time() + 28 * SECONDS_PER_MINUTE);
+  activity_insights_process_sleep_data(rtc_get_time());
+  cl_assert_equal_i(fake_kernel_services_notifications_ancs_notifications_count(), 1);
+  Uuid night1_id = s_last_timeline_id;
+
+  // Night 2: 11pm-11:30pm Friday is past the 9pm cutoff, starting a new sleep window with
+  // a new pin
+  rtc_set_time(rtc_get_time() + 16 * SECONDS_PER_HOUR + 15 * SECONDS_PER_MINUTE);
+  prv_add_sleep_session(16, 0.5);
+  activity_insights_process_sleep_data(rtc_get_time());
+  cl_assert(!uuid_equal(&night1_id, &s_last_timeline_id));
+
+  // Sleep midnight-6:30am Saturday; the notification fires again for the new window
+  rtc_set_time(rtc_get_time() + 6 * SECONDS_PER_HOUR + 45 * SECONDS_PER_MINUTE);
+  prv_add_sleep_session(0.5, 6.5);
+  activity_insights_process_sleep_data(rtc_get_time());
+  prv_minute_update(2);
+  rtc_set_time(rtc_get_time() + 28 * SECONDS_PER_MINUTE);
+  activity_insights_process_sleep_data(rtc_get_time());
+  cl_assert_equal_i(fake_kernel_services_notifications_ancs_notifications_count(), 2);
+}
+
+// ---------------------------------------------------------------------------------------
+// A sleep exit in the middle of the night is not a plausible wake-up, so it must not notify.
+// Skipping must not consume the window's notification: the real morning wake-up still does.
+void test_activity_insights__sleep_summary_notification_wake_window_gate(void) {
+  prv_use_utc_timezone();
+  prv_set_sleep_history_avg();
+
+  activity_insights_init(rtc_get_time());
+  rtc_set_time(rtc_get_time() + 13 * SECONDS_PER_HOUR + 30 * SECONDS_PER_MINUTE);
+
+  s_data.metric_history[ActivityMetricSleepState][0] = ActivitySleepStateAwake;
+  s_data.metric_history[ActivityMetricSleepStateSeconds][0] = 30 * SECONDS_PER_MINUTE;
+
+  // Sleep 10pm-11pm Thursday, awake at 11:30pm
+  prv_add_sleep_session(22, 1);
+  activity_insights_process_sleep_data(rtc_get_time());
+  cl_assert_equal_i(s_data.pins_added, 1);
+
+  // Sleep midnight-2am, awake at 2:05am with some activity: exit is outside the wake
+  // window, so no notification
+  rtc_set_time(rtc_get_time() + 2 * SECONDS_PER_HOUR + 35 * SECONDS_PER_MINUTE);
+  prv_add_sleep_session(1, 2);
+  activity_insights_process_sleep_data(rtc_get_time());
+  cl_assert_equal_i(s_data.pins_added, 2);
+  s_data.steps_per_minute = 80;
+  prv_minute_update(2);
+  rtc_set_time(rtc_get_time() + 28 * SECONDS_PER_MINUTE);
+  activity_insights_process_sleep_data(rtc_get_time());
+  cl_assert_equal_i(fake_kernel_services_notifications_ancs_notifications_count(), 0);
+
+  // Back to sleep 3am-7am; the real morning wake-up still notifies
+  rtc_set_time(rtc_get_time() + 4 * SECONDS_PER_HOUR + 30 * SECONDS_PER_MINUTE);
+  prv_add_sleep_session(1, 4);
+  activity_insights_process_sleep_data(rtc_get_time());
+  cl_assert_equal_i(s_data.pins_added, 3);
+  prv_minute_update(2);
+  rtc_set_time(rtc_get_time() + 28 * SECONDS_PER_MINUTE);
+  activity_insights_process_sleep_data(rtc_get_time());
+  cl_assert_equal_i(fake_kernel_services_notifications_ancs_notifications_count(), 1);
 }


### PR DESCRIPTION
## Problem

Users receive their "Good morning" sleep summary notification again hours after the real one — in the field trace, a duplicate arrived at 22:12 local, ~15 hours after the morning summary, and again the next day without any reboot in between (same symptom family as the mid-night summary complaints).

## Root cause

Two layers:

1. **Detection accuracy (out of scope here, tracked in FIRM-1969):** Kraepelin falsely detects ~40-60 min of "sleep" during sedentary-awake evening time. Sessions ending after 21:00 local (or starting before 12:00) escape nap reclassification and count as night sleep.
2. **Insights layer (this fix):** `prv_do_sleep_summary()` treated any change of the day's sleep bounds as new-sleep-to-report:
   - a pin update for an extended `sleep_exit_utc` cleared `s_sleep_pin_state.notified`, re-arming the notification;
   - any shift of `sleep_enter_utc` was treated as "new day" and reset the whole pin state.

   Either path re-fires the full summary notification 30 minutes after the (false) exit, once the user is briefly active. The field's false 19:48-20:42Z session produced the duplicate at exactly exit+30min.

## Fix design

- **Window-keyed dedup:** the sleep pin state is now keyed to the sleep-day window (the 21:00-local cutoff already used by `activity_sessions_prv_get_sleep_bounds_utc()`, extracted as `activity_sessions_prv_get_sleep_window_start_utc()`). Within one window the notification fires at most once: pin updates no longer clear `notified`, and only a new window resets the state. Exact-timestamp matching is gone, so bounds/enter shifts (which #1742 makes more common) and settings-state "time travel" resets can no longer re-arm it. The timeline pin still updates silently.
- **Wake-window gate (notification only):** the summary notification only fires when `sleep_exit_utc` lands in [04:00, 18:00) local. Skipping outside that window does not consume the once-per-window notification, so a mid-night false exit stays silent and the real morning wake-up still notifies. The pin is unaffected.
- **Persistence:** `SleepPinState` grows by a trailing `window_utc` field, persisted via the existing `ActivitySettingsKeyInsightSleepSummaryState` key. Older persisted blobs fail the settings read cleanly (`E_RANGE` zeroes the output — no partial misread of old-layout bytes), and a zeroed state is re-seeded at init as already-notified for the in-progress window, so the layout change cannot re-fire a summary the user already saw. Worst case is one missed summary right after the update.
- Cleanup: `AttributeIdIconTiny` is added with `attribute_list_add_resource_id()` instead of `attribute_list_add_uint32()`, silencing the "Adding attribute with type uint32 for non-uint32_t attribute" warning seen in field logs.

## Test plan

- New unit tests in `tests/fw/services/activity/test_activity_insights.c`:
  - `sleep_summary_no_renotify_same_window`: night sleep → morning summary fires once → same-window evening session extension (analog of the field's false session) → pin updates in place, no second notification.
  - `sleep_summary_notify_next_window`: the next night past the 21:00 cutoff starts a new window with a new pin, and the notification fires again.
  - `sleep_summary_notification_wake_window_gate`: a 02:00-local exit does not notify and does not consume the window's notification; the later 07:00 wake still notifies.
- Negative check: with the fix reverted (tests kept), all three new tests fail — the same-window repro fires 2 notifications, and the mid-night exit notifies at 02:35.
- `./waf test -M '.*activity.*'`: 12/12 suites pass (includes `test_activity`, which compiles the refactored `activity_sessions.c`).
- `./waf build` (obelix@pvt, normal variant) succeeds.

Fixes FIRM-3101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
