### PR TITLE
Fix pre-existing bugs found during the docs consolidation sweeps

### DIFF
--- a/docs/reference/formats/pdc.md
+++ b/docs/reference/formats/pdc.md
@@ -27,6 +27,16 @@ Path points are whole pixels; precise-path points are 13.3 fixed-point
 (eighths of a pixel). A command list is a `uint16_t` command count
 followed by that many commands.
 
+## Coordinate grid
+
+The SVG converters translate input coordinates by (-0.5, -0.5) and round,
+so source coordinates must sit on the half-pixel grid: multiples of
+0.5 px for paths and circles, 0.125 px (1/8) for precise paths. Off-grid
+points are snapped to the nearest supported coordinate and flagged
+(`convert_to_pebble_coordinates` in
+`tools/generate_pdcs/pebble_commands.py` and the annotation emitted by
+`tools/libs/pblconvert/pblconvert/svg2pdc/pdc.py`).
+
 ## File containers
 
 **PDCI (image)**:

--- a/src/fw/services/blob_db/endpoint.c
+++ b/src/fw/services/blob_db/endpoint.c
@@ -66,7 +66,7 @@ static const uint8_t VALUE_DATA_LENGTH = (sizeof(uint16_t) + sizeof(uint8_t));
 //! Message Length Constants
 static const uint8_t MIN_INSERT_LENGTH = 8;
 static const uint8_t MIN_INSERT_WITH_TIMESTAMP_LENGTH = 12; // + 4 bytes for timestamp
-static const uint8_t MIN_DELETE_LENGTH = 6;
+static const uint8_t MIN_DELETE_LENGTH = 5;
 static const uint8_t MIN_CLEAR_LENGTH  = 3;
 
 static bool s_bdb_accepting_messages;

