### PR TITLE
gitlint: allow 100-column commit message bodies

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -11,3 +11,6 @@ regex=[a-z0-9/]+: .*
 
 [title-max-length]
 line-length=100
+
+[body-max-line-length]
+line-length=100


### PR DESCRIPTION
The commit title limit is already 100 columns (`[title-max-length]`), but the body has no `[body-max-line-length]` override, so it falls back to gitlint's default 80-column B1 rule.

That default rejects trailers that cannot be shortened — a `Co-authored-by:` line with a `…@users.noreply.github.com` email is 84 columns — and forces awkward wrapping of body prose. This raises the body line limit to 100 to match the title.
