### PR TITLE
Watchface selector on touchscreen long press

### DIFF
--- a/include/pbl/services/touch/touch.h
+++ b/include/pbl/services/touch/touch.h
@@ -24,7 +24,14 @@ void touch_init(void);
 //! When disabled, the touch sensor is only active if apps have subscribed to touch events.
 void touch_set_backlight_enabled(bool enabled);
 
-//! @return true if at least one subscriber is currently registered for touch events.
+//! Mark (or unmark) one subscription as a system-internal consumer that must
+//! not count towards touch_has_app_subscribers(). Call with true after
+//! subscribing and with false before unsubscribing.
+void touch_set_system_subscribed(bool subscribed);
+
+//! @return true if at least one subscriber other than the system-internal
+//! ones (backlight, subscriptions marked via touch_set_system_subscribed())
+//! is currently registered for touch events.
 bool touch_has_app_subscribers(void);
 
 //! Globally enable or disable touch. When disabled:

--- a/src/fw/apps/system/watchfaces.c
+++ b/src/fw/apps/system/watchfaces.c
@@ -14,12 +14,22 @@
 #include "kernel/pbl_malloc.h"
 #include "process_management/app_manager.h"
 #include "process_management/app_menu_data_source.h"
+#include "process_management/process_manager.h"
 #include "shell/normal/watchface.h"
 #include "process_state/app_state/app_state.h"
 #include "resource/resource_ids.auto.h"
 #include "pbl/services/i18n/i18n.h"
 #include "shell/prefs.h"
 #include "system/passert.h"
+#ifdef CONFIG_TOUCH
+#include "applib/app_launch_reason.h"
+#include "applib/app_timer.h"
+#include "applib/touch_service.h"
+#include "applib/ui/animation.h"
+#include "applib/ui/property_animation.h"
+#include "applib/ui/vibes.h"
+#include <pbl/util/math.h>
+#endif
 
 #include <stdio.h>
 #include <string.h>
@@ -106,6 +116,276 @@ static void draw_row_callback(GContext* ctx, const Layer *cell_layer, MenuIndex 
                               subtitle, bitmap, false, GTextOverflowModeTrailingEllipsis);
 }
 
