### PR TITLE
moddable: update to 8.3.1

### DIFF
--- a/src/fw/process_management/pebble_process_info.h
+++ b/src/fw/process_management/pebble_process_info.h
@@ -168,9 +168,10 @@ typedef enum {
 // sdk.major:0x5 .minor:0x64 -- Add kModdableCreationFlagDebug (rev 103)
 // sdk.major:0x5 .minor:0x65 -- Expose speaker playback limits (rev 104)
 // sdk.major:0x5 .minor:0x66 -- Expose alarm service (alarm_service_peek_next) to apps (rev 105)
+// sdk.major:0x5 .minor:0x67 -- Explicit Resource Management in Moddable (rev 106)
 
 #define PROCESS_INFO_CURRENT_SDK_VERSION_MAJOR 0x5
-#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x66
+#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x67
 
 // The first SDK to ship with 2.x APIs
 #define PROCESS_INFO_FIRST_2X_SDK_VERSION_MAJOR 0x4

--- a/third_party/moddable/wscript_build
+++ b/third_party/moddable/wscript_build
@@ -147,6 +147,7 @@ else:
             'moddable/build/devices/pebble/modules/vibes/vibes.c',
             'moddable/build/devices/pebble/modules/wakeup/wakeup.c',
             'moddable/build/devices/pebble/modules/dictation/dictation.c',
+            'moddable/build/devices/pebble/modules/health/pebble-health.c',
             'moddable/modules/io/files/pebble/files-pebble.c',
             'moddable/build/tmp/pebble/release/host/mc.xs.c',
             'moddable/build/tmp/pebble/release/host/mc.resources.c',

--- a/tools/generate_native_sdk/exported_symbols.json
+++ b/tools/generate_native_sdk/exported_symbols.json
@@ -4,7 +4,7 @@
               "You should also make sure you are obeying our API design guidelines:",
               "https://pebbletechnology.atlassian.net/wiki/display/DEV/SDK+API+Design+Guidelines"
             ],
-  "revision" : "105",
+  "revision" : "106",
   "version" : "2.0",
   "files": [
     "include/pbl/drivers/ambient_light.h",


### PR DESCRIPTION
According to Peter Hoddie from Moddable "We did some work so that existing byte code will still run. [...] But, definitely confirm that existing apps (e.g. mods built with earlier byte code versions) before releasing"

Can confirm! Works!