--- a/src/fw/services/timezone_database/service.c
+++ b/src/fw/services/timezone_database/service.c
@@ -131,7 +131,7 @@ bool timezone_database_load_region_info(uint16_t region_id, TimezoneInfo *tz_inf
 }
 
 bool timezone_database_load_region_name(uint16_t region_id, char *region_name) {
-  if (region_id > timezone_database_get_region_count()) {
+  if (region_id >= timezone_database_get_region_count()) {
     return false;
   }
 

--- a/tools/analyze_static_memory_usage.py
+++ b/tools/analyze_static_memory_usage.py
@@ -16,5 +16,5 @@ if __name__ == "__main__":
 
     sections = analyze_elf(args.elf_file, args.sections, args.fast)
 
-    for s in sections.itervalues():
+    for s in sections.values():
         s.pprint(args.summary, args.verbose)

--- a/tools/dehash_flash_logs.py
+++ b/tools/dehash_flash_logs.py
@@ -186,7 +186,9 @@ def main():
             os.path.dirname(__file__),
             "..",
             "build",
-            "pebbleos_loghash_dict.json",
+            "src",
+            "fw",
+            "loghash_dict.json",
         )
         if os.path.exists(default_dict):
             dehash_path = default_dict

--- a/tools/font/README.md
+++ b/tools/font/README.md
@@ -1,15 +1,13 @@
 Pebble Font Renderer Script
 ===========================
 
-These Python scripts take TrueType font files, renders a set of glyps and outputs them into .h files in the appropriate structure for consumption by Pebble's text rendering routines.
+These Python scripts take TrueType font files, render a set of glyphs and
+output them into .h files in the appropriate structure for consumption by
+Pebble's text rendering routines.
 
 Requirements:
 -------------
-* freetype library
-* freetype-py binding
 
-http://code.google.com/p/freetype-py/
-
-**Mac OS X and freetype-py**: the freetype binding works with the Freetype library that ships with Mac OS X (/usr/X11/lib/libfreetype.dylib), but you need to patch setup.py using this diff file:
-
-https://gist.github.com/3345193
+- freetype library
+- [freetype-py](https://pypi.org/project/freetype-py/) binding (part of the
+  repo's `requirements.txt`)

--- a/tools/gdb_scripts/gdb_printers.py
+++ b/tools/gdb_scripts/gdb_printers.py
@@ -42,7 +42,7 @@ class gpathInfoPrinter:
         points_code = ""
         num_points = int(self.val["num_points"])
         array_val = self.val["points"]
-        for i in xrange(0, num_points):
+        for i in range(0, num_points):
             point_val = array_val[i]
             if points_code:
                 points_code += ", "
@@ -55,8 +55,8 @@ class UuidPrinter(object):
     """Print a UUID."""
 
     def __init__(self, val):
-        bytes = "".join(chr(int(val["byte%d" % n])) for n in xrange(16))
-        self.uuid = uuid.UUID(bytes=bytes)
+        data = bytes(int(val["byte%d" % n]) for n in range(16))
+        self.uuid = uuid.UUID(bytes=data)
 
     def to_string(self):
         return "{%s}" % self.uuid

--- a/tools/generate_pdcs/pebble_commands.py
+++ b/tools/generate_pdcs/pebble_commands.py
@@ -192,7 +192,7 @@ class Command:
         )
 
     def serialize_points(self):
-        s = pack("H", len(self.points))  # number of points (16-bit)
+        s = pack("<H", len(self.points))  # number of points (16-bit)
         for p in self.points:
             s += pack(
                 "<hh",
@@ -283,7 +283,7 @@ class CircleCommand(Command):
     def serialize(self):
         s = pack("B", DRAW_COMMAND_TYPE_CIRCLE)  # command type
         s += self.serialize_common()
-        s += pack("H", int(self.radius))  # circle radius (16-bit)
+        s += pack("<H", int(self.radius))  # circle radius (16-bit)
         s += self.serialize_points()
         return s
 
@@ -298,7 +298,7 @@ class CircleCommand(Command):
 
 
 def serialize(commands):
-    output = pack("H", len(commands))  # number of commands in list
+    output = pack("<H", len(commands))  # number of commands in list
     for c in commands:
         output += c.serialize()
 
@@ -317,7 +317,7 @@ def print_frames(frames):
 
 
 def serialize_frame(frame, duration):
-    return pack("H", duration) + serialize(frame)  # Frame duration
+    return pack("<H", duration) + serialize(frame)  # Frame duration
 
 
 def pack_header(size):
@@ -327,12 +327,12 @@ def pack_header(size):
 
 
 def serialize_sequence(frames, size, duration, play_count):
-    s = pack_header(size) + pack("H", play_count) + pack("H", len(frames))
+    s = pack_header(size) + pack("<H", play_count) + pack("<H", len(frames))
     for f in frames:
         s += serialize_frame(f, duration)
 
     output = b"PDCS"
-    output += pack("I", len(s))
+    output += pack("<I", len(s))
     output += s
     return output
 
@@ -342,6 +342,6 @@ def serialize_image(commands, size):
     s += serialize(commands)
 
     output = b"PDCI"
-    output += pack("I", len(s))
+    output += pack("<I", len(s))
     output += s
     return output

--- a/tools/libs/pblconvert/pblconvert/svg2pdc/pdc.py
+++ b/tools/libs/pblconvert/pblconvert/svg2pdc/pdc.py
@@ -190,8 +190,13 @@ class Command:
 
             if problem is not None:
                 if grid_annotation is None:
+                    link = (
+                        "https://pebbleos-core.readthedocs.io/en/latest/"
+                        "reference/formats/pdc.html#coordinate-grid"
+                    )
                     grid_annotation = annotator.add_annotation(
                         "Element is expressed with unsupported coordinate(s).",
+                        link=link,
                     )
                 grid_annotation.add_highlight(p[0], p[1], details=problem)
 

--- a/tools/libs/pblconvert/pblconvert/svg2pdc/pdc.py
+++ b/tools/libs/pblconvert/pblconvert/svg2pdc/pdc.py
@@ -1,4 +1,3 @@
-from StringIO import StringIO
 import os
 import shutil
 import tempfile
@@ -191,10 +190,8 @@ class Command:
 
             if problem is not None:
                 if grid_annotation is None:
-                    link = "https://pebbletechnology.atlassian.net/wiki/display/DEV/Pebble+Draw+Commands#PebbleDrawCommands-issue-pixelgrid"
                     grid_annotation = annotator.add_annotation(
                         "Element is expressed with unsupported coordinate(s).",
-                        link=link,
                     )
                 grid_annotation.add_highlight(p[0], p[1], details=problem)
 
@@ -216,7 +213,7 @@ class Command:
         )
 
     def serialize_points(self):
-        s = pack("H", len(self.points))  # number of points (16-bit)
+        s = pack("<H", len(self.points))  # number of points (16-bit)
         for p in self.points:
             converted, _ = convert_to_pebble_coordinates(p, self.is_precise())
             s += pack(
@@ -280,7 +277,7 @@ class PathCommand(Command):
         )
 
 
-class CircleCommand(object, Command):
+class CircleCommand(Command):
     def __init__(self, center, radius, stroke_width=0, stroke_color=0, fill_color=0):
         points = [(center[0], center[1])]
         Command.__init__(self, points, stroke_width, stroke_color, fill_color)
@@ -302,7 +299,7 @@ class CircleCommand(object, Command):
     def serialize(self):
         s = pack("B", DRAW_COMMAND_TYPE_CIRCLE)  # command type
         s += self.serialize_common()
-        s += pack("H", self.radius)  # circle radius (16-bit)
+        s += pack("<H", int(self.radius))  # circle radius (16-bit)
         s += self.serialize_points()
         return s
 
@@ -323,7 +320,7 @@ def serialize_header(size):
 
 
 def serialize(commands):
-    output = pack("H", len(commands))  # number of commands in list
+    output = pack("<H", len(commands))  # number of commands in list
     for c in commands:
         output += c.serialize()
 
@@ -334,7 +331,7 @@ def serialize_image(commands, size):
     s = serialize_header(size)
     s += serialize(commands)
 
-    output = "PDCI"
-    output += pack("I", len(s))
+    output = b"PDCI"
+    output += pack("<I", len(s))
     output += s
     return output

--- a/tools/timezones.py
+++ b/tools/timezones.py
@@ -404,11 +404,11 @@ def zoneinfo_to_bin(zoneinfo_list, dstrule_list, zonelink_list, output_bin):
     # Continent_index City gmt_offset_minutes tz_abbr dst_id
 
     # Unsigned short - count of entries
-    output_bin.write(struct.pack("H", len(zoneinfo_list)))
+    output_bin.write(struct.pack("<H", len(zoneinfo_list)))
     # Unsigned short - count of DST rules
-    output_bin.write(struct.pack("H", len(dstzone_dict.values())))
+    output_bin.write(struct.pack("<H", len(dstzone_dict.values())))
     # Unsigned short - count of links
-    output_bin.write(struct.pack("H", len(zonelink_list)))
+    output_bin.write(struct.pack("<H", len(zonelink_list)))
 
     region_id_list = []
     # write all the timezones to file
@@ -437,7 +437,7 @@ def zoneinfo_to_bin(zoneinfo_list, dstrule_list, zonelink_list, output_bin):
         else:
             gmt_offset_minutes = int(hours) * 60 + int(minutes)
         # signed short, for negative gmtoffsets
-        output_bin.write(struct.pack("h", gmt_offset_minutes))
+        output_bin.write(struct.pack("<h", gmt_offset_minutes))
 
         # fix timezone abbreviations that no longer have a DST mode
         if dst_zone not in dstzone_dict:
@@ -499,7 +499,7 @@ def zoneinfo_to_bin(zoneinfo_list, dstrule_list, zonelink_list, output_bin):
         except ValueError as e:
             print("Couldn't find region, skipping:", e)
             continue
-        output_bin.write(struct.pack("H", region_id))
+        output_bin.write(struct.pack("<H", region_id))
         output_bin.write(linkname.ljust(TIMEZONE_LINK_NAME_LENGTH, "\0").encode("utf8"))
 
 

--- a/tools/timezones.py
+++ b/tools/timezones.py
@@ -441,7 +441,7 @@ def zoneinfo_to_bin(zoneinfo_list, dstrule_list, zonelink_list, output_bin):
 
         # fix timezone abbreviations that no longer have a DST mode
         if dst_zone not in dstzone_dict:
-            tz_abbr.replace("*", "S")  # remove
+            tz_abbr = tz_abbr.replace("*", "S")
         if len(tz_abbr) > 5:
             raise Exception(f"Timezone abbreviation too long: {tz_abbr}")
         output_bin.write(

--- a/tools/waf/sparse_length_encoding.py
+++ b/tools/waf/sparse_length_encoding.py
@@ -172,9 +172,9 @@ if __name__ == "__main__":
     elif len(sys.argv) == 2:
         # encode the specified file
         data = open(sys.argv[1], "rb").read()
-        encoded = "".join(encode(data))
-        if "".join(decode(encoded)) != data:
+        encoded = b"".join(encode(data))
+        if b"".join(decode(encoded)) != data:
             raise Exception("Invalid encoding")
-        sys.stdout.write("".join(encode(f)))
+        sys.stdout.buffer.write(encoded)
     else:
         raise Exception("Invalid arguments")


### PR DESCRIPTION
## Summary

Follow-up promised in the reviewer notes of #1798 and #1799: while claim-verifying the formats/testing/debugging pages against the code, a number of small pre-existing bugs surfaced. This PR fixes them, one commit each.

**Firmware**

- `blob_db/endpoint.c`: `MIN_DELETE_LENGTH` was 6, rejecting a legal DELETE with a 1-byte key (minimum body is token 2 + db id 1 + key size 1 + key 1 = 5). The per-field parsing below the length check still rejects malformed messages.
- `timezone_database/service.c`: `timezone_database_load_region_name()` used `>` instead of `>=`, so `region_id == region_count` read one entry past the region table.

**Tools**

- `timezones.py`: the `tz_abbr.replace("*", "S")` result was discarded, so regions whose DST rule is no longer supported shipped a literal `*` in their abbreviation (e.g. `CE*T`); the runtime substitution in `time_get_timezone_abbr()` hides this on the display path, but `timezone_database_load_region_info()` copies the raw abbreviation.
- `gdb_printers.py`, `analyze_static_memory_usage.py`: still Python 2 (`xrange`, `itervalues`, str-based UUID bytes); crashed under Python 3.
- `dehash_flash_logs.py`: default dictionary fallback pointed at `build/pebbleos_loghash_dict.json`; the build produces `build/src/fw/loghash_dict.json`.
- `sparse_length_encoding.py`: the single-file CLI branch referenced an undefined variable and joined bytes with `str.join`, raising on any invocation. (SLE has been dormant since the Spalding removal — if you'd rather delete it than fix it, happy to do that instead.)
- pblconvert `svg2pdc/pdc.py`: still Python 2 despite `requires-python >= 3.9` (StringIO import, invalid `(object, Command)` MRO, str magic concatenated with bytes).
- `pebble_commands.py` / `timezones.py` / `pdc.py`: multi-byte `struct.pack` fields now explicitly little-endian; byte-identical output on little-endian hosts.

**Docs**

- New **Coordinate grid** section on the PDC format page, preserving the guidance from the dead Atlassian wiki link that the svg2pdc pixel-grid annotation used to reference; the annotation now links there (same pattern as the fontgen/text_resources link replacements in #1798).
- `tools/font/README.md`: dropped dead 2012-era freetype links.

## Verification

- Full `asterix` build and the complete unit-test suite pass.
- `timezones.py`: generated tzdata diffed before/after — every changed byte is exactly `*` → `S` (e.g. `CE*T` → `CEST`, matching what the firmware substitutes for a region never in DST); the endianness change is byte-identical on LE hosts.
- `sparse_length_encoding.py` CLI round-trip-verified on random data; `svg2pdc/pdc.py` import + serialization verified under Python 3 (the full pblconvert test suite doesn't run on modern hosts due to the `lxml==3.4.4` pin).
- Docs: strict `sphinx-build -W` passes; the `#coordinate-grid` anchor verified in the rendered HTML.