### PR TITLE
docs: add binary format and protocol reference pages

### DIFF
--- a/docs/development/sdk_export.md
+++ b/docs/development/sdk_export.md
@@ -97,3 +97,8 @@ Notes:
 - The generator errors out on exports it cannot find in the parsed headers
   and on inconsistent revision numbers, but it does not verify that the
   resulting `pebble.h` compiles — review its output.
+- The comment ledger above `PROCESS_INFO_CURRENT_SDK_VERSION_MINOR` is the
+  only mapping between SDK revisions and version minors: no formula relates
+  them (the minor once jumped `0x19` → `0x20` between revs 35 and 36, and a
+  few minors and revs are skipped or doubled up). Treat the ledger as
+  append-only history.

--- a/docs/reference/blob-db.md
+++ b/docs/reference/blob-db.md
@@ -1,0 +1,69 @@
+# BlobDB endpoint
+
+BlobDB is the key-value store the phone uses to push data to the watch
+(notifications, timeline pins, app metadata, weather, settings, …). Two
+Pebble Protocol endpoints speak it: `0xb1db` for phone-initiated writes
+(`src/fw/services/blob_db/endpoint.c`) and `0xb2db` for watch-initiated
+sync (`src/fw/services/blob_db/endpoint2.c`). Command opcodes and
+response codes are in `include/pbl/services/blob_db/endpoint_private.h`,
+database ids in `include/pbl/services/blob_db/api.h`. All multi-byte
+fields are little-endian.
+
+## Commands (endpoint `0xb1db`)
+
+Every message starts with a `uint8_t` command and a `uint16_t` token the
+watch echoes in its response. Keys and values are length-prefixed:
+`uint8_t key_size` + key bytes, `uint16_t value_size` + value bytes.
+
+| Command               | Opcode | Body after token                              |
+| --------------------- | ------ | --------------------------------------------- |
+| INSERT                | `0x01` | database id (`uint8_t`), key, value           |
+| DELETE                | `0x04` | database id, key                              |
+| CLEAR                 | `0x05` | database id — drops all entries               |
+| INSERT_WITH_TIMESTAMP | `0x0D` | database id, `uint32_t` timestamp, key, value |
+
+`0x02` (READ) and `0x03` (UPDATE) are defined but not implemented.
+INSERT_WITH_TIMESTAMP is for conflict resolution: if the watch's copy is
+newer, it answers DATA_STALE and the phone should re-sync. The timestamp
+is currently only honored for the Settings database; other databases
+treat it as a plain INSERT.
+
+The watch responds to every command with `uint16_t token` +
+`uint8_t response code`:
+
+| Code   | Meaning                                       |
+| ------ | --------------------------------------------- |
+| `0x01` | SUCCESS                                       |
+| `0x02` | GENERAL_FAILURE                               |
+| `0x03` | INVALID_OPERATION                             |
+| `0x04` | INVALID_DATABASE_ID                           |
+| `0x05` | INVALID_DATA                                  |
+| `0x06` | KEY_DOES_NOT_EXIST                            |
+| `0x07` | DATABASE_FULL                                 |
+| `0x08` | DATA_STALE                                    |
+| `0x09` | DB_NOT_SUPPORTED                              |
+| `0x0A` | DB_LOCKED                                     |
+| `0x0B` | TRY_LATER (endpoint not accepting writes yet) |
+
+## Sync commands (endpoint `0xb2db`)
+
+Opcodes `0x06`–`0x0C` (DIRTY_DBS, START_SYNC, WRITE, WRITEBACK,
+SYNC_DONE, VERSION, DIRTY_ALL) implement watch→phone writeback of dirty
+records; responses to these set bit 7 of the opcode. VERSION reports the
+protocol version (currently 1). Message layouts are the packed structs
+in `endpoint2.c`.
+
+## Database ids
+
+| Id     | Database     | Id     | Database      |
+| ------ | ------------ | ------ | ------------- |
+| `0x00` | Test         | `0x07` | Prefs         |
+| `0x01` | Pins         | `0x08` | Contacts      |
+| `0x02` | Apps         | `0x09` | WatchAppPrefs |
+| `0x03` | Reminders    | `0x0A` | Health        |
+| `0x04` | Notifs       | `0x0B` | AppGlance     |
+| `0x05` | Weather      | `0x0C` | Settings      |
+| `0x06` | iOSNotifPref |        |               |
+
+New databases register a `BlobDBId` and an entry in `s_blob_dbs` in
+`src/fw/services/blob_db/api.c`.

