### PR TITLE
comm/ble: reset s_is_connected in gap_le_advert_init()

### DIFF
--- a/src/fw/comm/ble/gap_le_advert.c
+++ b/src/fw/comm/ble/gap_le_advert.c
@@ -549,6 +549,9 @@ void gap_le_advert_init(void) {
     };
 
     s_is_advertising = false;
+    // Not cleared by the disconnect handler if the stack went down while
+    // connected (airplane mode): a stale true pauses the cycle timer.
+    s_is_connected = false;
     s_gap_le_advert_is_initialized = true;
   }
 unlock:

--- a/tests/fw/comm/test_gap_le_advert.c
+++ b/tests/fw/comm/test_gap_le_advert.c
@@ -79,11 +79,6 @@ void test_gap_le_advert__initialize(void) {
 
   regular_timer_init();
   gap_le_advert_init();
-
-  // gap_le_advert keeps its slave-connection state in a static that init() does
-  // not clear, so a prior test that connected as slave would leave advertising
-  // paused. Reset it through the public API for a clean slate each test.
-  gap_le_advert_handle_disconnect_as_slave();
 }
 
 void test_gap_le_advert__cleanup(void) {
@@ -636,6 +631,35 @@ void test_gap_le_advert__continue_after_slave_connection(void) {
   // scheduled:
   gap_le_advert_handle_disconnect_as_slave();
   cl_assert_equal_b(gap_le_is_advertising_enabled(), true);
+
+  free(ad);
+}
+
+// A stack restart while connected (airplane mode) never runs the disconnect
+// handler, so init() has to clear the connected state itself.
+void test_gap_le_advert__stack_restart_while_connected_resets_state(void) {
+  gap_le_advert_handle_connect_as_slave();
+  gap_le_advert_deinit();
+  gap_le_advert_init();
+
+  BLEAdData *ad = create_ad("A", NULL);
+  GAPLEAdvertisingJobTerm advert_term = {
+    .interval = GAPLEAdvertisingInterval_Short,
+    .duration_secs = 10,
+  };
+  GAPLEAdvertisingJobRef job = gap_le_advert_schedule(
+      ad, &advert_term, 1, unscheduled_callback, s_unscheduled_cb_data, 0);
+  cl_assert(job != NULL);
+  cl_assert_equal_b(gap_le_is_advertising_enabled(), true);
+
+  // The job must age and complete on schedule:
+  for (int i = 0; i < 10; ++i) {
+    cl_assert_equal_b(gap_le_is_advertising_enabled(), true);
+    regular_timer_fire_seconds(1);
+  }
+  cl_assert_equal_b(gap_le_is_advertising_enabled(), false);
+  cl_assert_equal_i(s_unscheduled_cb_count, 1);
+  cl_assert_equal_b(s_unscheduled_completed, true);
 
   free(ad);
 }


### PR DESCRIPTION
## Summary

`gap_le_advert.c` keeps its connected-as-slave state in a static (`s_is_connected`) that no init path clears. It is normally cleared by `gap_le_advert_handle_disconnect_as_slave()`, but when the BT stack is torn down **while a connection is up** (e.g. entering airplane mode), the module is deinitialized before any disconnect event can be delivered — and the handler returns early on `!s_gap_le_advert_is_initialized` regardless. The stale "connected" state survives into the next stack start.

## Symptom

After leaving airplane mode (having entered it while connected), `prv_cycle_timer_callback()` early-returns while "connected", so scheduled advertising jobs neither **age** nor **round-robin** until a real connect/disconnect cycle finally resets the flag:

- Reconnection advertising never leaves its initial 30-second 20 ms term (`gap_le_slave_reconnect.c`) and keeps advertising at the fast interval indefinitely — a battery drain that lasts as long as the phone stays away, i.e. exactly the case where reconnection advertising runs the longest.
- Finite advertising windows (e.g. timed discoverability) never expire.
- With multiple jobs scheduled, only one ever gets airtime.

Repro: connect watch to phone → enable airplane mode on the watch → disable it → keep the phone's BT off and observe the advertising interval never drops to the slow term.

(Found while debugging a fork that gates advertising on the connection state, where the stale flag escalated from "aging pauses" to "never advertises again until reboot".)

## Fix

Initialize `s_is_connected = false` in `gap_le_advert_init()`; a fresh stack has no slave connection by definition.

The test suite's `initialize()` was already carrying a workaround for this exact leak-across-init — this PR drops the workaround and adds a regression test that restarts the stack while connected and asserts a job scheduled on the fresh stack still ages and completes on schedule.

## Testing

- `test_gap_le_advert` suite passes with the fix; the new `stack_restart_while_connected_resets_state` case fails without the one-line fix.
- Field-tested the stack-restart scenario on a Time 2 (obelix@pvt): airplane-mode toggle while connected, phone reconnects normally afterwards.
