### PR TITLE
fw/graphics: consult the font's other own resource when the routed glyph lookup misses

### DIFF
--- a/src/fw/applib/graphics/text_resources.c
+++ b/src/fw/applib/graphics/text_resources.c
@@ -599,13 +599,33 @@ bool text_resources_init_font(ResAppNum app_num, uint32_t font_resource,
 // Leaf glyph lookup against a single font. This NEVER consults the fallback font, which is what
 // structurally bounds the fallback to depth 1: the fallback font is looked up with this helper, so
 // it can never trigger a further fallback and no recursion or cycle is possible.
+// Classification only picks which of the font's own resources to try FIRST: on a miss we retry the
+// font's other own resource, so a codepoint whose class routes it to base/extension is still found
+// in the other one. Skipped when the emoji font took over (owner != font_info).
 // @param owner_out if non-NULL, receives the FontInfo the glyph was looked up in
 static const GlyphData *prv_get_glyph_in_font(FontCache *font_cache, Codepoint codepoint,
                                               FontInfo *font_info, bool need_bitmap,
                                               const FontInfo **owner_out) {
-  const FontResource *font_res = prv_font_res_for_codepoint(codepoint, font_info, owner_out);
+  const FontInfo *owner = font_info;
+  const FontResource *font_res = prv_font_res_for_codepoint(codepoint, font_info, &owner);
   prv_check_font_cache(font_cache, font_res);
-  return prv_get_glyph_metadata_from_spi(codepoint, font_cache, font_res, need_bitmap);
+  const GlyphData *data = prv_get_glyph_metadata_from_spi(codepoint, font_cache, font_res,
+                                                          need_bitmap);
+  // Routed resource missed: try the font's other own resource. Classification is a lookup-order
+  // hint, not a hard partition. Skipped when the emoji font took over.
+  if (!data && owner == font_info) {
+    const FontResource *other = (font_res == &font_info->base)
+        ? (font_info->extended ? &font_info->extension : NULL)
+        : &font_info->base;
+    if (other) {
+      prv_check_font_cache(font_cache, other);
+      data = prv_get_glyph_metadata_from_spi(codepoint, font_cache, other, need_bitmap);
+    }
+  }
+  if (owner_out) {
+    *owner_out = owner;
+  }
+  return data;
 }
 
 // A substitute font bakes top_offset against its own baseline (== base max_height for PBF), so

--- a/tests/fw/applib/test_text_resources.c
+++ b/tests/fw/applib/test_text_resources.c
@@ -467,6 +467,132 @@ void test_text_resources__fallback_miss_yields_primary_wildcard(void) {
   cl_assert_equal_m(gothic_wildcard, g->data, glyph_get_size_bytes(g));
 }
 
+// Glyph-presence-driven routing (in-font base<->extension rescue)
+////////////////////////////////////
+
+// Mirror of #1709: a codepoint whose Unicode class routes it to the EXTENSION but which lives only
+// in the BASE (e.g. pi U+03C0) must still resolve to the base glyph once an extension is loaded,
+// instead of degrading to the fallback/wildcard. Works on the shipped fixtures: GOTHIC_18 base
+// carries U+03C0, the CJK extension does not.
+void test_text_resources__extension_routed_miss_rescued_from_base(void) {
+  const Codepoint PI = 0x03C0;
+
+  // Reference: base-only GOTHIC_18 resolves U+03C0 to its own glyph (no extension, so it routes to
+  // base directly).
+  cl_assert(text_resources_init_font(0, RESOURCE_ID_GOTHIC_18, 0, &s_font_info));
+  const GlyphData *base_g = text_resources_get_glyph(&s_font_cache, PI, &s_font_info, NULL);
+  cl_assert(base_g != NULL);
+  uint8_t base_size = glyph_get_size_bytes(base_g);
+  uint8_t base_bytes[CACHE_GLYPH_SIZE];
+  cl_assert(base_size <= sizeof(base_bytes));
+  memcpy(base_bytes, base_g->data, base_size);
+
+  // Now load GOTHIC_18 + CJK extension. U+03C0 is not latin-classified, so it routes to the
+  // extension, which lacks it. Without the in-font rescue this misses and yields the wildcard.
+  memset(&s_font_info, 0, sizeof(s_font_info));
+  cl_assert(text_resources_init_font(0, RESOURCE_ID_GOTHIC_18,
+                                     RESOURCE_ID_GOTHIC_18_EXTENDED, &s_font_info));
+  cl_assert(s_font_info.extended);
+
+  memset(&s_font_cache, 0, sizeof(s_font_cache));
+  keyed_circular_cache_init(&s_font_cache.line_cache, s_font_cache.cache_keys,
+                            s_font_cache.cache_data, sizeof(LineCacheData), LINE_CACHE_SIZE);
+
+  int16_t adjust = -1;
+  const GlyphData *g = text_resources_get_glyph(&s_font_cache, PI, &s_font_info, &adjust);
+  cl_assert(g != NULL);
+  cl_assert_equal_i(glyph_get_size_bytes(g), base_size);
+  cl_assert_equal_m(base_bytes, g->data, base_size);  // rescued from base, not the wildcard
+  cl_assert_equal_i(adjust, 0);                        // owner is the primary font
+}
+
+// #1709 itself: a latin-classified codepoint absent from the base but present in the extension must
+// resolve from the extension. The shipped GOTHIC_18 base already carries the extension's only latin
+// codepoint (U+2026), so we pair the extension with a base font that lacks it — GOTHIC_18_EMOJI —
+// which faithfully exercises the base-routed -> extension rescue path.
+void test_text_resources__base_routed_miss_rescued_from_extension(void) {
+  const Codepoint ELLIPSIS = 0x2026;
+
+  // Reference: the extension's own U+2026 glyph, captured by loading the extension as a base font.
+  static FontInfo s_probe;
+  memset(&s_probe, 0, sizeof(s_probe));
+  cl_assert(text_resources_init_font(0, RESOURCE_ID_GOTHIC_18_EXTENDED, 0, &s_probe));
+  const GlyphData *ext_g = text_resources_get_glyph(&s_font_cache, ELLIPSIS, &s_probe, NULL);
+  cl_assert(ext_g != NULL);
+  uint8_t ext_size = glyph_get_size_bytes(ext_g);
+  uint8_t ext_bytes[CACHE_GLYPH_SIZE];
+  cl_assert(ext_size <= sizeof(ext_bytes));
+  memcpy(ext_bytes, ext_g->data, ext_size);
+
+  // Base = emoji font (lacks U+2026) + CJK extension (has U+2026). U+2026 is latin-classified, so
+  // it routes to base, misses, and must be rescued from the extension.
+  memset(&s_font_info, 0, sizeof(s_font_info));
+  cl_assert(text_resources_init_font(0, RESOURCE_ID_GOTHIC_18_EMOJI,
+                                     RESOURCE_ID_GOTHIC_18_EXTENDED, &s_font_info));
+  cl_assert(s_font_info.extended);
+
+  memset(&s_font_cache, 0, sizeof(s_font_cache));
+  keyed_circular_cache_init(&s_font_cache.line_cache, s_font_cache.cache_keys,
+                            s_font_cache.cache_data, sizeof(LineCacheData), LINE_CACHE_SIZE);
+
+  int16_t adjust = -1;
+  const GlyphData *g = text_resources_get_glyph(&s_font_cache, ELLIPSIS, &s_font_info, &adjust);
+  cl_assert(g != NULL);
+  cl_assert_equal_i(glyph_get_size_bytes(g), ext_size);
+  cl_assert_equal_m(ext_bytes, g->data, ext_size);  // rescued from extension, not the wildcard
+  cl_assert_equal_i(adjust, 0);                       // owner is the primary font
+}
+
+// Regression guards for the in-font rescue: (a) a codepoint present in the routed resource still
+// wins over the other resource, and (b) a codepoint absent from both still yields the wildcard.
+void test_text_resources__in_font_rescue_regressions(void) {
+  const Codepoint ELLIPSIS = 0x2026;
+  const Codepoint ABSENT = 0x8888;  // absent from base, extension and fallback
+
+  // Base-only references for U+2026 (base carries its own ellipsis) and the wildcard for U+8888.
+  cl_assert(text_resources_init_font(0, RESOURCE_ID_GOTHIC_18, 0, &s_font_info));
+
+  const GlyphData *base_ellipsis = text_resources_get_glyph(&s_font_cache, ELLIPSIS, &s_font_info,
+                                                            NULL);
+  cl_assert(base_ellipsis != NULL);
+  uint8_t base_ellipsis_size = glyph_get_size_bytes(base_ellipsis);
+  uint8_t base_ellipsis_bytes[CACHE_GLYPH_SIZE];
+  cl_assert(base_ellipsis_size <= sizeof(base_ellipsis_bytes));
+  memcpy(base_ellipsis_bytes, base_ellipsis->data, base_ellipsis_size);
+
+  const GlyphData *base_wildcard = text_resources_get_glyph(&s_font_cache, ABSENT, &s_font_info,
+                                                            NULL);
+  cl_assert(base_wildcard != NULL);
+  uint8_t wildcard_size = glyph_get_size_bytes(base_wildcard);
+  uint8_t wildcard_bytes[CACHE_GLYPH_SIZE];
+  cl_assert(wildcard_size <= sizeof(wildcard_bytes));
+  memcpy(wildcard_bytes, base_wildcard->data, wildcard_size);
+
+  // Load GOTHIC_18 + CJK extension. Both base and extension carry U+2026 (with different bitmaps),
+  // so the routed resource (base) must win.
+  memset(&s_font_info, 0, sizeof(s_font_info));
+  cl_assert(text_resources_init_font(0, RESOURCE_ID_GOTHIC_18,
+                                     RESOURCE_ID_GOTHIC_18_EXTENDED, &s_font_info));
+  cl_assert(s_font_info.extended);
+
+  memset(&s_font_cache, 0, sizeof(s_font_cache));
+  keyed_circular_cache_init(&s_font_cache.line_cache, s_font_cache.cache_keys,
+                            s_font_cache.cache_data, sizeof(LineCacheData), LINE_CACHE_SIZE);
+
+  // (a) routed resource wins: U+2026 resolves to the BASE bytes, not the extension's.
+  const GlyphData *g_ellipsis = text_resources_get_glyph(&s_font_cache, ELLIPSIS, &s_font_info,
+                                                         NULL);
+  cl_assert(g_ellipsis != NULL);
+  cl_assert_equal_i(glyph_get_size_bytes(g_ellipsis), base_ellipsis_size);
+  cl_assert_equal_m(base_ellipsis_bytes, g_ellipsis->data, base_ellipsis_size);
+
+  // (b) absent everywhere still yields the primary wildcard.
+  const GlyphData *g_absent = text_resources_get_glyph(&s_font_cache, ABSENT, &s_font_info, NULL);
+  cl_assert(g_absent != NULL);
+  cl_assert_equal_i(glyph_get_size_bytes(g_absent), wildcard_size);
+  cl_assert_equal_m(wildcard_bytes, g_absent->data, wildcard_size);
+}
+
 void test_text_resources__test_glyph_decompression(void) {
   // There is no way to get the list of glyphs present in a font with the existing API. This list
   // of ranges lists the 371 glyphs currently in fontname.ttf


### PR DESCRIPTION
Fixes #1709.

When a language pack is loaded, a glyph that exists in the pack's extension font can still render as the missing-glyph box — and, in the mirror case, a glyph that exists in the base font can degrade to the 14px system fallback. ℃ (U+2103) from the issue is one instance of a whole class.

| № U+2116, ₽ U+20BD — before | after |
|---|---|
| <img width="200" alt="before: numero and ruble signs render as the missing-glyph box" src="https://github.com/user-attachments/assets/f170abc5-bad8-4609-bd58-b84fb1584678" /> | <img width="200" alt="after: numero and ruble signs render from the language pack" src="https://github.com/user-attachments/assets/701a01cd-a584-41db-8407-f984aa8c616f" /> |

## Mechanism

`prv_font_res_for_codepoint()` picks base vs extension purely from the codepoint's Unicode class: `codepoint_is_latin()` (0x0000–0x02AF and 0x2000–0x2BFF) → base, everything else → extension. The pick happens before any glyph-presence check, and the fallback chain in `prv_get_glyph()` never revisits the *other* resource of the same font — a miss goes straight to the process-global system fallback and then the wildcard box.

So the classification acts as a hard partition, when in reality it's only a guess about which resource carries the glyph. Both directions of a wrong guess are live bugs:

- **Latin-classified codepoint that only the extension carries.** 0x2000–0x2BFF spans ~2800 codepoints; the base Gothic fonts carry ~34 of them (dashes, quotes, ellipsis, €, ™, some math). Everything else in that block — letterlike symbols (℃ ℉ №), currency (₽ U+20BD, added to Unicode after the base fonts were cut), arrows, geometric shapes — is force-routed to base, misses, and renders as the wildcard box *even when the loaded language pack provides the glyph*. This is #1709, reproduced independently by a Japanese pack (℃) and a Russian pack (№, ₽ — screenshots above).
- **Non-latin codepoint that only the base carries.** With a pack loaded, π (U+03C0) and the spacing modifiers U+02C6–02DD classify as non-latin → routed to the extension. Packs typically don't carry them, so codepoints that render fine on a stock firmware degrade to the 14px system fallback (or the box) the moment a pack is installed. Installing a language pack should not break glyphs that worked without it.

## The fix

`prv_get_glyph_in_font()` — the single-font leaf resolver — now treats classification as a lookup-order hint instead of a partition: try the routed resource first; on a miss, try the font's other own resource (base ↔ extension) before giving up. The outer fallback chain (primary → system fallback → wildcard) is untouched, and the leaf still never consults the fallback font, so the depth-1 invariant holds as documented.

Scoping decisions:

- **Guarded on `owner == font_info`**: when the emoji font takes over, the routed resource belongs to a different `FontInfo`, and the rescue is skipped — the emoji substitution and baseline-adjust behavior from #1766 is unchanged. The two compose: that PR places glyphs that legitimately come from another font; this one stops base-present glyphs from being outsourced at all.
- **No baseline adjustment needed**: the rescue stays within the same `FontInfo`, so `prv_baseline_adjust()` yields 0 by construction — extension glyphs are already baked against their base font's own baseline.
- **Precedence is unchanged**: when both resources carry the codepoint, the routed one still wins, exactly as today. Behavior changes only on paths that previously ended in the system fallback or the wildcard box, where showing the font's own glyph is strictly better.
- **Strict no-op without a language pack**: every new path is gated on `font_info->extended` (or on being routed to the extension, which requires it). A firmware without a loaded extension resolves byte-for-byte as before.

The alternative — narrowing the 0x2000–0x2BFF "latin" range in `codepoint_is_latin()` — was rejected: the base fonts genuinely carry glyphs across that block (U+2013/2014, U+2018–201E, U+2026, U+20AC, U+2122, U+2212, …), and reclassifying them would regress each one to a pack lookup that packs don't cover. The nonstandard-emoji handling in the 0x25xx block also leans on the current classification.

Cost: one extra offset-table probe, only on lookups that missed their routed resource — i.e. paths that were already headed for the (more expensive) fallback-font lookup. The font cache negative-caches misses as before.

## Tested

`./pbl build` (obelix) and the full `./pbl test` suite pass.

Unit tests added in `test_text_resources.c`, all through the real resolver against the shipped PBF fixtures (no fixture regeneration needed):
1. **base-routed miss rescued from the extension** (the #1709 direction): the CJK extension fixture's only latin-classified codepoint is U+2026, and the shipped `GOTHIC_18_EMOJI` base font lacks it — pairing them makes U+2026 route to base, miss, and resolve from the extension. The resolver keys only on glyph presence and codepoint class, so this exercises exactly the issue's path.
2. **extension-routed miss rescued from base** (mirror direction): π U+03C0 with GOTHIC_18 + CJK extension resolves to the base π glyph at native size, baseline adjust 0.
3. **Regression guards**: U+2026 present in both resources resolves to the *base* bytes (routed resource wins; the two fixtures' ellipsis bitmaps genuinely differ), and a codepoint absent everywhere still yields the primary font's wildcard box.

Both rescue tests fail without the resolver change (verified by disabling the rescue block and re-running: got wildcard/fallback bytes instead of the expected glyphs).

On-device (obelix@pvt): a Russian language pack whose extension carries № (U+2116) and ₽ (U+20BD) — both absent from every base Gothic font — previously rendered both as the wildcard box; with this change they render from the pack (screenshots above). Latin text, base punctuation (— … « »), and emoji substitution are visually unchanged.