--- a/docs/reference/formats/font.md
+++ b/docs/reference/formats/font.md
@@ -1,0 +1,92 @@
+# Font resources (PBF)
+
+Fonts ship in firmware resources as binary PBF files, generated from TTF
+input by `tools/font/fontgen.py` and parsed at runtime by
+`src/fw/applib/graphics/text_resources.c`. The on-disk structs live in
+`src/fw/applib/fonts/fonts_private.h` and
+`src/fw/applib/graphics/text_resources.h`; `tools/font/` also contains
+standalone readers (`dump_font.py`, `pbf_extract.py`, `pbf_repack.py`).
+
+A PBF file is four consecutive sections, all multi-byte fields
+little-endian:
+
+1. `FontInfo` header
+2. hash table
+3. offset tables
+4. glyph table
+
+## FontInfo header
+
+"FontInfo" is the generator's name for the on-disk header; the firmware
+calls the struct `FontMetaDataV3` (`FontInfo` in `fonts_private.h` is an
+unrelated runtime struct).
+
+| Field                | Type       | Since | Notes                                          |
+| -------------------- | ---------- | ----- | ---------------------------------------------- |
+| `version`            | `uint8_t`  | v1    | 1, 2 or 3                                      |
+| `max_height`         | `uint8_t`  | v1    | tallest glyph in the font                      |
+| `number_of_glyphs`   | `uint16_t` | v1    |                                                |
+| `wildcard_codepoint` | `uint16_t` | v1    | rendered for missing glyphs; default U+25AF    |
+| `hash_table_size`    | `uint8_t`  | v2    | bucket count; the generator always writes 255  |
+| `codepoint_bytes`    | `uint8_t`  | v2    | 2, or 4 if any codepoint exceeds U+FFFF        |
+| `size`               | `uint8_t`  | v3    | size of this header (10), for future extension |
+| `features`           | `uint8_t`  | v3    | see below                                      |
+
+`features` bits (`FEATURE_OFFSET_16` / `FEATURE_RLE4` in
+`fonts_private.h`):
+
+- bit 0: glyph-table offsets are `uint16_t` if set, `uint32_t` if clear.
+  The generator sets it when the glyph table fits in 64 KiB.
+- bit 1: glyph bitmaps are RLE4-compressed if set, plain bitmaps if clear.
+- bits 2–7: reserved.
+
+## Hash table
+
+`hash_table_size` entries of 4 bytes each (`FontHashTableEntry`):
+`uint8_t hash`, `uint8_t count`, `uint16_t offset`. A codepoint hashes to
+bucket `codepoint % hash_table_size`; `offset` is the byte offset of the
+bucket's entries within the offset-tables section, and `count` is the
+number of entries there (collisions are chained contiguously, at most 128
+entries per bucket).
+
+## Offset tables
+
+Each bucket is a run of `{codepoint, glyph_offset}` entries, sorted by
+codepoint so the firmware can binary-search. Field widths vary per file:
+codepoints are 2 or 4 bytes (`codepoint_bytes`), glyph offsets 2 or 4
+bytes (`features` bit 0), giving entry sizes of 4–8 bytes
+(`OffsetTableEntry_2_2` … `_4_4` in `text_resources.h`).
+
+## Glyph table
+
+The table begins with one 32-bit zero word, so offset 0 means "glyph not
+present". Offsets are byte offsets from the start of the glyph table
+(version 1 counted 32-bit words instead). Glyphs are deduplicated: several
+codepoints may share one glyph offset.
+
+Each glyph is a packed 5-byte header (`GlyphHeaderData`) followed
+immediately by bitmap data:
+
+| Field           | Type      |
+| --------------- | --------- |
+| `width`         | `uint8_t` |
+| `height`        | `uint8_t` |
+| `left_offset`   | `int8_t`  |
+| `top_offset`    | `int8_t`  |
+| `horiz_advance` | `int8_t`  |
+
+With RLE4 enabled, the `height` byte instead stores the number of RLE
+units (the decoder recovers the height from the decompressed size).
+Version 1 used a different 8-byte header (`GlyphHeaderDataV1`).
+
+Bitmap data is 1 bit per pixel: rows are concatenated unaligned into one
+continuous bit stream, packed LSB-first into 32-bit words and zero-padded
+to a multiple of 4 bytes.
+
+RLE4 compression is a stream of 4-bit units, two per byte (low nibble
+first): each unit is `[symbol:1][length:3]`, emitting `length + 1`
+(1–8) copies of the symbol bit. An odd number of units is padded with a
+`(0,1)` unit, and the stream is zero-padded to a multiple of 4 bytes. The
+firmware decompresses in place in the glyph cache; the generator verifies
+at build time that every glyph is in-place decodable. The decoder-side
+description lives in `text_resources.c`.

