### PR TITLE
fw/apps/system/notifications: increase list density on large round displays

### DIFF
--- a/src/fw/apps/system/notifications.c
+++ b/src/fw/apps/system/notifications.c
@@ -514,6 +514,10 @@ static int16_t prv_get_cell_height(struct MenuLayer *menu_layer, MenuIndex *cell
   if (is_selected) {
     return MENU_CELL_ROUND_FOCUSED_TALL_CELL_HEIGHT;
   }
+#if PBL_DISPLAY_HEIGHT >= 200
+  // Larger round displays fit two unfocused rows on each side of the focused row
+  return ((DISP_ROWS - STATUS_BAR_LAYER_HEIGHT * 2) - MENU_CELL_ROUND_FOCUSED_TALL_CELL_HEIGHT) / 4;
+#endif
 #endif
   const PreferredContentSize runtime_platform_content_size =
       system_theme_get_default_content_size_for_runtime_platform();


### PR DESCRIPTION
## Summary

On getafix the notification list fit only 3 rows: one 61 px unfocused neighbor, the 84 px focused entry, and one more neighbor — unfocused rows used the Large content-size basic cell height while showing just a single line of text.

Size unfocused rows on large round displays (`PBL_DISPLAY_HEIGHT >= 200`) to fit two on each side of the focused row (`(220 − 84) / 4 = 34 px`), so five entries are visible at once. Same approach as the settings menu / health density changes. Spalding-size round displays and rectangular platforms are unchanged.

Fixes MOB-10373

## Testing

- Built for `getafix@dvt2` and `qemu_gabbro`.
- Verified in QEMU gabbro with injected test notifications (`notif test`): before 3 rows visible, after 5 rows — even spacing, no clipping at the circle edge, focused entry layout unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)