### PR TITLE
fw/shell/normal: remove double flip of back+up combo in left-hand mode

### DIFF
--- a/src/fw/shell/normal/watchface.c
+++ b/src/fw/shell/normal/watchface.c
@@ -24,18 +24,14 @@
 #include "pbl/services/notifications/do_not_disturb.h"
 #include <pbl/logging/logging.h>
 #include "system/passert.h"
-#ifdef CONFIG_ORIENTATION_MANAGER
-#include "shell/prefs.h"
-#endif 
 
 #define QUICK_LAUNCH_HOLD_MS (400)
 #define BIT_SET (1)
 #define BIT_CLEAR (0)
+// Button events are remapped at the driver level when the display is rotated
+// (left-hand mode), so these masks are correct in either orientation.
 #define COMBO_BACK_UP_BUTTONS ((BIT_SET << BUTTON_ID_BACK) | (BIT_SET << BUTTON_ID_UP))
 #define COMBO_UP_DOWN_BUTTONS ((BIT_SET << BUTTON_ID_UP) | (BIT_SET << BUTTON_ID_DOWN))
-#ifdef CONFIG_ORIENTATION_MANAGER
-#define COMBO_BACK_UP_FLIPPED_BUTTONS ((BIT_SET << BUTTON_ID_BACK) | (BIT_SET << BUTTON_ID_DOWN))
-#endif
 
 static ClickManager s_click_manager;
 static uint8_t s_buttons_pressed = BIT_CLEAR;
@@ -65,41 +61,20 @@ static bool prv_is_combo_pressed(uint8_t combo_buttons) {
 }
 
 static bool prv_combo_is_enabled(uint8_t combo_buttons) {
-#ifdef CONFIG_ORIENTATION_MANAGER
-  const bool orientation_flipped = display_orientation_is_left();
-  if (orientation_flipped && combo_buttons == COMBO_BACK_UP_FLIPPED_BUTTONS) {
-    return quick_launch_combo_back_up_is_enabled();
-  } else if (!orientation_flipped && combo_buttons == COMBO_BACK_UP_BUTTONS) {
-    return quick_launch_combo_back_up_is_enabled();
-  } else if (combo_buttons == COMBO_UP_DOWN_BUTTONS) {
-    return quick_launch_combo_up_down_is_enabled();
-  }
-#else
   if (combo_buttons == COMBO_BACK_UP_BUTTONS) {
     return quick_launch_combo_back_up_is_enabled();
   } else if (combo_buttons == COMBO_UP_DOWN_BUTTONS) {
     return quick_launch_combo_up_down_is_enabled();
   }
-#endif
   return false;
 }
 
 static AppInstallId prv_combo_get_app(uint8_t combo_buttons) {
-#ifdef CONFIG_ORIENTATION_MANAGER
-  if (combo_buttons == COMBO_BACK_UP_FLIPPED_BUTTONS) {
-    return quick_launch_combo_back_up_get_app();
-  } else if (combo_buttons == COMBO_BACK_UP_BUTTONS) {
-    return quick_launch_combo_back_up_get_app();
-  } else if (combo_buttons == COMBO_UP_DOWN_BUTTONS) {
-    return quick_launch_combo_up_down_get_app();
-  }
-#else
   if (combo_buttons == COMBO_BACK_UP_BUTTONS) {
     return quick_launch_combo_back_up_get_app();
   } else if (combo_buttons == COMBO_UP_DOWN_BUTTONS) {
     return quick_launch_combo_up_down_get_app();
   }
-#endif
   return INSTALL_ID_INVALID;
 }
 