--- a/docs/reference/formats/pbi.md
+++ b/docs/reference/formats/pbi.md
@@ -1,0 +1,52 @@
+# Bitmap resources (PBI)
+
+PBI is the raw bitmap format used for image resources and `GBitmap` data.
+The authoritative description is the Doxygen block in
+`src/fw/applib/graphics/gbitmap_pbi.h`; files are produced by
+`tools/bitmapgen.py` (shipped in the app SDK) and loaded by
+`gbitmap_init_with_data()` in `src/fw/applib/graphics/gbitmap.c`. The
+`info_flags` bit layout is `BitmapInfo` in
+`src/fw/applib/graphics/gtypes.h`.
+
+A PBI file is a 12-byte header, then pixel data, then (for palettized
+formats) the palette. All multi-byte fields are little-endian:
+
+| Offset | Field            | Type       | Notes                                  |
+| ------ | ---------------- | ---------- | -------------------------------------- |
+| 0      | `row_size_bytes` | `uint16_t` | row stride                             |
+| 2      | `info_flags`     | `uint16_t` | see below                              |
+| 4      | origin           | 4 bytes    | legacy; ignored by the firmware        |
+| 8      | `width`          | `uint16_t` |                                        |
+| 10     | `height`         | `uint16_t` |                                        |
+| 12     | pixel data       |            | `row_size_bytes × height` bytes        |
+| …      | palette          |            | ARGB8 entries; palettized formats only |
+
+`info_flags`:
+
+- bit 0: heap-allocated flag; always 0 in files
+- bits 1–3: pixel format (below)
+- bit 4: palette-heap-allocated flag; always 0 in files
+- bits 5–11: reserved
+- bits 12–15: file version, currently 1 (version 0 files are 2.x-era
+  1-bit bitmaps without a format field)
+
+## Pixel formats
+
+| Value | Format                     | Bits/pixel | Row stride                              |
+| ----- | -------------------------- | ---------- | --------------------------------------- |
+| 0     | `GBitmapFormat1Bit`        | 1          | word-aligned: `((width + 31) / 32) × 4` |
+| 1     | `GBitmapFormat8Bit`        | 8          | `width`                                 |
+| 2     | `GBitmapFormat1BitPalette` | 1          | byte-aligned: `ceil(width / 8)`         |
+| 3     | `GBitmapFormat2BitPalette` | 2          | byte-aligned: `ceil(width / 4)`         |
+| 4     | `GBitmapFormat4BitPalette` | 4          | byte-aligned: `ceil(width / 2)`         |
+
+(`GBitmapFormat8BitCircular` exists in the firmware for the round
+framebuffer but never appears in PBI files.)
+
+- **1Bit**: 1 = white, 0 = black; pixels packed LSB-first within each
+  32-bit word; padding bits are ignored.
+- **8Bit**: one `GColor8` (ARGB8, 2 bits per channel) byte per pixel.
+- **Palettized**: pixels are palette indices, packed MSB-first within
+  each byte. The palette follows the pixel data and holds exactly
+  2^bpp ARGB8 entries (2, 4 or 16); the SDK tooling reduces images to
+  the smallest bit depth that covers the colors used.

