### PR TITLE
fw/kernel: commit to PRF before the factory reset wipe

### DIFF
--- a/src/fw/kernel/util/factory_reset.c
+++ b/src/fw/kernel/util/factory_reset.c
@@ -74,17 +74,20 @@ void factory_reset(bool should_shutdown) {
   prv_factory_reset_non_pfs_data();
 
 #if !defined(CONFIG_RECOVERY_FW)
-  // pfs_format() holds the PFS mutex across the erase, blocking concurrent
-  // writes from the App task that would otherwise survive into a freshly-erased region.
-  pfs_format(false /* write_erase_headers */);
-
-  // "First use" is part of the PRF image for Snowy
+  // Commit to booting PRF before the filesystem wipe: it can take minutes,
+  // and a reset in that window (watchdog, crash, power loss) must land in
+  // PRF instead of rebooting a half-wiped normal firmware.
+  // "First use" is part of the PRF image for Snowy.
   boot_bit_set(BOOT_BIT_FORCE_PRF);
 #ifdef CONFIG_PBLBOOT
   // Invalidate both firmware slots so the bootloader doesn't boot into them
   firmware_storage_invalidate_firmware_slot(0);
   firmware_storage_invalidate_firmware_slot(1);
 #endif
+
+  // pfs_format() holds the PFS mutex across the erase, blocking concurrent
+  // writes from the App task that would otherwise survive into a freshly-erased region.
+  pfs_format(false /* write_erase_headers */);
 #else
   filesystem_regions_erase_all();
 #endif


### PR DESCRIPTION
## Problem

`factory_reset()` only set `BOOT_BIT_FORCE_PRF` and invalidated the firmware slots **after** `pfs_format()`, which holds the PFS mutex across a multi-minute flash erase. Any reset inside that window — task watchdog firing on a task blocked on the PFS mutex, a crash, or power loss — rebooted the watch straight back into normal firmware: pairing had already been wiped and the half-erased filesystem was silently reformatted on the next boot, so the watch came up unpaired as if the factory reset never happened (FIRM-3549, seen during 4.31 QA on getafix).

## Fix

Set the boot bit and invalidate both slots right after the non-PFS teardown, before starting the format. An interrupted factory reset now lands in PRF, which is the outcome the user asked for; a partially erased filesystem is harmless since it gets reformatted on first use anyway.

Verified with a clean `getafix@dvt` normal build.

Fixes FIRM-3549

🤖 Generated with [Claude Code](https://claude.com/claude-code)