@@ -140,40 +115,17 @@ static void prv_combo_back_timer_callback(void *data) {
 static void prv_check_combo_back_hold(void) {
   uint8_t combo_buttons = BIT_CLEAR;
 
-#ifdef CONFIG_ORIENTATION_MANAGER
-  const bool orientation_flipped = display_orientation_is_left();
-  if (orientation_flipped && prv_is_combo_pressed(COMBO_BACK_UP_FLIPPED_BUTTONS)) {
-    combo_buttons = COMBO_BACK_UP_FLIPPED_BUTTONS;
-  } else if (!orientation_flipped && prv_is_combo_pressed(COMBO_BACK_UP_BUTTONS)) {
-    combo_buttons = COMBO_BACK_UP_BUTTONS;
-  } else if (prv_is_combo_pressed(COMBO_UP_DOWN_BUTTONS)) {
-    combo_buttons = COMBO_UP_DOWN_BUTTONS;
-  }
-#else
   if (prv_is_combo_pressed(COMBO_BACK_UP_BUTTONS)) {
     combo_buttons = COMBO_BACK_UP_BUTTONS;
   } else if (prv_is_combo_pressed(COMBO_UP_DOWN_BUTTONS)) {
     combo_buttons = COMBO_UP_DOWN_BUTTONS;
   }
-#endif
 
   if (combo_buttons != BIT_CLEAR) {
     if (s_combo_back_hold_timer == NULL) {
       s_active_combo_buttons = combo_buttons;
       // Cancel individual button timers to prevent them from firing.
       // This ensures only the combo executes, not individual hold handlers.
-#ifdef CONFIG_ORIENTATION_MANAGER
-      if (combo_buttons == COMBO_BACK_UP_FLIPPED_BUTTONS) {
-        click_recognizer_reset(&s_click_manager.recognizers[BUTTON_ID_BACK]);
-        click_recognizer_reset(&s_click_manager.recognizers[BUTTON_ID_DOWN]);
-      } else if (combo_buttons == COMBO_BACK_UP_BUTTONS) {
-        click_recognizer_reset(&s_click_manager.recognizers[BUTTON_ID_BACK]);
-        click_recognizer_reset(&s_click_manager.recognizers[BUTTON_ID_UP]);
-      } else {
-        click_recognizer_reset(&s_click_manager.recognizers[BUTTON_ID_UP]);
-        click_recognizer_reset(&s_click_manager.recognizers[BUTTON_ID_DOWN]);
-      }
-#else
       if (combo_buttons == COMBO_BACK_UP_BUTTONS) {
         click_recognizer_reset(&s_click_manager.recognizers[BUTTON_ID_BACK]);
         click_recognizer_reset(&s_click_manager.recognizers[BUTTON_ID_UP]);
@@ -181,7 +133,6 @@ static void prv_check_combo_back_hold(void) {
         click_recognizer_reset(&s_click_manager.recognizers[BUTTON_ID_UP]);
         click_recognizer_reset(&s_click_manager.recognizers[BUTTON_ID_DOWN]);
       }
-#endif
       s_combo_back_hold_timer =
           app_timer_register(QUICK_LAUNCH_HOLD_MS, prv_combo_back_timer_callback, NULL);
     }


### PR DESCRIPTION
## Summary

With left-hand mode enabled, the "Back + Up" quick-launch combo fired on the buttons the user perceives as Back + Down (FIRM-3644).

Button events are already remapped up↔down at the driver level when the display is rotated (`button_is_pressed` applies the swap before reading the GPIO), so the button IDs reaching the watchface are screen-relative. The watchface-level inversion added in cb84939df applied a second flip on top of that, which cancelled the driver remap: in left-hand mode the code matched logical Back+Down, i.e. the physical/perceived Back+Down pair.

This removes the watchface-level inversion so the logical `COMBO_BACK_UP_BUTTONS` mask is matched in both orientations. Right-handed behavior is unchanged (the removed orientation branch was identical to the plain branch in that case).

Also fixes two latent bugs in the flipped path that disappear with it:
- the combo launch reported its source button as Up instead of Back
- `prv_is_any_combo_active()` never checked the flipped mask, so single-button handlers weren't suppressed during a flipped combo

Fixes FIRM-3644

## Testing

- `./waf configure --board obelix@pvt` + `./waf build` passes (reporter's board)

🤖 Generated with [Claude Code](https://claude.com/claude-code)