--- a/docs/reference/formats/pdc.md
+++ b/docs/reference/formats/pdc.md
@@ -1,0 +1,52 @@
+# Draw commands (PDC)
+
+Pebble Draw Commands are the vector-graphics format behind
+`GDrawCommand`: an image (`.pdc` / PDCI) or animation sequence (PDCS) of
+stroke/fill commands rendered at runtime. The packed structs and file
+magics are defined in `src/fw/applib/graphics/gdraw_command_private.h`;
+files are generated from SVG or JSON by `tools/generate_pdcs/` (the
+serializers and format docstring live in
+`tools/generate_pdcs/pebble_commands.py`), and `tools/pdc2png` renders
+them back to PNG. All multi-byte fields are little-endian.
+
+## Draw command
+
+| Field          | Type              | Notes                                                |
+| -------------- | ----------------- | ---------------------------------------------------- |
+| type           | `uint8_t`         | 1 = path, 2 = circle, 3 = precise path (0 = invalid) |
+| flags          | `uint8_t`         | bit 0: hidden; bits 1–7 reserved                     |
+| stroke color   | `uint8_t`         | ARGB8                                                |
+| stroke width   | `uint8_t`         |                                                      |
+| fill color     | `uint8_t`         | ARGB8                                                |
+| path: open     | `uint8_t` ×2      | 1 = open path, 0 = closed; second byte unused        |
+| circle: radius | `uint16_t`        | (shares the two bytes above)                         |
+| num_points     | `uint16_t`        | 1 for circles                                        |
+| points         | `int16_t` ×2 each | x, y per point                                       |
+
+Path points are whole pixels; precise-path points are 13.3 fixed-point
+(eighths of a pixel). A command list is a `uint16_t` command count
+followed by that many commands.
+
+## File containers
+
+**PDCI (image)**:
+
+| Field                  | Type                    |
+| ---------------------- | ----------------------- |
+| magic                  | `"PDCI"`                |
+| payload size           | `uint32_t`              |
+| version                | `uint8_t` (currently 1) |
+| reserved               | `uint8_t`               |
+| view-box width, height | `int16_t` ×2            |
+| command list           |                         |
+
+**PDCS (sequence)** replaces the command list with animation frames:
+
+| Field                       | Type                                          |
+| --------------------------- | --------------------------------------------- |
+| magic                       | `"PDCS"`                                      |
+| payload size                | `uint32_t`                                    |
+| version, reserved, view-box | as PDCI                                       |
+| play count                  | `uint16_t`                                    |
+| frame count                 | `uint16_t`                                    |
+| frames                      | `uint16_t` duration (ms) + command list, each |

--- a/docs/reference/formats/sle.md
+++ b/docs/reference/formats/sle.md
@@ -1,0 +1,27 @@
+# Sparse length encoding (SLE)
+
+SLE is a small run-length encoding tuned for binary blobs that mix long
+zero runs with otherwise incompressible data. The encoder is
+`tools/waf/sparse_length_encoding.py` (used by the `binary_header` waf
+feature in `tools/waf/binary_header.py` to embed compressed blobs as C
+arrays); the firmware-side decoder is `src/fw/util/sle.c`.
+
+The encoded stream is:
+
+- **1 header byte**: the escape byte, chosen by the encoder as a
+  least-frequent byte of the input (never `0x00`).
+- **Literal bytes**, copied through verbatim, until an escape byte
+  starts a 2–3 byte sequence:
+  - `ESC 0x00` — end of stream
+  - `ESC 0x01` — one literal escape byte
+  - `ESC b` (`0x02 ≤ b ≤ 0x7f`) — a run of `b` zero bytes (2–127)
+  - `ESC b c` (`b ≥ 0x80`) — a run of `((b & 0x7f) << 8 | c) + 0x80`
+    zero bytes (128–32895); longer runs are split
+
+A single isolated zero byte is emitted literally (a run of 1 cannot be
+encoded). Minimum overhead is 3 bytes: header plus end-of-stream.
+
+Both the encoder and the C decoder are currently dormant: the last
+in-tree user (compressed FPGA bitstreams for the Spalding board) was
+removed with the Spalding boards, and only the unit tests exercise them
+today.

