### PR TITLE
fw/drivers/imu/lsm6dso: atomic FIFO status read + INT1 ghost diagnostics

### DIFF
--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -360,7 +360,7 @@ static void prv_lsm6dso_recover(void);
 //! fifo_progress is set when FIFO data was consumed (samples or overrun).
 static bool prv_lsm6dso_service_int1(bool *fifo_progress) {
   bool ret;
-  uint8_t fifo_status2 = 0U;
+  uint8_t fifo_status[2] = {0U, 0U};
   uint8_t all_int_src = 0U;
   bool action_taken = false;
   bool fifo_overrun = false;
@@ -373,23 +373,19 @@ static bool prv_lsm6dso_service_int1(bool *fifo_progress) {
   // on these reads, so deferring it avoids stretching the gap between the FIFO
   // read and the ALL_INT_SRC read if this task gets preempted mid-handler.
   if (LSM6DSO->state->num_samples > 0U) {
-    ret = prv_lsm6dso_read(LSM6DSO_FIFO_STATUS2, &fifo_status2, 1);
+    // WTM/OVR flags and DIFF must come from one burst read: a split read can
+    // catch the FIFO counter mid-update and see WTM_IA set with DIFF reading 0
+    ret = prv_lsm6dso_read(LSM6DSO_FIFO_STATUS1, fifo_status, 2);
     if (!ret) {
-      PBL_LOG_ERR("Could not read FIFO_STATUS2 register");
+      PBL_LOG_ERR("Could not read FIFO_STATUS registers");
       return false;
     }
 
-    if ((fifo_status2 & LSM6DSO_FIFO_STATUS2_FIFO_OVR_IA) != 0U) {
+    if ((fifo_status[1] & LSM6DSO_FIFO_STATUS2_FIFO_OVR_IA) != 0U) {
       fifo_overrun = true;
-    } else if ((fifo_status2 & LSM6DSO_FIFO_STATUS2_FIFO_WTM_IA) != 0U) {
-      uint8_t status1;
-
-      if (!prv_lsm6dso_read(LSM6DSO_FIFO_STATUS1, &status1, 1)) {
-        PBL_LOG_ERR("Could not read FIFO_STATUS1 register");
-        return false;
-      }
-
-      samples = (((uint16_t)(fifo_status2 & LSM6DSO_FIFO_STATUS2_DIFF_HI_MASK)) << 8U) | status1;
+    } else if ((fifo_status[1] & LSM6DSO_FIFO_STATUS2_FIFO_WTM_IA) != 0U) {
+      samples = (((uint16_t)(fifo_status[1] & LSM6DSO_FIFO_STATUS2_DIFF_HI_MASK)) << 8U) |
+                fifo_status[0];
       if (samples > LSM6DSO_FIFO_SIZE) {
         samples = LSM6DSO_FIFO_SIZE;
       }
@@ -444,7 +440,7 @@ static bool prv_lsm6dso_service_int1(bool *fifo_progress) {
     // Registers not read this pass (gated on num_samples/shake state) log as 0
     PBL_LOG_WRN("INT1 triggered but no action taken (FIFO_STATUS2 0x%02" PRIx8
                 " ALL_INT_SRC 0x%02" PRIx8 " num_samples %" PRIu16 " shake_en %d)",
-                fifo_status2, all_int_src, LSM6DSO->state->num_samples,
+                fifo_status[1], all_int_src, LSM6DSO->state->num_samples,
                 LSM6DSO->state->shake_detection_enabled);
   }
 

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -355,10 +355,18 @@ static void prv_lsm6dso_drain_fifo(void) {
 }
 
 static void prv_lsm6dso_recover(void);
+static uint32_t prv_ms_since_last_fifo_read(void);
+
+//! INT1 servicing pass kind, logged by the no-action diagnostic
+typedef enum {
+  Lsm6dsoInt1PassInitial = 0,
+  Lsm6dsoInt1PassRequeue = 1,
+  Lsm6dsoInt1PassRetry = 2,
+} Lsm6dsoInt1Pass;
 
 //! Single INT1 servicing pass; returns true if any INT source was handled.
 //! fifo_progress is set when FIFO data was consumed (samples or overrun).
-static bool prv_lsm6dso_service_int1(bool *fifo_progress) {
+static bool prv_lsm6dso_service_int1(Lsm6dsoInt1Pass pass, bool *fifo_progress) {
   bool ret;
   uint8_t fifo_status[2] = {0U, 0U};
   uint8_t all_int_src = 0U;
@@ -439,9 +447,11 @@ static bool prv_lsm6dso_service_int1(bool *fifo_progress) {
   if (!action_taken) {
     // Registers not read this pass (gated on num_samples/shake state) log as 0
     PBL_LOG_WRN("INT1 triggered but no action taken (FIFO_STATUS2 0x%02" PRIx8
-                " ALL_INT_SRC 0x%02" PRIx8 " num_samples %" PRIu16 " shake_en %d)",
+                " ALL_INT_SRC 0x%02" PRIx8 " num_samples %" PRIu16 " shake_en %d pass %u"
+                " last_read %" PRIu32 "ms ago)",
                 fifo_status[1], all_int_src, LSM6DSO->state->num_samples,
-                LSM6DSO->state->shake_detection_enabled);
+                LSM6DSO->state->shake_detection_enabled, (unsigned int)pass,
+                prv_ms_since_last_fifo_read());
   }
 
   return action_taken;
@@ -449,7 +459,14 @@ static bool prv_lsm6dso_service_int1(bool *fifo_progress) {
 
 static void prv_lsm6dso_int1_work_handler(void) {
   bool fifo_progress = false;
-  bool action_taken = prv_lsm6dso_service_int1(&fifo_progress);
+  // Best-effort pass tagging: an ISR enqueue racing a pending requeue gets
+  // labeled as a requeue; diagnostic only
+  Lsm6dsoInt1Pass pass =
+      LSM6DSO->state->int1_requeued ? Lsm6dsoInt1PassRequeue : Lsm6dsoInt1PassInitial;
+  bool action_taken;
+
+  LSM6DSO->state->int1_requeued = false;
+  action_taken = prv_lsm6dso_service_int1(pass, &fifo_progress);
 
   // Sources asserting while the pad is high produce no new edge: requeue on
   // FIFO progress, recover when nothing was serviced (stuck pad). A pad held
@@ -459,6 +476,7 @@ static void prv_lsm6dso_int1_work_handler(void) {
   }
 
   if (fifo_progress) {
+    LSM6DSO->state->int1_requeued = true;
     accel_offload_work(prv_lsm6dso_int1_work_handler);
     return;
   }
@@ -472,8 +490,9 @@ static void prv_lsm6dso_int1_work_handler(void) {
   // Retry the servicing pass once (a latched wake-up or a fresh FIFO
   // threshold is visible on re-read) and only recover if the pad is still
   // high with nothing serviced.
-  action_taken = prv_lsm6dso_service_int1(&fifo_progress);
+  action_taken = prv_lsm6dso_service_int1(Lsm6dsoInt1PassRetry, &fifo_progress);
   if (fifo_progress) {
+    LSM6DSO->state->int1_requeued = true;
     accel_offload_work(prv_lsm6dso_int1_work_handler);
   } else if (!action_taken && gpio_input_read(&LSM6DSO->int1_in)) {
     prv_lsm6dso_recover();

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.h
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.h
@@ -34,6 +34,7 @@ typedef struct LSM6DSOState {
   uint8_t wk_ths_curr;
   bool recovery_pending;
   bool wu_active;
+  bool int1_requeued;
 } LSM6DSOState;
 
 typedef struct LSM6DSOConfig {


### PR DESCRIPTION
## Summary

Follow-up to #1729/#1730. A 2026-07-21 field capture on the hardened firmware showed the retry-before-recover fix working (zero recoveries/stalls), but revealed a new ghost signature: ~1 Hz "INT1 triggered but no action taken" warnings correlated with vibe motor activity, half of them reporting `FIFO_STATUS2 0x80` — WTM_IA set while DIFF read back 0 and the INT1 pad was already low at the re-check. That combination is self-contradictory (WTM_IA is a level flag implying DIFF >= watermark and a held-high pad), pointing at the split STATUS2-then-STATUS1 read catching the FIFO status mid-update.

- **Read FIFO_STATUS1/2 as a single two-byte burst** in the INT1 service path (the drain path already does this), so the WTM/OVR flags and the DIFF count come from one snapshot.
- **Tag the no-action diagnostic with pass context**: pass kind (0 = ISR-queued initial, 1 = requeued follow-up, 2 = pre-recovery retry) and milliseconds since the last FIFO read. The pass kind is numeric to keep the log dehashable. The next capture can then distinguish double-enqueued passes from fresh vibe-induced wake-up pulses.

## Testing

- Built `obelix@pvt` and `asterix` (normal variant), both clean.
- Log-level/diagnostic changes are field-validation oriented; awaiting next capture with vibe activity to confirm the 0x80 ghosts disappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)