### PR TITLE
fw/system: CRC-check recovery FW before reporting its version

### DIFF
--- a/src/fw/system/version.c
+++ b/src/fw/system/version.c
@@ -103,7 +103,7 @@ bool version_copy_update_fw_metadata(FirmwareMetadata *out_metadata) {
 
 bool version_copy_recovery_fw_version(char* dest, const int dest_len_bytes) {
   FirmwareMetadata out_metadata;
-  const bool check_crc = false;
+  const bool check_crc = true;
   bool success = prv_version_copy_flash_fw_metadata(&out_metadata,
                                                     FLASH_REGION_SAFE_FIRMWARE_BEGIN,
                                                     check_crc);

--- a/src/fw/system/version.h
+++ b/src/fw/system/version.h
@@ -36,7 +36,7 @@ bool version_copy_update_fw_metadata(FirmwareMetadata *out_metadata);
 //!
 //! @param dest: char[dest_len_bytes]
 //! @param dest_len_bytes size of dest in bytes
-//! @returns true on success, false otherwise
+//! @returns true on success, false if the recovery image fails CRC validation
 bool version_copy_recovery_fw_version(char* dest, const int dest_len_bytes);
 
 //! Checks to see if a valid PRF is installed with a correct checksum.


### PR DESCRIPTION
version_copy_recovery_fw_version() read the version tag from the PRF slot without validating the image, so the Settings recovery entry could show a plausible version string while the slot actually fails CRC validation. Check the CRC first so a corrupt PRF slot shows up as a blank Recovery entry, matching what the watch reports over Bluetooth.