--- a/docs/reference/formats/timezone.md
+++ b/docs/reference/formats/timezone.md
@@ -1,0 +1,53 @@
+# Timezone database
+
+The firmware's timezone list is a binary resource
+(`RESOURCE_ID_TIMEZONE_DATABASE`) built from an IANA tzdata snapshot
+(`resources/normal/base/tzdata/timezones_olson.txt`) by
+`tools/timezones.py`, wired into the resource build by
+`tools/waf/generate_timezone_data.py`. It is read by
+`src/fw/services/timezone_database/service.c`; the DST-rule struct is
+`TimezoneDSTRule` in `include/pbl/services/timezone_database.h`.
+
+Layout (little-endian): a 6-byte header, then region records, DST rules
+and link records.
+
+## Header
+
+`uint16_t region_count`, `uint16_t dst_rule_count`, `uint16_t link_count`.
+
+## Region records — 24 bytes each
+
+| Field           | Size | Notes                                                                                                            |
+| --------------- | ---- | ---------------------------------------------------------------------------------------------------------------- |
+| continent index | 1    | into a fixed 10-entry list: Africa, America, Antarctica, Asia, Atlantic, Australia, Europe, Indian, Pacific, Etc |
+| city name       | 15   | NUL-padded; full name is `continent/city`                                                                        |
+| GMT offset      | 2    | `int16_t`, minutes                                                                                               |
+| tz abbreviation | 5    | NUL-padded; may contain `*` as a `%s` placeholder for the D/S letter                                             |
+| DST rule id     | 1    | 0 = no DST                                                                                                       |
+
+## DST rules — 16 bytes per id
+
+Each DST id owns a pair of 8-byte `TimezoneDSTRule` records, start rule
+then end rule:
+
+| Field            | Size | Notes                                                                                                                                                                          |
+| ---------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ds_label`       | 1    | `'D'` enter DST, `'S'` leave, `'\0'` none                                                                                                                                      |
+| `wday`           | 1    | 0 = Sunday; 255 = any day                                                                                                                                                      |
+| `flag`           | 1    | bit 0: "last <wday>" (day-decrement); bit 1: rule time is standard time; bit 2: UTC; bit 3: wall time (written by the builder, never read — wall time is the firmware default) |
+| `month`          | 1    | 0-based                                                                                                                                                                        |
+| `mday`           | 1    | 1-based                                                                                                                                                                        |
+| `hour`, `minute` | 2    |                                                                                                                                                                                |
+| padding          | 1    |                                                                                                                                                                                |
+
+Rule id 0 ("no DST") is counted in `dst_rule_count` but not stored, so
+rule id _n_ lives at `(n - 1) × 16` bytes into the section. The mapping
+from tzdata rule names to ids (`dstzone_list` in `tools/timezones.py`)
+is append-only: the firmware hardcodes some ids (e.g. Brazil = 6), so
+the order must never change between database releases.
+
+## Link records — 35 bytes each
+
+`uint16_t region_id` plus a 33-byte NUL-padded alias (sized for the
+longest IANA name). Links resolve legacy aliases — old mobile OSes still
+send names like `US/Pacific` — to a region record.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -35,3 +35,30 @@ pulse2/reliable-transport.md
 pulse2/flash-imaging.md
 pulse2/history.md
 ```
