### PR TITLE
doxygen: burn down all documentation warnings (758 -> 0)

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1108,7 +1108,7 @@ EXCLUDE_SYMBOLS        =
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           =
+EXAMPLE_PATH           = sdk/docs/external_refs
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and

--- a/Doxyfile.rtd
+++ b/Doxyfile.rtd
@@ -15,3 +15,4 @@ QUIET                  = YES
 HTML_COLORSTYLE        = LIGHT
 HTML_EXTRA_STYLESHEET  = doxygen-awesome-css/doxygen-awesome.css
 GENERATE_TAGFILE       = docs/_apidoc/apidoc/pebbleos.tag
+WARN_AS_ERROR          = FAIL_ON_WARNINGS

--- a/include/bluetooth/bonding_sync.h
+++ b/include/bluetooth/bonding_sync.h
@@ -52,6 +52,7 @@ void bt_driver_handle_host_added_cccd(const BleCCCD *cccd);
 void bt_driver_handle_host_removed_cccd(const BleCCCD *cccd);
 
 //! Called by the BT driver after succesfully pairing a new device.
+//! @param bonding The newly created bonding.
 //! @param addr The address that is used to refer to the connection. This is used to associate
 //! the bonding with the GAPLEConnection.
 extern void bt_driver_cb_handle_create_bonding(const BleBonding *bonding,

--- a/include/bluetooth/bt_driver_ppog_reversed.h
+++ b/include/bluetooth/bt_driver_ppog_reversed.h
@@ -7,7 +7,8 @@
 
 #include <stdint.h>
 
-//! @file Kernel <-> BT driver API for the reversed PPoG GATT service: the
+//! @file
+//! Kernel <-> BT driver API for the reversed PPoG GATT service: the
 //! watch hosts the service and the phone is the GATT client.
 //! The bt_driver_cb_ppog_reversed_* callbacks are invoked from the BT driver
 //! task without bt_lock held.

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -132,7 +132,7 @@ extern void bt_driver_cb_gatt_handle_mtu_update(const GattDeviceMtuUpdateEvent *
 
 extern void bt_driver_cb_gatt_handle_notification(const GattServerNotifIndicEvent *event);
 
-//! @NOTE: The indication is unconditionally confirmed within the bt_driver as soon as one is
+//! @note The indication is unconditionally confirmed within the bt_driver as soon as one is
 //!        received.
 extern void bt_driver_cb_gatt_handle_indication(const GattServerNotifIndicEvent *event);
 

--- a/include/bluetooth/init.h
+++ b/include/bluetooth/init.h
@@ -26,7 +26,6 @@ void bt_driver_init(void);
 bool bt_driver_start(BTDriverConfig *config);
 
 //! Stops the Bluetooth stack.
-//! @return True if the stack stopped successfully.
 void bt_driver_stop(void);
 
 //! Powers down the BT controller if has yet to be used

--- a/include/bluetooth/pebble_bt.h
+++ b/include/bluetooth/pebble_bt.h
@@ -6,7 +6,8 @@
 #include <stdint.h>
 #include "pbl/util/uuid.h"
 
-//! @file This file contains Pebble-specific Bluetooth identifiers (numbers, UUIDs, etc.)
+//! @file
+//! This file contains Pebble-specific Bluetooth identifiers (numbers, UUIDs, etc.)
 //! Also see https://pebbletechnology.atlassian.net/wiki/display/DEV/Pebble+GATT+Services
 
 //! Our Bluetooth-SIG-Registered 16-bit UUID:

--- a/include/bluetooth/pebble_pairing_service.h
+++ b/include/bluetooth/pebble_pairing_service.h
@@ -218,6 +218,7 @@ extern void bt_driver_cb_pebble_pairing_service_handle_ios_app_termination_detec
 
 //! Indicate to the FW that the Connection Parameters characteristic has been written to with a new
 //! values.
+//! @param device The device that wrote to the characteristic.
 //! @param conn_params The value as written to the Connection Parameters characteristic. The BT
 //! driver lib is expected to validate any written values and only call this function with valid
 //! values.

--- a/include/pbl/os/mutex.h
+++ b/include/pbl/os/mutex.h
@@ -45,8 +45,8 @@ bool mutex_is_owned_recursive(PebbleRecursiveMutex *handle);
 
 void mutex_unlock_recursive(PebbleRecursiveMutex *handle);
 
-//! @return true if the calling task owns the mutex
+//! Asserts that the calling task's ownership of the mutex matches \c is_held
 void mutex_assert_held_by_curr_task(PebbleMutex *handle, bool is_held);
 
-//! @return true if the calling task owns the mutex
+//! Asserts that the calling task's ownership of the mutex matches \c is_held
 void mutex_assert_recursive_held_by_curr_task(PebbleRecursiveMutex *handle, bool is_held);

--- a/include/pbl/services/accel_manager.h
+++ b/include/pbl/services/accel_manager.h
@@ -55,7 +55,8 @@ int sys_accel_manager_set_sampling_rate(AccelManagerState *state, AccelSamplingR
 //! Reconfigure an existing subscription to use a sampling rate that's the lowest the hardware
 //! can support without introducing jitter and is at least min_rate_hz.
 //!
-//! @param min_rate_hz The lowest desired sample rate in millihertz.
+//! @param state The subscription to reconfigure.
+//! @param min_rate_mHz The lowest desired sample rate in millihertz.
 //! @return The resulting sample rate in millihertz. 0 if it's not possible to get a rate high
 //!         enough.
 uint32_t accel_manager_set_jitterfree_sampling_rate(AccelManagerState *state,

--- a/include/pbl/services/activity/activity.h
+++ b/include/pbl/services/activity/activity.h
@@ -326,21 +326,21 @@ typedef enum ActivationDelayInsightType ActivationDelayInsightType;
 //! @return True if the activation delay insight has fired
 bool activity_prefs_has_activation_delay_insight_fired(ActivationDelayInsightType type);
 
-//! @return Mark an activation delay insight as having fired
+//! Mark an activation delay insight as having fired
 void activity_prefs_set_activation_delay_insight_fired(ActivationDelayInsightType type);
 
 //! @return Which version of the health app was last opened
 //! @note 0 is "never opened"
 uint8_t activity_prefs_get_health_app_opened_version(void);
 
-//! @return Record that the health app has been opened at a given version
+//! Record that the health app has been opened at a given version
 void activity_prefs_set_health_app_opened_version(uint8_t version);
 
 //! @return Which version of the workout app was last opened
 //! @note 0 is "never opened"
 uint8_t activity_prefs_get_workout_app_opened_version(void);
 
-//! @return Record that the workout app has been opened at a given version
+//! Record that the workout app has been opened at a given version
 void activity_prefs_set_workout_app_opened_version(uint8_t version);
 
 //! Enable/disable activity insights
@@ -555,6 +555,8 @@ bool activity_test_send_fake_dls_records(void);
 //! Used by test apps (running on firmware): Set the current step count
 //! Useful for testing the health app
 //! @param[in] new_steps the number of steps to set the current steps to
+//! @param[in] current_avg the value to set the current step average to
+//! @param[in] daily_avg the value to set the daily step average to
 void activity_test_set_steps_and_avg(int32_t new_steps, int32_t current_avg, int32_t daily_avg);
 
 //! Used by test apps (running on firmware): Set the past seven days of history

--- a/include/pbl/services/activity/activity_algorithm.h
+++ b/include/pbl/services/activity/activity_algorithm.h
@@ -152,7 +152,7 @@ bool activity_algorithm_set_user(uint32_t height_mm, uint32_t weight_g, Activity
 //! Process accel samples
 //! @param[in] data pointer to the accel samples
 //! @param[in] num_samples number of samples to process
-//! @param[in] timestamp timestamp of the first sample in ms
+//! @param[in] timestamp_ms timestamp of the first sample in ms
 void activity_algorithm_handle_accel(AccelRawData *data, uint32_t num_samples,
                                      uint64_t timestamp_ms);
 

--- a/include/pbl/services/activity/health_util.h
+++ b/include/pbl/services/activity/health_util.h
@@ -48,6 +48,7 @@ GTextNodeText *health_util_create_text_node_with_text(const char *text, GFont fo
 //! @param[in,out] buffer the string buffer to write to
 //! @param buffer_size the size of the string buffer
 //! @param duration_s the duration is seconds
+//! @param leading_zero whether to include a leading zero in the formatted string
 //! @param i18n_owner i18n owner that must be called with i18n_free_all some time after usage
 //! @return snprintf-style number of bytes needed to be written not including the null terminator
 int health_util_format_hours_minutes_seconds(char *buffer, size_t buffer_size, int duration_s,

--- a/include/pbl/services/activity/insights_settings.h
+++ b/include/pbl/services/activity/insights_settings.h
@@ -90,15 +90,15 @@ typedef struct PACKED ActivityInsightSettings {
 
 
 //! Read a setting from the insights settings
-//! @param insights_name the name of the insight for which to get a setting
-//! @param[out] settings out an ActivityInsightSettings struct to which the data will be written
+//! @param insight_name the name of the insight for which to get a setting
+//! @param[out] settings_out an ActivityInsightSettings struct to which the data will be written
 //! @returns true if the setting was found and the data is valid, false otherwise
 //! @note if this function returns false, settings_out will be zeroed out.
 bool activity_insights_settings_read(const char *insight_name,
                                      ActivityInsightSettings *settings_out);
 
 //! Write a setting to the insights settings (used for testing)
-//! @param insights_name the name of the insight for which to get a setting
+//! @param insight_name the name of the insight for which to get a setting
 //! @param settings an ActivityInsightSettings struct which contains the data to be written
 //! @returns true if the setting was successfully saved
 bool activity_insights_settings_write(const char *insight_name,

--- a/include/pbl/services/activity/kraepelin/kraepelin_algorithm.h
+++ b/include/pbl/services/activity/kraepelin/kraepelin_algorithm.h
@@ -151,5 +151,6 @@ time_t kalg_activity_last_processed_time(KAlgState *state, KAlgActivityType acti
 void kalg_get_sleep_stats(KAlgState *state, KAlgOngoingSleepStats *stats);
 
 //! Tells the algorithm whether or not it should automatically track activities
+//! @param kalg_state the state structure passed into kalg_init
 //! @param enable true to start tracking, false to stop tracking
 void kalg_enable_activity_tracking(KAlgState *kalg_state, bool enable);

--- a/include/pbl/services/alarms/alarm.h
+++ b/include/pbl/services/alarms/alarm.h
@@ -78,7 +78,7 @@ void alarm_set_time(AlarmId id, int hour, int minute);
 void alarm_set_kind(AlarmId id, AlarmKind kind);
 
 //! @param id The alarm that should be updated
-//! @param scheduled_days[DAYS_PER_WEEK] A bool for each weekday (Sunday = index 0) enabled
+//! @param scheduled_days A bool for each weekday (Sunday = index 0) enabled
 //! each weekday that is marked as true
 void alarm_set_custom(AlarmId id, const bool scheduled_days[DAYS_PER_WEEK]);
 
@@ -109,7 +109,7 @@ bool alarm_get_info(AlarmId id, AlarmInfo *info_out);
 AlarmId alarm_get_most_recent_id(void);
 
 //! @param id The alarm for which the scheduled_days array should be updated for
-//! @param scheduled_days[DAYS_PER_WEEK] An empty bool array for each weekday (Sunday = index 0)
+//! @param scheduled_days An empty bool array for each weekday (Sunday = index 0)
 //! that is to be updated. Alarms will run on each weekday that is marked as true
 //! @return True if the alarm exists, False otherwise
 bool alarm_get_custom_days(AlarmId id, bool scheduled_days[DAYS_PER_WEEK]);
@@ -184,7 +184,7 @@ const char *alarm_get_string_for_kind(AlarmKind kind, bool all_caps);
 
 //! For an alarm of type custom, retrieve a string representing the days that the alarm is set for
 //! Example: 1 day: ("Mondays", "Tuesdays"), multiple days: ("Mon,Sat,Sun", "Tue,Thu")
-//! @param [in] scheduled_days[DAYS_PER_WEEK] A bool for each weekday (Sunday = index 0) enabled
+//! @param [in] scheduled_days A bool for each weekday (Sunday = index 0) enabled
 //! @param [out] alarm_day_text A character array that is to be updated with the days. It should
 //! have a minimum of 28 bytes allocated
 void alarm_get_string_for_custom(bool scheduled_days[DAYS_PER_WEEK], char *alarm_day_text);

--- a/include/pbl/services/app_cache.h
+++ b/include/pbl/services/app_cache.h
@@ -9,7 +9,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-//! @file app_cache.c
+//! @file
 //! AppCache
 //!
 //! The AppCache keeps track of a cache of the applications that have binaries that reside on the

--- a/include/pbl/services/app_inbox_service.h
+++ b/include/pbl/services/app_inbox_service.h
@@ -60,8 +60,12 @@ void app_inbox_service_init(void);
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Owner / Receiver (App) API
 
+//! @param storage The buffer (in app space) used to store incoming messages.
 //! @param storage_size The size of the buffer (in app space). Note that a header will be appended
 //! to the data of sizeof(AppInboxMessageHeader) bytes.
+//! @param message_handler Handler called when a message has been received.
+//! @param dropped_handler Handler called when one or more messages have been dropped.
+//! @param tag Tag identifying the inbox service.
 //! @note The event handler will be executed on the task that called this function.
 //! @see app_inbox_create_and_register() for the applib invocation.
 bool app_inbox_service_register(uint8_t *storage, size_t storage_size,
@@ -78,6 +82,7 @@ void app_inbox_service_unregister_all(void);
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Sender (Kernel) API
 
+//! @param tag Tag identifying the inbox service to write to.
 //! @param required_free_length The length in bytes of the data that needs to be written. Note that
 //! this should not include the size of the AppInboxMessageHeader. However, there must be at least
 //! (required_free_length + sizeof(AppInboxMessageHeader)) bytes free in the buffer in order to

--- a/include/pbl/services/app_outbox_service.h
+++ b/include/pbl/services/app_outbox_service.h
@@ -90,6 +90,9 @@ typedef void (*AppOutboxMessageHandler)(AppOutboxMessage *message);
 bool app_outbox_service_is_message_cancelled(AppOutboxMessage *message);
 
 //! Registers a consumer for a specific app outbox service tag.
+//! @param service_tag Tag of the app outbox service to register for.
+//! @param message_handler Callback invoked when a message is added.
+//! @param consumer_task The task on which `message_handler` is invoked.
 //! @param consumer_data_size The additional space that will be allocated for context by the app
 //! outbox service, on behalf of the consumer. The extra space will be appended to the message that
 //! gets passed into `message_handler`.
@@ -101,6 +104,7 @@ void app_outbox_service_register(AppOutboxServiceTag service_tag,
 //! Will invoke the sender's `sent_handler` with the status on the app task.
 //! @param message Pointer to the message to be consumed. Note that this message will have been
 //! free'd after this function returns and should not be used thereafter.
+//! @param status The status to report to the sender's `sent_handler`.
 void app_outbox_service_consume_message(AppOutboxMessage *message, AppOutboxStatus status);
 
 //! Closes the outbox.

--- a/include/pbl/services/blob_db/api.h
+++ b/include/pbl/services/blob_db/api.h
@@ -144,6 +144,8 @@ void blob_db_get_dirty_dbs(uint8_t *ids, uint8_t *num_ids);
 //! \param db_id the ID of the blob DB
 //! \param key a pointer to the key data
 //! \param key_len the lenght of the key, in bytes
+//! \param val a pointer to the value data
+//! \param val_len the length of the value, in bytes
 status_t blob_db_insert(BlobDBId db_id,
     const uint8_t *key, int key_len, const uint8_t *val, int val_len);
 
@@ -157,12 +159,18 @@ int blob_db_get_len(BlobDBId db_id,
 
 //! Get the value of length val_len for a given key
 //! \param db_id the ID of the blob DB
+//! \param key a pointer to the key data
+//! \param key_len the lenght of the key, in bytes
+//! \param val_out a buffer to store the value data
+//! \param val_len the length of the value, in bytes
 //! See \ref BlobDBReadImpl
 status_t blob_db_read(BlobDBId db_id,
     const uint8_t *key, int key_len, uint8_t *val_out, int val_len);
 
 //! Delete the key/val pair in a blob DB for a given key
 //! \param db_id the ID of the blob DB
+//! \param key a pointer to the key data
+//! \param key_len the lenght of the key, in bytes
 //! See \ref BlobDBDeleteImpl
 status_t blob_db_delete(BlobDBId db_id,
     const uint8_t *key, int key_len);
@@ -182,5 +190,7 @@ BlobDBDirtyItem *blob_db_get_dirty_list(BlobDBId db_id);
 //! Mark an item in a blob DB as having been synced
 //! \note This API is used upon receiving an ACK from the phone during sync
 //! \param db_id the ID of the blob DB
+//! \param key a pointer to the key data
+//! \param key_len the lenght of the key, in bytes
 //! \see BlobDBMarkSyncedImpl
 status_t blob_db_mark_synced(BlobDBId db_id, uint8_t *key, int key_len);

--- a/include/pbl/services/blob_db/ios_notif_pref_db.h
+++ b/include/pbl/services/blob_db/ios_notif_pref_db.h
@@ -37,7 +37,7 @@ void ios_notif_pref_db_free_prefs(iOSNotifPrefs *prefs);
 //! @param app_id The iOS app id to check. ex com.apple.MobileSMS
 //! @param length The length of the app_id
 //! @param attr_list AttributeList for the app
-//! @param attr_list ActionGroup for the app
+//! @param action_group ActionGroup for the app
 status_t ios_notif_pref_db_store_prefs(const uint8_t *app_id, int length, AttributeList *attr_list,
                                        TimelineItemActionGroup *action_group);
 

--- a/include/pbl/services/blob_db/pin_db.h
+++ b/include/pbl/services/blob_db/pin_db.h
@@ -36,7 +36,7 @@ status_t pin_db_next_item_header(TimelineItem *next_item_out,
                                  TimelineItemStorageFilterCallback filter);
 
 //! Determines whether or not the timeline entry has expired based on its age
-//! @param pin_timestamp - the timestamp of the pin being removed
+//! @param pin_end_timestamp - the timestamp of the pin being removed
 bool pin_db_has_entry_expired(time_t pin_end_timestamp);
 
 

--- a/include/pbl/services/blob_db/sync.h
+++ b/include/pbl/services/blob_db/sync.h
@@ -37,6 +37,7 @@ status_t blob_db_sync_db(BlobDBId db_id);
 //! @param db_id the BlobDBId of the database to sync
 //! @param key the key to sync
 //! @param key_len the length of the key to sync
+//! @param last_updated the last-updated timestamp of the record
 status_t blob_db_sync_record(BlobDBId db_id, const void *key, int key_len, time_t last_updated);
 
 //! Get the sync session for a given ID. Will NOT return sessions for individual records

--- a/include/pbl/services/blob_db/sync_util.h
+++ b/include/pbl/services/blob_db/sync_util.h
@@ -11,9 +11,13 @@
 // be very careful.
 
 //! A settings file each callback which checks if the there are dirty records in the file
+//! @param file The settings file being iterated
+//! @param info Info about the current record
 //! @param context The address of a bool which will get set
 bool sync_util_is_dirty_cb(SettingsFile *file, SettingsRecordInfo *info, void *context);
 
 //! A settings file each callback which builds a BlobDBDirtyItem list
+//! @param file The settings file being iterated
+//! @param info Info about the current record
 //! @param context The address of an empty dirty list which will get built
 bool sync_util_build_dirty_list_cb(SettingsFile *file, SettingsRecordInfo *info, void *context);

--- a/include/pbl/services/bluetooth/bluetooth_persistent_storage.h
+++ b/include/pbl/services/bluetooth/bluetooth_persistent_storage.h
@@ -126,7 +126,7 @@ bool bt_persistent_storage_get_local_device_name(char *local_device_name_out, si
 
 //! Stores the customized local device name
 //! @param local_device_name The device name to store
-//! @param size The size of the string
+//! @param max_size The size of the string
 void bt_persistent_storage_set_local_device_name(char *local_device_name, size_t max_size);
 
 //! Retrieve the airplane mode setting
@@ -134,7 +134,7 @@ void bt_persistent_storage_set_local_device_name(char *local_device_name, size_t
 bool bt_persistent_storage_get_airplane_mode_enabled(void);
 
 //! Store the airplane mode setting
-//! @param the airplane mode state to be saved
+//! @param enable the airplane mode state to be saved
 void bt_persistent_storage_set_airplane_mode_enabled(bool enable);
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/include/pbl/services/bluetooth/local_id.h
+++ b/include/pbl/services/bluetooth/local_id.h
@@ -12,6 +12,7 @@ void bt_local_id_configure_driver(void);
 void bt_local_id_set_device_name(const char *device_name);
 
 //! Copies the name of the local device into the given buffer.
+//! @param name_out Buffer into which the name is copied
 //! @param is_le Only consumed if the device used is dual mode. If so,
 //               this changes the name returned
 void bt_local_id_copy_device_name(char name_out[BT_DEVICE_NAME_BUFFER_SIZE], bool is_le);

--- a/include/pbl/services/comm_session/session.h
+++ b/include/pbl/services/comm_session/session.h
@@ -68,7 +68,7 @@ CommSession *comm_session_get_system_session(void);
 //! @note It is possible that the session becomes disconnected at any point in time.
 CommSession *comm_session_get_current_app_session(void);
 
-//! @param session_in_out[in, out] Pass in a pointer to session pointer to sanitize it. The current
+//! @param[in,out] session_in_out Pass in a pointer to session pointer to sanitize it. The current
 //! *session value can be NULL, to "auto-select" the session for the currently running app.
 //! After returning, if *session_in_out was non-NULL when passed in, it will be unchanged if the app
 //! is permitted to use it. If not, it *session_in_out will be set to NULL.
@@ -107,7 +107,7 @@ void comm_session_reset(CommSession *session);
 //! @param endpoint_id Which endpoint to send the pebble protocol message to.
 //! @param data Pointer to the buffer with data to send
 //! @param length The length of the data
-//! @param timeout The duration for how long the call is allowed to block. If the send buffer does
+//! @param timeout_ms The duration for how long the call is allowed to block. If the send buffer does
 //! not have enough space available to enqueue the data, this function will block up to timeout_ms.
 //! @return true if the data was successfully queued up for sending.
 bool comm_session_send_data(CommSession *session, uint16_t endpoint_id,

--- a/include/pbl/services/comm_session/session_send_buffer.h
+++ b/include/pbl/services/comm_session/session_send_buffer.h
@@ -33,7 +33,7 @@ SendBuffer * comm_session_send_buffer_begin_write(CommSession *session, uint16_t
 //! Copies data into the send buffer of the session.
 //! @note The caller must have called comm_session_send_buffer_begin_write() first.
 //! @note bt_lock() may be held when making the call.
-//! @param session The session for which to enqueue data
+//! @param send_buffer The send buffer of the session for which to enqueue data
 //! @param data Pointer to the data to enqueue
 //! @param length Length of the data to enqueue
 //! @return true if the data was successfully queued up for sending, or false if there was not
@@ -47,5 +47,5 @@ bool comm_session_send_buffer_write(SendBuffer *send_buffer, const uint8_t *data
 //! to the session that was passed in the ..._begin_write() call.
 //! @note The caller must have called comm_session_send_buffer_begin_write() first.
 //! @note bt_lock() may be held when making the call.
-//! @param session The session for which to release the send buffer.
+//! @param send_buffer The send buffer to release.
 void comm_session_send_buffer_end_write(SendBuffer *send_buffer);

--- a/include/pbl/services/comm_session/session_transport.h
+++ b/include/pbl/services/comm_session/session_transport.h
@@ -90,10 +90,9 @@ typedef enum TransportDestination {
 
 //! Called by a transport to open/create a Pebble Protocol session for it.
 //! @param transport Opaque reference to the underlying serial transport
-//! @param send_next Function pointer to the implementation for the transport to send data
-//! @param is_system True if the transport is connected to the Pebble App (either using
-//! "com.getpebble.private" iAP protocol identifier on iOS, or directly connected to the Android
-//! Pebble App), false if it was directly connected to a 3rd party application.
+//! @param implementation Function pointers implementing the transport (e.g. to send data)
+//! @param destination Whether the transport carries Pebble Protocol for the "system", a 3rd
+//! party app, or both (see \ref TransportDestination).
 //! @return True if the session was opened successfully, false if not
 //! bt_lock() is expected to be taken by the caller!
 CommSession * comm_session_open(Transport *transport, const TransportImplementation *implementation,
@@ -102,6 +101,7 @@ CommSession * comm_session_open(Transport *transport, const TransportImplementat
 //! Called by the transport to indicate that the session associated with the given transport needs
 //! to be closed and cleaned up.
 //! bt_lock() is expected to be taken by the caller!
+//! @param session The session to close.
 //! @param reason For analytics tracking.
 void comm_session_close(CommSession *session, CommSessionCloseReason reason);
 
@@ -121,7 +121,8 @@ void comm_session_receive_router_write(CommSession *session,
 size_t comm_session_send_queue_get_length(const CommSession *session);
 
 //! Copies bytes from the send buffer into another buffer.
-//! @param start_off The offset into the send buffer
+//! @param session The session whose send queue to copy from
+//! @param start_offset The offset into the send buffer
 //! @param length The number of bytes to copy
 //! @param[out] data_out Pointer to the buffer into which to copy the data
 //! @return The number of bytes copied
@@ -136,6 +137,7 @@ size_t comm_session_send_queue_copy(CommSession *session, uint32_t start_offset,
 //! @note Internally, a non-contiguous buffer is used, so it is possible that there is more data
 //! to read. To access the entire contents, call this function and comm_session_send_queue_consume()
 //! repeatedly until it returns zero.
+//! @param session The session whose send queue to read from
 //! @param data_out Pointer to the pointer to assign the read pointer to.
 //! @return The number of bytes that can be read starting at the read pointer.
 size_t comm_session_send_queue_get_read_pointer(const CommSession *session,

--- a/include/pbl/services/compositor/compositor.h
+++ b/include/pbl/services/compositor/compositor.h
@@ -6,7 +6,7 @@
 #include "applib/ui/property_animation.h"
 #include "applib/ui/window.h"
 
-//! @file kernel/services/compositor.h
+//! @file
 //! This file manages what's currently shown on the screen of your Pebble!
 //! There are two main things that are managed by the compositor...
 //!
@@ -16,13 +16,12 @@
 //! animations requested by the window stack. The compositor will also draw in
 //! the status bar when the app is in fullscreen, and the app will adjust its
 //! framebuffer's destination frame vertically. The framebuffer is simply
-//! bitblt'ed into the appropriate position whenever compositor_flush is called.
+//! bitblt'ed into the appropriate position whenever the compositor flushes
+//! to the display.
 //!
-//! @see \ref compositor_get_child_entity
-//! @see \ref compositor_set_entity_framebuffer
 //! @see \ref compositor_transition
-//! @see \ref window_stack_animation_schedule
-//! @see \ref app_emit_render_ready_event
+//! @see \ref compositor_render_app
+//! @see \ref compositor_app_render_ready
 //!
 //! <h3>Modal Window</h3>
 //! A modal window is a Window that can be rendered on top of an app without
@@ -30,7 +29,10 @@
 //! we can trust its contents. The modal window is animated up and down the
 //! screen when its pushed and popped. Since the window doesn't have a framebuffer
 //! of its own, we render it to the main framebuffer on top of everything else
-//! whenever compositor_flush is called.
+//! whenever the compositor flushes to the display.
+//!
+//! @see \ref compositor_render_modal
+//! @see \ref compositor_modal_render_ready
 //!
 
 //! Transition direction, from the current position to the next.

--- a/include/pbl/services/data_logging/dls_storage.h
+++ b/include/pbl/services/data_logging/dls_storage.h
@@ -35,12 +35,12 @@ int32_t dls_storage_read(DataLoggingSession *logging_session, uint8_t *buffer, i
 int32_t dls_storage_consume(DataLoggingSession *logging_session, int32_t num_bytes);
 
 //! Move the data from the circular buffer in memory to flash.
-//! @param[in] logging_session session to write to
+//! @param[in] session session to write to
 //! @return true on success, false on failure
 bool dls_storage_write_session(DataLoggingSession *session);
 
 //! Write data directly to logging session storage from a passed in buffer
-//! @param[in] logging_session session to write to
+//! @param[in] session session to write to
 //! @param[in] data buffer to write from
 //! @param[in] num_bytes number of bytes to write
 //! @return true on success, false on failure

--- a/include/pbl/services/ecompass.h
+++ b/include/pbl/services/ecompass.h
@@ -76,5 +76,5 @@ extern void ecomp_corr_reset(void);
 bool sys_ecompass_service_subscribed(void);
 
 //! Populate the provided data struct with compass data from the service.
-//! @param data[out] The struct to populate
+//! @param[out] data The struct to populate
 void sys_ecompass_get_last_heading(CompassHeadingData *data);

--- a/include/pbl/services/filesystem/app_file.h
+++ b/include/pbl/services/filesystem/app_file.h
@@ -24,6 +24,10 @@
 
 //! Make an app-file name from the given app_id and suffix string.
 //!
+//! @param buffer Buffer to write the file name into
+//! @param buffer_len Size of the buffer, in bytes
+//! @param app_id The app install id to make the file name for
+//! @param suffix The suffix string
 //! @param suffix_len strlen(suffix)
 //!
 //! @note buffer_len must be > APP_FILE_NAME_PREFIX_LENGTH + suffix_len to fit

--- a/include/pbl/services/filesystem/pfs.h
+++ b/include/pbl/services/filesystem/pfs.h
@@ -201,8 +201,7 @@ extern uint32_t pfs_crc_calculate_file(int fd, uint32_t offset, uint32_t num_byt
 extern PFSFileListEntry *pfs_create_file_list(PFSFilenameTestCallback callback);
 
 //! Delete a directory list returned by pfs_list_files
-//! @param callback - callback to be called for on filename
-//! @return - pointer to head node of linked list of names, or NULL if no names match
+//! @param list - pointer to head node of linked list of names
 extern void pfs_delete_file_list(PFSFileListEntry *list);
 
 //! Run each filename in the filesystem through the filter callback and delete all files that match

--- a/include/pbl/services/hrm/hrm_manager.h
+++ b/include/pbl/services/hrm/hrm_manager.h
@@ -115,6 +115,7 @@ bool sys_hrm_manager_set_update_interval(HRMSessionRef session, uint32_t update_
 //! @param[out] app_id if not NULL, the app_id belonging to this subscription is returned here
 //! @param[out] update_interval_s if not NULL, the requested update interval is returned here
 //! @param[out] expire_s if not NULL, the number of seconds that this subcription will expire in
+//! @param[out] features if not NULL, the features of this subscription are returned here
 //! @return true if succss, false if subscription was not found
 bool sys_hrm_manager_get_subscription_info(HRMSessionRef session, AppInstallId *app_id,
                                            uint32_t *update_interval_s, uint16_t *expire_s,

--- a/include/pbl/services/music.h
+++ b/include/pbl/services/music.h
@@ -84,7 +84,7 @@ bool music_is_volume_reporting_supported(void);
 //! @see music_is_command_supported
 void music_command_send(MusicCommand command);
 
-//! @param The command to test.
+//! @param command The command to test.
 //! @return True if the command is supported by the connected server.
 bool music_is_command_supported(MusicCommand command);
 

--- a/include/pbl/services/poll_remote.h
+++ b/include/pbl/services/poll_remote.h
@@ -38,6 +38,7 @@ void poll_remote_start(void);
 void poll_remote_stop(void);
 
 //! Sets the polling intervals.
+//! @param service The poll remote service for which to set the intervals.
 //! @param min_interval_minutes The minimum interval between two "poll services" requests.
 //! Calls to poll_remote_send_request() will be no-ops if min_interval_minutes has not been reached.
 //! @param max_interval_minutes The maximum interval between two "poll services" requests.

--- a/include/pbl/services/process_management/app_storage.h
+++ b/include/pbl/services/process_management/app_storage.h
@@ -34,8 +34,8 @@ typedef enum AppStorageGetAppInfoResult {
 
 //! Retrieve the process metadata for a given app_bank and performs sanity checks
 //! to make sure that the process in the specified app_bank can be run by the current system.
-//! @param app_info[in,out] Structure to be populated with information from flash.
-//! @param build_id_out[out] Buffer into which the GNU build ID of the process its executable
+//! @param[in,out] app_info Structure to be populated with information from flash.
+//! @param[out] build_id_out Buffer into which the GNU build ID of the process its executable
 //! should be copied. The buffer must be at least BUILD_ID_EXPECTED_LEN bytes. OK to pass NULL.
 //! If no build ID was present, the buffer will be filled with zeroes.
 //! @param app_id The app id for which the app metadata needs to be fetched.
@@ -58,7 +58,7 @@ void app_storage_get_file_name(char *name, size_t buf_length, AppInstallId app_i
 
 //! Computes the process image and relocation table size
 //! @param info pointer to a PebbleProcessInfo struct
-//! @param load_size_out[out] receives the computed size on success
+//! @param[out] load_size_out receives the computed size on success
 //! @return true if the size can be computed safely
 bool app_storage_get_process_load_size(const PebbleProcessInfo *info,
                                        size_t *load_size_out);

--- a/include/pbl/services/put_bytes/put_bytes_storage.h
+++ b/include/pbl/services/put_bytes/put_bytes_storage.h
@@ -73,6 +73,6 @@ void pb_storage_deinit(PutBytesStorage *storage, bool is_success);
 //! Some types of storage allow the state of a partial installation to be recovered (today, just
 //! firmware & resources).
 //! @param obj_type The type of resource to recover the install status of
-//! @param status[out] How many bytes have been written and their crc
+//! @param[out] status How many bytes have been written and their crc
 //! @return True iff the status struct was populated with valid data
 bool pb_storage_get_status(PutBytesObjectType obj_type, PbInstallStatus *status);

--- a/include/pbl/services/regular_timer.h
+++ b/include/pbl/services/regular_timer.h
@@ -41,7 +41,7 @@ void regular_timer_add_multiminute_callback(RegularTimerInfo* cb, uint16_t minut
 bool regular_timer_remove_callback(RegularTimerInfo* cb);
 
 //! Check if a regular timer is currently scheduled
-//! @params cb pointer to the RegularTimerInfo struct for the timer
+//! @param cb pointer to the RegularTimerInfo struct for the timer
 //! @returns true if scheduled or pending deletion, false otherwise
 bool regular_timer_is_scheduled(RegularTimerInfo *cb);
 
@@ -50,7 +50,7 @@ bool regular_timer_is_scheduled(RegularTimerInfo *cb);
 //! TODO: It would probably make sense to just fold this into the logic
 //!       for _is_scheduled() once we verify no consumers are relying on
 //!       this odd behavior
-//! @params cb pointer to the RegularTimerInfo struct for the timer
+//! @param cb pointer to the RegularTimerInfo struct for the timer
 bool regular_timer_pending_deletion(RegularTimerInfo *cb);
 
 

--- a/include/pbl/services/settings/settings_raw_iter.h
+++ b/include/pbl/services/settings/settings_raw_iter.h
@@ -101,7 +101,7 @@ bool settings_raw_iter_end(SettingsRawIter *iter);
 int settings_raw_iter_get_current_record_pos(SettingsRawIter *iter);
 
 //! Restore a previous record position from
-//! \ref setting_iter_get_current_record_pos
+//! \ref settings_raw_iter_get_current_record_pos
 void settings_raw_iter_set_current_record_pos(SettingsRawIter *iter, int pos);
 
 //! Return the resumed record position. This was set when we started searching for a record.

--- a/include/pbl/services/shared_prf_storage/shared_prf_storage.h
+++ b/include/pbl/services/shared_prf_storage/shared_prf_storage.h
@@ -47,6 +47,8 @@ bool shared_prf_storage_get_ble_pairing_data(SMPairingInfo *pairing_info_out,
 
 //! @param pairing_info Data structure containing all the pairing info available.
 //! @param name Optional device name to store. Pass NULL if not available.
+//! @param requires_address_pinning Whether the pairing requires address pinning.
+//! @param flags Pairing flags to store.
 void shared_prf_storage_store_ble_pairing_data(const SMPairingInfo *pairing_info,
                                                const char *name,
                                                bool requires_address_pinning,

--- a/include/pbl/services/shared_prf_storage/v3_sprf/shared_prf_storage_private.h
+++ b/include/pbl/services/shared_prf_storage/v3_sprf/shared_prf_storage_private.h
@@ -46,7 +46,7 @@ _Static_assert(sizeof(SprfMagic) == 4, "SprfMagic unexpected size");
 //!   main_fw_scratch: A region for normal fw to stash info in the future if needed
 //!
 //! Each entry, or field, has its own crc which is written once the write of the field is complete.
-//! @NOTE: The CRC _must_ be the first member of a field. There are static asserts to catch
+//! @note The CRC _must_ be the first member of a field. There are static asserts to catch
 //! this for current, please add a static assert for this if you create a new field
 //!
 //! A field is 'valid' iff a CRC of its contents matches the crc in flash

--- a/include/pbl/services/system_task.h
+++ b/include/pbl/services/system_task.h
@@ -23,11 +23,13 @@ void system_task_watchdog_feed(void);
 typedef void (*SystemTaskEventCallback)(void *data);
 
 //! @param cb Callback function that will later be called from the system task
+//! @param data Context pointer passed to the callback
 //! @param should_context_switch A boolean that indicates our ISR should context switch at the end instead of
 //!                              resuming the previous task. See portEND_SWITCHING_ISR()
 bool system_task_add_callback_from_isr(SystemTaskEventCallback cb, void *data, bool* should_context_switch);
 
 //! @param cb Callback function that will later be called from the system task
+//! @param data Context pointer passed to the callback
 bool system_task_add_callback(SystemTaskEventCallback cb, void *data);
 
 //! @param block True if callbacks should be rejected, False if they should be let through.

--- a/include/pbl/services/timeline/attribute.h
+++ b/include/pbl/services/timeline/attribute.h
@@ -166,8 +166,8 @@ bool attribute_copy(Attribute *dest, const Attribute *src, uint8_t **buffer,
 //! in the "out" list in a contiguous region of memory given by buffer
 //! @param out a pointer to the destination attribute list
 //! @param in a pointer to the source attribute list
-//! @param buffer a pointer to a region of memory at least \ref attribute_list_get_buffer_size(in)
-//! bytes
+//! @param buffer a pointer to a region of memory at least
+//! \ref attribute_list_get_buffer_size "attribute_list_get_buffer_size(in)" bytes
 //! @param buffer_end a pointer to the end of the buffer
 //! @return true if successful, false if buffer was not large enough
 bool attribute_list_copy(AttributeList *out, const AttributeList *in, uint8_t *buffer,
@@ -202,7 +202,7 @@ void attribute_list_add_uint32(AttributeList *list, AttributeId id, uint32_t uin
 //! Append an attribute or replace an existing one in an attribute list.
 //! @param list pointer to the attribute list
 //! @param id AttributeID of the attribute to add
-//! @param TimelineResourceId value to store as the content of the attribute
+//! @param resource_id value to store as the content of the attribute
 void attribute_list_add_resource_id(AttributeList *list, AttributeId id,
                                     uint32_t resource_id);
 
@@ -238,7 +238,7 @@ void attribute_list_add_attribute(AttributeList *list, const Attribute *new_attr
 
 //! Initializes an attribute list.
 //! @param num_attributes Number of attributes to initialize for this list
-//! @param list the attribute list to initialize
+//! @param list_out the attribute list to initialize
 void attribute_list_init_list(uint8_t num_attributes, AttributeList *list_out);
 
 //! Destroy an attribute list.
@@ -293,7 +293,7 @@ Uint32List *attribute_get_uint32_list(const AttributeList *attr_list, AttributeI
 //! @param attr_list a pointer to the list of attributes to serialize
 //! @param buffer a pointer to the buffer to write to
 //! @param buf_end the end of buffer
-//! @retuns the number of serialized bytes
+//! @returns the number of serialized bytes
 size_t attribute_list_serialize(const AttributeList *attr_list, uint8_t *buffer, uint8_t *buf_end);
 
 //! Calculate the required size for a buffer to store a list of attributes

--- a/include/pbl/services/timeline/item.h
+++ b/include/pbl/services/timeline/item.h
@@ -201,8 +201,8 @@ TimelineItem *timeline_item_create_with_attributes(time_t timestamp, uint16_t du
 //!                                 in order corresponding to action order
 //! @param required_size_for_strings    total size of all attribute strings
 //! @param string_buffer    pointer to pointer to the start of the string buffer (where attribute
-//!                         strings must be appended. The alloc string will set \code *string_buffer
-//!                         if \param string buffer is not NULL)
+//!                         strings must be appended. The alloc string will set \c *string_buffer
+//!                         if \c string_buffer is not NULL)
 TimelineItem *timeline_item_create(int num_attributes, int num_actions,
     uint8_t attributes_per_action[], size_t required_size_for_strings, uint8_t **string_buffer);
 
@@ -246,7 +246,7 @@ void timeline_item_deserialize_header(TimelineItem *item,
 
 //! Get the UTC-to-localtime adjusted timestamp of a serialized or deserialized header.
 //! Just returns the timestamp if the item is not an all day event or floating.
-//! @param pointer to the header of the item
+//! @param hdr pointer to the header of the item
 //! @return the potentially adjusted timestamp
 time_t timeline_item_get_tz_timestamp(CommonTimelineItemHeader *hdr);
 
@@ -254,7 +254,7 @@ time_t timeline_item_get_tz_timestamp(CommonTimelineItemHeader *hdr);
 //! @param item a pointer to the item to serialize
 //! @param buffer a pointer to the buffer to write to
 //! @param buffer_size the size of the buffer in bytes
-//! @returns the number of bytes written to \ref buffer
+//! @returns the number of bytes written to \c buffer
 size_t timeline_item_serialize_payload(TimelineItem *item, uint8_t *buffer,
     size_t buffer_size);
 
@@ -263,10 +263,10 @@ size_t timeline_item_get_serialized_payload_size(TimelineItem *item);
 
 //! Deserialize actions & attributes from payload
 //! @param item pointer to the item to deserialize
-//! @string_buffer buffer to store the strings in
-//! @string_buffer_size size of the string buffer in bytes
-//! @payload serialized payload buffer
-//! @payload_size size of the payload buffer in bytes
+//! @param string_buffer buffer to store the strings in
+//! @param string_buffer_size size of the string buffer in bytes
+//! @param payload serialized payload buffer
+//! @param payload_size size of the payload buffer in bytes
 //! @return true on success
 bool timeline_item_deserialize_payload(TimelineItem *item,
     char *string_buffer, size_t string_buffer_size, const uint8_t *payload, size_t payload_size);

--- a/include/pbl/services/timeline/layout_layer.h
+++ b/include/pbl/services/timeline/layout_layer.h
@@ -133,13 +133,13 @@ struct LayoutLayerConfig {
   void *context;
 };
 
-//! Call the correct \ref LayoutLayerConstructor for a given \ref LayoutId
+//! Call the correct \c LayoutLayerConstructor for a given \ref LayoutId
 LayoutLayer *layout_create(LayoutId id, const LayoutLayerConfig *config);
 
 //! Verify that the required attributes are there for the layout
 bool layout_verify(bool existing_attributes[], LayoutId id);
 
-//! Call the \ref LayoutLayerSizeGetter for a given layout
+//! Call the \c LayoutLayerSizeGetter for a given layout
 GSize layout_get_size(GContext *ctx, LayoutLayer *layout);
 
 const LayoutColors *layout_get_colors(const LayoutLayer *layout);

--- a/include/pbl/services/timeline/swap_layer.h
+++ b/include/pbl/services/timeline/swap_layer.h
@@ -62,8 +62,8 @@ typedef struct {
 //! layer_set_hidden((Layer *)&swap_layer, true);
 //! \endcode
 //! @note However, there are a few caveats:
-//! * To add content layers, you must use \ref swap_layer_add_child().
-//! * To change the frame of a scroll layer, use \ref swap_layer_set_frame().
+//! * To add content layers, you must use \c swap_layer_add_child().
+//! * To change the frame of a scroll layer, use \c swap_layer_set_frame().
 typedef struct SwapLayer {
   Layer layer;
   ArrowLayer arrow_layer;

--- a/include/pbl/services/timeline/timeline.h
+++ b/include/pbl/services/timeline/timeline.h
@@ -29,7 +29,7 @@ typedef struct {
 status_t timeline_init(TimelineNode **timeline);
 
 //! Add a timeline pin we've created to the timeline.
-//! Call \ref timeline_destroy_item after this in order to free up the memory used by the item.
+//! Call \ref timeline_item_destroy after this in order to free up the memory used by the item.
 //! @return true on success, false otherwise
 bool timeline_add(TimelineItem *item);
 
@@ -62,6 +62,7 @@ bool timeline_nodes_equal(TimelineNode *a, TimelineNode *b);
 //! returns the first parent_id of the item, which is the app's UUID (for pins) or source ID
 //! (for notifications). For reminders, it will return the parent_id of the parent, which is the
 //! app UUID of the pin that created the reminder.
+//! @param item the timeline item to get the originator of
 //! @param [out] id pointer to storage for returned uuid. Set to UUID_INVALID when false
 //!   is returned
 //! @return true if success, false on failure
@@ -80,7 +81,7 @@ int timeline_item_time_comparator(CommonTimelineItemHeader *new_common,
 
 //! Whether a Timeline item should show up in the Timeline direction with the exception of all
 //! day events.
-//! @param common The common header of the item to consider.
+//! @param header The common header of the item to consider.
 //! @param direction The Timeline direction.
 //! @return true if the item would show up, false otherwise.
 bool timeline_item_should_show(CommonTimelineItemHeader *header, TimelineIterDirection direction);

--- a/include/pbl/services/timeline/timeline_actions.h
+++ b/include/pbl/services/timeline/timeline_actions.h
@@ -24,13 +24,14 @@ void timeline_actions_add_action_to_root_level(TimelineItemAction *action,
 //! Creates the root level for a Timeline ActionMenu, needed for holding timeline actions.
 //! @param num_actions The number of actions the root level will hold.
 //! @param separator_index See (struct ActionMenuLevel).
+//! @param source The window/app that creates the action menu
 //! @return A pointer to the root level of the action menu.
 ActionMenuLevel *timeline_actions_create_action_menu_root_level(uint8_t num_actions,
                                                                 uint8_t separator_index,
                                                                 TimelineItemActionSource source);
 
 //! Creates a Timeline ActionMenu and pushes it to the screen
-//! @param config The configuration info for this new ActionMenu. The config context must be a
+//! @param base_config The configuration info for this new ActionMenu. The config context must be a
 //! pointer to the TimelineItem associated with this menu.
 //! @param window_stack Window stack to push the action menu to
 ActionMenu *timeline_actions_push_action_menu(ActionMenuConfig *base_config,
@@ -60,5 +61,7 @@ void timeline_actions_dismiss_all(NotificationInfo *notif_list, int num_notifica
 //! Invokes a timeline action
 //! @param action The action to perform
 //! @param pin The pin associated with the action
+//! @param cb Callback invoked when the action completes
+//! @param cb_data Context pointer passed to the callback
 void timeline_actions_invoke_action(const TimelineItemAction *action, const TimelineItem *pin,
                                     ActionCompleteCallback cb, void *cb_data);

--- a/include/pbl/services/timeline/timeline_resources.h
+++ b/include/pbl/services/timeline/timeline_resources.h
@@ -88,7 +88,7 @@ bool timeline_resources_get_id_system(TimelineResourceId timeline_id, TimelineRe
 //! @param timeline_res pointer to TimelineResourceInfo which contains the timeline resource ID and
 //! corresponding app UUID
 //! @param size the TimelineResourceSize requested
-//! @param resource_id outparam pointer to AppResourceIdInfo containing the ID and
+//! @param res_info_out outparam pointer to AppResourceIdInfo containing the ID and
 //! ResAppNum for the requested timeline resource (both 0 if the resource could not be located)
 void timeline_resources_get_id(const TimelineResourceInfo *timeline_res, TimelineResourceSize size,
                                AppResourceInfo *res_info_out);

--- a/include/pbl/services/timezone_database.h
+++ b/include/pbl/services/timezone_database.h
@@ -55,14 +55,14 @@ int timezone_database_get_region_count(void);
 //! Note, this does not populate the actual bounds of the current DST period and instead leaves
 //! the .dst_start and .dst_end members in tz_info uninitialized.
 //!
-//! @param The region ID to look up
-//! @param tz_info[out] The TimezoneInfo strcuture to populate with the region
+//! @param region_id The region ID to look up
+//! @param[out] tz_info The TimezoneInfo strcuture to populate with the region
 bool timezone_database_load_region_info(uint16_t region_id, TimezoneInfo *tz_info);
 
 //! Load a timezone name for a given region ID.
 //!
 //! @param region_id The region ID to look up
-//! @param region_name[out] The resulting null-terminated name, including both the continent and
+//! @param[out] region_name The resulting null-terminated name, including both the continent and
 //!                         the city name. This buffer must be at least TIMEZONE_NAME_LENGTH long
 //!                         in bytes.
 //! @return True if successful, false if the region ID was invalid.
@@ -71,8 +71,8 @@ bool timezone_database_load_region_name(uint16_t region_id, char *region_name);
 //! Load a pair of DST rules for the given id.
 //!
 //! @param dst_id The DST rule ID to look up
-//! @param start[out] a TimezoneDSTRule structure to populate with the rule to enter DST
-//! @param start[out] a TimezoneDSTRule structure to populate with the rule to leave DST
+//! @param[out] start a TimezoneDSTRule structure to populate with the rule to enter DST
+//! @param[out] end a TimezoneDSTRule structure to populate with the rule to leave DST
 //! @return true if successful, false if the dst_id is invalid or the database is malformed
 bool timezone_database_load_dst_rule(uint8_t dst_id, TimezoneDSTRule *start, TimezoneDSTRule *end);
 

--- a/include/pbl/util/circular_buffer.h
+++ b/include/pbl/util/circular_buffer.h
@@ -38,6 +38,7 @@ bool circular_buffer_write(CircularBuffer* buffer, const void* data, uint16_t le
 //! @note After the client is done writing data, it _must_ call circular_buffer_write_finish()
 //! so that the CircularBuffer can update the length of the data it contains and update its internal
 //! bookkeeping
+//! @param buffer The circular buffer to write to.
 //! @param[out] data_out Pointer to storage for the pointer that is set the the start of the
 //! writable area when the function returns, or NULL if there is no space available.
 //! @return The maximum number of bytes that can be written starting at the returned the pointer.
@@ -46,6 +47,7 @@ uint16_t circular_buffer_write_prepare(CircularBuffer *buffer, uint8_t **data_ou
 
 //! To be used after circular_buffer_write_prepare(), to make the CircularBuffer update the length
 //! of the data it contains.
+//! @param buffer The circular buffer that was written to.
 //! @param written_length The length that has just been writted at the pointer provided by
 //! circular_buffer_write_prepare().
 void circular_buffer_write_finish(CircularBuffer *buffer, uint16_t written_length);
@@ -86,7 +88,7 @@ uint16_t circular_buffer_copy_offset(const CircularBuffer* buffer, uint16_t star
 //! In case the requested length wraps around the edges of the circular buffer, a heap-allocated
 //! copy is made.
 //! @param buffer The buffer to read or copy from.
-//! @param[out] data_ptr_out After returning, it will point to the byte array with the data. NOTE:
+//! @param[out] data_out After returning, it will point to the byte array with the data. NOTE:
 //! This can be NULL in the case the malloc_imp wasn't able to allocate the buffer.
 //! @param[in] length The length of the data to read. If this is longer than what
 //! circular_buffer_get_read_space_remaining() returns, the function will return false.

--- a/include/pbl/util/heap.h
+++ b/include/pbl/util/heap.h
@@ -47,6 +47,7 @@ typedef struct Heap {
 //! Initialize the heap inside the specified boundaries, zero-ing out the free
 //! list data structure.
 //!     @note Assumes 0 is not a valid address for allocation.
+//!     @param heap The heap to initialize
 //!     @param start The start of the heap will be the first int-aligned address >= start
 //!     @param end The end of the heap will be the last sizeof(HeaderBlock) aligned
 //!         address that is < end
@@ -70,6 +71,7 @@ void heap_set_corruption_handler(Heap *heap, CorruptionHandler corruption_handle
 //! endo of the buffer, while small fragments are taken from the start of the
 //! buffer.
 //! @note heap_init() must be called prior to using heap_malloc().
+//! @param heap The heap to allocate from
 //! @param nbytes Number of bytes to be allocated. Must be > 0.
 //! @param client_pc The PC register of the client who caused this malloc. Only used when
 //!                  CONFIG_MALLOC_INSTRUMENTATION is defined.
@@ -88,6 +90,7 @@ void heap_free(Heap* const heap, void* ptr, uintptr_t client_pc);
 //! Allocate a new block of the given size, and copy over the data at ptr into
 //! the new block. If the new size is smaller than the old size, will only copy
 //! over as much data as possible. Frees ptr.
+//! @param heap The heap to allocate from
 //! @param ptr Points to the memory region to re-allocate.
 //! @param nbytes The total number of bytes to allocate.
 //! @param client_pc The PC register of the client who caused this malloc. Only used when
@@ -116,6 +119,7 @@ uint32_t heap_get_minimum_headroom(Heap *heap);
 
 //! Used for debugging.
 //! Calculates and outputs the current memory usage on the given heap.
+//!     @param heap The heap to calculate the totals for
 //!     @param used Output, will contain the number of bytes currently
 //!         allocated and in use.
 //!     @param free Output, will contain the number of unallocated bytes.

--- a/include/pbl/util/list.h
+++ b/include/pbl/util/list.h
@@ -48,11 +48,13 @@ void list_remove(ListNode *node, ListNode **head, ListNode **tail);
 
 //! Appends new_node to the tail of the list that node is part of.
 //! @param node Any node in the list, can be NULL (will result in a list containing only new_node)
+//! @param new_node The node to append
 //! Always returns the tail of the list.
 ListNode* list_append(ListNode *node, ListNode *new_node);
 
 //! Appends new_node to the head of the list that node is part of.
 //! @param node Any node in the list, can be NULL (will result in a list containing only new_node)
+//! @param new_node The node to prepend
 //! Always returns the head of the list.
 ListNode* list_prepend(ListNode *node, ListNode *new_node);
 
@@ -83,7 +85,7 @@ uint32_t list_count_to_head_from(ListNode *node);
 //! Counts the number of nodes from head to tail
 uint32_t list_count(ListNode *node);
 
-//! Gets the node at <index> away, where positive index is towards the tail
+//! Gets the node at \c index away, where positive index is towards the tail
 ListNode* list_get_at(ListNode *node, int32_t index);
 
 //! Adds a node to a list ordered by given comparator.
@@ -104,7 +106,6 @@ bool list_contains(const ListNode *head, const ListNode *node);
 //! @param node The list node from which to depart the search
 //! @param filter_callback A function returning true in case the node that is passed in matches the
 //! filter criteria, and false if it doesn't and should be skipped.
-//! @param found_node The node to be evaluated by the filter callback
 //! @param data Optional callback data
 ListNode* list_find(ListNode *node, ListFilterCallback filter_callback, void *data);
 
@@ -112,7 +113,6 @@ ListNode* list_find(ListNode *node, ListFilterCallback filter_callback, void *da
 //! @param node The list node from which to depart the search
 //! @param filter_callback A function returning true in case the node that is passed in matches the
 //! filter criteria, and false if it doesn't and should be skipped.
-//! @param found_node The node to be evaluated by the filter callback
 //! @param wrap_around True if the search should continue from the head if the tail has been reached
 //! @param data Optional callback data
 ListNode* list_find_next(ListNode *node, ListFilterCallback filter_callback, bool wrap_around, void *data);
@@ -121,7 +121,6 @@ ListNode* list_find_next(ListNode *node, ListFilterCallback filter_callback, boo
 //! @param node The list node from which to depart the search
 //! @param filter_callback A function returning true in case the node that is passed in matches the
 //! filter criteria, and false if it doesn't and should be skipped.
-//! @param found_node The node to be evaluated by the filter callback
 //! @param wrap_around True if the search should continue from the tail if the head has been reached
 //! @param data Optional callback data
 ListNode* list_find_prev(ListNode *node, ListFilterCallback filter_callback, bool wrap_around, void *data);
@@ -135,7 +134,7 @@ ListNode* list_concatenate(ListNode *list_a, ListNode *list_b);
 //! Iterates over each node and passes it into callback given
 //! @param[in] head The head of the list that we want to iterate over.
 //! @param[in] each_cb The callback function to pass each node into
-//! @param[in] data Optional callback data
+//! @param[in] context Optional callback data
 void list_foreach(ListNode *head, ListForEachCallback each_cb, void *context);
 
 //! Dump a list to PBL_LOG

--- a/include/pbl/util/math.h
+++ b/include/pbl/util/math.h
@@ -43,6 +43,8 @@ int32_t sign_extend(uint32_t a, int bits);
 int32_t serial_distance32(uint32_t start, uint32_t end);
 
 //! Calculates the distance (end - start), taking a roll-over into account as good as it can get.
+//! @param start the start value
+//! @param end the end value
 //! @param bits the number of bits that are valid in start and end.
 int32_t serial_distance(uint32_t start, uint32_t end, int bits);
 

--- a/include/pbl/util/math_fixed.h
+++ b/include/pbl/util/math_fixed.h
@@ -164,9 +164,9 @@ static __inline__ Fixed_S16_3 Fixed_S16_3_S32_16_mul(Fixed_S16_3 a, Fixed_S32_16
 //!   num_input_coefficients
 //! @param[in] ca pointer to array of output side coefficients. Must be an array of size
 //!   num_output_coefficients
-//! @param[in|out] state_x pointer to array to hold the history of x. Must be an array
+//! @param[in,out] state_x pointer to array to hold the history of x. Must be an array
 //!   of size num_input_coefficients
-//! @param[in|out] state_y pointer to array to hold the history of y. Must be an array
+//! @param[in,out] state_y pointer to array to hold the history of y. Must be an array
 //!   of size num_output_coefficients
 //! @return the filtered output value, y[n]
 Fixed_S64_32 math_fixed_recursive_filter(Fixed_S64_32 x,

--- a/include/pbl/util/slist.h
+++ b/include/pbl/util/slist.h
@@ -27,11 +27,13 @@ SingleListNode* slist_insert_after(SingleListNode *node, SingleListNode *new_nod
 
 //! Prepends new_node to the head of the list.
 //! @param head The current head of the list, can be NULL.
+//! @param new_node The node to prepend.
 //! Always returns the new head of the list.
 SingleListNode* slist_prepend(SingleListNode *head, SingleListNode *new_node);
 
 //! Appends new_node to the tail of the list that head is part of.
 //! @param head Any node in the list, can be NULL (will result in a list containing only new_node).
+//! @param new_node The node to append.
 //! Always returns the tail of the list.
 SingleListNode* slist_append(SingleListNode *head, SingleListNode *new_node);
 

--- a/include/pbl/util/string.h
+++ b/include/pbl/util/string.h
@@ -35,8 +35,9 @@ uintptr_t str_to_address(const char *address_str);
 
 const char *bool_to_str(bool b);
 
-//! @param hex 12-digit hex string representing a BT address
-//! @param addr Points to a SS1 BD_ADDR_t as defined in BTBTypes.h
+//! @param hex_str 12-digit hex string representing a BT address
+//! @param bd_addr Points to a SS1 BD_ADDR_t as defined in BTBTypes.h
+//! @param bd_addr_size Size of the bd_addr buffer, in bytes
 //! @return True on success
 bool convert_bt_addr_hex_str_to_bd_addr(const char *hex_str, uint8_t *bd_addr, const unsigned int bd_addr_size);
 

--- a/include/pebbleos/cron.h
+++ b/include/pebbleos/cron.h
@@ -90,7 +90,7 @@ struct CronJob {
 //! Add a cron job. This will make the service hold a reference to the specified job, so it must
 //! not leave scope or be destroyed until it is unscheduled.
 //! The job only gets scheduled once. For re-scheduling, you can call this on the job again.
-//! @params job pointer to the CronJob struct to be scheduled.
+//! @param job pointer to the CronJob struct to be scheduled.
 //! @returns time_t for when the job is destined to go off.
 time_t cron_job_schedule(CronJob *job);
 
@@ -98,7 +98,7 @@ time_t cron_job_schedule(CronJob *job);
 //! This will make the service hold a reference to the new job, so it must
 //! not leave scope or be destroyed until it is unscheduled.
 //! @param job pointer to the CronJob after which we want our job to run. job must be scheduled.
-//! @params new_job pointer to the CronJob struct to be scheduled. new_job must be unscheduled.
+//! @param new_job pointer to the CronJob struct to be scheduled. new_job must be unscheduled.
 //! @returns time_t for when the job is destined to go off.
 //! @note This API makes no guarantee that the two jobs will be scheduled back to back,
 //! only that new_job will have the same scheduled time as job and that it will trigger
@@ -106,23 +106,23 @@ time_t cron_job_schedule(CronJob *job);
 time_t cron_job_schedule_after(CronJob *new_job, CronJob *job);
 
 //! Remove a scheduled cron job.
-//! @params job pointer to the CronJob struct to be unscheduled.
+//! @param job pointer to the CronJob struct to be unscheduled.
 //! @return true if the job was successfully removed (false may indicate no job was
 //!  scheduled at all or the cb is currently executing)
 bool cron_job_unschedule(CronJob *job);
 
 //! Check if a cron job is scheduled.
-//! @params job pointer to the CronJob struct to be checked for being scheduled.
+//! @param job pointer to the CronJob struct to be checked for being scheduled.
 //! @returns true if scheduled or pending deletion, false otherwise
 bool cron_job_is_scheduled(CronJob *job);
 
 //! Calculate cron job's destined execution time, from the current time.
-//! @params job pointer to the CronJob struct to get the execution time for.
+//! @param job pointer to the CronJob struct to get the execution time for.
 //! @returns time_t for when the job is destined to go off.
 time_t cron_job_get_execute_time(const CronJob *job);
 
 //! Calculate cron job's destined execution time if it were scheduled at the given time.
-//! @params job pointer to the CronJob struct to get the execution time for.
-//! @params local_epoch the epoch for getting the job's execution time.
+//! @param job pointer to the CronJob struct to get the execution time for.
+//! @param local_epoch the epoch for getting the job's execution time.
 //! @returns time_t for when the job is destined to go off.
 time_t cron_job_get_execute_time_from_epoch(const CronJob *job, time_t local_epoch);

--- a/lib/util/heap.c
+++ b/lib/util/heap.c
@@ -412,6 +412,7 @@ static void prv_sanity_check_block(Heap * const heap, HeapInfo_t *block) {
 }
 
 //! Finds a segment where data of the size n_units  will fit.
+//!     @param heap the heap to search.
 //!     @param n_units number of ALIGNMENT_SIZE units this segment requires.
 static HeapInfo_t *find_segment(Heap* const heap, unsigned long n_units) {
   HeapInfo_t *heap_info_ptr = NULL;
@@ -457,6 +458,8 @@ static HeapInfo_t *find_segment(Heap* const heap, unsigned long n_units) {
 //! Split a block into two smaller blocks, returning a pointer to the new second block.
 //! The first block will be available at the same location as before, but with a smaller size.
 //! Assumes the block is big enough to be split and is unallocated.
+//! @param heap the heap the block belongs to.
+//! @param block the block to split.
 //! @param first_part_size the size of the new block, in ALIGNMENT_SIZE units, including the beginer
 static HeapInfo_t* split_block(Heap *heap, HeapInfo_t* block, size_t first_part_size) {
   HeapInfo_t* second_block = (HeapInfo_t*) (((Alignment_t*) block) + first_part_size);
@@ -482,6 +485,7 @@ static HeapInfo_t* split_block(Heap *heap, HeapInfo_t* block, size_t first_part_
 }
 
 //! Allocated the block in the given HeapInfo_t segment.
+//!     @param heap the heap to allocate from.
 //!     @param n_units number of ALIGNMENT_SIZE units this segment requires (including space for the beginer).
 //!     @param heap_info_ptr the segment where the block should be allocated.
 static HeapInfo_t *allocate_block(Heap* const heap, unsigned long n_units, HeapInfo_t* heap_info_ptr) {

--- a/src/fw/applib/app_exit_reason.h
+++ b/src/fw/applib/app_exit_reason.h
@@ -32,7 +32,7 @@ typedef enum AppExitReason {
 AppExitReason app_exit_reason_get(void);
 
 //! Set the app exit reason to a new reason.
-//! @param reason The new app exit reason
+//! @param exit_reason The new app exit reason
 void app_exit_reason_set(AppExitReason exit_reason);
 
 //!   @} // group ExitReason

--- a/src/fw/applib/app_focus_service.h
+++ b/src/fw/applib/app_focus_service.h
@@ -56,7 +56,7 @@ typedef struct {
 
 //! Subscribe to the focus event service. Once subscribed, the handlers get called every time the
 //! app gains or loses focus.
-//! @param handler Handlers which will be called on will-focus and did-focus events.
+//! @param handlers Handlers which will be called on will-focus and did-focus events.
 //! @see AppFocusHandlers
 void app_focus_service_subscribe_handlers(AppFocusHandlers handlers);
 

--- a/src/fw/applib/app_glance.h
+++ b/src/fw/applib/app_glance.h
@@ -28,7 +28,7 @@
 //!
 //!   The main window's unload handler is usually a good place to call \ref app_glance_reload.
 //!
-//!   @warning \ref PBL_PLATFORM_APLITE does not support App Glance.
+//!   @warning @c PBL_PLATFORM_APLITE does not support App Glance.
 //!
 //!   Example code:
 //!   \code{.c}

--- a/src/fw/applib/app_inbox.h
+++ b/src/fw/applib/app_inbox.h
@@ -20,6 +20,7 @@ typedef void (*AppInboxDroppedHandler)(uint32_t num_dropped_messages);
 //! Opaque reference to an app inbox.
 typedef struct AppInbox AppInbox;
 
+//! @param buffer_size The size in bytes of the buffer to allocate for incoming message payloads.
 //! @param min_num_messages The minimum number of messages that the inbox should be able to hold
 //! if the total payload size is exactly buffer_size. This is used to calculate how much additional
 //! buffer space has to be allocated for message header overhead.

--- a/src/fw/applib/app_logging.h
+++ b/src/fw/applib/app_logging.h
@@ -42,7 +42,6 @@ void app_log_vargs(uint8_t log_level, const char *src_filename, int src_line_num
 //! @param src_line_number The line number in the source file where the log originates from
 //! @param fmt A C formatting string
 //! @param ... The arguments for the formatting string
-//! @param log_level
 //! \sa snprintf for details about the C formatting string.
 #if __clang__
 void app_log(uint8_t log_level, const char* src_filename, int src_line_number, const char* fmt,

--- a/src/fw/applib/app_message/app_message.h
+++ b/src/fw/applib/app_message/app_message.h
@@ -214,7 +214,7 @@ typedef void (*AppMessageInboxReceived)(DictionaryIterator *iterator, void *cont
 
 //! Called after an incoming message is dropped.
 //!
-//! \param[in] result
+//! \param[in] reason
 //!   The reason why the message was dropped.  Some possibilities include \ref APP_MSG_BUSY and
 //!   \ref APP_MSG_BUFFER_OVERFLOW.
 //!
@@ -245,7 +245,7 @@ typedef void (*AppMessageOutboxSent)(DictionaryIterator *iterator, void *context
 //!   the iterator cannot be modified or saved off as the library will re-open the dictionary with dict_begin() after
 //!   this callback returns.
 //!
-//! \param[in] result
+//! \param[in] reason
 //!   The result of the operation.  Some possibilities for the value include \ref APP_MSG_SEND_TIMEOUT,
 //!   \ref APP_MSG_SEND_REJECTED, \ref APP_MSG_NOT_CONNECTED, \ref APP_MSG_APP_NOT_RUNNING, and the combination
 //!   `(APP_MSG_NOT_CONNECTED | APP_MSG_APP_NOT_RUNNING)`.

--- a/src/fw/applib/app_smartstrap.h
+++ b/src/fw/applib/app_smartstrap.h
@@ -11,7 +11,7 @@
 //! @{
 //!
 
-//! The default request timeout in milliseconds (see \ref smartstrap_set_timeout).
+//! The default request timeout in milliseconds (see @c smartstrap_set_timeout).
 #define SMARTSTRAP_TIMEOUT_DEFAULT 250
 
 //! The service_id to specify in order to read/write raw data to the smartstrap.
@@ -151,13 +151,13 @@ void app_smartstrap_attribute_destroy(SmartstrapAttribute *attribute);
 //! @returns Whether or not the service is available.
 bool app_smartstrap_service_is_available(SmartstrapServiceId service_id);
 
-//! Returns the ServiceId which the attribute was created for (see \ref
+//! Returns the ServiceId which the attribute was created for (see @c
 //! smartstrap_attribute_create).
 //! @param attribute The SmartstrapAttribute for which to obtain the service ID.
 //! @returns The SmartstrapServiceId which the attribute was created with.
 SmartstrapServiceId app_smartstrap_attribute_get_service_id(SmartstrapAttribute *attribute);
 
-//! Gets the AttributeId which the attribute was created for (see \ref smartstrap_attribute_create).
+//! Gets the AttributeId which the attribute was created for (see @c smartstrap_attribute_create).
 //! @param attribute The SmartstrapAttribute for which to obtain the attribute ID.
 //! @returns The SmartstrapAttributeId which the attribute was created with.
 SmartstrapAttributeId app_smartstrap_attribute_get_attribute_id(SmartstrapAttribute *attribute);

--- a/src/fw/applib/app_wakeup.h
+++ b/src/fw/applib/app_wakeup.h
@@ -19,12 +19,12 @@
 
 //! The type of function which can be called when a wakeup event occurs.  
 //! The arguments will be the id of the wakeup event that occurred, 
-//! as well as the scheduled cookie provided to \ref wakeup_schedule.
+//! as well as the scheduled cookie provided to @c wakeup_schedule.
 typedef void (*WakeupHandler)(WakeupId wakeup_id, int32_t cookie);
 
 //! Registers a WakeupHandler to be called when wakeup events occur.
 //! @note The handler is only called for wakeup events which occur while the app is already running;
-//!       use \ref launch_reason() === \ref APP_LAUNCH_WAKEUP to detect when the app was launched by a wakeup event.
+//!       use @c launch_reason() === \ref APP_LAUNCH_WAKEUP to detect when the app was launched by a wakeup event.
 //! @param handler The callback that gets called when the wakeup event occurs
 void app_wakeup_service_subscribe(WakeupHandler handler);
 
@@ -51,7 +51,7 @@ void app_wakeup_cancel(WakeupId wakeup_id);
 void app_wakeup_cancel_all(void);
 
 //! Retrieves the wakeup event info for an app that was launched
-//! by a wakeup_event (ie. \ref launch_reason() === APP_LAUNCH_WAKEUP)
+//! by a wakeup_event (ie. @c launch_reason() === APP_LAUNCH_WAKEUP)
 //! so that an app may display information regarding the wakeup event
 //! @param wakeup_id WakeupId for the wakeup event that caused the app to wakeup
 //! @param cookie App provided reason for the wakeup event

--- a/src/fw/applib/applib_resource.h
+++ b/src/fw/applib/applib_resource.h
@@ -31,7 +31,7 @@
 #define RESOURCE_ID_FONT_FALLBACK RESOURCE_ID_GOTHIC_14
 
 //! Opaque reference to a resource.
-//! @see \ref resource_get_handle()
+//! @see @c resource_get_handle()
 typedef void * ResHandle;
 
 //! Gets the resource handle for a file identifier.

--- a/src/fw/applib/applib_resource_private.h
+++ b/src/fw/applib/applib_resource_private.h
@@ -28,6 +28,10 @@ bool applib_resource_munmap_all();
 //! Tries to load a resource as memory-mapped data. If this isn't supported on the system
 //! or for a given resource if will try to allocate data and load it into RAM instead.
 //! Have a look at \ref resource_load_byte_range_system for the discussion of arguments
+//! @param app_num The app the resource belongs to
+//! @param resource_id The ID of the resource
+//! @param offset The offset in bytes into the resource
+//! @param length The number of bytes to load
 //! @param used_aligned True, if you want this function to allocate 7 extra bytes if it cannot mmap
 //! @return NULL, if the resource coudln't be memory-mapped or allocated
 void *applib_resource_mmap_or_load(ResAppNum app_num, uint32_t resource_id,

--- a/src/fw/applib/bluetooth/ble_ad_parse.h
+++ b/src/fw/applib/bluetooth/ble_ad_parse.h
@@ -27,7 +27,7 @@ bool ble_ad_includes_service(const BLEAdData *ad, const Uuid *service_uuid);
 
 //! If present, copies the Service UUIDs from the advertisement data.
 //! @param ad The advertisement data
-//! @param[out] uuids_out An array of Uuid`s into which the found Service UUIDs
+//! @param[out] uuids_out An array of Uuids into which the found Service UUIDs
 //! will be copied.
 //! @param num_uuids The size of the uuids_out array.
 //! @return The total number of found Service UUIDs. This might be a larger

--- a/src/fw/applib/bluetooth/ble_client.h
+++ b/src/fw/applib/bluetooth/ble_client.h
@@ -56,7 +56,7 @@ BTErrno ble_client_set_service_change_handler(BLEClientServiceChangeHandler hand
 //! @param service_uuids An array of the Service UUIDs that the application is
 //! interested in and the system should filter by. Passing NULL will discover
 //! all services on the device.
-//! @param num_uuids The number of Uuid`s in the service_uuids array. Ignored
+//! @param num_uuids The number of Uuids in the service_uuids array. Ignored
 //! when NULL is passed for the service_uuids argument.
 //! @return BTErrnoOK if the filter was set up successfully,
 //! or TODO....
@@ -120,7 +120,7 @@ typedef void (*BLEClientWriteHandler)(BLECharacteristic characteristic,
 //! (un)subscribed.
 //! @param subscription_type The type of subscription. If the client is now
 //! unsubscribed, the type will be BLESubscriptionNone.
-//! @param The error or status as returned by the remote server. If the
+//! @param error The error or status as returned by the remote server. If the
 //! (un)subscription was successful, this remote server is supposed to send
 //! BLEGATTErrorSuccess.
 typedef void (*BLEClientSubscribeHandler)(BLECharacteristic characteristic,

--- a/src/fw/applib/bluetooth/ble_device.h
+++ b/src/fw/applib/bluetooth/ble_device.h
@@ -9,10 +9,10 @@
 //! paired devices (connected or not) and devices for which there is a Bluetooth
 //! connection to the system (but not necessarily paired and not necessarily
 //! connected to the application).
-//! @param[out] devices_out An array of BTDevice`s into which the known
+//! @param[out] devices_out An array of BTDevices into which the known
 //! devices will be copied.
 //! @param[in,out] num_devices_out In: the size of the devices_out array.
-//! Out: the number of BTDevice`s that were copied.
+//! Out: the number of BTDevices that were copied.
 //! @return The total number of known devices. This might be a larger
 //! number than num_devices_out will contain, if the passed array was not large
 //! enough to hold all the connected devices.

--- a/src/fw/applib/bluetooth/ble_ibeacon.h
+++ b/src/fw/applib/bluetooth/ble_ibeacon.h
@@ -37,23 +37,23 @@ typedef struct {
 } BLEiBeacon;
 
 //! Gets the UUID of the iBeacon.
-//! @param The iBeacon
+//! @param ibeacon The iBeacon
 //! @return The UUID that the iBeacon advertised. In iOS' CoreBluetooth,
 //! this corresponds to the "proximityUUID" property of instances of CLBeacon.
 Uuid ble_ibeacon_get_uuid(const BLEiBeacon *ibeacon);
 
 //! Gets the major value of the iBeacon.
-//! @param The iBeacon
+//! @param ibeacon The iBeacon
 //! @return The major, custom value.
 uint16_t ble_ibeacon_get_major(const BLEiBeacon *ibeacon);
 
 //! Gets the minor value of the iBeacon.
-//! @param The iBeacon
+//! @param ibeacon The iBeacon
 //! @return The minor, custom value.
 uint16_t ble_ibeacon_get_minor(const BLEiBeacon *ibeacon);
 
 //! Gets the estimated distance to the iBeacon, in centimeters.
-//! @param The iBeacon
+//! @param ibeacon The iBeacon
 //! @return The estimated distance in centimeters.
 uint16_t ble_ibeacon_get_distance_cm(const BLEiBeacon *ibeacon);
 

--- a/src/fw/applib/connection_service.h
+++ b/src/fw/applib/connection_service.h
@@ -34,7 +34,7 @@
 //! connection with the Pebble watch (since companion app messages are routed
 //! directly to the watch)
 //!
-//!     @{
+//!   @{
 //! Callback type for connection events
 //! @param connected true on connection, false on disconnection
 typedef void (*ConnectionHandler)(bool connected);
@@ -59,7 +59,7 @@ typedef struct {
 //! Subscribe to the connection event service. Once subscribed, the appropriate
 //! handler gets called based on the type of connection event and user provided
 //! handlers
-//! @param ConnectionHandlers A struct populated with the handlers to
+//! @param conn_handlers A struct populated with the handlers to
 //! be called when the specified connection event occurs. If a given handler is
 //! NULL, no function will be called.
 void connection_service_subscribe(ConnectionHandlers conn_handlers);

--- a/src/fw/applib/fonts/fonts.h
+++ b/src/fw/applib/fonts/fonts.h
@@ -45,7 +45,7 @@ GFont fonts_get_system_emoji_font_for_size(unsigned int font_size);
 
 //! Loads a custom font.
 //! @param handle The resource handle of the font to load. See resource_ids.auto.h
-//! for a list of resource IDs, and use \ref resource_get_handle() to obtain the resource handle.
+//! for a list of resource IDs, and use @c resource_get_handle() to obtain the resource handle.
 //! @return An opaque pointer to the loaded font, or a pointer to the default
 //! (fallback) font if the specified font cannot be loaded.
 //! @see Read the <a href="http://developer.getpebble.com/guides/pebble-apps/resources/">App

--- a/src/fw/applib/graphics/gbitmap_pbi.h
+++ b/src/fw/applib/graphics/gbitmap_pbi.h
@@ -23,7 +23,7 @@
 //! The metadata describes how long each row of pixels is in the buffer (the stride).
 //! The following restrictions on stride are in place for different formats:
 //!
-//! - \ref GBitmapFormat1Bit:
+//! - \ref GBitmapFormat1Bit "GBitmapFormat1Bit":
 //!   Each row must be a multiple of 32 pixels (4 bytes). Using the `bounds` field,
 //!   the area that is actually relevant can be specified.
 //!   For example, when the image is 29 by 5 pixels
@@ -40,12 +40,12 @@
 //!   it will result in a black pixel.
 //!   ![](pixel_bit_values.png)
 //!
-//! - \ref GBitmapFormat8Bit:
+//! - \ref GBitmapFormat8Bit "GBitmapFormat8Bit":
 //!   Each pixel in the bitmap is represented by 1 byte. The color value of that byte correspends to
 //!   a GColor.argb value.
 //!   There is no restriction on row_size_bytes / stride.
 //!
-//! - \ref GBitmapFormat1BitPalette, \ref GBitmapFormat2BitPalette, \ref GBitmapFormat4BitPalette:
+//! - \ref GBitmapFormat1BitPalette, \ref GBitmapFormat2BitPalette, \ref GBitmapFormat4BitPalette "GBitmapFormat4BitPalette":
 //!   Each pixel in the bitmap is represented by the number of bits the format specifies. Pixels
 //!   must be packed.
 //!   For example, in GBitmapFormat2BitPalette, each pixel uses 2 bits. This means 4 pixels / byte.
@@ -66,8 +66,8 @@
 //! @see \ref gbitmap_create_with_data
 //! @see \ref gbitmap_create_with_resource
 //!
-//!       @{
-//!       @} // end addtogroup pbi_file_format
+//!   @{
+//!   @} // end addtogroup pbi_file_format
 //!     @} // end addtogroup FileFormats
 //!   @} // end addtogroup Resources
 //! @} // end addtogroup Foundation

--- a/src/fw/applib/graphics/gbitmap_png.h
+++ b/src/fw/applib/graphics/gbitmap_png.h
@@ -51,8 +51,8 @@
 //! @see \ref gbitmap_create_from_png_data
 //! @see \ref gbitmap_create_with_resource
 //!
-//!       @{
-//!       @} // end addtogroup png_file_format
+//!   @{
+//!   @} // end addtogroup png_file_format
 //!     @} // end addtogroup FileFormats
 //!   @} // end addtogroup Resources
 //! @} // end addtogroup Foundation

--- a/src/fw/applib/graphics/gdraw_command.h
+++ b/src/fw/applib/graphics/gdraw_command.h
@@ -134,27 +134,27 @@ void gdraw_command_set_point(GDrawCommand *command, uint16_t point_idx, GPoint p
 GPoint gdraw_command_get_point(GDrawCommand *command, uint16_t point_idx);
 
 //! Set the radius of a circle command
-//! @note This only works for commands of type \ref GDrawCommandCircle
+//! @note This only works for commands of type \ref GDrawCommandTypeCircle
 //! @param command \ref GDrawCommand from which to set the circle radius
 //! @param radius The radius to set for the circle.
 void gdraw_command_set_radius(GDrawCommand *command, uint16_t radius);
 
 //! Get the radius of a circle command.
-//! @note this only works for commands of type\ref GDrawCommandCircle.
+//! @note this only works for commands of type \ref GDrawCommandTypeCircle.
 //! @param command \ref GDrawCommand from which to get the circle radius
-//! @return The radius in pixels if command is of type \ref GDrawCommandCircle
+//! @return The radius in pixels if command is of type \ref GDrawCommandTypeCircle
 uint16_t gdraw_command_get_radius(GDrawCommand *command);
 
 //! Set the path of a stroke command to be open
-//! @note This only works for commands of type \ref GDrawCommandPath and
-//! \ref GDrawCommandPrecisePath
+//! @note This only works for commands of type \ref GDrawCommandTypePath and
+//! \ref GDrawCommandTypePrecisePath
 //! @param command \ref GDrawCommand for which to set the path open status
 //! @param path_open true if path should be hidden
 void gdraw_command_set_path_open(GDrawCommand *command, bool path_open);
 
 //! Return whether a stroke command path is open
-//! @note This only works for commands of type \ref GDrawCommandPath and
-//! \ref GDrawCommandPrecisePath
+//! @note This only works for commands of type \ref GDrawCommandTypePath and
+//! \ref GDrawCommandTypePrecisePath
 //! @param command \ref GDrawCommand from which to get the path open status
 //! @return true if the path is open
 bool gdraw_command_get_path_open(GDrawCommand *command);

--- a/src/fw/applib/graphics/gdraw_command_image.h
+++ b/src/fw/applib/graphics/gdraw_command_image.h
@@ -65,7 +65,7 @@ void gdraw_command_image_draw(GContext *ctx, GDrawCommandImage *image, GPoint of
 //! @param ctx The destination graphics context in which to draw
 //! @param image Image to draw
 //! @param offset Offset from draw context origin to draw the image
-//! @param processors Contains function pointers to draw modified commands in the image
+//! @param processor Contains function pointers to draw modified commands in the image
 void gdraw_command_image_draw_processed(GContext *ctx, GDrawCommandImage *image, GPoint offset,
                                         GDrawCommandProcessor *processor);
 

--- a/src/fw/applib/graphics/gdraw_command_list.h
+++ b/src/fw/applib/graphics/gdraw_command_list.h
@@ -27,7 +27,7 @@ typedef struct GDrawCommandProcessor GDrawCommandProcessor;
 
 //! Callback for iterating over GDrawCommands
 //! @param processor GDrawCommandProcessor that is currently iterating over the GDrawCommandList.
-//! @param proccessed_command Copy of the current GDrawCommand that can be modified
+//! @param processed_command Copy of the current GDrawCommand that can be modified
 //! @param processed_command_max_size Size of GDrawCommand being processed
 //! @param list list of GDrawCommands that will be modified by the processor
 //! @param command Current GDrawCommand being processed

--- a/src/fw/applib/graphics/gdraw_command_sequence.h
+++ b/src/fw/applib/graphics/gdraw_command_sequence.h
@@ -40,7 +40,7 @@ GDrawCommandSequence *gdraw_command_sequence_create_with_resource_system(ResAppN
 GDrawCommandSequence *gdraw_command_sequence_clone(GDrawCommandSequence *sequence);
 
 //! Deletes the \ref GDrawCommandSequence structure and frees associated data
-//! @param image Pointer to the sequence to destroy
+//! @param sequence Pointer to the sequence to destroy
 void gdraw_command_sequence_destroy(GDrawCommandSequence *sequence);
 
 //! @internal

--- a/src/fw/applib/graphics/gdraw_command_transforms.h
+++ b/src/fw/applib/graphics/gdraw_command_transforms.h
@@ -64,6 +64,8 @@ GPoint gpoint_attract_to_square(GPoint point, GSize size, int32_t normalized);
 
 //! Creates a GPointIndexLookup based on the angle to the center of an image
 //! Points in the image whose ray with the image's center has a smaller angle are animated first.
+//! @param list GDrawCommandList to create the lookup for
+//! @param origin Center point against which the angle of each point is measured
 //! @param angle Angle at which to consider zero. Points at this angle animate first.
 //! @see GPointIndexLookup
 GPointIndexLookup *gdraw_command_list_create_index_lookup_by_angle(GDrawCommandList *list,
@@ -76,6 +78,7 @@ GPointIndexLookup *gdraw_command_list_create_index_lookup_by_angle(GDrawCommandL
 //! is most closest to its destination animation point.
 //! Choosing a target in the image's perimeter opposite of the destination animation point results
 //! in a paper flipping effect.
+//! @param list GDrawCommandList to create the lookup for
 //! @param target Point to compare against in image coordinates. (0, 0) is top left.
 //! @see GPointIndexLookup
 GPointIndexLookup *gdraw_command_list_create_index_lookup_by_distance(GDrawCommandList *list,
@@ -84,8 +87,8 @@ GPointIndexLookup *gdraw_command_list_create_index_lookup_by_distance(GDrawComma
 //! Shifts the delay index of all points at or above a given delay index.
 //! \note This shifts the delay index up, so be sure to insert the last most delays first.
 //! @param lookup GPointIndexLookup to add delay to
-//! @param index Delay index to add delay to
-//! @param amount Amount of delay to add in index units
+//! @param delay_index Delay index to add delay to
+//! @param delay_amount Amount of delay to add in index units
 //! @see GPointIndexLookup
 void gpoint_index_lookup_add_at(GPointIndexLookup *lookup, int delay_index, int delay_amount);
 
@@ -101,6 +104,7 @@ void gpoint_index_lookup_set_groups(GPointIndexLookup *lookup, int num_groups,
 
 //! Performs a scaling and translation transform on a list with each point being delayed by delay
 //! segments assigned based on a GPointIndexLookup.
+//! @param list GDrawCommandList to transform
 //! @param size Native size of the points within the command list. This is used for scaling.
 //! @param from Position and size to start from in local drawing coordinates.
 //! @param to Position and size to end at in local drawing coordinates.
@@ -120,6 +124,7 @@ void gdraw_command_list_scale_segmented_to(
 
 //! Performs a scaling and translation transform on an image with each point being delayed by delay
 //! segments assigned based on a GPointIndexLookup.
+//! @param image GDrawCommandImage to transform
 //! @param from Position and size to start from in local drawing coordinates.
 //! @param to Position and size to end at from in local drawing coordinates.
 //! @param normalized Normalized animation position to transform to.

--- a/src/fw/applib/graphics/graphics_private.h
+++ b/src/fw/applib/graphics/graphics_private.h
@@ -28,6 +28,7 @@ void graphics_private_draw_horizontal_line(GContext *ctx, int16_t y, Fixed_S16_3
 
 //! Draws horizontal line into framebuffer, requires adjustment for drawing_box and clip_box
 //! @param ctx Graphics context for drawing
+//! @param framebuffer Address of framebuffer to draw into
 //! @param y Integral Y coordinate for line
 //! @param x1 Integral X coordinate for starting point
 //! @param x2 Integral X coordinate for ending point
@@ -51,9 +52,12 @@ void graphics_private_draw_vertical_line(GContext *ctx, int16_t x, Fixed_S16_3 y
 //! Note: this does not adjust for drawing_box
 //! Note: this only works for lines where x1 < x2
 //! @param ctx Graphics context for drawing
+//! @param framebuffer Address of framebuffer to draw into
+//! @param clip_box Address of clipping rectangle to perform clipping check
 //! @param y Integral Y coordinate for line
 //! @param x1 Fixedpoint X coordinate for starting point
 //! @param x2 Fixedpoint X coordinate for ending point
+//! @param color Color to be used
 //! @internal
 void graphics_private_draw_horizontal_line_prepared(GContext *ctx, GBitmap *framebuffer,
                                                     GRect *clip_box, int16_t y, Fixed_S16_3 x1,
@@ -64,9 +68,12 @@ void graphics_private_draw_horizontal_line_prepared(GContext *ctx, GBitmap *fram
 //! Note: this does not adjust for drawing_box
 //! Note: this only works for lines where y1 < y2
 //! @param ctx Graphics context for drawing
+//! @param framebuffer Address of framebuffer to draw into
+//! @param clip_box Address of clipping rectangle to perform clipping check
 //! @param x Integral X coordinate for line
 //! @param y1 Fixedpoint Y coordinate for starting point
 //! @param y2 Fixedpoint Y coordinate for ending point
+//! @param color Color to be used
 //! @internal
 void graphics_private_draw_vertical_line_prepared(GContext *ctx, GBitmap *framebuffer,
                                                   GRect *clip_box, int16_t x, Fixed_S16_3 y1,
@@ -75,7 +82,6 @@ void graphics_private_draw_vertical_line_prepared(GContext *ctx, GBitmap *frameb
 //! Blends pixel at given coordinates into given bitmap (framebuffer)
 //! Will use given clip_box for clipping
 //! Note: this will not adjust for drawing_box
-//! @param ctx Graphics context for plotting
 //! @param framebuffer Address of framebuffer to plot pixel into
 //! @param clip_box Address of clipping rectangle to perform clipping check
 //! @param x Integral X coordinate of the point
@@ -100,7 +106,7 @@ void graphics_private_plot_horizontal_line(GContext *ctx, int16_t y, Fixed_S16_3
 //! Blends vertical line between given points using current stroke color
 //! Will adjust to drawing_box and clip_box
 //! @param ctx Graphics context for plotting
-//! @param x X coordinate of line
+//! @param y X coordinate of line
 //! @param y1 Starting point for the line
 //! @param y2 Ending point for the line
 //! @param opacity Value that will be reverted and applied to alpha channel
@@ -118,12 +124,14 @@ void graphics_private_draw_horizontal_line_delta_aa(GContext *ctx, int16_t y, Fi
 void graphics_patch_trace_of_moving_rect(GContext *ctx, int16_t *prev_x, GRect current);
 
 //! will move all pixels in the bitmap by delta_x.
+//! @param bitmap Bitmap whose pixels to move
 //! @param delta_x Number of pixels to move. Positive is right, negative is left.
 //! @param patch_garbage If set, will fill the undefined pixels with the edge-most color.
 void graphics_private_move_pixels_horizontally(GBitmap *bitmap, int16_t delta_x,
                                                bool patch_garbage);
 
 //! will move all pixels in the bitmap by delta_y - they will leave a trace of undefined pixels
+//! @param bitmap Bitmap whose pixels to move
 //! @param delta_y Number of pixels to move. Positive is down, negative is up.
 void graphics_private_move_pixels_vertically(GBitmap *bitmap, int16_t delta_y);
 

--- a/src/fw/applib/graphics/gtransform.h
+++ b/src/fw/applib/graphics/gtransform.h
@@ -99,8 +99,8 @@
                        .d = GTransformNumberOne,      \
                        .tx = tx_v,        \
                        .ty = ty_v }
-//! @param tx_v X translation factor (type is char, int, float, etc)
-//! @param ty_v Y translation factor (type is char, int, float, etc)
+//! @param tx X translation factor (type is char, int, float, etc)
+//! @param ty Y translation factor (type is char, int, float, etc)
 #define GTransformTranslationFromNumber(tx, ty)  \
         GTransformTranslation(GTransformNumberFromNumber(tx), GTransformNumberFromNumber(ty))
 
@@ -239,7 +239,7 @@ bool gtransform_invert(GTransform *t_new, GTransform *t);
 GPointPrecise gpoint_transform(GPoint point, const GTransform * const t);
 
 //! Transforms a single GVector (dx,dy) based on the transformation matrix
-//! @param point GVector to be transformed
+//! @param vector GVector to be transformed
 //! @param t Pointer to transformation matrix to apply to the GVector
 //! @return GVectorPrecise after transforming the GVector; if t is NULL then just convert the
 //! GVector to a GVectorPrecise.

--- a/src/fw/applib/graphics/gtypes.h
+++ b/src/fw/applib/graphics/gtypes.h
@@ -322,6 +322,10 @@ static inline uint32_t gpoint_distance_squared(GPoint a, GPoint b) {
 bool gpoint_equal(const GPoint * const point_a, const GPoint * const point_b);
 
 //! Sorts an array of gpoints using a given GPointComparator
+//! @param points Array of points to sort
+//! @param num_points Number of points in the array
+//! @param comparator GPointComparator to compare the points with
+//! @param context Callback context passed to the comparator
 //! @param reverse false to maintain order, true to reverse the order
 void gpoint_sort(GPoint *points, size_t num_points, GPointComparator comparator, void *context,
     bool reverse);
@@ -564,13 +568,11 @@ bool grect_is_empty(const GRect* const rect);
 //! the origin will offset, so that the final rectangle overlaps with the original.
 //! For example, a GRect with size (-10, -5) and origin (20, 20), will be standardized
 //! to size (10, 5) and origin (10, 15).
-//! @param[in] rect The rectangle to convert.
-//! @param[out] rect The standardized rectangle.
+//! @param[in,out] rect The rectangle to convert, set to the standardized rectangle.
 void grect_standardize(GRect *rect);
 
 //! Trim one rectangle using the edges of a second rectangle.
-//! @param[in] rect_to_clip The rectangle that needs to be clipped (in place).
-//! @param[out] rect_to_clip The clipped rectangle.
+//! @param[in,out] rect_to_clip The rectangle that needs to be clipped (in place).
 //! @param rect_clipper The rectangle of which the edges will serve as "scissors"
 //! in order to trim `rect_to_clip`.
 void grect_clip(GRect * const rect_to_clip, const GRect * const rect_clipper);
@@ -649,7 +651,7 @@ typedef struct {
 //!    (GEdgeInsets){.top = v1, .right = v2, .bottom = v3, .left = v2}
 //!  - four values v1, v2, v3, v4 to configure it with
 //!    (GEdgeInsets){.top = v1, .right = v2, .bottom = v3, .left = v4}
-//! @see \ref grect_insets
+//! @see \ref grect_inset
 #define GEdgeInsets(...) \
   GEdgeInsetsN(__VA_ARGS__, GEdgeInsets4, GEdgeInsets3, GEdgeInsets2, GEdgeInsets1)(__VA_ARGS__)
 
@@ -733,7 +735,7 @@ typedef struct __attribute__ ((__packed__)) GBitmapLegacy2 {
   //! Pointer to the address where the image data lives
   void *addr;
   //! @note The number of bytes per row may have restrictions depending on the format:
-  //! - \ref GBitmapFormat1Bit: Must be a multiple of 4 (eg. word-padded)
+  //! - \ref GBitmapFormat1Bit "GBitmapFormat1Bit": Must be a multiple of 4 (eg. word-padded)
   //! - All palettized formats must have byte-aligned rows.
   //! Also, the following should (naturally) be true: `(row_size_bytes * 8 >= bounds.w)`
   uint16_t row_size_bytes;
@@ -801,7 +803,7 @@ typedef struct __attribute__ ((__packed__)) GBitmap {
   //! Pointer to the address where the image data lives
   void *addr;
   //! @note The number of bytes per row may have restrictions depending on the format:
-  //! - \ref GBitmapFormat1Bit: Must be a multiple of 4 (eg. word-padded)
+  //! - \ref GBitmapFormat1Bit "GBitmapFormat1Bit": Must be a multiple of 4 (eg. word-padded)
   //! - All palettized formats must have byte-aligned rows.
   //! Also, the following should (naturally) be true: `(row_size_bytes * 8 >= bounds.w)`
   //! 0, if bitmap has a variable row size (GBitmapFormat8BitCircular)
@@ -1089,8 +1091,8 @@ typedef enum GAlign {
 //! Aligns one rectangle within another rectangle, using an alignment parameter.
 //! The relative coordinate systems of both rectangles are assumed to be the same.
 //! When clip is true, `rect` is also clipped by the constraint.
-//! @param[in] rect The rectangle to align (in place)
-//! @param[out] rect The aligned and optionally clipped rectangle
+//! @param[in,out] rect The rectangle to align (in place), set to the aligned and
+//! optionally clipped rectangle
 //! @param inside_rect The rectangle in which to align `rect`
 //! @param alignment Determines the alignment of `rect` within `inside_rect` by
 //! specifying what edges of should overlap.
@@ -1303,7 +1305,7 @@ typedef struct PACKED {
   //! Text drawing functions MUST use this as text color
   GColor text_color;
   //! This color MUST be used as the tint color when using the drawing functions
-  //! \ref graphics_draw_bitmap_in_rect and \ref graphics_draw_rotated_bitmap_in_rect
+  //! \ref graphics_draw_bitmap_in_rect and \ref graphics_draw_rotated_bitmap
   //! on Basalt with the compositing mode as GCompOpOr.
   GColor tint_color;
   //! Bitmap compositing functions MUST use this as the compositing mode

--- a/src/fw/applib/graphics/text_layout_private.h
+++ b/src/fw/applib/graphics/text_layout_private.h
@@ -39,16 +39,16 @@ typedef struct {
 //!   - "   dog" // whitespace is trimmed if word wraps
 //!   - "\n"
 //!   - "jumps"
-//! 
-//! - Word start points to first printable codepoint in word, inclusive,
-//!   including whitespace
-//! - Word end points to codepoint after the last printable codepoint in a word,
-//!   excluding whitespace (eg, end of word, exclusive); note this codepoint may
-//!   not be valid since it may be the end of the string
-//! - The preceeding whitespace of a word is trimmed if the word wraps
-//! - Reserved codepoints are skipped
-//! - Newlines are treated as stand-alone words so as to not mess up the height
-//!   and width word metrics
+//!
+//!   - Word start points to first printable codepoint in word, inclusive,
+//!     including whitespace
+//!   - Word end points to codepoint after the last printable codepoint in a word,
+//!     excluding whitespace (eg, end of word, exclusive); note this codepoint may
+//!     not be valid since it may be the end of the string
+//!   - The preceeding whitespace of a word is trimmed if the word wraps
+//!   - Reserved codepoints are skipped
+//!   - Newlines are treated as stand-alone words so as to not mess up the height
+//!     and width word metrics
 typedef struct {
   utf8_t* start;
   utf8_t* end;

--- a/src/fw/applib/graphics/text_resources.h
+++ b/src/fw/applib/graphics/text_resources.h
@@ -106,6 +106,9 @@ typedef struct FontCache {
   const FontResource *cached_font;
 } FontCache;
 
+//! @param font_cache The font cache to look up the glyph in
+//! @param codepoint The codepoint to get the glyph for
+//! @param font_info The font to get the glyph from
 //! @param baseline_adjust_out optional: pixels to add to the glyph's top_offset when drawing,
 //! non-zero only when another font (emoji or system fallback) supplied the glyph
 const GlyphData *text_resources_get_glyph(FontCache *font_cache, Codepoint codepoint,
@@ -123,7 +126,7 @@ int8_t text_resources_get_glyph_horiz_advance(FontCache *font_cache, Codepoint c
 //! @param app_num the ResAppNum associated with this font (i.e. system or app?)
 //! @param font_resource the "base" resource id
 //! @param extension_resource the "extension" resource id
-//! @fontinfo a pointer to the fontinfo struct to initialize
+//! @param font_info a pointer to the fontinfo struct to initialize
 bool text_resources_init_font(ResAppNum app_num, uint32_t font_resource,
                               uint32_t extension_resource, FontInfo *font_info);
 

--- a/src/fw/applib/graphics/utf8.h
+++ b/src/fw/applib/graphics/utf8.h
@@ -48,16 +48,16 @@ size_t utf8_copy_character(utf8_t *dest, utf8_t *origin, size_t length);
 //! @return Number of bytes written (1-4), or 0 on error (invalid codepoint)
 size_t utf8_encode_codepoint(Codepoint codepoint, utf8_t *dest);
 
-//! Returns the length of the string if this length is less than \ref max_size bytes. Otherwise, it
+//! Returns the length of the string if this length is less than @c max_size bytes. Otherwise, it
 //! returns the length of the string up until the end of the last valid codepoint that fits into
-//! \ref max_size bytes and \ref truncated is set to true (it is set to false if the string is not
+//! @c max_size bytes and @c truncated is set to true (it is set to false if the string is not
 //! truncated)
 //! @param text A null-terminated UTF-8 c-string.
 //! @param max_size maximum allowable size, in bytes, of the string (including null terminator)
-//! @return length of string in bytes (will always be less than \ref max_size)
+//! @return length of string in bytes (will always be less than @c max_size)
 size_t utf8_get_size_truncate(const char *text, size_t max_size);
 
-//! Truncates \ref in_string to at most \ref max_length bytes (including the null
+//! Truncates @c in_string to at most @c max_length bytes (including the null
 //! terminator) with ellipsis.
 //! @param in_string A null-terminated UTF-8 c-string.
 //! @param[out] out_buffer A buffer where the truncated string will be output,

--- a/src/fw/applib/health_service.h
+++ b/src/fw/applib/health_service.h
@@ -315,7 +315,7 @@ HealthServiceAccessibilityMask health_service_metric_accessible(
 //! @param time_start Earliest UTC time you are interested in.
 //! @param time_end Latest UTC time you are interested in.
 //! @param scope \ref HealthServiceTimeScope value describing how the average should be computed.
-//! @return A \HealthServiceAccessibilityMask value decribing whether averaged data is available.
+//! @return A \ref HealthServiceAccessibilityMask value decribing whether averaged data is available.
 HealthServiceAccessibilityMask health_service_metric_averaged_accessible(
     HealthMetric metric, time_t time_start, time_t time_end, HealthServiceTimeScope scope);
 
@@ -329,7 +329,7 @@ HealthServiceAccessibilityMask health_service_metric_averaged_accessible(
 //! @param time_end Latest UTC time you are interested in.
 //! @param aggregation The aggregation to perform
 //! @param scope \ref HealthServiceTimeScope value describing how the average should be computed.
-//! @return A \HealthServiceAccessibilityMask value decribing whether averaged data is available.
+//! @return A \ref HealthServiceAccessibilityMask value decribing whether averaged data is available.
 HealthServiceAccessibilityMask health_service_metric_aggregate_averaged_accessible(
     HealthMetric metric, time_t time_start, time_t time_end, HealthAggregation aggregation,
     HealthServiceTimeScope scope);

--- a/src/fw/applib/legacy2/ui/property_animation_legacy2.h
+++ b/src/fw/applib/legacy2/ui/property_animation_legacy2.h
@@ -10,7 +10,7 @@
 // Legacy2 Property Animations
 //
 
-//! @file property_animation_legacy2_legacy2.h
+//! @file property_animation_legacy2.h
 
 //! @addtogroup UI
 //! @{
@@ -122,7 +122,7 @@ void property_animation_legacy2_init(struct PropertyAnimationLegacy2 *property_a
 //! sense to pass in a `static const` struct pointer.
 //! @param subject Pointer to the "subject" being animated. This will be passed in when the
 //! getter/setter accessors are called,
-//! see \ref PropertyAnimationLegacy2Accessors, \ref GPointSetter, and friends. The value of this
+//! see \ref PropertyAnimationAccessors, \ref GPointSetter, and friends. The value of this
 //! pointer will be copied into the `.subject` field of the PropertyAnimationLegacy2 struct.
 //! @param from_value Pointer to the value that the subject should animate from
 //! @param to_value Pointer to the value that the subject should animate to

--- a/src/fw/applib/plugin_service.h
+++ b/src/fw/applib/plugin_service.h
@@ -21,7 +21,7 @@
 //! Plug-in services are identified by UUID. The client of a service will get a pointer to an event structure
 //! param block whose content is unique to each service.
 //!
-//!     @{
+//!   @{
 
 
 //! Generic structure of a plug-in event that will be received by an app
@@ -50,6 +50,7 @@ bool plugin_service_unsubscribe(Uuid *uuid);
 
 
 //! Send an event for a plug-in service
+//! @param uuid The UUID of the plug-in service
 //! @param type the event type
 //! @param data the event data structure
 void plugin_service_send_event(Uuid *uuid, uint8_t type, PluginEventData *data);

--- a/src/fw/applib/template_string.h
+++ b/src/fw/applib/template_string.h
@@ -77,7 +77,7 @@ typedef struct TemplateStringError {
 //! @param reeval_cond Pointer to a structure that will be filled with information on when to
 //!                    re-evaluate the string. Maybe be NULL
 //! @param vars Pointer to variables that affect how the template string will be evaluated
-//! @param errors Pointer to a TemplateStringError that will be set to contain information about
+//! @param error Pointer to a TemplateStringError that will be set to contain information about
 //!               the first error detected in the template string upon failure
 //! @return True if the template string is successfully evaluated and the output written to the
 //!         provided output string buffer, false otherwise

--- a/src/fw/applib/ui/action_menu_hierarchy.h
+++ b/src/fw/applib/ui/action_menu_hierarchy.h
@@ -24,7 +24,7 @@ typedef void (*ActionMenuPerformActionCb)(ActionMenu *action_menu,
 
 //! Callback invoked for each item in an action menu hierarchy.
 //! @param item the current action menu item
-//! @param a caller-provided context callback
+//! @param context a caller-provided callback context
 typedef void (*ActionMenuEachItemCb)(const ActionMenuItem *item, void *context);
 
 //! enum value that controls whether menu items are displayed in a grid
@@ -39,7 +39,7 @@ typedef enum {
 //! @return a pointer to the string label. NULL if invalid.
 char *action_menu_item_get_label(const ActionMenuItem *item);
 
-//! Getter for the action_data pointer of a given \ref ActionMenuitem.
+//! Getter for the action_data pointer of a given \ref ActionMenuItem.
 //! @see action_menu_level_add_action
 //! @param item the \ref ActionMenuItem of interest
 //! @return a pointer to the data. NULL if invalid.

--- a/src/fw/applib/ui/action_menu_window.h
+++ b/src/fw/applib/ui/action_menu_window.h
@@ -35,7 +35,7 @@ struct ActionMenu;
 typedef struct ActionMenu ActionMenu;
 
 //! Callback executed after the ActionMenu has closed, so memory may be freed.
-//! @param root_level the root level passed to the ActionMenu
+//! @param menu the ActionMenu
 //! @param performed_action the ActionMenuItem for the action that was performed,
 //! NULL if the ActionMenu is closing without an action being selected by the user
 //! @param context the context passed to the ActionMenu
@@ -44,7 +44,7 @@ typedef void (*ActionMenuDidCloseCb)(ActionMenu *menu,
                                      void *context);
 
 //! Callback executed immediately before the ActionMenu closes.
-//! @param root_level the root ActionMenuLevel passed to the ActionMenu
+//! @param menu the ActionMenu
 //! @param performed_action the ActionMenuItem for the action that was performed,
 //! NULL if the ActionMenu is closing without an action being selected by the user
 //! @param context the context passed to the ActionMenu

--- a/src/fw/applib/ui/animation.h
+++ b/src/fw/applib/ui/animation.h
@@ -374,7 +374,7 @@ typedef struct AnimationHandlers {
 bool animation_set_handlers(Animation *animation, AnimationHandlers callbacks, void *context);
 
 //! Gets the callbacks for the animation.
-//! @param animation The animation for which to set up the callbacks.
+//! @param animation_h The animation for which to set up the callbacks.
 //! @return the callbacks in use by this animation
 AnimationHandlers animation_get_handlers(Animation *animation_h);
 

--- a/src/fw/applib/ui/animation_interpolate.h
+++ b/src/fw/applib/ui/animation_interpolate.h
@@ -8,7 +8,7 @@
 
 #include <stdint.h>
 
-//! @file interpolate.h
+//! @file animation_interpolate.h
 //! Routines for interpolating between values and points. Useful for animations.
 
 typedef struct MoookConfig {
@@ -97,6 +97,8 @@ int64_t interpolate_moook_in_only(int32_t normalized, int64_t from, int64_t to);
 //! @param normalized Time of the point in the ease curve
 //! @param from Starting point in space of the animation
 //! @param to Ending point in space of the animation
+//! @param num_frames_from Number of frames in the animation that do not consist of the Moook
+//! ease out curve.
 //! @param bounce_back Whether to lead up to the end point from the opposite direction if we were
 //! to lead up from the start poing, which a normal Moook curve would do.
 int64_t interpolate_moook_out(int32_t normalized, int64_t from, int64_t to,

--- a/src/fw/applib/ui/dialogs/actionable_dialog.h
+++ b/src/fw/applib/ui/dialogs/actionable_dialog.h
@@ -28,7 +28,7 @@ void actionable_dialog_init(ActionableDialog *actionable_dialog, const char *dia
 Dialog *actionable_dialog_get_dialog(ActionableDialog *actionable_dialog);
 
 //! Sets the type of action bar to used to one of the pre-defined types or a custom one.
-//! @param actionable_dialog Pointer to a \ref ActioanbleDialog whom which to set
+//! @param actionable_dialog Pointer to a \ref ActionableDialog whom which to set
 //! @param action_bar_type The type of action bar to give the passed dialog
 //! @param action_bar Pointer to an \ref ActionBarLayer to assign to the dialog
 //! @note:  The pointer to an \ref ActionBarLayer is optional and only required when the

--- a/src/fw/applib/ui/dialogs/expandable_dialog.h
+++ b/src/fw/applib/ui/dialogs/expandable_dialog.h
@@ -68,7 +68,7 @@ void expandable_dialog_close_cb(ClickRecognizerRef recognizer, void *e_dialog);
 
 //! Intializes an ExpandableDialog
 //! @param expandable_dialog Pointer to an \ref ExpandableDialog
-//! param dialog_name The name to give the \ref ExpandableDialog
+//! @param dialog_name The name to give the \ref ExpandableDialog
 void expandable_dialog_init(ExpandableDialog *expandable_dialog, const char *dialog_name);
 
 //! Retrieves the internal Dialog object of the Expandable Dialog.
@@ -119,7 +119,7 @@ void expandable_dialog_set_body_font(ExpandableDialog *expandable_dialog, GFont 
 //! @param resource_id The resource id of the resource to be used to create the select bitmap
 //! @param select_click_handler Handler to call when the select handler is clicked in the
 //!     Expandable Dialog's action bar layer.
-//! @note Passing \ref RESOURCE_ID_INVALID as the resource_id to the function will allow you
+//! @note Passing @c RESOURCE_ID_INVALID as the resource_id to the function will allow you
 //!     to set an action with no icon appearing in the \ref ActionBarLayer
 void expandable_dialog_set_select_action(ExpandableDialog *expandable_dialog,
                                          uint32_t resource_id,

--- a/src/fw/applib/ui/kino/kino_reel/scale_segmented.h
+++ b/src/fw/applib/ui/kino/kino_reel/scale_segmented.h
@@ -49,28 +49,36 @@ KinoReel *kino_reel_scale_segmented_create(KinoReel *from_reel, bool take_owners
                                            GRect screen_frame);
 
 //! Sets a GPointIndexLookup
-//! @param index_lookup GPointIndexLookup with the assigned delay multiplier for each point
+//! @param reel KinoReel to modify
+//! @param creator Creator of a GPointIndexLookup with the assigned delay multiplier for each point
+//! @param context Context to pass to the creator
+//! @param take_ownership true if this KinoReel will free `context` when destroyed
 void kino_reel_scale_segmented_set_delay_lookup_creator(
     KinoReel *reel, GPointIndexLookupCreator creator, void *context, bool take_ownership);
 
 //! Sets a GPointIndexLookup based on the distance to a target
+//! @param reel KinoReel to modify
 //! @param target Position to pull and stretch the image from in image coordinates.
 bool kino_reel_scale_segmented_set_delay_by_distance(KinoReel *reel, GPoint target);
 
 //! Set the point duration
+//! @param reel KinoReel to modify
 //! @param point_duration Fraction of the total animation time a point should animate.
 void kino_reel_scale_segmented_set_point_duration(KinoReel *reel, Fixed_S32_16 point_duration);
 
 //! Set the effect duration. Ignored if expand and bounce are disabled
-//! @param effect_duration Fraction of the total animation time an effect should animate.
+//! @param reel KinoReel to modify
+//! @param point_duration Fraction of the total animation time an effect should animate.
 void kino_reel_scale_segmented_set_effect_duration(KinoReel *reel, Fixed_S32_16 point_duration);
 
 //! Set the magnitude of the deflate effect
+//! @param reel KinoReel to modify
 //! @param expand Expansion length of `to` in pixels that would result in a deflation animation.
 //! Set as 0 to disable.
 void kino_reel_scale_segmented_set_deflate_effect(KinoReel *reel, int16_t expand);
 
 //! Set the magnitude of the bounce back effect. Requires all frames to be set before use.
+//! @param reel KinoReel to modify
 //! @param bounce Overshoot length of `to` in pixels that would result in a bounce back animation.
 //! Set as 0 to disable.
 void kino_reel_scale_segmented_set_bounce_effect(KinoReel *reel, int16_t bounce);
@@ -80,6 +88,7 @@ void kino_reel_scale_segmented_set_interpolate(KinoReel *reel,
                                                InterpolateInt64Function interpolate);
 
 //! Set from stroke width
+//! @param reel KinoReel to modify
 //! @param from Fixed_S16_3 From stroke width operator value
 //! @param from_op GStrokeWidthOp operation to start with
 //! @see GStrokeWidthOp
@@ -87,6 +96,7 @@ void kino_reel_scale_segmented_set_from_stroke_width(KinoReel *reel, Fixed_S16_3
                                                      GStrokeWidthOp from_op);
 
 //! Set to stroke width
+//! @param reel KinoReel to modify
 //! @param to Fixed_S16_3 To stroke width operator value
 //! @param to_op GStrokeWidthOp operation to end with
 //! @see GStrokeWidthOp

--- a/src/fw/applib/ui/kino/kino_reel/unfold.h
+++ b/src/fw/applib/ui/kino/kino_reel/unfold.h
@@ -23,7 +23,7 @@
 //! without a deflation and bounce back effect. The effects can be simultaneous or independent and
 //! are achieved by overlapping two invocations of \ref gdraw_command_image_scale_segmented_to.
 //! The unfold effect is achieved by using a GPointIndexLookup created by
-//! \ref gdraw_command_image_create_index_lookup_by_angle.
+//! \ref gdraw_command_list_create_index_lookup_by_angle.
 //! @param from_reel KinoReel to display and animate.
 //! @param take_ownership true if this KinoReel will free `image` when destroyed.
 //! @param screen_frame Position and size of the parent KinoLayer in absolute drawing coordinates.

--- a/src/fw/applib/ui/layer.h
+++ b/src/fw/applib/ui/layer.h
@@ -139,7 +139,6 @@ typedef struct DataLayer {
 //! * `update_proc` : `NULL` (draws nothing)
 //! @param layer The layer to initialize
 //! @param frame The frame at which the layer should be initialized.
-//! @param data_size The size (in bytes) of memory to initialize after the layer struct.
 //! @see \ref layer_set_frame()
 //! @see \ref layer_set_bounds()
 void layer_init(Layer *layer, const GRect *frame);

--- a/src/fw/applib/ui/menu_cell_layer.h
+++ b/src/fw/applib/ui/menu_cell_layer.h
@@ -17,6 +17,7 @@
 //!   @addtogroup Layer Layers
 //!   @{
 //!     @addtogroup MenuLayer
+//!   @{
 
 //! @internal
 //! TODO: PBL-21467 Implement MenuCellLayer

--- a/src/fw/applib/ui/menu_layer.h
+++ b/src/fw/applib/ui/menu_layer.h
@@ -263,7 +263,7 @@ typedef struct MenuLayerCallbacks {
 
   //! Callback that gets called to get the height of a cell.
   //! This can get called at various moments throughout the life of a menu.
-  //! @note When `NULL`, the default height of \ref MENU_CELL_BASIC_CELL_HEIGHT pixels is used.
+  //! @note When `NULL`, the default height of @c MENU_CELL_BASIC_CELL_HEIGHT pixels is used.
   //! Developers may wish to use \ref MENU_CELL_ROUND_FOCUSED_SHORT_CELL_HEIGHT
   //! and \ref MENU_CELL_ROUND_UNFOCUSED_SHORT_CELL_HEIGHT on a round display
   //! to respect the system aesthetic.
@@ -666,7 +666,7 @@ void menu_layer_set_scroll_vibe_on_wrap(MenuLayer *menu_layer, bool scroll_vibe_
 //! Controls if the \ref MenuLayer wil generate a vibe when blocked at the top or bottom.
 //! Defaults to false for every platform
 //! @param menu_layer The menu layer for which to enable or disable the behavior.
-//! @param scroll_vibe_on_wrap true = enable the vibe on cursor block, false = disable it.
+//! @param scroll_vibe_on_blocked true = enable the vibe on cursor block, false = disable it.
 //! @see \ref menu_layer_get_scroll_vibe_behavior
 //! @see \ref menu_layer_set_scroll_vibe_on_wrap
 void menu_layer_set_scroll_vibe_on_blocked(MenuLayer *menu_layer, bool scroll_vibe_on_blocked);

--- a/src/fw/applib/ui/progress_window.h
+++ b/src/fw/applib/ui/progress_window.h
@@ -104,6 +104,7 @@ void progress_window_set_result_success(ProgressWindow *window);
 //! Tell the ProgressWindow it should animate in a way to show failure. When the animation is
 //! complete, .callbacks.finished will be called if previously provided.
 //!
+//! @param window ProgressWindow to modify
 //! @param timeline_res_id optional timeline resource, can be 0 if not desired
 //! @param message optional message, can be NULL
 //! @param delay duration of the progress bar shrinking animation in milliseconds

--- a/src/fw/applib/ui/property_animation.h
+++ b/src/fw/applib/ui/property_animation.h
@@ -234,8 +234,8 @@ PropertyAnimation *property_animation_create_layer_bounds(struct Layer *layer, G
 //! layer_get_bounds() as accessors and uses the `layer` parameter as the subject for the animation.
 //! The same defaults are used as with \ref animation_create().
 //! @param layer the layer that will be animated
-//! @param from_origin the origin that the bounds should animate from
-//! @param to_origin the origin that the layer should animate to
+//! @param from the origin that the bounds should animate from
+//! @param to the origin that the layer should animate to
 //! @return A handle to the property animation. `NULL` if animation could not be created
 PropertyAnimation *property_animation_create_bounds_origin(struct Layer *layer, GPoint *from,
     GPoint *to);

--- a/src/fw/applib/ui/recognizer/recognizer.h
+++ b/src/fw/applib/ui/recognizer/recognizer.h
@@ -86,7 +86,7 @@ void recognizer_set_simultaneous_with(Recognizer *recognizer,
 
 //! Check whether a recognizer should evaluate simultaneously with \a test
 //! @param recognizer recognizer to be tested against
-//! @param test check whether this recognizer is evaluated simultaneously with \ref recognizer
+//! @param test check whether this recognizer is evaluated simultaneously with @c recognizer
 //! @return true if the two recognizers will be evaluated simultaneously
 bool recognizer_should_evaluate_simultaneously(const Recognizer *recognizer,
                                                const Recognizer *test);
@@ -103,6 +103,7 @@ bool recognizer_has_triggered(const Recognizer *recognizer);
 
 //! Set the user data attached to the recognizer
 //! @param recognizer recognizer to modify
+//! @param data user data to attach
 void recognizer_set_user_data(Recognizer *recognizer, void *data);
 
 //! Get the user data attached to the recognizer

--- a/src/fw/applib/ui/recognizer/recognizer_impl.h
+++ b/src/fw/applib/ui/recognizer/recognizer_impl.h
@@ -41,10 +41,11 @@ typedef struct RecognizerImpl {
 //! recognizers to instantiate a recognizer from the base class. A recognizer created from this
 //! function cannot be used without an implementation.
 //! @note A recognizer cannot be created without implementation details
+//! @param impl recognizer implementation
 //! @param data recognizer-specific data (copied into created recognizer)
-//! @param size data size
+//! @param data_size data size
 //! @param event_cb event callback
-//! @param event_context context to provide to event callback
+//! @param user_data context to provide to event callback
 //! @return NULL if an error occurs, otherwise a pointer to the newly created recognizer
 Recognizer *recognizer_create_with_data(const RecognizerImpl *impl, const void *data,
                                         size_t data_size, RecognizerEventCb event_cb,

--- a/src/fw/applib/ui/status_bar_layer.h
+++ b/src/fw/applib/ui/status_bar_layer.h
@@ -129,8 +129,6 @@ typedef struct StatusBarLayer {
 //! * Frame: `GRect(0, 0, screen_width, STATUS_BAR_LAYER_HEIGHT)`
 //! The status bar is automatically marked dirty after this operation.
 //! You can call \ref layer_set_frame() to create a StatusBarLayer of a different width.
-//! @return A pointer to the StatusBarLayer, which will be allocated to the heap,
-//! `NULL` if the StatusBarLayer could not be created
 void status_bar_layer_init(StatusBarLayer *status_bar_layer);
 
 //! Creates a new StatusBarLayer on the heap and initializes it with the default values.
@@ -199,7 +197,7 @@ void status_bar_layer_set_title(StatusBarLayer *status_bar_layer, const char *te
 const char *status_bar_layer_get_title(const StatusBarLayer *status_bar_layer);
 
 //! Resets title text to clock text
-//! @param status_bar_layer The StatusBarLayer of which to reset the title to clock
+//! @param cb_data The StatusBarLayer of which to reset the title to clock
 void status_bar_layer_reset_title(void *cb_data);
 
 //! Sets the info section to display arbitrary text

--- a/src/fw/applib/ui/window_private.h
+++ b/src/fw/applib/ui/window_private.h
@@ -38,7 +38,7 @@ bool window_has_status_bar(Window *window);
 
 //! @param window Pointer to the \ref Window to set
 //! @param overrides_back_button Boolean indicating if the back button has been overriden
-//!     in the \ref ClickConfigProvidier of the passed \ref Window
+//!     in the \ref ClickConfigProvider of the passed \ref Window
 void window_set_overrides_back_button(Window *window, bool overrides_back_button);
 
 //! @internal

--- a/src/fw/applib/ui/window_stack_private.h
+++ b/src/fw/applib/ui/window_stack_private.h
@@ -48,12 +48,12 @@ bool window_transition_context_has_legacy_window_to(WindowStack *stack, Window *
 
 //! Transitioning function called when the current visible window disappears.
 //! If there is no window_to pointer (it is NULL), then this is a no-op.
-//! @param context The \ref WindowTransitionContext of the transitioning window
+//! @param context The \ref WindowTransitioningContext of the transitioning window
 void window_transition_context_disappear(WindowTransitioningContext *context);
 
 //! Transitioning function called when the new window, window_to in the context, appears on
 //! the screen.  If there is no window_to pointer (it is NULL), then this is a no-op.
-//! @param context The \ref WindowTransitionContext of the transitioning window
+//! @param context The \ref WindowTransitioningContext of the transitioning window
 void window_transition_context_appear(WindowTransitioningContext *context);
 
 //! @internal

--- a/src/fw/applib/unobstructed_area_service.h
+++ b/src/fw/applib/unobstructed_area_service.h
@@ -69,6 +69,7 @@
 //! the final unobstructed area passed into `will_change` to set up a \ref PropertyAnimation. A
 //! separate example would be to save the animation progress passed to your `change` handler for
 //! use in your own custom easing curve in your layer update procedure.
+//!   @{
 
 //! Handler that will be called just before the unobstructed area will begin changing
 //! @param final_unobstructed_screen_area The final unobstructed screen area after

--- a/src/fw/applib/voice/dictation_session.h
+++ b/src/fw/applib/voice/dictation_session.h
@@ -25,6 +25,7 @@
 //!
 //! If these calls are made on a platform that does not support voice dictation,
 //! \ref dictation_session_create will return NULL and the other calls will do nothing.
+//!   @{
 
 typedef struct DictationSession DictationSession;
 
@@ -86,7 +87,7 @@ typedef void (*DictationSessionStatusCallback)(DictationSession *session,
 
 //! Create a dictation session. The session object can be used more than once to get a
 //! transcription. When a transcription is received a buffer will be allocated to store the text in
-//! with a maximum size specified by \ref buffer_size. When a transcription is accepted by the user
+//! with a maximum size specified by @c buffer_size. When a transcription is accepted by the user
 //! or a failure of some sort occurs, the callback specified will be called with the status and the
 //! transcription if one was accepted.
 //! @param buffer_size       size of buffer to allocate for the transcription text; text will be

--- a/src/fw/applib/voice/transcription_dialog.h
+++ b/src/fw/applib/voice/transcription_dialog.h
@@ -69,7 +69,7 @@ void transcription_dialog_update_text(TranscriptionDialog *transcription_dialog,
 //! being displayed is what they intended.
 //! @param transcription_dialog Pointer to the \ref TranscriptionDialog to set
 //! @param callback The \ref TranscriptionConfirmationCallback to call if the user confirms text
-//! @param callback_context The \ref callback_context to pass to the confirmation handler
+//! @param callback_context The @c callback_context to pass to the confirmation handler
 //! @note If the callback_context is NULL, then the \ref TranscriptionDialog will be passed
 //!     the callback handler.
 void transcription_dialog_set_callback(TranscriptionDialog *transcription_dialog,

--- a/src/fw/apps/prf/mfg_menu.c
+++ b/src/fw/apps/prf/mfg_menu.c
@@ -128,7 +128,7 @@ static void prv_battery_state_handler(BatteryChargeState charge) {
   layer_mark_dirty(simple_menu_layer_get_layer(data->menu_layer));
 }
 
-//! @param[out] out_items
+//! @param[out] out_menu_items
 static size_t prv_create_menu_items(SimpleMenuItem** out_menu_items) {
 
   // Define a const blueprint on the stack.

--- a/src/fw/apps/prf/mfg_vibration.h
+++ b/src/fw/apps/prf/mfg_vibration.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-//! @file mfg_vibe.h
+//! @file
 //!
 //! Boring test app that vibes 5 times and quits
 

--- a/src/fw/apps/prf/recovery_first_use/getting_started_button_combo.h
+++ b/src/fw/apps/prf/recovery_first_use/getting_started_button_combo.h
@@ -7,7 +7,7 @@
 #include "pbl/services/new_timer/new_timer.h"
 #include "util/bitset.h"
 
-//! @file prf_button_combo.h
+//! @file
 //!
 //! This file implements a monitor that watches which buttons are held down. This file looks for
 //! 3 combinations.

--- a/src/fw/apps/system/health/activity_detail_card.h
+++ b/src/fw/apps/system/health/activity_detail_card.h
@@ -8,7 +8,7 @@
 #include "applib/ui/ui.h"
 
 //! Creates a health activity detail window
-//! @param HealthData pointer to the health data to be given to this card
+//! @param health_data pointer to the health data to be given to this card
 //! @return A pointer to a newly allocated health activity detail window
 Window *health_activity_detail_card_create(HealthData *health_data);
 

--- a/src/fw/apps/system/health/detail_card.h
+++ b/src/fw/apps/system/health/detail_card.h
@@ -101,7 +101,7 @@ void health_detail_card_configure(HealthDetailCard *detail_card,
 //! Sets the zones for any daily history (steps/sleep)
 //! @param zones pointer to the HealthDetailZone to be set
 //! @param num_zones number of zones in the pointer
-//! @wparam weekly_max pointer to the weekly max to be set
+//! @param weekly_max pointer to the weekly max to be set
 //! @param format_hours_and_minutes whether to a format the values for hours and minutes in label
 //! @param show_crown whether to set the `show_crown` in the zone with weekly max
 //! @param fill_color color to fill all the progress bars with except today

--- a/src/fw/apps/system/health/hr_detail_card.h
+++ b/src/fw/apps/system/health/hr_detail_card.h
@@ -8,7 +8,7 @@
 #include "applib/ui/ui.h"
 
 //! Creates a health hr detail window
-//! @param HealthData pointer to the health data to be given to this card
+//! @param health_data pointer to the health data to be given to this card
 //! @return A pointer to a newly allocated health hr detail window
 Window *health_hr_detail_card_create(HealthData *health_data);
 

--- a/src/fw/apps/system/health/sleep_detail_card.h
+++ b/src/fw/apps/system/health/sleep_detail_card.h
@@ -8,7 +8,7 @@
 #include "applib/ui/ui.h"
 
 //! Creates a health sleep detail window
-//! @param HealthData pointer to the health data to be given to this card
+//! @param health_data pointer to the health data to be given to this card
 //! @return A pointer to a newly allocated health sleep detail window
 Window *health_sleep_detail_card_create(HealthData *health_data);
 

--- a/src/fw/apps/system/health/sleep_summary_card.h
+++ b/src/fw/apps/system/health/sleep_summary_card.h
@@ -29,6 +29,7 @@ Layer *health_sleep_summary_card_create(HealthData *health_data);
 void health_sleep_summary_card_select_click_handler(Layer *layer);
 
 //! Set the card to a given view
+//! @param layer A pointer to an existing layer with extra data
 //! @param view the view type to show
 void health_sleep_summary_card_set_view(Layer *layer, SleepSummaryView view);
 

--- a/src/fw/apps/system/health/ui.h
+++ b/src/fw/apps/system/health/ui.h
@@ -12,6 +12,8 @@ void health_ui_draw_text_in_box(GContext *ctx, const char *text, const GRect dra
 //! Render the "TYPICAL <day>" pill with a single value line below the header.
 //! Used on narrow displays and on the sleep card.
 //!
+//! @param ctx Graphics context to draw with.
+//! @param layer Layer to render into.
 //! @param value_text Pre-formatted value text for the lower line (e.g. the
 //!   daily-total step count, or the typical sleep duration).
 void health_ui_render_typical_text_box(GContext *ctx, Layer *layer,
@@ -22,6 +24,8 @@ void health_ui_render_typical_text_box(GContext *ctx, Layer *layer,
 //! wide (>= 200px) displays for the activity card. The caller supplies all four
 //! strings so the renderer stays generic (not steps-specific).
 //!
+//! @param ctx Graphics context to draw with.
+//! @param layer Layer to render into.
 //! @param left_value  Pre-formatted value for the left column (top).
 //! @param left_label  Label for the left column (bottom).
 //! @param right_value Pre-formatted value for the right column (top).

--- a/src/fw/apps/system/launcher/default/app_glance.h
+++ b/src/fw/apps/system/launcher/default/app_glance.h
@@ -14,7 +14,7 @@ typedef struct LauncherAppGlance LauncherAppGlance;
 
 //! Called when a launcher app glance's current slice has been updated. The glance will
 //! automatically be redrawn after this function is called.
-//! @param The glance whose current slice has been updated
+//! @param glance The glance whose current slice has been updated
 typedef void (*LauncherAppGlanceCurrentSliceUpdated)(LauncherAppGlance *glance);
 
 typedef struct LauncherAppGlanceHandlers {

--- a/src/fw/apps/system/launcher/default/app_glance_service.h
+++ b/src/fw/apps/system/launcher/default/app_glance_service.h
@@ -35,7 +35,7 @@ typedef struct LauncherAppGlanceService {
   KinoReel *generic_glance_icon;
   //! The resource ID of the generic glance icon
   uint32_t generic_glance_icon_resource_id;
-  //! A \ref KinoReelPlayer for the currently selected glance
+  //! A \ref KinoPlayer for the currently selected glance
   KinoPlayer glance_reel_player;
 } LauncherAppGlanceService;
 

--- a/src/fw/apps/system/timeline/layer.h
+++ b/src/fw/apps/system/timeline/layer.h
@@ -120,7 +120,7 @@ void timeline_layer_init(TimelineLayer *layer, const GRect *frame,
 void timeline_layer_set_sidebar_color(TimelineLayer *timeline_layer, GColor color);
 
 //! Sets the sidebar width
-//! @param layer Pointer to the TimelineLayer.
+//! @param timeline_layer Pointer to the TimelineLayer.
 //! @param width Width to set the TimelineLayer sidebar to.
 void timeline_layer_set_sidebar_width(TimelineLayer *timeline_layer, int16_t width);
 

--- a/src/fw/apps/system/timeline/model.h
+++ b/src/fw/apps/system/timeline/model.h
@@ -45,14 +45,16 @@ bool timeline_model_is_empty(void);
 int timeline_model_get_num_items(void);
 
 //! Iterate the model towards the "next" direction
-//! @new_idx Set the raw index of the new iterator if new_idx is not NULL
-//! @has_next, set to whether or not there is a new third item in the list, i.e. false = iterate but
-//! show no more new items
+//! @param new_idx Set the raw index of the new iterator if new_idx is not NULL
+//! @param has_next set to whether or not there is a new third item in the list, i.e. false =
+//! iterate but show no more new items
 //! @return whether or not the current item is at the end of the list, i.e. false = stop iterating
 bool timeline_model_iter_next(int *new_idx, bool *has_next);
 
 //! Iterate the model towards the "prev" direction
-//! @new_idx Set the raw index of the new iterator if new_idx is not NULL
+//! @param new_idx Set the raw index of the new iterator if new_idx is not NULL
+//! @param has_prev set to whether or not there is a new item in the list, i.e. false =
+//! iterate but show no more new items
 //! @return whether or not the current item is at the beginning of the list, i.e. stop iterating
 bool timeline_model_iter_prev(int *new_idx, bool *has_prev);
 

--- a/src/fw/apps/system/timeline/peek_layer.h
+++ b/src/fw/apps/system/timeline/peek_layer.h
@@ -72,9 +72,9 @@ void peek_layer_set_icon_with_size(PeekLayer *peek_layer, const TimelineResource
                                    TimelineResourceSize res_size, GRect icon_from);
 
 //! Set the peek layer to have a stretching animation to a frame.
-//! @param align_in_frame if true, scale the image to the resource size and align within icon_to
-//! instead of scaling to the icon_to size
 void peek_layer_set_scale_to(PeekLayer *peek_layer, GRect icon_to);
+//! Same as peek_layer_set_scale_to, but with an image. If align_in_frame is true, scale the
+//! image to the resource size and align within icon_to instead of scaling to the icon_to size.
 void peek_layer_set_scale_to_image(PeekLayer *peek_layer, const TimelineResourceInfo *timeline_res,
                                    TimelineResourceSize res_size, GRect icon_to,
                                    bool align_in_frame);

--- a/src/fw/apps/system/timeline/relbar.h
+++ b/src/fw/apps/system/timeline/relbar.h
@@ -13,7 +13,8 @@ typedef enum {
 } RelationshipBarOffsetType;
 
 //! Create the animations for the relationship bars
-//! @param layer Pointer to the \ref TimelineLayer to create the relationship bar animation for
+//! @param timeline_layer Pointer to the \ref TimelineLayer to create the relationship bar
+//! animation for
 //! @param duration Duration in ms of the animation to create
 //! @param interpolate Custom interpolation function to use for the animation
 Animation *timeline_relbar_layer_create_animation(TimelineLayer *timeline_layer, uint32_t duration,

--- a/src/fw/apps/system/timeline/text_node.h
+++ b/src/fw/apps/system/timeline/text_node.h
@@ -141,7 +141,7 @@ typedef struct {
 typedef struct {
   GTextNode node;
   //! Pointer to a UTF-8 string for drawing. If the node was allocated with
-  //! \ref graphics_create_text_node having been called with a positive integer, text will be
+  //! \ref graphics_text_node_create_text having been called with a positive integer, text will be
   //! pointing to a writable text buffer that is pointing to the end of the node's memory.
   const char *text;
   GFont font;
@@ -166,10 +166,11 @@ typedef struct {
   GTextNodeTextDynamicUpdate update;
   void *user_data; //!< User data that will be passed to the user-defined update function
   //! Size of the buffer that will be passed to the update callback. If the node was allocated with
-  //! \ref graphics_create_text_node_dynamic, this is the buffer size that was passed to the buffer,
+  //! \ref graphics_text_node_create_text_dynamic, this is the buffer size that was passed to the
+  //! buffer,
   //! and the buffer it describes is at the end of the node's memory.
   size_t buffer_size;
-  //! If the node was created with \ref graphics_create_text_node_dynamic, this is the buffer
+  //! If the node was created with \ref graphics_text_node_create_text_dynamic, this is the buffer
   //! described by `.buffer_size`.
   union { uint32_t _align; } buffer[];
 } GTextNodeTextDynamic;

--- a/src/fw/comm/ble/gap_le_advert.h
+++ b/src/fw/comm/ble/gap_le_advert.h
@@ -70,7 +70,7 @@ typedef void (*GAPLEAdvertisingJobUnscheduleCallback)(GAPLEAdvertisingJobRef job
 //! Based on the given minimum and maximum interval values, an interval is
 //! used depending on other time related tasks the Bluetooth controller has to
 //! perform.
-//! @discussion Note that scheduled jobs will be unscheduled when the Bluetooth
+//! @note Scheduled jobs will be unscheduled when the Bluetooth
 //! stack is torn down (e.g. when going into Airplane Mode).
 //! @param payload The payload with the advertising and scan response data to
 //! be scheduled for air-time. @see ble_ad_parse.h for functions to build the
@@ -81,6 +81,7 @@ typedef void (*GAPLEAdvertisingJobUnscheduleCallback)(GAPLEAdvertisingJobRef job
 //! of seconds that the advertisement payload has to be on-air.
 //! The job is not guaranteed to get a consecutive period of air-time nor is it guaranteed that
 //! it will get air-time immediately after returning from this function.
+//! @param num_terms The number of terms in the terms array.
 //! @param callback Pointer to a function that should be called when the job
 //! is unscheduled. Note: bt_lock() *WILL* be held during the callback to
 //! prevent subtle concurrency problems that can cause out-of-order state
@@ -88,7 +89,6 @@ typedef void (*GAPLEAdvertisingJobUnscheduleCallback)(GAPLEAdvertisingJobRef job
 //! @see GAPLEAdvertisingJobUnscheduleCallback for more info.
 //! @param callback_data Pointer to arbitrary client data that is passed as an
 //! argument with the unschedule callback.
-
 //! @param tag A tag that will be used for debug logging.
 //! @return Reference to the scheduled job, or NULL if the parameters were not
 //! valid.
@@ -107,8 +107,8 @@ void gap_le_advert_unschedule(GAPLEAdvertisingJobRef advertisement_job);
 //! Unschedules existing advertisement jobs of particular tag types. Only
 //! reschedules advertisements after all the requested tag types have been
 //! removed
-//! @param types an array of tags for the Advertisement Types to remove
-//! @param num_types the length of the 'types' list
+//! @param tag_types an array of tags for the Advertisement Types to remove
+//! @param num_types the length of the 'tag_types' list
 void gap_le_advert_unschedule_job_types(
     GAPLEAdvertisingJobTag *tag_types, size_t num_types);
 

--- a/src/fw/comm/ble/gatt_client_accessors.c
+++ b/src/fw/comm/ble/gatt_client_accessors.c
@@ -466,7 +466,11 @@ static bool prv_copy_included_service_refs_cb(const GATTServiceNode *inc_service
 }
 
 //! Copies object references associated with service_ref into refs_out.
-//! @param callback This callback determines references for what objects need to be copied out
+//! @param service_ref The service with which the objects are associated
+//! @param refs_out The array into which the references are copied
+//! @param num_refs_out The size of the refs_out array
+//! @param matching_uuids If not NULL, only copy references for objects with a matching Uuid
+//! @param callbacks These callbacks determine references for what objects need to be copied out
 //! (characteristics, descriptors or included services)
 static uint8_t prv_locked_copy_refs_with_service_ref(BLEService service_ref,
                                                      uintptr_t refs_out[],

--- a/src/fw/comm/ble/gatt_client_accessors.h
+++ b/src/fw/comm/ble/gatt_client_accessors.h
@@ -6,7 +6,8 @@
 #include <bluetooth/bluetooth_types.h>
 #include <bluetooth/gatt_service_types.h>
 
-//! @file This file contains functions to access any discovered GATT Services,
+//! @file
+//! This file contains functions to access any discovered GATT Services,
 //! Characteristics and Descriptors. The data structures are used internally
 //! in gatt_client_accessors.c and gatt_client_discovery.c.
 
@@ -42,9 +43,10 @@ uint8_t gatt_client_service_get_characteristics(BLEService service_ref,
 // TODO: add public API to applib
 //! Copies BLECharacteristic references associated with the service, filtered by an array of
 //! Characteristic UUIDs.
+//! @param service_ref The service of which to copy the characteristic references.
 //! @param characteristics_out The array into which the matching BLECharacteristic references
 //! will be copied.
-//! @param matching_characteristic_uuids The array of Characteristic Uuid`s that will be used to
+//! @param matching_characteristic_uuids The array of Characteristic Uuids that will be used to
 //! determine what references to copy. For every matching characteristic, the reference will be
 //! copied into the `characteristics_out` array, at the same index as the Uuid
 //! in the `matching_characteristic_uuids` array. The array must contain each Uuid only once.

--- a/src/fw/comm/ble/gatt_client_operations.h
+++ b/src/fw/comm/ble/gatt_client_operations.h
@@ -3,7 +3,8 @@
 
 #pragma once
 
-//! @file This file contains adapter code between Bluetopia's GATT APIs and
+//! @file
+//! This file contains adapter code between Bluetopia's GATT APIs and
 //! Pebble's GATT/API code. The functions in this file take the the internal
 //! reference types BLECharacteristic and BLEDescriptor to perform operations
 //! upon those remote resources. The implementation uses the functions

--- a/src/fw/comm/ble/gatt_client_subscriptions.h
+++ b/src/fw/comm/ble/gatt_client_subscriptions.h
@@ -49,6 +49,7 @@ BTErrno gatt_client_subscriptions_subscribe(BLECharacteristic characteristic,
                                             GAPLEClient client);
 
 //! Gets the length of the next notification in the buffer that was received.
+//! @param client The client for which to get the next notification header.
 //! @param[out] header_out The header of the notification, containing the value length and the
 //! characteristic reference.
 //! @return True if there is a notification in the buffer, false if not
@@ -60,8 +61,11 @@ bool gatt_client_subscriptions_get_notification_header(GAPLEClient client,
 //! until 0 is returned.
 //! @see gatt_client_subscriptions_get_notification_value_length() to get the length of the next
 //! notification.
+//! @param[out] characteristic_ref_out The characteristic for which the notification was sent.
+//! @param[out] value_out Buffer into which the notification's value is copied.
 //! @param[in,out] value_length_in_out Cannot be NULL. In: the size of the value_out buffer.
 //! Out: the number of bytes copied into the value_out buffer.
+//! @param client The client for which to consume the next notification.
 //! @param[out] has_more_out Cannot be NULL. Will be set to true if there are more notifications
 //! in the buffer, or to false if there are no more notifiations in the buffer.
 //! @return The length of the next notification's payload, if there is any (has_more_out is true),
@@ -83,6 +87,7 @@ void gatt_client_subscriptions_cleanup_by_client(GAPLEClient client);
 
 //! Frees the GATTClientSubscriptionNode nodes that might have been associated
 //! with the connection as result of gatt_client_subscriptions_subscribe calls.
+//! @param connection The connection for which to free the subscription nodes.
 //! @param should_unsubscribe If true, the current subscriptions will be unsubscribed before
 //! cleanup. If false, the current subscriptions will not be unsubscribed (this is useful when
 //! the connection is already severed.) No unsubscription events will be emitted regardless of the

--- a/src/fw/comm/ble/gatt_service_changed.h
+++ b/src/fw/comm/ble/gatt_service_changed.h
@@ -6,7 +6,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-//! @file This module contains the "Generic Attribute Profile Service" code, both the server and
+//! @file
+//! This module contains the "Generic Attribute Profile Service" code, both the server and
 //! client parts. Both ends can optionally implement this service (and client). iOS does for example
 //! and so does Pebble. The one characteristic this service has is called "Service Changed". Its
 //! purpose is to indicate to the other side whenever there are changes to the local GATT database

--- a/src/fw/comm/ble/kernel_le_client/ancs/ancs_util.h
+++ b/src/fw/comm/ble/kernel_le_client/ancs/ancs_util.h
@@ -17,6 +17,11 @@ bool ancs_util_is_complete_notif_attr_response(const uint8_t* data, const size_t
 bool ancs_util_is_complete_app_attr_dict(const uint8_t* data, const size_t length, bool* out_error);
 
 //! Extract pointers to the start of each attribute in attr_list
+//! @param data The raw attribute dictionary data to parse
+//! @param length Length of data in bytes
+//! @param attr_list List of attributes to look for
+//! @param num_attrs Number of attributes in attr_list
+//! @param out_attr_ptrs Array that receives a pointer to each found attribute
 //! @param out_error Set if the dictionary was invalid and could not be parsed;
 //! if true, bail out!
 //! @return True if all requested attributes are present and complete; false if

--- a/src/fw/drivers/accel.h
+++ b/src/fw/drivers/accel.h
@@ -102,9 +102,9 @@ uint32_t accel_get_sampling_interval(void);
 
 //! Set the max number of samples the driver may batch.
 //!
-//! @param n Maximum number of samples the driver can batch
+//! @param num_samples Maximum number of samples the driver can batch
 //!
-//! When n=0, the accelerometer driver must not call accel_cb_new_sample().
+//! When num_samples=0, the accelerometer driver must not call accel_cb_new_sample().
 //!
 //! When n=1, the accelerometer driver must call accel_cb_new_sample() for
 //! each sample as soon as the hardware has acquired it.
@@ -215,12 +215,15 @@ extern void accel_cb_shake_detected(IMUCoordinateAxis axis, int32_t direction);
 //!        negative axis
 extern void accel_cb_double_tap_detected(IMUCoordinateAxis axis, int32_t direction);
 
+//! Callback to be invoked from a thread context to perform offloaded driver work.
+typedef void (*AccelOffloadCallback)(void);
+
 //! Function called by driver when it needs to offload work from an ISR context.
 //! It is up to the implementer to decide how this should work
 //!
 //! @param cb The callback to be invoked from a thread context
-//! @param data Data to be passed to the callback, NULL if none
-typedef void (*AccelOffloadCallback)(void);
+//! @param should_context_switch Set to true if a context switch should be
+//!        performed when returning from the ISR
 extern void accel_offload_work_from_isr(AccelOffloadCallback cb, bool *should_context_switch);
 
 //! Function called by driver when it needs to offload work.

--- a/src/fw/drivers/battery.h
+++ b/src/fw/drivers/battery.h
@@ -90,6 +90,7 @@ typedef struct ADCVoltageMonitorReading {
 ADCVoltageMonitorReading battery_read_voltage_monitor(void);
 
 //! Convert a ADCVoltageMonitorReading into a single mV reading using a given dividing ratio.
+//! @param reading The voltage monitor reading to convert.
 //! @param numerator The numerator to multiply the result by.
 //! @param denominator The denominator to divide the result by.
 uint32_t battery_convert_reading_to_millivolts(ADCVoltageMonitorReading reading,

--- a/src/fw/drivers/flash.h
+++ b/src/fw/drivers/flash.h
@@ -193,7 +193,7 @@ uint32_t flash_calculate_legacy_defective_checksum(uint32_t flash_addr,
 //! to increase the internal reference counter that prevents flash peripheral from powering down.
 void flash_use(void);
 
-//! Convenience for \ref flash_release_many(1)
+//! Convenience for \ref flash_release_many with num_locks = 1
 void flash_release(void);
 
 //! Call this after you finished accessing external flash

--- a/src/fw/drivers/flash/qspi_flash.h
+++ b/src/fw/drivers/flash/qspi_flash.h
@@ -11,6 +11,8 @@
 #include "system/status_codes.h"
 
 //! Initialize the QSPI flash
+//! @param dev The QSPI flash device to initialize
+//! @param part The description of the QSPI flash part
 //! @param coredump_mode If true, don't use anything that might not be available mid-crash, such
 //!                      as FreeRTOS calls or other system services.
 void qspi_flash_init(QSPIFlash *dev, QSPIFlashPart *part, bool coredump_mode);

--- a/src/fw/drivers/qspi.h
+++ b/src/fw/drivers/qspi.h
@@ -21,32 +21,39 @@ void qspi_use(QSPIPort *dev);
 void qspi_release(QSPIPort *dev);
 
 //! Perform an indirect read operation
+//! @param dev The QSPI port to use
 //! @param instruction The instruction to issue
 //! @param dummy_cycles How many cycles to wait before reading data
 //! @param buffer The buffer to read into
 //! @param length The number of bytes to read
+//! @param is_ddr Whether to use DDR (double data rate) mode
 void qspi_indirect_read_no_addr(QSPIPort *dev, uint8_t instruction, uint8_t dummy_cycles,
                                 void *buffer, uint32_t length, bool is_ddr);
 
 //! Perform an indirect read operation with an address
+//! @param dev The QSPI port to use
 //! @param instruction The instruction to issue
 //! @param addr The address to read from
 //! @param dummy_cycles How many cycles to wait before reading data
 //! @param buffer The buffer to read into
 //! @param length The number of bytes to read
+//! @param is_ddr Whether to use DDR (double data rate) mode
 void qspi_indirect_read(QSPIPort *dev, uint8_t instruction, uint32_t addr, uint8_t dummy_cycles,
                         void *buffer, uint32_t length, bool is_ddr);
 
 //! Performs an indirect read operation with DMA
+//! @param dev The QSPI port to use
 //! @param instruction The instruction to issue
 //! @param start_addr The address to read from
 //! @param dummy_cycles How many cycles to wait before reading data
 //! @param buffer The buffer to read into
 //! @param length The number of bytes to read
+//! @param is_ddr Whether to use DDR (double data rate) mode
 void qspi_indirect_read_dma(QSPIPort *dev, uint8_t instruction, uint32_t start_addr,
                             uint8_t dummy_cycles, void *buffer, uint32_t length, bool is_ddr);
 
 //! Perform an indirect write operation
+//! @param dev The QSPI port to use
 //! @param instruction The instruction to issue
 //! @param buffer The buffer to write from or NULL if no data should be written
 //! @param length The number of bytes to write or 0 if no data should be written
@@ -54,6 +61,7 @@ void qspi_indirect_write_no_addr(QSPIPort *dev, uint8_t instruction, const void 
                                  uint32_t length);
 
 //! Perform an indirect write operation with an address
+//! @param dev The QSPI port to use
 //! @param instruction The instruction to issue
 //! @param addr The address to write to
 //! @param buffer The buffer to write from or NULL if no data should be written
@@ -62,10 +70,12 @@ void qspi_indirect_write(QSPIPort *dev, uint8_t instruction, uint32_t addr, cons
                          uint32_t length);
 
 //! Perform an indirect write operation in single SPI mode (not quad SPI)
+//! @param dev The QSPI port to use
 //! @param instruction The instruction to issue
 void qspi_indirect_write_no_addr_1line(QSPIPort *dev, uint8_t instruction);
 
 //! Perform an automatic poll operation which will wait for the specified bits to be set/cleared
+//! @param dev The QSPI port to use
 //! @param instruction The instruction to issue
 //! @param bit_mask The bit(s) to poll on (wait for)
 //! @param should_be_set Whether the bits should be set or cleared (true / false respectively)
@@ -74,10 +84,12 @@ bool qspi_poll_bit(QSPIPort *dev, uint8_t instruction, uint8_t bit_mask, bool sh
                    uint32_t timeout_us);
 
 //! Puts the QSPI in memory-mapped mode
+//! @param dev The QSPI port to use
 //! @param instruction The instruction to issue
 //! @param addr address of data that will be accessed via memory mapping
 //! @param dummy_cycles How many cycles to wait before we can start reading the mapped memory
 //! @param length length of data that will be accessed via memory mapping
+//! @param is_ddr Whether to use DDR (double data rate) mode
 void qspi_mmap_start(QSPIPort *dev, uint8_t instruction, uint32_t addr, uint8_t dummy_cycles,
                      uint32_t length, bool is_ddr);
 

--- a/src/fw/drivers/rtc.h
+++ b/src/fw/drivers/rtc.h
@@ -56,7 +56,8 @@ void rtc_set_time_tm(struct tm* time_tm);
 void rtc_get_time_tm(struct tm* time_tm);
 
 // FIXME: PBL-41066 this should just return a uint64_t
-//! @return millisecond port of the current second.
+//! @param[out] out_seconds The current time in seconds.
+//! @param[out] out_ms Millisecond portion of the current second.
 void rtc_get_time_ms(time_t* out_seconds, uint16_t* out_ms);
 
 //! Saves the timezone_info to RTC registers
@@ -108,6 +109,7 @@ bool rtc_alarm_is_initialized(void);
 ///////////////////////////////////////////////////////////////////////////////
 
 //! @param buffer Buffer used to write the string into. Must be at least TIME_STRING_BUFFER_SIZE
+//! @param t The time to convert.
 const char* time_t_to_string(char* buffer, time_t t);
 
 #ifdef CONFIG_SOC_NRF52

--- a/src/fw/drivers/uart.h
+++ b/src/fw/drivers/uart.h
@@ -23,10 +23,10 @@ typedef struct UARTRXErrorFlags {
   };
 } UARTRXErrorFlags;
 
-//! The type of function which can be called from within the UART ISR (@see \Ref
+//! The type of function which can be called from within the UART ISR (@see
 //! uart_set_*_interrupt_handler)
 //! @return Whether or not the ISR should context switch at the end instead of resuming the previous
-//! task (@see \Ref portEND_SWITCHING_ISR)
+//! task (@see portEND_SWITCHING_ISR)
 typedef bool (*UARTRXInterruptHandler)(UARTDevice *dev, uint8_t data,
                                        const UARTRXErrorFlags *err_flags);
 typedef bool (*UARTTXInterruptHandler)(UARTDevice *dev);
@@ -75,6 +75,8 @@ uint8_t uart_read_byte(UARTDevice *dev);
 
 //! Starts the use of DMA for receiving (the DMARequest must be configured)
 //! @param[in] dev The UART device
+//! @param buffer The buffer into which received data is written
+//! @param length The size of the buffer in bytes
 void uart_start_rx_dma(UARTDevice *dev, void *buffer, uint32_t length);
 
 //! Stops the use of DMA for receiving (the DMARequest must be configured)

--- a/src/fw/flash_region/flash_region.c
+++ b/src/fw/flash_region/flash_region.c
@@ -14,8 +14,8 @@
 //! Do some upkeep in between erases to keep the rest of the system stable since erases block
 //! the current task for so long.
 //!
-//! @param erase_count[in, out] Counter variable to track how many times we've run this upkeep
-//                              function
+//! @param[in, out] erase_count Counter variable to track how many times we've run this upkeep
+//!                             function
 //! @param feed_watchdog Whether we should feed the task_watchdog for the current task or not
 static void prv_erase_upkeep(int *erase_count, bool feed_watchdog) {
   (*erase_count)++;

--- a/src/fw/kernel/task_timer.h
+++ b/src/fw/kernel/task_timer.h
@@ -48,6 +48,7 @@ TaskTimerID task_timer_create(TaskTimerManager *manager);
 
 //! Schedule an existing timer to execute in timeout_ms. If the timer was already started, it will
 //! be rescheduled for the new time.
+//! @param[in] manager The manager that owns the timer
 //! @param[in] timer ID
 //! @param[in] timeout_ms timeout in milliseconds
 //! @param[in] cb pointer to the user's callback procedure
@@ -60,11 +61,13 @@ bool task_timer_start(TaskTimerManager *manager, TaskTimerID timer, uint32_t tim
 
 //! Stop a timer. For repeating timers, even if this method returns false (callback is currently
 //! executing) the timer will not run again. Safe to call on timers that aren't currently started.
+//! @param[in] manager The manager that owns the timer
 //! @param[in] timer ID
 //! @return False if timer's callback is current executing, true if not.
 bool task_timer_stop(TaskTimerManager *manager, TaskTimerID timer);
 
 //! Get scheduled status of a timer
+//! @param[in] manager The manager that owns the timer
 //! @param[in] timer ID
 //! @param[out] expire_ms_p if not NULL, the number of milliseconds until this timer will fire is
 //!                         returned in *expire_ms_p. If the timer is not scheduled (return value
@@ -73,5 +76,6 @@ bool task_timer_stop(TaskTimerManager *manager, TaskTimerID timer);
 bool task_timer_scheduled(TaskTimerManager *manager, TaskTimerID timer, uint32_t *expire_ms_p);
 
 //! Delete a timer
+//! @param[in] manager The manager that owns the timer
 //! @param[in] timer ID
 void task_timer_delete(TaskTimerManager *manager, TaskTimerID timer);

--- a/src/fw/kernel/task_timer_manager.h
+++ b/src/fw/kernel/task_timer_manager.h
@@ -27,6 +27,7 @@ typedef struct TaskTimerManager {
 
 
 //! Initialize a passed in manager object.
+//! @param[in] manager The manager object to initialize
 //! @param[in] semaphore a sempahore the TaskTimerManager should give if the next expiring timer
 //!                      has changed. The task event loop should block on this same semphore to
 //!                      handle timer updates in a timely fashion.

--- a/src/fw/kernel/ui/modals/modal_manager.h
+++ b/src/fw/kernel/ui/modals/modal_manager.h
@@ -82,7 +82,8 @@ typedef enum ModalProperty {
 void modal_manager_init(void);
 
 //! Sets whether modal windows are enabled.
-//! @param enabled Boolean indicating whether enabled or disabled
+//! @param priority The minimum priority of modal windows that can be pushed; stacks with a
+//! lower priority are locked.
 //! Note that this is usable before modal_manager_init is called and modal_manager_init will not
 //! reset this state.
 void modal_manager_set_min_priority(ModalPriority priority);
@@ -98,7 +99,7 @@ ClickManager *modal_manager_get_click_manager(void);
 //! Returns the first \ref WindowStack to pass the given filter callback.
 //! Iterates down from the highest priority to the lowest priority.
 //! @param filter_cb The \ref ModalContextFilterCallback
-//! @param context Context to pass to the callback
+//! @param ctx Context to pass to the callback
 //! @returns pointer to a \ref WindowStack
 WindowStack *modal_manager_find_window_stack(ModalContextFilterCallback filter_cb, void *ctx);
 
@@ -122,7 +123,7 @@ void modal_manager_handle_button_event(PebbleEvent *event);
 void modal_manager_pop_all(void);
 
 //! Pops all windows from modal stacks with priorities less than the given priority
-//! @param the max priorirty stack to pop all windows from
+//! @param priority The max priority stack to pop all windows from
 void modal_manager_pop_all_below_priority(ModalPriority priority);
 
 //! Called from the kernel event loop between events to handle any changes that have been made
@@ -137,7 +138,6 @@ ModalProperty modal_manager_get_properties(void);
 
 //! Renders the highest priority top opaque window and all windows with higher priority.
 //! @param ctx The \ref GContext in which to render.
-//! @return Modal properties such as whether the modals are transparent or unfocusable
 void modal_manager_render(GContext *ctx);
 
 //! Determines whether the given modal window is visible. Use window_manager_is_window_visible if

--- a/src/fw/kernel/util/interval_timer.h
+++ b/src/fw/kernel/util/interval_timer.h
@@ -43,9 +43,10 @@ typedef struct {
 //! Intervals are averaged together in a moving average that includes the last n intervals. The
 //! number of intervals to average over is configurable.
 //!
+//! @param timer The timer to initialize
 //! @param min_expected_ms The minimum number of milliseconds between samples
-//! @param min_expected_ms The maximum number of milliseconds between samples
-//! @param weighting_factor_inverted
+//! @param max_expected_ms The maximum number of milliseconds between samples
+//! @param weighting_factory_inverted
 //!     1 / alpha. Specified as a inverted number to avoid dealing with floats. The higher the
 //!     number the less responsive to recent changes our average is.
 void interval_timer_init(IntervalTimer *timer, uint32_t min_expected_ms, uint32_t max_expected_ms,
@@ -55,6 +56,7 @@ void interval_timer_init(IntervalTimer *timer, uint32_t min_expected_ms, uint32_
 //! Safe to call from an ISR.
 void interval_timer_take_sample(IntervalTimer *timer);
 
+//! @param timer The timer to query
 //! @param[out] average_ms_out The average ms for the interval.
 //! @return The number of valid intervals that are in our moving average. Note that this value
 //!         will never be larger than num_intervals_in_average.

--- a/src/fw/popups/notifications/notifications_presented_list.h
+++ b/src/fw/popups/notifications/notifications_presented_list.h
@@ -63,9 +63,11 @@ typedef void (*NotificationListEachCallback)(Uuid *id, NotificationType type, vo
 
 //! Executes the specified callback for each notificaiton in the presented list
 //! @param callback If null this function is a no-op
+//! @param cb_data Context passed to the callback
 void notifications_presented_list_each(NotificationListEachCallback callback, void *cb_data);
 
 //! Deinits the notification presented list
 //! @param callback - If non-null, notifies the caller what item is being removed.
 //!            The callback routine should not try to modify the notification list
+//! @param cb_data Context passed to the callback
 void notifications_presented_list_deinit(NotificationListEachCallback callback, void *cb_data);

--- a/src/fw/popups/phone_formatting.h
+++ b/src/fw/popups/phone_formatting.h
@@ -20,7 +20,7 @@ void phone_format_caller_name(const char *full_name, char *destination, size_t l
 //! +55 408
 //! 555-1212
 //! @param phone_number String containing original phone number
-//! @param destination buffer to copy the formatted phone number into.
+//! @param formatted_phone_number buffer to copy the formatted phone number into.
 //! @param length Size of the destination buffer.
 void phone_format_phone_number(const char *phone_number, char *formatted_phone_number,
                                size_t length);

--- a/src/fw/popups/switch_worker_ui.h
+++ b/src/fw/popups/switch_worker_ui.h
@@ -9,8 +9,6 @@
 //! @param new_worker_id The new ID that we'd like to ask the user to switch to
 //! @param set_as_default Whether this new worker should become the default after being accepted
 //! @param window_stack Which window stack to push the dialog to
-//! @param exit_callback Callback to be called on dialog pop (may be NULL if not used)
-//! @param callback_context Context which is passed to provided callbacks
 void switch_worker_confirm(AppInstallId new_worker_id, bool set_as_default,
                            WindowStack *window_stack);
 

--- a/src/fw/popups/timeline/timeline_item_layer.h
+++ b/src/fw/popups/timeline/timeline_item_layer.h
@@ -28,7 +28,7 @@ typedef struct {
 void timeline_item_layer_update_proc(Layer* layer, GContext* ctx);
 
 //! Initialize a timeline item layer
-//! @param layer a pointer to the TimelineItemLayer to initialize
+//! @param item_layer a pointer to the TimelineItemLayer to initialize
 //! @param frame the frame with which to initialize the layer
 void timeline_item_layer_init(TimelineItemLayer *item_layer, const GRect *frame);
 
@@ -36,8 +36,9 @@ void timeline_item_layer_init(TimelineItemLayer *item_layer, const GRect *frame)
 void timeline_item_layer_deinit(TimelineItemLayer *item_layer);
 
 //! Set the timeline item displayed by the TimelineItemLayer
-//! @param layer a pointer to the TimelineItemLayer
+//! @param item_layer a pointer to the TimelineItemLayer
 //! @param item a pointer to the item to use
+//! @param info a pointer to the TimelineLayoutInfo to use for the item
 void timeline_item_layer_set_item(TimelineItemLayer *item_layer, TimelineItem *item,
     TimelineLayoutInfo *info);
 

--- a/src/fw/process_management/app_install_manager.h
+++ b/src/fw/process_management/app_install_manager.h
@@ -174,7 +174,7 @@ bool app_install_get_uuid_for_install_id(AppInstallId install_id, Uuid *uuid_out
 
 //! Gets whether the app is a watchface given an AppInstallId. This loads an entry to obtain its
 //! information, use \ref app_install_entry_is_watchface if your context has an AppInstallEntry.
-//! @param install_id AppInstallId of the application
+//! @param app_id AppInstallId of the application
 //! @return true if the app is a watchface, false otherwise
 bool app_install_is_watchface(AppInstallId app_id);
 

--- a/src/fw/process_management/app_menu_data_source.h
+++ b/src/fw/process_management/app_menu_data_source.h
@@ -90,6 +90,7 @@ void app_menu_data_source_deinit(AppMenuDataSource *source);
 
 //! Will load the icons for each `AppMenuNode`. Will automatically be unloaded when
 //! `app_menu_data_source_deinit` is called.
+//! @param source The AppMenuDataSource to enable icons for
 //! @param fallback_icon_id The fallback resource id that should be used if the entry does not have
 //! an icon.
 void app_menu_data_source_enable_icons(AppMenuDataSource *source, uint32_t fallback_icon_id);

--- a/src/fw/process_management/pebble_process_md.h
+++ b/src/fw/process_management/pebble_process_md.h
@@ -50,7 +50,7 @@ typedef enum {
 
 //! This structure is used internally to describe the process. This struct here is actually a polymorphic base
 //! class, and can be casted to either \ref PebbleProcessMdSystem or \ref PebbleProcessMdFlash depending on the value
-//! of \ref is_flash_based. Clients shouldn't do this casting themselves though, and instead should use the
+//! of @c process_storage. Clients shouldn't do this casting themselves though, and instead should use the
 //! process_metadata_get_* functions to safely retreive values from this struct.
 typedef struct PebbleProcessMd {
   Uuid uuid;
@@ -117,7 +117,7 @@ typedef struct PebbleProcessMdFlash {
   Version sdk_version;
 
   //! The bank this process will get it's code and data from. This field is only valid if the
-  //! \ref process_storage is ProcessStorageFlash
+  //! @c process_storage is ProcessStorageFlash
   uint32_t code_bank_num;
 
   //! The bank this app will get its resources from
@@ -158,11 +158,18 @@ ResourceVersion process_metadata_get_res_version(const PebbleProcessMd *md);
 const uint8_t *process_metadata_get_build_id(const PebbleProcessMd *md);
 
 //! @param[out] md
+//! @param flash_header The process info header read from flash
+//! @param process_bank_num The flash bank the process binary is stored in
+//! @param task The task the process will run as
+//! @param build_id_buffer Optional buffer holding the build id to copy, may be NULL
 void process_metadata_init_with_flash_header(PebbleProcessMdFlash *md,
     const PebbleProcessInfo *flash_header, int process_bank_num, PebbleTask task,
     uint8_t *build_id_buffer);
 
 //! @param[out] md
+//! @param info The process info header
+//! @param bin_resource_id The resource id of the process binary
+//! @param task The task the process will run as
 void process_metadata_init_with_resource_header(PebbleProcessMdResource *md,
     const PebbleProcessInfo *info, int bin_resource_id, PebbleTask task);
 

--- a/src/fw/process_management/process_manager.h
+++ b/src/fw/process_management/process_manager.h
@@ -102,10 +102,8 @@ void process_manager_init_context(ProcessContext* context,
 bool process_manager_check_SDK_compatible(const AppInstallId id);
 
 //! Request that a process be launched.
-//! @param id The app to launch. Note that this app may not be cached
-//! @param args The args to the app
-//! @param animation The animation that should be used to show the app
-//! @prama launch_reason The launch reason for the app starting
+//! @param config The launch configuration of the process to launch. Note that this app may not
+//! be cached
 void process_manager_launch_process(const ProcessLaunchConfig *config);
 
 //! Close the given process. This is the highest level call which transfers control to the manager of that type of
@@ -138,7 +136,7 @@ bool process_manager_send_event_to_process(PebbleTask task, PebbleEvent* e);
 //! Get the number of messages currently waiting to be processed by the process
 uint32_t process_manager_process_events_waiting(PebbleTask task);
 
-//! Wrapper for \ref send_event_to_app to send callback events to the app
+//! Wrapper for \ref process_manager_send_event_to_process to send callback events to the app
 void process_manager_send_callback_event_to_process(PebbleTask task, void (*callback)(void *), void *data);
 
 //! Send a kill event for the given process to KernelMain

--- a/src/fw/services/app_cache/service.c
+++ b/src/fw/services/app_cache/service.c
@@ -27,7 +27,7 @@
 
 PBL_LOG_MODULE_DEFINE(service_app_cache, CONFIG_SERVICE_APP_CACHE_LOG_LEVEL);
 
-//! @file app_cache.c
+//! @file
 //! App Cache
 
 //! The App Cache keeps track of the install date, last launch, launch count, and size of an

--- a/src/fw/services/app_order_endpoint/service.c
+++ b/src/fw/services/app_order_endpoint/service.c
@@ -15,7 +15,7 @@
 
 PBL_LOG_MODULE_DEFINE(service_app_order_endpoint, CONFIG_SERVICE_APP_ORDER_ENDPOINT_LOG_LEVEL);
 
-//! @file app_order_endpoint.c
+//! @file
 //! App Order Endpoint
 //!
 //! There is only 1 way to use this endpoint

--- a/src/fw/services/filesystem/pfs.c
+++ b/src/fw/services/filesystem/pfs.c
@@ -1002,6 +1002,8 @@ typedef enum {
   NoFDAvail = -1
 } AvailFdStatus;
 
+//! @param name the name of the file to look for
+//! @param[out] fdp populated with the fd that was found or is available
 //! @param is_tmp specified to indicate whether or not you are looking for
 //!        a tmp file
 static AvailFdStatus get_avail_fd(const char *name, int *fdp, bool is_tmp) {

--- a/src/fw/services/i18n/i18n.c
+++ b/src/fw/services/i18n/i18n.c
@@ -96,9 +96,11 @@ static uint32_t prv_next_index(uint32_t curidx, uint32_t hashsize, uint32_t step
 }
 
 //! Lookup a translated string.
-//! @param rlen[out] Can be NULL. If non-null will be populated with the length of the translated
+//! @param msgid The message id (original string) to look up.
+//! @param db The domain binding containing the translations.
+//! @param[out] rlen Can be NULL. If non-null will be populated with the length of the translated
 //!                  string.
-//! @param rstring[out] Can be NULL. If non-null this buffer will be populated with the translated
+//! @param[out] rstring Can be NULL. If non-null this buffer will be populated with the translated
 //!                     string. This buffer will be null-terminated.
 //! @param rstring_len The length of the rstring buffer.
 static void prv_lookup(const char *msgid, struct DomainBinding *db,

--- a/src/fw/services/music/service.c
+++ b/src/fw/services/music/service.c
@@ -15,7 +15,8 @@
 
 PBL_LOG_MODULE_DEFINE(service_music, CONFIG_SERVICE_MUSIC_LOG_LEVEL);
 
-//! @file This module implements the music service. It provides an abstraction layer on top of the
+//! @file
+//! This module implements the music service. It provides an abstraction layer on top of the
 //! various underlying music metadata and control services: the Pebble Protocol
 //! music endpoint (see music_endpoint.c) and Apple Media Service (see ams.c).
 //! This module also caches the last known metadata and media player state.

--- a/src/fw/services/notifications/ancs/ancs_item.c
+++ b/src/fw/services/notifications/ancs/ancs_item.c
@@ -42,6 +42,7 @@ static bool prv_should_add_sender_attr(const ANCSAttribute *app_id, const ANCSAt
           title && title->length > 0);
 }
 
+//! @param pstring The pstring to copy into the buffer
 //! @param buffer The buffer into which to copy the pstring attr. The buffer
 //! is assumed to be large enough to contain the string plus an optional
 //! ellipsis plus the zero terminator.
@@ -116,6 +117,11 @@ static int prv_set_multimedia_action_msg(char *buffer, size_t length) {
 
 //! @param buffer Pointer to a buffer large enough to hold all attribute strings required by
 //! the action. If buffer points to null, a new buffer will be allocated
+//! @param action The timeline item action to fill in
+//! @param ancs_action_id The ANCS action id (positive or negative action)
+//! @param title The ANCS title attribute of the notification
+//! @param app_id The ANCS app id attribute of the notification
+//! @param properties The ANCS properties of the notification
 //! @return Pointer to the end of the buffer (*buffer + size of strings)
 static uint8_t *prv_fill_native_ancs_action(uint8_t **buffer,
                                             TimelineItemAction *action,

--- a/src/fw/services/notifications/notification_storage.c
+++ b/src/fw/services/notifications/notification_storage.c
@@ -155,7 +155,7 @@ static void prv_reclaim_space(size_t size_needed, int fd) {
   }
 }
 
-//! Check whether there exists @ref size_needed available space in storage after compression
+//! Check whether there exists @c size_needed available space in storage after compression
 static bool prv_is_storage_full(size_t size_needed, size_t *size_available, int fd) {
   *size_available = 0;
   NotificationIterState iter_state = {

--- a/src/fw/shell/prefs_private.h
+++ b/src/fw/shell/prefs_private.h
@@ -18,7 +18,7 @@
 //! @param[in] key the preference's name, as defined in prefs.c
 //! @param[in] key_len the length of key
 //! @param[in] value pointer to the new value
-//! @param[in] length of the value
+//! @param[in] value_len the length of the value
 //! @return true on success, false if failure
 bool prefs_private_write_backing(const uint8_t *key, size_t key_len, const void *value,
                                int value_len);
@@ -33,7 +33,7 @@ int prefs_private_get_backing_len(const uint8_t *key, size_t key_len);
 //! @param[in] key the preference's name, as defined in prefs.c
 //! @param[in] key_len the length of key
 //! @param[out] value the value will be written into this pointer
-//! @param[in] length of the value
+//! @param[in] value_len the length of the value
 //! @return true on success, false if failure
 bool prefs_private_read_backing(const uint8_t *key, size_t key_len, void *value, int value_len);
 

--- a/src/fw/shell/system_theme.h
+++ b/src/fw/shell/system_theme.h
@@ -62,7 +62,7 @@ typedef enum TextStyleFont {
 //! @return The font key of the font class using the user's preferred content size.
 const char *system_theme_get_font_key(TextStyleFont font);
 
-//! @param content_size The desired content size.
+//! @param size The desired content size.
 //! @param font The desired font class to obtain a font key of.
 //! @return The font key of the given content size and font class.
 const char *system_theme_get_font_key_for_size(PreferredContentSize size, TextStyleFont font);
@@ -71,7 +71,7 @@ const char *system_theme_get_font_key_for_size(PreferredContentSize size, TextSt
 //! @return The font of the font class using the user's preferred content size.
 GFont system_theme_get_font(TextStyleFont font);
 
-//! @param content_size The desired content size.
+//! @param size The desired content size.
 //! @param font The desired font class to obtain a font of.
 //! @return The font of the given content size and font class.
 GFont system_theme_get_font_for_size(PreferredContentSize size, TextStyleFont font);

--- a/src/fw/syscall/syscall.h
+++ b/src/fw/syscall/syscall.h
@@ -304,6 +304,7 @@ WatchInfoColor sys_watch_info_get_color(void);
 //! @} // end addtogroup Foundation
 
 //! @addtogroup Preferences
+//! @{
 
 //! Users can toggle Quiet Time manually or on schedule. Watchfaces and apps should respect this
 //! choice and avoid disturbing actions such as vibration if quiet time is active.

--- a/src/fw/system/version.h
+++ b/src/fw/system/version.h
@@ -35,6 +35,7 @@ bool version_copy_update_fw_metadata(FirmwareMetadata *out_metadata);
 //! dest_len_bytes - 1 before being null-terminated via strncpy()
 //!
 //! @param dest: char[dest_len_bytes]
+//! @param dest_len_bytes size of dest in bytes
 //! @returns true on success, false otherwise
 bool version_copy_recovery_fw_version(char* dest, const int dest_len_bytes);
 
@@ -50,7 +51,7 @@ const uint8_t * version_get_build_id(size_t *out_len);
 //! Copies a hex C-string of the build id into the supplied buffer.
 //! Get the build id from an elf, using `arm-none-eabi-readelf -n pebbleos.elf`
 //! @param[out] buffer The buffer into which the string should be copied.
-//! @param max_length The length of buffer.
+//! @param buffer_bytes_left The length of buffer.
 void version_copy_current_build_id_hex_string(char *buffer, size_t buffer_bytes_left);
 
 //! Like version_copy_current_build_id_hex_string, but is copied from the specified Elf section.

--- a/src/fw/util/dict.h
+++ b/src/fw/util/dict.h
@@ -387,8 +387,7 @@ DictionaryResult dict_serialize_tuplets__deprecated(DictionarySerializeCallback 
 //! @param tuplets The array of tuplets
 //! @param tuplets_count The number of tuplets in the array
 //! @param buffer The buffer in which to write the serialized dictionary
-//! @param [in] size_in_out The available buffer size in bytes
-//! @param [out] size_in_out The number of bytes written
+//! @param [in,out] size_in_out In: the available buffer size in bytes. Out: the number of bytes written.
 //! @return \ref DICT_OK, \ref DICT_NOT_ENOUGH_STORAGE or \ref DICT_INVALID_ARGS
 DictionaryResult dict_serialize_tuplets_to_buffer(const Tuplet * const tuplets, const uint8_t tuplets_count, uint8_t *buffer, uint32_t *size_in_out);
 
@@ -400,8 +399,7 @@ DictionaryResult dict_serialize_tuplets_to_buffer__deprecated(const uint8_t tupl
 //! @param tuplets The array of tuplets
 //! @param tuplets_count The number of tuplets in the array
 //! @param buffer The buffer in which to write the serialized dictionary
-//! @param [in] size_in_out The available buffer size in bytes
-//! @param [out] size_in_out The number of bytes written
+//! @param [in,out] size_in_out In: the available buffer size in bytes. Out: the number of bytes written.
 //! @return \ref DICT_OK, \ref DICT_NOT_ENOUGH_STORAGE or \ref DICT_INVALID_ARGS
 DictionaryResult dict_serialize_tuplets_to_buffer_with_iter(DictionaryIterator *iter, const Tuplet * const tuplets, const uint8_t tuplets_count, uint8_t *buffer, uint32_t *size_in_out);
 
@@ -437,7 +435,7 @@ extern const Tuple * const NULL_TUPLE;
 //! Therefore the Tuple can be used after the callback returns, until the destination dictionary
 //! storage is free'd (by the application itself).
 //! @param old_tuple The values that will be replaced with `new_tuple`. The key, value and type will be
-//! equal to the previous tuple in the old destination dictionary, however the `old_tuple points
+//! equal to the previous tuple in the old destination dictionary, however the `old_tuple` points
 //! to a stack-allocated copy of the old data.
 //! @param context Pointer to application specific data
 //! The storage backing `old_tuple` can only be used during the callback and

--- a/src/fw/util/graphics.h
+++ b/src/fw/util/graphics.h
@@ -8,10 +8,9 @@
 //! This function extracts a value for a specific bit per pixel depth from an image buffer
 //! at a specific x y position.
 //! @note inlined to support performance requirements of iterating over every pixel in an image
-//! @param buffer pointer to a buffer containing pixel image data
+//! @param raw_image_buffer pointer to a buffer containing pixel image data
 //! @param x the x coordinates for the pixel to retrieve
 //! @param y the y coordinates for the pixel to retrieve
-//! @param width provides the image width
 //! @param row_stride_bytes the byte-aligned width in bytes
 //! @param bitdepth bits per pixel for the image (1,2,4 or 8 supported)
 //! @return The value from the image buffer at the specified coordinates

--- a/src/fw/util/pstring.h
+++ b/src/fw/util/pstring.h
@@ -33,10 +33,12 @@ PascalString16 *pstring_create_pstring16_from_string(char string[]);
 
 void pstring_destroy_pstring16(PascalString16 *pstring);
 
+//! @param pstring The pstring to convert.
 //! @param string_out Array of chars to hold the converted pstring.
 //!                   Must be at least size (pstring->length + 1).
 void pstring_pstring16_to_string(const PascalString16 *pstring, char *string_out);
 
+//! @param string The string to convert.
 //! @param pstring_out Array of chars to hold the converted string.
 //!                    Must be at least size (string + 1).
 void pstring_string_to_pstring16(char string[], PascalString16 *pstring_out);

--- a/src/fw/util/time/time.h
+++ b/src/fw/util/time/time.h
@@ -90,13 +90,7 @@ typedef enum DayInWeek {
 
 //! Obtain the number of seconds and milliseconds part since the epoch.
 //!   This is a non-standard C function provided for convenience.
-//! @param tloc Optionally points to an address of a time_t variable to store the time in.
-//!   You may pass NULL into tloc if you don't need a time_t variable to be set
-//!   with the seconds since the epoch
-//! @param out_ms Optionally points to an address of a uint16_t variable to store the
-//!   number of milliseconds since the last second in.
-//!   If you only want to use the return value, you may pass NULL into out_ms instead
-//! @return The number of milliseconds since the last second
+//!   Parameters are documented with the SDK declaration in pbl_std.h.
 uint16_t time_ms(time_t *tloc, uint16_t *out_ms);
 
 //!   @} // end addtogroup StandardTime
@@ -131,6 +125,7 @@ typedef struct TimezoneInfo {
 //! Provides the timezone abbreviation string for the given time. Uses the utc_time provided
 //! to correct the abbreviation for daylight savings time if applicable
 //! @param out_buf should have length TZ_LEN
+//! @param utc_time time used to determine whether daylight savings applies
 void time_get_timezone_abbr(char *out_buf, time_t utc_time);
 
 //! Provides the gmt offset
@@ -199,7 +194,7 @@ int time_util_get_minute_of_day(time_t utc_sec);
 //! Adds a delta to the minute of the day and will wrap to the next or previous day if the
 //! resulting minutes would have been out of bounds
 //! @param minute Minute to adjust
-//! @param delta Minutes to add to \ref minute
+//! @param delta Minutes to add to @c minute
 //! @return Adjusted minutes
 int time_util_minute_of_day_adjust(int minute, int delta);
 


### PR DESCRIPTION
Burns down all Doxygen warnings in one sweep: **758 → 0** (measured over `include`, `lib`, `src`, `subsys` — the input set the API reference uses since #1774 landed). This is the first follow-up teased in #1774; rebased onto main after that merge.

## What's in here

All changes are comment-only, split per area (`include:`, `applib:`, `fw:`, `lib/util:`), plus two config lines:

- `EXAMPLE_PATH = sdk/docs/external_refs` — the example HTML files that several applib headers `\include` have existed there all along but were never wired up, so the snippets were silently dropped from every build.
- `WARN_AS_ERROR = FAIL_ON_WARNINGS` in `Doxyfile.rtd` (per review) — the RTD PR build now fails when new documentation warnings are introduced, locking in the zero. `FAIL_ON_WARNINGS` reports all warnings before exiting nonzero, unlike `YES` which aborts on the first. Scoped to the RTD config so local and legacy waf docs builds are unaffected.

Fix categories: `@param` tags left behind by parameter renames, malformed `@param x[out]` attribute placement, `\ref` targets that were renamed (fixed) or removed (demoted to `@c`), stale `@return` on functions that became void, `\file` statements with outdated names, unknown commands (`@prama`, `@params`, `@NOTE`, `@retuns`), and missing `@param` docs where the meaning is derivable from the signature or implementation.

Two systematic root causes worth knowing:
- `//!     @{` group-opens indented ≥4 spaces after a blank line are parsed as Markdown code blocks, so the group never opens — that was all seven "unbalanced grouping" warnings.
- A single unterminated backtick merges adjacent doc blocks and cascades into bogus `@param` warnings (three separate instances: `dict.h`, `ble_ad_parse.h`/`ble_client.h`, `timeline/item.h`).

The compositor.h file-level overview also referenced four functions that no longer exist anywhere in the tree; rewritten against the current API.

## Verification

- Full doxygen run: 0 warnings (re-verified after the rebase onto post-#1774 main).
- Diff audited to be comment-only (the sole exceptions: the two config lines above and hoisting a typedef above its doc comment in `drivers/accel.h`).
- Firmware builds clean (qemu_emery, 1794/1794).

## Deliberately not fixed (need code changes, separate PRs)

- `interval_timer.h`: the C parameter is literally named `weighting_factory_inverted`; docs now match the code, typo and all.
- `pbl_std.h:85` duplicates the `time_ms` declaration from `time.h` with a different parameter name.
