### PR TITLE
applib: touch drag-to-scroll and tap-to-select for ScrollLayer / MenuLayer

### DIFF
--- a/src/fw/applib/ui/menu_layer.c
+++ b/src/fw/applib/ui/menu_layer.c
@@ -29,6 +29,10 @@
 //! @return True if there was an animation to cancel, false otherwise
 static bool prv_cancel_selection_animation(MenuLayer *menu_layer);
 
+#ifdef CONFIG_TOUCH
+static void prv_menu_layer_handle_tap(ScrollLayer *scroll_layer, GPoint point, void *context);
+#endif
+
 //////////////////////
 // Menu Layer
 //
@@ -205,6 +209,10 @@ static void prv_menu_click_config_provider(MenuLayer *menu_layer) {
   }
   window_single_repeating_click_subscribe(BUTTON_ID_DOWN, 100 /*ms*/,
       (ClickHandler)menu_down_click_handler);
+#ifdef CONFIG_TOUCH
+  // Route touch taps (as opposed to drag-scrolls) to row selection.
+  scroll_layer_set_touch_tap_handler(&menu_layer->scroll_layer, prv_menu_layer_handle_tap);
+#endif
 }
 
 static inline uint16_t prv_menu_layer_get_num_sections(MenuLayer *menu_layer) {
@@ -683,6 +691,87 @@ void menu_layer_update_proc(Layer *scroll_content_layer, GContext* ctx) {
 
   task_free(render_iter);
 }
+
+#ifdef CONFIG_TOUCH
+typedef struct MenuHitTestIterator {
+  MenuIterator it;
+  int16_t target_y;  // content-space Y coordinate to locate
+  MenuIndex found_index;
+  bool found;
+  bool is_header;
+} MenuHitTestIterator;
+
+static void prv_menu_hit_test_row_callback(MenuIterator *iterator) {
+  MenuHitTestIterator *it = (MenuHitTestIterator *)iterator;
+  const int16_t top = it->it.cursor.y;
+  if (it->target_y >= top && it->target_y < top + it->it.cursor.h) {
+    it->found = true;
+    it->is_header = false;
+    it->found_index = it->it.cursor.index;
+    it->it.should_continue = false;
+  }
+}
+
+static void prv_menu_hit_test_section_callback(MenuIterator *iterator) {
+  MenuHitTestIterator *it = (MenuHitTestIterator *)iterator;
+  const int16_t top = it->it.cursor.y;
+  if (it->target_y >= top && it->target_y < top + it->it.cursor.h) {
+    it->found = true;
+    it->is_header = true;
+    it->it.should_continue = false;
+  }
+}
+
+//! Locate the row whose cell spans the given content-space Y coordinate.
+//! @return true and fill *index_out if a normal row is hit; false for a section
+//! header, a separator gap, or out of bounds.
+static bool prv_menu_layer_find_row_at_content_y(MenuLayer *menu_layer, int16_t content_y,
+                                                 MenuIndex *index_out) {
+  MenuHitTestIterator it = {
+    .it = {
+      .menu_layer = menu_layer,
+      .cursor = menu_layer->cache.cursor,
+      .row_callback_after_geometry = prv_menu_hit_test_row_callback,
+      .section_callback = prv_menu_hit_test_section_callback,
+      .should_continue = true,
+    },
+    .target_y = content_y,
+  };
+
+  // Walk down from the cached anchor, then up, mirroring the render pass, so we
+  // cover the anchor row plus everything above and below it.
+  prv_menu_layer_walk_downward_from_iterator(&it.it);
+  if (!it.found) {
+    it.it.cursor = menu_layer->cache.cursor;
+    it.it.should_continue = true;
+    prv_menu_layer_walk_upward_from_iterator(&it.it);
+  }
+
+  if (it.found && !it.is_header) {
+    *index_out = it.found_index;
+    return true;
+  }
+  return false;
+}
+
+static void prv_menu_layer_handle_tap(ScrollLayer *scroll_layer, GPoint point, void *context) {
+  MenuLayer *menu_layer = context;
+  const int16_t content_y = point.y - scroll_layer_get_content_offset(scroll_layer).y;
+
+  MenuIndex index;
+  if (!prv_menu_layer_find_row_at_content_y(menu_layer, content_y, &index)) {
+    return;
+  }
+
+  // Move the selection to the tapped row, then fire the same callback as a
+  // physical SELECT press.
+  menu_layer_set_selected_index(menu_layer, index, MenuRowAlignNone, false /*animated*/);
+  if (menu_layer->callbacks.select_click) {
+    menu_layer->callbacks.select_click(menu_layer, &menu_layer->selection.index,
+                                       menu_layer->callback_context);
+  }
+}
+#endif  // CONFIG_TOUCH
 
 void menu_layer_init_scroll_layer_callbacks(MenuLayer *menu_layer) {
   ScrollLayer *scroll_layer = &menu_layer->scroll_layer;

--- a/src/fw/applib/ui/scroll_layer.c
+++ b/src/fw/applib/ui/scroll_layer.c
@@ -6,6 +6,8 @@
 #include "applib/applib_malloc.auto.h"
 #include "applib/graphics/gtypes.h"
 #include "applib/graphics/graphics.h"
+#include "applib/pbl_std/pbl_std.h"
+#include "applib/touch_service.h"
 #include "applib/ui/content_indicator_private.h"
 #include "applib/ui/shadows.h"
 #include "applib/ui/window.h"
@@ -112,7 +114,41 @@ bool scroll_layer_is_instance(const Layer *layer) {
   return layer && layer->property_changed_proc == scroll_layer_property_changed_proc;
 }
 
+#ifdef CONFIG_TOUCH
+// Distance (px) the finger must travel before a gesture is treated as a drag
+// rather than a tap.
+#define SCROLL_TOUCH_DRAG_THRESHOLD_PX 10
+// A gesture below the drag threshold that lifts off within this many ms is a tap.
+#define SCROLL_TOUCH_TAP_MAX_MS 300
+
+//! Transient state for the in-progress touch gesture. Only one touch gesture is
+//! ever in flight (touch events are delivered to the single focused
+//! subscriber), so a single file-static instance is sufficient.
+typedef struct ScrollTouchGesture {
+  ScrollLayer *scroll_layer;  // gesture target, NULL when idle
+  int16_t start_y;
+  int16_t start_offset_y;
+  int64_t down_time_ms;
+  bool dragging;
+} ScrollTouchGesture;
+
+static ScrollTouchGesture s_touch_gesture;
+
+//! Tap handler of the scroll layer currently set up for touch. Captured while
+//! its click config provider runs (see scroll_layer_click_config_provider), so
+//! it always reflects the single focused/subscribed scroll layer.
+static ScrollLayerTapHandler s_active_tap_handler;
+#endif  // CONFIG_TOUCH
+
 void scroll_layer_deinit(ScrollLayer *scroll_layer) {
+#ifdef CONFIG_TOUCH
+  // Never let a destroyed scroll layer be referenced by the active gesture or a
+  // pending touch event.
+  if (s_touch_gesture.scroll_layer == scroll_layer) {
+    s_touch_gesture.scroll_layer = NULL;
+  }
+  touch_service_unsubscribe();
+#endif
   animation_destroy(property_animation_get_animation(scroll_layer->animation));
   content_indicator_destroy_for_scroll_layer(scroll_layer);
   layer_deinit(&scroll_layer->layer);
@@ -282,7 +318,80 @@ void scroll_layer_scroll_down_click_handler(ClickRecognizerRef recognizer, void 
   (void)recognizer;
 }
 
+#ifdef CONFIG_TOUCH
+static int64_t prv_touch_now_ms(void) {
+  time_t seconds;
+  uint16_t milliseconds;
+  time_ms(&seconds, &milliseconds);
+  return ((int64_t)seconds * 1000) + milliseconds;
+}
+
+static void prv_scroll_layer_stop_animation(ScrollLayer *scroll_layer) {
+  Animation *animation = property_animation_get_animation(scroll_layer->animation);
+  if (animation && animation_is_scheduled(animation)) {
+    animation_unschedule(animation);
+  }
+}
+
+static void prv_scroll_layer_touch_handler(const TouchEvent *event, void *context) {
+  ScrollLayer *scroll_layer = context;
+  switch (event->type) {
+    case TouchEvent_Touchdown:
+      // Stop any running scroll animation and start following from here.
+      prv_scroll_layer_stop_animation(scroll_layer);
+      s_touch_gesture = (ScrollTouchGesture) {
+        .scroll_layer = scroll_layer,
+        .start_y = event->y,
+        .start_offset_y = scroll_layer_get_content_offset(scroll_layer).y,
+        .down_time_ms = prv_touch_now_ms(),
+        .dragging = false,
+      };
+      break;
+    case TouchEvent_PositionUpdate: {
+      if (s_touch_gesture.scroll_layer != scroll_layer) {
+        break;
+      }
+      const int16_t delta_y = event->y - s_touch_gesture.start_y;
+      if (!s_touch_gesture.dragging) {
+        // Hold off until the finger has clearly committed to a drag.
+        if (ABS(delta_y) < SCROLL_TOUCH_DRAG_THRESHOLD_PX) {
+          break;
+        }
+        s_touch_gesture.dragging = true;
+      }
+      // The internal setter hard-clamps to the content bounds (honoring
+      // clips_content_offset), matching button scrolling.
+      prv_scroll_layer_set_content_offset_internal(
+          scroll_layer, GPoint(0, s_touch_gesture.start_offset_y + delta_y));
+      break;
+    }
+    case TouchEvent_Liftoff: {
+      if (s_touch_gesture.scroll_layer != scroll_layer) {
+        break;
+      }
+      const bool was_dragging = s_touch_gesture.dragging;
+      const int64_t elapsed_ms = prv_touch_now_ms() - s_touch_gesture.down_time_ms;
+      s_touch_gesture.scroll_layer = NULL;
+      if (!was_dragging && elapsed_ms < SCROLL_TOUCH_TAP_MAX_MS && s_active_tap_handler) {
+        GRect global_frame;
+        layer_get_global_frame(&scroll_layer->layer, &global_frame);
+        const GPoint local = GPoint(event->x - global_frame.origin.x,
+                                    event->y - global_frame.origin.y);
+        s_active_tap_handler(scroll_layer, local, get_callback_context(scroll_layer));
+      }
+      break;
+    }
+  }
+}
+#endif  // CONFIG_TOUCH
+
 static void scroll_layer_click_config_provider(ScrollLayer *scroll_layer) {
+#ifdef CONFIG_TOUCH
+  // Reset before the client provider runs; it may (re)register a tap handler via
+  // scroll_layer_set_touch_tap_handler().
+  s_active_tap_handler = NULL;
+#endif
+
   // Config UP / DOWN button behavior:
   window_single_repeating_click_subscribe(BUTTON_ID_UP, 100, scroll_layer_scroll_up_click_handler);
   window_single_repeating_click_subscribe(BUTTON_ID_DOWN, 100, scroll_layer_scroll_down_click_handler);
@@ -293,6 +402,26 @@ static void scroll_layer_click_config_provider(ScrollLayer *scroll_layer) {
   if (scroll_layer->callbacks.click_config_provider) {
     scroll_layer->callbacks.click_config_provider(get_callback_context(scroll_layer));
   }
+
+#ifdef CONFIG_TOUCH
+  // Ride along on the existing click setup to also grab touch input. This runs
+  // on every window appear, so the focused scroll layer re-subscribes as the
+  // single touch handler. Only the (single, per-task) most recent subscriber
+  // receives events; coordinating touch across concurrent scroll layers or an
+  // app's own touch subscription is out of scope for now.
+  if (touch_service_is_enabled()) {
+    touch_service_subscribe(prv_scroll_layer_touch_handler, scroll_layer);
+  }
+#endif
+}
+
+void scroll_layer_set_touch_tap_handler(ScrollLayer *scroll_layer, ScrollLayerTapHandler handler) {
+  (void)scroll_layer;
+#ifdef CONFIG_TOUCH
+  s_active_tap_handler = handler;
+#else
+  (void)handler;
+#endif
 }
 
 void scroll_layer_set_click_config_onto_window(ScrollLayer *scroll_layer, struct Window *window) {

--- a/src/fw/applib/ui/scroll_layer.h
+++ b/src/fw/applib/ui/scroll_layer.h
@@ -52,6 +52,13 @@ struct ScrollLayer;
 //! Function signature for the `.content_offset_changed_handler` callback.
 typedef void (*ScrollLayerCallback)(struct ScrollLayer *scroll_layer, void *context);
 
+//! @internal
+//! Signature for the internal handler invoked when a touch tap (as opposed to a
+//! drag) is detected on a touch-enabled platform. `point` is in the scroll
+//! layer's frame coordinates.
+typedef void (*ScrollLayerTapHandler)(struct ScrollLayer *scroll_layer, GPoint point,
+                                      void *context);
+
 //! All the callbacks that the ScrollLayer exposes for use by applications.
 //! @note The context parameter can be set using scroll_layer_set_context() and
 //! gets passed in as context with all of these callbacks.
@@ -328,6 +335,13 @@ bool scroll_layer_get_clips_content_offset(ScrollLayer *scroll_layer);
 //! @internal
 //! True, if the passed layer is a scroll_layer; false otherwise.
 bool scroll_layer_is_instance(const Layer *layer);
+
+//! @internal
+//! Register the handler invoked when a touch tap (not a drag) is detected on the
+//! scroll layer currently being configured. Higher-level layers (e.g. MenuLayer)
+//! call this from their click config provider. Pass NULL to opt out. No-op on
+//! platforms without a touchscreen.
+void scroll_layer_set_touch_tap_handler(ScrollLayer *scroll_layer, ScrollLayerTapHandler handler);
 
 //!     @} // end addtogroup ScrollLayer
 //!   @} // end addtogroup Layer


### PR DESCRIPTION
## Summary

On touch-enabled platforms, make `ScrollLayer` and `MenuLayer` respond to
touch: a vertical **drag scrolls** the content, and a **tap selects** a menu
row (equivalent to a physical SELECT press). Existing apps that use these
widgets get this for free — no app changes, no new settings, and no public SDK
surface is added.

## Motivation

Pebble Time 2 (and other `CONFIG_TOUCH` boards) have a touchscreen, but the
core scrolling widgets were button-only. This adds the two most common touch
interactions — scroll and select — at the widget level, so the bulk of the
system UI and third-party apps built on `ScrollLayer`/`MenuLayer` become
touch-usable without modification.

## Approach

- **Guarded by `CONFIG_TOUCH`** (the firmware Kconfig symbol, as used by the
  neighbouring `layer.c` / `event_loop.c`), so the code is compiled out on
  non-touch boards.
- **No new public API.** The scroll layer subscribes to the touch service from
  inside its existing click-config provider
  (`scroll_layer_click_config_provider`), which already runs on every window
  appear. This means the focused scroll layer re-subscribes as the touch
  handler exactly when it takes over the buttons, and it needs no change to the
  app-facing API.

### ScrollLayer (drag + tap dispatch)

- **Touchdown** records the start Y and the start content offset and stops any
  running scroll animation, so the content follows the finger from where it
  was.
- **Position updates** are ignored until the finger has moved more than a 10px
  threshold; past that the gesture is a confirmed drag and ΔY is applied to the
  content offset via the existing internal setter, which hard-clamps to the
  content bounds (honouring `clips_content_offset`), matching button scrolling.
- **Liftoff**: if the gesture never became a drag and lifted off within 300ms
  it is dispatched as a *tap* to an optional internal handler; a confirmed drag
  just finalises the position.
- The subscription is torn down in `scroll_layer_deinit()` so a destroyed
  layer can never be referenced by a pending touch event.

### MenuLayer (tap-to-select)

- Registers an internal tap handler on its scroll layer. On a tap, the tap's
  content-space Y coordinate is mapped to a row by walking the existing cell
  iterator. **Section headers and separator gaps are ignored.** A hit row is
  selected via `menu_layer_set_selected_index()` and then fires the **same
  `select_click` callback as a physical SELECT press** — identical handling, no
  separate code path.

### File-scope static gesture state (design premise)

The in-flight gesture state and the active tap handler are held in **file-scope
statics**, not in the `ScrollLayer`/`MenuLayer` structs. This relies on a
deliberate premise:

> There is a single physical touchscreen, so **only one touch gesture is ever
> in flight at a time** (touch events are delivered to the single focused
> subscriber).

Because of this, per-layer storage is unnecessary — and, importantly, it keeps
the widget structs unchanged: **no struct growth and therefore no ABI impact**
(`applib_malloc.json` sizes and the `size_2x`/`size_3x` static asserts are
untouched, which matters because `MenuLayer` currently has zero `size_2x`
headroom).

## Watchface restriction: not affected

This targets **watchapp** contexts only and does not interfere with the touch
service's watchface restriction. The touch service already returns no per-task
state for watchfaces (`sys_app_is_watchface()`), so a `ScrollLayer`/`MenuLayer`
living in a watchface simply subscribes to nothing — the behaviour is inert
there by construction. The existing **Settings → Display → Touch** toggle
(`touch_service_set_globally_enabled`) continues to gate touch globally; no new
setting is introduced.

## Out of scope for v1 (open problems)

These are intentionally not implemented and left as follow-ups:

- **Rubber-banding / over-scroll resistance** at the ends — v1 hard-clamps only.
- **Touch long-press** (SELECT-long-press equivalent).
- **Button/touch mutual-exclusion** when both are used at once.
- **Live follow-through** of the Settings → Display → Touch toggle mid-app
  (subscription is decided at window-appear time).
- **Paging-mode interaction** — a drag applies the offset directly and does not
  page-align.

A separate, independent line of work (kept on a different branch) explores a
kernel-level "gesture → button synthesis" bridge to help apps that use their
own click handlers instead of `ScrollLayer`/`MenuLayer`; it is **not** part of
this PR and does not touch this code.

## Testing

- **Builds**: `qemu_emery` (touch), `qemu_flint` (non-touch, code correctly
  compiled out), and `obelix@pvt`/`@slot1` (real Pebble Time 2 target) all
  build cleanly; the feature's symbols are present on touch targets and absent
  on non-touch.
- **Real hardware**: sideloaded onto a Pebble Time 2 and **confirmed that touch
  vertical scrolling works** in the launcher / Settings menus.
- **Logic**: the drag/tap state machine and the row hit-test interval logic are
  covered by a standalone check.
- Note: the bundled `qemu-pebble` build does not raise the touch IRQ, so the
  end-to-end touch path could not be exercised purely in QEMU; verification was
  done on real hardware plus the logic checks above.

## Compatibility

- No new SDK function is exported (`exported_symbols.json` and the SDK revision
  are unchanged); the only added function is `@internal` and used solely by
  `MenuLayer`.
- No new settings; existing `ScrollLayer`/`MenuLayer` apps benefit unmodified.
- No struct/ABI changes.