+#ifdef CONFIG_TOUCH
+////////////////////////////////////////////////////////////////////////////
+// Carousel selector, entered by long-pressing the touchscreen on a watchface
+
+#define SELECTOR_SWIPE_MIN_PX (30)
+#define SELECTOR_SLIDE_DURATION_MS (150)
+//! The finger that long-pressed to open the selector may still be down when we
+//! subscribe and gets re-reported as a fresh touchdown; ignore contacts that
+//! start within this window so releasing that finger isn't taken as a tap.
+#define SELECTOR_ENTRY_GRACE_MS (500)
+
+typedef struct WatchfacesSelectorData {
+  Window window;
+  Layer chevron_layer;
+  Layer content_layer;
+  AppMenuDataSource data_source;
+  AppInstallId active_watchface_id;
+  uint16_t index;
+  int16_t touch_down_x;
+  int16_t touch_down_y;
+  bool touch_tracking;
+  bool entry_grace;
+  AppTimer *entry_grace_timer;
+  PropertyAnimation *slide_animation;
+} WatchfacesSelectorData;
+
+static void prv_selector_content_update_proc(Layer *layer, GContext *ctx) {
+  WatchfacesSelectorData *data = window_get_user_data(layer_get_window(layer));
+  const uint16_t count = app_menu_data_source_get_count(&data->data_source);
+  if (count == 0) {
+    return;
+  }
+  AppMenuNode *node = app_menu_data_source_get_node_at_index(&data->data_source, data->index);
+
+  const GRect bounds = layer->bounds;
+  graphics_context_set_text_color(ctx, GColorWhite);
+
+  // Watchface icon (falls back to the generic watchface icon), centered above the name
+  GBitmap *icon = app_menu_data_source_get_node_icon(&data->data_source, node);
+  if (icon) {
+    const GSize icon_size = gbitmap_get_bounds(icon).size;
+    const GCompOp op = (gbitmap_get_format(icon) == GBitmapFormat1Bit) ? GCompOpTint : GCompOpSet;
+    graphics_context_set_compositing_mode(ctx, op);
+    const GRect icon_rect = GRect((bounds.size.w - icon_size.w) / 2,
+                                  bounds.size.h / 2 - 48 - icon_size.h, icon_size.w, icon_size.h);
+    graphics_draw_bitmap_in_rect(ctx, icon, &icon_rect);
+  }
+
+  // Watchface name, centered
+  GFont name_font = fonts_get_system_font(FONT_KEY_GOTHIC_28_BOLD);
+  const GRect name_rect = GRect(10, bounds.size.h / 2 - 36, bounds.size.w - 20, 64);
+  graphics_draw_text(ctx, node->name, name_font, name_rect, GTextOverflowModeTrailingEllipsis,
+                     GTextAlignmentCenter, NULL);
+
+  GFont small_font = fonts_get_system_font(FONT_KEY_GOTHIC_18);
+
+  // "Active" badge under the name for the current default
+  if (node->install_id == data->active_watchface_id) {
+    const GRect active_rect = GRect(10, bounds.size.h / 2 + 30, bounds.size.w - 20, 24);
+    graphics_draw_text(ctx, i18n_get("Active", data), small_font, active_rect,
+                       GTextOverflowModeTrailingEllipsis, GTextAlignmentCenter, NULL);
+  }
+
+  // Position counter at the bottom
+  char counter[12];
+  snprintf(counter, sizeof(counter), "%d/%d", data->index + 1, count);
+  const GRect counter_rect = GRect(10, bounds.size.h - 42, bounds.size.w - 20, 24);
+  graphics_draw_text(ctx, counter, small_font, counter_rect, GTextOverflowModeTrailingEllipsis,
+                     GTextAlignmentCenter, NULL);
+}
+
+static void prv_selector_chevron_update_proc(Layer *layer, GContext *ctx) {
+  WatchfacesSelectorData *data = window_get_user_data(layer_get_window(layer));
+  if (app_menu_data_source_get_count(&data->data_source) < 2) {
+    return;
+  }
+  const GRect bounds = layer->bounds;
+  graphics_context_set_text_color(ctx, GColorWhite);
+  GFont font = fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD);
+  const GRect left_rect = GRect(6, bounds.size.h / 2 - 16, 20, 28);
+  const GRect right_rect = GRect(bounds.size.w - 26, bounds.size.h / 2 - 16, 20, 28);
+  graphics_draw_text(ctx, "<", font, left_rect, GTextOverflowModeTrailingEllipsis,
+                     GTextAlignmentCenter, NULL);
+  graphics_draw_text(ctx, ">", font, right_rect, GTextOverflowModeTrailingEllipsis,
+                     GTextAlignmentCenter, NULL);
+}
+
+static void prv_selector_slide(WatchfacesSelectorData *data, int direction) {
+  if (data->slide_animation) {
+    animation_unschedule(property_animation_get_animation(data->slide_animation));
+    data->slide_animation = NULL;
+  }
+  GRect to = data->window.layer.bounds;
+  GRect from = to;
+  from.origin.x = (direction > 0) ? to.size.w : -to.size.w;
+  layer_set_frame(&data->content_layer, &from);
+  data->slide_animation = property_animation_create_layer_frame(&data->content_layer, &from, &to);
+  if (data->slide_animation) {
+    Animation *animation = property_animation_get_animation(data->slide_animation);
+    animation_set_duration(animation, SELECTOR_SLIDE_DURATION_MS);
+    animation_set_curve(animation, AnimationCurveEaseOut);
+    animation_schedule(animation);
+  }
+  layer_mark_dirty(&data->content_layer);
+}
+
+//! direction: +1 = next (slide in from the right), -1 = previous
+static void prv_selector_navigate(WatchfacesSelectorData *data, int direction) {
+  const uint16_t count = app_menu_data_source_get_count(&data->data_source);
+  if (count < 2) {
+    return;
+  }
+  data->index = (data->index + count + direction) % count;
+  // Swiping selects: the face landed on becomes the default, so backing out
+  // of the selector returns to it.
+  AppMenuNode *node = app_menu_data_source_get_node_at_index(&data->data_source, data->index);
+  watchface_set_default_install_id(node->install_id);
+  data->active_watchface_id = node->install_id;
+  prv_selector_slide(data, direction);
+}
+
+static void prv_selector_select(WatchfacesSelectorData *data) {
+  const uint16_t count = app_menu_data_source_get_count(&data->data_source);
+  if (count == 0) {
+    return;
+  }
+  AppMenuNode *node = app_menu_data_source_get_node_at_index(&data->data_source, data->index);
+  // Launching with APP_LAUNCH_USER makes app_manager persist this watchface
+  // as the new default once it starts successfully.
+  app_manager_put_launch_app_event(&(AppLaunchEventConfig) {
+    .id = node->install_id,
+    .common.reason = APP_LAUNCH_USER,
+    .common.button = BUTTON_ID_SELECT,
+  });
+}
+
+static void prv_selector_touch_handler(const TouchEvent *event, void *context) {
+  WatchfacesSelectorData *data = context;
+  switch (event->type) {
+    case TouchEvent_Touchdown:
+      if (data->entry_grace) {
+        break;
+      }
+      data->touch_tracking = true;
+      data->touch_down_x = event->x;
+      data->touch_down_y = event->y;
+      break;
+    case TouchEvent_Liftoff: {
+      // Ignore the liftoff of the long press that opened the selector
+      if (!data->touch_tracking) {
+        break;
+      }
+      data->touch_tracking = false;
+      const int16_t dx = event->x - data->touch_down_x;
+      const int16_t dy = event->y - data->touch_down_y;
+      if (ABS(dx) >= SELECTOR_SWIPE_MIN_PX && ABS(dx) > ABS(dy)) {
+        // Swipe left moves forward, swipe right moves back
+        prv_selector_navigate(data, (dx < 0) ? 1 : -1);
+      } else if (ABS(dx) < SELECTOR_SWIPE_MIN_PX && ABS(dy) < SELECTOR_SWIPE_MIN_PX) {
+        prv_selector_select(data);
+      }
+      break;
+    }
+    case TouchEvent_PositionUpdate:
+      break;
+  }
+}
+
+static void prv_selector_up_click_handler(ClickRecognizerRef recognizer, void *context) {
+  prv_selector_navigate(context, -1);
+}
+
+static void prv_selector_down_click_handler(ClickRecognizerRef recognizer, void *context) {
+  prv_selector_navigate(context, 1);
+}
+
+static void prv_selector_select_click_handler(ClickRecognizerRef recognizer, void *context) {
+  prv_selector_select(context);
+}
+
+static void prv_selector_click_config_provider(void *context) {
+  window_single_click_subscribe(BUTTON_ID_UP, prv_selector_up_click_handler);
+  window_single_click_subscribe(BUTTON_ID_DOWN, prv_selector_down_click_handler);
+  window_single_click_subscribe(BUTTON_ID_SELECT, prv_selector_select_click_handler);
+  window_set_click_context(BUTTON_ID_UP, context);
+  window_set_click_context(BUTTON_ID_DOWN, context);
+  window_set_click_context(BUTTON_ID_SELECT, context);
+}
+
+static void prv_selector_data_source_changed(void *context) {
+  WatchfacesSelectorData *data = context;
+  const uint16_t count = app_menu_data_source_get_count(&data->data_source);
+  if (count > 0 && data->index >= count) {
+    data->index = count - 1;
+  }
+  layer_mark_dirty(&data->content_layer);
+  layer_mark_dirty(&data->chevron_layer);
+}
+
+static void prv_selector_entry_grace_timer_callback(void *context) {
+  WatchfacesSelectorData *data = context;
+  data->entry_grace_timer = NULL;
+  data->entry_grace = false;
+}
+
+static void prv_selector_window_load(Window *window) {
+  WatchfacesSelectorData *data = window_get_user_data(window);
+
+  app_menu_data_source_init(&data->data_source, &(AppMenuDataSourceCallbacks) {
+    .changed = prv_selector_data_source_changed,
+    .filter = prv_app_filter_callback,
+  }, data);
+  app_menu_data_source_enable_icons(&data->data_source,
+                                    RESOURCE_ID_MENU_LAYER_GENERIC_WATCHFACE_ICON);
+
+  data->active_watchface_id = watchface_get_default_install_id();
+  const uint16_t row = app_menu_data_source_get_index_of_app_with_install_id(
+      &data->data_source, data->active_watchface_id);
+  data->index = (row == (uint16_t)-1) ? 0 : row;
+
+  layer_init(&data->chevron_layer, &window->layer.bounds);
+  layer_set_update_proc(&data->chevron_layer, prv_selector_chevron_update_proc);
+  layer_add_child(&window->layer, &data->chevron_layer);
+
+  layer_init(&data->content_layer, &window->layer.bounds);
+  layer_set_update_proc(&data->content_layer, prv_selector_content_update_proc);
+  layer_add_child(&window->layer, &data->content_layer);
+
+  data->entry_grace = true;
+  data->entry_grace_timer = app_timer_register(SELECTOR_ENTRY_GRACE_MS,
+                                               prv_selector_entry_grace_timer_callback, data);
+  touch_service_subscribe(prv_selector_touch_handler, data);
+  vibes_short_pulse();
+}
+
+static void prv_selector_window_unload(Window *window) {
+  WatchfacesSelectorData *data = window_get_user_data(window);
+  if (data->entry_grace_timer) {
+    app_timer_cancel(data->entry_grace_timer);
+    data->entry_grace_timer = NULL;
+  }
+  if (data->slide_animation) {
+    animation_unschedule(property_animation_get_animation(data->slide_animation));
+    data->slide_animation = NULL;
+  }
+  touch_service_unsubscribe();
+  layer_deinit(&data->content_layer);
+  layer_deinit(&data->chevron_layer);
+  app_menu_data_source_deinit(&data->data_source);
+  i18n_free_all(data);
+}
+
+static void prv_selector_init(void) {
+  WatchfacesSelectorData *data = app_malloc_check(sizeof(WatchfacesSelectorData));
+  *data = (WatchfacesSelectorData){};
+  app_state_set_user_data(data);
+
+  Window *window = &data->window;
+  window_init(window, WINDOW_NAME("Watchface Selector"));
+  window_set_user_data(window, data);
+  window_set_background_color(window, GColorBlack);
+  window_set_click_config_provider_with_context(window, prv_selector_click_config_provider, data);
+  window_set_window_handlers(window, &(WindowHandlers) {
+    .load = prv_selector_window_load,
+    .unload = prv_selector_window_unload,
+  });
+  app_window_stack_push(window, true /* animated */);
+}
+#endif // CONFIG_TOUCH
+
 ///////////////////
 // Window callbacks
 
