### PR TITLE
services/touch: synthesize button clicks from touch, and route action-bar taps

### DIFF
--- a/include/pbl/services/touch/touch.h
+++ b/include/pbl/services/touch/touch.h
@@ -24,6 +24,11 @@ void touch_init(void);
 //! When disabled, the touch sensor is only active if apps have subscribed to touch events.
 void touch_set_backlight_enabled(bool enabled);
 
+//! Enable or disable the kernel's touch subscription used by the touch->click
+//! synthesis bridge. Like the backlight subscription, it powers the sensor but
+//! is not counted as an app subscriber by touch_has_app_subscribers().
+void touch_set_synthesis_enabled(bool enabled);
+
 //! @return true if at least one subscriber is currently registered for touch events.
 bool touch_has_app_subscribers(void);
 

--- a/src/fw/applib/ui/action_bar_layer.c
+++ b/src/fw/applib/ui/action_bar_layer.c
@@ -13,6 +13,34 @@
 #include "system/passert.h"
 #include "pbl/util/trig.h"
 
+#ifdef CONFIG_TOUCH_CLICK_SYNTHESIS
+#include "services/touch/touch_click_synth.h"
+#include "syscall/syscall.h"
+
+// Publish the current action bar geometry and icon presence to the kernel-side
+// touch-to-click synthesis bridge, so a tap on the bar routes to UP/SELECT/DOWN
+// by vertical zone. Cleared (present=false) whenever the bar has no window.
+static void prv_publish_touch_descriptor(ActionBarLayer *action_bar) {
+  ActionBarSynthDescriptor desc = (ActionBarSynthDescriptor) { 0 };
+  if (action_bar->window) {
+    desc.present = true;
+    layer_get_global_frame(&action_bar->layer, &desc.frame);
+    if (action_bar->icons[0]) {
+      desc.icon_mask |= ACTION_BAR_SYNTH_ICON_UP;
+    }
+    if (action_bar->icons[1]) {
+      desc.icon_mask |= ACTION_BAR_SYNTH_ICON_SELECT;
+    }
+    if (action_bar->icons[2]) {
+      desc.icon_mask |= ACTION_BAR_SYNTH_ICON_DOWN;
+    }
+  }
+  sys_touch_click_synth_set_action_bar(&desc);
+}
+#else
+static void prv_publish_touch_descriptor(ActionBarLayer *action_bar) {}
+#endif
+
 const int16_t MAX_ICON_HEIGHT = 18;
 
 const int64_t PRESS_ANIMATION_DURATION_MS = 144;
@@ -339,6 +367,7 @@ void action_bar_layer_set_icon_animated(ActionBarLayer *action_bar, ButtonId but
     action_bar->icon_change_times[index] = 0;
   }
   layer_mark_dirty(&action_bar->layer);
