### PR TITLE
[RFC/Demo] BLE HID camera remote — working prototype, not for merge

### DIFF
--- a/include/bluetooth/hid_service.h
+++ b/include/bluetooth/hid_service.h
@@ -1,0 +1,106 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <bluetooth/bluetooth_types.h>
+
+//! Two input reports carry the same Consumer usages in two different forms, on
+//! purpose: report 1 as a bitmap bit, report 2 as a 16-bit Array selector. Both
+//! are exposed so the two can be compared on real phones across models and OS
+//! versions. This is the one place that says why; everything else points here.
+//!
+//! The Array form is not assumed safe. Broken handling of 16-bit usage-range
+//! Consumer arrays around iOS 16 is reported by HID device authors rather than
+//! documented by Apple -- no advisory, release note or radar has been found to
+//! cite -- so it is a reason to keep a fallback, not an established fact. The
+//! bitmap is that fallback.
+//!
+//! Measured, as opposed to reported: on one iOS version, Volume Up and Volume
+//! Down fire the camera shutter on both forms, and Snapshot 0x065 takes a
+//! screenshot rather than a photo. No Android result either way.
+
+//! Bits of the report 1 Consumer Control input report. @see the HID report map.
+#define BLE_HID_CONSUMER_VOLUME_UP   (1 << 0)
+#define BLE_HID_CONSUMER_VOLUME_DOWN (1 << 1)
+#define BLE_HID_CONSUMER_PLAY_PAUSE  (1 << 2)
+#define BLE_HID_CONSUMER_NEXT_TRACK  (1 << 3)
+#define BLE_HID_CONSUMER_PREV_TRACK  (1 << 4)
+#define BLE_HID_CONSUMER_MUTE        (1 << 5)
+#define BLE_HID_CONSUMER_SNAPSHOT    (1 << 6)
+
+//! Consumer page usage IDs of those same seven bits. The report map is built
+//! from these, so it cannot drift from the mapping below.
+#define BLE_HID_USAGE_VOLUME_UP   (0x0E9)
+#define BLE_HID_USAGE_VOLUME_DOWN (0x0EA)
+#define BLE_HID_USAGE_PLAY_PAUSE  (0x0CD)
+#define BLE_HID_USAGE_NEXT_TRACK  (0x0B5)
+#define BLE_HID_USAGE_PREV_TRACK  (0x0B6)
+#define BLE_HID_USAGE_MUTE        (0x0E2)
+#define BLE_HID_USAGE_SNAPSHOT    (0x065)
+
+//! Largest usage report 2 can carry. @see Usage Maximum in the report map.
+#define BLE_HID_USAGE_MAX (0x3FF)
+
+//! The one usage -> report 1 bit table, so the report map and the send path
+//! cannot disagree about which bit a usage is.
+//! @return The report 1 bit for `usage`, or 0 if report 1 does not carry it.
+static inline uint8_t ble_hid_consumer_usage_to_bit(uint16_t usage) {
+  switch (usage) {
+    case BLE_HID_USAGE_VOLUME_UP:
+      return BLE_HID_CONSUMER_VOLUME_UP;
+    case BLE_HID_USAGE_VOLUME_DOWN:
+      return BLE_HID_CONSUMER_VOLUME_DOWN;
+    case BLE_HID_USAGE_PLAY_PAUSE:
+      return BLE_HID_CONSUMER_PLAY_PAUSE;
+    case BLE_HID_USAGE_NEXT_TRACK:
+      return BLE_HID_CONSUMER_NEXT_TRACK;
+    case BLE_HID_USAGE_PREV_TRACK:
+      return BLE_HID_CONSUMER_PREV_TRACK;
+    case BLE_HID_USAGE_MUTE:
+      return BLE_HID_CONSUMER_MUTE;
+    case BLE_HID_USAGE_SNAPSHOT:
+      return BLE_HID_CONSUMER_SNAPSHOT;
+    default:
+      return 0;
+  }
+}
+
+//! @return True if the BT driver lib supports exposing the GATT HID service.
+bool bt_driver_is_hid_service_supported(void);
+
+//! Sends a one-byte Consumer Control input report (report 1) to the subscribed
+//! device. Bit 0 = Volume Increment, bit 1 = Volume Decrement, bit 2 =
+//! Play/Pause, bit 3 = Scan Next, bit 4 = Scan Previous, bit 5 = Mute,
+//! bit 6 = Snapshot.
+bool bt_driver_hid_service_send_consumer_report(uint8_t bits);
+
+//! @return True if a connected device has subscribed to report 1.
+bool bt_driver_hid_service_is_subscribed(void);
+
+//! Sends a Consumer Control usage selector (report 2). The report map keeps
+//! Logical Minimum and Usage Minimum equal, so the value on the wire is the
+//! usage itself. 0 sits below both and is therefore "no controls asserted",
+//! i.e. the release; anything above BLE_HID_USAGE_MAX is outside the range.
+bool bt_driver_hid_service_send_consumer_usage(uint16_t usage);
+
+//! @return True if a connected device has subscribed to report 2.
+bool bt_driver_hid_service_usage_is_subscribed(void);
+
+//! Called when a connected device (un)subscribes to a HID input report.
+//! @param device The peer, or all-zero when the driver could not name it. That
+//! happens on an unsubscribe caused by the link going away, which is the case
+//! the FW most needs to hear about, so it is reported rather than swallowed.
+//! An implementation must therefore not key off `device`.
+//! @param is_subscribed The new state of the report that changed. One event per
+//! report characteristic, so an implementation that cares about a specific
+//! report should read it back with bt_driver_hid_service_is_subscribed() or
+//! bt_driver_hid_service_usage_is_subscribed() rather than trust this flag.
+//! @note There is exactly one implementation, in
+//! src/fw/services/bluetooth/ble_hid.c. Keep it that way: a second one would
+//! have to rediscover both of the above.
+extern void bt_driver_cb_hid_service_update_subscription(const BTDeviceInternal *device,
+                                                         bool is_subscribed);

--- a/include/bluetooth/responsiveness.h
+++ b/include/bluetooth/responsiveness.h
@@ -32,6 +32,7 @@ typedef enum {
   BtConsumerTimelineActionMenu,
   BtConsumerPRF,
   BtConsumerPebblePairingServiceRemoteDevice,
+  BtConsumerHidRemote,
   BtConsumerUnitTests, // For unit testing
   NumBtConsumer,
 } BtConsumer;
@@ -52,6 +53,7 @@ typedef void (*ResponsivenessGrantedHandler)(void);
 #define MIN_LATENCY_MODE_TIMEOUT_APP_FETCH_SECS            (5)
 #define MIN_LATENCY_MODE_TIMEOUT_APP_MESSAGE_SECS          (10)
 #define MIN_LATENCY_MODE_TIMEOUT_CD_SECS                   (10)
+#define MIN_LATENCY_MODE_TIMEOUT_HID_SECS                  (60)
 #define MIN_LATENCY_MODE_TIMEOUT_PROTOCOL_RECV_SECS        (60)
 #define MIN_LATENCY_MODE_TIMEOUT_PUT_BYTES_SECS            (60)
 #define MIN_LATENCY_MODE_TIMEOUT_SCREENSHOT_SECS           (5)

--- a/include/pbl/btutil/sm_util.h
+++ b/include/pbl/btutil/sm_util.h
@@ -8,6 +8,17 @@ typedef struct SM128BitKey SM128BitKey;
 
 bool sm_is_pairing_info_equal_identity(const SMPairingInfo *a, const SMPairingInfo *b);
 
+//! @return True if `stored` still holds `expected`'s encryption key material.
+//! @note The LTK is the only field that tells one pairing from another. The identity address and
+//! the IRK both survive a re-pair of the same phone, which is exactly the case a deferred delete
+//! has to notice.
+//! @note Only the halves `expected` marks valid are compared: a deferred delete carries the one
+//! half of the bonding the BT driver handed it, while what is stored holds both. No valid half
+//! means nothing was compared, and matching on the address alone is what this exists to avoid, so
+//! that never matches.
+bool sm_pairing_info_encryption_keys_match(const SMPairingInfo *stored,
+                                           const SMPairingInfo *expected);
+
 bool sm_is_pairing_info_empty(const SMPairingInfo *p);
 
 bool sm_is_pairing_info_irk_not_used(const SM128BitKey *irk_key);

--- a/include/pbl/services/bluetooth/ble_hid.h
+++ b/include/pbl/services/bluetooth/ble_hid.h
@@ -1,0 +1,82 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "system/status_codes.h"
+
+//! Which HID input report carries a Consumer Control usage. The caller always
+//! states it: there is no implicit routing, so a failed press always names the
+//! path it was tried on.
+//! @note Both forms are exposed on purpose, so the same Consumer usage can be
+//! sent as a bitmap bit and as an Array selector and the two compared on real
+//! phones across models and OS versions. @see <bluetooth/hid_service.h> for why
+//! the Array form is not assumed safe and what has actually been measured.
+//! @note If the Array form holds across the target phone matrix, report 1 goes
+//! away. What follows is a pointer to that work, not an inventory of it. Start
+//! from
+//! `git grep -n 'BleHidReportPath\|BLE_HID_CONSUMER_\|_consumer_report\|hid_service_is_subscribed'`
+//! which reaches the FW, the three driver backends, the prompt commands, the
+//! Camera app and the tests; then the parts no identifier names -- report 1's
+//! half of the NimBLE report map, its Report characteristic and its
+//! report-reference, and the arity of "hid usage" / "hid tap". Dropping it from
+//! the report map makes every bonded phone re-pair, so it is a release decision
+//! rather than a cleanup.
+typedef enum {
+  //! Report 1, the fixed 7-usage bitfield. Fails for a usage it does not declare.
+  BleHidReportPathBitmap = 0,
+  //! Report 2, the 16-bit Consumer usage array.
+  BleHidReportPathUsage,
+} BleHidReportPath;
+
+//! Sets up the HID remote service. Called when the BT stack comes up.
+void ble_hid_init(void);
+
+//! Tears down the HID remote service. Called when the BT stack goes down.
+void ble_hid_deinit(void);
+
+//! @param path The report the caller intends to use. Readiness is per report:
+//! a peer can subscribe to one and not the other.
+//! @return True if the watch can currently act as a HID remote over `path`
+//! (driver supports it and a bonded device has subscribed to that report).
+bool ble_hid_is_ready(BleHidReportPath path);
+
+//! Presses a Consumer Control usage. It stays held until released, or until the
+//! safety timeout expires and ble_hid releases it on the caller's behalf. Safe
+//! to call from any task; the report goes out on KernelBG, so a success only
+//! means the press was accepted, not that the report reached the phone.
+//! @note On success the held state is published before this returns, so a
+//! caller may release immediately afterwards without racing the send.
+//! @note That forced release is best effort, not a guarantee. If the lift
+//! cannot be sent -- KernelBG backed up, or the send failing with the peer
+//! still subscribed -- it is retried for a bounded window past the safety
+//! timeout, and if it still cannot go out ble_hid logs at ERR and forgets the
+//! usage without having lifted it. The key is then left down on the phone until
+//! something presses again; nothing in here can do better, since the entire
+//! window was spent failing to send. A peer that unsubscribes or disconnects is
+//! not that case: a HOGP host drops every key it knows about, so the state is
+//! cleared with no report and nothing is left down.
+//! @param usage A Consumer page usage, 1..BLE_HID_USAGE_MAX.
+//! @param path Which report to send it on. Report 1 does not carry every usage
+//! and is not silently swapped for report 2 when it cannot.
+//! @return S_SUCCESS if the press was accepted, S_NO_ACTION_REQUIRED if the
+//! same usage is already held on the same path, E_INVALID_ARGUMENT for a usage
+//! out of range or a path that cannot carry it, E_INVALID_OPERATION if nothing
+//! is subscribed to that report, E_BUSY if another usage is held, E_INTERNAL if
+//! the work could not be queued.
+status_t ble_hid_consumer_press(uint16_t usage, BleHidReportPath path);
+
+//! Releases the currently held usage. Errors if `usage` is not what is held.
+//! The release always goes out on the report the press used, so the caller
+//! cannot release a report 2 press on report 1.
+//! @return S_SUCCESS if the release was accepted, S_NO_ACTION_REQUIRED if
+//! nothing is held, E_INVALID_ARGUMENT if something else is held, E_INTERNAL if
+//! the work could not be queued -- in which case the safety timeout takes over,
+//! with the best-effort caveat on ble_hid_consumer_press().
+status_t ble_hid_consumer_release(uint16_t usage);
+
+//! Raises/lowers the BLE connection responsiveness for the HID remote.
+void ble_hid_set_low_latency(bool enabled);

--- a/include/pbl/services/bluetooth/bluetooth_persistent_storage.h
+++ b/include/pbl/services/bluetooth/bluetooth_persistent_storage.h
@@ -56,6 +56,17 @@ void bt_persistent_storage_delete_ble_pairing_by_id(BTBondingID);
 
 void bt_persistent_storage_delete_ble_pairing_by_addr(const BTDeviceInternal *device);
 
