### PR TITLE
RFC: honor the phone's Do Not Disturb on the watch (ANCS silent flag)

### DIFF
--- a/include/pbl/services/notifications/alerts_preferences_private.h
+++ b/include/pbl/services/notifications/alerts_preferences_private.h
@@ -52,6 +52,11 @@ NotificationStatusBarStyle alerts_preferences_get_notification_status_bar_style(
 
 void alerts_preferences_set_notification_status_bar_style(NotificationStatusBarStyle style);
 
+//! Whether notifications delivered silently on the phone get quiet delivery on the watch
+bool alerts_preferences_get_respect_phone_silence(void);
+
+void alerts_preferences_set_respect_phone_silence(bool enable);
+
 bool alerts_preferences_get_vibrate(void);
 
 void alerts_preferences_set_vibrate(bool enable);

--- a/include/pbl/services/timeline/item.h
+++ b/include/pbl/services/timeline/item.h
@@ -38,8 +38,9 @@ typedef enum {
   TimelineItemFlagFromWatch = 1 << 3,
   TimelineItemFlagFromANCS = 1 << 4,
   TimelineItemFlagPersistent = 1 << 5,
+  TimelineItemFlagSilent = 1 << 6,
   // This should always be the bitmask for unused bits.
-  TimelineItemFlagUnused = ~((1 << 6) - 1)
+  TimelineItemFlagUnused = ~((1 << 7) - 1)
 } TimelineItemFlag;
 
 //! Enumeration of the different types of actions a TimelineItem can have.
@@ -132,6 +133,11 @@ typedef struct PACKED {
       uint8_t from_watch:1;
       //! Indicates that this notification was added by ANCS (iOS)
       uint8_t ancs_notif:1;
+      //! Reserved: mirrors TimelineItemFlagPersistent, set by the phone. Not used on the watch.
+      uint8_t persistent_flag:1;
+      //! Indicates the notification was delivered silently on the phone (iOS ANCS EventFlagSilent,
+      //! or set by a companion app on the wire flags byte).
+      uint8_t silent:1;
     };
     uint8_t flags;
   };

--- a/src/fw/comm/ble/kernel_le_client/ancs/ancs.c
+++ b/src/fw/comm/ble/kernel_le_client/ancs/ancs.c
@@ -1066,6 +1066,10 @@ static void prv_handle_ns_notification(uint32_t length, const uint8_t *notificat
     properties |= ANCSProperty_MultiMedia;
   }
 
+  if (nsnotification->event_flags & EventFlagSilent) {
+    properties |= ANCSProperty_Silent;
+  }
+
   if (s_ancs_client->version >= ANCSVersion_iOS9OrNewer) {
     properties |= ANCSProperty_iOS9;
   }

--- a/src/fw/comm/ble/kernel_le_client/ancs/ancs_types.h
+++ b/src/fw/comm/ble/kernel_le_client/ancs/ancs_types.h
@@ -231,4 +231,5 @@ typedef enum {
   ANCSProperty_VoiceMail = (1 << 2),
   ANCSProperty_MultiMedia = (1 << 3),
   ANCSProperty_iOS9 = (1 << 4),
+  ANCSProperty_Silent = (1 << 5),
 } ANCSProperty;

--- a/src/fw/popups/notifications/notification_window.c
+++ b/src/fw/popups/notifications/notification_window.c
@@ -1483,6 +1483,18 @@ static void prv_do_notification_vibe(NotificationWindowData *data, Uuid *id) {
   }
 }
 
