### PR TITLE
drivers/imu: recover stuck INT1 in shake-only mode

### DIFF
--- a/include/pbl/drivers/imu/lis2dw12/lis2dw12.h
+++ b/include/pbl/drivers/imu/lis2dw12/lis2dw12.h
@@ -26,6 +26,7 @@ typedef struct LIS2DW12State {
   uint32_t int1_period_ms;
   uint32_t num_recoveries;
   uint8_t wk_ths_curr;
+  uint8_t shake_stuck_passes;
   AccelDriverSample last_sample;
   bool last_sample_valid;
   bool recovery_pending;

--- a/include/pbl/drivers/imu/lsm6dso/lsm6dso.h
+++ b/include/pbl/drivers/imu/lsm6dso/lsm6dso.h
@@ -32,6 +32,7 @@ typedef struct LSM6DSOState {
   uint32_t int1_period_ms;
   uint32_t num_recoveries;
   uint8_t wk_ths_curr;
+  uint8_t shake_stuck_passes;
   bool recovery_pending;
   bool wu_active;
   bool int1_requeued;

--- a/src/fw/drivers/imu/lis2dw12/lis2dw12.c
+++ b/src/fw/drivers/imu/lis2dw12/lis2dw12.c
@@ -29,12 +29,10 @@ PBL_LOG_MODULE_DEFINE(driver_accel_lis2dw12, CONFIG_DRIVER_IMU_LOG_LEVEL);
 //   adjusted automatically when ODR changes (we just have 2 bits...), so it is
 //   possible to notice sensitivity changes when changing sampling interval.
 // - INT1 mixes level (FIFO threshold) and latched (wake-up) sources on a
-//   rising-edge EXTI, and FIFO overruns sometimes leave the pad latched HIGH
-//   (needs more investigation), so edges can be lost. The work handler
-//   re-checks the pad level after servicing, and a watchdog timer recovers
-//   the stream if no FIFO samples have been read within the expected time
-//   window (FIFO reads are tracked instead of INT1 edges, which shake events
-//   would keep feeding).
+//   rising-edge EXTI, so a pad latched HIGH yields no further edges: shake
+//   events die and the pending interrupt blocks deep sleep. The work handler
+//   re-checks the pad after servicing; a watchdog recovers the stream (FIFO
+//   cadence while sampling, fixed-rate pad poll in shake-only mode).
 
 // Time to wait after reset (us)
 #define LIS2DW12_RESET_TIME_US 5
@@ -47,6 +45,12 @@ PBL_LOG_MODULE_DEFINE(driver_accel_lis2dw12, CONFIG_DRIVER_IMU_LOG_LEVEL);
 // stalled (>1x to tolerate scheduling jitter), and threshold lower bound
 #define LIS2DW12_STALL_MARGIN 2U
 #define LIS2DW12_STALL_MIN_MS 1000U
+
+// INT1 watchdog poll rate in shake-only mode (no FIFO cadence to track)
+#define LIS2DW12_SHAKE_WDT_PERIOD_S 5U
+
+// Consecutive stuck-high watchdog passes before a full stream recovery
+#define LIS2DW12_SHAKE_STUCK_PASSES_MAX 3U
 
 // Scale range when in 12-bit mode (low-power mode 1)
 #define LIS2DW12_S12_SCALE_RANGE (1U << (12U - 1U))
@@ -401,6 +405,8 @@ static void prv_lis2dw12_int1_work_handler(void) {
 static void prv_lis2dw12_int1_irq_handler(bool *should_context_switch) {
   // A rising edge proves the pad was low, i.e. the wake-up source deasserted
   LIS2DW12->state->wu_active = false;
+  // ... which also breaks any stuck-high streak the watchdog counted
+  LIS2DW12->state->shake_stuck_passes = 0U;
   accel_offload_work_from_isr(prv_lis2dw12_int1_work_handler, should_context_switch);
 }
 
@@ -552,6 +558,25 @@ static uint32_t prv_stall_threshold_ms(void) {
              LIS2DW12_STALL_MIN_MS);
 }
 
+//! Arm/disarm the INT1 stall watchdog to match the active INT1 sources.
+//! Call after num_samples or shake_detection_enabled changes.
+static void prv_update_int1_watchdog(void) {
+  regular_timer_remove_callback(&LIS2DW12->state->int1_wdt_timer);
+  LIS2DW12->state->shake_stuck_passes = 0U;
+
+  if (LIS2DW12->state->num_samples > 0U) {
+    LIS2DW12->state->last_fifo_read_tick = rtc_get_ticks();
+    LIS2DW12->state->int1_period_ms =
+        (LIS2DW12->state->sampling_interval_us * LIS2DW12->state->num_samples) / 1000;
+    regular_timer_add_multisecond_callback(
+        &LIS2DW12->state->int1_wdt_timer,
+        MAX(DIVIDE_CEIL(LIS2DW12->state->int1_period_ms, 1000UL), 1U));
+  } else if (LIS2DW12->state->shake_detection_enabled) {
+    regular_timer_add_multisecond_callback(&LIS2DW12->state->int1_wdt_timer,
+                                           LIS2DW12_SHAKE_WDT_PERIOD_S);
+  }
+}
+
 //! Shared by the INT1 watchdog and the accel_peek staleness trigger;
 //! re-validates the stall at execution time.
 static void prv_stall_check_work_cb(void) {
@@ -561,6 +586,24 @@ static void prv_stall_check_work_cb(void) {
 
   // Sampling may have stopped between scheduling and execution
   if (LIS2DW12->state->num_samples == 0U) {
+    // Shake-only mode: re-run the servicing pass if the pad is stuck high
+    // (reading the INT source clears the latch); escalate to a full recovery
+    // after consecutive passes that never release it.
+    if (LIS2DW12->state->shake_detection_enabled &&
+        gpio_input_read(&LIS2DW12->int1_in)) {
+      prv_lis2dw12_int1_work_handler();
+      // A pad released by the pass is healthy; count only a still-high pad
+      if (!gpio_input_read(&LIS2DW12->int1_in)) {
+        LIS2DW12->state->shake_stuck_passes = 0U;
+      } else if (++LIS2DW12->state->shake_stuck_passes >= LIS2DW12_SHAKE_STUCK_PASSES_MAX) {
+        PBL_LOG_WRN("INT1 pad stuck high for %" PRIu8 " shake watchdog passes, recovering",
+                    LIS2DW12->state->shake_stuck_passes);
+        prv_lis2dw12_recover();
+        LIS2DW12->state->shake_stuck_passes = 0U;
+      }
+    } else {
+      LIS2DW12->state->shake_stuck_passes = 0U;
+    }
     return;
   }
 
@@ -698,8 +741,15 @@ uint32_t accel_set_sampling_interval(uint32_t interval_us) {
     // FIXME: we should technically stop and drain the FIFO here, otherwise
     // we may report existing samples in the FIFO buffer with an incorrect timestamp
 
+    const uint32_t prev_interval_us = LIS2DW12->state->sampling_interval_us;
     if (!prv_configure_odr(interval_us, LIS2DW12->state->shake_detection_enabled)) {
       PBL_LOG_ERR("Could not configure ODR");
+    }
+
+    // Re-arm the watchdog only on an actual ODR change (a re-arm resets the
+    // stall tracking, so repeat calls must not defer it)
+    if (LIS2DW12->state->sampling_interval_us != prev_interval_us) {
+      prv_update_int1_watchdog();
     }
   }
 
@@ -747,8 +797,6 @@ void accel_set_num_samples(uint32_t num_samples) {
     if (!prv_lis2dw12_write(LIS2DW12_FIFO_CTRL, &val, 1)) {
       PBL_LOG_ERR("Could not write FIFO_CTRL register");
     }
-
-    regular_timer_remove_callback(&LIS2DW12->state->int1_wdt_timer);
   } else {
     // Configure FIFO in CONT mode with threshold
     ret = prv_lis2dw12_enable_fifo((uint8_t)num_samples);
@@ -758,10 +806,6 @@ void accel_set_num_samples(uint32_t num_samples) {
     }
 
     LIS2DW12->state->last_sample_valid = false;
-    LIS2DW12->state->last_fifo_read_tick = rtc_get_ticks();
-    LIS2DW12->state->int1_period_ms = (LIS2DW12->state->sampling_interval_us * num_samples) / 1000;
-    regular_timer_add_multisecond_callback(&LIS2DW12->state->int1_wdt_timer,
-                                           DIVIDE_CEIL(LIS2DW12->state->int1_period_ms, 1000UL));
   }
 
   // Re-configure INT1
@@ -772,6 +816,8 @@ void accel_set_num_samples(uint32_t num_samples) {
   }
 
   LIS2DW12->state->num_samples = num_samples;
+  // Arm/disarm the INT1 liveness watchdog for the new source configuration
+  prv_update_int1_watchdog();
 
   PBL_LOG_DBG("Set number of samples to %" PRIu32, num_samples);
 }
@@ -912,6 +958,8 @@ void accel_enable_shake_detection(bool on) {
 
   LIS2DW12->state->shake_detection_enabled = on;
   LIS2DW12->state->wu_active = false;
+  // Arm/disarm the INT1 liveness watchdog now that shake routing changed
+  prv_update_int1_watchdog();
 
   PBL_LOG_DBG("%s shake detection", on ? "Enabled" : "Disabled");
 }

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -33,11 +33,10 @@ PBL_LOG_MODULE_DEFINE(driver_accel_lsm6dso, CONFIG_DRIVER_IMU_LOG_LEVEL);
 //   adjusted automatically when ODR changes, so it is possible to notice
 //   sensitivity changes when changing sampling interval.
 // - INT1 mixes level (FIFO threshold) and latched (wake-up) sources on a
-//   rising-edge EXTI, and (like the LIS2DW12) FIFO overruns can leave the pad
-//   latched HIGH, so edges can be lost. The work handler re-checks the pad
-//   level after servicing, and a watchdog timer recovers the stream if no
-//   FIFO samples have been read within the expected time window (FIFO reads
-//   are tracked instead of INT1 edges, which shake events would keep feeding).
+//   rising-edge EXTI, so a pad latched HIGH yields no further edges: shake
+//   events die and the pending interrupt blocks deep sleep. The work handler
+//   re-checks the pad after servicing; a watchdog recovers the stream (FIFO
+//   cadence while sampling, fixed-rate pad poll in shake-only mode).
 
 // Time to wait after reset (us)
 #define LSM6DSO_RESET_TIME_US 5
@@ -50,6 +49,12 @@ PBL_LOG_MODULE_DEFINE(driver_accel_lsm6dso, CONFIG_DRIVER_IMU_LOG_LEVEL);
 // stalled (>1x to tolerate scheduling jitter), and threshold lower bound
 #define LSM6DSO_STALL_MARGIN 2U
 #define LSM6DSO_STALL_MIN_MS 1000U
+
+// INT1 watchdog poll rate in shake-only mode (no FIFO cadence to track)
+#define LSM6DSO_SHAKE_WDT_PERIOD_S 5U
+
+// Consecutive stuck-high watchdog passes before a full stream recovery
+#define LSM6DSO_SHAKE_STUCK_PASSES_MAX 3U
 
 // Scale range for 16-bit two's complement samples
 #define LSM6DSO_S16_SCALE_RANGE (1U << (16U - 1U))
@@ -502,6 +507,8 @@ static void prv_lsm6dso_int1_work_handler(void) {
 static void prv_lsm6dso_int1_irq_handler(bool *should_context_switch) {
   // A rising edge proves the pad was low, i.e. the wake-up source deasserted
   LSM6DSO->state->wu_active = false;
+  // ... which also breaks any stuck-high streak the watchdog counted
+  LSM6DSO->state->shake_stuck_passes = 0U;
   accel_offload_work_from_isr(prv_lsm6dso_int1_work_handler, should_context_switch);
 }
 
@@ -658,6 +665,25 @@ static uint32_t prv_stall_threshold_ms(void) {
              LSM6DSO_STALL_MIN_MS);
 }
 
+//! Arm/disarm the INT1 stall watchdog to match the active INT1 sources.
+//! Call after num_samples or shake_detection_enabled changes.
+static void prv_update_int1_watchdog(void) {
+  regular_timer_remove_callback(&LSM6DSO->state->int1_wdt_timer);
+  LSM6DSO->state->shake_stuck_passes = 0U;
+
+  if (LSM6DSO->state->num_samples > 0U) {
+    LSM6DSO->state->last_fifo_read_tick = rtc_get_ticks();
+    LSM6DSO->state->int1_period_ms =
+        (LSM6DSO->state->sampling_interval_us * LSM6DSO->state->num_samples) / 1000;
+    regular_timer_add_multisecond_callback(
+        &LSM6DSO->state->int1_wdt_timer,
+        MAX(DIVIDE_CEIL(LSM6DSO->state->int1_period_ms, 1000UL), 1U));
+  } else if (LSM6DSO->state->shake_detection_enabled) {
+    regular_timer_add_multisecond_callback(&LSM6DSO->state->int1_wdt_timer,
+                                           LSM6DSO_SHAKE_WDT_PERIOD_S);
+  }
+}
+
 //! Shared by the INT1 watchdog and the accel_peek staleness trigger;
 //! re-validates the stall at execution time.
 static void prv_stall_check_work_cb(void) {
@@ -667,6 +693,24 @@ static void prv_stall_check_work_cb(void) {
 
   // Sampling may have stopped between scheduling and execution
   if (LSM6DSO->state->num_samples == 0U) {
+    // Shake-only mode: re-run the servicing pass if the pad is stuck high
+    // (reading the INT source clears the latch); escalate to a full recovery
+    // after consecutive passes that never release it.
+    if (LSM6DSO->state->shake_detection_enabled &&
+        gpio_input_read(&LSM6DSO->int1_in)) {
+      prv_lsm6dso_int1_work_handler();
+      // A pad released by the pass is healthy; count only a still-high pad
+      if (!gpio_input_read(&LSM6DSO->int1_in)) {
+        LSM6DSO->state->shake_stuck_passes = 0U;
+      } else if (++LSM6DSO->state->shake_stuck_passes >= LSM6DSO_SHAKE_STUCK_PASSES_MAX) {
+        PBL_LOG_WRN("INT1 pad stuck high for %" PRIu8 " shake watchdog passes, recovering",
+                    LSM6DSO->state->shake_stuck_passes);
+        prv_lsm6dso_recover();
+        LSM6DSO->state->shake_stuck_passes = 0U;
+      }
+    } else {
+      LSM6DSO->state->shake_stuck_passes = 0U;
+    }
     return;
   }
 
@@ -795,8 +839,15 @@ uint32_t accel_set_sampling_interval(uint32_t interval_us) {
     // FIXME: we should technically stop and drain the FIFO here, otherwise
     // we may report existing samples in the FIFO buffer with an incorrect timestamp
 
+    const uint32_t prev_interval_us = LSM6DSO->state->sampling_interval_us;
     if (!prv_configure_odr(interval_us, LSM6DSO->state->shake_detection_enabled)) {
       PBL_LOG_ERR("Could not configure ODR");
+    }
+
+    // Re-arm the watchdog only on an actual ODR change (a re-arm resets the
+    // stall tracking, so repeat calls must not defer it)
+    if (LSM6DSO->state->sampling_interval_us != prev_interval_us) {
+      prv_update_int1_watchdog();
     }
   }
 
@@ -844,8 +895,6 @@ void accel_set_num_samples(uint32_t num_samples) {
     if (!prv_lsm6dso_write(LSM6DSO_FIFO_CTRL4, &val, 1)) {
       PBL_LOG_ERR("Could not write FIFO_CTRL4 register");
     }
-
-    regular_timer_remove_callback(&LSM6DSO->state->int1_wdt_timer);
   } else {
     // Configure FIFO in continuous mode with threshold
     ret = prv_lsm6dso_enable_fifo((uint16_t)num_samples);
@@ -853,11 +902,6 @@ void accel_set_num_samples(uint32_t num_samples) {
       PBL_LOG_ERR("Could not enable FIFO");
       return;
     }
-
-    LSM6DSO->state->last_fifo_read_tick = rtc_get_ticks();
-    LSM6DSO->state->int1_period_ms = (LSM6DSO->state->sampling_interval_us * num_samples) / 1000;
-    regular_timer_add_multisecond_callback(&LSM6DSO->state->int1_wdt_timer,
-                                           DIVIDE_CEIL(LSM6DSO->state->int1_period_ms, 1000UL));
   }
 
   // Re-configure INT1
@@ -868,6 +912,8 @@ void accel_set_num_samples(uint32_t num_samples) {
   }
 
   LSM6DSO->state->num_samples = num_samples;
+  // Arm/disarm the INT1 liveness watchdog for the new source configuration
+  prv_update_int1_watchdog();
 
   PBL_LOG_DBG("Set number of samples to %" PRIu32, num_samples);
 }
@@ -994,6 +1040,8 @@ void accel_enable_shake_detection(bool on) {
 
   LSM6DSO->state->shake_detection_enabled = on;
   LSM6DSO->state->wu_active = false;
+  // Arm/disarm the INT1 liveness watchdog now that shake routing changed
+  prv_update_int1_watchdog();
 
   PBL_LOG_DBG("%s shake detection", on ? "Enabled" : "Disabled");
 }


### PR DESCRIPTION
## Summary

Safety net for a rare-but-still-occurring INT1 wedge in **shake-detection-only mode** (no FIFO sampling — e.g. health tracking off). The v4.26.0 fixes (stale-WU_IA clear before shake enable, INT1 pad re-check after servicing, FIFO stall watchdog) closed the main wedge *entry* paths and reduced field occurrence ~7×. But once the pad does latch HIGH in shake-only mode, there is still **no recovery path**: the stall watchdog is only armed while FIFO sampling is active (`num_samples > 0`), and the pad re-check only runs when an edge fires — which a latched-high pad never produces again. Shake events die and the pending interrupt blocks deep sleep until a reboot or the 4% low-power runlevel happens to power-cycle the accelerometer.

## Field evidence

**Pre-v4.26 (epidemic, both drivers):** fleet query for the wedge signature (shake=0, peek≥100, cpu_running>1.5%, sleep2<95%, discharging, ≥2%/hr) shows ~9,700 stuck hours across ~600 devices on v4.9–v4.23 (v4.23.0 alone: 1465 hrs / 80 devices / 3.64M device-hours). Obelix `C111131100UV` logged 12 episodes at ~21× idle drain (0.15 → 3.2 %/hr), each ending only at the 4% low-power runlevel — which disables the accel manager as a side effect (`enable_mask` omits `R_LowPower`), accidentally performing the same quiesce/re-assert that `prv_*_recover()` does. Episodes span the obelix LIS2DW12→LSM6DSO driver switch (v4.17), confirming the shared design gap rather than a chip errata.

**Post-v4.26 (residual):** v4.26–v4.29: no wedges observed (5.7k device-hours). v4.30.0: obelix `C111131102WG` wedged 2026-07-23 13:02 with all v4.26 fixes present — shake dead, peek pinned ~111/hr, 1.5–2.9 %/hr drain, sleep2 91%, for 7+ hours until the v4.30.1 upgrade **reboot** cleared it (1 device / 1366 on that release, health off = shake-only mode). Nothing in current code could have recovered it.

## The fix (mirrored in LSM6DSO + LIS2DW12)

- `prv_update_int1_watchdog()`: single place that arms the stall watchdog — FIFO watermark cadence while sampling, **fixed 5s pad poll in shake-only mode** (new), disarmed when INT1 has no source. Called from `accel_set_num_samples`, `accel_enable_shake_detection`, and `accel_set_sampling_interval` (the last also fixes a stale-cadence corner when ODR changes mid-sampling).
- Shake-only stall check: pad high → re-run the INT1 servicing pass (reading the INT source clears the latch and releases the pad, dispatching any real shake; recovers directly when nothing was serviced). A source that re-reads asserted on every pass escalates to full `prv_*_recover()` after **3 consecutive stuck passes**; the counter resets on any genuine INT1 edge, a low pad, or rearm.

Cost when healthy: one GPIO read every 5s, only while idle in shake-only mode.

## Open question

During the wedge, `accel_peek_count` roughly doubles (60/hr baseline — the stationary service's 1-min check — to 110–124/hr). The extra ~1/min peek source isn't obvious from current callers (stationary, applib, debug console); input welcome — it may point at an additional symptom or cause.

## Verification

- `obelix@pvt` and `getafix@dvt2` build clean (both drivers compile + link)
- `qemu_emery` boots to watchface in QEMU
- codex review, 2 rounds — all findings addressed (WU_IA re-assert loophole → 3-pass escalation; IRQ-edge counter reset; sampling-interval rearm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)