+//! Like bt_persistent_storage_delete_ble_pairing_by_addr(), but only deletes a
+//! record whose stored key material still matches `expected`.
+//! For deferred deletes: re-pairing the same phone reuses its identity address
+//! and its IRK, so it lands on the very record an in-flight delete was aimed at.
+//! Only the LTK tells the two apart. Halves of `expected` that are marked
+//! invalid are not compared, so one half of a bonding is enough to identify it;
+//! an `expected` with no encryption info at all never matches.
+//! @return True if a matching pairing was found and deleted.
+bool bt_persistent_storage_delete_ble_pairing_by_addr_if_matches(const BTDeviceInternal *device,
+                                                                 const SMPairingInfo *expected);
+
 bool bt_persistent_storage_get_ble_pairing_by_id(BTBondingID bonding,
                                                  SMIdentityResolvingKey *IRK_out,
                                                  BTDeviceInternal *device_out,
@@ -163,3 +174,11 @@ void bt_persistent_storage_delete_all_pairings(void);
 //! Unit testing
 int bt_persistent_storage_get_raw_data(const void *key, size_t key_len,
                                        void *data_out, size_t buf_len);
+
+//! The guarded delete of bt_persistent_storage_delete_ble_pairing_by_addr_if_matches(), entered by
+//! id instead of by address. Its by-address lookup applies the same key comparison before it picks
+//! an id, so the re-check inside the delete transaction -- the only one that runs with the record
+//! held, and the one the race is about -- cannot be reached from there.
+//! @return True if a matching pairing was found and deleted.
+bool bt_persistent_storage_delete_ble_pairing_by_id_if_matches(BTBondingID bonding,
+                                                               const SMPairingInfo *expected);

--- a/include/pbl/services/shared_prf_storage/shared_prf_storage.h
+++ b/include/pbl/services/shared_prf_storage/shared_prf_storage.h
@@ -56,6 +56,19 @@ void shared_prf_storage_store_ble_pairing_data(const SMPairingInfo *pairing_info
 
 void shared_prf_storage_erase_ble_pairing_data(void);
 
+//! Erase the stored BLE pairing, but only if it still holds `expected`'s key
+//! material.
+//! @note The read and the erase happen under one lock. The stored pairing is
+//! what is being checked, so a pairing written in between would otherwise be
+//! erased by a delete aimed at the one it replaced.
+//! @param expected The key material the stored pairing must still hold. Only the
+//! halves `expected` marks valid are compared; no valid half never matches.
+//! @param erased_out Optional. When the erase happened, the pairing that was
+//! erased, so the caller can notify the BT driver outside this lock.
+//! @return True if the stored pairing matched and was erased.
+bool shared_prf_storage_erase_ble_pairing_data_if_matches(const SMPairingInfo *expected,
+                                                          SMPairingInfo *erased_out);
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 //! BLE Pinned Address
 

--- a/include/pbl/services/system_task.h
+++ b/include/pbl/services/system_task.h
@@ -32,6 +32,16 @@ bool system_task_add_callback_from_isr(SystemTaskEventCallback cb, void *data, b
 //! @param data Context pointer passed to the callback
 bool system_task_add_callback(SystemTaskEventCallback cb, void *data);
 
+//! Like system_task_add_callback(), but reports a full queue instead of waiting
+//! on it. system_task_add_callback() blocks for up to 3 s and then reboots the
+//! watch, which is not an option for a caller that holds a lock KernelBG needs,
+//! runs on KernelBG itself, or runs on a task the rest of the system waits on.
+//! @param cb Callback function that will later be called from the system task
+//! @param data Context pointer passed to the callback
+//! @return True if the callback was queued. False if the queue is full or
+//! callbacks are blocked; the caller owns whatever it was going to hand over.
+bool system_task_add_callback_nonblocking(SystemTaskEventCallback cb, void *data);
+
 //! @param block True if callbacks should be rejected, False if they should be let through.
 void system_task_block_callbacks(bool block);
 

--- a/lib/btutil/sm_util.c
+++ b/lib/btutil/sm_util.c
@@ -21,6 +21,47 @@ bool sm_is_pairing_info_equal_identity(const SMPairingInfo *a, const SMPairingIn
 #pragma GCC diagnostic pop
 
 // -------------------------------------------------------------------------------------------------
+static bool prv_encryption_info_matches(const SMLongTermKey *stored_ltk, uint16_t stored_ediv,
+                                        uint64_t stored_rand, const SMLongTermKey *ltk,
+                                        uint16_t ediv, uint64_t rand) {
+  return (memcmp(stored_ltk, ltk, sizeof(*ltk)) == 0) && (stored_ediv == ediv) &&
+         (stored_rand == rand);
+}
+
+bool sm_pairing_info_encryption_keys_match(const SMPairingInfo *stored,
+                                           const SMPairingInfo *expected) {
+  bool compared = false;
+
+  if (expected->is_remote_encryption_info_valid) {
+    if (!stored->is_remote_encryption_info_valid ||
+        !prv_encryption_info_matches(&stored->remote_encryption_info.ltk,
+                                     stored->remote_encryption_info.ediv,
+                                     stored->remote_encryption_info.rand,
+                                     &expected->remote_encryption_info.ltk,
+                                     expected->remote_encryption_info.ediv,
+                                     expected->remote_encryption_info.rand)) {
+      return false;
+    }
+    compared = true;
+  }
+
+  if (expected->is_local_encryption_info_valid) {
+    if (!stored->is_local_encryption_info_valid ||
+        !prv_encryption_info_matches(&stored->local_encryption_info.ltk,
+                                     stored->local_encryption_info.ediv,
+                                     stored->local_encryption_info.rand,
+                                     &expected->local_encryption_info.ltk,
+                                     expected->local_encryption_info.ediv,
+                                     expected->local_encryption_info.rand)) {
+      return false;
+    }
+    compared = true;
+  }
+
+  return compared;
+}
+
+// -------------------------------------------------------------------------------------------------
 bool sm_is_pairing_info_empty(const SMPairingInfo *p) {
   return (!p->is_local_encryption_info_valid &&
           !p->is_remote_encryption_info_valid &&

--- a/src/bluetooth-fw/Kconfig
+++ b/src/bluetooth-fw/Kconfig
@@ -28,6 +28,26 @@ module = BT
 module-str = Bluetooth
 source "subsys/logging/Kconfig.template.log_level"
 
+config BT_HID_REMOTE
+    bool "BLE HID camera remote"
+    depends on BT_FW_NIMBLE
+    default y
+    help
+      Expose a HID-over-GATT service with a Consumer Control report, so the
+      watch can act as a remote. On the one iOS version this has been tried
+      on, sending Volume Increment fires the camera shutter while the Camera
+      app is in the foreground. Nothing else has been measured.
+
+      On by default on this prototype branch, so test builds carry the
+      feature without extra configure flags. A mergeable version would ship
+      disabled until the report map is settled: it declares the same
+      Consumer usages twice, as a bitmap and as a 16-bit usage array, and
+      which of the two to keep is still being compared across phone models
+      and OS versions. A host caches the report map when it bonds, so
+      defaulting this on would freeze the two-report map onto every phone
+      that pairs, and answering the question afterwards would mean a re-pair
+      for each of them.
+
 config GH3X2X_TUNING_SERVICE_ENABLED
     bool "GH3X2X tuning service"
     depends on HRM_GH3X2X

--- a/src/bluetooth-fw/nimble/dis_service.c
+++ b/src/bluetooth-fw/nimble/dis_service.c
@@ -1,0 +1,179 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "dis_service.h"
+
+#include <board/board.h>
+#include <host/ble_gatt.h>
+#include <host/ble_hs.h>
+#include <host/ble_uuid.h>
+#include <os/os_mbuf.h>
+#include <string.h>
+#include <system/passert.h>
+
+#define DIS_SERVICE_UUID               (0x180A)
+#define DIS_CHR_SYSTEM_ID_UUID         (0x2A23)
+#define DIS_CHR_MODEL_NUMBER_UUID      (0x2A24)
+#define DIS_CHR_SERIAL_NUMBER_UUID     (0x2A25)
+#define DIS_CHR_FIRMWARE_REVISION_UUID (0x2A26)
+#define DIS_CHR_HARDWARE_REVISION_UUID (0x2A27)
+#define DIS_CHR_SOFTWARE_REVISION_UUID (0x2A28)
+#define DIS_CHR_MANUFACTURER_NAME_UUID (0x2A29)
+#define DIS_CHR_PNP_ID_UUID            (0x2A50)
+
+// BT_VENDOR_ID is a Bluetooth SIG company identifier (it is what we put in the
+// company id field of our manufacturer-specific advertising data), so the PnP
+// vendor id source says "Bluetooth SIG" rather than "USB Implementer's Forum".
+#define DIS_PNP_VENDOR_ID_SOURCE_BT_SIG (0x01)
+#define DIS_PNP_PRODUCT_ID              (0x0001)
+#define DIS_PNP_PRODUCT_VERSION         (0x0100)
+
+typedef enum {
+  DisFieldModelNumber = 0,
+  DisFieldSerialNumber,
+  DisFieldFirmwareRevision,
+  DisFieldSoftwareRevision,
+  DisFieldManufacturerName,
+  //! Registered but never populated, exactly as ble_svc_dis left them: both
+  //! read back empty. Kept so the pre-existing DIS characteristics keep their
+  //! ATT handles.
+  DisFieldHardwareRevision,
+  DisFieldSystemId,
+} DisField;
+
+// PnP ID, 7 bytes little-endian.
+static const uint8_t s_pnp_id[] = {
+    DIS_PNP_VENDOR_ID_SOURCE_BT_SIG,
+    (uint8_t)(BT_VENDOR_ID & 0xFFU),
+    (uint8_t)((BT_VENDOR_ID >> 8) & 0xFFU),
+    (uint8_t)(DIS_PNP_PRODUCT_ID & 0xFFU),
+    (uint8_t)((DIS_PNP_PRODUCT_ID >> 8) & 0xFFU),
+    (uint8_t)(DIS_PNP_PRODUCT_VERSION & 0xFFU),
+    (uint8_t)((DIS_PNP_PRODUCT_VERSION >> 8) & 0xFFU),
+};
+
+static const DisInfo *s_dis_info;
+
+static const char *prv_field_value(DisField field) {
+  if (!s_dis_info) {
+    return "";
+  }
+  switch (field) {
+    case DisFieldModelNumber:
+      return s_dis_info->model_number;
+    case DisFieldSerialNumber:
+      return s_dis_info->serial_number;
+    case DisFieldFirmwareRevision:
+      return s_dis_info->fw_revision;
+    case DisFieldSoftwareRevision:
+      return s_dis_info->sw_revision;
+    case DisFieldManufacturerName:
+      return s_dis_info->manufacturer;
+    case DisFieldHardwareRevision:
+    case DisFieldSystemId:
+    default:
+      return "";
+  }
+}
+
+static int prv_access_string(uint16_t conn_handle, uint16_t attr_handle,
+                             struct ble_gatt_access_ctxt *ctxt, void *arg) {
+  if (ctxt->op != BLE_GATT_ACCESS_OP_READ_CHR) {
+    return BLE_ATT_ERR_UNLIKELY;
+  }
+  const char *value = prv_field_value((DisField)(uintptr_t)arg);
+  // Not zero terminated by design.
+  return (os_mbuf_append(ctxt->om, value, strlen(value)) == 0) ? 0
+                                                              : BLE_ATT_ERR_INSUFFICIENT_RES;
+}
+
+static int prv_access_pnp_id(uint16_t conn_handle, uint16_t attr_handle,
+                             struct ble_gatt_access_ctxt *ctxt, void *arg) {
+  if (ctxt->op != BLE_GATT_ACCESS_OP_READ_CHR) {
+    return BLE_ATT_ERR_UNLIKELY;
+  }
+  return (os_mbuf_append(ctxt->om, s_pnp_id, sizeof(s_pnp_id)) == 0)
+             ? 0
+             : BLE_ATT_ERR_INSUFFICIENT_RES;
+}
+
+// Characteristic order is exactly the one of ble_svc_dis_defs[], with PnP ID
+// appended, so every pre-existing DIS characteristic keeps its ATT handle. DIS
+// still grows from 15 to 17 attributes, which shifts every service registered
+// after it by +2. A normal OTA update reboots with
+// RebootReasonCode_SoftwareUpdate, which arms the Service Changed indication so
+// bonded peers rediscover; a firmware flashed over SWD/DFU does not, and leaves
+// those peers with a stale GATT cache.
+static const struct ble_gatt_svc_def s_dis_svc[] = {
+    {
+        .type = BLE_GATT_SVC_TYPE_PRIMARY,
+        .uuid = BLE_UUID16_DECLARE(DIS_SERVICE_UUID),
+        .characteristics =
+            (struct ble_gatt_chr_def[]){
+                {
+                    .uuid = BLE_UUID16_DECLARE(DIS_CHR_MODEL_NUMBER_UUID),
+                    .access_cb = prv_access_string,
+                    .arg = (void *)(uintptr_t)DisFieldModelNumber,
+                    .flags = BLE_GATT_CHR_F_READ,
+                },
+                {
+                    .uuid = BLE_UUID16_DECLARE(DIS_CHR_SERIAL_NUMBER_UUID),
+                    .access_cb = prv_access_string,
+                    .arg = (void *)(uintptr_t)DisFieldSerialNumber,
+                    .flags = BLE_GATT_CHR_F_READ,
+                },
+                {
+                    .uuid = BLE_UUID16_DECLARE(DIS_CHR_HARDWARE_REVISION_UUID),
+                    .access_cb = prv_access_string,
+                    .arg = (void *)(uintptr_t)DisFieldHardwareRevision,
+                    .flags = BLE_GATT_CHR_F_READ,
+                },
+                {
+                    .uuid = BLE_UUID16_DECLARE(DIS_CHR_FIRMWARE_REVISION_UUID),
+                    .access_cb = prv_access_string,
+                    .arg = (void *)(uintptr_t)DisFieldFirmwareRevision,
+                    .flags = BLE_GATT_CHR_F_READ,
+                },
+                {
+                    .uuid = BLE_UUID16_DECLARE(DIS_CHR_SOFTWARE_REVISION_UUID),
+                    .access_cb = prv_access_string,
+                    .arg = (void *)(uintptr_t)DisFieldSoftwareRevision,
+                    .flags = BLE_GATT_CHR_F_READ,
+                },
+                {
+                    .uuid = BLE_UUID16_DECLARE(DIS_CHR_MANUFACTURER_NAME_UUID),
+                    .access_cb = prv_access_string,
+                    .arg = (void *)(uintptr_t)DisFieldManufacturerName,
+                    .flags = BLE_GATT_CHR_F_READ,
+                },
+                {
+                    .uuid = BLE_UUID16_DECLARE(DIS_CHR_SYSTEM_ID_UUID),
+                    .access_cb = prv_access_string,
+                    .arg = (void *)(uintptr_t)DisFieldSystemId,
+                    .flags = BLE_GATT_CHR_F_READ,
+                },
+                {
+                    // Mandated by HOGP for a HID device. Appended last so the
+                    // characteristics above keep their handles.
+                    .uuid = BLE_UUID16_DECLARE(DIS_CHR_PNP_ID_UUID),
+                    .access_cb = prv_access_pnp_id,
+                    .flags = BLE_GATT_CHR_F_READ,
+                },
+                {
+                    0,
+                },
+            },
+    },
+    {
+        0,
+    },
+};
+
+void dis_service_init(const DisInfo *info) {
+  s_dis_info = info;
+
+  int rc = ble_gatts_count_cfg(s_dis_svc);
+  PBL_ASSERTN(rc == 0);
+  rc = ble_gatts_add_svcs(s_dis_svc);
+  PBL_ASSERTN(rc == 0);
+}

--- a/src/bluetooth-fw/nimble/dis_service.h
+++ b/src/bluetooth-fw/nimble/dis_service.h
@@ -1,0 +1,9 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include <bluetooth/dis.h>
+
+//! @param info Device info to serve. Must stay valid for as long as the stack runs.
+void dis_service_init(const DisInfo *info);

--- a/src/bluetooth-fw/nimble/hid_service.c
+++ b/src/bluetooth-fw/nimble/hid_service.c
@@ -1,0 +1,421 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "hid_service.h"
+
+#include <bluetooth/hid_service.h>
+
+#ifdef CONFIG_BT_HID_REMOTE
+
+#include <host/ble_gap.h>
+#include <host/ble_gatt.h>
+#include <host/ble_hs.h>
+#include <host/ble_uuid.h>
+#include <os/os_mbuf.h>
+#include <pbl/logging/logging.h>
+#include <system/passert.h>
+
+#include "nimble_type_conversions.h"
+
+PBL_LOG_MODULE_DECLARE(bt, CONFIG_BT_LOG_LEVEL);
+
+#define HID_SERVICE_UUID              (0x1812)
+#define HID_CHR_HID_INFO_UUID         (0x2A4A)
+#define HID_CHR_REPORT_MAP_UUID       (0x2A4B)
+#define HID_CHR_CONTROL_POINT_UUID    (0x2A4C)
+#define HID_CHR_REPORT_UUID           (0x2A4D)
+#define HID_CHR_PROTOCOL_MODE_UUID    (0x2A4E)
+#define HID_DSC_REPORT_REFERENCE_UUID (0x2908)
+
+// Report Protocol; the boot protocol is intentionally not supported.
+#define HID_PROTOCOL_MODE_REPORT (0x01)
+
+// Report 1's descriptor bytes are cached by every bonded phone, so the seven
+// usages it declares are frozen. Each must also stay inside one byte, which is
+// the Usage item width the report map below uses.
+_Static_assert(BLE_HID_USAGE_VOLUME_UP == 0xE9, "report 1 usage changed");
+_Static_assert(BLE_HID_USAGE_VOLUME_DOWN == 0xEA, "report 1 usage changed");
+_Static_assert(BLE_HID_USAGE_PLAY_PAUSE == 0xCD, "report 1 usage changed");
+_Static_assert(BLE_HID_USAGE_NEXT_TRACK == 0xB5, "report 1 usage changed");
+_Static_assert(BLE_HID_USAGE_PREV_TRACK == 0xB6, "report 1 usage changed");
+_Static_assert(BLE_HID_USAGE_MUTE == 0xE2, "report 1 usage changed");
+_Static_assert(BLE_HID_USAGE_SNAPSHOT == 0x65, "report 1 usage changed");
+
+// Consumer Control only: a Keyboard collection would make iOS hide the
+// on-screen keyboard. Report 1 is a bitfield of named usages; report 2 is a
+// generic usage selector, appended to the same collection so every byte of
+// report 1 stays exactly as the phones already cached it.
+static const uint8_t s_hid_report_map[] = {
+    0x05, 0x0C,                            // Usage Page (Consumer)
+    0x09, 0x01,                            // Usage (Consumer Control)
+    0xA1, 0x01,                            // Collection (Application)
+    0x85, 0x01,                            //   Report ID (1)
+    0x15, 0x00,                            //   Logical Minimum (0)
+    0x25, 0x01,                            //   Logical Maximum (1)
+    0x75, 0x01,                            //   Report Size (1)
+    0x95, 0x07,                            //   Report Count (7)
+    0x09, BLE_HID_USAGE_VOLUME_UP,         //   Usage (Volume Increment)  -> bit 0
+    0x09, BLE_HID_USAGE_VOLUME_DOWN,       //   Usage (Volume Decrement)  -> bit 1
+    0x09, BLE_HID_USAGE_PLAY_PAUSE,        //   Usage (Play/Pause)        -> bit 2
+    0x09, BLE_HID_USAGE_NEXT_TRACK,        //   Usage (Scan Next Track)   -> bit 3
+    0x09, BLE_HID_USAGE_PREV_TRACK,        //   Usage (Scan Prev Track)   -> bit 4
+    0x09, BLE_HID_USAGE_MUTE,              //   Usage (Mute)              -> bit 5
+    0x09, BLE_HID_USAGE_SNAPSHOT,          //   Usage (Snapshot)          -> bit 6
+    0x81, 0x02,                            //   Input (Data, Var, Abs)
+    0x95, 0x01,                            //   Report Count (1)
+    0x81, 0x03,                            //   Input (Const, Var, Abs)   padding to a byte
+    0x85, 0x02,                            //   Report ID (2)
+    // An Array field reports an index, resolved as
+    // Usage Minimum + (value - Logical Minimum), so the two minima must match
+    // for a raw usage to mean itself. Both are 1, which also puts 0 outside the
+    // logical range: HID 1.11 6.2.2.5 makes that "no controls asserted", which
+    // is what a release is.
+    0x15, 0x01,                            //   Logical Minimum (1)
+    0x26, 0xFF, 0x03,                      //   Logical Maximum (0x3FF)
+    0x19, 0x01,                            //   Usage Minimum (0x01)
+    0x2A, 0xFF, 0x03,                      //   Usage Maximum (0x3FF)
+    0x75, 0x10,                            //   Report Size (16)
+    0x95, 0x01,                            //   Report Count (1)
+    0x81, 0x00,                            //   Input (Data, Array, Abs)
+    0xC0
+};
+
+// bcdHID 0x0111 (LE), country code 0, flags = NormallyConnectable.
+static const uint8_t s_hid_information[] = {0x11, 0x01, 0x00, 0x02};
+
+// Report Reference: Report ID 1, type Input.
+static const uint8_t s_report_reference[] = {0x01, 0x01};
+
+// Report Reference: Report ID 2, type Input.
+static const uint8_t s_usage_report_reference[] = {0x02, 0x01};
+
+static uint16_t s_report_val_handle;
+static uint16_t s_usage_report_val_handle;
+//! One global subscription pair per report, not an array:
+//! MYNEWT_VAL_BLE_MAX_CONNECTIONS is 1, so there can only ever be one subscriber.
+static uint16_t s_subscribed_conn_handle;
+static uint16_t s_usage_subscribed_conn_handle;
+static bool s_is_subscribed;
+static bool s_usage_is_subscribed;
+static uint8_t s_last_report;
+//! The usage report 2 last carried. Held as one 16-bit word rather than the two
+//! wire bytes so the read handler, which runs on NimbleHost, cannot catch a
+//! half-written value from the KernelBG sender.
+static uint16_t s_last_usage;
+
+static int prv_access_protocol_mode(uint16_t conn_handle, uint16_t attr_handle,
+                                    struct ble_gatt_access_ctxt *ctxt, void *arg) {
+  switch (ctxt->op) {
+    case BLE_GATT_ACCESS_OP_READ_CHR: {
+      const uint8_t mode = HID_PROTOCOL_MODE_REPORT;
+      return (os_mbuf_append(ctxt->om, &mode, sizeof(mode)) == 0) ? 0
+                                                                 : BLE_ATT_ERR_INSUFFICIENT_RES;
+    }
+    case BLE_GATT_ACCESS_OP_WRITE_CHR:
+      // Accept and ignore: we always stay in report protocol mode.
+      return 0;
+    default:
+      return BLE_ATT_ERR_UNLIKELY;
+  }
+}
+
+static int prv_access_report_map(uint16_t conn_handle, uint16_t attr_handle,
+                                 struct ble_gatt_access_ctxt *ctxt, void *arg) {
+  if (ctxt->op != BLE_GATT_ACCESS_OP_READ_CHR) {
+    return BLE_ATT_ERR_UNLIKELY;
+  }
+  return (os_mbuf_append(ctxt->om, s_hid_report_map, sizeof(s_hid_report_map)) == 0)
+             ? 0
+             : BLE_ATT_ERR_INSUFFICIENT_RES;
+}
+
+static int prv_access_report(uint16_t conn_handle, uint16_t attr_handle,
+                             struct ble_gatt_access_ctxt *ctxt, void *arg) {
+  if (ctxt->op != BLE_GATT_ACCESS_OP_READ_CHR) {
+    return BLE_ATT_ERR_UNLIKELY;
+  }
+  return (os_mbuf_append(ctxt->om, &s_last_report, sizeof(s_last_report)) == 0)
+             ? 0
+             : BLE_ATT_ERR_INSUFFICIENT_RES;
+}
+
+static int prv_access_usage_report(uint16_t conn_handle, uint16_t attr_handle,
+                                   struct ble_gatt_access_ctxt *ctxt, void *arg) {
+  if (ctxt->op != BLE_GATT_ACCESS_OP_READ_CHR) {
+    return BLE_ATT_ERR_UNLIKELY;
+  }
+  // Report Size 16, Report Count 1, little-endian on the wire.
+  const uint16_t usage = s_last_usage;
+  const uint8_t report[2] = {(uint8_t)(usage & 0xFF), (uint8_t)(usage >> 8)};
+  return (os_mbuf_append(ctxt->om, report, sizeof(report)) == 0) ? 0
+                                                                 : BLE_ATT_ERR_INSUFFICIENT_RES;
+}
+
+static int prv_access_report_reference(uint16_t conn_handle, uint16_t attr_handle,
+                                       struct ble_gatt_access_ctxt *ctxt, void *arg) {
+  if (ctxt->op != BLE_GATT_ACCESS_OP_READ_DSC) {
+    return BLE_ATT_ERR_UNLIKELY;
+  }
+  return (os_mbuf_append(ctxt->om, s_report_reference, sizeof(s_report_reference)) == 0)
+             ? 0
+             : BLE_ATT_ERR_INSUFFICIENT_RES;
+}
+
+static int prv_access_usage_report_reference(uint16_t conn_handle, uint16_t attr_handle,
+                                             struct ble_gatt_access_ctxt *ctxt, void *arg) {
+  if (ctxt->op != BLE_GATT_ACCESS_OP_READ_DSC) {
+    return BLE_ATT_ERR_UNLIKELY;
+  }
+  return (os_mbuf_append(ctxt->om, s_usage_report_reference, sizeof(s_usage_report_reference)) == 0)
+             ? 0
+             : BLE_ATT_ERR_INSUFFICIENT_RES;
+}
+
+static int prv_access_hid_information(uint16_t conn_handle, uint16_t attr_handle,
+                                      struct ble_gatt_access_ctxt *ctxt, void *arg) {
+  if (ctxt->op != BLE_GATT_ACCESS_OP_READ_CHR) {
+    return BLE_ATT_ERR_UNLIKELY;
+  }
+  return (os_mbuf_append(ctxt->om, s_hid_information, sizeof(s_hid_information)) == 0)
+             ? 0
+             : BLE_ATT_ERR_INSUFFICIENT_RES;
+}
+
+static int prv_access_control_point(uint16_t conn_handle, uint16_t attr_handle,
+                                    struct ble_gatt_access_ctxt *ctxt, void *arg) {
+  // Accept and ignore suspend / exit-suspend.
+  return (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) ? 0 : BLE_ATT_ERR_UNLIKELY;
+}
+
+// Deliberate HOGP deviation: only Report Map and Report carry READ_ENC.
+// BLE_SM_SC_ONLY with BLE_SM_LVL 4 escalates any security flag to
+// LESC+authenticated+16-byte key, and iOS reads HID Information before
+// encryption is up, so gating the rest would break the pairing flow.
+static const struct ble_gatt_svc_def s_hid_svc[] = {
+    {
+        .type = BLE_GATT_SVC_TYPE_PRIMARY,
+        .uuid = BLE_UUID16_DECLARE(HID_SERVICE_UUID),
+        .characteristics =
+            (struct ble_gatt_chr_def[]){
+                {
+                    .uuid = BLE_UUID16_DECLARE(HID_CHR_PROTOCOL_MODE_UUID),
+                    .access_cb = prv_access_protocol_mode,
+                    .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_WRITE_NO_RSP,
+                },
+                {
+                    .uuid = BLE_UUID16_DECLARE(HID_CHR_REPORT_MAP_UUID),
+                    .access_cb = prv_access_report_map,
+                    .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_READ_ENC,
+                },
+                {
+                    .uuid = BLE_UUID16_DECLARE(HID_CHR_REPORT_UUID),
+                    .access_cb = prv_access_report,
+                    // READ_ENC also gates the CCCD, so the peer must bond
+                    // before it can subscribe. NimBLE adds the CCCD itself.
+                    .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY |
+                             BLE_GATT_CHR_F_READ_ENC,
+                    .val_handle = &s_report_val_handle,
+                    .descriptors =
+                        (struct ble_gatt_dsc_def[]){
+                            {
+                                .uuid = BLE_UUID16_DECLARE(HID_DSC_REPORT_REFERENCE_UUID),
+                                .att_flags = BLE_ATT_F_READ,
+                                .access_cb = prv_access_report_reference,
+                            },
+                            {
+                                0,
+                            },
+                        },
+                },
+                {
+                    .uuid = BLE_UUID16_DECLARE(HID_CHR_HID_INFO_UUID),
+                    .access_cb = prv_access_hid_information,
+                    .flags = BLE_GATT_CHR_F_READ,
+                },
+                {
+                    .uuid = BLE_UUID16_DECLARE(HID_CHR_CONTROL_POINT_UUID),
+                    .access_cb = prv_access_control_point,
+                    .flags = BLE_GATT_CHR_F_WRITE_NO_RSP,
+                },
+                {
+                    // Appended last for the same reason the service is
+                    // registered last: every handle before it keeps its value.
+                    .uuid = BLE_UUID16_DECLARE(HID_CHR_REPORT_UUID),
+                    .access_cb = prv_access_usage_report,
+                    .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY |
+                             BLE_GATT_CHR_F_READ_ENC,
+                    .val_handle = &s_usage_report_val_handle,
+                    .descriptors =
+                        (struct ble_gatt_dsc_def[]){
+                            {
+                                .uuid = BLE_UUID16_DECLARE(HID_DSC_REPORT_REFERENCE_UUID),
+                                .att_flags = BLE_ATT_F_READ,
+                                .access_cb = prv_access_usage_report_reference,
+                            },
+                            {
+                                0,
+                            },
+                        },
+                },
+                {
+                    0,
+                },
+            },
+    },
+    {
+        0,
+    },
+};
+
+static void prv_handle_subscribe_event(struct ble_gap_event *event) {
+  // A zeroed handle is hid_service_deinit()'s, never a real attribute's, so it
+  // must not match either characteristic.
+  const uint16_t attr_handle = event->subscribe.attr_handle;
+  const bool is_report = (s_report_val_handle != 0) && (attr_handle == s_report_val_handle);
+  const bool is_usage_report =
+      (s_usage_report_val_handle != 0) && (attr_handle == s_usage_report_val_handle);
+  if (!is_report && !is_usage_report) {
+    return;
+  }
+  if (event->subscribe.cur_notify == event->subscribe.prev_notify) {
+    return;
+  }
+
+  // Drop our view of the subscription first: on a BLE_GAP_SUBSCRIBE_REASON_TERM
+  // the connection is often already gone, and bailing out with the flag still
+  // set would leave us claiming to be subscribed over a dead link.
+  const bool is_subscribed = (event->subscribe.cur_notify != 0);
+  if (is_report) {
+    s_is_subscribed = is_subscribed;
+    s_subscribed_conn_handle = event->subscribe.conn_handle;
+    if (!is_subscribed) {
+      s_last_report = 0;
+    }
+  } else {
+    s_usage_is_subscribed = is_subscribed;
+    s_usage_subscribed_conn_handle = event->subscribe.conn_handle;
+    if (!is_subscribed) {
+      s_last_usage = 0;
+    }
+  }
+
+  // A zeroed device rather than no call at all: on a
+  // BLE_GAP_SUBSCRIBE_REASON_TERM the link is usually already gone, and the FW
+  // has to hear that the subscription ended or it keeps a usage held until its
+  // own 10 s timeout and answers E_BUSY to every press in between. The one
+  // implementation of this callback only reads is_subscribed.
+  BTDeviceInternal device = {};
+  struct ble_gap_conn_desc desc;
+  if (ble_gap_conn_find(event->subscribe.conn_handle, &desc) == 0) {
+    nimble_addr_to_pebble_device(&desc.peer_id_addr, &device);
+  } else {
+    PBL_LOG_DBG("HID subscribe: no conn descriptor for handle %u", event->subscribe.conn_handle);
+  }
+  bt_driver_cb_hid_service_update_subscription(&device, is_subscribed);
+}
+
+static int prv_handle_gap_event(struct ble_gap_event *event, void *arg) {
+  switch (event->type) {
+    case BLE_GAP_EVENT_SUBSCRIBE:
+      prv_handle_subscribe_event(event);
+      break;
+    default:
+      break;
+  }
+  return 0;
+}
+
+static struct ble_gap_event_listener s_gap_event_listener;
+
+void hid_service_init(void) {
+  // ble_gatts_start() fills the handles back in; clearing them keeps init and
+  // deinit symmetric so a stale handle cannot survive a stack restart.
+  s_report_val_handle = 0;
+  s_usage_report_val_handle = 0;
+  s_subscribed_conn_handle = 0;
+  s_usage_subscribed_conn_handle = 0;
+  s_is_subscribed = false;
+  s_usage_is_subscribed = false;
+  s_last_report = 0;
+  s_last_usage = 0;
+
+  int rc = ble_gatts_count_cfg(s_hid_svc);
+  PBL_ASSERTN(rc == 0);
+  rc = ble_gatts_add_svcs(s_hid_svc);
+  PBL_ASSERTN(rc == 0);
+  // Called on every bt_driver_start, but the listener list is only cleared on
+  // nimble_port_init, so tolerate EALREADY.
+  rc = ble_gap_event_listener_register(&s_gap_event_listener, prv_handle_gap_event, NULL);
+  PBL_ASSERTN(rc == 0 || rc == BLE_HS_EALREADY);
+}
+
+void hid_service_deinit(void) {
+  // ble_gatts_reset() drops the handles, so none of this may outlive the stack.
+  s_report_val_handle = 0;
+  s_usage_report_val_handle = 0;
+  s_subscribed_conn_handle = 0;
+  s_usage_subscribed_conn_handle = 0;
+  s_is_subscribed = false;
+  s_usage_is_subscribed = false;
+  s_last_report = 0;
+  s_last_usage = 0;
+}
+
+bool bt_driver_is_hid_service_supported(void) { return true; }
+
+bool bt_driver_hid_service_is_subscribed(void) { return s_is_subscribed; }
+
+bool bt_driver_hid_service_send_consumer_report(uint8_t bits) {
+  if (!s_is_subscribed) {
+    return false;
+  }
+
+  struct os_mbuf *om = ble_hs_mbuf_from_flat(&bits, sizeof(bits));
+  if (!om) {
+    PBL_LOG_ERR("HID report 0x%02x: out of mbufs", bits);
+    return false;
+  }
+
+  int rc = ble_gatts_notify_custom(s_subscribed_conn_handle, s_report_val_handle, om);
+  // ble_gatts_notify_custom always consumes the mbuf, even on error.
+  if (rc != 0) {
+    PBL_LOG_ERR("HID report 0x%02x notify failed: 0x%04x", bits, (uint16_t)rc);
+    return false;
+  }
+
+  // Only commit once the peer has been told, so a read of the Report
+  // characteristic cannot report a state that was never notified.
+  s_last_report = bits;
+  return true;
+}
+
+bool bt_driver_hid_service_usage_is_subscribed(void) { return s_usage_is_subscribed; }
+
+bool bt_driver_hid_service_send_consumer_usage(uint16_t usage) {
+  if (usage > BLE_HID_USAGE_MAX) {
+    PBL_LOG_ERR("HID usage 0x%04x is outside the declared range", usage);
+    return false;
+  }
+  if (!s_usage_is_subscribed) {
+    return false;
+  }
+
+  const uint8_t report[2] = {(uint8_t)(usage & 0xFF), (uint8_t)(usage >> 8)};
+  struct os_mbuf *om = ble_hs_mbuf_from_flat(report, sizeof(report));
+  if (!om) {
+    PBL_LOG_ERR("HID usage 0x%03x: out of mbufs", usage);
+    return false;
+  }
+
+  int rc = ble_gatts_notify_custom(s_usage_subscribed_conn_handle, s_usage_report_val_handle, om);
+  // ble_gatts_notify_custom always consumes the mbuf, even on error.
+  if (rc != 0) {
+    PBL_LOG_ERR("HID usage 0x%03x notify failed: 0x%04x", usage, (uint16_t)rc);
+    return false;
+  }
+
+  s_last_usage = usage;
+  return true;
+}
+
+#endif  // CONFIG_BT_HID_REMOTE

--- a/src/bluetooth-fw/nimble/hid_service.h
+++ b/src/bluetooth-fw/nimble/hid_service.h
@@ -1,0 +1,8 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+void hid_service_init(void);
+
+void hid_service_deinit(void);

--- a/src/bluetooth-fw/nimble/init.c
+++ b/src/bluetooth-fw/nimble/init.c
@@ -1,6 +1,7 @@
 /* SPDX-FileCopyrightText: 2025 Google LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include "dis_service.h"
 #include "gh3x2x_tuning_service.h"
 
 #include <FreeRTOS.h>
@@ -13,7 +14,6 @@
 #include <nimble/nimble_port.h>
 #include <pbl/os/tick.h>
 #include <semphr.h>
-#include <services/dis/ble_svc_dis.h>
 #include <services/bas/ble_svc_bas.h>
 #include <services/gap/ble_svc_gap.h>
 #include <services/gatt/ble_svc_gatt.h>
@@ -137,15 +137,10 @@ bool bt_driver_start(BTDriverConfig *config) {
   (void)xSemaphoreTake(s_host_started, 0);
 
   s_dis_info = config->dis_info;
-  ble_svc_dis_model_number_set(s_dis_info.model_number);
-  ble_svc_dis_serial_number_set(s_dis_info.serial_number);
-  ble_svc_dis_firmware_revision_set(s_dis_info.fw_revision);
-  ble_svc_dis_software_revision_set(s_dis_info.sw_revision);
-  ble_svc_dis_manufacturer_name_set(s_dis_info.manufacturer);
 
   ble_svc_gap_init();
   ble_svc_gatt_init();
-  ble_svc_dis_init();
+  dis_service_init(&s_dis_info);
   pebble_pairing_service_init();
   ble_svc_bas_init();
   ppog_reversed_service_init();

--- a/src/bluetooth-fw/nimble/init.c
+++ b/src/bluetooth-fw/nimble/init.c
@@ -3,6 +3,7 @@
 
 #include "dis_service.h"
 #include "gh3x2x_tuning_service.h"
+#include "hid_service.h"
 
 #include <FreeRTOS.h>
 #include <bluetooth/init.h>
@@ -149,6 +150,12 @@ bool bt_driver_start(BTDriverConfig *config) {
   gh3x2x_tuning_service_init();
 #endif
 
+#ifdef CONFIG_BT_HID_REMOTE
+  // Registered last on purpose: NimBLE assigns ATT handles in registration
+  // order, so appending here adds no shift of its own.
+  hid_service_init();
+#endif
+
   ble_hs_sched_start();
   f_rc = xSemaphoreTake(s_host_started, milliseconds_to_ticks(s_bt_stack_start_stop_timeout_ms));
   if (f_rc != pdTRUE) {
@@ -183,6 +190,10 @@ err:
   s_driver_state = DriverStateStopped;
   (void)ble_gatts_reset();
 
+#ifdef CONFIG_BT_HID_REMOTE
+  hid_service_deinit();
+#endif
+
   return false;
 }
 
@@ -197,6 +208,10 @@ void bt_driver_stop(void) {
   s_driver_state = DriverStateStopped;
 
   ble_gatts_reset();
+
+#ifdef CONFIG_BT_HID_REMOTE
+  hid_service_deinit();
+#endif
 
   nimble_store_unload();
 }

--- a/src/bluetooth-fw/nimble/init.c
+++ b/src/bluetooth-fw/nimble/init.c
@@ -28,6 +28,12 @@ PBL_LOG_MODULE_DEFINE(bt, CONFIG_BT_LOG_LEVEL);
 
 static const uint32_t s_bt_stack_start_stop_timeout_ms = 10000;
 
+#ifdef CONFIG_BT_HID_REMOTE
+// Generic HID (0x03C0), not Keyboard (0x03C1): the watch exposes a Consumer
+// Control collection only, so showing up as a keyboard would be misleading.
+#define BT_APPEARANCE_GENERIC_HID (0x03C0)
+#endif
+
 extern void pebble_pairing_service_init(void);
 extern void ppog_reversed_service_init(void);
 extern void nimble_discover_init(void);
@@ -140,6 +146,9 @@ bool bt_driver_start(BTDriverConfig *config) {
   s_dis_info = config->dis_info;
 
   ble_svc_gap_init();
+#ifdef CONFIG_BT_HID_REMOTE
+  ble_svc_gap_device_appearance_set(BT_APPEARANCE_GENERIC_HID);
+#endif
   ble_svc_gatt_init();
   dis_service_init(&s_dis_info);
   pebble_pairing_service_init();

--- a/src/bluetooth-fw/nimble/nimble_store.c
+++ b/src/bluetooth-fw/nimble/nimble_store.c
@@ -326,7 +326,7 @@ static BleStoreValueCCCD *prv_nimble_store_find_cccd(const struct ble_store_key_
 static int prv_nimble_store_read_cccd(const struct ble_store_key_cccd *key_cccd,
                                       struct ble_store_value_cccd *value_cccd) {
   BleStoreValueCCCD *s;
-  int ret;
+  int ret = 0;
 
   mutex_lock_recursive(s_store_mutex);
 

--- a/src/bluetooth-fw/nimble/nimble_store.c
+++ b/src/bluetooth-fw/nimble/nimble_store.c
@@ -6,11 +6,15 @@
 #include <bluetooth/sm_types.h>
 #include <host/ble_hs.h>
 #include <host/ble_hs_hci.h>
+#include <host/ble_sm.h>
 #include <host/ble_store.h>
+#include <syscfg/syscfg.h>
 #include <kernel/event_loop.h>
 #include <kernel/pbl_malloc.h>
+#include <pbl/btutil/sm_util.h>
 #include <pbl/os/mutex.h>
 #include <pbl/services/bluetooth/bluetooth_persistent_storage.h>
+#include <pbl/services/system_task.h>
 #include <string.h>
 #include <pbl/logging/logging.h>
 #include <system/passert.h>
@@ -24,6 +28,17 @@ PBL_LOG_MODULE_DECLARE(bt, CONFIG_BT_LOG_LEVEL);
 
 #define BLE_FLAG_SECURE_CONNECTIONS 0x01
 #define BLE_FLAG_AUTHENTICATED 0x02
+
+//! Free slots KernelBG must still have before we hand it a store *write*.
+//! Purely a courtesy to the rest of the system: the store callbacks run on
+//! NimbleHost, which can produce CCCD writes faster than KernelBG drains them,
+//! and a dropped write self-heals -- the peer rewrites its CCCD on the next
+//! connection. A dropped delete does not, so deletes are allowed the last slot.
+//! @note This is not what keeps us off the blocking path any more.
+//! system_task_add_callback_nonblocking() is: it cannot wait and cannot reboot,
+//! which matters because we hold ble_hs_mutex here and KernelBG needs that same
+//! lock (advertising, the GATT client op queue) to drain its queue.
+#define KERNEL_BG_QUEUE_MARGIN_WRITE 4
 
 typedef struct {
   ListNode node;
@@ -215,6 +230,196 @@ static void prv_notify_host_bonding_changed(const int obj_type,
   }
 }
 
+typedef enum {
+  NimbleStoreOpCCCDStore,
+  NimbleStoreOpCCCDDelete,
+  NimbleStoreOpSecDelete,
+} NimbleStoreOp;
+
+//! One deferred settings-file operation.
+typedef struct {
+  NimbleStoreOp op;
+  union {
+    BleCCCD cccd;
+    struct {
+      int obj_type;
+      //! The whole entry we were told to drop, not just its address: by the time
+      //! KernelBG runs, the address may name a different bonding.
+      struct ble_store_value_sec value_sec;
+    } sec;
+  };
+} NimbleStoreWork;
+
+//! @return True if NimBLE still holds keys of `obj_type` for `peer_addr`.
+static bool prv_sec_is_present(int obj_type, const ble_addr_t *peer_addr) {
+  const struct ble_store_key_sec key_sec = {
+    .peer_addr = *peer_addr,
+    .idx = 0,
+  };
+
+  mutex_lock_recursive(s_store_mutex);
+  const bool present = (prv_nimble_store_find_sec(obj_type, &key_sec) != NULL);
+  mutex_unlock_recursive(s_store_mutex);
+
+  return present;
+}
+
+//! @return True if `peer` still has a bonding, so a CCCD of its own is worth
+//! keeping. Runs on KernelBG, off ble_hs_mutex, and takes the store lock and the
+//! db lock one after the other rather than nested, which is the order the rest
+//! of the glue uses.
+static bool prv_peer_is_bonded(const BTDeviceInternal *peer) {
+  ble_addr_t peer_addr;
+  pebble_device_to_nimble_addr(peer, &peer_addr);
+
+  // NimBLE's own view first. It is written synchronously on the host task before
+  // the work that reads it here was queued, so it cannot lag behind this item,
+  // and the common case never reaches the settings file at all.
+  if (prv_sec_is_present(BLE_STORE_OBJ_TYPE_PEER_SEC, &peer_addr) ||
+      prv_sec_is_present(BLE_STORE_OBJ_TYPE_OUR_SEC, &peer_addr)) {
+    return true;
+  }
+
+  // The bonding reaches flash from KernelMain, on a queue this one is not
+  // ordered against, so an empty list is not proof on its own.
+  return bt_persistent_storage_get_ble_pairing_by_addr(peer, NULL, NULL);
+}
+
+static void prv_handle_sec_delete(const NimbleStoreWork *work) {
+  const struct ble_store_value_sec *value_sec = &work->sec.value_sec;
+  BleBonding expected;
+
+  // Cheap first cut. The repeat-pairing path drops the old keys and immediately
+  // pairs again, and the new keys land in the in-memory list synchronously on
+  // the host task while this is still queued.
+  if (prv_sec_is_present(work->sec.obj_type, &value_sec->peer_addr)) {
+    PBL_LOG_DBG("SEC delete: obj=%d superseded by a newer bonding, skipping", work->sec.obj_type);
+    return;
+  }
+
+  // The real guard is the key material, not the check above and not the address.
+  // bt_persistent_storage_delete_ble_pairing_by_addr() runs a full-file scan, the
+  // record delete, a CCCD sweep and a shared-PRF erase, and can be preempted
+  // throughout; a re-pair that completes in that window writes its fresh keys
+  // over the very record it is walking, because the identity and the IRK are
+  // unchanged. Hand the storage the keys we were told to drop so it can tell the
+  // two apart.
+  //
+  // These are the same conversions the write path used to build what was stored,
+  // so the ltk / ediv / rand compared on the other side are the ones that were
+  // written.
+  memset(&expected, 0, sizeof(expected));
+  switch (work->sec.obj_type) {
+    case BLE_STORE_OBJ_TYPE_PEER_SEC:
+      prv_convert_peer_sec_to_bonding(value_sec, &expected);
+      break;
+    case BLE_STORE_OBJ_TYPE_OUR_SEC:
+      prv_convert_our_sec_to_bonding(value_sec, &expected);
+      break;
+    default:
+      return;
+  }
+  nimble_addr_to_pebble_device(&value_sec->peer_addr, &expected.pairing_info.identity);
+
+  PBL_LOG_INFO("SEC delete: obj=%d addr=" BT_DEVICE_ADDRESS_FMT, work->sec.obj_type,
+               BT_DEVICE_ADDRESS_XPLODE(expected.pairing_info.identity.address));
+  if (!bt_persistent_storage_delete_ble_pairing_by_addr_if_matches(
+          &expected.pairing_info.identity, &expected.pairing_info)) {
+    PBL_LOG_DBG("SEC delete: no stored bonding holds these keys, nothing to do");
+  }
+}
+
+static void prv_handle_store_work_cb(void *data) {
+  NimbleStoreWork *work = data;
+
+  switch (work->op) {
+    case NimbleStoreOpCCCDStore:
+      // A "Forget device" runs on KernelMain and is not ordered against this
+      // queue, so the bonding can be gone by the time we get here. Writing then
+      // takes a fresh id for a record nothing sweeps any more, and
+      // bt_persistent_storage_register_existing_ble_bondings() restores it into
+      // NimBLE's list on every boot, so it accumulates with each pair/unpair.
+      if (!prv_peer_is_bonded(&work->cccd.peer)) {
+        PBL_LOG_WRN("CCCD store for handle %u skipped: peer is no longer bonded",
+                    work->cccd.chr_val_handle);
+      } else if (bt_persistent_storage_store_cccd(&work->cccd) == BT_CCCD_ID_INVALID) {
+        // The subscription is live either way; only its persistence is lost, and
+        // the peer rewrites the CCCD on its next connection.
+        PBL_LOG_ERR("CCCD store for handle %u failed", work->cccd.chr_val_handle);
+      }
+      break;
+    case NimbleStoreOpCCCDDelete:
+      if (!bt_persistent_storage_delete_cccd(&work->cccd.peer, work->cccd.chr_val_handle)) {
+        PBL_LOG_WRN("CCCD delete for handle %u matched no stored record",
+                    work->cccd.chr_val_handle);
+      }
+      break;
+    case NimbleStoreOpSecDelete:
+      prv_handle_sec_delete(work);
+      break;
+  }
+
+  kernel_free(work);
+}
+
+//! @return True if `work` removes state rather than adding it, in which case
+//! dropping it leaves the settings file wrong for good.
+static bool prv_work_is_delete(const NimbleStoreWork *work) {
+  return (work->op != NimbleStoreOpCCCDStore);
+}
+
+//! A dropped store costs one subscription until the peer rewrites it. A dropped
+//! delete is permanent: a stale CCCD with flags != 0 survives in the file, and
+//! bt_persistent_storage_register_existing_ble_bondings() restores it on the
+//! next boot as a live subscription, so the FW reports the HID service ready and
+//! sends reports the phone never asked for and ignores. Only a re-pair clears
+//! that.
+static void prv_log_dropped_work(const NimbleStoreWork *work, const char *reason) {
+  switch (work->op) {
+    case NimbleStoreOpCCCDStore:
+      PBL_LOG_WRN("%s, dropping the CCCD store for handle %u", reason, work->cccd.chr_val_handle);
+      break;
+    case NimbleStoreOpCCCDDelete:
+      PBL_LOG_ERR("%s, dropping the CCCD delete for handle %u; nothing will retry it", reason,
+                  work->cccd.chr_val_handle);
+      break;
+    case NimbleStoreOpSecDelete:
+      PBL_LOG_ERR("%s, dropping the SEC delete for obj=%d; nothing will retry it", reason,
+                  work->sec.obj_type);
+      break;
+  }
+}
+
+//! Queues the settings-file half of a store update onto KernelBG.
+//! Each transaction is a full open/scan/write/close, and NimBLE runs the store
+//! callbacks with ble_hs_mutex held, so doing that inline stalls every task that
+//! needs the host lock for as long as the flash takes.
+//! @note One FIFO fed from one task, so the operations reach the settings file
+//! in the order NimBLE issued them.
+static void prv_queue_work(const NimbleStoreWork *work) {
+  if (!prv_work_is_delete(work) &&
+      (system_task_get_available_space() <= KERNEL_BG_QUEUE_MARGIN_WRITE)) {
+    prv_log_dropped_work(work, "KernelBG backed up");
+    return;
+  }
+
+  NimbleStoreWork *copy = kernel_malloc(sizeof(*copy));
+  if (copy == NULL) {
+    prv_log_dropped_work(work, "Out of memory");
+    return;
+  }
+  *copy = *work;
+
+  // Non-blocking on purpose: we hold ble_hs_mutex. The margin above cannot
+  // guarantee the send finds room -- KernelMain, KernelHRM and BT ISRs all feed
+  // the same queue, and there is a kernel_malloc() between the check and the
+  // send -- so the send itself has to be the one that refuses to wait.
+  if (!system_task_add_callback_nonblocking(prv_handle_store_work_cb, copy)) {
+    prv_log_dropped_work(work, "KernelBG queue full or callbacks blocked");
+    kernel_free(copy);
+  }
+}
+
 typedef struct {
   int obj_type;
   struct ble_store_value_sec value_sec;
@@ -252,6 +457,23 @@ static int prv_nimble_store_write_sec(const int obj_type,
 
   prv_nimble_store_upsert_sec(obj_type, value_sec);
 
+  // Not queued onto KernelBG with the rest of the store work, on purpose. The
+  // settings file is never touched from here: bt_driver_cb_handle_create_bonding()
+  // does all of it on KernelMain, so nothing heavy runs under ble_hs_mutex
+  // either way, and moving it would only trade one queue for another. What it
+  // would add is a drop policy, and the queued item is the only copy of a
+  // freshly negotiated LTK -- losing it leaves NimBLE thinking the peer is
+  // bonded while the FW has no keys on file. The cost of keeping it here is
+  // that event_put() waits up to 3 s on a full KernelMain queue and then
+  // reboots, with ble_hs_mutex held.
+  //
+  // kernel_malloc_check(), i.e. a panic, and not BLE_HS_ENOMEM, even though the
+  // rest of this file now degrades gracefully: ble_sm_persist_keys() discards
+  // what the store write returns, so an error here does not abort the bonding.
+  // It would leave the link encrypted and the peer bonded with the FW holding no
+  // keys at all -- silently, and only until the next reconnect. A failed 70-byte
+  // kernel allocation is a system-wide failure, not a BLE one; the panic at
+  // least records a reboot reason on a watch that has no console.
   NimbleStoreSecWrittenContext *ctx = kernel_malloc_check(sizeof(*ctx));
   *ctx = (NimbleStoreSecWrittenContext) {
     .obj_type = obj_type,
@@ -262,8 +484,12 @@ static int prv_nimble_store_write_sec(const int obj_type,
   return 0;
 }
 
+static int prv_other_sec_obj_type(int obj_type) {
+  return (obj_type == BLE_STORE_OBJ_TYPE_OUR_SEC) ? BLE_STORE_OBJ_TYPE_PEER_SEC
+                                                  : BLE_STORE_OBJ_TYPE_OUR_SEC;
+}
+
 static int prv_nimble_store_delete_sec(int obj_type, const struct ble_store_key_sec *key_sec) {
-  BTDeviceInternal device;
   BleStoreValueSec *s;
   ListNode **sec_list = prv_find_sec_list_for_obj_type(obj_type);
 
@@ -279,15 +505,33 @@ static int prv_nimble_store_delete_sec(int obj_type, const struct ble_store_key_
   // Previously we relied on bt_driver_handle_host_removed_bonding() to remove
   // the entry as a side-effect, but that reads the identity from SPRF which
   // may already be erased by a prior iteration, causing an infinite loop.
+  // The key may name the peer by index rather than by address, so take the
+  // whole entry we found rather than anything off the key.
+  const struct ble_store_value_sec value_sec = s->value_sec;
   list_remove((ListNode *)s, sec_list, NULL);
+  const bool other_half_remains = (prv_nimble_store_find_sec(
+      prv_other_sec_obj_type(obj_type),
+      &(struct ble_store_key_sec){ .peer_addr = value_sec.peer_addr, .idx = 0 }) != NULL);
   mutex_unlock_recursive(s_store_mutex);
 
   kernel_free(s);
 
-  nimble_addr_to_pebble_device(&key_sec->peer_addr, &device);
-  PBL_LOG_INFO("SEC delete: obj=%d addr=" BT_DEVICE_ADDRESS_FMT, obj_type,
-               BT_DEVICE_ADDRESS_XPLODE(device.address));
-  bt_persistent_storage_delete_ble_pairing_by_addr(&device);
+  if (other_half_remains) {
+    // ble_store_util_delete_peer() drops OUR_SEC and then PEER_SEC, but PebbleOS
+    // keeps both halves in one bonding record, so queueing on each would run the
+    // same full-file delete twice under the db lock and get nothing for it. Let
+    // the half that leaves NimBLE with no keys at all for this peer carry it.
+    return 0;
+  }
+
+  const NimbleStoreWork work = {
+    .op = NimbleStoreOpSecDelete,
+    .sec = {
+      .obj_type = obj_type,
+      .value_sec = value_sec,
+    },
+  };
+  prv_queue_work(&work);
 
   return 0;
 }
@@ -364,53 +608,58 @@ static void prv_nimble_store_insert_cccd(const struct ble_store_value_cccd *valu
 }
 
 static int prv_nimble_store_write_cccd(const struct ble_store_value_cccd *value_cccd) {
-  BleCCCD cccd;
-  BTCCCDID cccd_id;
+  NimbleStoreWork work = {
+    .op = NimbleStoreOpCCCDStore,
+  };
 
-  nimble_addr_to_pebble_device(&value_cccd->peer_addr, &cccd.peer);
-  cccd.chr_val_handle = value_cccd->chr_val_handle;
-  cccd.flags = value_cccd->flags;
-  cccd.value_changed = value_cccd->value_changed;
+  nimble_addr_to_pebble_device(&value_cccd->peer_addr, &work.cccd.peer);
+  work.cccd.chr_val_handle = value_cccd->chr_val_handle;
+  work.cccd.flags = value_cccd->flags;
+  work.cccd.value_changed = value_cccd->value_changed;
 
-  cccd_id = bt_persistent_storage_store_cccd(&cccd);
-  if (cccd_id == BT_CCCD_ID_INVALID) {
-    return BLE_HS_ESTORE_CAP;
-  }
-
+  // The in-memory list is all NimBLE needs before this returns.
   mutex_lock_recursive(s_store_mutex);
   prv_nimble_store_insert_cccd(value_cccd);
   mutex_unlock_recursive(s_store_mutex);
 
+  prv_queue_work(&work);
+
+  // Always success: whether the settings file had room is only known once
+  // KernelBG has run, and BLE_HS_ESTORE_CAP would send NimBLE round the
+  // overflow path to free space that we cannot report on anyway.
   return 0;
 }
 
 static int prv_nimble_store_delete_cccd(const struct ble_store_key_cccd *key_cccd) {
-  bool res;
-  int ret = 0;
-  BTDeviceInternal peer;
+  NimbleStoreWork work = {
+    .op = NimbleStoreOpCCCDDelete,
+  };
   BleStoreValueCCCD *s;
-
-  nimble_addr_to_pebble_device(&key_cccd->peer_addr, &peer);
-  res = bt_persistent_storage_delete_cccd(&peer, key_cccd->chr_val_handle);
-  if (!res) {
-    return BLE_HS_ENOENT;
-  }
 
   mutex_lock_recursive(s_store_mutex);
 
   s = prv_nimble_store_find_cccd(key_cccd);
   if (s == NULL) {
-    ret = BLE_HS_ENOENT;
-    goto unlock;
+    mutex_unlock_recursive(s_store_mutex);
+    return BLE_HS_ENOENT;
   }
+
+  // The key may leave chr_val_handle at 0 to mean "any", as
+  // ble_store_util_delete_peer() does, but the settings file only ever matches
+  // an exact handle. Resolve the wildcard against the entry we just found.
+  nimble_addr_to_pebble_device(&s->value_cccd.peer_addr, &work.cccd.peer);
+  work.cccd.chr_val_handle = s->value_cccd.chr_val_handle;
+  work.cccd.flags = s->value_cccd.flags;
+  work.cccd.value_changed = s->value_cccd.value_changed;
 
   list_remove((ListNode *)s, (ListNode **)&s_cccds, NULL);
   kernel_free(s);
 
-unlock:
   mutex_unlock_recursive(s_store_mutex);
 
-  return ret;
+  prv_queue_work(&work);
+
+  return 0;
 }
 
 static int prv_nimble_store_read(const int obj_type, const union ble_store_key *key,
@@ -450,9 +699,33 @@ static int prv_nimble_store_delete(int obj_type, const union ble_store_key *key)
   }
 }
 
+//! Which BLE_STORE_GEN_KEY_* NimBLE can ask for is a syscfg property, and this
+//! callback may only touch the settings file for the ones NimBLE requests
+//! *without* ble_hs_lock() held. Only BLE_STORE_GEN_KEY_IRK qualifies -- it
+//! comes from ble_hs_startup_go(). LTK and CSRK come from
+//! ble_sm_key_exch_exec(), which runs under ble_hs_lock(), and reading the
+//! settings file there is the deadlock this whole file was rewritten to remove.
+//! They are unreachable only because of the settings pinned below:
+//! ble_sm_key_dist() clears BLE_SM_PAIR_KEY_DIST_ENC for Secure Connections, so
+//! with SC-only pairing no LTK is ever distributed, and with ENC-only key
+//! distribution BLE_SM_PAIR_KEY_DIST_SIGN is never set, so no CSRK is either.
+_Static_assert(MYNEWT_VAL(BLE_SM_SC_ONLY) == 1,
+               "gen_key: SC-only pairing is what keeps BLE_STORE_GEN_KEY_LTK unreachable");
+_Static_assert(MYNEWT_VAL(BLE_SM_LEGACY) == 0,
+               "gen_key: legacy pairing would distribute an LTK under ble_hs_lock()");
+_Static_assert((MYNEWT_VAL(BLE_SM_OUR_KEY_DIST) & BLE_SM_PAIR_KEY_DIST_SIGN) == 0,
+               "gen_key: distributing a CSRK would ask for one under ble_hs_lock()");
+
 static int prv_nimble_store_gen_key(uint8_t key, struct ble_store_gen_key *gen_key,
                                     uint16_t conn_handle) {
   SM128BitKey stored_keys[SMRootKeyTypeNum];
+
+  // The settings-file read stays inside the switch, so a syscfg change that
+  // re-enables the LTK or CSRK paths costs a rejected pairing rather than the
+  // reboot it used to.
+  if (key != BLE_STORE_GEN_KEY_IRK) {
+    return BLE_HS_ENOTSUP;
+  }
 
   if (!bt_persistent_storage_get_root_key(SMRootKeyTypeIdentity,
                                           &stored_keys[SMRootKeyTypeIdentity])) {
@@ -467,13 +740,7 @@ static int prv_nimble_store_gen_key(uint8_t key, struct ble_store_gen_key *gen_k
     bt_persistent_storage_set_root_keys(stored_keys);
   }
 
-  switch (key) {
-    case BLE_STORE_GEN_KEY_IRK:
-      memcpy(gen_key->irk, stored_keys[SMRootKeyTypeIdentity].data, KEY_SIZE);
-      break;
-    default:
-      return BLE_HS_ENOTSUP;
-  }
+  memcpy(gen_key->irk, stored_keys[SMRootKeyTypeIdentity].data, KEY_SIZE);
 
   return 0;
 }
@@ -569,8 +836,19 @@ void bt_driver_handle_host_added_bonding(const BleBonding *bonding) {
   prv_nimble_store_upsert_sec(BLE_STORE_OBJ_TYPE_OUR_SEC, &value_sec);
 }
 
+//! Drops the peer's keys, but only the ones the caller was handed.
+//! @note Content-matched, not address-matched. The host half of a delete releases
+//! its lock before calling here, and a re-pair of the same phone keeps its
+//! identity address and its IRK, so by the time this runs the lists can already
+//! hold the fresh keys of a bonding that flash and shared PRF consider current.
+//! Removing those by address leaves the phone bonded and the watch without keys
+//! until the next boot rebuilds the lists.
+//! @note Both halves are judged as one, the way the settings file holds them:
+//! only the halves `bonding` marks valid are compared, and a `bonding` with no
+//! valid encryption info at all matches nothing -- the same rule
+//! bt_persistent_storage_delete_ble_pairing_by_addr_if_matches() applies, since
+//! falling back to the address is exactly what this exists to avoid.
 void bt_driver_handle_host_removed_bonding(const BleBonding *bonding) {
-  BleStoreValueSec *s_sec;
   struct ble_store_key_sec key_sec;
 
   PBL_LOG_INFO("Host removed bonding: addr=" BT_DEVICE_ADDRESS_FMT " random=%u",
@@ -582,16 +860,41 @@ void bt_driver_handle_host_removed_bonding(const BleBonding *bonding) {
 
   mutex_lock_recursive(s_store_mutex);
 
-  s_sec = prv_nimble_store_find_sec(BLE_STORE_OBJ_TYPE_OUR_SEC, &key_sec);
-  if (s_sec != NULL) {
-    list_remove((ListNode *)s_sec, (ListNode **)&s_our_value_secs, NULL);
-    kernel_free(s_sec);
+  BleStoreValueSec *our_sec = prv_nimble_store_find_sec(BLE_STORE_OBJ_TYPE_OUR_SEC, &key_sec);
+  BleStoreValueSec *peer_sec = prv_nimble_store_find_sec(BLE_STORE_OBJ_TYPE_PEER_SEC, &key_sec);
+
+  if ((our_sec == NULL) && (peer_sec == NULL)) {
+    // The usual outcome of a deferred delete: NimBLE dropped both halves itself
+    // before the work was queued.
+    mutex_unlock_recursive(s_store_mutex);
+    return;
   }
 
-  s_sec = prv_nimble_store_find_sec(BLE_STORE_OBJ_TYPE_PEER_SEC, &key_sec);
-  if (s_sec != NULL) {
-    list_remove((ListNode *)s_sec, (ListNode **)&s_peer_value_secs, NULL);
-    kernel_free(s_sec);
+  // These are the conversions the write path used to build what the host stored,
+  // so the ltk / ediv / rand compared below are the ones it was given.
+  BleBonding held;
+  memset(&held, 0, sizeof(held));
+  if (our_sec != NULL) {
+    prv_convert_our_sec_to_bonding(&our_sec->value_sec, &held);
+  }
+  if (peer_sec != NULL) {
+    prv_convert_peer_sec_to_bonding(&peer_sec->value_sec, &held);
+  }
+
+  if (!sm_pairing_info_encryption_keys_match(&held.pairing_info, &bonding->pairing_info)) {
+    mutex_unlock_recursive(s_store_mutex);
+    PBL_LOG_DBG("Host removed bonding: our keys are a newer pairing's, keeping them");
+    return;
+  }
+
+  if (our_sec != NULL) {
+    list_remove((ListNode *)our_sec, (ListNode **)&s_our_value_secs, NULL);
+    kernel_free(our_sec);
+  }
+
+  if (peer_sec != NULL) {
+    list_remove((ListNode *)peer_sec, (ListNode **)&s_peer_value_secs, NULL);
+    kernel_free(peer_sec);
   }
 
   mutex_unlock_recursive(s_store_mutex);

--- a/src/bluetooth-fw/qemu/hid_service.c
+++ b/src/bluetooth-fw/qemu/hid_service.c
@@ -1,0 +1,24 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <bluetooth/hid_service.h>
+
+bool bt_driver_is_hid_service_supported(void) {
+  return false;
+}
+
+bool bt_driver_hid_service_send_consumer_report(uint8_t bits) {
+  return false;
+}
+
+bool bt_driver_hid_service_is_subscribed(void) {
+  return false;
+}
+
+bool bt_driver_hid_service_send_consumer_usage(uint16_t usage) {
+  return false;
+}
+
+bool bt_driver_hid_service_usage_is_subscribed(void) {
+  return false;
+}

--- a/src/bluetooth-fw/stub/hid_service.c
+++ b/src/bluetooth-fw/stub/hid_service.c
@@ -1,0 +1,24 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <bluetooth/hid_service.h>
+
+bool bt_driver_is_hid_service_supported(void) {
+  return false;
+}
+
+bool bt_driver_hid_service_send_consumer_report(uint8_t bits) {
+  return false;
+}
+
+bool bt_driver_hid_service_is_subscribed(void) {
+  return false;
+}
+
+bool bt_driver_hid_service_send_consumer_usage(uint16_t usage) {
+  return false;
+}
+
+bool bt_driver_hid_service_usage_is_subscribed(void) {
+  return false;
+}

--- a/src/fw/apps/system/camera_remote/camera_remote.c
+++ b/src/fw/apps/system/camera_remote/camera_remote.c
@@ -1,0 +1,497 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "camera_remote.h"
+
+#ifdef CONFIG_BT_HID_REMOTE
+
+#include "applib/app.h"
+#include "applib/app_timer.h"
+#include "applib/fonts/fonts.h"
+#include "applib/persist.h"
+#include "applib/ui/app_window_stack.h"
+#include "applib/ui/ui.h"
+#include "kernel/pbl_malloc.h"
+#include "pbl/services/bluetooth/ble_hid.h"
+#include "pbl/services/i18n/i18n.h"
+#include "process_state/app_state/app_state.h"
+#include <bluetooth/hid_service.h>
+#include <pbl/logging/logging.h>
+#include <pbl/util/size.h>
+
+#include <stdio.h>
+
+// There is no subscription-state event to listen to, so poll instead: the phone
+// often subscribes a second or two after the app is opened.
+#define CAMERA_REMOTE_READINESS_POLL_MS (1000)
+
+#define CAMERA_REMOTE_PICKER_HOLD_MS (500)
+
+// A held Volume Up in the iOS Camera app starts a QuickTake video instead of
+// taking a photo, so the shutter has to be a tap, not a hold. 20-50 ms works.
+// This is camera policy and lives here; ble_hid only guarantees that a usage
+// nobody releases is released eventually.
+#define CAMERA_REMOTE_TAP_MS (30)
+
+//! App-scoped persist keys. Key 1 held an index into a table of report bits in
+//! the first prototype; both the table and its meaning are gone, so the usage
+//! itself is stored under a new key rather than risk reading the old value.
+#define CAMERA_REMOTE_PERSIST_KEY_RETIRED_INDEX (1)
+#define CAMERA_REMOTE_PERSIST_KEY_USAGE (2)
+#define CAMERA_REMOTE_PERSIST_KEY_PATH (3)
+
+// The picker is the comparison surface the two report forms exist for: a long
+// press on Select chooses the Consumer usage and the report it goes out on, so
+// a bitmap bit and an Array selector can be tried against the same phone
+// without a serial console. AC Back / AC Forward are above 0xFF on purpose, to
+// show the full 10-bit range survives. The picker labels are untranslated on
+// purpose. @see BleHidReportPath for what settling the comparison would remove.
+typedef struct {
+  const char *name;
+  uint16_t usage;
+} CameraRemoteCode;
+
+static const CameraRemoteCode s_codes[] = {
+    {"Volume Up", BLE_HID_USAGE_VOLUME_UP},
+    {"Volume Down", BLE_HID_USAGE_VOLUME_DOWN},
+    {"Snapshot", BLE_HID_USAGE_SNAPSHOT},
+    {"Menu Left", 0x044},
+    {"Menu Right", 0x045},
+    {"AC Back", 0x224},
+    {"AC Forward", 0x225},
+};
+
+//! Picker labels, indexed by BleHidReportPath.
+static const char *const s_path_names[] = {"Report 1", "Report 2"};
+
+//! Cached so the send path never touches flash.
+static uint16_t s_usage;
+static BleHidReportPath s_path;
+
+static void prv_load_settings(void) {
+  // The prototype's key is never read again, so drop it rather than leave it in
+  // the app's persist file forever.
+  if (persist_exists(CAMERA_REMOTE_PERSIST_KEY_RETIRED_INDEX)) {
+    persist_delete(CAMERA_REMOTE_PERSIST_KEY_RETIRED_INDEX);
+  }
+
+  // A missing key and a failed read both read back as 0, which is neither a
+  // valid usage nor a stored path other than the default, so both fall back
+  // silently on a first run. The values reach a HID report and the table can
+  // change between firmware versions, so check them rather than trust them.
+  s_usage = s_codes[0].usage;
+  s_path = BleHidReportPathBitmap;
+
+  const int32_t stored_usage = persist_read_int(CAMERA_REMOTE_PERSIST_KEY_USAGE);
+  if (stored_usage != 0) {
+    bool known = false;
+    for (unsigned i = 0; i < ARRAY_LENGTH(s_codes); ++i) {
+      if (s_codes[i].usage == (uint16_t)stored_usage) {
+        s_usage = s_codes[i].usage;
+        known = true;
+        break;
+      }
+    }
+    if (!known) {
+      PBL_LOG_WRN("Camera remote: unknown stored usage 0x%x, using the default",
+                  (unsigned)stored_usage);
+    }
+  }
+
+  const int32_t stored_path = persist_read_int(CAMERA_REMOTE_PERSIST_KEY_PATH);
+  if ((stored_path >= 0) && (stored_path < (int32_t)ARRAY_LENGTH(s_path_names))) {
+    s_path = (BleHidReportPath)stored_path;
+  } else {
+    PBL_LOG_WRN("Camera remote: stored path %d out of range, using the default",
+                (int)stored_path);
+  }
+}
+
+static void prv_save_setting(uint32_t key, int32_t value) {
+  const status_t rv = persist_write_int(key, value);
+  if (FAILED(rv)) {
+    PBL_LOG_WRN("Camera remote: could not save setting %u (%d)", (unsigned)key, (int)rv);
+  }
+}
+
+//! @return False if the picked report cannot carry the picked usage, which
+//! ble_hid_consumer_press() rejects rather than quietly rerouting.
+static bool prv_selection_is_valid(void) {
+  return ((s_path != BleHidReportPathBitmap) || (ble_hid_consumer_usage_to_bit(s_usage) != 0));
+}
+
+static const char *prv_usage_name(uint16_t usage) {
+  for (unsigned i = 0; i < ARRAY_LENGTH(s_codes); ++i) {
+    if (s_codes[i].usage == usage) {
+      return s_codes[i].name;
+    }
+  }
+  return "?";
+}
+
+static const char *prv_status_label(status_t rv) {
+  switch (rv) {
+    case S_NO_ACTION_REQUIRED:
+      // The same usage is already down, so nothing was queued and no second
+      // photo is coming. PASSED() would call that "sent" and the user would be
+      // left wondering why two presses gave one photo.
+      return "held";
+    case E_INVALID_ARGUMENT:
+      // Covers both an out-of-range usage and a report that cannot carry it.
+      return "bad code";
+    case E_INVALID_OPERATION:
+      return "not subd";
+    case E_BUSY:
+      return "busy";
+    default:
+      return PASSED(rv) ? "sent" : "error";
+  }
+}
+
+typedef struct {
+  Window window;
+  TextLayer title_text;
+  TextLayer body_text;
+  TextLayer code_text;
+  TextLayer path_text;
+  TextLayer hint_text;
+  TextLayer status_text;
+  AppTimer *readiness_timer;
+  //! Runs the release half of a tap; NULL when nothing is held.
+  AppTimer *release_timer;
+  uint16_t held_usage;
+  //! Readiness currently on screen, invalid until the first update.
+  bool shown_ready;
+  bool shown_ready_valid;
+  //! Back the text layers above, so they must outlive every draw.
+  char code[28];
+  char path[24];
+  char status[24];
+
+  Window picker_window;
+  SimpleMenuLayer picker_menu;
+  SimpleMenuItem picker_usage_items[ARRAY_LENGTH(s_codes)];
+  SimpleMenuItem picker_path_items[ARRAY_LENGTH(s_path_names)];
+  SimpleMenuSection picker_sections[2];
+  char picker_subtitles[ARRAY_LENGTH(s_codes)][8];
+} CameraRemoteAppData;
+
+static void prv_update_readiness(CameraRemoteAppData *data) {
+  // text_layer_set_text() always marks the layer dirty, so re-setting the same
+  // string would redraw the window on every poll.
+  const bool ready = ble_hid_is_ready(s_path);
+  if (data->shown_ready_valid && (data->shown_ready == ready)) {
+    return;
+  }
+  data->shown_ready = ready;
+  data->shown_ready_valid = true;
+
+  text_layer_set_text(&data->body_text,
+                      ready ? i18n_get("Open the Camera app on your phone", data)
+                            : i18n_get("Not connected. Pair your phone first.", data));
+}
+
+static void prv_update_selection(CameraRemoteAppData *data) {
+  snprintf(data->code, sizeof(data->code), "%s 0x%03x", prv_usage_name(s_usage), (unsigned)s_usage);
+  text_layer_set_text(&data->code_text, data->code);
+  // Which report a press goes out on is the whole point of the picker, so say
+  // it, and say when the combination cannot be sent instead of only failing on
+  // press.
+  snprintf(data->path, sizeof(data->path), "Path: %s%s", s_path_names[s_path],
+           prv_selection_is_valid() ? "" : " (n/a)");
+  text_layer_set_text(&data->path_text, data->path);
+}
+
+static void prv_readiness_timer_cb(void *context);
+
+static void prv_schedule_readiness_timer(CameraRemoteAppData *data) {
+  data->readiness_timer =
+      app_timer_register(CAMERA_REMOTE_READINESS_POLL_MS, prv_readiness_timer_cb, data);
+  if (!data->readiness_timer) {
+    PBL_LOG_WRN("Camera remote: no readiness timer, the screen will not refresh");
+  }
+}
+
+static void prv_readiness_timer_cb(void *context) {
+  CameraRemoteAppData *data = context;
+  prv_schedule_readiness_timer(data);
+  // The low-latency request expires after MIN_LATENCY_MODE_TIMEOUT_HID_SECS;
+  // re-arm it here so the link stays fast for as long as the app is open, not
+  // just for a minute after the last press. The timer belongs to the app, not
+  // to a window, so this keeps working while the picker is on top.
+  ble_hid_set_low_latency(true);
+  prv_update_readiness(data);
+}
+
+static void prv_cancel_readiness_timer(CameraRemoteAppData *data) {
+  if (data->readiness_timer) {
+    app_timer_cancel(data->readiness_timer);
+    data->readiness_timer = NULL;
+  }
+}
+
+//! Sends the release half of a tap. Idempotent, so leaving the app can call it
+//! without knowing whether the timer already did.
+//! @note The status is dropped and held_usage cleared either way. A failure
+//! means ble_hid could not queue the work, and it retries that itself until it
+//! either lifts the key or gives up loudly; a second release from here would
+//! only be refused, and holding the usage would stop the app pressing again --
+//! which is the one thing that can still clear a key ble_hid gave up on.
+static void prv_release_held(CameraRemoteAppData *data) {
+  if (data->release_timer) {
+    app_timer_cancel(data->release_timer);
+    data->release_timer = NULL;
+  }
+  if (data->held_usage != 0) {
+    ble_hid_consumer_release(data->held_usage);
+    data->held_usage = 0;
+  }
+}
+
+static void prv_release_timer_cb(void *context) {
+  CameraRemoteAppData *data = context;
+  data->release_timer = NULL;
+  prv_release_held(data);
+}
+
+static void prv_usage_selected(int index, void *context) {
+  CameraRemoteAppData *data = context;
+  s_usage = s_codes[index].usage;
+  prv_save_setting(CAMERA_REMOTE_PERSIST_KEY_USAGE, s_usage);
+  prv_update_selection(data);
+  app_window_stack_remove(&data->picker_window, true /* animated */);
+}
+
+static void prv_path_selected(int index, void *context) {
+  CameraRemoteAppData *data = context;
+  s_path = (BleHidReportPath)index;
+  prv_save_setting(CAMERA_REMOTE_PERSIST_KEY_PATH, s_path);
+  prv_update_selection(data);
+  // Readiness is per report, so the other report may well have a different one.
+  prv_update_readiness(data);
+  app_window_stack_remove(&data->picker_window, true /* animated */);
+}
+
+static void prv_picker_window_load(Window *window) {
+  CameraRemoteAppData *data = window_get_user_data(window);
+
+  for (unsigned i = 0; i < ARRAY_LENGTH(s_codes); ++i) {
+    snprintf(data->picker_subtitles[i], sizeof(data->picker_subtitles[i]), "0x%03x",
+             (unsigned)s_codes[i].usage);
+    data->picker_usage_items[i] = (SimpleMenuItem){
+        .title = s_codes[i].name,
+        .subtitle = data->picker_subtitles[i],
+        .callback = prv_usage_selected,
+    };
+  }
+  for (unsigned i = 0; i < ARRAY_LENGTH(s_path_names); ++i) {
+    data->picker_path_items[i] = (SimpleMenuItem){
+        .title = s_path_names[i],
+        .callback = prv_path_selected,
+    };
+  }
+  data->picker_sections[0] = (SimpleMenuSection){
+      .title = "Usage",
+      .items = data->picker_usage_items,
+      .num_items = ARRAY_LENGTH(data->picker_usage_items),
+  };
+  data->picker_sections[1] = (SimpleMenuSection){
+      .title = "Report",
+      .items = data->picker_path_items,
+      .num_items = ARRAY_LENGTH(data->picker_path_items),
+  };
+
+  simple_menu_layer_init(&data->picker_menu, &window->layer.bounds, window, data->picker_sections,
+                         ARRAY_LENGTH(data->picker_sections), data);
+  // Open on the usage that is actually selected. set_selected_index() keeps the
+  // current section, which is the first one right after init.
+  for (unsigned i = 0; i < ARRAY_LENGTH(s_codes); ++i) {
+    if (s_codes[i].usage == s_usage) {
+      simple_menu_layer_set_selected_index(&data->picker_menu, i, false /* animated */);
+      break;
+    }
+  }
+  layer_add_child(&window->layer, simple_menu_layer_get_layer(&data->picker_menu));
+}
+
+static void prv_picker_window_unload(Window *window) {
+  CameraRemoteAppData *data = window_get_user_data(window);
+  simple_menu_layer_deinit(&data->picker_menu);
+}
+
+static void prv_select_click(ClickRecognizerRef recognizer, void *context) {
+  CameraRemoteAppData *data = context;
+  const status_t rv = ble_hid_consumer_press(s_usage, s_path);
+  snprintf(data->status, sizeof(data->status), "%s 0x%03x", prv_status_label(rv),
+           (unsigned)s_usage);
+  // S_SUCCESS only, not PASSED(): ble_hid_consumer_press() answers
+  // S_NO_ACTION_REQUIRED when the same usage and path are already held, and this
+  // would then overwrite data->release_timer without cancelling the timer it
+  // replaces. The first would still fire, clear the handle that by then refers
+  // to the second, and release the key; the second would fire later against a
+  // handle nothing owns, and prv_release_held() could cancel an already-fired
+  // one. Leave release_timer alone and let the press that is already down keep
+  // the release it came with.
+  if (rv == S_SUCCESS) {
+    data->held_usage = s_usage;
+    data->release_timer = app_timer_register(CAMERA_REMOTE_TAP_MS, prv_release_timer_cb, data);
+    if (!data->release_timer) {
+      // ble_hid's safety timeout is seconds away and best effort at that, so
+      // release now rather than leave the shutter held.
+      PBL_LOG_WRN("Camera remote: no release timer, releasing immediately");
+      prv_release_held(data);
+    }
+  }
+  prv_update_readiness(data);
+  text_layer_set_text(&data->status_text, data->status);
+}
+
+static void prv_select_long_click(ClickRecognizerRef recognizer, void *context) {
+  CameraRemoteAppData *data = context;
+  app_window_stack_push(&data->picker_window, true /* animated */);
+}
+
+static void prv_click_config(void *context) {
+  // BACK keeps its default handler, which pops the window.
+  window_single_click_subscribe(BUTTON_ID_SELECT, prv_select_click);
+  window_long_click_subscribe(BUTTON_ID_SELECT, CAMERA_REMOTE_PICKER_HOLD_MS,
+                              prv_select_long_click, NULL);
+}
+
+static void prv_window_load(Window *window) {
+  CameraRemoteAppData *data = window_get_user_data(window);
+
+  GRect bounds;
+  layer_get_bounds(window_get_root_layer(window), &bounds);
+
+  GRect title_frame = bounds;
+  title_frame.size.h = 26;
+  text_layer_init(&data->title_text, &title_frame);
+  text_layer_set_font(&data->title_text, fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD));
+  text_layer_set_text_alignment(&data->title_text, GTextAlignmentCenter);
+  text_layer_set_text(&data->title_text, i18n_get("Camera", data));
+  layer_add_child(window_get_root_layer(window), text_layer_get_layer(&data->title_text));
+
+  GRect body_frame = bounds;
+  body_frame.origin.y = 26;
+  body_frame.size.h = 38;
+  text_layer_init(&data->body_text, &body_frame);
+  text_layer_set_font(&data->body_text, fonts_get_system_font(FONT_KEY_GOTHIC_18));
+  text_layer_set_text_alignment(&data->body_text, GTextAlignmentCenter);
+  layer_add_child(window_get_root_layer(window), text_layer_get_layer(&data->body_text));
+
+  GRect code_frame = bounds;
+  code_frame.origin.y = 64;
+  code_frame.size.h = 22;
+  text_layer_init(&data->code_text, &code_frame);
+  text_layer_set_font(&data->code_text, fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD));
+  text_layer_set_text_alignment(&data->code_text, GTextAlignmentCenter);
+  layer_add_child(window_get_root_layer(window), text_layer_get_layer(&data->code_text));
+
+  GRect path_frame = bounds;
+  path_frame.origin.y = 86;
+  path_frame.size.h = 20;
+  text_layer_init(&data->path_text, &path_frame);
+  text_layer_set_font(&data->path_text, fonts_get_system_font(FONT_KEY_GOTHIC_18));
+  text_layer_set_text_alignment(&data->path_text, GTextAlignmentCenter);
+  layer_add_child(window_get_root_layer(window), text_layer_get_layer(&data->path_text));
+
+  GRect hint_frame = bounds;
+  hint_frame.origin.y = 106;
+  hint_frame.size.h = 18;
+  text_layer_init(&data->hint_text, &hint_frame);
+  text_layer_set_font(&data->hint_text, fonts_get_system_font(FONT_KEY_GOTHIC_14));
+  text_layer_set_text_alignment(&data->hint_text, GTextAlignmentCenter);
+  text_layer_set_text(&data->hint_text, "Hold Select: settings");
+  layer_add_child(window_get_root_layer(window), text_layer_get_layer(&data->hint_text));
+
+  GRect status_frame = bounds;
+  status_frame.origin.y = bounds.size.h - 24;
+  status_frame.size.h = 24;
+  text_layer_init(&data->status_text, &status_frame);
+  text_layer_set_font(&data->status_text, fonts_get_system_font(FONT_KEY_GOTHIC_14));
+  text_layer_set_text_alignment(&data->status_text, GTextAlignmentCenter);
+  text_layer_set_text(&data->status_text, data->status);
+  layer_add_child(window_get_root_layer(window), text_layer_get_layer(&data->status_text));
+
+  prv_update_readiness(data);
+  prv_update_selection(data);
+  prv_schedule_readiness_timer(data);
+
+  // The remote is useless at the default connection interval; the poller
+  // re-arms this, and it must be undone on unload or the link stays pinned in
+  // a high-power state. Pushing the picker does not unload this window, so the
+  // request survives the trip into the picker and back.
+  ble_hid_set_low_latency(true);
+}
+
+static void prv_window_unload(Window *window) {
+  CameraRemoteAppData *data = window_get_user_data(window);
+  prv_cancel_readiness_timer(data);
+  prv_release_held(data);
+  ble_hid_set_low_latency(false);
+}
+
+static void prv_handle_init(void) {
+  CameraRemoteAppData *data = app_malloc_check(sizeof(CameraRemoteAppData));
+  data->readiness_timer = NULL;
+  data->release_timer = NULL;
+  data->held_usage = 0;
+  data->shown_ready_valid = false;
+  data->code[0] = '\0';
+  data->path[0] = '\0';
+  data->status[0] = '\0';
+  app_state_set_user_data(data);
+
+  prv_load_settings();
+
+  window_init(&data->window, WINDOW_NAME("Camera Remote"));
+  window_set_user_data(&data->window, data);
+  window_set_window_handlers(&data->window, &(WindowHandlers){
+                                                .load = prv_window_load,
+                                                .unload = prv_window_unload,
+                                            });
+  window_set_click_config_provider_with_context(&data->window, prv_click_config, data);
+
+  window_init(&data->picker_window, WINDOW_NAME("Camera Remote Code"));
+  window_set_user_data(&data->picker_window, data);
+  window_set_window_handlers(&data->picker_window, &(WindowHandlers){
+                                                       .load = prv_picker_window_load,
+                                                       .unload = prv_picker_window_unload,
+                                                   });
+
+  app_window_stack_push(&data->window, true /* animated */);
+}
+
+static void prv_handle_deinit(void) {
+  CameraRemoteAppData *data = app_state_get_user_data();
+  // Safety net in case the window never got unloaded.
+  prv_cancel_readiness_timer(data);
+  prv_release_held(data);
+  ble_hid_set_low_latency(false);
+  i18n_free_all(data);
+  app_free(data);
+}
+
+static void prv_main(void) {
+  prv_handle_init();
+
+  app_event_loop();
+
+  prv_handle_deinit();
+}
+
+const PebbleProcessMd *camera_remote_get_app_info(void) {
+  static const PebbleProcessMdSystem s_app_md = {
+    .common = {
+      .main_func = prv_main,
+      // UUID: 78d71f3a-f372-40a8-a44a-38a01d958e7c
+      .uuid = {0x78, 0xd7, 0x1f, 0x3a, 0xf3, 0x72, 0x40, 0xa8,
+               0xa4, 0x4a, 0x38, 0xa0, 0x1d, 0x95, 0x8e, 0x7c},
+    },
+    .name = i18n_noop("Camera"),
+  };
+  return (const PebbleProcessMd *)&s_app_md;
+}
+
+#endif  // CONFIG_BT_HID_REMOTE

--- a/src/fw/apps/system/camera_remote/camera_remote.h
+++ b/src/fw/apps/system/camera_remote/camera_remote.h
@@ -1,0 +1,8 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include "process_management/pebble_process_md.h"
+
+const PebbleProcessMd *camera_remote_get_app_info(void);

--- a/src/fw/comm/ble/gap_le_slave_discovery.c
+++ b/src/fw/comm/ble/gap_le_slave_discovery.c
@@ -26,8 +26,11 @@
 #include <bluetooth/pebble_pairing_service.h>
 #include <bluetooth/bluetooth_types.h>
 #include <pbl/btutil/bt_uuid.h>
+#include <pbl/logging/logging.h>
 #include <pbl/util/attributes.h>
 #include <pbl/util/size.h>
+
+PBL_LOG_MODULE_DECLARE(bt, CONFIG_BT_LOG_LEVEL);
 
 static GAPLEAdvertisingJobRef s_discovery_advert_job;
 
@@ -41,28 +44,33 @@ static void prv_job_unschedule_callback(GAPLEAdvertisingJobRef job,
 }
 
 // -----------------------------------------------------------------------------
-//! Schedules the discovery advertisement job.
-//! We don't want to be advertising at a high rate infinitely. When duration
-//! is 0, a short period of high-rate advertising will be used. When this short
-//! period is completed, an indefinite, low-rate job will be scheduled.
-static void prv_schedule_ad_job(void) {
-  BLEAdData *ad = ble_ad_create();
-
+//! Builds the advertisement + scan response payload.
+//! @return False if the manufacturer-specific data did not fit, which is the
+//! one element the mobile app cannot do without.
+static bool prv_build_ad_payload(BLEAdData *ad, bool include_hid_uuid) {
   // Advertisement part:
   // Centrals will be filtering on Service UUID first. Assuming that the
   // central is only doing a scan request if the Service UUID matches with their
   // interests, to save radio time / battery life we keep the advertisement part
-  // as "small" as possible (21 bytes currently).
+  // as "small" as possible. With the default 11-character device name it is 25
+  // bytes of the 31 available, or 27 with the HRM service also advertised.
+  // A name longer than 17 characters (15 with HRM also advertised) overflows
+  // the 31-byte advertisement, and elements that no longer fit spill into the
+  // scan response, where they compete with the manufacturer-specific data.
+  // These figures include the HID Service UUID; without CONFIG_BT_HID_REMOTE
+  // everything is 2 bytes smaller and the name limits 2 characters longer.
   // Advertise "BR/EDR Not Supported" alongside General Discoverable: these are
   // BLE-only watches, so dual-mode hosts must connect over LE instead of attempting
   // a classic page (which would time out).
-  ble_ad_set_flags(ad, GAP_LE_AD_FLAGS_GEN_DISCOVERABLE_MASK |
-                       GAP_LE_AD_FLAGS_BR_EDR_NOT_SUPPORTED_MASK);
+  if (!ble_ad_set_flags(ad, GAP_LE_AD_FLAGS_GEN_DISCOVERABLE_MASK |
+                            GAP_LE_AD_FLAGS_BR_EDR_NOT_SUPPORTED_MASK)) {
+    PBL_LOG_WRN("AD flags did not fit the advertising payload");
+  }
 
   // *DO NOT* use pebble_bt_uuid_expand() here!
   // ble_ad_set_service_uuids() will be "smart" and include only the 16-bit UUID, but only if the
   // BT SIG Base UUID is used.
-  Uuid service_uuids[2];
+  Uuid service_uuids[3];
   size_t num_uuids = 0;
 
 #if defined(CONFIG_HRM) && !defined(CONFIG_RECOVERY_FW)
@@ -76,12 +84,27 @@ static void prv_schedule_ad_job(void) {
   // Pebble Pairing Service UUID:
   service_uuids[num_uuids++] = bt_uuid_expand_16bit(PEBBLE_BT_PAIRING_SERVICE_UUID_16BIT);
 
-  ble_ad_set_service_uuids(ad, service_uuids, num_uuids);
+#ifdef CONFIG_BT_HID_REMOTE
+  // Human Interface Device Service, so hosts see the watch as an input device.
+  if (include_hid_uuid) {
+    service_uuids[num_uuids++] = bt_uuid_expand_16bit(0x1812);
+  }
+#else
+  (void)include_hid_uuid;
+#endif
+
+  if (!ble_ad_set_service_uuids(ad, service_uuids, num_uuids)) {
+    PBL_LOG_WRN("Service UUIDs did not fit the advertising payload");
+  }
 
   char device_name[BT_DEVICE_NAME_BUFFER_SIZE];
   bt_local_id_copy_device_name(device_name, true);
-  ble_ad_set_local_name(ad, device_name);
-  ble_ad_set_tx_power_level(ad);
+  if (!ble_ad_set_local_name(ad, device_name)) {
+    PBL_LOG_WRN("Device name did not fit the advertising payload");
+  }
+  if (!ble_ad_set_tx_power_level(ad)) {
+    PBL_LOG_WRN("TX power level did not fit the advertising payload");
+  }
 
   // Scan response part:
   ble_ad_start_scan_response(ad);
@@ -120,10 +143,41 @@ static void prv_schedule_ad_job(void) {
          mfg_get_serial_number(),
          MFG_SERIAL_NUMBER_SIZE);
 
-  ble_ad_set_manufacturer_specific_data(ad,
-                                       BT_VENDOR_ID,
-                                       (const uint8_t *) &mfg_data,
-                                       sizeof(struct ManufacturerSpecificData));
+  return ble_ad_set_manufacturer_specific_data(ad,
+                                               BT_VENDOR_ID,
+                                               (const uint8_t *) &mfg_data,
+                                               sizeof(struct ManufacturerSpecificData));
+}
+
+// -----------------------------------------------------------------------------
+//! Schedules the discovery advertisement job.
+//! We don't want to be advertising at a high rate infinitely. When duration
+//! is 0, a short period of high-rate advertising will be used. When this short
+//! period is completed, an indefinite, low-rate job will be scheduled.
+static void prv_schedule_ad_job(void) {
+  BLEAdData *ad = ble_ad_create();
+  if (!ad) {
+    PBL_LOG_ERR("Out of memory for the advertising payload");
+    return;
+  }
+
+  if (!prv_build_ad_payload(ad, true /* include_hid_uuid */)) {
+    PBL_LOG_WRN("Manufacturer specific data did not fit the advertising payload");
+#ifdef CONFIG_BT_HID_REMOTE
+    // That data is what the mobile app identifies the watch by, so drop the HID
+    // UUID and rebuild: it is only a discovery-time hint, an already-bonded
+    // phone finds the HID service over GATT regardless. ble_ad_create() starts
+    // from an all-zero header, so this resets the payload the same way.
+    PBL_LOG_WRN("Rebuilding it without the HID service UUID");
+    memset(ad, 0, sizeof(BLEAdData));
+    if (!prv_build_ad_payload(ad, false /* include_hid_uuid */)) {
+      // Unreachable today: the longest name BT_DEVICE_NAME_BUFFER_SIZE allows
+      // always frees enough room once the HID UUID is gone. Should that stop
+      // holding, this ships a payload strictly worse than the first attempt.
+      PBL_LOG_WRN("Manufacturer specific data still does not fit; dropped");
+    }
+#endif
+  }
 
   // Values chosen according to Apple Accessory Design Guidelines.
   const GAPLEAdvertisingJobTerm advert_terms[] = {

--- a/src/fw/comm/internals/bt_conn_mgr.c
+++ b/src/fw/comm/internals/bt_conn_mgr.c
@@ -84,6 +84,7 @@ static const char *prv_consumer_name(BtConsumer consumer) {
     [BtConsumerTimelineActionMenu] = "TimelineActionMenu",
     [BtConsumerPRF] = "PRF",
     [BtConsumerPebblePairingServiceRemoteDevice] = "PebblePairingServiceRemoteDevice",
+    [BtConsumerHidRemote] = "HidRemote",
     [BtConsumerUnitTests] = "UnitTests",
   };
 

--- a/src/fw/console/prompt_commands.c
+++ b/src/fw/console/prompt_commands.c
@@ -26,6 +26,7 @@
 #include "prompt.h"
 #include "resource/resource_storage_flash.h"
 #include "pbl/services/compositor/compositor.h"
+#include "pbl/services/new_timer/new_timer.h"
 #include "pbl/services/system_task.h"
 #include "pbl/services/filesystem/pfs.h"
 #include "syscall/syscall.h"
@@ -43,6 +44,9 @@
 
 #include <bluetooth/responsiveness.h>
 #include <bluetooth/gatt_discovery.h>
+#include <bluetooth/hid_service.h>
+
+#include "pbl/services/bluetooth/ble_hid.h"
 
 #if MEMFAULT
 #include "memfault/components.h"
@@ -1204,6 +1208,156 @@ void command_bt_disc_stop(void) {
   }
   bt_unlock();
 }
+
+#ifdef CONFIG_BT_HID_REMOTE
+// Long enough for a phone to register the key, short enough not to read as a
+// hold. Debug policy: the real one lives in whichever app does the pressing.
+#define BLE_HID_PROMPT_TAP_MS (30)
+
+// Whatever "hid usage" pressed last, so "hid usage 0" knows what to release.
+// Written from KernelBG, where the prompt commands run, and from NewTimer in
+// prv_hid_tap_release_cb(), so it is volatile rather than a plain static.
+static volatile uint16_t s_hid_pressed_usage;
+
+// The release half of "hid tap". Prompt commands run on KernelBG and the press
+// is queued to that same task, so sleeping here would only stall the callback
+// that has to send it, and the tap would collapse to nothing. Kept for the
+// lifetime of the FW, like the ble_hid one, so it cannot be freed mid-fire.
+static TimerID s_hid_tap_timer = TIMER_INVALID_ID;
+
+//! @note Runs on the NewTimer task. ble_hid_consumer_release() only queues to
+//! KernelBG from here, and prompt_send_response() would assert outside a
+//! command, so the outcome only shows up in the log.
+static void prv_hid_tap_release_cb(void *data) {
+  const uint16_t usage = (uint16_t)(uintptr_t)data;
+  const status_t rv = ble_hid_consumer_release(usage);
+  if (FAILED(rv)) {
+    PBL_LOG_WRN("HID: tap release of 0x%03x failed (%d)", (unsigned)usage, (int)rv);
+    return;
+  }
+  s_hid_pressed_usage = 0;
+}
+
+static bool prv_hid_parse_usage(const char *usage_hex, uint16_t *usage) {
+  char *end = NULL;
+  const unsigned long value = strtoul(usage_hex, &end, 16);
+
+  if ((end == usage_hex) || (*end != '\0') || (value > BLE_HID_USAGE_MAX)) {
+    return false;
+  }
+  *usage = (uint16_t)value;
+  return true;
+}
+
+static bool prv_hid_parse_path(const char *path_str, BleHidReportPath *path) {
+  if (strcmp(path_str, "1") == 0) {
+    *path = BleHidReportPathBitmap;
+  } else if (strcmp(path_str, "2") == 0) {
+    *path = BleHidReportPathUsage;
+  } else {
+    return false;
+  }
+  return true;
+}
+
+//! @return ble_hid_consumer_press()'s status. S_SUCCESS means this call is the
+//! one that put the key down, which is what a caller pairing it with a release
+//! has to distinguish from S_NO_ACTION_REQUIRED.
+static status_t prv_hid_press(uint16_t usage, BleHidReportPath path, char *buffer, size_t size) {
+  const status_t rv = ble_hid_consumer_press(usage, path);
+  if (PASSED(rv)) {
+    s_hid_pressed_usage = usage;
+  }
+  prompt_send_response_fmt(buffer, size, "HID: press 0x%03x on report %u -> %d", (unsigned)usage,
+                           (path == BleHidReportPathBitmap) ? 1u : 2u, (int)rv);
+  return rv;
+}
+
+static void prv_hid_release(uint16_t usage, char *buffer, size_t size) {
+  const status_t rv = ble_hid_consumer_release(usage);
+  if (PASSED(rv)) {
+    s_hid_pressed_usage = 0;
+  }
+  prompt_send_response_fmt(buffer, size, "HID: release 0x%03x -> %d", (unsigned)usage, (int)rv);
+}
+
+void command_hid_usage(const char *usage_hex, const char *path_str) {
+  char buffer[64];
+  uint16_t usage;
+  BleHidReportPath path;
+
+  if (!prv_hid_parse_usage(usage_hex, &usage)) {
+    prompt_send_response("HID: expected a hex usage 0..3ff, e.g. e9");
+  } else if (!prv_hid_parse_path(path_str, &path)) {
+    prompt_send_response("HID: expected a report: 1 bitmap, 2 usage array");
+  } else if (usage == 0) {
+    // The release goes out on whichever report the press used, so the path
+    // argument cannot steer it; it is only parsed to keep the arity uniform.
+    prv_hid_release(s_hid_pressed_usage, buffer, sizeof(buffer));
+    prompt_send_response("HID: released on the press's own report; the path argument is ignored");
+  } else {
+    prv_hid_press(usage, path, buffer, sizeof(buffer));
+    prompt_send_response("HID: held down; send \"hid usage 0 1\" to release, or leave it to the "
+                         "ble_hid safety timeout");
+  }
+  prompt_command_finish();
+}
+
+void command_hid_tap(const char *usage_hex, const char *path_str) {
+  char buffer[64];
+  uint16_t usage;
+  BleHidReportPath path;
+
+  if (!prv_hid_parse_usage(usage_hex, &usage) || (usage == 0)) {
+    prompt_send_response("HID: expected a hex usage 1..3ff, e.g. e9");
+    prompt_command_finish();
+    return;
+  }
+  if (!prv_hid_parse_path(path_str, &path)) {
+    prompt_send_response("HID: expected a report: 1 bitmap, 2 usage array");
+    prompt_command_finish();
+    return;
+  }
+
+  if (s_hid_tap_timer == TIMER_INVALID_ID) {
+    s_hid_tap_timer = new_timer_create();
+  }
+  if (s_hid_tap_timer == TIMER_INVALID_ID) {
+    prompt_send_response("HID: no timer for the release half of the tap");
+    prompt_command_finish();
+    return;
+  }
+
+  // S_SUCCESS only, not PASSED(): prv_hid_press() answers S_NO_ACTION_REQUIRED
+  // when the same usage and path are already held, and arming the release then
+  // would lift the press that is already down rather than one of our own.
+  if (prv_hid_press(usage, path, buffer, sizeof(buffer)) == S_SUCCESS) {
+    // A held Volume Up starts a QuickTake video on iOS instead of taking a
+    // photo, so a tap has to be short. This is the console stand-in for what
+    // the Camera app does with an app_timer.
+    if (new_timer_start(s_hid_tap_timer, BLE_HID_PROMPT_TAP_MS, prv_hid_tap_release_cb,
+                        (void *)(uintptr_t)usage, 0 /* flags */)) {
+      prompt_send_response_fmt(buffer, sizeof(buffer), "HID: releasing in %u ms",
+                               (unsigned)BLE_HID_PROMPT_TAP_MS);
+    } else {
+      prv_hid_release(usage, buffer, sizeof(buffer));
+    }
+  }
+  prompt_command_finish();
+}
+
+void command_hid_status(void) {
+  char buffer[96];
+  prompt_send_response_fmt(buffer, sizeof(buffer),
+                           "HID: supported=%s bits_sub=%s usage_sub=%s ready1=%s ready2=%s",
+                           bt_driver_is_hid_service_supported() ? "yes" : "no",
+                           bt_driver_hid_service_is_subscribed() ? "yes" : "no",
+                           bt_driver_hid_service_usage_is_subscribed() ? "yes" : "no",
+                           ble_hid_is_ready(BleHidReportPathBitmap) ? "yes" : "no",
+                           ble_hid_is_ready(BleHidReportPathUsage) ? "yes" : "no");
+  prompt_command_finish();
+}
+#endif  // CONFIG_BT_HID_REMOTE
 
 extern void hc_endpoint_logging_set_level(uint8_t level);
 void command_ble_logging_set_level(const char *level) {

--- a/src/fw/console/prompt_commands.h
+++ b/src/fw/console/prompt_commands.h
@@ -111,6 +111,12 @@ extern void command_bt_set_name(const char *bt_name);
 
 extern void command_bt_status(void);
 
+#ifdef CONFIG_BT_HID_REMOTE
+extern void command_hid_usage(const char *usage_hex, const char *path_str);
+extern void command_hid_tap(const char *usage_hex, const char *path_str);
+extern void command_hid_status(void);
+#endif
+
 // extern void command_get_remote_prefs(void);
 // extern void command_del_remote_pref(const char*);
 // extern void command_bt_sniff_bounce(void);
@@ -327,6 +333,11 @@ static const Command s_prompt_commands[] = {
   { "bt cp set", command_bt_conn_param_set, 4 },
   { "bt disc start", command_bt_disc_start, 2 },
   { "bt disc stop", command_bt_disc_stop, 0 },
+#ifdef CONFIG_BT_HID_REMOTE
+  { "hid usage", command_hid_usage, 2 },
+  { "hid tap", command_hid_tap, 2 },
+  { "hid status", command_hid_status, 0 },
+#endif
   { "timezone clear", command_timezone_clear, 0 },
   { "battery status", command_print_battery_status, 0 },
 #ifndef CONFIG_RELEASE

--- a/src/fw/services/bluetooth/ble_hid.c
+++ b/src/fw/services/bluetooth/ble_hid.c
@@ -1,0 +1,568 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "pbl/services/bluetooth/ble_hid.h"
+
+#include "comm/ble/gap_le_connection.h"
+#include "comm/bt_conn_mgr.h"
+#include "comm/bt_lock.h"
+#include "kernel/pebble_tasks.h"
+#include "pbl/os/mutex.h"
+#include "pbl/os/tick.h"
+#include "pbl/services/new_timer/new_timer.h"
+#include "pbl/services/system_task.h"
+#include <pbl/drivers/rtc.h>
+#include <pbl/logging/logging.h>
+
+#include <bluetooth/hid_service.h>
+#include <bluetooth/responsiveness.h>
+
+PBL_LOG_MODULE_DECLARE(service_bluetooth, CONFIG_SERVICE_BLUETOOTH_LOG_LEVEL);
+
+#ifdef CONFIG_BT_HID_REMOTE
+
+// A lost release leaves the key held down on the phone, which is not harmless:
+// a held Volume Up in the iOS Camera app starts a QuickTake video. Release for
+// the caller if it never gets round to it. 10 s is long enough not to cut a
+// legitimate hold short -- a volume ramp or a fast-forward runs a few seconds --
+// and short enough that a stuck key reads as a glitch rather than a dead phone.
+#define BLE_HID_HOLD_TIMEOUT_MS (10000)
+
+// How often a release that could not go out is tried again.
+#define BLE_HID_RELEASE_RETRY_MS (30)
+
+// How long past the hold timeout those retries keep going. The budget is time
+// rather than a number of attempts: what a retry waits out is a KernelBG
+// backlog or an exhausted mbuf pool, and neither is measured in attempts.
+// 3 s is what system_task_add_callback() itself waits on this very queue before
+// it calls the system broken and reboots, so giving up sooner would abandon a
+// key on a backlog the kernel still considers survivable. KernelBG now also
+// carries the BLE store's settings-file work -- a bonding delete is a full-file
+// scan, a transaction per CCCD record and a shared-PRF erase -- so backlogs of
+// that order are ordinary here.
+#define BLE_HID_RELEASE_GRACE_MS (3000)
+
+//! Free KernelBG slots we insist on before queueing work. From anything but the
+//! app task, system_task_add_callback() blocks up to 3 s on a full queue and
+//! then reboots, and from KernelBG itself it can never drain.
+#define BLE_HID_KERNEL_BG_QUEUE_MARGIN (10)
+
+//! How much of s_press_generation rides in a packed cb_data. The same width on
+//! all three layouts below, so a generation compares the same way whichever one
+//! it travelled in. A million presses between two wraps, against callbacks that
+//! live for milliseconds.
+#define BLE_HID_GENERATION_MASK (0xFFFFFU)
+
+//! Timer cb_data layout. The purpose tells a forced release from a retry, and
+//! the press generation makes a fire left over from an earlier press
+//! detectable: new_timer_start() cannot recall one that is already in flight.
+#define BLE_HID_TIMER_PURPOSE_MASK (0x1U)
+#define BLE_HID_TIMER_PURPOSE_HOLD (0x0U)
+#define BLE_HID_TIMER_PURPOSE_RETRY (0x1U)
+#define BLE_HID_TIMER_GENERATION_SHIFT (1U)
+
+//! Press cb_data layout. The usage and the report ride along rather than being
+//! read back from the statics, so a press queued while an earlier one is still
+//! pending cannot overwrite them, and the generation is the only thing that
+//! tells two presses of the same usage on the same report apart. The release
+//! layout is the generation on its own, so it needs no shifts of its own.
+#define BLE_HID_PRESS_USAGE_MASK (0x3FFU)
+#define BLE_HID_PRESS_PATH_SHIFT (10U)
+#define BLE_HID_PRESS_PATH_MASK (0x1U)
+#define BLE_HID_PRESS_GENERATION_SHIFT (11U)
+
+_Static_assert(BLE_HID_USAGE_MAX <= BLE_HID_PRESS_USAGE_MASK,
+               "a usage no longer fits a packed press");
+_Static_assert(BleHidReportPathUsage <= BLE_HID_PRESS_PATH_MASK,
+               "a path no longer fits a packed press");
+_Static_assert(((uint64_t)BLE_HID_GENERATION_MASK << BLE_HID_PRESS_GENERATION_SHIFT) <= UINT32_MAX,
+               "a packed press overflows a 32-bit cb_data");
+
+static TimerID s_release_timer = TIMER_INVALID_ID;
+//! Usage currently held down (0 if none) and the report it went out on.
+//! @note s_held_usage is the publication flag for all of this state, so a press
+//! writes it last and a release clears it last. Everything else -- the path, the
+//! generation -- must already be in place when a reader sees it non-zero.
+//! Volatile because App, KernelBG, NewTimer and the BT host task all touch these
+//! and the ordering, not just the value, is what makes the protocol work.
+static volatile uint16_t s_held_usage;
+static volatile BleHidReportPath s_held_path;
+//! Bumped by every press before it publishes a held state. Read on the NewTimer
+//! task and on KernelBG; a single aligned word, so a reader never sees a torn
+//! value. The increment is a read-modify-write and ble_hid_consumer_press() is
+//! called from the app task (the Camera app) and from KernelBG (the prompt
+//! commands), so it is done under s_press_mutex rather than left to volatile.
+static volatile uint32_t s_press_generation;
+//! When the held usage has to be back up by, come what may: the hold timeout
+//! plus the retry grace, counted from the press. Written with the held state
+//! and under the same lock, so it belongs to exactly one generation and no
+//! reader needs a second word to work out which. Truncated rtc ticks: a 64-bit
+//! RtcTicks could be read torn by the four tasks that look at this.
+static volatile uint32_t s_release_deadline;
+
+//! Serialises the claim-and-publish block of ble_hid_consumer_press(): the
+//! s_held_usage test, the generation bump, the writes of s_held_path and
+//! s_held_usage, and arming the hold timer. Without it two callers can both find
+//! s_held_usage == 0, lose one increment, both arm the one shared timer and both
+//! queue a press, and only one of the two can ever be released.
+//! @note Held by pressers only. Deliberately not taken by prv_release_timer_cb()
+//! or the KernelBG callbacks: NewTimer runs at max priority and holds the timer
+//! manager's lock around a start, and the press path takes that lock while
+//! holding this one. Everything outside the publish block relies on the
+//! generation guard instead, which is what it is there for.
+//! @note Created by ble_hid_init(), which bluetooth_ctl.c runs before
+//! bt_driver_start() -- the point at which the GATT service becomes
+//! subscribable -- so nothing that reaches this lock can find it NULL.
+static PebbleMutex *s_press_mutex;
+
+static void prv_release_timer_cb(void *packed);
+static void prv_release_system_task_cb(void *packed);
+
+//! @note The generation is a parameter rather than a read of s_press_generation,
+//! so a caller that has already validated one cannot accidentally pack a newer.
+static void *prv_pack_timer(uint32_t generation, unsigned purpose) {
+  return (void *)(uintptr_t)(
+      ((generation & BLE_HID_GENERATION_MASK) << BLE_HID_TIMER_GENERATION_SHIFT) |
+      (purpose & BLE_HID_TIMER_PURPOSE_MASK));
+}
+
+//! @note The generation is all a release needs to carry, and it needs it for the
+//! same reason a timer does one queue earlier: a release sits on the KernelBG
+//! queue behind other work, and by the time it runs the press it was queued for
+//! may be over and another one under way.
+static void *prv_pack_release(uint32_t generation) {
+  return (void *)(uintptr_t)(generation & BLE_HID_GENERATION_MASK);
+}
+
+static void *prv_pack_press(uint32_t generation, uint16_t usage, BleHidReportPath path) {
+  return (void *)(uintptr_t)(
+      ((generation & BLE_HID_GENERATION_MASK) << BLE_HID_PRESS_GENERATION_SHIFT) |
+      (((unsigned)path & BLE_HID_PRESS_PATH_MASK) << BLE_HID_PRESS_PATH_SHIFT) |
+      ((unsigned)usage & BLE_HID_PRESS_USAGE_MASK));
+}
+
+//! @return True if `generation` is still the press everything is about.
+static bool prv_generation_is_current(uint32_t generation) {
+  return (generation == (s_press_generation & BLE_HID_GENERATION_MASK));
+}
+
+//! The clock the release deadline is kept on. Truncated to 32 bits on purpose:
+//! every comparison below is a signed difference, so the wrap is harmless, and
+//! at RTC_TICKS_HZ half the range is days against a budget of seconds.
+static uint32_t prv_now_ticks(void) {
+  return (uint32_t)rtc_get_ticks();
+}
+
+static bool prv_deadline_passed(uint32_t deadline) {
+  return ((int32_t)(prv_now_ticks() - deadline) >= 0);
+}
+
+//! Hands work to KernelBG without ever waiting on it, except from the app task.
+//! @return True if the work was queued.
+//! @note The app has its own eight-deep queue and is meant to wait on it, which
+//! is what system_task_add_callback() does for it by design. Every other caller
+//! here is somewhere waiting is not allowed: NewTimer drives every other timer
+//! in the system, the BT host task holds ble_hs_mutex, and KernelBG cannot drain
+//! its own queue. For those, the margin keeps the BLE store's settings-file work
+//! from being crowded out, and the send itself refuses to block -- the margin
+//! alone cannot promise the slot is still there when we send.
+//! @note KernelBG now also carries that store work, so a shutter press from the
+//! Camera app can sit in the app's syscall waiting for a flash transaction, and
+//! the UI sits with it. That coupling did not exist before the store deferral.
+static bool prv_queue_to_kernel_bg(SystemTaskEventCallback cb, void *data) {
+  if (pebble_task_get_current() == PebbleTask_App) {
+    return system_task_add_callback(cb, data);
+  }
+  if (system_task_get_available_space() <= BLE_HID_KERNEL_BG_QUEUE_MARGIN) {
+    return false;
+  }
+  return system_task_add_callback_nonblocking(cb, data);
+}
+
+//! Rejects a path that cannot carry `usage`, rather than rerouting it.
+static status_t prv_check_path(uint16_t usage, BleHidReportPath path) {
+  switch (path) {
+    case BleHidReportPathBitmap:
+      // No silent fallback to report 2: it would hide which form the usage went
+      // out as, and telling the two apart is the only reason the path is a
+      // parameter at all.
+      return (ble_hid_consumer_usage_to_bit(usage) != 0) ? S_SUCCESS : E_INVALID_ARGUMENT;
+    case BleHidReportPathUsage:
+      return S_SUCCESS;
+    default:
+      return E_INVALID_ARGUMENT;
+  }
+}
+
+//! The only place a report goes out. `usage` 0 releases whatever is held.
+static bool prv_send(uint16_t usage, BleHidReportPath path) {
+  if (path == BleHidReportPathBitmap) {
+    return bt_driver_hid_service_send_consumer_report(ble_hid_consumer_usage_to_bit(usage));
+  }
+  return bt_driver_hid_service_send_consumer_usage(usage);
+}
+
+//! Asks the driver rather than caching: a subscription can end with the link
+//! already gone, and a mirror of it here would then be stale in exactly the
+//! case that matters.
+static bool prv_path_is_subscribed(BleHidReportPath path) {
+  switch (path) {
+    case BleHidReportPathBitmap:
+      return bt_driver_hid_service_is_subscribed();
+    case BleHidReportPathUsage:
+      return bt_driver_hid_service_usage_is_subscribed();
+    default:
+      return false;
+  }
+}
+
+//! Re-arms the release timer, or gives up and lets a new press through.
+//! @note `generation` must be the one the caller has just validated: both
+//! give-up exits clear s_held_usage, and doing that for a press that has moved
+//! on would drop the flag a newer press is relying on. Nothing here holds
+//! s_press_mutex, so the guard is re-run against the one action that outlives
+//! this call.
+//! @note Runs on KernelBG and on NewTimer, neither of which may ask the driver
+//! whether the peer is still subscribed. It does not need to: the retry ends up
+//! back in prv_release_system_task_cb(), which does ask, and clears the state
+//! outright once the peer has gone. So the loop only keeps going while the peer
+//! is still there or while KernelBG is too backed up to say.
+static void prv_schedule_release_retry(uint32_t generation) {
+  if (!prv_generation_is_current(generation)) {
+    return;
+  }
+  if (prv_deadline_passed(s_release_deadline)) {
+    // Out of budget with the key still down on the phone. Nothing here can lift
+    // it -- the whole window was spent failing to -- so say so at ERR and drop
+    // the state rather than imply it went up. Forgetting is the recovery: the
+    // next press is accepted, and its own release lifts the stuck key.
+    PBL_LOG_ERR("BLE HID: usage 0x%03x is still down after %u ms, giving up on the release",
+                (unsigned)s_held_usage,
+                (unsigned)(BLE_HID_HOLD_TIMEOUT_MS + BLE_HID_RELEASE_GRACE_MS));
+    s_held_usage = 0;
+    return;
+  }
+  // Again, right up against the start. A press can land anywhere above -- the
+  // checks read state it writes -- and it arms the one shared timer with its own
+  // hold; starting a retry for the older generation on top of that would leave
+  // the new press with no safety net at all. Nothing to clear on this exit: that
+  // press could only have been accepted with s_held_usage already 0, so the held
+  // state is its own now.
+  if (!prv_generation_is_current(generation)) {
+    return;
+  }
+  if ((s_release_timer == TIMER_INVALID_ID) ||
+      !new_timer_start(s_release_timer, BLE_HID_RELEASE_RETRY_MS, prv_release_timer_cb,
+                       prv_pack_timer(generation, BLE_HID_TIMER_PURPOSE_RETRY), 0 /* flags */)) {
+    PBL_LOG_ERR("BLE HID: no release timer, usage 0x%03x is left down", (unsigned)s_held_usage);
+    s_held_usage = 0;
+  }
+}
+
+static void prv_release_system_task_cb(void *packed) {
+  const uint32_t generation = (uint32_t)(uintptr_t)packed & BLE_HID_GENERATION_MASK;
+
+  if (!prv_generation_is_current(generation)) {
+    // Queued for a press that is already over. Two releases can be in flight at
+    // once -- the tap timer and an unsubscribe both queue one -- and without
+    // this the second would lift the press that came after them and leave the
+    // flag clear, so the press that follows *it* reads as stale and sends
+    // nothing. The shutter would then silently do nothing.
+    return;
+  }
+  const uint16_t usage = s_held_usage;
+  if (usage == 0) {
+    // Already released, e.g. by the app just before the hold timer fired.
+    return;
+  }
+  const BleHidReportPath path = s_held_path;
+  if (prv_send(0, path) || !prv_path_is_subscribed(path)) {
+    // Released, or the peer is gone and whatever key state it had is moot.
+    s_held_usage = 0;
+    return;
+  }
+  // The send failed with the peer still there (out of mbufs, notify error).
+  PBL_LOG_WRN("BLE HID: release of 0x%03x failed, retrying", (unsigned)usage);
+  prv_schedule_release_retry(generation);
+}
+
+//! @note Runs on the NewTimer task, which is max priority and drives every
+//! other timer, so never talk to the BT stack from here: bt_lock can be held
+//! by a lower-priority task for a long time. Hand off to KernelBG instead.
+static void prv_release_timer_cb(void *packed) {
+  const uintptr_t data = (uintptr_t)packed;
+  const unsigned purpose = data & BLE_HID_TIMER_PURPOSE_MASK;
+  const uint32_t generation = (data >> BLE_HID_TIMER_GENERATION_SHIFT) & BLE_HID_GENERATION_MASK;
+
+  if (!prv_generation_is_current(generation)) {
+    // Armed for a press that has since been replaced. Acting now would release
+    // the press that replaced it.
+    // @note This rests on task_timer.c dropping the manager mutex before it
+    // reads cb_data, and on NewTimer running at configMAX_PRIORITIES - 1.
+    // Together they mean nothing can slip a new_timer_start() into that window
+    // and swap this fire's packed generation for a newer one, which is the only
+    // way a stale fire could read as current.
+    return;
+  }
+  if (s_held_usage == 0) {
+    // Released normally; nothing left to force. Not stopping the timer on a
+    // normal release is deliberate, but not because the stop would block: it
+    // does not. task_timer_stop() takes the manager mutex, unlinks the timer
+    // and returns !executing, and new_timer.h documents the return value the
+    // same way. The reason is that a release is asynchronous and may retry on
+    // this same timer, so the safety net has to stay armed until the state is
+    // actually clear. A leftover fire lands here and costs nothing.
+    return;
+  }
+  if (purpose == BLE_HID_TIMER_PURPOSE_HOLD) {
+    PBL_LOG_WRN("BLE HID: usage 0x%03x held for %u ms, forcing the release",
+                (unsigned)s_held_usage, (unsigned)BLE_HID_HOLD_TIMEOUT_MS);
+  }
+  // Never waits: stalling here would stall every timer in the system. The
+  // generation rides along so a release that queues now but runs after the next
+  // press cannot lift it.
+  if (prv_queue_to_kernel_bg(prv_release_system_task_cb, prv_pack_release(generation))) {
+    return;
+  }
+  PBL_LOG_WRN("BLE HID: KernelBG would not take the release, retrying");
+  prv_schedule_release_retry(generation);
+}
+
+//! Arms the safety net that releases a usage the caller forgot about.
+//! @note Must be called with s_held_usage and s_press_generation already set.
+//! @note Deliberately no TIMER_START_FLAG_FAIL_IF_EXECUTING. It would close the
+//! cb_data window prv_release_timer_cb() documents, but it also refuses the
+//! start whenever a leftover fire happens to be running, which would turn a
+//! benign overlap into a failed shutter press. The generation guard already
+//! covers the overlap, and prv_schedule_release_retry() re-arms from inside the
+//! callback, where the flag would refuse every time.
+static bool prv_arm_hold_timer(uint32_t generation) {
+  return (s_release_timer != TIMER_INVALID_ID) &&
+         new_timer_start(s_release_timer, BLE_HID_HOLD_TIMEOUT_MS, prv_release_timer_cb,
+                         prv_pack_timer(generation, BLE_HID_TIMER_PURPOSE_HOLD), 0 /* flags */);
+}
+
+static void prv_press_system_task_cb(void *packed) {
+  const uintptr_t data = (uintptr_t)packed;
+  const uint16_t usage = (uint16_t)(data & BLE_HID_PRESS_USAGE_MASK);
+  const BleHidReportPath path =
+      (BleHidReportPath)((data >> BLE_HID_PRESS_PATH_SHIFT) & BLE_HID_PRESS_PATH_MASK);
+  const uint32_t generation = (data >> BLE_HID_PRESS_GENERATION_SHIFT) & BLE_HID_GENERATION_MASK;
+
+  // The generation, not just the usage and the path: a presser on the app task
+  // waits inside system_task_add_callback() for as long as its queue is full,
+  // and by the time it gets a slot the key it published can have been released
+  // and the same usage pressed again on the same report. The usage and path
+  // alone would match that, so this would send a second report for a press that
+  // is over and, on a send failure, clear a held state belonging to the press
+  // that replaced it -- whose own release would then be a no-op.
+  if (!prv_generation_is_current(generation) || (s_held_usage != usage) ||
+      (s_held_path != path)) {
+    PBL_LOG_DBG("BLE HID: press of 0x%03x is stale, not sending", (unsigned)usage);
+    return;
+  }
+  PBL_LOG_DBG("BLE HID: press 0x%03x on report %u", (unsigned)usage,
+              (path == BleHidReportPathBitmap) ? 1u : 2u);
+  if (!prv_send(usage, path)) {
+    // Nothing went out, so nothing is held: a later press must not see E_BUSY,
+    // and a release must not send a lift for a key that never went down. Only
+    // if this press is still the current one, for the reason above.
+    if (prv_generation_is_current(generation)) {
+      s_held_usage = 0;
+    }
+  }
+}
+
+bool ble_hid_is_ready(BleHidReportPath path) {
+  return (bt_driver_is_hid_service_supported() && prv_path_is_subscribed(path));
+}
+
+status_t ble_hid_consumer_press(uint16_t usage, BleHidReportPath path) {
+  if ((usage == 0) || (usage > BLE_HID_USAGE_MAX)) {
+    return E_INVALID_ARGUMENT;
+  }
+  const status_t rv = prv_check_path(usage, path);
+  if (FAILED(rv)) {
+    return rv;
+  }
+  if (!bt_driver_is_hid_service_supported() || !prv_path_is_subscribed(path)) {
+    return E_INVALID_OPERATION;
+  }
+  // Re-arm the low-latency request, which expires after
+  // MIN_LATENCY_MODE_TIMEOUT_HID_SECS. Done here rather than in the app so the
+  // prompt commands get it too.
+  ble_hid_set_low_latency(true);
+
+  // Claiming the held state and publishing it has to be one step: the app task
+  // and KernelBG both press, and two callers that each find s_held_usage == 0
+  // would otherwise both go on to publish.
+  mutex_lock(s_press_mutex);
+
+  if (s_held_usage != 0) {
+    const bool same_key = (s_held_usage == usage) && (s_held_path == path);
+    mutex_unlock(s_press_mutex);
+    // Report Count is 1 on both reports, so only one usage can be held.
+    // Already down means the safety net stays anchored to the first press:
+    // pushing it out would let a repeat hold the key indefinitely, and there is
+    // one shared timer, so re-arming it would silently cancel a release retry.
+    return same_key ? S_NO_ACTION_REQUIRED : E_BUSY;
+  }
+
+  // Publish the held state here, in the caller's context, before queueing the
+  // send. A caller that taps -- presses and releases a few ms later -- has to
+  // see it, and the KernelBG callback has not necessarily run by then.
+  // s_held_usage goes last: it is what every reader keys off, and NewTimer runs
+  // at max priority and can cut in between any two of these. A leftover hold
+  // timer that saw the new generation but the old s_held_usage would queue a
+  // forced release against the press that is only just starting, and one that
+  // saw the new s_held_usage but the old s_held_path would release the wrong
+  // report. The deadline goes with the generation for the same reason: nothing
+  // reads it without first matching a generation, and nothing can be matching
+  // this one until the timer below is armed.
+  // Masked on the way in, so the counter itself never holds anything a packed
+  // cb_data cannot carry and the comparisons below match what went out.
+  const uint32_t generation = (s_press_generation + 1) & BLE_HID_GENERATION_MASK;
+  s_press_generation = generation;
+  s_release_deadline =
+      prv_now_ticks() +
+      (uint32_t)milliseconds_to_ticks(BLE_HID_HOLD_TIMEOUT_MS + BLE_HID_RELEASE_GRACE_MS);
+  s_held_path = path;
+  s_held_usage = usage;
+  const bool armed = prv_arm_hold_timer(generation);
+  if (!armed) {
+    // Nothing has gone out yet, so refusing costs nothing, and without the
+    // safety net a lost release holds the key until the link drops -- a held
+    // Volume Up is a video rather than a photo.
+    s_held_usage = 0;
+  }
+
+  mutex_unlock(s_press_mutex);
+
+  if (!armed) {
+    PBL_LOG_ERR("BLE HID: no hold timer, refusing the press of 0x%03x", (unsigned)usage);
+    return E_INTERNAL;
+  }
+
+  // Outside the lock: from the app task this waits on the app's own queue, and
+  // holding the lock across that wait would stall a presser on another task.
+  if (!prv_queue_to_kernel_bg(prv_press_system_task_cb,
+                              prv_pack_press(generation, usage, path))) {
+    PBL_LOG_WRN("BLE HID: could not queue the press of 0x%03x", (unsigned)usage);
+    // Only if this press is still the current one: a release and a new press can
+    // both have run by now, and clearing the flag then would drop theirs.
+    if (prv_generation_is_current(generation)) {
+      s_held_usage = 0;
+    }
+    return E_INTERNAL;
+  }
+  return S_SUCCESS;
+}
+
+status_t ble_hid_consumer_release(uint16_t usage) {
+  // Generation first, held usage second. A press that slips in between then
+  // leaves us carrying the older generation, so the release is discarded rather
+  // than lifting a key that has only just gone down; the hold timer covers the
+  // one it was meant for. The other order would let it release the new press.
+  const uint32_t generation = s_press_generation;
+  const uint16_t held = s_held_usage;
+  if (held == 0) {
+    return S_NO_ACTION_REQUIRED;
+  }
+  if (usage != held) {
+    return E_INVALID_ARGUMENT;
+  }
+  // No path argument: the release goes out on s_held_path, so a report 2 press
+  // cannot be released on report 1 and leave the key down.
+  if (!prv_queue_to_kernel_bg(prv_release_system_task_cb, prv_pack_release(generation))) {
+    // The hold timer still covers it.
+    PBL_LOG_WRN("BLE HID: could not queue the release of 0x%03x", (unsigned)usage);
+    return E_INTERNAL;
+  }
+  return S_SUCCESS;
+}
+
+void ble_hid_set_low_latency(bool enabled) {
+  bt_lock();
+  {
+    GAPLEConnection *connection = gap_le_connection_get_gateway();
+    if (connection) {
+      conn_mgr_set_ble_conn_response_time(
+          connection, BtConsumerHidRemote, enabled ? ResponseTimeMin : ResponseTimeMax,
+          MIN_LATENCY_MODE_TIMEOUT_HID_SECS);
+    }
+  }
+  bt_unlock();
+}
+
+void bt_driver_cb_hid_service_update_subscription(const BTDeviceInternal *device,
+                                                  bool is_subscribed) {
+  // One event per report characteristic, so read both back rather than trust
+  // whichever one arrived last.
+  PBL_LOG_DBG("BLE HID: subscribed bits=%u usage=%u", bt_driver_hid_service_is_subscribed(),
+              bt_driver_hid_service_usage_is_subscribed());
+
+  // Read before s_held_usage, for the reason in ble_hid_consumer_release().
+  const uint32_t generation = s_press_generation;
+  if ((s_held_usage == 0) || prv_path_is_subscribed(s_held_path)) {
+    return;
+  }
+  // The peer stopped listening, or went away, with a key held. Let KernelBG
+  // clear it through the normal release path rather than write the state from
+  // here; if the queue will not take it, the hold timer still will. Runs on the
+  // BT host task, so it must not block and must not touch a timer.
+  if (!prv_queue_to_kernel_bg(prv_release_system_task_cb, prv_pack_release(generation))) {
+    PBL_LOG_WRN("BLE HID: could not queue the forced release of 0x%03x", (unsigned)s_held_usage);
+  }
+}
+
+void ble_hid_init(void) {
+  if (s_press_mutex == NULL) {
+    // Kept for the lifetime of the FW, like the timer below: a stack restart
+    // must not free a lock a presser may be waiting on.
+    s_press_mutex = mutex_create();
+  }
+  s_held_usage = 0;
+  s_held_path = BleHidReportPathBitmap;
+  // s_press_generation is deliberately not reset: keeping it monotonic across a
+  // stack restart is what stops a timer armed before the restart from matching.
+
+  if (!bt_driver_is_hid_service_supported() || (s_release_timer != TIMER_INVALID_ID)) {
+    return;
+  }
+  // Created outside bt_lock: new_timer_create takes the TaskTimerManager mutex,
+  // which NimbleHost may hold while waiting for bt_lock. The timer is kept for
+  // the lifetime of the FW so a restart cannot free one that is about to fire.
+  s_release_timer = new_timer_create();
+  if (s_release_timer == TIMER_INVALID_ID) {
+    PBL_LOG_ERR("BLE HID: failed to create the release timer");
+  }
+}
+
+void ble_hid_deinit(void) {
+  // The timer outlives bt_driver_stop(), so an armed one would post a release
+  // against a stopped host and could clear a flag owned by the next session.
+  if (s_release_timer != TIMER_INVALID_ID) {
+    new_timer_stop(s_release_timer);
+  }
+  // Nothing can be sent to a host that is going down, and a HOGP host drops
+  // every key it knows about when the link goes, so forgetting is the release.
+  s_held_usage = 0;
+}
+
+#else
+
+bool ble_hid_is_ready(BleHidReportPath path) { return false; }
+
+status_t ble_hid_consumer_press(uint16_t usage, BleHidReportPath path) {
+  return E_INVALID_OPERATION;
+}
+
+status_t ble_hid_consumer_release(uint16_t usage) { return S_NO_ACTION_REQUIRED; }
+
+void ble_hid_set_low_latency(bool enabled) {}
+
+void ble_hid_init(void) {}
+
+void ble_hid_deinit(void) {}
+
+#endif  // CONFIG_BT_HID_REMOTE

--- a/src/fw/services/bluetooth/bluetooth_ctl.c
+++ b/src/fw/services/bluetooth/bluetooth_ctl.c
@@ -15,6 +15,7 @@
 #include "pbl/os/mutex.h"
 #include "pbl/services/analytics/analytics.h"
 #include "pbl/services/bluetooth/ble_bas.h"
+#include "pbl/services/bluetooth/ble_hid.h"
 #include "pbl/services/bluetooth/bluetooth_persistent_storage.h"
 #include "pbl/services/bluetooth/dis.h"
 #include "pbl/services/bluetooth/local_addr.h"
@@ -77,6 +78,13 @@ static void prv_comm_start(void) {
   // no-op bonding handlers, so doing it early is harmless for them too.
   bt_persistent_storage_register_existing_ble_bondings();
 
+  // Before the driver, not after: bt_driver_start() is where the HID GATT
+  // service becomes subscribable, and a subscribe event landing on the host
+  // task before ble_hid_init() has made its lock would race the press path.
+  // Nothing in here touches the driver beyond asking whether the backend
+  // supports the service at all, which is a per-backend constant.
+  ble_hid_init();
+
   s_comm_is_running = bt_driver_start(config);
   kernel_free(config);
 
@@ -100,6 +108,7 @@ static void prv_comm_stop(void) {
     return;
   }
   ble_bas_deinit();
+  ble_hid_deinit();
 #if defined(CONFIG_HRM) && !defined(CONFIG_RECOVERY_FW)
   ble_hrm_deinit();
 #endif

--- a/src/fw/services/bluetooth/bluetooth_persistent_storage_normal.c
+++ b/src/fw/services/bluetooth/bluetooth_persistent_storage_normal.c
@@ -150,27 +150,42 @@ static void prv_update_bondings(BTBondingID id, BtPersistBondingType type) {
   }
 }
 
+//! Read a record out of an already open file.
+//! @note The caller owns `fd` and holds prv_lock(); this takes neither. Split out
+//! so a caller that has to read and write one record without letting go of the
+//! lock can share the read with prv_file_get().
+//! @return the size of the data read, 0 if the record is missing or does not fit
+static unsigned int prv_file_get_locked(SettingsFile *fd, const void *key, size_t key_len,
+                                        void *data_out, size_t buf_len) {
+  // Zero the output up front so callers that ignore the return value (a 0 length on
+  // read failure or an oversized record) read defined zeros, not stack garbage.
+  memset(data_out, 0, buf_len);
+
+  unsigned int data_len = settings_file_get_len(fd, key, key_len);
+  // If a big enough buffer wasn't passed in, then the data can't be read.
+  if (data_len > buf_len ||
+      settings_file_get(fd, key, key_len, data_out, buf_len) != S_SUCCESS) {
+    data_len = 0;
+  }
+  return data_len;
+}
+
 //! Returns the size of the data read. If the buffer provided is too small then 0 is returned
 static int prv_file_get(const void *key, size_t key_len, void *data_out, size_t buf_len) {
   unsigned int data_len = 0;
-  // Zero the output up front so callers that ignore the return value (a 0 length on
-  // open/read failure or an oversized record) read defined zeros, not stack garbage.
-  memset(data_out, 0, buf_len);
   prv_lock();
   {
     SettingsFile fd;
     status_t rv = settings_file_open(&fd, BT_PERSISTENT_STORAGE_FILE_NAME,
                                      BT_PERSISTENT_STORAGE_FILE_SIZE);
     if (rv != S_SUCCESS) {
+      // Zero the output so callers that ignore the return value read defined
+      // zeros, not stack garbage. The read path below does its own.
+      memset(data_out, 0, buf_len);
       goto cleanup;
     }
 
-    data_len = settings_file_get_len(&fd, key, key_len);
-    // If a big enough buffer wasn't passed in, then the data can't be read.
-    if (data_len > buf_len ||
-        settings_file_get(&fd, key, key_len, data_out, buf_len) != S_SUCCESS) {
-      data_len = 0;
-    }
+    data_len = prv_file_get_locked(&fd, key, key_len, data_out, buf_len);
 
     settings_file_close(&fd);
   }
@@ -297,6 +312,13 @@ cleanup:
   return free_key;
 }
 
+//! Where the next free-CCCD scan starts. Only a hint: the scan still wraps over
+//! the whole id space and still verifies each id, so a wrong hint costs at most
+//! the scan it would have done anyway. Without it every CCCD write re-reads the
+//! settings file up to 255 times, and CCCD writes come in on the BT host task.
+//! @note prv_lock() must be held when accessing this variable.
+static BTCCCDID s_next_free_cccd_hint;
+
 //! Get the next available CCCDID
 static BTCCCDID prv_get_free_cccd() {
   BTCCCDID free_cccd = BT_CCCD_ID_INVALID;
@@ -310,11 +332,14 @@ static BTCCCDID prv_get_free_cccd() {
     goto cleanup;
   }
 
-  for (BTCCCDID id = 0U; id < BT_CCCD_ID_INVALID; id++) {
+  BTCCCDID id = s_next_free_cccd_hint;
+  for (unsigned i = 0U; i < BT_CCCD_ID_INVALID; i++) {
     if (!settings_file_exists(&fd, &id, sizeof(id))) {
       free_cccd = id;
+      s_next_free_cccd_hint = (BTCCCDID)((id + 1U) % BT_CCCD_ID_INVALID);
       break;
     }
+    id = (BTCCCDID)((id + 1U) % BT_CCCD_ID_INVALID);
   }
 
   settings_file_close(&fd);
@@ -443,9 +468,16 @@ BtPersistBondingType prv_get_type_for_id(BTBondingID id) {
   return data.type;
 }
 
-bool prv_delete_pairing_with_type_by_id(BTBondingID bonding, BtPersistBondingType type,
-                                        BtPersistBondingData *data_out) {
-  if (!prv_file_get(&bonding, sizeof(bonding), data_out, sizeof(*data_out))) {
+static bool prv_ble_pairing_keys_match(const BtPersistLEPairingInfo *stored,
+                                       const SMPairingInfo *expected);
+
+//! Read the record, check it is still the one we were asked to drop, delete it.
+//! @note The caller owns `fd` and holds prv_lock(); nothing here takes it again.
+static bool prv_verify_and_delete_pairing_locked(SettingsFile *fd, BTBondingID bonding,
+                                                 BtPersistBondingType type,
+                                                 BtPersistBondingData *data_out,
+                                                 const SMPairingInfo *expected_ble_keys) {
+  if (!prv_file_get_locked(fd, &bonding, sizeof(bonding), data_out, sizeof(*data_out))) {
     return false;
   }
 
@@ -454,11 +486,54 @@ bool prv_delete_pairing_with_type_by_id(BTBondingID bonding, BtPersistBondingTyp
     return false;
   }
 
-  if (prv_file_set(&bonding, sizeof(bonding), NULL, 0) == GapBondingFileSetFail) {
+  if (expected_ble_keys != NULL &&
+      !prv_ble_pairing_keys_match(&data_out->ble_data.pairing_info, expected_ble_keys)) {
+    PBL_LOG_DBG("Bonding %d no longer holds the keys we were told to delete, skipping", bonding);
+    return false;
+  }
+
+  const status_t rv = settings_file_delete(fd, &bonding, sizeof(bonding));
+  if (rv != S_SUCCESS) {
+    PBL_LOG_ERR("Failed to update gap bonding db, rv = %"PRId32, rv);
     return false;
   }
 
   return true;
+}
+
+//! @param expected_ble_keys When non-NULL, the key material the record must
+//! still hold, re-checked here rather than only at the caller's lookup: the
+//! lookup is a whole file scan and a new bonding for the same identity is
+//! written over this very record.
+//! @note Read, check and delete run under one prv_lock() on one open file. The
+//! record is the thing being checked, so releasing the lock in between makes the
+//! check worthless: this runs on KernelBG for a deferred delete, and
+//! bt_persistent_storage_store_ble_pairing() runs on KernelMain, which preempts
+//! it the moment the lock is dropped and writes the new bonding into this id.
+bool prv_delete_pairing_with_type_by_id(BTBondingID bonding, BtPersistBondingType type,
+                                        BtPersistBondingData *data_out,
+                                        const SMPairingInfo *expected_ble_keys) {
+  bool deleted = false;
+  // Matches prv_file_get(): a caller that ignores our return value still reads
+  // defined zeros when the file will not open.
+  memset(data_out, 0, sizeof(*data_out));
+
+  prv_lock();
+  {
+    SettingsFile fd;
+    if (settings_file_open(&fd, BT_PERSISTENT_STORAGE_FILE_NAME,
+                           BT_PERSISTENT_STORAGE_FILE_SIZE) != S_SUCCESS) {
+      goto cleanup;
+    }
+
+    deleted = prv_verify_and_delete_pairing_locked(&fd, bonding, type, data_out,
+                                                   expected_ble_keys);
+
+    settings_file_close(&fd);
+  }
+cleanup:
+  prv_unlock();
+  return deleted;
 }
 
 bool prv_has_active_gateway_by_type(BtPersistBondingType desired_type) {
@@ -551,6 +626,50 @@ static bool prv_is_pairing_info_equal_identity(const BtPersistLEPairingInfo *a,
           memcmp(&a->irk, &b->irk, sizeof(SMIdentityResolvingKey)) == 0);
 }
 
+static bool prv_ble_encryption_info_matches(const BtPersistLEEncryptionInfo *stored,
+                                            const SMLongTermKey *ltk, uint16_t ediv,
+                                            uint64_t rand) {
+  return (memcmp(&stored->ltk, ltk, sizeof(*ltk)) == 0) && (stored->ediv == ediv) &&
+         (stored->rand == rand);
+}
+
+//! @return True if `stored` still holds the key material of `expected`.
+//! @note The LTK is the only field that tells one bonding from another here. The
+//! identity address and the IRK survive a re-pair of the same phone, which is
+//! exactly the case a deferred delete has to notice.
+//! @note Only the halves `expected` marks valid are compared: a deferred delete
+//! carries the one half of the bonding the BT driver handed it, while the record
+//! holds both. No valid half means nothing to compare, and matching on the
+//! address alone is what this exists to avoid, so that never matches.
+static bool prv_ble_pairing_keys_match(const BtPersistLEPairingInfo *stored,
+                                       const SMPairingInfo *expected) {
+  bool compared = false;
+
+  if (expected->is_remote_encryption_info_valid) {
+    if (!stored->is_remote_encryption_info_valid ||
+        !prv_ble_encryption_info_matches(&stored->remote_encryption_info,
+                                         &expected->remote_encryption_info.ltk,
+                                         expected->remote_encryption_info.ediv,
+                                         expected->remote_encryption_info.rand)) {
+      return false;
+    }
+    compared = true;
+  }
+
+  if (expected->is_local_encryption_info_valid) {
+    if (!stored->is_local_encryption_info_valid ||
+        !prv_ble_encryption_info_matches(&stored->local_encryption_info,
+                                         &expected->local_encryption_info.ltk,
+                                         expected->local_encryption_info.ediv,
+                                         expected->local_encryption_info.rand)) {
+      return false;
+    }
+    compared = true;
+  }
+
+  return compared;
+}
+
 static bool prv_get_key_for_sm_pairing_info_itr(SettingsFile *file,
                                                 SettingsRecordInfo *info, void *context) {
   // check entry is valid
@@ -586,7 +705,8 @@ static BTBondingID prv_get_key_for_sm_pairing_info(const SMPairingInfo *pairing_
   return itr_data.key_out;
 }
 
-static bool prv_delete_ble_pairing_by_id(BTBondingID bonding);
+static bool prv_delete_ble_pairing_by_id(BTBondingID bonding,
+                                         const SMPairingInfo *expected_keys);
 
 //! Only a single BLE pairing is supported at a time. The buffer below is sized generously to absorb
 //! any legacy state where the bonding DB ended up with multiple entries (e.g. after a PRF pairing
@@ -640,7 +760,7 @@ static void prv_delete_other_ble_bondings(BTBondingID keep_id) {
 
   for (uint8_t i = 0; i < itr_data.count; i++) {
     PBL_LOG_INFO("Removing stale BLE bonding %d (kept %d)", itr_data.ids[i], keep_id);
-    prv_delete_ble_pairing_by_id(itr_data.ids[i]);
+    prv_delete_ble_pairing_by_id(itr_data.ids[i], NULL);
   }
 }
 
@@ -828,79 +948,169 @@ static void prv_remove_ble_bonding_from_bt_driver(const BtPersistBondingData *de
   bt_driver_handle_host_removed_bonding(&bonding);
 }
 
-status_t prv_delete_all_cccd_for_addr(const BTDeviceInternal *dev) {
-  status_t rv;
+//! How many of a peer's CCCDs one sweep pass collects. Sized for the handful a
+//! peer actually subscribes to, so one pass normally finishes the job; anything
+//! beyond that only saves a pass on a peer that will never exist.
+//! Kept small because CollectCCCDForAddrItrData sits on the stack of whichever
+//! task deletes the bonding, under an open SettingsFile and its iteration. Those
+//! tasks are KernelBG (the BT driver's deferred SEC delete) and KernelMain
+//! ("Forget device", and replacing a bonding), each with a 4 KB stack.
+//! At 4 the struct is around 60 bytes; the cost of growing it is linear and
+//! lands on the deepest call chain either task has.
+#define BT_CCCD_SWEEP_BATCH_MAX 4
 
-  prv_lock();
-  {
-  SettingsFile fd;
-  rv = settings_file_open(&fd, BT_PERSISTENT_STORAGE_FILE_NAME,
-                          BT_PERSISTENT_STORAGE_FILE_SIZE);
-  if (rv) {
-    goto cleanup;
+typedef struct {
+  const BTDeviceInternal *peer;
+  BTCCCDID ids[BT_CCCD_SWEEP_BATCH_MAX];
+  BtPersistCCCDData data[BT_CCCD_SWEEP_BATCH_MAX];
+  uint8_t count;
+} CollectCCCDForAddrItrData;
+
+static bool prv_collect_cccd_for_addr_itr(SettingsFile *file, SettingsRecordInfo *info,
+                                          void *context) {
+  // Only a whole record is usable. A short one would leave chr_val_handle at 0,
+  // which prv_nimble_store_find_cccd_cb() reads as "any handle", so passing it
+  // to bt_driver_handle_host_removed_cccd() would evict an arbitrary CCCD of
+  // this peer from the driver's in-memory list.
+  // "Shorter than", not "different from": these structs can only grow, and a
+  // record written by a later firmware would otherwise become un-sweepable
+  // forever while prv_ble_cccd_internal_for_each_itr() and prv_find_cccd_itr()
+  // keep restoring it on every boot. get_val() below reads the prefix we know.
+  if (info->val_len < (int)sizeof(BtPersistCCCDData) || info->key_len != sizeof(BTCCCDID)) {
+    return true; // continue iterating
   }
 
-  for (BTCCCDID id = 0U; id < BT_CCCD_ID_INVALID; id++) {
-    if (settings_file_exists(&fd, &id, sizeof(id))) {
-      BtPersistCCCDData stored_data;
+  CollectCCCDForAddrItrData *itr_data = context;
 
-      rv = settings_file_get(&fd, &id, sizeof(id), &stored_data, sizeof(stored_data));
-      if (rv) {
-        goto cleanup;
+  BtPersistCCCDData stored_data = {};
+  info->get_val(file, (uint8_t *)&stored_data, sizeof(stored_data));
+  if (!bt_device_internal_equal(itr_data->peer, &stored_data.peer)) {
+    return true; // continue iterating
+  }
+
+  BTCCCDID key;
+  info->get_key(file, (uint8_t *)&key, info->key_len);
+
+  itr_data->ids[itr_data->count] = key;
+  itr_data->data[itr_data->count] = stored_data;
+  itr_data->count++;
+
+  return (itr_data->count < BT_CCCD_SWEEP_BATCH_MAX);
+}
+
+//! Delete every CCCD belonging to `dev`.
+//! Collects a batch in one linear pass and then deletes it, rather than probing
+//! all 255 ids: every probe re-reads the whole settings file, and this runs with
+//! the db lock held on a path the BT host task can be waiting behind.
+status_t prv_delete_all_cccd_for_addr(const BTDeviceInternal *dev) {
+  status_t rv = S_SUCCESS;
+
+  while (true) {
+    CollectCCCDForAddrItrData itr_data = {
+      .peer = dev,
+      .count = 0,
+    };
+    if (!prv_file_each(prv_collect_cccd_for_addr_itr, &itr_data)) {
+      return E_INTERNAL;
+    }
+    if (itr_data.count == 0) {
+      break;
+    }
+
+    for (uint8_t i = 0; i < itr_data.count; i++) {
+      BleCCCD cccd_to_delete = {
+        .peer = *dev,
+        .chr_val_handle = itr_data.data[i].chr_val_handle,
+        .flags = itr_data.data[i].flags,
+        .value_changed = itr_data.data[i].value_changed,
+      };
+
+      // Outside the db lock on purpose: this reaches into the driver's own
+      // store lock, and nesting the two here would invert the order the store
+      // callbacks take them in.
+      bt_driver_handle_host_removed_cccd(&cccd_to_delete);
+
+      if (prv_file_set(&itr_data.ids[i], sizeof(itr_data.ids[i]), NULL, 0) ==
+          GapBondingFileSetFail) {
+        rv = E_INTERNAL;
       }
+    }
 
-      if (bt_device_internal_equal(dev, &stored_data.peer)) {
-        BleCCCD cccd_to_delete = {
-          .peer = *dev,
-          .chr_val_handle = stored_data.chr_val_handle,
-          .flags = stored_data.flags,
-          .value_changed = stored_data.value_changed,
-        };
-
-        bt_driver_handle_host_removed_cccd(&cccd_to_delete);
-
-        rv = settings_file_delete(&fd, &id, sizeof(id));
-        if (rv) {
-          goto cleanup;
-        }
-      }
+    // A short batch means the pass saw every match. Stop on a failed delete too,
+    // or the next pass would collect the same record again.
+    if ((itr_data.count < BT_CCCD_SWEEP_BATCH_MAX) || FAILED(rv)) {
+      break;
     }
   }
 
-  settings_file_close(&fd);
-
-  }
-cleanup:
-  prv_unlock();
   return rv;
 }
 
-static bool prv_delete_ble_pairing_by_id(BTBondingID bonding) {
+static bool prv_delete_ble_pairing_by_id(BTBondingID bonding,
+                                         const SMPairingInfo *expected_keys) {
   BtPersistBondingData deleted_data;
-  if (!prv_delete_pairing_with_type_by_id(bonding, BtPersistBondingTypeBLE, &deleted_data)) {
+  if (!prv_delete_pairing_with_type_by_id(bonding, BtPersistBondingTypeBLE, &deleted_data,
+                                          expected_keys)) {
     return false;
   }
 
-  status_t rv;
-  rv = prv_delete_all_cccd_for_addr(&deleted_data.ble_data.pairing_info.identity);
-  PBL_ASSERTN(rv == S_SUCCESS);
-
+  // Before the sweep, not after. The sweep is several full-file passes and the
+  // task doing it sits on flash throughout, which is exactly when KernelBG gets
+  // scheduled and runs a deferred CCCD store. That store's guard,
+  // prv_peer_is_bonded(), answers from the BT driver's in-memory key lists
+  // first, so while they still hold this peer it reports "bonded" for a bonding
+  // that is already gone from flash and writes a record the sweep has passed.
+  // Dropping the keys first makes the guard fall through to the settings file,
+  // where the record no longer is.
+  // @note Safe in this order: the sweep walks flash and only calls
+  // bt_driver_handle_host_removed_cccd(), which touches the driver's CCCD list
+  // alone, and bt_driver_handle_host_removed_bonding() touches only its sec
+  // lists. Neither depends on the other having run.
   prv_remove_ble_bonding_from_bt_driver(&deleted_data);
 
+  // Not fatal: the bonding itself is already gone, which is what the caller
+  // asked for, and leftover CCCD records are inert. Asserting here would reboot
+  // the watch mid re-pairing over a stale record we can do nothing about.
+  const status_t rv = prv_delete_all_cccd_for_addr(&deleted_data.ble_data.pairing_info.identity);
+  if (FAILED(rv)) {
+    PBL_LOG_ERR("Failed to delete the CCCDs of bonding %d, rv = %"PRId32, bonding, rv);
+  }
+
+  // Known gap, deliberately left open. `bonding` is an id, and prv_get_free_key()
+  // hands out the lowest free one, so from the moment the delete above released
+  // the db lock a re-pair can have taken this very id for a live bonding. The
+  // notification is then aimed at the wrong bonding: the handlers key their state
+  // off the id (GAPLEConnection::bonding_id, the connect intent, the active
+  // gateway), so a WillDelete can reset the gateway of a connection that is up.
+  // Only the deferred delete on KernelBG can hit it -- every other caller runs on
+  // KernelMain, which is also the only task that stores a pairing, so it cannot
+  // race itself.
+  // Reordering does not help: from KernelBG this call only queues onto
+  // KernelMain, so the id is stale by construction no matter where it sits here.
+  // Closing it means the handlers identifying the bonding by something other than
+  // its id, and their signature is shared by bt_local_addr, gap_le_connection,
+  // gap_le_connect and kernel_le_client.
   prv_call_ble_bonding_change_handlers(bonding, BtPersistBondingOpWillDelete);
   return true;
 }
 
 void bt_persistent_storage_delete_ble_pairing_by_id(BTBondingID bonding) {
-  if (!prv_delete_ble_pairing_by_id(bonding)) {
+  if (!prv_delete_ble_pairing_by_id(bonding, NULL)) {
     return;
   }
   // TODO: Make sure this matches what we have stored
   shared_prf_storage_erase_ble_pairing_data();
 }
 
+bool bt_persistent_storage_delete_ble_pairing_by_id_if_matches(BTBondingID bonding,
+                                                               const SMPairingInfo *expected) {
+  return prv_delete_ble_pairing_by_id(bonding, expected);
+}
+
 typedef struct {
   BTDeviceInternal device;
+  //! When non-NULL, only a record still holding this key material is a match.
+  const SMPairingInfo *expected_keys;
   SMIdentityResolvingKey irk_out;
   char name_out[BT_DEVICE_NAME_BUFFER_SIZE];
   BTBondingID id_out;
@@ -925,6 +1135,11 @@ static bool prv_find_by_addr_itr(SettingsFile *file,
   if (stored_data.type == BtPersistBondingTypeBLE &&
       bt_device_equal(&itr_data->device.opaque,
                       &stored_data.ble_data.pairing_info.identity.opaque)) {
+    if (itr_data->expected_keys != NULL &&
+        !prv_ble_pairing_keys_match(&stored_data.ble_data.pairing_info,
+                                    itr_data->expected_keys)) {
+      return true; // right identity, wrong bonding: keep looking
+    }
     itr_data->irk_out = stored_data.ble_data.pairing_info.irk;
     strncpy(itr_data->name_out, stored_data.ble_data.name, BT_DEVICE_NAME_BUFFER_SIZE);
     itr_data->id_out = key;
@@ -935,18 +1150,44 @@ static bool prv_find_by_addr_itr(SettingsFile *file,
   return true; // continue iterating
 }
 
-void bt_persistent_storage_delete_ble_pairing_by_addr(const BTDeviceInternal *device) {
+static bool prv_delete_ble_pairing_by_addr(const BTDeviceInternal *device,
+                                           const SMPairingInfo *expected_keys) {
   FindByAddrItrData itr_data = {
     .device = *device,
+    .expected_keys = expected_keys,
     .found = false,
   };
   prv_file_each(prv_find_by_addr_itr, &itr_data);
 
   if (!itr_data.found) {
-    return;
+    return false;
   }
 
-  bt_persistent_storage_delete_ble_pairing_by_id(itr_data.id_out);
+  if (!prv_delete_ble_pairing_by_id(itr_data.id_out, expected_keys)) {
+    return false;
+  }
+
+  if (expected_keys != NULL) {
+    // Shared PRF is a second store with a lock of its own, and prv_update_bondings()
+    // pushes every gateway pairing into it, so a re-pair that completed while this
+    // delete was queued has already put its fresh keys there. Guard it with the same
+    // key material the record was guarded with rather than erasing whatever is in the
+    // slot: this is the copy PRF boots from, and wiping it strands the phone.
+    shared_prf_storage_erase_ble_pairing_data_if_matches(expected_keys, NULL);
+  } else {
+    // TODO: Make sure this matches what we have stored
+    shared_prf_storage_erase_ble_pairing_data();
+  }
+  return true;
+}
+
+void bt_persistent_storage_delete_ble_pairing_by_addr(const BTDeviceInternal *device) {
+  prv_delete_ble_pairing_by_addr(device, NULL);
+}
+
+bool bt_persistent_storage_delete_ble_pairing_by_addr_if_matches(const BTDeviceInternal *device,
+                                                                 const SMPairingInfo *expected) {
+  return prv_delete_ble_pairing_by_addr(device, expected);
 }
 
 static void prv_fill_ble_data(SMIdentityResolvingKey *irk_in,

--- a/src/fw/services/bluetooth/bluetooth_persistent_storage_prf.c
+++ b/src/fw/services/bluetooth/bluetooth_persistent_storage_prf.c
@@ -22,6 +22,8 @@
 #include <pbl/btutil/bt_device.h>
 #include <pbl/btutil/sm_util.h>
 
+#include <string.h>
+
 PBL_LOG_MODULE_DECLARE(service_bluetooth, CONFIG_SERVICE_BLUETOOTH_LOG_LEVEL);
 
 
@@ -135,17 +137,26 @@ bool bt_persistent_storage_update_ble_device_name(BTBondingID bonding, const cha
                                                       device_name, BtPersistBondingOpDidChange));
 }
 
-static void prv_remove_ble_bonding_from_bt_driver(void) {
+//! @note Kept out of the shared PRF lock on purpose: this reaches into the BT
+//! driver's own store lock, and nesting the two would invert the order the store
+//! callbacks take them in.
+static void prv_remove_pairing_from_bt_driver(const SMPairingInfo *pairing_info) {
   if (!bt_ctl_is_bluetooth_running()) {
     return;
   }
   BleBonding bonding = {
     .is_gateway = true,
+    .pairing_info = *pairing_info,
   };
-  if (!shared_prf_storage_get_ble_pairing_data(&bonding.pairing_info, NULL, NULL, NULL)) {
+  bt_driver_handle_host_removed_bonding(&bonding);
+}
+
+static void prv_remove_ble_bonding_from_bt_driver(void) {
+  SMPairingInfo pairing_info;
+  if (!shared_prf_storage_get_ble_pairing_data(&pairing_info, NULL, NULL, NULL)) {
     return;
   }
-  bt_driver_handle_host_removed_bonding(&bonding);
+  prv_remove_pairing_from_bt_driver(&pairing_info);
 }
 
 void bt_persistent_storage_delete_ble_pairing_by_id(BTBondingID bonding) {
@@ -157,6 +168,30 @@ void bt_persistent_storage_delete_ble_pairing_by_id(BTBondingID bonding) {
 
 void bt_persistent_storage_delete_ble_pairing_by_addr(const BTDeviceInternal *device) {
   bt_persistent_storage_delete_ble_pairing_by_id(BLE_BONDING_ID);
+}
+
+//! The PRF twin of the normal FW's guarded delete. Re-pairing the same phone
+//! reuses its identity address and its IRK and lands in this same single slot,
+//! so only the LTK says whether what is stored is still the bonding this delete
+//! was aimed at.
+//! @note The check and the erase run as one transaction inside shared PRF
+//! storage. The stored pairing is the thing being checked, so reading it here
+//! and erasing it afterwards would let a re-pair that completes in between have
+//! its fresh keys erased by a delete aimed at the pairing it replaced: this runs
+//! on KernelBG for a deferred delete, and bt_persistent_storage_store_ble_pairing()
+//! runs on KernelMain, which preempts it as soon as it blocks on flash.
+bool bt_persistent_storage_delete_ble_pairing_by_addr_if_matches(const BTDeviceInternal *device,
+                                                                 const SMPairingInfo *expected) {
+  SMPairingInfo erased;
+  if (!shared_prf_storage_erase_ble_pairing_data_if_matches(expected, &erased)) {
+    PBL_LOG_DBG("Stored BLE pairing no longer holds the keys to delete, skipping");
+    return false;
+  }
+
+  PBL_LOG_INFO("Deleted stored BLE pairing");
+  prv_remove_pairing_from_bt_driver(&erased);
+  prv_call_ble_bonding_change_handlers(BLE_BONDING_ID, BtPersistBondingOpWillDelete);
+  return true;
 }
 
 bool bt_persistent_storage_get_ble_pairing_by_id(BTBondingID bonding,

--- a/src/fw/services/bluetooth/wscript_build
+++ b/src/fw/services/bluetooth/wscript_build
@@ -3,6 +3,7 @@
 
 sources = [
     'ble_bas.c',
+    'ble_hid.c',
     'bluetooth_ctl.c',
     'bluetooth_persistent_storage_debug.c',
     'bluetooth_prompt.c',

--- a/src/fw/services/shared_prf_storage/shared_prf_storage.c
+++ b/src/fw/services/shared_prf_storage/shared_prf_storage.c
@@ -410,72 +410,76 @@ void shared_prf_storage_set_root_keys(SM128BitKey *keys_in) {
 //! BLE Pairing Data APIs
 //!
 
+//! Read the stored BLE pairing with the lock already held.
+//! @note Takes no lock of its own, so a caller that has to read and then write
+//! the pairing without letting go of the lock can share the read.
+static bool prv_get_ble_pairing_data_locked(SMPairingInfo *pairing_info_out, char *name_out,
+                                            bool *requires_address_pinning_out,
+                                            uint8_t *flags) {
+  SprfBlePairingData data;
+  if (!SPRF_FETCH_FIELD(data, ble_pairing_data)) {
+    return false;
+  }
+
+  if (!data.fields) {
+    // The pairing stored is empty
+    return false;
+  }
+
+  if (pairing_info_out) {
+    *pairing_info_out = (SMPairingInfo) {
+      .local_encryption_info.ltk = data.l_ltk,
+      .local_encryption_info.ediv = data.l_ediv,
+      .local_encryption_info.rand = data.l_rand,
+
+      .remote_encryption_info.ltk = data.r_ltk,
+      .remote_encryption_info.ediv = data.r_ediv,
+      .remote_encryption_info.rand = data.r_rand,
+
+      .irk = data.irk,
+      .identity = data.identity,
+      .csrk = data.csrk,
+
+      .is_mitm_protection_enabled = data.is_mitm_protection_enabled,
+
+      .is_local_encryption_info_valid =
+      SPRF_FLAG_IS_SET(data.fields, SprfValidFields_LocalEncryptionInfoValid),
+      .is_remote_encryption_info_valid =
+      SPRF_FLAG_IS_SET(data.fields, SprfValidFields_RemoteEncryptionInfoValid),
+      .is_remote_identity_info_valid =
+      SPRF_FLAG_IS_SET(data.fields, SprfValidFields_RemoteIdentityInfoValid),
+      .is_remote_signing_info_valid =
+      SPRF_FLAG_IS_SET(data.fields, SprfValidFields_RemoteSigningInfoValid),
+    };
+  }
+
+  if (requires_address_pinning_out) {
+    *requires_address_pinning_out = data.requires_address_pinning;
+  }
+  if (flags) {
+    *flags = data.flags;
+  }
+
+  if (name_out) {
+    SprfBlePairingName name_data = {};
+    const bool name_rv = SPRF_FETCH_FIELD(name_data, ble_pairing_name);
+    // Should we return a failure on a failed name get?
+    if (name_rv) {
+      strncpy(name_out, name_data.name, BT_DEVICE_NAME_BUFFER_SIZE);
+    } else {
+      name_out[0] = '\0';
+    }
+  }
+  return true;
+}
+
 bool shared_prf_storage_get_ble_pairing_data(SMPairingInfo *pairing_info_out, char *name_out,
                                              bool *requires_address_pinning_out,
                                              uint8_t *flags) {
   bool rv;
   prv_lock();
-  {
-    SprfBlePairingData data;
-    rv = SPRF_FETCH_FIELD(data, ble_pairing_data);
-    if (!rv) {
-      goto unlock;
-    }
-
-    if (!data.fields) {
-      // The pairing stored is empty
-      rv = false;
-      goto unlock;
-    }
-
-    if (pairing_info_out) {
-      *pairing_info_out = (SMPairingInfo) {
-        .local_encryption_info.ltk = data.l_ltk,
-        .local_encryption_info.ediv = data.l_ediv,
-        .local_encryption_info.rand = data.l_rand,
-
-        .remote_encryption_info.ltk = data.r_ltk,
-        .remote_encryption_info.ediv = data.r_ediv,
-        .remote_encryption_info.rand = data.r_rand,
-
-        .irk = data.irk,
-        .identity = data.identity,
-        .csrk = data.csrk,
-
-        .is_mitm_protection_enabled = data.is_mitm_protection_enabled,
-
-        .is_local_encryption_info_valid =
-        SPRF_FLAG_IS_SET(data.fields, SprfValidFields_LocalEncryptionInfoValid),
-        .is_remote_encryption_info_valid =
-        SPRF_FLAG_IS_SET(data.fields, SprfValidFields_RemoteEncryptionInfoValid),
-        .is_remote_identity_info_valid =
-        SPRF_FLAG_IS_SET(data.fields, SprfValidFields_RemoteIdentityInfoValid),
-        .is_remote_signing_info_valid =
-        SPRF_FLAG_IS_SET(data.fields, SprfValidFields_RemoteSigningInfoValid),
-      };
-    }
-
-    if (requires_address_pinning_out) {
-      *requires_address_pinning_out = data.requires_address_pinning;
-    }
-    if (flags) {
-      *flags = data.flags;
-    }
-
-    if (name_out) {
-      SprfBlePairingName name_data = {};
-      const bool name_rv = SPRF_FETCH_FIELD(name_data, ble_pairing_name);
-      // Should we return a failure on a failed name get?
-      if (name_rv) {
-        strncpy(name_out, name_data.name, BT_DEVICE_NAME_BUFFER_SIZE);
-      } else {
-        name_out[0] = '\0';
-      }
-    }
-    rv = true;
-  }
-
-unlock:
+  rv = prv_get_ble_pairing_data_locked(pairing_info_out, name_out, requires_address_pinning_out,
+                                       flags);
   prv_unlock();
   return rv;
 }
@@ -539,6 +543,30 @@ void shared_prf_storage_erase_ble_pairing_data(void) {
     SPRF_ERASE_FIELD(ble_pairing_name);
   }
   prv_unlock();
+}
+
+bool shared_prf_storage_erase_ble_pairing_data_if_matches(const SMPairingInfo *expected,
+                                                          SMPairingInfo *erased_out) {
+  bool erased = false;
+  prv_lock();
+  {
+    SMPairingInfo stored;
+    if (!prv_get_ble_pairing_data_locked(&stored, NULL, NULL, NULL) ||
+        !sm_pairing_info_encryption_keys_match(&stored, expected)) {
+      goto unlock;
+    }
+
+    SPRF_ERASE_FIELD(ble_pairing_data);
+    SPRF_ERASE_FIELD(ble_pairing_name);
+
+    if (erased_out) {
+      *erased_out = stored;
+    }
+    erased = true;
+  }
+unlock:
+  prv_unlock();
+  return erased;
 }
 
 //!

--- a/src/fw/services/system_task/service.c
+++ b/src/fw/services/system_task/service.c
@@ -188,6 +188,24 @@ bool system_task_add_callback(SystemTaskEventCallback cb, void *data) {
   return true;
 }
 
+bool system_task_add_callback_nonblocking(SystemTaskEventCallback cb, void *data) {
+  if (!prv_is_accepting_callbacks()) {
+    return false;
+  }
+
+  SystemTaskEvent event = {
+    .cb = cb,
+    .data = data,
+  };
+
+  // Deliberately no handle_system_task_send_failure(): the point of this variant
+  // is that a full queue is the caller's problem, not a reboot.
+  QueueHandle_t queue = (pebble_task_get_current() == PebbleTask_App) ?
+      s_from_app_system_task_queue : s_system_task_queue;
+
+  return (xQueueSendToBack(queue, &event, 0) == pdTRUE);
+}
+
 void system_task_block_callbacks(bool block) {
   s_should_block_callbacks = block;
 }

--- a/src/fw/shell/normal/system_app_registry_list.json
+++ b/src/fw/shell/normal/system_app_registry_list.json
@@ -569,6 +569,15 @@
       "md_fn": "send_text_app_get_info"
     },
     {
+      "id": -101,
+      "enum": "CAMERA_REMOTE",
+      "md_fn": "camera_remote_get_app_info",
+      "color_argb8": "GColorBlueMoonARGB8",
+      "ifdefs": [
+        "CONFIG_BT_HID_REMOTE"
+      ]
+    },
+    {
       "id": -84,
       "enum": "VIBE_SCORE",
       "md_fn": "vibe_score_demo_get_info",

--- a/tests/fakes/fake_shared_prf_storage.c
+++ b/tests/fakes/fake_shared_prf_storage.c
@@ -8,6 +8,7 @@
 
 static int s_prf_storage_ble_store_count;
 static int s_prf_storage_ble_delete_count;
+static int s_prf_storage_ble_delete_if_matches_count;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 //! Test functions
@@ -15,6 +16,7 @@ static int s_prf_storage_ble_delete_count;
 void fake_shared_prf_storage_reset_counts(void) {
   s_prf_storage_ble_store_count = 0;
   s_prf_storage_ble_delete_count = 0;
+  s_prf_storage_ble_delete_if_matches_count = 0;
 }
 
 int fake_shared_prf_storage_get_ble_store_count(void) {
@@ -23,6 +25,10 @@ int fake_shared_prf_storage_get_ble_store_count(void) {
 
 int fake_shared_prf_storage_get_ble_delete_count(void) {
   return s_prf_storage_ble_delete_count;
+}
+
+int fake_shared_prf_storage_get_ble_delete_if_matches_count(void) {
+  return s_prf_storage_ble_delete_if_matches_count;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -66,6 +72,14 @@ void shared_prf_storage_store_ble_pairing_data(const SMPairingInfo *pairing_info
 
 void shared_prf_storage_erase_ble_pairing_data(void) {
   s_prf_storage_ble_delete_count++;
+}
+
+bool shared_prf_storage_erase_ble_pairing_data_if_matches(const SMPairingInfo *expected,
+                                                          SMPairingInfo *erased_out) {
+  s_prf_storage_ble_delete_if_matches_count++;
+  // shared_prf_storage_get_ble_pairing_data() has nothing to hand back here, so the real one would
+  // find nothing to compare against and leave the slot alone.
+  return false;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/fakes/fake_shared_prf_storage.h
+++ b/tests/fakes/fake_shared_prf_storage.h
@@ -6,3 +6,7 @@
 void fake_shared_prf_storage_reset_counts(void);
 int fake_shared_prf_storage_get_ble_store_count(void);
 int fake_shared_prf_storage_get_ble_delete_count(void);
+
+//! How many times the guarded erase was asked to drop the stored pairing. Counted apart from the
+//! unconditional erase: which of the two a delete path uses is the thing under test.
+int fake_shared_prf_storage_get_ble_delete_if_matches_count(void);

--- a/tests/fakes/fake_system_task.h
+++ b/tests/fakes/fake_system_task.h
@@ -38,6 +38,10 @@ bool system_task_add_callback(SystemTaskEventCallback cb, void *data) {
   return true;
 }
 
+bool system_task_add_callback_nonblocking(SystemTaskEventCallback cb, void *data) {
+  return system_task_add_callback(cb, data);
+}
+
 bool system_task_add_callback_from_isr(SystemTaskEventCallback cb, void *data,
                                        bool *should_context_switch) {
   *should_context_switch = false;

--- a/tests/fakes/fake_system_task.h
+++ b/tests/fakes/fake_system_task.h
@@ -23,12 +23,27 @@ static ListNode *s_system_task_callback_head = NULL;
 static bool s_invoke_as_current = false;
 static uint32_t system_task_available_space = ~(uint32_t)0;
 
+//! One callback accepted but held back before it reaches the queue. The real
+//! system_task_add_callback() makes a caller wait for a free slot rather than
+//! failing it, so work can be handed over long before it is queued and can land
+//! behind work the caller never saw. See fake_system_task_defer_next_add().
+static SystemTaskEventCallback s_deferred_cb = NULL;
+static void *s_deferred_data = NULL;
+static bool s_defer_next_add = false;
+
 bool system_task_add_callback(SystemTaskEventCallback cb, void *data) {
+  cl_assert(cb);
+  if (s_defer_next_add) {
+    s_defer_next_add = false;
+    s_deferred_cb = cb;
+    s_deferred_data = data;
+    return true;
+  }
+
   SystemTaskCallbackNode *node = (SystemTaskCallbackNode *) malloc(sizeof(SystemTaskCallbackNode));
   cl_assert(node != NULL);
   list_init(&node->node);
 
-  cl_assert(cb);
   node->callback = cb;
   node->data = data;
 
@@ -61,6 +76,25 @@ void system_task_set_available_space(uint32_t space) {
 //
 void stub_invoke_system_task_as_current(void) {
   s_invoke_as_current = !s_invoke_as_current;
+}
+
+//! Accept the next add without queueing it, standing in for a caller parked in
+//! system_task_add_callback() until a slot frees up. Release it with
+//! fake_system_task_flush_deferred().
+void fake_system_task_defer_next_add(void) {
+  s_defer_next_add = true;
+}
+
+//! Queue whatever fake_system_task_defer_next_add() held back, as if the slot
+//! its caller was waiting for had just come free.
+void fake_system_task_flush_deferred(void) {
+  SystemTaskEventCallback cb = s_deferred_cb;
+  void *data = s_deferred_data;
+  s_deferred_cb = NULL;
+  s_deferred_data = NULL;
+  if (cb) {
+    system_task_add_callback(cb, data);
+  }
 }
 
 ////////////////////////////////////
@@ -104,6 +138,10 @@ void fake_system_task_callbacks_invoke_pending(void) {
 }
 
 void fake_system_task_callbacks_cleanup(void) {
+  s_defer_next_add = false;
+  s_deferred_cb = NULL;
+  s_deferred_data = NULL;
+
   SystemTaskCallbackNode *node = (SystemTaskCallbackNode *) s_system_task_callback_head;
   while (node) {
     SystemTaskCallbackNode *next = (SystemTaskCallbackNode *) list_get_next(&node->node);

--- a/tests/fw/services/bluetooth/test_ble_hid.c
+++ b/tests/fw/services/bluetooth/test_ble_hid.c
@@ -1,0 +1,609 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "pbl/services/bluetooth/ble_hid.h"
+
+#include "comm/ble/gap_le_connection.h"
+
+#include <bluetooth/hid_service.h>
+#include <pbl/util/size.h>
+
+#include <clar.h>
+
+#include <string.h>
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Stubs & Fakes
+
+#include "fake_new_timer.h"
+#include "fake_pbl_malloc.h"
+#include "fake_rtc.h"
+#include "fake_system_task.h"
+
+#include "stubs_bt_conn_mgr.h"
+#include "stubs_bt_lock.h"
+#include "stubs_logging.h"
+#include "stubs_mutex.h"
+#include "stubs_passert.h"
+#include "stubs_tick.h"
+
+// The hold timeout ble_hid.c arms after every press, and the window it keeps
+// retrying a release for after that.
+#define TEST_HOLD_TIMEOUT_MS (10000)
+#define TEST_RELEASE_GRACE_MS (3000)
+#define TEST_RELEASE_RETRY_MS (30)
+
+//! One entry per report that actually went out, so a test can assert both what
+//! was sent and which report it was sent on.
+typedef struct {
+  BleHidReportPath path;
+  uint16_t value;  //!< The report 1 bit mask, or the report 2 usage.
+} SendRecord;
+
+static SendRecord s_sends[64];
+static int s_num_sends;
+
+static bool s_hid_supported;
+static bool s_bitmap_subscribed;
+static bool s_usage_subscribed;
+static bool s_send_succeeds;
+
+static void prv_record_send(BleHidReportPath path, uint16_t value) {
+  cl_assert(s_num_sends < (int)ARRAY_LENGTH(s_sends));
+  s_sends[s_num_sends++] = (SendRecord){.path = path, .value = value};
+}
+
+bool bt_driver_is_hid_service_supported(void) {
+  return s_hid_supported;
+}
+
+bool bt_driver_hid_service_is_subscribed(void) {
+  return s_bitmap_subscribed;
+}
+
+bool bt_driver_hid_service_usage_is_subscribed(void) {
+  return s_usage_subscribed;
+}
+
+//! @note The subscription check is not decoration: a notify to a peer that has
+//! not subscribed to this report is refused by every real backend before it
+//! reaches the wire (@see src/bluetooth-fw/nimble/hid_service.c), and the
+//! release path branches on exactly that. A fake that sent anyway would let a
+//! test pin a branch the hardware cannot reach.
+bool bt_driver_hid_service_send_consumer_report(uint8_t bits) {
+  if (!s_bitmap_subscribed) {
+    return false;
+  }
+  prv_record_send(BleHidReportPathBitmap, bits);
+  return s_send_succeeds;
+}
+
+bool bt_driver_hid_service_send_consumer_usage(uint16_t usage) {
+  if (!s_usage_subscribed) {
+    return false;
+  }
+  prv_record_send(BleHidReportPathUsage, usage);
+  return s_send_succeeds;
+}
+
+//! No gateway, so ble_hid_set_low_latency() is a no-op here. The conn_mgr call
+//! it would make is covered by test_bt_conn_mgr.
+GAPLEConnection *gap_le_connection_get_gateway(void) {
+  return NULL;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Helpers
+
+//! @return The single ble_hid release timer, which is the only timer in this
+//! test binary.
+static TimerID prv_running_timer(void) {
+  return stub_new_timer_get_next();
+}
+
+static void prv_fire_running_timer(void) {
+  const TimerID timer = prv_running_timer();
+  cl_assert(timer != TIMER_INVALID_ID);
+  cl_assert_equal_b(true, stub_new_timer_fire(timer));
+}
+
+static void prv_assert_send(int index, BleHidReportPath path, uint16_t value) {
+  cl_assert(index < s_num_sends);
+  cl_assert_equal_i(path, s_sends[index].path);
+  cl_assert_equal_i(value, s_sends[index].value);
+}
+
+//! Moves the clock the release deadline is kept on. Firing a timer does not,
+//! so anything that cares about the deadline has to say so.
+static void prv_advance_ms(uint32_t ms) {
+  fake_rtc_increment_ticks(((RtcTicks)ms * RTC_TICKS_HZ) / 1000);
+}
+
+//! Fires the retry timer `count` times with the clock moving as it would on a
+//! watch, and checks it is still armed each time round.
+static void prv_run_retries(int count) {
+  for (int i = 0; i < count; ++i) {
+    cl_assert(prv_running_timer() != TIMER_INVALID_ID);
+    cl_assert_equal_i(TEST_RELEASE_RETRY_MS, (int)stub_new_timer_timeout(prv_running_timer()));
+    prv_advance_ms(TEST_RELEASE_RETRY_MS);
+    prv_fire_running_timer();
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Setup / teardown
+
+void test_ble_hid__initialize(void) {
+  memset(s_sends, 0, sizeof(s_sends));
+  s_num_sends = 0;
+  s_hid_supported = true;
+  s_bitmap_subscribed = true;
+  s_usage_subscribed = true;
+  s_send_succeeds = true;
+  // fake_system_task decrements this per queued callback and only gives it back
+  // when the callback runs, so reset it rather than inherit the last test's.
+  system_task_set_available_space(~(uint32_t)0);
+  // Same for the clock: the release deadline is absolute, so a test that ran
+  // it forward must not shorten the next test's window.
+  fake_rtc_init(0 /* initial_ticks */, 0 /* initial_time */);
+
+  ble_hid_init();
+}
+
+void test_ble_hid__cleanup(void) {
+  // Drops the held usage and stops the timer. The timer and the mutex outlive
+  // this on purpose -- ble_hid keeps them for the lifetime of the FW -- so the
+  // fakes' own cleanup helpers must not run.
+  ble_hid_deinit();
+  fake_system_task_callbacks_cleanup();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Tests
+
+void test_ble_hid__press_then_release_on_the_usage_path(void) {
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  // The send is queued to KernelBG, not done in the caller's context.
+  cl_assert_equal_i(0, s_num_sends);
+
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(1, s_num_sends);
+  prv_assert_send(0, BleHidReportPathUsage, BLE_HID_USAGE_VOLUME_UP);
+
+  cl_assert_equal_i(S_SUCCESS, ble_hid_consumer_release(BLE_HID_USAGE_VOLUME_UP));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(2, s_num_sends);
+  prv_assert_send(1, BleHidReportPathUsage, 0);
+}
+
+void test_ble_hid__press_then_release_on_the_bitmap_path(void) {
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathBitmap));
+  fake_system_task_callbacks_invoke_pending();
+  // The bitmap path sends the bit, not the usage.
+  cl_assert_equal_i(1, s_num_sends);
+  prv_assert_send(0, BleHidReportPathBitmap, BLE_HID_CONSUMER_VOLUME_UP);
+
+  cl_assert_equal_i(S_SUCCESS, ble_hid_consumer_release(BLE_HID_USAGE_VOLUME_UP));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(2, s_num_sends);
+  prv_assert_send(1, BleHidReportPathBitmap, 0);
+}
+
+void test_ble_hid__release_follows_the_path_the_press_used(void) {
+  // Both reports are subscribed, so only the stored path can decide this one.
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(S_SUCCESS, ble_hid_consumer_release(BLE_HID_USAGE_VOLUME_UP));
+  fake_system_task_callbacks_invoke_pending();
+
+  cl_assert_equal_i(2, s_num_sends);
+  prv_assert_send(1, BleHidReportPathUsage, 0);
+}
+
+void test_ble_hid__a_tap_sends_the_press_before_the_release(void) {
+  // What the Camera app does: press, then release a few ms later, both before
+  // KernelBG has run either of them.
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  cl_assert_equal_i(S_SUCCESS, ble_hid_consumer_release(BLE_HID_USAGE_VOLUME_UP));
+
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(2, s_num_sends);
+  prv_assert_send(0, BleHidReportPathUsage, BLE_HID_USAGE_VOLUME_UP);
+  prv_assert_send(1, BleHidReportPathUsage, 0);
+}
+
+void test_ble_hid__press_while_another_usage_is_held_is_busy(void) {
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  cl_assert_equal_i(E_BUSY,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_DOWN, BleHidReportPathUsage));
+
+  fake_system_task_callbacks_invoke_pending();
+  // Only the first press was ever queued.
+  cl_assert_equal_i(1, s_num_sends);
+  prv_assert_send(0, BleHidReportPathUsage, BLE_HID_USAGE_VOLUME_UP);
+}
+
+void test_ble_hid__same_usage_on_another_path_is_busy(void) {
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  // Same usage, other report: still a second key going down, so still E_BUSY.
+  cl_assert_equal_i(E_BUSY,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathBitmap));
+
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(1, s_num_sends);
+}
+
+void test_ble_hid__repeat_press_is_idempotent_and_does_not_rearm_the_timer(void) {
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  const int starts = s_num_new_timer_start_calls;
+
+  cl_assert_equal_i(S_NO_ACTION_REQUIRED,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  // The safety net stays anchored to the first press: re-arming it would let a
+  // repeat hold the key open indefinitely.
+  cl_assert_equal_i(starts, s_num_new_timer_start_calls);
+
+  fake_system_task_callbacks_invoke_pending();
+  // And the repeat did not queue a second report either.
+  cl_assert_equal_i(1, s_num_sends);
+}
+
+void test_ble_hid__release_without_a_press_is_a_no_op(void) {
+  cl_assert_equal_i(S_NO_ACTION_REQUIRED, ble_hid_consumer_release(BLE_HID_USAGE_VOLUME_UP));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(0, s_num_sends);
+}
+
+void test_ble_hid__release_of_another_usage_is_rejected(void) {
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(1, s_num_sends);
+
+  cl_assert_equal_i(E_INVALID_ARGUMENT, ble_hid_consumer_release(BLE_HID_USAGE_VOLUME_DOWN));
+  fake_system_task_callbacks_invoke_pending();
+  // Nothing was lifted, so the key is still down and still releasable.
+  cl_assert_equal_i(1, s_num_sends);
+
+  cl_assert_equal_i(S_SUCCESS, ble_hid_consumer_release(BLE_HID_USAGE_VOLUME_UP));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(2, s_num_sends);
+  prv_assert_send(1, BleHidReportPathUsage, 0);
+}
+
+void test_ble_hid__a_failed_send_leaves_nothing_held(void) {
+  s_send_succeeds = false;
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(1, s_num_sends);
+
+  // Nothing went out, so nothing is held: the next press must not see E_BUSY.
+  s_send_succeeds = true;
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_DOWN, BleHidReportPathUsage));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(2, s_num_sends);
+  prv_assert_send(1, BleHidReportPathUsage, BLE_HID_USAGE_VOLUME_DOWN);
+}
+
+void test_ble_hid__hold_timeout_forces_a_release(void) {
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(1, s_num_sends);
+
+  cl_assert_equal_i(TEST_HOLD_TIMEOUT_MS, (int)stub_new_timer_timeout(prv_running_timer()));
+  prv_fire_running_timer();
+  // The timer runs on NewTimer, so it hands the send to KernelBG rather than
+  // talking to the driver itself.
+  cl_assert_equal_i(1, s_num_sends);
+
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(2, s_num_sends);
+  prv_assert_send(1, BleHidReportPathUsage, 0);
+
+  // Nothing is held any more.
+  cl_assert_equal_i(S_NO_ACTION_REQUIRED, ble_hid_consumer_release(BLE_HID_USAGE_VOLUME_UP));
+}
+
+void test_ble_hid__a_stale_release_does_not_lift_a_later_press(void) {
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(1, s_num_sends);
+
+  // Two releases end up queued for the same press: the hold timer's and the
+  // caller's. That is the case the generation guard exists for.
+  prv_fire_running_timer();
+  cl_assert_equal_i(S_SUCCESS, ble_hid_consumer_release(BLE_HID_USAGE_VOLUME_UP));
+  cl_assert_equal_i(2, (int)fake_system_task_count_callbacks());
+
+  // Run only the first. It lifts the key and clears the held state.
+  fake_system_task_callbacks_invoke(1);
+  cl_assert_equal_i(2, s_num_sends);
+  prv_assert_send(1, BleHidReportPathUsage, 0);
+
+  // A new press starts a new generation while the second release is still
+  // queued behind it.
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_DOWN, BleHidReportPathUsage));
+
+  fake_system_task_callbacks_invoke_pending();
+  // The leftover release must be dropped, and the new press must go out. If it
+  // were not dropped it would send a lift, and the press behind it would then
+  // read as stale and send nothing at all.
+  cl_assert_equal_i(3, s_num_sends);
+  prv_assert_send(2, BleHidReportPathUsage, BLE_HID_USAGE_VOLUME_DOWN);
+
+  // And the new press is still held, i.e. the stale release did not clear it.
+  cl_assert_equal_i(S_SUCCESS, ble_hid_consumer_release(BLE_HID_USAGE_VOLUME_DOWN));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(4, s_num_sends);
+  prv_assert_send(3, BleHidReportPathUsage, 0);
+}
+
+void test_ble_hid__a_press_kernel_bg_will_not_take_holds_nothing(void) {
+  // Below the margin prv_queue_to_kernel_bg() insists on off the app task.
+  system_task_set_available_space(5);
+  cl_assert_equal_i(E_INTERNAL,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  cl_assert_equal_i(0, (int)fake_system_task_count_callbacks());
+
+  // Nothing was queued, so nothing is held and the next press is not refused.
+  system_task_set_available_space(~(uint32_t)0);
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_DOWN, BleHidReportPathUsage));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(1, s_num_sends);
+  prv_assert_send(0, BleHidReportPathUsage, BLE_HID_USAGE_VOLUME_DOWN);
+}
+
+void test_ble_hid__a_release_kernel_bg_will_not_take_is_retried(void) {
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(1, s_num_sends);
+
+  system_task_set_available_space(5);
+  cl_assert_equal_i(E_INTERNAL, ble_hid_consumer_release(BLE_HID_USAGE_VOLUME_UP));
+  // The hold timer still covers it, still at its full timeout.
+  cl_assert_equal_i(TEST_HOLD_TIMEOUT_MS, (int)stub_new_timer_timeout(prv_running_timer()));
+
+  // It fires, cannot queue either, and re-arms itself as a short retry.
+  prv_fire_running_timer();
+  cl_assert_equal_i(1, s_num_sends);
+  cl_assert(prv_running_timer() != TIMER_INVALID_ID);
+  cl_assert_equal_i(TEST_RELEASE_RETRY_MS, (int)stub_new_timer_timeout(prv_running_timer()));
+
+  system_task_set_available_space(~(uint32_t)0);
+  prv_advance_ms(TEST_RELEASE_RETRY_MS);
+  prv_fire_running_timer();
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(2, s_num_sends);
+  prv_assert_send(1, BleHidReportPathUsage, 0);
+}
+
+void test_ble_hid__a_release_the_peer_will_not_take_is_retried(void) {
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(1, s_num_sends);
+
+  // Still subscribed, but the notify fails -- an exhausted mbuf pool, say. This
+  // is the branch the field hits; the queue-refusal one below is rarer.
+  s_send_succeeds = false;
+  cl_assert_equal_i(S_SUCCESS, ble_hid_consumer_release(BLE_HID_USAGE_VOLUME_UP));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(2, s_num_sends);
+  prv_assert_send(1, BleHidReportPathUsage, 0);
+
+  // The lift did not reach the peer, so the key is still down and a retry is
+  // armed on the same timer.
+  cl_assert(prv_running_timer() != TIMER_INVALID_ID);
+  cl_assert_equal_i(TEST_RELEASE_RETRY_MS, (int)stub_new_timer_timeout(prv_running_timer()));
+
+  s_send_succeeds = true;
+  prv_advance_ms(TEST_RELEASE_RETRY_MS);
+  prv_fire_running_timer();
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(3, s_num_sends);
+  prv_assert_send(2, BleHidReportPathUsage, 0);
+  cl_assert_equal_i(S_NO_ACTION_REQUIRED, ble_hid_consumer_release(BLE_HID_USAGE_VOLUME_UP));
+}
+
+void test_ble_hid__a_release_is_retried_for_longer_than_a_kernel_bg_backlog(void) {
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(1, s_num_sends);
+
+  // KernelBG stays below the margin throughout: backed up, not gone. One BLE
+  // store transaction on that queue costs far more than the five fires -- about
+  // 120 ms -- that the retries used to be budgeted for, so a bound counted in
+  // attempts abandoned the key on an ordinary backlog.
+  system_task_set_available_space(5);
+  cl_assert_equal_i(E_INTERNAL, ble_hid_consumer_release(BLE_HID_USAGE_VOLUME_UP));
+  prv_fire_running_timer();
+  prv_run_retries(60);
+
+  // Still trying, well past the old budget, and nothing has been sent.
+  cl_assert(prv_running_timer() != TIMER_INVALID_ID);
+  cl_assert_equal_i(1, s_num_sends);
+
+  // The backlog clears and the lift finally goes out.
+  system_task_set_available_space(~(uint32_t)0);
+  prv_fire_running_timer();
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(2, s_num_sends);
+  prv_assert_send(1, BleHidReportPathUsage, 0);
+  cl_assert_equal_i(S_NO_ACTION_REQUIRED, ble_hid_consumer_release(BLE_HID_USAGE_VOLUME_UP));
+}
+
+void test_ble_hid__the_release_gives_up_once_the_deadline_passes(void) {
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(1, s_num_sends);
+
+  system_task_set_available_space(5);
+  cl_assert_equal_i(E_INTERNAL, ble_hid_consumer_release(BLE_HID_USAGE_VOLUME_UP));
+
+  // The deadline is absolute and taken from the press: the hold timeout plus
+  // the grace, whenever within it the release was attempted.
+  prv_advance_ms(TEST_HOLD_TIMEOUT_MS + TEST_RELEASE_GRACE_MS + 1);
+  prv_fire_running_timer();
+
+  // It stops rather than retrying for ever, and it sends no lift it never
+  // managed: the key really is still down on the phone, and the ERR log is the
+  // only honest report of that.
+  cl_assert_equal_i(TIMER_INVALID_ID, prv_running_timer());
+  cl_assert_equal_i(1, s_num_sends);
+
+  // Giving up drops the held state so the service is not wedged, and the press
+  // that is now accepted is what can clear the stuck key: its own release
+  // lifts whatever the phone still has down.
+  system_task_set_available_space(~(uint32_t)0);
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(2, s_num_sends);
+  prv_assert_send(1, BleHidReportPathUsage, BLE_HID_USAGE_VOLUME_UP);
+
+  cl_assert_equal_i(S_SUCCESS, ble_hid_consumer_release(BLE_HID_USAGE_VOLUME_UP));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(3, s_num_sends);
+  prv_assert_send(2, BleHidReportPathUsage, 0);
+}
+
+void test_ble_hid__an_unsubscribe_drops_the_held_usage_without_a_lift(void) {
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(1, s_num_sends);
+
+  s_usage_subscribed = false;
+  const BTDeviceInternal device = {};
+  bt_driver_cb_hid_service_update_subscription(&device, false);
+  // Runs on the BT host task, so it queues rather than sends.
+  cl_assert_equal_i(1, s_num_sends);
+
+  fake_system_task_callbacks_invoke_pending();
+  // No lift goes out and none is needed: the notify would be refused anyway,
+  // and a HOGP host drops every key it knows about when the subscription ends.
+  // The state is cleared instead, and this is the branch the field takes every
+  // time a phone walks away with the shutter down.
+  cl_assert_equal_i(1, s_num_sends);
+  cl_assert_equal_i(S_NO_ACTION_REQUIRED, ble_hid_consumer_release(BLE_HID_USAGE_VOLUME_UP));
+
+  // Nothing is retried either: the leftover hold timer finds nothing held.
+  prv_advance_ms(TEST_HOLD_TIMEOUT_MS);
+  prv_fire_running_timer();
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(1, s_num_sends);
+  cl_assert_equal_i(TIMER_INVALID_ID, prv_running_timer());
+}
+
+void test_ble_hid__a_press_queued_before_a_later_one_does_not_disturb_it(void) {
+  // A presser on the app task waits inside system_task_add_callback() for a
+  // slot on its own eight-deep queue, so the held state is published long
+  // before the send is queued.
+  fake_system_task_defer_next_add();
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  cl_assert_equal_i(0, (int)fake_system_task_count_callbacks());
+
+  // While it waits, the hold timer lifts the key...
+  prv_advance_ms(TEST_HOLD_TIMEOUT_MS);
+  prv_fire_running_timer();
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(1, s_num_sends);
+  prv_assert_send(0, BleHidReportPathUsage, 0);
+
+  // ...and the same usage goes down again on the same report, so nothing but
+  // the generation tells the two presses apart.
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(2, s_num_sends);
+  prv_assert_send(1, BleHidReportPathUsage, BLE_HID_USAGE_VOLUME_UP);
+
+  // The first presser finally gets its slot. Its send is for a press that is
+  // over, so nothing goes out: a repeat would put a key down that the press it
+  // belonged to can no longer lift, and a failed one would clear a held state
+  // that is not its own -- after which the owner's release is a no-op.
+  fake_system_task_flush_deferred();
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(2, s_num_sends);
+
+  // The second press is still held and still releasable.
+  cl_assert_equal_i(S_SUCCESS, ble_hid_consumer_release(BLE_HID_USAGE_VOLUME_UP));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(3, s_num_sends);
+  prv_assert_send(2, BleHidReportPathUsage, 0);
+}
+
+void test_ble_hid__unsubscribe_of_the_other_report_leaves_the_key_alone(void) {
+  cl_assert_equal_i(S_SUCCESS,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  fake_system_task_callbacks_invoke_pending();
+
+  // Report 1 goes away; the press was on report 2, which is still subscribed.
+  s_bitmap_subscribed = false;
+  const BTDeviceInternal device = {};
+  bt_driver_cb_hid_service_update_subscription(&device, false);
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(1, s_num_sends);
+
+  cl_assert_equal_i(S_SUCCESS, ble_hid_consumer_release(BLE_HID_USAGE_VOLUME_UP));
+}
+
+void test_ble_hid__is_ready_follows_the_path_it_is_asked_about(void) {
+  s_bitmap_subscribed = true;
+  s_usage_subscribed = false;
+  cl_assert_equal_b(true, ble_hid_is_ready(BleHidReportPathBitmap));
+  cl_assert_equal_b(false, ble_hid_is_ready(BleHidReportPathUsage));
+
+  s_bitmap_subscribed = false;
+  s_usage_subscribed = true;
+  cl_assert_equal_b(false, ble_hid_is_ready(BleHidReportPathBitmap));
+  cl_assert_equal_b(true, ble_hid_is_ready(BleHidReportPathUsage));
+
+  // A driver without the service is never ready, whatever is subscribed.
+  s_hid_supported = false;
+  cl_assert_equal_b(false, ble_hid_is_ready(BleHidReportPathBitmap));
+  cl_assert_equal_b(false, ble_hid_is_ready(BleHidReportPathUsage));
+}
+
+void test_ble_hid__press_on_an_unsubscribed_path_is_refused(void) {
+  s_usage_subscribed = false;
+  cl_assert_equal_i(E_INVALID_OPERATION,
+                    ble_hid_consumer_press(BLE_HID_USAGE_VOLUME_UP, BleHidReportPathUsage));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(0, s_num_sends);
+}
+
+void test_ble_hid__bitmap_path_refuses_a_usage_it_cannot_carry(void) {
+  // AC Back, which report 1 does not declare. No silent reroute onto report 2.
+  cl_assert_equal_i(E_INVALID_ARGUMENT, ble_hid_consumer_press(0x224, BleHidReportPathBitmap));
+  cl_assert_equal_i(S_SUCCESS, ble_hid_consumer_press(0x224, BleHidReportPathUsage));
+
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(1, s_num_sends);
+  prv_assert_send(0, BleHidReportPathUsage, 0x224);
+}
+
+void test_ble_hid__out_of_range_usages_are_refused(void) {
+  cl_assert_equal_i(E_INVALID_ARGUMENT, ble_hid_consumer_press(0, BleHidReportPathUsage));
+  cl_assert_equal_i(E_INVALID_ARGUMENT,
+                    ble_hid_consumer_press(BLE_HID_USAGE_MAX + 1, BleHidReportPathUsage));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(0, s_num_sends);
+}

--- a/tests/fw/services/bluetooth/test_bluetooth_persistent_storage.c
+++ b/tests/fw/services/bluetooth/test_bluetooth_persistent_storage.c
@@ -470,6 +470,158 @@ void test_bluetooth_persistent_storage__delete_ble_pairing_by_id(void) {
   cl_assert(!ret);
 }
 
+void test_bluetooth_persistent_storage__delete_ble_pairing_by_addr_if_matches(void) {
+  SMIdentityResolvingKey irk_out;
+  BTDeviceInternal device_out;
+
+  SMPairingInfo pairing = (SMPairingInfo) {
+    .irk = (SMIdentityResolvingKey) {
+      .data = {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x00,
+      },
+    },
+    .identity = (BTDeviceInternal) {
+      .address = (BTDeviceAddress) {
+        .octets = {
+          0x11, 0x12, 0x13, 0x14, 0x15, 0x16,
+        },
+      },
+      .is_classic = false,
+      .is_random_address = false,
+    },
+    .remote_encryption_info = {
+      .ltk = (SMLongTermKey) {
+        .data = {
+          0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7,
+          0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf,
+        },
+      },
+      .ediv = 0x1234,
+      .rand = 0x0123456789abcdefULL,
+    },
+    .is_remote_encryption_info_valid = true,
+    .is_remote_identity_info_valid = true,
+  };
+
+  BTBondingID id = bt_persistent_storage_store_ble_pairing(&pairing, true /* is_gateway */, NULL,
+                                                           false /* requires_address_pinning */,
+                                                           0 /* flags */);
+  cl_assert(id != BT_BONDING_ID_INVALID);
+
+  // A delete carrying key material we never stored must leave the bonding alone,
+  // and must not wipe the shared PRF copy either.
+  SMPairingInfo other_keys = pairing;
+  other_keys.remote_encryption_info.ltk.data[0] = 0xff;
+  const int prf_delete_count = fake_shared_prf_storage_get_ble_delete_count();
+  cl_assert_equal_b(bt_persistent_storage_delete_ble_pairing_by_addr_if_matches(&pairing.identity,
+                                                                                &other_keys),
+                    false);
+  cl_assert_equal_i(fake_shared_prf_storage_get_ble_delete_count(), prf_delete_count);
+  cl_assert_equal_b(bt_persistent_storage_get_ble_pairing_by_id(id, &irk_out, &device_out, NULL),
+                    true);
+
+  // Re-pairing the same phone keeps its identity and its IRK, so the new keys land
+  // in this very record. A delete queued for the keys it replaced must not take it.
+  SMPairingInfo repaired = pairing;
+  repaired.remote_encryption_info.ltk.data[0] = 0x5a;
+  cl_assert_equal_i(bt_persistent_storage_store_ble_pairing(&repaired, true /* is_gateway */, NULL,
+                                                            false /* requires_address_pinning */,
+                                                            0 /* flags */),
+                    id);
+  cl_assert_equal_b(bt_persistent_storage_delete_ble_pairing_by_addr_if_matches(&pairing.identity,
+                                                                                &pairing),
+                    false);
+  cl_assert_equal_b(bt_persistent_storage_get_ble_pairing_by_id(id, &irk_out, &device_out, NULL),
+                    true);
+
+  // The keys that are actually stored do delete it, and take the shared PRF copy with them --
+  // through the guarded erase, so a re-pair that has already refreshed that copy keeps it.
+  const int prf_guarded_count = fake_shared_prf_storage_get_ble_delete_if_matches_count();
+  const int prf_unconditional_count = fake_shared_prf_storage_get_ble_delete_count();
+  cl_assert_equal_b(bt_persistent_storage_delete_ble_pairing_by_addr_if_matches(&pairing.identity,
+                                                                                &repaired),
+                    true);
+  cl_assert_equal_b(bt_persistent_storage_get_ble_pairing_by_id(id, &irk_out, &device_out, NULL),
+                    false);
+  cl_assert_equal_i(fake_shared_prf_storage_get_ble_delete_if_matches_count(),
+                    prf_guarded_count + 1);
+  cl_assert_equal_i(fake_shared_prf_storage_get_ble_delete_count(), prf_unconditional_count);
+}
+
+//! The by-address lookup applies the same key comparison before it ever picks an id, so it cannot
+//! hand the delete transaction a record whose keys have moved on. Enter by id, which is where the
+//! record is read, checked and deleted under one lock, to exercise that check.
+void test_bluetooth_persistent_storage__delete_ble_pairing_by_id_if_matches(void) {
+  SMIdentityResolvingKey irk_out;
+  BTDeviceInternal device_out;
+
+  SMPairingInfo pairing = (SMPairingInfo) {
+    .irk = (SMIdentityResolvingKey) {
+      .data = {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x00,
+      },
+    },
+    .identity = (BTDeviceInternal) {
+      .address = (BTDeviceAddress) {
+        .octets = {
+          0x11, 0x12, 0x13, 0x14, 0x15, 0x16,
+        },
+      },
+      .is_classic = false,
+      .is_random_address = false,
+    },
+    .remote_encryption_info = {
+      .ltk = (SMLongTermKey) {
+        .data = {
+          0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7,
+          0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf,
+        },
+      },
+      .ediv = 0x1234,
+      .rand = 0x0123456789abcdefULL,
+    },
+    .is_remote_encryption_info_valid = true,
+    .is_remote_identity_info_valid = true,
+  };
+
+  BTBondingID id = bt_persistent_storage_store_ble_pairing(&pairing, true /* is_gateway */, NULL,
+                                                           false /* requires_address_pinning */,
+                                                           0 /* flags */);
+  cl_assert(id != BT_BONDING_ID_INVALID);
+
+  // A different LTK under the same id is a re-pair that landed here while the delete was queued.
+  SMPairingInfo other_ltk = pairing;
+  other_ltk.remote_encryption_info.ltk.data[0] = 0x5a;
+  cl_assert_equal_b(bt_persistent_storage_delete_ble_pairing_by_id_if_matches(id, &other_ltk),
+                    false);
+  cl_assert_equal_b(bt_persistent_storage_get_ble_pairing_by_id(id, &irk_out, &device_out, NULL),
+                    true);
+
+  // The whole encryption half has to match, not just the LTK.
+  SMPairingInfo other_rand = pairing;
+  other_rand.remote_encryption_info.rand ^= 1ULL;
+  cl_assert_equal_b(bt_persistent_storage_delete_ble_pairing_by_id_if_matches(id, &other_rand),
+                    false);
+  cl_assert_equal_b(bt_persistent_storage_get_ble_pairing_by_id(id, &irk_out, &device_out, NULL),
+                    true);
+
+  // Keys the record does not carry at all do not match either: a half the caller marks invalid is
+  // not compared, and with no valid half left there is nothing but the identity to go on.
+  SMPairingInfo identity_only = pairing;
+  identity_only.is_remote_encryption_info_valid = false;
+  cl_assert_equal_b(bt_persistent_storage_delete_ble_pairing_by_id_if_matches(id, &identity_only),
+                    false);
+  cl_assert_equal_b(bt_persistent_storage_get_ble_pairing_by_id(id, &irk_out, &device_out, NULL),
+                    true);
+
+  // The keys that are actually stored do delete it.
+  cl_assert_equal_b(bt_persistent_storage_delete_ble_pairing_by_id_if_matches(id, &pairing), true);
+  cl_assert_equal_b(bt_persistent_storage_get_ble_pairing_by_id(id, &irk_out, &device_out, NULL),
+                    false);
+}
+
 void test_bluetooth_persistent_storage__ble_ancs_bonding(void) {
   bool ret;
 

--- a/tests/fw/services/bluetooth/test_bluetooth_persistent_storage_prf.c
+++ b/tests/fw/services/bluetooth/test_bluetooth_persistent_storage_prf.c
@@ -341,4 +341,81 @@ void test_bluetooth_persistent_storage_prf__delete_ble_pairing_by_id(void) {
                                                false /* auto_accept_re_pairing */);  cl_assert(id != BT_BONDING_ID_INVALID);
 }
 
+void test_bluetooth_persistent_storage_prf__delete_ble_pairing_by_addr_if_matches(void) {
+  SMIdentityResolvingKey irk_out;
+  BTDeviceInternal device_out;
+
+  SMPairingInfo pairing = (SMPairingInfo) {
+    .irk = (SMIdentityResolvingKey) {
+      .data = {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x00
+      },
+    },
+    .identity = (BTDeviceInternal) {
+      .address = (BTDeviceAddress) {
+        .octets = {
+          0x11, 0x12, 0x13, 0x14, 0x15, 0x16
+        },
+      },
+      .is_classic = false,
+      .is_random_address = false,
+    },
+    .remote_encryption_info = {
+      .ltk = (SMLongTermKey) {
+        .data = {
+          0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7,
+          0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf
+        },
+      },
+      .ediv = 0x1234,
+      .rand = 0x0123456789abcdefULL,
+    },
+    .is_remote_encryption_info_valid = true,
+    .is_remote_identity_info_valid = true,
+  };
+
+  BleBonding ble_bonding = (BleBonding) {
+    .is_gateway = true,
+    .pairing_info = pairing,
+  };
+  bonding_sync_add_bonding(&ble_bonding);
+  BTBondingID id = bt_persistent_storage_store_ble_pairing(&pairing, true /* is_gateway */, NULL,
+                                                           false /* requires_address_pinning */,
+                                                           0 /* flags */);
+  cl_assert(id != BT_BONDING_ID_INVALID);
+
+  // A delete carrying key material we never stored must leave the pairing alone,
+  // in shared PRF storage and in the driver's copy both.
+  SMPairingInfo other_keys = pairing;
+  other_keys.remote_encryption_info.ltk.data[0] = 0xff;
+  cl_assert_equal_b(bt_persistent_storage_delete_ble_pairing_by_addr_if_matches(&pairing.identity,
+                                                                                &other_keys),
+                    false);
+  cl_assert_equal_b(bt_persistent_storage_get_ble_pairing_by_id(id, &irk_out, &device_out, NULL),
+                    true);
+  cl_assert_equal_b(bonding_sync_contains_pairing_info(&pairing, true /* is_gateway */), true);
+
+  // Re-pairing the same phone keeps its identity and its IRK, so the new keys land
+  // in this one slot. A delete queued for the keys they replaced must not take it.
+  SMPairingInfo repaired = pairing;
+  repaired.remote_encryption_info.ltk.data[0] = 0x5a;
+  cl_assert(bt_persistent_storage_store_ble_pairing(&repaired, true /* is_gateway */, NULL,
+                                                    false /* requires_address_pinning */,
+                                                    0 /* flags */) != BT_BONDING_ID_INVALID);
+  cl_assert_equal_b(bt_persistent_storage_delete_ble_pairing_by_addr_if_matches(&pairing.identity,
+                                                                                &pairing),
+                    false);
+  cl_assert_equal_b(bt_persistent_storage_get_ble_pairing_by_id(id, &irk_out, &device_out, NULL),
+                    true);
+
+  // The keys that are actually stored do delete it.
+  cl_assert_equal_b(bt_persistent_storage_delete_ble_pairing_by_addr_if_matches(&pairing.identity,
+                                                                                &repaired),
+                    true);
+  cl_assert_equal_b(bt_persistent_storage_get_ble_pairing_by_id(id, &irk_out, &device_out, NULL),
+                    false);
+  cl_assert_equal_b(bonding_sync_contains_pairing_info(&pairing, true /* is_gateway */), false);
+}
+
 

--- a/tests/fw/services/bluetooth/wscript_build
+++ b/tests/fw/services/bluetooth/wscript_build
@@ -32,6 +32,14 @@ clar(bld,
 
 clar(bld,
      sources_ant_glob=(
+      "src/fw/services/bluetooth/ble_hid.c "
+      "tests/fakes/fake_rtc.c "
+     ),
+     test_sources_ant_glob="test_ble_hid.c",
+     defines=['CONFIG_BT_HID_REMOTE'])
+
+clar(bld,
+     sources_ant_glob=(
         "src/fw/services/bluetooth/local_addr.c"
      ),
      test_sources_ant_glob="test_local_addr.c")

--- a/tests/stubs/stubs_system_task.h
+++ b/tests/stubs/stubs_system_task.h
@@ -10,6 +10,11 @@ bool system_task_add_callback(SystemTaskEventCallback cb, void *data) {
   return true;
 }
 
+bool system_task_add_callback_nonblocking(SystemTaskEventCallback cb, void *data) {
+  cb(data);
+  return true;
+}
+
 uint32_t system_task_get_available_space(void) {
   return 0;
 }

--- a/third_party/nimble/wscript_build
+++ b/third_party/nimble/wscript_build
@@ -7,7 +7,6 @@ nimble_includes = [
     'mynewt-nimble/nimble/host/services/gap/include',
     'mynewt-nimble/nimble/host/services/gatt/include',
     'mynewt-nimble/nimble/host/services/ias/include',
-    'mynewt-nimble/nimble/host/services/dis/include',
     'mynewt-nimble/nimble/host/services/lls/include',
     'mynewt-nimble/nimble/host/services/tps/include',
     'mynewt-nimble/nimble/host/util/include',
@@ -34,6 +33,7 @@ nimble_sources = bld.path.ant_glob(
     excl = [
         'mynewt-nimble/nimble/host/src/ble_gatts_lcl.c', # has a duplicate define, not needed anyway
         'mynewt-nimble/porting/nimble/src/hal_timer.c',
+        'mynewt-nimble/nimble/host/services/dis/src/*.c', # replaced by our own dis_service.c
     ]
 )
 


### PR DESCRIPTION
This started with @asyba's question in https://github.com/coredevices/PebbleOS/pull/1772#issuecomment-5104919119: can the watch trigger the iPhone's camera, the way Garmin does it? I've played with that on a Garmin — it's bad there: it only works through the Garmin app, which brings up its own camera. There's a better way: the watch pretends to be a BLE HID device and presses the shutter button in the native camera app. No MFi, no companion app. It's also what #1372 asks for.

This is a prototype demonstrating the concept. **Not proposed for merging** — the PR exists so people can play with it and collect data from different phones.

## Why Consumer Control and not a keyboard

iOS maps Volume Up/Down from external HID devices to the shutter while the camera app is open. The obvious approach — pretend to be a keyboard — has a fatal side effect: iOS treats any device with a keyboard collection as a hardware keyboard and hides the on-screen keyboard for as long as the device is connected. For a watch, "as long as it is connected" means "always". Consumer Control (usage page 0x0C) carries the same media keys — volume, play/pause — without being a keyboard, and the on-screen keyboard stays where it is.

## What works

Tested on an iPhone 15 Pro (iOS 26.5.2): Volume Up and Volume Down fire the shutter. A fun one: Snapshot (0x65) is reportedly the proper way to take a photo on Android, but on the iPhone it takes a screenshot. I haven't tested Android and claim nothing about it.

## How to play with it

`./pbl configure --board obelix@pvt -DCONFIG_RELEASE=y` — the feature is enabled by default on this branch. Camera app: short Select takes a shot, long Select opens the settings (which key to send and in which form).

The service exposes the same usage in two forms: report 1 is a bitmap of seven keys, report 2 is a 16-bit Array selector. This is deliberate: the Array form has a reputation for being broken on iOS 16, and I want to compare both on real phones before keeping one. How you can help: press Volume Up via report 1 and via report 2 (switchable in the settings) and report what worked — phone model, OS version. If the Array form survives everywhere, the bitmap and its fork in the API get deleted.

Internally this is already shaped as a system BT API: `ble_hid_consumer_press(usage, path)` / `ble_hid_consumer_release(usage)` — the Camera app is just a client of it and knows nothing about HID. It is not exposed in the ABI for third-party apps (no syscall, no SDK export): this is a test, too early to put it into the ABI.

## Bugs fixed along the way

They were in my way, so I had to fix them:

1. **The watch rebooted on pairing.** NimBLE invokes the ble_store callbacks with `ble_hs_mutex` held, and the glue called straight into the settings file from there — storing one CCCD is three full-file transactions. My second Report CCCD doubled the work done at pairing time and turned a latent stall into a reliable watchdog reboot. Same lock pair as 119cb96e3.
2. **`prv_nimble_store_read_cccd()` returned an uninitialised `ret`** on the success path. `ble_gatts_bonding_restored()` stops walking the store on any non-zero rc, so restoring subscriptions after a reconnect either worked or silently broke depending on stack garbage. A one-liner that affects everyone — happy to send it as a separate PR right away.
3. **The vendored `ble_svc_dis` cannot express PnP ID**, which HOGP mandates — replaced it with an in-tree implementation. Note it changes the GATT database (+2 attributes, a handle shift after DIS), so a phone flashed over an existing pairing may be looking at a stale GATT cache.
4. **`system_task`**: added a non-blocking callback variant (the blocking one, called from a non-App task, waits 3 seconds on a full queue and then reboots the watch).

## Honestly, about the quality of these fixes

My reboot fix is incomplete and in places a workaround. The flash moved to the KernelBG queue, but sec key writes travel via KernelMain while deletes travel via KernelBG: two queues with no ordering between them. That forced the deferred bonding delete to be matched by LTK (repeat pairing reuses the same record — identity and IRK both match), while the proper shape is a single serialised path for all store mutations: it removes the LTK matching entirely and closes the remaining `WillDelete`-on-a-reused-id window. Likewise the free-CCCD-id hint works around the record's synthetic key; the proper shape is a composite key (peer, chr_val_handle).

I can see #1708 rewriting this same store glue for GATT caching — I'd suggest we synchronise, but later; right now this is just a prototype.

If you have no plans of your own for this bug and the plan sounds reasonable — I'll do it properly and bring it as a separate PR. It would improve pairing robustness against flash latency, bonding-delete correctness under the repeat-pairing race, and the CCCD storage schema — and it unblocks building the camera button (and BT APIs for apps in general) properly and extensibly.