+// Returns true if the stored notification was delivered silently by the phone
+// (iOS via ANCS EventFlagSilent, or a companion app that set the silent flag).
+static bool prv_notification_is_phone_silent(Uuid *id) {
+  TimelineItem item = {};
+  if (!notification_storage_get(id, &item)) {
+    return false;
+  }
+  const bool is_phone_silent = item.header.silent;
+  timeline_item_free_allocated_buffer(&item);
+  return is_phone_silent;
+}
+
 static void prv_handle_notification_added_common(Uuid *id, NotificationType type) {
   NotificationWindowData *data = &s_notification_window_data;
 
@@ -1494,6 +1506,12 @@ static void prv_handle_notification_added_common(Uuid *id, NotificationType type
 
   if (do_not_disturb_is_active() && 
       alerts_preferences_dnd_get_show_notifications() == DndNotificationModeHide) {
+    return;
+  }
+
+  // Quiet delivery: keep phone-silent notifications out of the popup/vibe/backlight path
+  if (type == NotificationMobile && alerts_preferences_get_respect_phone_silence() &&
+      prv_notification_is_phone_silent(id)) {
     return;
   }
 

--- a/src/fw/services/blob_db/settings_blob_db.c
+++ b/src/fw/services/blob_db/settings_blob_db.c
@@ -141,6 +141,7 @@ static const char *s_syncable_notif_prefs[] = {
   "notifDesignStyle",
   "notifVibeDelay",
   "notifBacklight",
+  "notifRespectPhoneSilence",
   "dndMotionBacklight",
   "dndTouchBacklight",
 };

--- a/src/fw/services/notifications/alerts_preferences.c
+++ b/src/fw/services/notifications/alerts_preferences.c
@@ -97,6 +97,9 @@ static bool s_notification_backlight = true;  // true = enable backlight (defaul
 #define PREF_KEY_NOTIF_STATUS_BAR_STYLE "notifStatusBarStyle"
 static NotificationStatusBarStyle s_notification_status_bar_style = NotificationStatusBarStyle_Default;
 
+#define PREF_KEY_NOTIF_RESPECT_PHONE_SILENCE "notifRespectPhoneSilence"
+static bool s_respect_phone_silence = false;  // true = quiet delivery for phone-silent ANCS notifs
+
 ///////////////////////////////////
 //! Legacy preference keys
 ///////////////////////////////////
@@ -345,6 +348,7 @@ void alerts_preferences_init(void) {
   RESTORE_PREF(PREF_KEY_NOTIF_VIBE_DELAY, s_notification_vibe_delay);
   RESTORE_PREF(PREF_KEY_NOTIF_BACKLIGHT, s_notification_backlight);
   RESTORE_PREF(PREF_KEY_NOTIF_STATUS_BAR_STYLE, s_notification_status_bar_style);
+  RESTORE_PREF(PREF_KEY_NOTIF_RESPECT_PHONE_SILENCE, s_respect_phone_silence);
   RESTORE_PREF(PREF_KEY_DND_AUTO_DISMISS, s_dnd_auto_dismiss);
 #undef RESTORE_PREF
 
@@ -432,6 +436,15 @@ bool alerts_preferences_get_notification_backlight(void) {
 void alerts_preferences_set_notification_backlight(bool enable) {
   s_notification_backlight = enable;
   SET_PREF(PREF_KEY_NOTIF_BACKLIGHT, s_notification_backlight);
+}
+
+bool alerts_preferences_get_respect_phone_silence(void) {
+  return s_respect_phone_silence;
+}
+
+void alerts_preferences_set_respect_phone_silence(bool enable) {
+  s_respect_phone_silence = enable;
+  SET_PREF(PREF_KEY_NOTIF_RESPECT_PHONE_SILENCE, s_respect_phone_silence);
 }
 
 NotificationStatusBarStyle alerts_preferences_get_notification_status_bar_style(void) {
@@ -722,6 +735,7 @@ void alerts_preferences_handle_blob_db_event(PebbleBlobDBEvent *event) {
   RELOAD_IF_MATCH(PREF_KEY_NOTIF_VIBE_DELAY, s_notification_vibe_delay);
   RELOAD_IF_MATCH(PREF_KEY_NOTIF_BACKLIGHT, s_notification_backlight);
   RELOAD_IF_MATCH(PREF_KEY_NOTIF_STATUS_BAR_STYLE, s_notification_status_bar_style);
+  RELOAD_IF_MATCH(PREF_KEY_NOTIF_RESPECT_PHONE_SILENCE, s_respect_phone_silence);
   RELOAD_IF_MATCH(PREF_KEY_DND_MOTION_BACKLIGHT, s_dnd_motion_backlight);
   RELOAD_IF_MATCH(PREF_KEY_DND_TOUCH_BACKLIGHT, s_dnd_touch_backlight);
   RELOAD_IF_MATCH(PREF_KEY_DND_MUTE_SPEAKER, s_dnd_mute_speaker);

--- a/src/fw/services/notifications/ancs/ancs_notifications.c
+++ b/src/fw/services/notifications/ancs/ancs_notifications.c
@@ -349,6 +349,7 @@ void ancs_notifications_handle_message(uint32_t uid,
   notification->header.type = TimelineItemTypeNotification;
   notification->header.layout = LayoutIdNotification;
   notification->header.ancs_notif = true;
+  notification->header.silent = ((properties & ANCSProperty_Silent) != 0);
 
   notification_storage_lock();
   // filter out duplicate notifications

--- a/tests/fw/comm/test_ancs.c
+++ b/tests/fw/comm/test_ancs.c
@@ -563,6 +563,23 @@ void test_ancs__notification_parsing(void) {
   prv_cmp_last_received_notification(&s_unknown_app_unique_title_parsed_item);
 }
 
+// EventFlagSilent must be propagated as ANCSProperty_Silent and end up as
+// header.silent on the stored notification
+void test_ancs__silent_event_flag(void) {
+  // Without the Silent flag the stored notification must not be marked silent
+  prv_send_notification((uint8_t *)&s_complete_dict);
+  cl_assert_equal_i(fake_kernel_services_notifications_ancs_notifications_count(), 1);
+  TimelineItem *notification = fake_notification_storage_get_last_notification();
+  cl_assert_equal_i(notification->header.silent, 0);
+
+  // With the Silent flag the stored notification must be marked silent
+  prv_send_notification_with_event_flags((uint8_t *)&s_complete_dict, EventFlagSilent);
+  cl_assert_equal_i(fake_kernel_services_notifications_ancs_notifications_count(), 2);
+  notification = fake_notification_storage_get_last_notification();
+  cl_assert_equal_i(notification->header.silent, 1);
+  cl_assert_equal_i(notification->header.ancs_notif, 1);
+}
+
 // Make sure we send an ANCS_DISCONNECTED event whenever our session goes away
 void test_ancs__disconnection(void) {
   // Simulate a disconnection/reconnection

--- a/tests/fw/services/notifications/test_ancs_notifications.c
+++ b/tests/fw/services/notifications/test_ancs_notifications.c
@@ -144,6 +144,79 @@ void test_ancs_notifications__handle_phone_call_message(void) {
   cl_assert_equal_i(event.phone.source, PhoneCallSource_ANCS_Legacy);
 }
 
+static void prv_send_social_message(uint32_t uid, ANCSProperty properties) {
+  static const uint8_t app_id[] = {
+      0x00,
+      17, 0x00,
+      'c', 'o', 'm', '.', 't', 'e', 's', 't', 's', '.',
+      'F', 'a', 'k', 'e', 'A', 'p', 'p',
+  };
+  static const uint8_t title[] = {
+      0x01,
+      5, 0x00,
+      'T', 'i', 't', 'l', 'e',
+  };
+  static const uint8_t subtitle[] = {
+      0x02,
+      0x00, 0x00,
+  };
+  static const uint8_t message[] = {
+      0x03,
+      5, 0x00,
+      'H', 'e', 'l', 'l', 'o',
+  };
+  static const uint8_t date[] = {
+      0x05,
+      0x00, 0x00,
+  };
+  static const uint8_t positive_action[] = {
+      0x06,
+      0x00, 0x00,
+  };
+  static const uint8_t negative_action[] = {
+      0x07,
+      0x00, 0x00,
+  };
+
+  ANCSAttribute *notif_attributes[] = {
+    [FetchedNotifAttributeIndexAppID] = (ANCSAttribute *)&app_id,
+    [FetchedNotifAttributeIndexTitle] = (ANCSAttribute *)&title,
+    [FetchedNotifAttributeIndexSubtitle] = (ANCSAttribute *)&subtitle,
+    [FetchedNotifAttributeIndexMessage] = (ANCSAttribute *)&message,
+    [FetchedNotifAttributeIndexDate]= (ANCSAttribute *)&date,
+    [FetchedNotifAttributeIndexPositiveActionLabel] = (ANCSAttribute *)&positive_action,
+    [FetchedNotifAttributeIndexNegativeActionLabel] = (ANCSAttribute *)&negative_action,
+  };
+
+  static const uint8_t app_display_name[] = {
+    0x00,
+    7, 0x0,
+    'F', 'a', 'k', 'e', 'A', 'p', 'p',
+  };
+
+  ANCSAttribute *app_attributes[] = {
+    [FetchedAppAttributeIndexDisplayName] = (ANCSAttribute *)&app_display_name,
+  };
+
+  ancs_notifications_handle_message(uid, properties, notif_attributes, app_attributes);
+}
+
+void test_ancs_notifications__silent_property_sets_silent_header(void) {
+  // Force the "update existing" path so the stored item is captured by the fake storage
+  fake_notification_storage_set_existing_ancs_notification(&(Uuid)UUID_SYSTEM, UINT32_MAX);
+
+  // Without ANCSProperty_Silent the stored notification is not marked silent
+  prv_send_social_message(37, ANCSProperty_None);
+  cl_assert_equal_i(fake_notification_storage_get_store_count(), 1);
+  cl_assert_equal_i(fake_notification_storage_get_last_notification()->header.silent, 0);
+
+  // With ANCSProperty_Silent the stored notification is marked silent
+  prv_send_social_message(38, ANCSProperty_Silent);
+  cl_assert_equal_i(fake_notification_storage_get_store_count(), 2);
+  cl_assert_equal_i(fake_notification_storage_get_last_notification()->header.silent, 1);
+  cl_assert_equal_i(fake_notification_storage_get_last_notification()->header.ancs_notif, 1);
+}
+
 void test_ancs_notifications__handle_phone_call_removed(void) {
   const uint32_t uid = 5;
 

--- a/tests/fw/ui/test_notification_window.c
+++ b/tests/fw/ui/test_notification_window.c
@@ -8,6 +8,7 @@
 #include "apps/system/settings/notifications_private.h"
 #include "popups/notifications/notification_window.h"
 #include "popups/notifications/notification_window_private.h"
+#include "popups/notifications/notifications_presented_list.h"
 #include "resource/timeline_resource_ids.auto.h"
 #include "pbl/services/timeline/notification_layout.h"
 #include "pbl/util/trig.h"
@@ -19,7 +20,7 @@
 
 #include "stubs_action_menu.h"
 #include "stubs_alarm_layout.h"
-#include "stubs_alerts.h"
+// stubs_alerts.h intentionally omitted; see local replacements below
 // stubs_alerts_preferences.h intentionally omitted; see local replacements below
 #include "stubs_analytics.h"
 #include "stubs_ancs_filtering.h"
@@ -50,7 +51,7 @@
 #include "stubs_menu_cell_layer.h"
 #include "stubs_modal_manager.h"
 #include "stubs_mutex.h"
-#include "stubs_notification_storage.h"
+// stubs_notification_storage.h intentionally omitted; see local replacements below
 #include "stubs_passert.h"
 #include "stubs_pbl_malloc.h"
 #include "stubs_pebble_process_info.h"
@@ -122,6 +123,107 @@ bool alerts_preferences_dnd_get_auto_dismiss(void) {
 bool alerts_preferences_get_notification_vibe_delay(void) {
   return false;
 }
+
+static bool s_respect_phone_silence;
+
+bool alerts_preferences_get_respect_phone_silence(void) {
+  return s_respect_phone_silence;
+}
+
+// Local replacements for stubs_alerts.h so the notification-added path can be
+// exercised and the vibe gate observed per test.
+#include "pbl/services/notifications/alerts_private.h"
+
+static AlertMask s_alert_mask;
+static bool s_should_notify;
+static bool s_should_vibrate;
+static int s_should_vibrate_call_count;
+
+AlertMask alerts_get_mask(void) {
+  return s_alert_mask;
+}
+
+void alerts_set_mask(AlertMask mask) {
+  s_alert_mask = mask;
+}
+
+uint32_t alerts_get_notification_window_timeout_ms(void) {
+  return 0;
+}
+
+void alerts_incoming_alert_analytics(void) {}
+
+void alerts_set_notification_vibe_timestamp(void) {}
+
+bool alerts_should_enable_backlight_for_type(AlertType type) {
+  return false;
+}
+
+bool alerts_should_notify_for_type(AlertType type) {
+  return s_should_notify;
+}
+
+bool alerts_should_vibrate_for_type(AlertType type) {
+  s_should_vibrate_call_count++;
+  return s_should_vibrate;
+}
+
+// Local replacements for stubs_notification_storage.h so a stored item can be
+// read back by the quiet-delivery check.
+#include "pbl/services/notifications/notification_storage.h"
+
+static TimelineItem s_stored_notification;
+static bool s_has_stored_notification;
+static int s_notification_remove_count;
+
+void notification_storage_init(void) {}
+
+void notification_storage_lock(void) {}
+
+void notification_storage_unlock(void) {}
+
+void notification_storage_store(TimelineItem *notification) {}
+
+bool notification_storage_notification_exists(const Uuid *id) {
+  return false;
+}
+
+size_t notification_storage_get_len(const Uuid *uuid) {
+  return 0;
+}
+
+bool notification_storage_get(const Uuid *id, TimelineItem *item_out) {
+  if (!s_has_stored_notification || !uuid_equal(id, &s_stored_notification.header.id)) {
+    return false;
+  }
+  *item_out = s_stored_notification;
+  return true;
+}
+
+void notification_storage_set_status(const Uuid *id, uint8_t status) {}
+
+bool notification_storage_get_status(const Uuid *id, uint8_t *status) {
+  return false;
+}
+
+void notification_storage_remove(const Uuid *id) {
+  s_notification_remove_count++;
+}
+
+bool notification_storage_find_ancs_notification_id(uint32_t ancs_uid, Uuid *uuid_out) {
+  return false;
+}
+
+bool notification_storage_find_ancs_notification_by_timestamp(
+    TimelineItem *notification, CommonTimelineItemHeader *header_out) {
+  return false;
+}
+
+void notification_storage_rewrite(void (*iter_callback)(TimelineItem *notification,
+    SerializedTimelineItemHeader *header, void *data), void *data) {}
+
+void notification_storage_iterate(
+    bool (*iter_callback)(void *data, SerializedTimelineItemHeader *header_id), void *data) {}
 
 int16_t interpolate_int16(int32_t normalized, int16_t from, int16_t to) {
   return to;
@@ -333,6 +435,14 @@ void test_notification_window__initialize(void) {
   attribute_list_destroy_list(&s_test_data.statics.attr_list);
   s_test_data = (NotificationWindowTestData) {};
   s_notification_status_bar_style = NotificationStatusBarStyle_Default;
+  s_respect_phone_silence = false;
+  s_should_notify = false;
+  s_should_vibrate = false;
+  s_should_vibrate_call_count = 0;
+  s_stored_notification = (TimelineItem) {};
+  s_has_stored_notification = false;
+  s_notification_remove_count = 0;
+  notifications_presented_list_init();
   // Reset the notification window so each test gets a fresh prv_init_notification_window
   // call with the correct status-bar style.  Without this, s_in_use=true from a previous
   // test (e.g. big_bold setting LargeBold mode) would prevent re-initialization and leave
@@ -494,6 +604,86 @@ void test_notification_window__body_icon(void) {
   };
   prv_prepare_canvas_and_render_notification_windows(0 /* num_down_scrolls */);
   FAKE_GRAPHICS_CONTEXT_CHECK_DEST_BITMAP_FILE();
+}
+
+// Quiet delivery (phone-silent ANCS notifications)
+//////////////////////
+
+static const Uuid s_quiet_notif_id = {0x6b, 0x03, 0x2c, 0xd8, 0x0a, 0x2e, 0x4e, 0x5a,
+                                      0x92, 0x22, 0x71, 0x8e, 0x4b, 0xb2, 0x8e, 0x11};
+
+//! Store a notification and dispatch a NotificationAdded event for it.
+static void prv_store_and_add_notification(const Uuid *id, bool ancs_notif, bool silent) {
+  s_stored_notification = (TimelineItem) {
+    .header = (CommonTimelineItemHeader) {
+      .id = *id,
+      .type = TimelineItemTypeNotification,
+      .layout = LayoutIdNotification,
+      .ancs_notif = ancs_notif,
+      .silent = silent,
+    },
+  };
+  s_has_stored_notification = true;
+
+  PebbleSysNotificationEvent event = {
+    .type = NotificationAdded,
+    .notification_id = (Uuid *)id,
+  };
+  notification_window_handle_notification(&event);
+}
+
+static void prv_setup_quiet_delivery_test(void) {
+  s_should_notify = true;
+  s_should_vibrate = true;
+  // Content for the layout created when the window loads the notification
+  s_test_data = (NotificationWindowTestData) {
+    .icon_id = TIMELINE_RESOURCE_NOTIFICATION_GENERIC,
+    .title = "Quiet",
+    .body = "Delivered silently on the phone",
+  };
+}
+
+void test_notification_window__silent_ancs_suppressed_when_pref_on(void) {
+  prv_setup_quiet_delivery_test();
+  s_respect_phone_silence = true;
+
+  // Platform-neutral: suppression works from header.silent alone, even without ancs_notif
+  // (the companion-app / Android wire-flag case).
+  prv_store_and_add_notification(&s_quiet_notif_id, false /* ancs_notif */, true /* silent */);
+
+  // No popup: the window was never initialized and nothing was presented
+  cl_assert(!s_in_use);
+  cl_assert_equal_i(notifications_presented_list_count(), 0);
+  // No vibe: the vibe gate was never consulted
+  cl_assert_equal_i(s_should_vibrate_call_count, 0);
+  // The item remains in storage
+  TimelineItem item = {};
+  cl_assert(notification_storage_get(&s_quiet_notif_id, &item));
+  cl_assert_equal_i(s_notification_remove_count, 0);
+}
+
+void test_notification_window__non_silent_ancs_shown_when_pref_on(void) {
+  prv_setup_quiet_delivery_test();
+  s_respect_phone_silence = true;
+
+  prv_store_and_add_notification(&s_quiet_notif_id, true /* ancs_notif */, false /* silent */);
+
+  cl_assert(s_in_use);
+  cl_assert_equal_i(notifications_presented_list_count(), 1);
+  cl_assert(uuid_equal(notifications_presented_list_current(), &s_quiet_notif_id));
+  cl_assert(s_should_vibrate_call_count > 0);
+}
+
+void test_notification_window__silent_ancs_shown_when_pref_off(void) {
+  prv_setup_quiet_delivery_test();
+  s_respect_phone_silence = false;
+
+  prv_store_and_add_notification(&s_quiet_notif_id, true /* ancs_notif */, true /* silent */);
+
+  cl_assert(s_in_use);
+  cl_assert_equal_i(notifications_presented_list_count(), 1);
+  cl_assert(uuid_equal(notifications_presented_list_current(), &s_quiet_notif_id));
+  cl_assert(s_should_vibrate_call_count > 0);
 }
 
 void test_notification_window__big_bold(void) {

--- a/tests/stubs/stubs_alerts_preferences.h
+++ b/tests/stubs/stubs_alerts_preferences.h
@@ -33,3 +33,7 @@ bool WEAK alerts_preferences_get_notification_vibe_delay(void) {
 NotificationStatusBarStyle WEAK alerts_preferences_get_notification_status_bar_style(void) {
   return NotificationStatusBarStyle_Default;
 }
+
+bool WEAK alerts_preferences_get_respect_phone_silence(void) {
+  return false;
+}


### PR DESCRIPTION
> **Paired PR:** the companion-app half lives in [coredevices/mobileapp#304](https://github.com/coredevices/mobileapp/pull/304) — it makes the existing "Respect Phone Do Not Disturb" toggle work on both platforms (un-gating it and syncing the `notifRespectPhoneSilence` watch pref to the firmware) and declares the `TimelineItem.Flag.SILENT` wire flag (bit 6). That PR deliberately leaves Android behaviour unchanged (it implements only the iOS-enabling half); the Android wiring is called out there as a maintainer decision. This firmware PR is self-contained and inert without the synced pref.

## The problem

When an iPhone is in Do Not Disturb / Focus, the watch still buzzes and pops up every notification. To get silence you mute the phone, then separately mute the watch, then remember to undo both. I went Pebble → Garmin → back to Pebble, and inheriting the phone's silence is the one thing I miss — on Garmin the watch just mirrors the phone.

## What the firmware does today

`prv_handle_ns_notification()` reads the ANCS `EventFlags` and acts on exactly two bits — `EventFlagMultiMedia` and `EventFlagPreExisting`. `EventFlagSilent` is declared in `ancs_types.h` and tested nowhere, so the phone's silent state has no effect on the watch. Inherited from `google/pebble`, which didn't use the bit either.

## What this PR does

Reads `EventFlagSilent` into a new per-item header flag (`header.silent`), and — **when the opt-in `notifRespectPhoneSilence` preference is set** — keeps silent notifications out of the popup/vibration/backlight path while still storing and listing them. Mirrors the existing Quiet Time hide path.

Deliberate design choices:

- **No watch UI.** The preference is exposed over blob-db settings sync (`s_syncable_notif_prefs`), so the **companion app owns the toggle**. Defaults off — the firmware is inert until an app opts in. I deliberately did *not* add a watch-side settings row; see *Why no watch menu row* below.
- **Platform-neutral gate.** Suppression is keyed on `header.silent` *alone*, not on the item being an ANCS notification. So a companion app *could* drive the same behavior on Android by setting the silent flag on the wire `flags` byte (`TimelineItemFlagSilent`, bit 6), with no firmware change — see question 1.
- **Storage-compatible.** `silent` uses bit 6 of the header flags byte (always zero in stored items); bit 5 stays reserved for the existing `TimelineItemFlagPersistent`.

## The flag

Apple's ANCS spec names bit 0 `EventFlagSilent` (Table 3-3 of the [appendix](https://developer.apple.com/library/archive/documentation/CoreBluetooth/Reference/AppleNotificationCenterServiceSpecification/Appendix/Appendix.html)). The name is the spec's own statement of intent — the notification is silent — so honoring it by staying silent on the watch is the natural reading.

Apple doesn't document *when* iOS sets it, so I characterized it empirically on-device. The bit maps to exactly one thing: **the notification was intercepted by an active Do Not Disturb / Focus**, honoring that Focus's per-app/per-person allow-list (an allow-listed sender does *not* get the bit, so it still alerts). It is **not** set by the hardware Ring/Silent switch, ringer volume, per-app "Mute for 1 hour", or Screen Time. Effectively the iOS counterpart of Android's `Ranking.matchesInterruptionFilter()`.

## Why no watch menu row

The notification path is asymmetric:
- **iOS:** notifications reach the watch **directly over ANCS**; the companion app is never in the path (no iOS API to read other apps' notifications). Only the firmware can see the silent bit and act on it. Enforcement **must** be firmware-side.
- **Android:** the app **is** in the path (`NotificationListenerService`), sees `Ranking.matchesInterruptionFilter()`, and already ships a "Respect Phone Do Not Disturb" toggle that drops locally. Enforcement is app-side.

A watch-side toggle would work on iOS but do nothing on Android (where the app owns it), or be a second toggle to reconcile. Instead: firmware exposes a synced preference and no UI; the app owns the visible toggle and enforces per platform.

For the record: my own daily-driver watch currently runs exactly that watch-side toggle as a personal stopgap, and it works fine for me on iOS. I'm deliberately *not* proposing it as this PR — a settings row that silently does nothing on Android is a bad product decision. I'd rather land the mechanism and let the companion app own the switch than ship that crutch.

## Questions

**1. How should Android be wired?** Your call; it lives entirely in the companion app — the firmware commit is identical either way, and the paired app PR ships neither variant on Android (it keeps the status quo):
- **Leave as-is (what the app PR keeps):** the Android app keeps dropping DND-suppressed notifications locally; this firmware change benefits iOS only (nothing sets `header.silent` on Android, so the gate is a no-op there).
- **Forward-but-quiet:** the Android app would set `TimelineItemFlagSilent` and forward instead of dropping → DND-suppressed notifications appear silently in the list, matching iOS. (Changes existing Android behaviour: they currently vanish.) The app PR declares the wire flag so this needs no protocol change, but does not implement the emit path — it's left as a maintainer choice.

**2. Is ANCS the right transport,** given the exact trigger isn't spelled out by Apple? (I've now characterized it empirically — see *The flag* — but it's still Apple's undocumented behaviour, not a contract.) [`INFocusStatusCenter`](https://developer.apple.com/documentation/intents/infocusstatuscenter) (iOS 15+) lets a companion app read Focus state with user authorisation and relay it — fully documented semantics, at the cost of an entitlement and app work.

## Known behaviour

If the notification window is already open when a silent notification arrives, it is not inserted into the live list until the window reloads (still lands in storage / the notifications app). Identical to the existing Quiet Time hide early-return directly above the new gate — intentional, but flagged.

## Tested

`./pbl build` (obelix) and the affected `./pbl test` suites pass: `test_ancs`, `test_ancs_notifications`, `test_notification_window` (obelix + gabbro), `test_timeline_item`, `test_notification_storage`.

Unit tests added cover: the ANCS layer propagating the flag, the flag reaching the stored item, and the suppression path itself (with `header.silent = true` / `header.ancs_notif = false`, proving the gate is platform-neutral, plus the two negative cases).

On-device (obelix, via my personal watch-side-toggle build — same suppression path): with the preference on, notifications caught by an active Focus/DND land in the list silently, while everything else alerts normally — including senders allow-listed in the Focus. The hardware silent switch, ringer volume at 0, per-app "Mute for 1 hour", and Screen Time all leave the notification alerting (they do not set the flag); details under *The flag*.

## Companion-app side — see the paired PR

[coredevices/mobileapp#304](https://github.com/coredevices/mobileapp/pull/304) un-gates the existing "Respect Phone Do Not Disturb" toggle so it shows on both platforms and mirrors it to the synced `notifRespectPhoneSilence` pref — a hidden `BoolWatchPref`, so there's no duplicate row — which enables this feature on iOS; and it declares `TimelineItem.Flag.SILENT` as the wire counterpart of this bit. It intentionally does **not** change Android notification handling — the Android forward-but-quiet path (question 1) is left as a maintainer decision.