@@ -190,7 +470,21 @@ static void handle_init(void) {
 // App boilerplate
 
 static void s_main(void) {
+#ifdef CONFIG_TOUCH
+  // Only the shell's long-press path launches with APP_LAUNCH_SYSTEM and
+  // WatchfacesLaunchArgs; quick launch reuses args for small integer action
+  // codes, so the reason gate must come before the args dereference.
+  const WatchfacesLaunchArgs *args =
+      (app_launch_reason() == APP_LAUNCH_SYSTEM) ?
+          process_manager_get_current_process_args() : NULL;
+  if (args && args->selector_mode) {
+    prv_selector_init();
+  } else {
+    handle_init();
+  }
+#else
   handle_init();
+#endif
 
   app_event_loop();
 }

--- a/src/fw/apps/system/watchfaces.c
+++ b/src/fw/apps/system/watchfaces.c
@@ -26,6 +26,7 @@
 #include "applib/app_timer.h"
 #include "applib/touch_service.h"
 #include "applib/ui/animation.h"
+#include "applib/ui/content_indicator.h"
 #include "applib/ui/property_animation.h"
 #include "applib/ui/vibes.h"
 #include <pbl/util/math.h>
@@ -179,10 +180,10 @@ static void prv_selector_content_update_proc(Layer *layer, GContext *ctx) {
                        GTextOverflowModeTrailingEllipsis, GTextAlignmentCenter, NULL);
   }
 
