### PR TITLE
fw/comm/ble: Add log when ppog can't allocate packet

### DIFF
--- a/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
+++ b/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
@@ -1389,6 +1389,9 @@ static const PPoGATTPacket * prv_prepare_next_reset_packet(const PPoGATTClient *
                                                       uint16_t *payload_size_out) {
   PPoGATTPacket *packet = prv_lazily_allocate_packet_if_needed(client, heap_packet_in_out);
   if (!packet) {
+    PBL_LOG_WRN("Couldn't allocate reset packet: role=%u state=%u type=%u",
+                client->role, client->state,
+                (unsigned) client->out.reset_packet_to_send.type);
     return NULL;
   }
 


### PR DESCRIPTION
Triaging MOB-10077 suggested this as a possibility - add log to know in future.