### PR TITLE
correct the string "just once"

### DIFF
--- a/src/fw/applib/ui/day_picker.c
+++ b/src/fw/applib/ui/day_picker.c
@@ -48,7 +48,7 @@ static const char *prv_kind_strings[DayPickerKindNumItems] = {
   [DayPickerKindWeekdays] = "Weekdays",
   [DayPickerKindWeekends] = "Weekends",
   [DayPickerKindCustom] = "Custom",
-  [DayPickerKindJustOnce] = "Just Once",
+  [DayPickerKindJustOnce] = "Once",
 };
 
 const char *day_picker_kind_get_string(DayPickerKind kind) {


### PR DESCRIPTION
The alarm scheduling contains the string "Just Once", how ever in the translation files only the strings "Once" are contained. Since "Just Once" is not used anywhere else, changing it seems to be the best approach.