-  // Position counter at the bottom
+  // Position counter below the Active badge
   char counter[12];
   snprintf(counter, sizeof(counter), "%d/%d", data->index + 1, count);
-  const GRect counter_rect = GRect(10, bounds.size.h - 42, bounds.size.w - 20, 24);
+  const GRect counter_rect = GRect(10, bounds.size.h / 2 + 58, bounds.size.w - 20, 24);
   graphics_draw_text(ctx, counter, small_font, counter_rect, GTextOverflowModeTrailingEllipsis,
                      GTextAlignmentCenter, NULL);
 }
@@ -193,14 +194,12 @@ static void prv_selector_chevron_update_proc(Layer *layer, GContext *ctx) {
     return;
   }
   const GRect bounds = layer->bounds;
-  graphics_context_set_text_color(ctx, GColorWhite);
-  GFont font = fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD);
-  const GRect left_rect = GRect(6, bounds.size.h / 2 - 16, 20, 28);
-  const GRect right_rect = GRect(bounds.size.w - 26, bounds.size.h / 2 - 16, 20, 28);
-  graphics_draw_text(ctx, "<", font, left_rect, GTextOverflowModeTrailingEllipsis,
-                     GTextAlignmentCenter, NULL);
-  graphics_draw_text(ctx, ">", font, right_rect, GTextOverflowModeTrailingEllipsis,
-                     GTextAlignmentCenter, NULL);
+  const GRect top_rect = GRect(0, 8, bounds.size.w, 16);
+  const GRect bottom_rect = GRect(0, bounds.size.h - 24, bounds.size.w, 16);
+  content_indicator_draw_arrow(ctx, &top_rect, ContentIndicatorDirectionUp, GColorWhite,
+                               GColorBlack, GAlignCenter);
+  content_indicator_draw_arrow(ctx, &bottom_rect, ContentIndicatorDirectionDown, GColorWhite,
+                               GColorBlack, GAlignCenter);
 }
 
 static void prv_selector_slide(WatchfacesSelectorData *data, int direction) {
@@ -210,7 +209,7 @@ static void prv_selector_slide(WatchfacesSelectorData *data, int direction) {
   }
   GRect to = data->window.layer.bounds;
   GRect from = to;
-  from.origin.x = (direction > 0) ? to.size.w : -to.size.w;
+  from.origin.y = (direction > 0) ? to.size.h : -to.size.h;
   layer_set_frame(&data->content_layer, &from);
   data->slide_animation = property_animation_create_layer_frame(&data->content_layer, &from, &to);
   if (data->slide_animation) {
@@ -222,7 +221,7 @@ static void prv_selector_slide(WatchfacesSelectorData *data, int direction) {
   layer_mark_dirty(&data->content_layer);
 }
 
-//! direction: +1 = next (slide in from the right), -1 = previous
+//! direction: +1 = next (slide in from the bottom), -1 = previous
 static void prv_selector_navigate(WatchfacesSelectorData *data, int direction) {
   const uint16_t count = app_menu_data_source_get_count(&data->data_source);
   if (count < 2) {
@@ -271,9 +270,10 @@ static void prv_selector_touch_handler(const TouchEvent *event, void *context) {
       data->touch_tracking = false;
       const int16_t dx = event->x - data->touch_down_x;
       const int16_t dy = event->y - data->touch_down_y;
-      if (ABS(dx) >= SELECTOR_SWIPE_MIN_PX && ABS(dx) > ABS(dy)) {
-        // Swipe left moves forward, swipe right moves back
-        prv_selector_navigate(data, (dx < 0) ? 1 : -1);
+      if (ABS(dy) >= SELECTOR_SWIPE_MIN_PX && ABS(dy) > ABS(dx)) {
+        // Swipe up moves forward, swipe down moves back; horizontal swipes
+        // are ignored.
+        prv_selector_navigate(data, (dy < 0) ? 1 : -1);
       } else if (ABS(dx) < SELECTOR_SWIPE_MIN_PX && ABS(dy) < SELECTOR_SWIPE_MIN_PX) {
         prv_selector_select(data);
       }

--- a/src/fw/apps/system/watchfaces.h
+++ b/src/fw/apps/system/watchfaces.h
@@ -7,4 +7,10 @@
 
 #define WATCHFACES_APP_COLOR_PRIMARY GColorJazzberryJam
 
+//! Launch args for the Watchfaces app. When selector_mode is set, the app
+//! opens the touch carousel selector instead of the menu list.
+typedef struct WatchfacesLaunchArgs {
+  bool selector_mode;
+} WatchfacesLaunchArgs;
+
 const PebbleProcessMd* watchfaces_get_app_info();

--- a/src/fw/services/touch/touch.c
+++ b/src/fw/services/touch/touch.c
@@ -25,6 +25,11 @@ static int16_t s_last_y;
 static PebbleMutex *s_touch_mutex;
 
 static uint8_t s_subscriber_count = 0;
+//! Subscriptions explicitly marked as system-internal (e.g. the watchface
+//! long-press hook): they keep the sensor powered but must not count as
+//! "an app is using touch". The backlight subscription is tracked separately
+//! via s_backlight_subscribed and excluded the same way.
+static uint8_t s_system_subscriber_count = 0;
 static bool s_backlight_subscribed = false;
 static bool s_globally_enabled = true;
 static bool s_rotated = false;
@@ -55,6 +60,17 @@ static void prv_remove_subscriber_cb(PebbleTask task) {
   mutex_unlock(s_touch_mutex);
 }
 
+void touch_set_system_subscribed(bool subscribed) {
+  mutex_lock(s_touch_mutex);
+  if (subscribed) {
+    s_system_subscriber_count++;
+  } else {
+    PBL_ASSERTN(s_system_subscriber_count > 0);
+    s_system_subscriber_count--;
+  }
+  mutex_unlock(s_touch_mutex);
+}
+
 void touch_init(void) {
   s_touch_mutex = mutex_create();
 
@@ -66,10 +82,10 @@ void touch_init(void) {
 
 bool touch_has_app_subscribers(void) {
   mutex_lock(s_touch_mutex);
-  // The backlight gesture subscription is tracked in s_subscriber_count as
-  // well; exclude it so this only reflects real app subscribers.
-  const uint8_t backlight_count = s_backlight_subscribed ? 1 : 0;
-  const bool has_apps = s_subscriber_count > backlight_count;
+  // Exclude the system-internal subscriptions (backlight, marked system
+  // subscribers) so this only reflects real app subscribers.
+  const uint8_t excluded = (s_backlight_subscribed ? 1 : 0) + s_system_subscriber_count;
+  const bool has_apps = s_subscriber_count > excluded;
   mutex_unlock(s_touch_mutex);
   return has_apps;
 }

--- a/src/fw/shell/normal/watchface.c
+++ b/src/fw/shell/normal/watchface.c
@@ -21,6 +21,11 @@
 #include "applib/app_timer.h"
 #include "applib/app_launch_reason.h"
 #include "applib/ui/click_internal.h"
+#ifdef CONFIG_TOUCH
+#include "applib/touch_service.h"
+#include "apps/system/watchfaces.h"
+#include <pbl/util/math.h>
+#endif
 #include "pbl/services/notifications/do_not_disturb.h"
 #include <pbl/logging/logging.h>
 #include "system/passert.h"
@@ -41,6 +46,17 @@ static ClickManager s_click_manager;
 static uint8_t s_buttons_pressed = BIT_CLEAR;
 static AppTimer *s_combo_back_hold_timer = NULL;
 static uint8_t s_active_combo_buttons = BIT_CLEAR;
+
+#ifdef CONFIG_TOUCH
+//! Hold a finger on the watchface for this long to open the watchface selector.
+#define TOUCH_HOLD_MS (2000)
+//! Movement beyond this many pixels cancels the hold (it's a drag, not a press).
+#define TOUCH_HOLD_SLOP_PX (20)
+
+static AppTimer *s_touch_hold_timer = NULL;
+static int16_t s_touch_hold_x;
+static int16_t s_touch_hold_y;
+#endif
 
 static bool prv_should_ignore_button_click(void) {
   if (app_manager_get_task_context()->closing_state != ProcessRunState_Running) {
@@ -301,6 +317,61 @@ static void prv_dismiss_timeline_peek(ClickRecognizerRef recognizer, void *data)
   timeline_peek_dismiss();
 }
 
+#ifdef CONFIG_TOUCH
+static bool prv_touch_ignore(void) {
+  const bool modal_focused = modal_manager_get_enabled() &&
+      !(modal_manager_get_properties() & ModalProperty_Unfocused);
+  return prv_should_ignore_button_click() || modal_focused ||
+         !app_manager_is_watchface_running();
+}
+
+static void prv_touch_hold_cancel(void) {
+  if (s_touch_hold_timer != NULL) {
+    app_timer_cancel(s_touch_hold_timer);
+    s_touch_hold_timer = NULL;
+  }
+}
+
+static void prv_touch_hold_timer_callback(void *data) {
+  s_touch_hold_timer = NULL;
+  if (prv_touch_ignore()) {
+    return;
+  }
+  static const WatchfacesLaunchArgs s_selector_args = { .selector_mode = true };
+  app_manager_put_launch_app_event(&(AppLaunchEventConfig) {
+    .id = APP_ID_WATCHFACES,
+    .common.reason = APP_LAUNCH_SYSTEM,
+    .common.args = &s_selector_args,
+  });
+}
+
+static void prv_watchface_touch_handler(const TouchEvent *event, void *context) {
+  if (prv_touch_ignore()) {
+    prv_touch_hold_cancel();
+    return;
+  }
+  switch (event->type) {
+    case TouchEvent_Touchdown:
+      prv_touch_hold_cancel();
+      s_touch_hold_x = event->x;
+      s_touch_hold_y = event->y;
+      s_touch_hold_timer =
+          app_timer_register(TOUCH_HOLD_MS, prv_touch_hold_timer_callback, NULL);
+      break;
+    case TouchEvent_PositionUpdate:
+      if (s_touch_hold_timer != NULL &&
+          (ABS(event->x - s_touch_hold_x) > TOUCH_HOLD_SLOP_PX ||
+           ABS(event->y - s_touch_hold_y) > TOUCH_HOLD_SLOP_PX)) {
+        prv_touch_hold_cancel();
+      }
+      break;
+    case TouchEvent_Liftoff:
+      prv_touch_hold_cancel();
+      break;
+  }
+}
+#endif // CONFIG_TOUCH
+
 static void prv_watchface_configure_click_handlers(void) {
   prv_configure_click_handler(BUTTON_ID_UP, prv_launch_up_down);
   prv_configure_click_handler(BUTTON_ID_DOWN, prv_launch_up_down);
@@ -311,6 +382,12 @@ static void prv_watchface_configure_click_handlers(void) {
 void watchface_init(void) {
   click_manager_init(&s_click_manager);
   prv_watchface_configure_click_handlers();
+#ifdef CONFIG_TOUCH
+  // Kernel-side subscription: keeps the touch sensor powered so a long press
+  // on the watchface can open the selector. Foreground gating happens in the
+  // handler itself.
+  touch_service_subscribe(prv_watchface_touch_handler, NULL);
+#endif
 }
 
 void watchface_handle_button_event(PebbleEvent *e) {

--- a/src/fw/shell/normal/watchface.c
+++ b/src/fw/shell/normal/watchface.c
@@ -24,6 +24,7 @@
 #ifdef CONFIG_TOUCH
 #include "applib/touch_service.h"
 #include "apps/system/watchfaces.h"
+#include "pbl/services/touch/touch.h"
 #include <pbl/util/math.h>
 #endif
 #include "pbl/services/notifications/do_not_disturb.h"
@@ -385,8 +386,10 @@ void watchface_init(void) {
 #ifdef CONFIG_TOUCH
   // Kernel-side subscription: keeps the touch sensor powered so a long press
   // on the watchface can open the selector. Foreground gating happens in the
-  // handler itself.
+  // handler itself. Marked as a system subscription so it doesn't trigger the
+  // touch-backlight override meant for third-party touch apps.
   touch_service_subscribe(prv_watchface_touch_handler, NULL);
+  touch_set_system_subscribed(true);
 #endif
 }
 

--- a/tests/fw/services/test_touch.c
+++ b/tests/fw/services/test_touch.c
@@ -211,6 +211,29 @@ void test_touch__has_app_subscribers_backlight(void) {
   cl_assert(!touch_has_app_subscribers());
 }
 
+void test_touch__has_app_subscribers_system(void) {
+  // Subscriptions marked as system-internal (e.g. the watchface long-press
+  // hook) keep the sensor powered but must not count as app subscribers, or
+  // the event loop would light the backlight on every touchdown and bypass
+  // the wake-gesture preference. Unmarked subscribers keep counting so the
+  // touch-backlight behavior for third-party touch apps is unaffected.
+  cl_assert(!touch_has_app_subscribers());
+
+  s_add_subscriber_cb(PebbleTask_KernelMain);
+  touch_set_system_subscribed(true);
+  cl_assert(!touch_has_app_subscribers());
+
+  s_add_subscriber_cb(PebbleTask_App);
+  cl_assert(touch_has_app_subscribers());
+
+  s_remove_subscriber_cb(PebbleTask_App);
+  cl_assert(!touch_has_app_subscribers());
+
+  touch_set_system_subscribed(false);
+  s_remove_subscriber_cb(PebbleTask_KernelMain);
+  cl_assert(!touch_has_app_subscribers());
+}
+
 void test_touch__globally_enabled_default_true(void) {
   // Default state after init is enabled; no setter call required.
   cl_assert(touch_service_is_globally_enabled());


### PR DESCRIPTION
## Summary

Hold a finger on the watchface for 2 s (touchscreen platforms only, e.g. obelix/getafix) to open a new carousel selector UI in the Watchfaces app:

- Full-screen card per installed watchface: icon, name, Active badge, position counter, up/down arrows (`content_indicator_draw_arrow`).
- Swipe up/down slides between watchfaces (with wrap-around); the face landed on is immediately persisted as the new default, so backing out returns to it.
- Tap or SELECT launches the face (`APP_LAUNCH_USER`, so app_manager persists it as default). BACK exits. UP/DOWN buttons also navigate.
- Entered only via `WatchfacesLaunchArgs.selector_mode` from the shell long-press hook; the regular Watchfaces menu list is unchanged.

Implementation:

- `src/fw/shell/normal/watchface.c`: kernel-side touch subscription + 2 s hold timer (20 px slop cancel; suppressed while a modal is focused, in low power, or when a non-watchface is foreground).
- `src/fw/apps/system/watchfaces.c`: the selector UI. Touch contacts starting within 500 ms of window load are ignored so the entry long-press finger is not read as a tap on real hardware.
- All touch code is gated on `CONFIG_TOUCH`; non-touch platforms compile it out (verified with a `qemu_flint` build).

Also fixes a regression found while testing: `touch_has_app_subscribers()` counted any kernel-side subscriber as an app, so the new permanent subscription made the event loop light the backlight on every touchdown and bypass the touch-wake preference. Fixed with a new `touch_set_system_subscribed()` opt-out that only the watchface long-press hook uses -- the touchdown-driven backlight for third-party touch apps is unchanged (unit test added).

## Power

- Master Touch setting off: chip fully sleeps, feature disabled — unchanged.
- Touch on + touch-wake enabled (default): chip was already powered 24/7 for the backlight subscription — zero delta.
- Touch on + touch-wake off: chip now idles in its auto-sleep mode (µA) instead of deep sleep so the long press works; known tradeoff, fallback is a foreground-only subscription if telemetry flags it.

## Testing

- Verified end-to-end in the getafix QEMU emulator (qemu_gabbro) with injected touch: long-press open, swipe navigation + wrap, swipe-persists-default, tap-launch, back-exit, drag-slop cancel, button navigation.
- `./pbl test` suite green; new `test_touch__has_app_subscribers_system` fails before the backlight fix and passes after.
- Dual-slot getafix dvt2 PBZ built and sideloaded for on-device testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
