### PR TITLE
timeline: fix double dot during exit animation on round displays

### DIFF
--- a/src/fw/apps/system/timeline/peek_layer.c
+++ b/src/fw/apps/system/timeline/peek_layer.c
@@ -245,7 +245,10 @@ static void prv_scale_to_did_stop(KinoLayer *kino_layer, bool finished, void *co
   PeekLayer *peek_layer = context;
   GRect icon_to = kino_reel_transform_get_to_frame(
       kino_layer_get_reel(&peek_layer->kino_layer));
-  peek_layer->show_dot = prv_is_dot_size(icon_to.size);
+  // A visible kino layer keeps rendering its end-as-dot frame at the screen center; drawing the
+  // static dot too shows a second dot when the layer origin is offset (e.g. peek_offset_y)
+  peek_layer->show_dot = prv_is_dot_size(icon_to.size) &&
+                         layer_get_hidden((Layer *)&peek_layer->kino_layer);
   kino_layer_set_callbacks(kino_layer, (KinoLayerCallbacks) { 0 }, NULL);
 }
 


### PR DESCRIPTION
On timeline exit the peek icon folds into a dot rendered by the kino reel in global coordinates, landing at the exact screen center. When the fold stops, show_dot is enabled and the peek layer then also draws the static dot, centered in its local bounds. With the Large content size style the peek layer frame is offset by peek_offset_y = -7, so both dots are visible simultaneously ~7 px apart until the compositor transition paints over them.

Only enable the static dot when the kino layer is hidden; while it is visible it already renders its resting end-as-dot frame.

Only reproduces on getafix: the dot animation is round-only and the peek frame offset only applies at PreferredContentSizeLarge (>=200 px displays). Verified before/after on qemu_gabbro with screendump bursts of the timeline exit.

Fixes FIRM-2012
Fixes FIRM-3534