+  prv_publish_touch_descriptor(action_bar);
 }
 
 void action_bar_layer_set_icon(ActionBarLayer *action_bar, ButtonId button_id,
@@ -369,6 +398,7 @@ void action_bar_layer_add_to_window(ActionBarLayer *action_bar, struct Window *w
 
   action_bar->window = window;
   action_bar_update_click_config_provider(action_bar);
+  prv_publish_touch_descriptor(action_bar);
 }
 
 void action_bar_layer_remove_from_window(ActionBarLayer *action_bar) {
@@ -378,6 +408,7 @@ void action_bar_layer_remove_from_window(ActionBarLayer *action_bar) {
   layer_remove_from_parent(&action_bar->layer);
   window_set_click_config_provider_with_context(action_bar->window, NULL, NULL);
   action_bar->window = NULL;
+  prv_publish_touch_descriptor(action_bar);
 }
 
 void action_bar_layer_set_background_color(ActionBarLayer *action_bar, GColor background_color) {

--- a/src/fw/apps/system/music.c
+++ b/src/fw/apps/system/music.c
@@ -1046,6 +1046,9 @@ static void prv_handle_deinit(void) {
   music_request_reduced_latency(false);
 
   MusicAppData *data = app_state_get_user_data();
+  // Clear the touch-synthesis action bar descriptor so it can't route taps
+  // once we've left the app.
+  action_bar_layer_remove_from_window(&data->action_bar);
   if (data->temporarily_show_progress_timer) {
     app_timer_cancel(data->temporarily_show_progress_timer);
   }

--- a/src/fw/kernel/event_loop.c
+++ b/src/fw/kernel/event_loop.c
@@ -61,6 +61,9 @@
 #include "pbl/services/system_task.h"
 #ifdef CONFIG_TOUCH
 #include "pbl/services/touch/touch.h"
+#ifdef CONFIG_TOUCH_CLICK_SYNTHESIS
+#include "services/touch/touch_click_synth.h"
+#endif
 #endif
 #include "pbl/services/vibe_pattern.h"
 #include "pbl/services/alarms/alarm.h"
@@ -292,6 +295,11 @@ static NOINLINE void prv_minimal_event_handler(PebbleEvent* e) {
 
 #ifdef CONFIG_TOUCH
     case PEBBLE_TOUCH_EVENT: {
+#ifdef CONFIG_TOUCH_CLICK_SYNTHESIS
+      // Feed the tap detector before the backlight early-returns below, so it
+      // sees every touch event type (touchdown/position/liftoff).
+      touch_click_synth_handle_touch(&e->touch.event);
+#endif
       // For touch-subscribed apps, tie the backlight to the touch: on while a
       // finger is down, timed out after liftoff. Release on liftoff ungated
       // so the refcount can't leak if the app unsubscribed or DnD turned on mid-touch.

--- a/src/fw/services/services_common/service.c
+++ b/src/fw/services/services_common/service.c
@@ -24,6 +24,9 @@
 #include "pbl/services/put_bytes/put_bytes.h"
 #include "pbl/services/shared_prf_storage/shared_prf_storage.h"
 #include "pbl/services/touch/touch.h"
+#ifdef CONFIG_TOUCH_CLICK_SYNTHESIS
+#include "services/touch/touch_click_synth.h"
+#endif
 #include "drivers/touch/touch_sensor.h"
 #include "pbl/services/vibe_pattern.h"
 #include "pbl/services/runlevel_impl.h"
@@ -51,6 +54,9 @@ void services_common_init(void) {
 
 #ifdef CONFIG_TOUCH
   touch_init();
+#ifdef CONFIG_TOUCH_CLICK_SYNTHESIS
+  touch_click_synth_init();
+#endif
 #endif
 
 #ifdef CONFIG_HRM

--- a/src/fw/services/touch/Kconfig
+++ b/src/fw/services/touch/Kconfig
@@ -9,6 +9,17 @@ config SERVICE_TOUCH
 
 if SERVICE_TOUCH
 
+config TOUCH_CLICK_SYNTHESIS
+    bool "Touch-to-click synthesis"
+    default n
+    help
+      Kernel-level bridge that synthesizes a SELECT button click from a touch
+      tap, so apps that use their own click handlers (rather than
+      ScrollLayer/MenuLayer) respond to touch. Only active while a watchapp is
+      in the foreground, and suppressed while the focused app consumes touch
+      directly. Experimental; can be disabled independently of the touch driver
+      as an escape hatch.
+
 module = SERVICE_TOUCH
 module-str = Touch
 source "subsys/logging/Kconfig.template.log_level"

--- a/src/fw/services/touch/touch.c
+++ b/src/fw/services/touch/touch.c
@@ -26,6 +26,7 @@ static PebbleMutex *s_touch_mutex;
 
 static uint8_t s_subscriber_count = 0;
 static bool s_backlight_subscribed = false;
+static bool s_synthesis_subscribed = false;
 static bool s_globally_enabled = true;
 static bool s_rotated = false;
 
@@ -66,10 +67,12 @@ void touch_init(void) {
 
 bool touch_has_app_subscribers(void) {
   mutex_lock(s_touch_mutex);
-  // The backlight gesture subscription is tracked in s_subscriber_count as
-  // well; exclude it so this only reflects real app subscribers.
-  const uint8_t backlight_count = s_backlight_subscribed ? 1 : 0;
-  const bool has_apps = s_subscriber_count > backlight_count;
+  // The backlight and touch->click synthesis subscriptions are tracked in
+  // s_subscriber_count as well; exclude them so this only reflects real app
+  // subscribers (both are kernel-internal holders of the sensor).
+  const uint8_t excluded = (s_backlight_subscribed ? 1 : 0) +
+                           (s_synthesis_subscribed ? 1 : 0);
+  const bool has_apps = s_subscriber_count > excluded;
   mutex_unlock(s_touch_mutex);
   return has_apps;
 }
@@ -115,6 +118,22 @@ void touch_set_backlight_enabled(bool enabled) {
     return;
   } else if (!enabled && s_backlight_subscribed) {
     s_backlight_subscribed = false;
+    mutex_unlock(s_touch_mutex);
+    prv_remove_subscriber_cb(PebbleTask_KernelMain);
+    return;
+  }
+  mutex_unlock(s_touch_mutex);
+}
+
+void touch_set_synthesis_enabled(bool enabled) {
+  mutex_lock(s_touch_mutex);
+  if (enabled && !s_synthesis_subscribed) {
+    s_synthesis_subscribed = true;
+    mutex_unlock(s_touch_mutex);
+    prv_add_subscriber_cb(PebbleTask_KernelMain);
+    return;
+  } else if (!enabled && s_synthesis_subscribed) {
+    s_synthesis_subscribed = false;
     mutex_unlock(s_touch_mutex);
     prv_remove_subscriber_cb(PebbleTask_KernelMain);
     return;

--- a/src/fw/services/touch/touch_click_synth.c
+++ b/src/fw/services/touch/touch_click_synth.c
@@ -148,12 +148,14 @@ void touch_click_synth_handle_touch(const TouchEvent *event) {
 
       // A drag past the threshold is a swipe. A predominantly vertical swipe
       // maps to UP/DOWN; horizontal swipes are ignored for now (BACK is a
-      // later phase). Direct spatial mapping: a swipe toward the top of the
-      // screen is UP, toward the bottom is DOWN.
+      // later phase). Content-scroll convention (matches ScrollLayer/MenuLayer
+      // touch and common touch UIs): flicking the finger up reveals content
+      // further down -> DOWN button; flicking down reveals earlier content ->
+      // UP button. So the button is opposite the finger's travel direction.
       const int16_t dx = event->x - s_state.start_x;
       const int16_t dy = event->y - s_state.start_y;
       if (ABS(dy) > ABS(dx) && ABS(dy) >= SYNTH_TAP_MOVE_THRESHOLD_PX) {
-        prv_synthesize_click(dy < 0 ? BUTTON_ID_UP : BUTTON_ID_DOWN);
+        prv_synthesize_click(dy < 0 ? BUTTON_ID_DOWN : BUTTON_ID_UP);
       }
       break;
     }

--- a/src/fw/services/touch/touch_click_synth.c
+++ b/src/fw/services/touch/touch_click_synth.c
@@ -34,6 +34,47 @@ static SynthState s_state;
 
 static EventServiceInfo s_focus_event_info;
 
+// Kernel-side copy of the focused window's action bar, published by applib via
+// syscall. Read when routing a tap to a bar zone.
+static ActionBarSynthDescriptor s_action_bar;
+
+void touch_click_synth_set_action_bar(const ActionBarSynthDescriptor *descriptor) {
+  s_action_bar = *descriptor;
+}
+
+// If the tap at (x, y) lands on the action bar, return the button for its
+// vertical zone (top -> UP, middle -> SELECT, bottom -> DOWN), falling back to
+// SELECT for a zone whose icon is absent. Returns false if there is no action
+// bar or the tap is outside it, leaving the caller's default (SELECT) in place.
+static bool prv_action_bar_button_for_tap(int16_t x, int16_t y, ButtonId *button_out) {
+  if (!s_action_bar.present) {
+    return false;
+  }
+  const GRect *f = &s_action_bar.frame;
+  if (x < f->origin.x || x >= f->origin.x + f->size.w ||
+      y < f->origin.y || y >= f->origin.y + f->size.h ||
+      f->size.h <= 0) {
+    return false;
+  }
+
+  // Split the bar into three equal vertical zones.
+  const int16_t zone = (int16_t)(((int32_t)(y - f->origin.y) * 3) / f->size.h);
+  ButtonId button;
+  uint8_t icon_bit;
+  if (zone <= 0) {
+    button = BUTTON_ID_UP;
+    icon_bit = ACTION_BAR_SYNTH_ICON_UP;
+  } else if (zone == 1) {
+    button = BUTTON_ID_SELECT;
+    icon_bit = ACTION_BAR_SYNTH_ICON_SELECT;
+  } else {
+    button = BUTTON_ID_DOWN;
+    icon_bit = ACTION_BAR_SYNTH_ICON_DOWN;
+  }
+  *button_out = (s_action_bar.icon_mask & icon_bit) ? button : BUTTON_ID_SELECT;
+  return true;
+}
+
 // A focused (non-unfocused) modal receives button events in
 // launcher_handle_button_event, so the bridge must synthesize for it too (e.g.
 // the notification-detail popup, action menus, dialogs). Mirrors the
@@ -61,6 +102,11 @@ static void prv_set_active(bool active) {
   s_state.active = active;
   s_state.finger_down = false;
   s_state.dragging = false;
+  if (!active) {
+    // Leaving the foreground (e.g. back to the watchface): drop any stale action
+    // bar descriptor so it can't route taps in the next context.
+    s_action_bar = (ActionBarSynthDescriptor) { 0 };
+  }
   // Hold or release the touch sensor. This subscription is excluded from
   // touch_has_app_subscribers() so it never suppresses our own synthesis.
   touch_set_synthesis_enabled(active);
@@ -137,11 +183,14 @@ void touch_click_synth_handle_touch(const TouchEvent *event) {
       }
 
       if (!s_state.dragging) {
-        // Tap -> SELECT, if it lifted off quickly enough.
+        // Tap: SELECT by default, or UP/SELECT/DOWN when it lands on the action
+        // bar (by vertical zone), if it lifted off quickly enough.
         const uint64_t elapsed_ms =
             ((uint64_t)(rtc_get_ticks() - s_state.down_ticks) * 1000) / RTC_TICKS_HZ;
         if (elapsed_ms < SYNTH_TAP_MAX_MS) {
-          prv_synthesize_click(BUTTON_ID_SELECT);
+          ButtonId button = BUTTON_ID_SELECT;
+          prv_action_bar_button_for_tap(s_state.start_x, s_state.start_y, &button);
+          prv_synthesize_click(button);
         }
         break;
       }

--- a/src/fw/services/touch/touch_click_synth.c
+++ b/src/fw/services/touch/touch_click_synth.c
@@ -1,0 +1,127 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "services/touch/touch_click_synth.h"
+
+#include "applib/event_service_client.h"
+#include "drivers/button_id.h"
+#include "drivers/rtc.h"
+#include "kernel/events.h"
+#include "pbl/services/touch/touch.h"
+#include "process_management/app_manager.h"
+#include "pbl/util/math.h"
+
+// Tap thresholds mirror ScrollLayer's touch handling so the tap definition is
+// consistent across the codebase.
+#define SYNTH_TAP_MOVE_THRESHOLD_PX 10
+#define SYNTH_TAP_MAX_MS 300
+
+// Transient tap-gesture state plus the foreground gate. A single physical
+// touchscreen means only one gesture is ever in flight, so a single
+// file-static instance suffices.
+typedef struct {
+  bool active;       // gate: a watchapp is the focused foreground process
+  bool finger_down;
+  bool dragging;     // moved past the tap threshold -> not a tap
+  int16_t start_x;
+  int16_t start_y;
+  RtcTicks down_ticks;
+} SynthState;
+
+static SynthState s_state;
+
+static EventServiceInfo s_focus_event_info;
+
+static void prv_set_active(bool active) {
+  if (active == s_state.active) {
+    return;
+  }
+  s_state.active = active;
+  s_state.finger_down = false;
+  s_state.dragging = false;
+  // Hold or release the touch sensor. This subscription is excluded from
+  // touch_has_app_subscribers() so it never suppresses our own synthesis.
+  touch_set_synthesis_enabled(active);
+}
+
+static void prv_focus_handler(PebbleEvent *e, void *context) {
+  // Active only while a watchapp (not a watchface) is the focused foreground
+  // process. This matches the "on while viewing an app" power profile of the
+  // ScrollLayer/MenuLayer touch support: on a modal overlay or a return to the
+  // watchface, focus is lost and the sensor is released.
+  const bool active = e->app_focus.in_focus && !app_manager_is_watchface_running();
+  prv_set_active(active);
+}
+
+static void prv_synthesize_select_click(void) {
+  // A button down immediately followed by a button up registers as exactly one
+  // SELECT single-click in the click recognizer, and flows through the normal
+  // button path (kernel arbitration -> the focused app/modal click manager).
+  PebbleEvent down = {
+    .type = PEBBLE_BUTTON_DOWN_EVENT,
+    .button = { .button_id = BUTTON_ID_SELECT },
+  };
+  PebbleEvent up = {
+    .type = PEBBLE_BUTTON_UP_EVENT,
+    .button = { .button_id = BUTTON_ID_SELECT },
+  };
+  event_put(&down);
+  event_put(&up);
+}
+
+void touch_click_synth_handle_touch(const TouchEvent *event) {
+  if (!s_state.active) {
+    return;
+  }
+
+  switch (event->type) {
+    case TouchEvent_Touchdown:
+      s_state.finger_down = true;
+      s_state.dragging = false;
+      s_state.start_x = event->x;
+      s_state.start_y = event->y;
+      s_state.down_ticks = rtc_get_ticks();
+      break;
+
+    case TouchEvent_PositionUpdate:
+      if (s_state.finger_down && !s_state.dragging) {
+        if (ABS(event->x - s_state.start_x) > SYNTH_TAP_MOVE_THRESHOLD_PX ||
+            ABS(event->y - s_state.start_y) > SYNTH_TAP_MOVE_THRESHOLD_PX) {
+          s_state.dragging = true;  // committed to a drag, not a tap
+        }
+      }
+      break;
+
+    case TouchEvent_Liftoff: {
+      if (!s_state.finger_down) {
+        break;
+      }
+      s_state.finger_down = false;
+      if (s_state.dragging) {
+        break;
+      }
+      const uint64_t elapsed_ms =
+          ((uint64_t)(rtc_get_ticks() - s_state.down_ticks) * 1000) / RTC_TICKS_HZ;
+      if (elapsed_ms >= SYNTH_TAP_MAX_MS) {
+        break;
+      }
+      // A tap. Only synthesize when the focused app does not consume touch
+      // itself (ScrollLayer/MenuLayer or a custom touch_service subscriber),
+      // to avoid a double action.
+      if (touch_has_app_subscribers()) {
+        break;
+      }
+      prv_synthesize_select_click();
+      break;
+    }
+  }
+}
+
+void touch_click_synth_init(void) {
+  s_state = (SynthState){ 0 };
+  s_focus_event_info = (EventServiceInfo) {
+    .type = PEBBLE_APP_DID_CHANGE_FOCUS_EVENT,
+    .handler = prv_focus_handler,
+  };
+  event_service_client_subscribe(&s_focus_event_info);
+}

--- a/src/fw/services/touch/touch_click_synth.c
+++ b/src/fw/services/touch/touch_click_synth.c
@@ -7,6 +7,7 @@
 #include "drivers/button_id.h"
 #include "drivers/rtc.h"
 #include "kernel/events.h"
+#include "kernel/ui/modals/modal_manager.h"
 #include "pbl/services/touch/touch.h"
 #include "process_management/app_manager.h"
 #include "pbl/util/math.h"
@@ -21,7 +22,7 @@
 // touchscreen means only one gesture is ever in flight, so a single
 // file-static instance suffices.
 typedef struct {
-  bool active;       // gate: a watchapp is the focused foreground process
+  bool active;       // sensor-hold state (driven by focus events)
   bool finger_down;
   bool dragging;     // moved past the tap threshold -> not a tap
   int16_t start_x;
@@ -32,6 +33,26 @@ typedef struct {
 static SynthState s_state;
 
 static EventServiceInfo s_focus_event_info;
+
+// A focused (non-unfocused) modal receives button events in
+// launcher_handle_button_event, so the bridge must synthesize for it too (e.g.
+// the notification-detail popup, action menus, dialogs). Mirrors the
+// is_modal_focused test there.
+static bool prv_modal_focused(void) {
+  return modal_manager_get_enabled() &&
+         !(modal_manager_get_properties() & ModalProperty_Unfocused);
+}
+
+// The synthesis gate. Re-evaluated live at touch time (not just cached from the
+// focus event) so a delayed or missed PEBBLE_APP_DID_CHANGE_FOCUS_EVENT can't
+// leave the bridge unable to respond while the sensor is on. Active whenever a
+// focused modal is up, or the foreground process is a watchapp (not a
+// watchface). Synthesized buttons route to whoever holds focus (app or modal)
+// via the normal kernel button path, so a bare "not the watchface" test here is
+// sufficient regardless of app/modal focus split.
+static bool prv_gate_ok(void) {
+  return prv_modal_focused() || !app_manager_is_watchface_running();
+}
 
 static void prv_set_active(bool active) {
   if (active == s_state.active) {
@@ -46,12 +67,15 @@ static void prv_set_active(bool active) {
 }
 
 static void prv_focus_handler(PebbleEvent *e, void *context) {
-  // Active only while a watchapp (not a watchface) is the focused foreground
-  // process. This matches the "on while viewing an app" power profile of the
-  // ScrollLayer/MenuLayer touch support: on a modal overlay or a return to the
-  // watchface, focus is lost and the sensor is released.
-  const bool active = e->app_focus.in_focus && !app_manager_is_watchface_running();
-  prv_set_active(active);
+  // Drive the sensor hold from focus changes. This matches the "on while
+  // viewing an app or a focusing modal" power profile of the
+  // ScrollLayer/MenuLayer touch support: on a return to the watchface with no
+  // focused modal, the sensor is released. A focusing modal (notification
+  // popup, action menu, ...) takes focus from the app -> in_focus is false for
+  // it, so it is included explicitly. The synthesis decision itself is a live
+  // re-check (prv_gate_ok), so this event only needs to be roughly right.
+  const bool watchapp_focused = e->app_focus.in_focus && !app_manager_is_watchface_running();
+  prv_set_active(watchapp_focused || prv_modal_focused());
 }
 
 static void prv_synthesize_click(ButtonId button_id) {
@@ -71,7 +95,13 @@ static void prv_synthesize_click(ButtonId button_id) {
 }
 
 void touch_click_synth_handle_touch(const TouchEvent *event) {
-  if (!s_state.active) {
+  // Live gate re-check: robust to focus-event timing (e.g. a focusing modal's
+  // did_focus fires only when its entrance transition completes) as long as the
+  // sensor is on. If it isn't a valid synthesis target right now, drop the event
+  // and any in-flight gesture state.
+  if (!prv_gate_ok()) {
+    s_state.finger_down = false;
+    s_state.dragging = false;
     return;
   }
 

--- a/src/fw/services/touch/touch_click_synth.c
+++ b/src/fw/services/touch/touch_click_synth.c
@@ -11,7 +11,8 @@
 #include "process_management/app_manager.h"
 #include "pbl/util/math.h"
 
-// Tap thresholds mirror ScrollLayer's touch handling so the tap definition is
+// Movement threshold that separates a tap from a swipe, and the tap timeout.
+// Both mirror ScrollLayer's touch handling so the gesture definitions are
 // consistent across the codebase.
 #define SYNTH_TAP_MOVE_THRESHOLD_PX 10
 #define SYNTH_TAP_MAX_MS 300
@@ -53,17 +54,17 @@ static void prv_focus_handler(PebbleEvent *e, void *context) {
   prv_set_active(active);
 }
 
-static void prv_synthesize_select_click(void) {
+static void prv_synthesize_click(ButtonId button_id) {
   // A button down immediately followed by a button up registers as exactly one
-  // SELECT single-click in the click recognizer, and flows through the normal
-  // button path (kernel arbitration -> the focused app/modal click manager).
+  // single-click in the click recognizer, and flows through the normal button
+  // path (kernel arbitration -> the focused app/modal click manager).
   PebbleEvent down = {
     .type = PEBBLE_BUTTON_DOWN_EVENT,
-    .button = { .button_id = BUTTON_ID_SELECT },
+    .button = { .button_id = button_id },
   };
   PebbleEvent up = {
     .type = PEBBLE_BUTTON_UP_EVENT,
-    .button = { .button_id = BUTTON_ID_SELECT },
+    .button = { .button_id = button_id },
   };
   event_put(&down);
   event_put(&up);
@@ -97,21 +98,33 @@ void touch_click_synth_handle_touch(const TouchEvent *event) {
         break;
       }
       s_state.finger_down = false;
-      if (s_state.dragging) {
-        break;
-      }
-      const uint64_t elapsed_ms =
-          ((uint64_t)(rtc_get_ticks() - s_state.down_ticks) * 1000) / RTC_TICKS_HZ;
-      if (elapsed_ms >= SYNTH_TAP_MAX_MS) {
-        break;
-      }
-      // A tap. Only synthesize when the focused app does not consume touch
-      // itself (ScrollLayer/MenuLayer or a custom touch_service subscriber),
-      // to avoid a double action.
+
+      // Arbitration (shared by tap and swipe): if the focused app consumes
+      // touch itself (ScrollLayer/MenuLayer or a custom touch_service
+      // subscriber), don't synthesize anything, to avoid a double action.
       if (touch_has_app_subscribers()) {
         break;
       }
-      prv_synthesize_select_click();
+
+      if (!s_state.dragging) {
+        // Tap -> SELECT, if it lifted off quickly enough.
+        const uint64_t elapsed_ms =
+            ((uint64_t)(rtc_get_ticks() - s_state.down_ticks) * 1000) / RTC_TICKS_HZ;
+        if (elapsed_ms < SYNTH_TAP_MAX_MS) {
+          prv_synthesize_click(BUTTON_ID_SELECT);
+        }
+        break;
+      }
+
+      // A drag past the threshold is a swipe. A predominantly vertical swipe
+      // maps to UP/DOWN; horizontal swipes are ignored for now (BACK is a
+      // later phase). Direct spatial mapping: a swipe toward the top of the
+      // screen is UP, toward the bottom is DOWN.
+      const int16_t dx = event->x - s_state.start_x;
+      const int16_t dy = event->y - s_state.start_y;
+      if (ABS(dy) > ABS(dx) && ABS(dy) >= SYNTH_TAP_MOVE_THRESHOLD_PX) {
+        prv_synthesize_click(dy < 0 ? BUTTON_ID_UP : BUTTON_ID_DOWN);
+      }
       break;
     }
   }

--- a/src/fw/services/touch/touch_click_synth.h
+++ b/src/fw/services/touch/touch_click_synth.h
@@ -11,8 +11,9 @@
 //! click handlers (rather than ScrollLayer/MenuLayer) respond to touch:
 //!   - a tap        -> SELECT
 //!   - a vertical swipe -> UP / DOWN
-//! Runs on KernelMain, active only while a watchapp is the focused foreground
-//! process, and suppressed while the focused app consumes touch directly.
+//! Runs on KernelMain, active while a watchapp is the focused foreground
+//! process or a focusing modal (notification popup, action menu, ...) is up,
+//! and suppressed while the focused app consumes touch directly.
 
 //! Initialize the bridge. Subscribes to app focus changes for foreground
 //! gating. Call once from services init on KernelMain.

--- a/src/fw/services/touch/touch_click_synth.h
+++ b/src/fw/services/touch/touch_click_synth.h
@@ -3,17 +3,35 @@
 
 #pragma once
 
+#include "applib/graphics/gtypes.h"
 #include "pbl/services/touch/touch_event.h"
+
+#include <stdbool.h>
+#include <stdint.h>
 
 //! Touch-to-click synthesis bridge.
 //!
 //! Synthesizes button clicks from touch gestures so apps that use their own
 //! click handlers (rather than ScrollLayer/MenuLayer) respond to touch:
-//!   - a tap        -> SELECT
+//!   - a tap        -> SELECT (or UP/SELECT/DOWN over an action bar)
 //!   - a vertical swipe -> UP / DOWN
 //! Runs on KernelMain, active while a watchapp is the focused foreground
 //! process or a focusing modal (notification popup, action menu, ...) is up,
 //! and suppressed while the focused app consumes touch directly.
+
+//! Icon-presence bits for ActionBarSynthDescriptor.icon_mask.
+#define ACTION_BAR_SYNTH_ICON_UP     (1 << 0)
+#define ACTION_BAR_SYNTH_ICON_SELECT (1 << 1)
+#define ACTION_BAR_SYNTH_ICON_DOWN   (1 << 2)
+
+//! Kernel-visible snapshot of the focused window's action bar, published by the
+//! applib ActionBarLayer (via syscall) so the KernelMain bridge can route a tap
+//! landing on the bar to UP/SELECT/DOWN by its vertical zone.
+typedef struct ActionBarSynthDescriptor {
+  bool present;       //!< an action bar is currently shown
+  GRect frame;        //!< its rectangle in global screen coordinates
+  uint8_t icon_mask;  //!< ACTION_BAR_SYNTH_ICON_* bits for the icons that exist
+} ActionBarSynthDescriptor;
 
 //! Initialize the bridge. Subscribes to app focus changes for foreground
 //! gating. Call once from services init on KernelMain.
@@ -22,3 +40,7 @@ void touch_click_synth_init(void);
 //! Feed a raw touch event to the bridge's tap detector. Called inline from the
 //! kernel event loop's PEBBLE_TOUCH_EVENT handling.
 void touch_click_synth_handle_touch(const TouchEvent *event);
+
+//! Publish (or clear) the focused window's action bar descriptor. Called on
+//! KernelMain from the sys_touch_click_synth_set_action_bar syscall handler.
+void touch_click_synth_set_action_bar(const ActionBarSynthDescriptor *descriptor);

--- a/src/fw/services/touch/touch_click_synth.h
+++ b/src/fw/services/touch/touch_click_synth.h
@@ -1,0 +1,21 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include "pbl/services/touch/touch_event.h"
+
+//! Touch-to-click synthesis bridge (Phase 1: tap -> SELECT).
+//!
+//! Synthesizes a SELECT button click from a touch tap so apps that use their
+//! own click handlers (rather than ScrollLayer/MenuLayer) respond to touch.
+//! Runs on KernelMain, active only while a watchapp is the focused foreground
+//! process, and suppressed while the focused app consumes touch directly.
+
+//! Initialize the bridge. Subscribes to app focus changes for foreground
+//! gating. Call once from services init on KernelMain.
+void touch_click_synth_init(void);
+
+//! Feed a raw touch event to the bridge's tap detector. Called inline from the
+//! kernel event loop's PEBBLE_TOUCH_EVENT handling.
+void touch_click_synth_handle_touch(const TouchEvent *event);

--- a/src/fw/services/touch/touch_click_synth.h
+++ b/src/fw/services/touch/touch_click_synth.h
@@ -5,10 +5,12 @@
 
 #include "pbl/services/touch/touch_event.h"
 
-//! Touch-to-click synthesis bridge (Phase 1: tap -> SELECT).
+//! Touch-to-click synthesis bridge.
 //!
-//! Synthesizes a SELECT button click from a touch tap so apps that use their
-//! own click handlers (rather than ScrollLayer/MenuLayer) respond to touch.
+//! Synthesizes button clicks from touch gestures so apps that use their own
+//! click handlers (rather than ScrollLayer/MenuLayer) respond to touch:
+//!   - a tap        -> SELECT
+//!   - a vertical swipe -> UP / DOWN
 //! Runs on KernelMain, active only while a watchapp is the focused foreground
 //! process, and suppressed while the focused app consumes touch directly.
 

--- a/src/fw/services/touch/wscript_build
+++ b/src/fw/services/touch/wscript_build
@@ -5,6 +5,9 @@ sources = [
     'touch.c',
 ]
 
+if bld.env.CONFIG_TOUCH_CLICK_SYNTHESIS:
+    sources.append('touch_click_synth.c')
+
 bld.stlib(
     use=['fw_includes'],
     source=sources,

--- a/src/fw/syscall/syscall.h
+++ b/src/fw/syscall/syscall.h
@@ -315,3 +315,10 @@ bool sys_do_not_disturb_is_active(void);
 //! @param timestamp_out Set to the UTC time of the next enabled alarm.
 //! @return True if at least one enabled alarm is scheduled.
 bool sys_alarm_get_next_enabled(time_t *timestamp_out);
+
+#ifdef CONFIG_TOUCH_CLICK_SYNTHESIS
+#include "services/touch/touch_click_synth.h"
+//! Publish (or clear) the focused window's action bar descriptor to the
+//! touch-to-click synthesis bridge running on KernelMain.
+void sys_touch_click_synth_set_action_bar(const ActionBarSynthDescriptor *descriptor);
+#endif

--- a/src/fw/syscall/syscall_touch_click_synth.c
+++ b/src/fw/syscall/syscall_touch_click_synth.c
@@ -1,0 +1,23 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "syscall/syscall.h"
+#include "syscall/syscall_internal.h"
+
+#ifdef CONFIG_TOUCH_CLICK_SYNTHESIS
+
+#include "services/touch/touch_click_synth.h"
+
+// Publish the focused window's action bar descriptor from applib (app task) to
+// the KernelMain synthesis bridge, so a tap on the bar can be routed to
+// UP/SELECT/DOWN by its vertical zone.
+DEFINE_SYSCALL(void, sys_touch_click_synth_set_action_bar,
+               const ActionBarSynthDescriptor *descriptor) {
+  if (PRIVILEGE_WAS_ELEVATED) {
+    syscall_assert_userspace_buffer(descriptor, sizeof(*descriptor));
+  }
+  ActionBarSynthDescriptor local = *descriptor;
+  touch_click_synth_set_action_bar(&local);
+}
+
+#endif  // CONFIG_TOUCH_CLICK_SYNTHESIS

--- a/tests/fw/services/test_touch_click_arbitration.c
+++ b/tests/fw/services/test_touch_click_arbitration.c
@@ -1,0 +1,245 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+// Verification for the proposed touch->button "synthesis bridge" arbitration.
+//
+// This test does NOT implement the synthesis bridge. It models the bridge's
+// suppression *decision* (the proposal: synthesize a button only when the
+// focused app is NOT a direct touch subscriber) against the REAL touch service
+// bookkeeping (touch_has_app_subscribers()), plus a dummy "app touch handler"
+// standing in for ScrollLayer/MenuLayer or a custom touch_service subscriber.
+//
+// Goal: show that with the arbitration in place, a single touch never produces
+// a double action (app touch handling AND a synthesized button), and to make
+// the async-subscription timing window observable.
+//
+// Note on isolation: touch.c's subscriber count is a module static that
+// touch_init() does not reset. In the firmware it is drained on app exit via
+// event_service_clear_process_subscriptions(); here the test drains it in
+// cleanup so each case starts from zero subscribers.
+
+#include "clar.h"
+
+#include "kernel/events.h"
+#include "kernel/pebble_tasks.h"
+#include "pbl/services/event_service.h"
+#include "pbl/services/touch/touch.h"
+#include "pbl/services/touch/touch_event.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "fake_events.h"
+
+// Stubs (same set as test_touch.c)
+#include "stubs_analytics.h"
+#include "stubs_logging.h"
+#include "stubs_mutex.h"
+#include "stubs_passert.h"
+
+void kernel_free(void *p) {}
+
+// Capture the touch service's subscriber add/remove callbacks. In the real
+// system these fire on KernelMain when it processes a PEBBLE_SUBSCRIPTION_EVENT
+// (i.e. app-task subscribe/unsubscribe is asynchronous). Calling them here
+// models that kernel-side processing point exactly.
+static EventServiceAddSubscriberCallback s_add_subscriber_cb;
+static EventServiceRemoveSubscriberCallback s_remove_subscriber_cb;
+
+void event_service_init(PebbleEventType type, EventServiceAddSubscriberCallback add_cb,
+                        EventServiceRemoveSubscriberCallback remove_cb) {
+  cl_assert(type == PEBBLE_TOUCH_EVENT || type == PEBBLE_GESTURE_EVENT);
+  s_add_subscriber_cb = add_cb;
+  s_remove_subscriber_cb = remove_cb;
+}
+
+static bool s_touch_sensor_enabled;
+void touch_sensor_set_enabled(bool enabled) { s_touch_sensor_enabled = enabled; }
+
+//////////////////////////////////////////////////////////////////////////////
+// Test-side subscriber bookkeeping (drains leaks in cleanup).
+
+static int s_net_app_subs;
+
+static void prv_app_subscribe(void) {
+  s_add_subscriber_cb(PebbleTask_App);  // models KernelMain processing the sub
+  s_net_app_subs++;
+}
+
+static void prv_app_unsubscribe(void) {
+  s_remove_subscriber_cb(PebbleTask_App);
+  s_net_app_subs--;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Models used only by this test (NOT the real bridge / app)
+
+// The proposed arbitration decision the synthesis bridge would make.
+static bool prv_bridge_should_synthesize(void) {
+  return !touch_has_app_subscribers();
+}
+
+static int s_synthesized_buttons;  // buttons the bridge would emit
+static int s_app_touch_actions;    // actions the dummy app touch handler took
+
+// Deliver a single touch gesture to BOTH would-be consumers, exactly as the
+// real system would: the kernel synthesis bridge and the app's own touch
+// handler both observe the same PEBBLE_TOUCH_EVENT. `app_handles_touch` models
+// whether the focused app actually consumes touch (ScrollLayer/MenuLayer or a
+// custom subscriber). It is kept independent from the subscriber count so we
+// can also exercise the "partial coverage" and timing-window cases.
+static void prv_deliver_gesture(bool app_handles_touch) {
+  if (prv_bridge_should_synthesize()) {
+    s_synthesized_buttons++;
+  }
+  if (app_handles_touch) {
+    s_app_touch_actions++;
+  }
+}
+
+static int prv_total_actions(void) {
+  return s_synthesized_buttons + s_app_touch_actions;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void test_touch_click_arbitration__initialize(void) {
+  fake_event_init();
+  s_add_subscriber_cb = NULL;
+  s_remove_subscriber_cb = NULL;
+  s_touch_sensor_enabled = false;
+  s_net_app_subs = 0;
+  s_synthesized_buttons = 0;
+  s_app_touch_actions = 0;
+  touch_init();
+  touch_reset();
+  touch_service_set_globally_enabled(true);
+}
+
+void test_touch_click_arbitration__cleanup(void) {
+  // Drain any subscribers the test left registered so the module-static count
+  // in touch.c doesn't leak into the next test.
+  while (s_net_app_subs > 0) {
+    prv_app_unsubscribe();
+  }
+}
+
+// Baseline: a button-only app (no touch subscriber) gets button emulation, and
+// there is exactly one action (the synthesized button).
+void test_touch_click_arbitration__button_only_app_gets_synthesis(void) {
+  cl_assert(!touch_has_app_subscribers());
+
+  prv_deliver_gesture(false /* app does not handle touch */);
+
+  cl_assert_equal_i(s_synthesized_buttons, 1);
+  cl_assert_equal_i(s_app_touch_actions, 0);
+  cl_assert_equal_i(prv_total_actions(), 1);  // no double action
+}
+
+// A touch-consuming app (ScrollLayer/MenuLayer or custom subscriber) suppresses
+// synthesis: exactly one action (the app's), never a double.
+void test_touch_click_arbitration__touch_app_suppresses_synthesis(void) {
+  // App subscribes in window_load; the kernel processes it (this callback).
+  prv_app_subscribe();
+  cl_assert(touch_has_app_subscribers());
+
+  prv_deliver_gesture(true /* app handles touch */);
+
+  cl_assert_equal_i(s_synthesized_buttons, 0);  // suppressed
+  cl_assert_equal_i(s_app_touch_actions, 1);
+  cl_assert_equal_i(prv_total_actions(), 1);  // no double action
+}
+
+// Q2: dynamic subscribe/unsubscribe within a window (e.g. a screen that only
+// uses touch sometimes). Suppression must track the current subscription.
+void test_touch_click_arbitration__dynamic_subscribe_unsubscribe_tracks(void) {
+  // Phase 1: not subscribed -> button emulation.
+  prv_deliver_gesture(false);
+  cl_assert_equal_i(s_synthesized_buttons, 1);
+  cl_assert_equal_i(s_app_touch_actions, 0);
+
+  // Phase 2: app subscribes -> synthesis suppressed, app handles.
+  prv_app_subscribe();
+  prv_deliver_gesture(true);
+  cl_assert_equal_i(s_synthesized_buttons, 1);  // unchanged
+  cl_assert_equal_i(s_app_touch_actions, 1);
+
+  // Phase 3: app unsubscribes -> button emulation resumes.
+  prv_app_unsubscribe();
+  cl_assert(!touch_has_app_subscribers());
+  prv_deliver_gesture(false);
+  cl_assert_equal_i(s_synthesized_buttons, 2);
+  cl_assert_equal_i(s_app_touch_actions, 1);
+
+  // Every gesture produced exactly one action across all phases.
+  cl_assert_equal_i(prv_total_actions(), 3);
+}
+
+// Q1 (no race with the *coupled* sensor design): the sensor is powered only
+// while a subscriber exists, and the enable happens in the same callback that
+// increments the count. So no touch event can be delivered before the count
+// reflects the subscription -> the first touch after subscribe already sees the
+// subscriber and is suppressed.
+void test_touch_click_arbitration__coupled_sensor_is_race_free(void) {
+  cl_assert(!s_touch_sensor_enabled);
+
+  // App subscribes: sensor comes up AND count flips together.
+  prv_app_subscribe();
+  cl_assert(s_touch_sensor_enabled);
+  cl_assert(touch_has_app_subscribers());
+
+  // Only now can touch events flow; the very first one is already suppressed.
+  prv_deliver_gesture(true);
+  cl_assert_equal_i(s_synthesized_buttons, 0);
+  cl_assert_equal_i(prv_total_actions(), 1);
+}
+
+// Q1 (the race that the *persistent-sensor* bridge design would introduce): if
+// the bridge keeps the sensor on globally, touch events can arrive in the small
+// window after the app calls subscribe() but before KernelMain processes the
+// PEBBLE_SUBSCRIPTION_EVENT (count not yet incremented). This test makes that
+// window observable: a gesture in that window is (wrongly) synthesized.
+void test_touch_click_arbitration__persistent_sensor_has_timing_window(void) {
+  // Persistent-sensor bridge: touch flows regardless of app subscription.
+  // Model the window: the app has *called* subscribe(), but the kernel has not
+  // yet run the add-subscriber callback, so the count is still 0.
+  cl_assert(!touch_has_app_subscribers());
+
+  prv_deliver_gesture(false /* app not yet wired up to handle */);
+  // The bridge synthesized a button even though the app is about to own touch.
+  cl_assert_equal_i(s_synthesized_buttons, 1);
+
+  // Kernel now processes the subscription; subsequent gestures are suppressed.
+  prv_app_subscribe();
+  prv_deliver_gesture(true);
+  cl_assert_equal_i(s_synthesized_buttons, 1);  // no further synthesis
+  cl_assert_equal_i(s_app_touch_actions, 1);
+}
+
+// Q3 (partial coverage is conservative/safe): a window that BOTH subscribes to
+// touch and uses button click config. Any touch subscription suppresses ALL
+// synthesis for that app -> the click config gets no touch emulation, but there
+// is never a double action. Suppression errs toward "do nothing", not misfire.
+void test_touch_click_arbitration__partial_coverage_never_double_fires(void) {
+  prv_app_subscribe();  // window has a touch subscriber
+
+  // Gesture that the app's touch handler consumes: no synthesized button even
+  // though the same window also has button handlers installed.
+  prv_deliver_gesture(true);
+  cl_assert_equal_i(s_synthesized_buttons, 0);
+  cl_assert_equal_i(s_app_touch_actions, 1);
+  cl_assert_equal_i(prv_total_actions(), 1);
+}
+
+// The backlight touch-wake subscription must NOT be mistaken for an app
+// subscriber, otherwise the bridge would suppress itself whenever the backlight
+// feature is on. Confirms the arbitration key ignores the backlight holder.
+void test_touch_click_arbitration__backlight_does_not_suppress(void) {
+  touch_set_backlight_enabled(true);
+  cl_assert(!touch_has_app_subscribers());
+
+  prv_deliver_gesture(false);
+  cl_assert_equal_i(s_synthesized_buttons, 1);  // still emulated
+
+  touch_set_backlight_enabled(false);
+}

--- a/tests/fw/services/test_touch_click_synth.c
+++ b/tests/fw/services/test_touch_click_synth.c
@@ -204,16 +204,17 @@ void test_touch_click_synth__tap_synthesizes_one_select_click(void) {
 
 // --- vertical swipe -> UP / DOWN --------------------------------------------
 
-void test_touch_click_synth__swipe_up_synthesizes_up(void) {
+// Content-scroll convention: the button is opposite the finger's travel.
+void test_touch_click_synth__swipe_up_synthesizes_down(void) {
   prv_focus(true);
-  prv_swipe(100, 150, 100, 100);  // finger moves up (dy = -50)
-  prv_assert_single_click(BUTTON_ID_UP);
+  prv_swipe(100, 150, 100, 100);  // finger moves up (dy = -50) -> content down
+  prv_assert_single_click(BUTTON_ID_DOWN);
 }
 
-void test_touch_click_synth__swipe_down_synthesizes_down(void) {
+void test_touch_click_synth__swipe_down_synthesizes_up(void) {
   prv_focus(true);
-  prv_swipe(100, 100, 100, 150);  // finger moves down (dy = +50)
-  prv_assert_single_click(BUTTON_ID_DOWN);
+  prv_swipe(100, 100, 100, 150);  // finger moves down (dy = +50) -> content up
+  prv_assert_single_click(BUTTON_ID_UP);
 }
 
 void test_touch_click_synth__horizontal_swipe_ignored(void) {
@@ -288,12 +289,12 @@ void test_touch_click_synth__modal_focused_swipe_synthesizes_up_down(void) {
   s_modal_focused = true;
   prv_focus(false);
 
-  prv_swipe(100, 150, 100, 100);       // up
-  prv_assert_single_click(BUTTON_ID_UP);
+  prv_swipe(100, 150, 100, 100);       // finger up -> content down
+  prv_assert_single_click(BUTTON_ID_DOWN);
 
   s_cap_n = 0;
-  prv_swipe(100, 100, 100, 150);       // down
-  prv_assert_single_click(BUTTON_ID_DOWN);
+  prv_swipe(100, 100, 100, 150);       // finger down -> content up
+  prv_assert_single_click(BUTTON_ID_UP);
 }
 
 // The synthesis decision is a live re-check, so it does not depend on the modal

--- a/tests/fw/services/test_touch_click_synth.c
+++ b/tests/fw/services/test_touch_click_synth.c
@@ -105,6 +105,22 @@ static void prv_tap(int16_t x, int16_t y, uint32_t duration_ms) {
   prv_touch(TouchEvent_Liftoff, x + 1, y + 1);
 }
 
+// A swipe: touchdown at (sx,sy), a position update and liftoff at (ex,ey).
+static void prv_swipe(int16_t sx, int16_t sy, int16_t ex, int16_t ey) {
+  prv_touch(TouchEvent_Touchdown, sx, sy);
+  prv_touch(TouchEvent_PositionUpdate, ex, ey);
+  s_ticks += 50;
+  prv_touch(TouchEvent_Liftoff, ex, ey);
+}
+
+static void prv_assert_single_click(ButtonId button_id) {
+  cl_assert_equal_i(s_cap_n, 2);
+  cl_assert_equal_i(s_cap[0].type, PEBBLE_BUTTON_DOWN_EVENT);
+  cl_assert_equal_i(s_cap[0].button.button_id, button_id);
+  cl_assert_equal_i(s_cap[1].type, PEBBLE_BUTTON_UP_EVENT);
+  cl_assert_equal_i(s_cap[1].button.button_id, button_id);
+}
+
 void test_touch_click_synth__initialize(void) {
   fake_event_init();
   s_add_subscriber_cb = NULL;
@@ -173,15 +189,31 @@ void test_touch_click_synth__tap_synthesizes_one_select_click(void) {
   cl_assert_equal_i(s_cap[1].button.button_id, BUTTON_ID_SELECT);
 }
 
-void test_touch_click_synth__drag_does_not_synthesize(void) {
+// --- vertical swipe -> UP / DOWN --------------------------------------------
+
+void test_touch_click_synth__swipe_up_synthesizes_up(void) {
   prv_focus(true);
+  prv_swipe(100, 150, 100, 100);  // finger moves up (dy = -50)
+  prv_assert_single_click(BUTTON_ID_UP);
+}
 
-  prv_touch(TouchEvent_Touchdown, 100, 100);
-  prv_touch(TouchEvent_PositionUpdate, 100, 140);  // moved > 10px -> drag
-  s_ticks += 50;
-  prv_touch(TouchEvent_Liftoff, 100, 140);
+void test_touch_click_synth__swipe_down_synthesizes_down(void) {
+  prv_focus(true);
+  prv_swipe(100, 100, 100, 150);  // finger moves down (dy = +50)
+  prv_assert_single_click(BUTTON_ID_DOWN);
+}
 
-  cl_assert_equal_i(s_cap_n, 0);
+void test_touch_click_synth__horizontal_swipe_ignored(void) {
+  prv_focus(true);
+  prv_swipe(100, 100, 160, 105);  // predominantly horizontal (dx=60, dy=5)
+  cl_assert_equal_i(s_cap_n, 0);  // BACK is a later phase
+}
+
+void test_touch_click_synth__swipe_suppressed_by_app_subscriber(void) {
+  prv_focus(true);
+  prv_app_subscribe();            // app consumes touch itself
+  prv_swipe(100, 150, 100, 100);
+  cl_assert_equal_i(s_cap_n, 0);  // suppressed -> no double action
 }
 
 void test_touch_click_synth__slow_tap_does_not_synthesize(void) {

--- a/tests/fw/services/test_touch_click_synth.c
+++ b/tests/fw/services/test_touch_click_synth.c
@@ -1,0 +1,212 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+// Unit tests for the Phase 1 touch->click synthesis bridge (tap -> SELECT).
+// Drives the real touch service (touch.c) and bridge (touch_click_synth.c),
+// stubbing the surrounding kernel/driver hooks, and asserts:
+//   - foreground gating (active only for a focused watchapp),
+//   - a tap synthesizes exactly one SELECT down+up,
+//   - drags / slow taps do not synthesize,
+//   - synthesis is suppressed while an app consumes touch directly.
+
+#include "clar.h"
+
+#include "kernel/events.h"
+#include "kernel/pebble_tasks.h"
+#include "pbl/services/event_service.h"
+#include "pbl/services/touch/touch.h"
+#include "pbl/services/touch/touch_event.h"
+#include "applib/event_service_client.h"
+#include "services/touch/touch_click_synth.h"
+#include "drivers/rtc.h"
+#include "drivers/button_id.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "fake_events.h"
+#include "stubs_analytics.h"
+#include "stubs_logging.h"
+#include "stubs_mutex.h"
+#include "stubs_passert.h"
+
+void kernel_free(void *p) {}
+
+// --- touch.c subscriber callbacks (captured via event_service_init) ---
+static EventServiceAddSubscriberCallback s_add_subscriber_cb;
+static EventServiceRemoveSubscriberCallback s_remove_subscriber_cb;
+
+void event_service_init(PebbleEventType type, EventServiceAddSubscriberCallback add_cb,
+                        EventServiceRemoveSubscriberCallback remove_cb) {
+  cl_assert(type == PEBBLE_TOUCH_EVENT || type == PEBBLE_GESTURE_EVENT);
+  s_add_subscriber_cb = add_cb;
+  s_remove_subscriber_cb = remove_cb;
+}
+
+static bool s_sensor_enabled;
+void touch_sensor_set_enabled(bool enabled) { s_sensor_enabled = enabled; }
+
+// --- the bridge's focus subscription (captured) ---
+static EventServiceEventHandler s_focus_handler;
+void event_service_client_subscribe(EventServiceInfo *info) {
+  if (info->type == PEBBLE_APP_DID_CHANGE_FOCUS_EVENT) {
+    s_focus_handler = info->handler;
+  }
+}
+void event_service_client_unsubscribe(EventServiceInfo *info) {}
+
+// --- controllable environment ---
+static bool s_is_watchface;
+bool app_manager_is_watchface_running(void) { return s_is_watchface; }
+
+static RtcTicks s_ticks;
+RtcTicks rtc_get_ticks(void) { return s_ticks; }
+
+// --- capture every posted event (the synthesized SELECT down/up) ---
+#define MAX_CAP 8
+static PebbleEvent s_cap[MAX_CAP];
+static int s_cap_n;
+static void prv_capture(PebbleEvent *e) {
+  if (s_cap_n < MAX_CAP) {
+    s_cap[s_cap_n++] = *e;
+  }
+}
+
+// --- helpers ---
+static int s_net_app_subs;
+static void prv_app_subscribe(void) {
+  s_add_subscriber_cb(PebbleTask_App);
+  s_net_app_subs++;
+}
+static void prv_app_unsubscribe(void) {
+  s_remove_subscriber_cb(PebbleTask_App);
+  s_net_app_subs--;
+}
+
+static void prv_focus(bool in_focus) {
+  PebbleEvent e = {
+    .type = PEBBLE_APP_DID_CHANGE_FOCUS_EVENT,
+    .app_focus = { .in_focus = in_focus },
+  };
+  cl_assert(s_focus_handler != NULL);
+  s_focus_handler(&e, NULL);
+}
+
+static void prv_touch(TouchEventType type, int16_t x, int16_t y) {
+  TouchEvent te = { .type = type, .x = x, .y = y };
+  touch_click_synth_handle_touch(&te);
+}
+
+// A tap: touchdown, small (in-threshold) move, liftoff after `duration_ms`.
+static void prv_tap(int16_t x, int16_t y, uint32_t duration_ms) {
+  prv_touch(TouchEvent_Touchdown, x, y);
+  s_ticks += duration_ms;  // RTC_TICKS_HZ == 1000
+  prv_touch(TouchEvent_Liftoff, x + 1, y + 1);
+}
+
+void test_touch_click_synth__initialize(void) {
+  fake_event_init();
+  s_add_subscriber_cb = NULL;
+  s_remove_subscriber_cb = NULL;
+  s_focus_handler = NULL;
+  s_sensor_enabled = false;
+  s_is_watchface = false;
+  s_ticks = 1000;
+  s_cap_n = 0;
+  s_net_app_subs = 0;
+  memset(s_cap, 0, sizeof(s_cap));
+
+  touch_init();
+  touch_reset();
+  touch_service_set_globally_enabled(true);
+  touch_click_synth_init();
+
+  fake_event_set_callback(prv_capture);
+}
+
+void test_touch_click_synth__cleanup(void) {
+  fake_event_set_callback(NULL);
+  // Release the bridge's sensor hold and any app subscription so touch.c's
+  // module-static subscriber count doesn't leak into the next test.
+  prv_focus(false);
+  while (s_net_app_subs > 0) {
+    prv_app_unsubscribe();
+  }
+}
+
+// --- gating -----------------------------------------------------------------
+
+void test_touch_click_synth__watchapp_focus_activates_sensor(void) {
+  cl_assert(!s_sensor_enabled);
+  s_is_watchface = false;
+
+  prv_focus(true);   // a watchapp is focused
+  cl_assert(s_sensor_enabled);      // bridge holds the sensor
+
+  prv_focus(false);  // focus lost (modal/exit)
+  cl_assert(!s_sensor_enabled);     // released
+}
+
+void test_touch_click_synth__watchface_does_not_activate(void) {
+  s_is_watchface = true;
+
+  prv_focus(true);   // watchface focused
+  cl_assert(!s_sensor_enabled);     // bridge stays inactive
+
+  prv_tap(100, 100, 100);
+  cl_assert_equal_i(s_cap_n, 0);    // no synthesis at the watchface
+}
+
+// --- tap -> SELECT ----------------------------------------------------------
+
+void test_touch_click_synth__tap_synthesizes_one_select_click(void) {
+  prv_focus(true);  // active, no app subscriber
+
+  prv_tap(120, 140, 80 /* ms */);
+
+  // Exactly one SELECT down followed by one SELECT up.
+  cl_assert_equal_i(s_cap_n, 2);
+  cl_assert_equal_i(s_cap[0].type, PEBBLE_BUTTON_DOWN_EVENT);
+  cl_assert_equal_i(s_cap[0].button.button_id, BUTTON_ID_SELECT);
+  cl_assert_equal_i(s_cap[1].type, PEBBLE_BUTTON_UP_EVENT);
+  cl_assert_equal_i(s_cap[1].button.button_id, BUTTON_ID_SELECT);
+}
+
+void test_touch_click_synth__drag_does_not_synthesize(void) {
+  prv_focus(true);
+
+  prv_touch(TouchEvent_Touchdown, 100, 100);
+  prv_touch(TouchEvent_PositionUpdate, 100, 140);  // moved > 10px -> drag
+  s_ticks += 50;
+  prv_touch(TouchEvent_Liftoff, 100, 140);
+
+  cl_assert_equal_i(s_cap_n, 0);
+}
+
+void test_touch_click_synth__slow_tap_does_not_synthesize(void) {
+  prv_focus(true);
+
+  prv_tap(100, 100, 350 /* ms, exceeds the 300ms tap window */);
+
+  cl_assert_equal_i(s_cap_n, 0);
+}
+
+// --- arbitration ------------------------------------------------------------
+
+void test_touch_click_synth__app_touch_subscriber_suppresses(void) {
+  prv_focus(true);      // bridge active
+  prv_app_subscribe();  // app consumes touch itself (ScrollLayer/MenuLayer/etc.)
+
+  prv_tap(100, 100, 80);
+
+  cl_assert_equal_i(s_cap_n, 0);  // suppressed -> no double action
+}
+
+// --- gate off ---------------------------------------------------------------
+
+void test_touch_click_synth__inactive_ignores_taps(void) {
+  // No focus event -> bridge inactive.
+  prv_tap(100, 100, 80);
+  cl_assert_equal_i(s_cap_n, 0);
+}

--- a/tests/fw/services/test_touch_click_synth.c
+++ b/tests/fw/services/test_touch_click_synth.c
@@ -13,6 +13,7 @@
 
 #include "kernel/events.h"
 #include "kernel/pebble_tasks.h"
+#include "kernel/ui/modals/modal_manager.h"
 #include "pbl/services/event_service.h"
 #include "pbl/services/touch/touch.h"
 #include "pbl/services/touch/touch_event.h"
@@ -59,6 +60,15 @@ void event_service_client_unsubscribe(EventServiceInfo *info) {}
 // --- controllable environment ---
 static bool s_is_watchface;
 bool app_manager_is_watchface_running(void) { return s_is_watchface; }
+
+// Modal focus state. s_modal_focused true models a focusing modal (a modal
+// exists and does not carry ModalProperty_Unfocused), e.g. the notification
+// popup; false models "no focused modal".
+static bool s_modal_focused;
+bool modal_manager_get_enabled(void) { return true; }
+ModalProperty modal_manager_get_properties(void) {
+  return s_modal_focused ? ModalProperty_Exists : ModalProperty_Unfocused;
+}
 
 static RtcTicks s_ticks;
 RtcTicks rtc_get_ticks(void) { return s_ticks; }
@@ -128,6 +138,7 @@ void test_touch_click_synth__initialize(void) {
   s_focus_handler = NULL;
   s_sensor_enabled = false;
   s_is_watchface = false;
+  s_modal_focused = false;
   s_ticks = 1000;
   s_cap_n = 0;
   s_net_app_subs = 0;
@@ -145,6 +156,8 @@ void test_touch_click_synth__cleanup(void) {
   fake_event_set_callback(NULL);
   // Release the bridge's sensor hold and any app subscription so touch.c's
   // module-static subscriber count doesn't leak into the next test.
+  s_modal_focused = false;
+  s_is_watchface = false;
   prv_focus(false);
   while (s_net_app_subs > 0) {
     prv_app_unsubscribe();
@@ -238,7 +251,72 @@ void test_touch_click_synth__app_touch_subscriber_suppresses(void) {
 // --- gate off ---------------------------------------------------------------
 
 void test_touch_click_synth__inactive_ignores_taps(void) {
-  // No focus event -> bridge inactive.
+  // At the watchface with no focused modal the live gate is closed.
+  s_is_watchface = true;
+  s_modal_focused = false;
+  prv_tap(100, 100, 80);
+  cl_assert_equal_i(s_cap_n, 0);
+}
+
+// --- focusing modal (notification popup, action menu, ...) -------------------
+
+void test_touch_click_synth__modal_focus_activates_sensor(void) {
+  // A focusing modal over the watchface: its did_focus reports in_focus=false,
+  // but the bridge must still hold the sensor.
+  s_is_watchface = true;
+  s_modal_focused = true;
+
+  prv_focus(false);              // the modal's did_focus(in_focus=false)
+  cl_assert(s_sensor_enabled);   // held via the modal_focused path
+
+  s_modal_focused = false;
+  prv_focus(false);              // modal dismissed, back to the watchface
+  cl_assert(!s_sensor_enabled);  // released
+}
+
+void test_touch_click_synth__modal_focused_tap_synthesizes_select(void) {
+  s_is_watchface = true;   // over the watchface...
+  s_modal_focused = true;  // ...but a focusing modal is up
+  prv_focus(false);
+
+  prv_tap(120, 140, 80);
+  prv_assert_single_click(BUTTON_ID_SELECT);
+}
+
+void test_touch_click_synth__modal_focused_swipe_synthesizes_up_down(void) {
+  s_is_watchface = true;
+  s_modal_focused = true;
+  prv_focus(false);
+
+  prv_swipe(100, 150, 100, 100);       // up
+  prv_assert_single_click(BUTTON_ID_UP);
+
+  s_cap_n = 0;
+  prv_swipe(100, 100, 100, 150);       // down
+  prv_assert_single_click(BUTTON_ID_DOWN);
+}
+
+// The synthesis decision is a live re-check, so it does not depend on the modal
+// having delivered a did_focus event first (its transition may still be
+// animating). With the sensor already on, a tap synthesizes regardless.
+void test_touch_click_synth__recheck_synthesizes_without_focus_event(void) {
+  s_is_watchface = true;
+  s_modal_focused = true;
+  // Deliberately no prv_focus() call: s_state.active is still false.
+
+  prv_tap(120, 140, 80);
+  prv_assert_single_click(BUTTON_ID_SELECT);
+}
+
+// The live re-check also blocks stale synthesis: if focus has already returned
+// to the watchface but the sensor lingers on, no click is synthesized.
+void test_touch_click_synth__recheck_blocks_stale_active_at_watchface(void) {
+  prv_focus(true);         // a watchapp was focused (sensor on)
+  cl_assert(s_sensor_enabled);
+
+  s_is_watchface = true;   // now at the watchface, no focused modal,
+  s_modal_focused = false; // but before the focus event was processed
+
   prv_tap(100, 100, 80);
   cl_assert_equal_i(s_cap_n, 0);
 }

--- a/tests/fw/services/test_touch_click_synth.c
+++ b/tests/fw/services/test_touch_click_synth.c
@@ -149,7 +149,21 @@ void test_touch_click_synth__initialize(void) {
   touch_service_set_globally_enabled(true);
   touch_click_synth_init();
 
+  // No action bar published by default.
+  ActionBarSynthDescriptor no_bar = { 0 };
+  touch_click_synth_set_action_bar(&no_bar);
+
   fake_event_set_callback(prv_capture);
+}
+
+// Publish an action bar occupying the right edge, with the given icon mask.
+static void prv_set_action_bar(int16_t x, int16_t y, int16_t w, int16_t h, uint8_t icon_mask) {
+  ActionBarSynthDescriptor desc = {
+    .present = true,
+    .frame = { .origin = { x, y }, .size = { w, h } },
+    .icon_mask = icon_mask,
+  };
+  touch_click_synth_set_action_bar(&desc);
 }
 
 void test_touch_click_synth__cleanup(void) {
@@ -320,4 +334,80 @@ void test_touch_click_synth__recheck_blocks_stale_active_at_watchface(void) {
 
   prv_tap(100, 100, 80);
   cl_assert_equal_i(s_cap_n, 0);
+}
+
+// --- action bar tap routing -------------------------------------------------
+
+// A right-edge action bar 34px wide, 168px tall, split into three 56px zones:
+// UP [0,56), SELECT [56,112), DOWN [112,168).
+#define AB_X 166
+#define AB_W 34
+#define AB_H 168
+#define AB_MASK_ALL (ACTION_BAR_SYNTH_ICON_UP | ACTION_BAR_SYNTH_ICON_SELECT | \
+                     ACTION_BAR_SYNTH_ICON_DOWN)
+
+void test_touch_click_synth__tap_on_action_bar_up_zone_synthesizes_up(void) {
+  prv_focus(true);
+  prv_set_action_bar(AB_X, 0, AB_W, AB_H, AB_MASK_ALL);
+  prv_tap(180, 20, 80);  // top zone
+  prv_assert_single_click(BUTTON_ID_UP);
+}
+
+void test_touch_click_synth__tap_on_action_bar_select_zone_synthesizes_select(void) {
+  prv_focus(true);
+  prv_set_action_bar(AB_X, 0, AB_W, AB_H, AB_MASK_ALL);
+  prv_tap(180, 84, 80);  // middle zone
+  prv_assert_single_click(BUTTON_ID_SELECT);
+}
+
+void test_touch_click_synth__tap_on_action_bar_down_zone_synthesizes_down(void) {
+  prv_focus(true);
+  prv_set_action_bar(AB_X, 0, AB_W, AB_H, AB_MASK_ALL);
+  prv_tap(180, 150, 80);  // bottom zone
+  prv_assert_single_click(BUTTON_ID_DOWN);
+}
+
+void test_touch_click_synth__tap_left_of_action_bar_synthesizes_select(void) {
+  prv_focus(true);
+  prv_set_action_bar(AB_X, 0, AB_W, AB_H, AB_MASK_ALL);
+  prv_tap(80, 20, 80);  // outside the bar (main content area)
+  prv_assert_single_click(BUTTON_ID_SELECT);
+}
+
+// A zone whose icon is absent falls back to SELECT rather than a dead tap.
+void test_touch_click_synth__tap_on_iconless_zone_falls_back_to_select(void) {
+  prv_focus(true);
+  prv_set_action_bar(AB_X, 0, AB_W, AB_H, ACTION_BAR_SYNTH_ICON_SELECT);  // only SELECT
+  prv_tap(180, 20, 80);  // UP zone, but no UP icon
+  prv_assert_single_click(BUTTON_ID_SELECT);
+}
+
+void test_touch_click_synth__no_action_bar_right_edge_tap_synthesizes_select(void) {
+  prv_focus(true);
+  // No action bar published (initialize cleared it).
+  prv_tap(180, 20, 80);  // right edge, but no bar
+  prv_assert_single_click(BUTTON_ID_SELECT);
+}
+
+// A swipe is unaffected by the action bar: it stays a full-screen UP/DOWN.
+void test_touch_click_synth__swipe_over_action_bar_still_scrolls(void) {
+  prv_focus(true);
+  prv_set_action_bar(AB_X, 0, AB_W, AB_H, AB_MASK_ALL);
+  prv_swipe(180, 150, 180, 100);  // finger up over the bar -> content down
+  prv_assert_single_click(BUTTON_ID_DOWN);
+}
+
+// Leaving the foreground clears the descriptor so it can't route later taps.
+void test_touch_click_synth__deactivation_clears_action_bar(void) {
+  prv_focus(true);
+  prv_set_action_bar(AB_X, 0, AB_W, AB_H, AB_MASK_ALL);
+
+  s_is_watchface = true;
+  prv_focus(false);   // back to the watchface -> bridge deactivates
+
+  // Re-enter a (different) app with no action bar; a right-edge tap is SELECT.
+  s_is_watchface = false;
+  prv_focus(true);
+  prv_tap(180, 20, 80);
+  prv_assert_single_click(BUTTON_ID_SELECT);
 }

--- a/tests/fw/services/wscript_build
+++ b/tests/fw/services/wscript_build
@@ -470,6 +470,11 @@ clar(ctx,
     test_sources_ant_glob = "test_touch.c")
 
 clar(ctx,
+    sources_ant_glob = "src/fw/services/touch/touch.c" \
+        " tests/fakes/fake_events.c",
+    test_sources_ant_glob = "test_touch_click_arbitration.c")
+
+clar(ctx,
     sources_ant_glob = \
         "src/fw/services/hrm/hrm_manager.c " \
         "lib/os/tick.c " \

--- a/tests/fw/services/wscript_build
+++ b/tests/fw/services/wscript_build
@@ -475,6 +475,12 @@ clar(ctx,
     test_sources_ant_glob = "test_touch_click_arbitration.c")
 
 clar(ctx,
+    sources_ant_glob = "src/fw/services/touch/touch.c" \
+        " src/fw/services/touch/touch_click_synth.c" \
+        " tests/fakes/fake_events.c",
+    test_sources_ant_glob = "test_touch_click_synth.c")
+
+clar(ctx,
     sources_ant_glob = \
         "src/fw/services/hrm/hrm_manager.c " \
         "lib/os/tick.c " \


### PR DESCRIPTION
**Depends on: #1784** (touch_service list_node fix — required for correct subscriber-count arbitration).

## What

A kernel-side **touch-to-click synthesis bridge**: it maps touch gestures to the **existing** button semantics of whatever app/modal is focused, so apps that use their own click handlers (rather than ScrollLayer/MenuLayer) respond to touch:

- tap → `SELECT` (or `UP`/`SELECT`/`DOWN` by vertical zone when the tap lands on an `ActionBarLayer`, e.g. the Music app's volume / play-pause bar)
- vertical swipe → `UP` / `DOWN`

## How it differs from #1773 (design note)

Unlike #1773, which changes the **applib** ScrollLayer/MenuLayer widgets that third-party apps link against, this bridge is a **kernel-side input mapping with no applib/ABI change**. It does not modify any widget; it posts the same `PEBBLE_BUTTON_DOWN`/`PEBBLE_BUTTON_UP` events a physical press would, which flow through the normal click path. So it introduces no new per-widget behavior and no SDK surface.

## Gating & arbitration

- **Build-time:** behind `CONFIG_TOUCH_CLICK_SYNTHESIS` (Kconfig, **default n**) — not compiled into default builds.
- **Runtime:** only runs while the global touch service is enabled (persisted `touch_enabled` pref, default on) and the foreground is a non-watchface app or a focused modal.
- **Arbitration:** suppressed when the focused window consumes touch itself (`touch_has_app_subscribers()`), so it never double-handles apps that already use ScrollLayer/MenuLayer touch (#1773) or their own touch subscription.

## Note on third-party apps (re: the #1773 review discussion)

When the Kconfig is enabled, the bridge does map touch onto the **existing** button handlers of the focused app, including third-party apps that have no touch handling of their own — giving them touch as an alternate way to trigger their current button actions (never new behavior, and never for apps that already handle touch). There is no per-app / system-app-only restriction today. If maintainers prefer limiting synthesis to system apps or adding a dedicated runtime toggle, that's a straightforward follow-up and we're happy to add it.

## Testing

Unit tests: `test_touch_click_synth` (23) + `test_touch_click_arbitration`. Verified on-device (Pebble Time 2): tap→SELECT and swipe on Notifications; ActionBar up/select/down taps in Music; no misfires on the watchface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
