### PR TITLE
fw: doxygen sweep follow-up code fixes

### DIFF
--- a/src/fw/applib/pbl_std/pbl_std.h
+++ b/src/fw/applib/pbl_std/pbl_std.h
@@ -82,12 +82,6 @@ uint16_t pbl_override_time_ms_legacy(time_t *t_loc, uint16_t *out_ms);
 //!   0 if the value does not fit.
 size_t pbl_strftime(char* s, size_t maxsize, const char* format, const struct tm* tm_p);
 
-//! Returns the current UTC time in Unix Timestamp Format with Milliseconds
-//!     @param t_utc if provided receives current UTC Unix Time seconds portion
-//!     @param out_ms if provided receives current Unix Time milliseconds portion
-//!     @return Current Unix Time milliseconds portion
-uint16_t time_ms(time_t *t_utc, uint16_t *out_ms);
-
 //!   @} // end addtogroup StandardTime
 //! @} // end addtogroup StandardC
 

--- a/src/fw/kernel/util/interval_timer.h
+++ b/src/fw/kernel/util/interval_timer.h
@@ -46,11 +46,11 @@ typedef struct {
 //! @param timer The timer to initialize
 //! @param min_expected_ms The minimum number of milliseconds between samples
 //! @param max_expected_ms The maximum number of milliseconds between samples
-//! @param weighting_factory_inverted
+//! @param weighting_factor_inverted
 //!     1 / alpha. Specified as a inverted number to avoid dealing with floats. The higher the
 //!     number the less responsive to recent changes our average is.
 void interval_timer_init(IntervalTimer *timer, uint32_t min_expected_ms, uint32_t max_expected_ms,
-                         uint32_t weighting_factory_inverted);
+                         uint32_t weighting_factor_inverted);
 
 //! Record a sample that marks the start/end of an interval.
 //! Safe to call from an ISR.

--- a/src/fw/util/time/time.h
+++ b/src/fw/util/time/time.h
@@ -90,7 +90,9 @@ typedef enum DayInWeek {
 
 //! Obtain the number of seconds and milliseconds part since the epoch.
 //!   This is a non-standard C function provided for convenience.
-//!   Parameters are documented with the SDK declaration in pbl_std.h.
+//! @param tloc if provided receives the current UTC Unix Time seconds portion
+//! @param out_ms if provided receives the current Unix Time milliseconds portion
+//! @return Current Unix Time milliseconds portion
 uint16_t time_ms(time_t *tloc, uint16_t *out_ms);
 
 //!   @} // end addtogroup StandardTime


### PR DESCRIPTION
The two code-change fixes deliberately left out of the comment-only warning sweep in #1775:

- **`interval_timer.h`**: the `interval_timer_init` parameter was declared as `weighting_factory_inverted` — the implementation and struct field already use `weighting_factor_inverted`. Header-only rename to match.
- **`time_ms` dedup**: `pbl_std.h` re-declared `time_ms` with a different parameter name (`t_utc` vs `tloc`) while already including `util/time/time.h`, which holds the canonical declaration. The duplicate is dropped and the full parameter docs move to `time.h`, whose comment previously deferred to pbl_std.h.

## Verification

- doxygen: 0 warnings.
- Firmware builds clean (qemu_emery) — both headers are inputs to the native SDK generator, so the build exercises that path too.
