### PR TITLE
system_task: drop audio/mic ISR callbacks instead of resetting on full queue

### DIFF
--- a/include/pbl/services/system_task.h
+++ b/include/pbl/services/system_task.h
@@ -28,6 +28,12 @@ typedef void (*SystemTaskEventCallback)(void *data);
 //!                              resuming the previous task. See portEND_SWITCHING_ISR()
 bool system_task_add_callback_from_isr(SystemTaskEventCallback cb, void *data, bool* should_context_switch);
 
+//! Same as system_task_add_callback_from_isr(), except a full queue drops the callback and
+//! returns false instead of resetting the system. Only use this when losing the callback is
+//! tolerable, e.g. a periodic refill that a later interrupt retries.
+bool system_task_add_callback_from_isr_droppable(SystemTaskEventCallback cb, void *data,
+                                                 bool *should_context_switch);
+
 //! @param cb Callback function that will later be called from the system task
 //! @param data Context pointer passed to the callback
 bool system_task_add_callback(SystemTaskEventCallback cb, void *data);

--- a/src/fw/drivers/mic/nrf5/pdm.c
+++ b/src/fw/drivers/mic/nrf5/pdm.c
@@ -173,9 +173,12 @@ static void prv_process_pdm_buffer(MicDeviceState *state, int16_t *pdm_data) {
   if (available_data >= frame_size_bytes && !state->main_pending) {
     state->main_pending = true;
 
-    // Dispatch to low-priority system task instead of kernel event queue
+    // Dispatch to low-priority system task instead of kernel event queue.
+    // A drop is retried on the next PDM buffer event; losing samples beats
+    // resetting the system over a full queue.
     bool should_context_switch = false;
-    if (!system_task_add_callback_from_isr(prv_dispatch_samples_system_task, NULL, &should_context_switch)) {
+    if (!system_task_add_callback_from_isr_droppable(prv_dispatch_samples_system_task, NULL,
+                                                     &should_context_switch)) {
       state->main_pending = false;
     }
   }

--- a/src/fw/drivers/mic/sf32lb52/pdm.c
+++ b/src/fw/drivers/mic/sf32lb52/pdm.c
@@ -259,9 +259,12 @@ static void prv_dma_data_processing(uint8_t* data, uint16_t size)
   if (available_data >= frame_size_bytes  && !s_state->main_pending) {
     s_state->main_pending = true;
     
-    // Dispatch to system task instead of kernel event queue (matches asterix behavior)
+    // Dispatch to system task instead of kernel event queue (matches asterix behavior).
+    // A drop is retried on the next PDM buffer event; losing samples beats
+    // resetting the system over a full queue.
     bool should_context_switch = false;
-    if (!system_task_add_callback_from_isr(prv_dispatch_samples_system_task, NULL, &should_context_switch)) {
+    if (!system_task_add_callback_from_isr_droppable(prv_dispatch_samples_system_task, NULL,
+                                                     &should_context_switch)) {
       s_state->main_pending = false;
     }
   }

--- a/src/fw/drivers/speaker/nrf5/da7212.c
+++ b/src/fw/drivers/speaker/nrf5/da7212.c
@@ -301,10 +301,12 @@ static void prv_maybe_request_refill_from_isr(AudioDeviceState *state) {
     return;
   }
 
+  // A dropped refill is retried on the next I2S buffer event; a momentary
+  // underrun beats resetting the system over a full queue.
   state->callback_pending = true;
   bool should_context_switch = false;
-  if (!system_task_add_callback_from_isr(prv_audio_trans_bg, state,
-                                         &should_context_switch)) {
+  if (!system_task_add_callback_from_isr_droppable(prv_audio_trans_bg, state,
+                                                   &should_context_switch)) {
     state->callback_pending = false;
   }
 }

--- a/src/fw/drivers/speaker/qemu/audio.c
+++ b/src/fw/drivers/speaker/qemu/audio.c
@@ -88,12 +88,12 @@ void qemu_audio_irq_handler(AudioDevice *dev) {
   // Clear the interrupt
   REG32(dev->base_addr + AUDIO_INTSTAT) = INT_BUFAVAIL;
 
-  // Schedule callback on system task
+  // Schedule callback on system task; a drop is retried on the next interrupt
   if (dev->state->trans_cb) {
     bool should_context_switch = false;
-    system_task_add_callback_from_isr(prv_audio_system_task_cb,
-                                      (void *)dev->state,
-                                      &should_context_switch);
+    system_task_add_callback_from_isr_droppable(prv_audio_system_task_cb,
+                                                (void *)dev->state,
+                                                &should_context_switch);
     portEND_SWITCHING_ISR(should_context_switch);
   }
 }

--- a/src/fw/drivers/speaker/sf32lb52/audec.c
+++ b/src/fw/drivers/speaker/sf32lb52/audec.c
@@ -479,11 +479,13 @@ static void prv_dma_request_processing(AudioDeviceState* state) {
     // Only one refill callback may be in flight: this ISR fires every half
     // buffer, and enqueueing on each one floods the system task queue when
     // KernelBG is starved, tripping the Event Queue Full reset.
+    // A dropped refill is retried on the next half-buffer IRQ; a momentary
+    // underrun beats resetting the system over a full queue.
     if(state->trans_cb && !state->callback_pending &&
        free_size >= CFG_AUDIO_PLAYBACK_PIPE_SIZE) {
         bool system_task_switch_context = false;
         state->callback_pending = true;
-        if (!system_task_add_callback_from_isr(prv_audio_trans_bg, (void*)state,
+        if (!system_task_add_callback_from_isr_droppable(prv_audio_trans_bg, (void*)state,
                 &system_task_switch_context)) {
             state->callback_pending = false;
         }

--- a/src/fw/services/system_task/service.c
+++ b/src/fw/services/system_task/service.c
@@ -138,26 +138,42 @@ static void handle_system_task_send_failure(SystemTaskEventCallback cb, uintptr_
   reset_due_to_software_failure();
 }
 
+static bool prv_send_to_queue_from_isr(SystemTaskEventCallback cb, void *data,
+                                       bool *should_context_switch) {
+  SystemTaskEvent event = {
+    .cb = cb,
+    .data = data,
+  };
+
+  signed portBASE_TYPE tmp = pdFALSE;
+  bool success = (xQueueSendToBackFromISR(s_system_task_queue, &event, &tmp) == pdTRUE);
+  *should_context_switch = (tmp == pdTRUE);
+
+  return success;
+}
+
 bool system_task_add_callback_from_isr(SystemTaskEventCallback cb, void *data, bool* should_context_switch) {
   // Capture caller LR at entry; reading from a deeper helper is unreliable.
   uintptr_t caller_lr = (uintptr_t)__builtin_return_address(0);
   if (!prv_is_accepting_callbacks()) {
     return false;
   }
-  SystemTaskEvent event = {
-    .cb = cb,
-    .data = data,
-  };
 
-  signed portBASE_TYPE tmp;
-  bool success = (xQueueSendToBackFromISR(s_system_task_queue, &event, &tmp) == pdTRUE);
+  bool success = prv_send_to_queue_from_isr(cb, data, should_context_switch);
   if (!success) {
     handle_system_task_send_failure(cb, caller_lr);
   }
 
-  *should_context_switch = (tmp == pdTRUE);
-
   return success;
+}
+
+bool system_task_add_callback_from_isr_droppable(SystemTaskEventCallback cb, void *data,
+                                                 bool *should_context_switch) {
+  if (!prv_is_accepting_callbacks()) {
+    return false;
+  }
+
+  return prv_send_to_queue_from_isr(cb, data, should_context_switch);
 }
 
 bool system_task_add_callback(SystemTaskEventCallback cb, void *data) {

--- a/tests/fakes/fake_system_task.h
+++ b/tests/fakes/fake_system_task.h
@@ -44,6 +44,12 @@ bool system_task_add_callback_from_isr(SystemTaskEventCallback cb, void *data,
   return system_task_add_callback(cb, data);
 }
 
+bool system_task_add_callback_from_isr_droppable(SystemTaskEventCallback cb, void *data,
+                                                 bool *should_context_switch) {
+  *should_context_switch = false;
+  return system_task_add_callback(cb, data);
+}
+
 uint32_t system_task_get_available_space(void) {
   return system_task_available_space;
 }


### PR DESCRIPTION
## Summary

A full system task queue during `system_task_add_callback_from_isr()` is always fatal: the failure handler sets `RebootReasonCode_EventQueueFull` and resets the watch. The audio and mic drivers throttle themselves to one in-flight callback and already have recovery branches for a failed enqueue — but those branches were dead code, because the queue-full case never returns.

Real-world consequence (FIRM-3657, dup of FIRM-3470, same signature as FIRM-3563): a sound alarm fires at the top of the minute while KernelBG is stalled in the activity minute handler's settings-file scan; the audio codec DMA refill ISR meets a full queue and the watch reboots mid-alarm. The v4.31.0 refill throttle shrank audio's own queue footprint to one entry, but a single enqueue into a queue filled by *other* producers still resets.

This PR adds `system_task_add_callback_from_isr_droppable()`, which returns false on a full queue instead of resetting, and switches the loss-tolerant periodic ISR producers to it:

- speaker refill: sf32lb52 audec, nrf5 da7212, QEMU
- mic sample dispatch: sf32lb52 PDM, nrf5 PDM

All of these are retried on the next DMA/I2S/PDM interrupt, so the worst case becomes a momentary underrun / a few lost mic samples instead of a reboot. The fatal variant is unchanged for everything else.

Fixes FIRM-2626

## Testing

- Full builds pass on `obelix@pvt`, `asterix`, and `qemu_emery` (covers every touched driver plus the service).
- `gitlint` clean over all three commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)