+
+## Pebble Protocol endpoints
+
+Wire formats of the Bluetooth protocol spoken between the firmware and
+the phone apps.
+
+```{toctree}
+:maxdepth: 1
+
+blob-db.md
+```
+
+## Binary formats
+
+The file and resource formats produced by the firmware tooling. These
+pages summarize the layouts; the packed structs in the referenced
+sources stay authoritative.
+
+```{toctree}
+:maxdepth: 1
+
+formats/font.md
+formats/pbi.md
+formats/pdc.md
+formats/timezone.md
+formats/sle.md
+```

--- a/src/fw/applib/graphics/text_resources.c
+++ b/src/fw/applib/graphics/text_resources.c
@@ -184,7 +184,7 @@ static uint32_t prv_get_glyph_data_offset(Codepoint codepoint, FontCache *font_c
   // Compute the offset of the glyph data (relative to the beginning
   // of the font blob).
   //
-  // See: https://pebbletechnology.atlassian.net/wiki/display/DEV/Pebble+Resource+Pack+Format
+  // See: docs/reference/formats/font.md
   uint32_t address;
   const uint32_t version = FONT_VERSION(font_res->md.version);
   if (version == FONT_VERSION_1) {

--- a/tools/bitmapgen.py
+++ b/tools/bitmapgen.py
@@ -56,14 +56,16 @@ DEFAULT_COLOR_REDUCTION = NEAREST
 # Bitmap struct only contains a color palette for GBitmapFormat(1/2/4)BitPalette
 
 # Bitmap struct (NB: All fields are little-endian)
+# See docs/reference/formats/pbi.md for the rendered spec.
 #             (uint16_t) row_size_bytes
 #             (uint16_t) info_flags
 #                    bit      0 : is heap allocated (must be zero for bitmap files)
-#                    bits  1-5  : bitmap_format
-#                    bits  6-11 : reserved, must be 0
+#                    bits  1-3  : bitmap_format
+#                    bit      4 : is palette heap allocated (must be zero for bitmap files)
+#                    bits  5-11 : reserved, must be 0
 #                    bits 12-15 : file version
-#             (int16_t)  bounds.origin.x
-#             (int16_t)  bounds.origin.y
+#             (int16_t)  bounds.origin.x (legacy, ignored by the firmware)
+#             (int16_t)  bounds.origin.y (legacy, ignored by the firmware)
 #             (int16_t)  bounds.size.w
 #             (int16_t)  bounds.size.h
 #             (uint8_t)[] image data (row_size_bytes-aligned, 0-padded rows of bits)

--- a/tools/font/fontgen.py
+++ b/tools/font/fontgen.py
@@ -13,7 +13,7 @@ import json
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
 
-# Font v3 -- https://pebbletechnology.atlassian.net/wiki/display/DEV/Pebble+Resource+Pack+Format
+# Font v3 -- see docs/reference/formats/font.md for the rendered spec
 #   FontInfo
 #       (uint8_t)  version                           - v1
 #       (uint8_t)  max_height                        - v1
@@ -44,27 +44,26 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
 #       from the start of offset_tables, and offset_table_size gives the number of glyph_tables in
 #       the list (i.e., the number of codepoints that hash to the same value).
 #
-#   (uint32_t) offset_tables[][]
+#   offset_tables[][]
 #       this list of tables contains offsets into the glyph_table for the codepoint.
-#       each offset is counted in 32-bit blocks from the start of glyph_table.
+#       each offset is counted in bytes from the start of glyph_table (v1 files
+#       counted 32-bit blocks instead).
 #       packed:     (codepoint_bytes [uint16_t | uint32_t]) codepoint
 #                   (features[0] [uint16_t | uint32_t]) offset
 #
-#   (uint32_t) glyph_table[]
-#       [0]: the 32-bit block for offset 0 is used to indicate that a glyph is not supported
-#       then for each glyph:
-#       [offset + 0]  packed:   (int_8) offset_top
-#                               (int_8) offset_left,
-#                              (uint_8) bitmap_height,       NB: in v3, if RLE4 compressed, this
-#                                                                field is contains the number of
+#   glyph_table[]
+#       starts with one zeroed 32-bit block: offset 0 indicates that a glyph is
+#       not supported. then for each glyph, a packed 5-byte header:
+#                              (uint_8) bitmap_width
+#                              (uint_8) bitmap_height        NB: in v3, if RLE4 compressed, this
+#                                                                field contains the number of
 #                                                                RLE4 units.
-#                              (uint_8) bitmap_width (LSB)
-#
-#       [offset + 1]           (int_8) horizontal_advance
-#                              (24 bits) zero padding
-#       [offset + 2] bitmap data (unaligned rows of bits), padded with 0's at
-#       the end to make the bitmap data as a whole use multiples of 32-bit
-#       blocks
+#                               (int_8) offset_left
+#                               (int_8) offset_top
+#                               (int_8) horizontal_advance
+#       followed immediately by the bitmap data (unaligned rows of bits), padded
+#       with 0's at the end to make the bitmap data a multiple of 4 bytes
+#       (v1 files used a different, 8-byte glyph header)
 
 MIN_CODEPOINT = 0x20
 MAX_2_BYTES_CODEPOINT = 0xFFFF

--- a/tools/libs/pblconvert/pblconvert/svg2pdc/pdc.py
+++ b/tools/libs/pblconvert/pblconvert/svg2pdc/pdc.py
@@ -159,25 +159,10 @@ def convert_to_png(pdc_data):
 
 
 class Command:
-    """
-    Draw command serialized structure:
-    | Bytes | Field
-    | 1     | Draw command type
-    | 1     | Reserved byte
-    | 1     | Stroke color
-    | 1     | Stroke width
-    | 1     | Fill color
-    For Paths:
-    | 1     | Open path
-    | 1     | Unused/Reserved
-    For Circles:
-    | 2     | Radius
-    Common:
-    | 2     | Number of points (should always be 1 for circles)
-    | n * 4 | Array of n points in the format below:
-    Point:
-    | 2     | x
-    | 2     | y
+    """Serialized draw command.
+
+    Format spec: docs/reference/formats/pdc.md; the canonical serializers
+    live in tools/generate_pdcs/pebble_commands.py.
     """
 
     def __init__(


### PR DESCRIPTION
## Summary

Next installment of the docs consolidation series (after #1779 and #1783): a reference section for the binary formats and wire protocols that so far were only documented in code comments.

New pages under **Reference**:

- **Binary formats**: PBF font resources, PBI bitmaps, PDC draw commands, the timezone database, and sparse length encoding
- **Pebble Protocol endpoints**: the BlobDB endpoint (`0xb1db`/`0xb2db`) wire protocol
- plus a note in the SDK export page that the revision ledger in `pebble_process_info.h` is the only rev↔minor mapping

The pages summarize the layouts and deep-link the packed structs, which stay authoritative. Every claim was verified against the current code rather than trusting the Pebble-era comments.

## Source cleanups

- `tools/font/fontgen.py` still described the **v1** font layout (offsets in 32-bit blocks, two-word glyph header); corrected to the v2/v3 reality (byte offsets, packed 5-byte header) that the tool and firmware actually implement
- `tools/bitmapgen.py` described a 5-bit `info_flags` format field; corrected to match the firmware's `BitmapInfo` (3-bit format + palette-heap flag) and marked the origin fields as ignored
- dead Atlassian wiki links in `fontgen.py` and `text_resources.c` replaced with pointers to the new pages
- pblconvert's `svg2pdc/pdc.py` carried a drifted duplicate of the PDC format docstring from `generate_pdcs/pebble_commands.py`; deduped to a pointer

## Notes for reviewers

While verifying the specs a few pre-existing code issues surfaced (BlobDB `MIN_DELETE_LENGTH` off-by-one, a region-id bounds check in `timezone_database/service.c`, SLE + pblconvert svg2pdc being dormant/py3-broken). Deliberately **not** touched here to keep this docs-only; happy to follow up separately.