### PR TITLE
Adds a new "Hibernate" quick-launch toggle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,8 @@
 	url = https://github.com/MersenneTwister-Lab/TinyMT
 [submodule "third_party/hal_sifli/SiFli-SDK"]
 	path = third_party/hal_sifli/SiFli-SDK
-	url = https://github.com/coredevices/SiFli-SDK.git
+	url = https://github.com/caco3/SiFli-SDK.git
+	branch = hibernate-vbat-ldo
 [submodule "third_party/memfault/memfault-firmware-sdk"]
 	path = third_party/memfault/memfault-firmware-sdk
 	url = https://github.com/memfault/memfault-firmware-sdk.git

--- a/resources/normal/base/lang/ca_ES/tintin.po
+++ b/resources/normal/base/lang/ca_ES/tintin.po
@@ -3500,6 +3500,12 @@ msgstr "Martell pneumàtic"
 msgid "Gentle"
 msgstr "Suau"
 
+
+msgid "Hibernate"
+msgstr ""
+
+msgid "Do you want to hibernate?"
+msgstr ""
 #~ msgid "Default"
 #~ msgstr "Per defecte"
 

--- a/resources/normal/base/lang/de_DE/tintin.po
+++ b/resources/normal/base/lang/de_DE/tintin.po
@@ -3459,6 +3459,12 @@ msgstr "Presslufthammer"
 msgid "Gentle"
 msgstr "Sanft"
 
+
+msgid "Hibernate"
+msgstr ""
+
+msgid "Do you want to hibernate?"
+msgstr ""
 #~ msgid "Default"
 #~ msgstr "Standard"
 

--- a/resources/normal/base/lang/en_TW/tintin.po
+++ b/resources/normal/base/lang/en_TW/tintin.po
@@ -3496,6 +3496,12 @@ msgstr "Jackhammer"
 msgid "Gentle"
 msgstr "Gentle"
 
+
+msgid "Hibernate"
+msgstr ""
+
+msgid "Do you want to hibernate?"
+msgstr ""
 #~ msgid "Default"
 #~ msgstr "Default"
 

--- a/resources/normal/base/lang/es_ES/tintin.po
+++ b/resources/normal/base/lang/es_ES/tintin.po
@@ -3496,6 +3496,12 @@ msgstr "Martillo neumático"
 msgid "Gentle"
 msgstr "Suave"
 
+
+msgid "Hibernate"
+msgstr ""
+
+msgid "Do you want to hibernate?"
+msgstr ""
 #~ msgid "Default"
 #~ msgstr "Normal"
 

--- a/resources/normal/base/lang/fr_FR/tintin.po
+++ b/resources/normal/base/lang/fr_FR/tintin.po
@@ -3506,6 +3506,12 @@ msgstr "Marteau piqueur"
 msgid "Gentle"
 msgstr "Doux"
 
+
+msgid "Hibernate"
+msgstr ""
+
+msgid "Do you want to hibernate?"
+msgstr ""
 #~ msgid "Default"
 #~ msgstr "Normal"
 

--- a/resources/normal/base/lang/it_IT/tintin.po
+++ b/resources/normal/base/lang/it_IT/tintin.po
@@ -3425,6 +3425,12 @@ msgstr "Martellante"
 msgid "Gentle"
 msgstr "Delicato"
 
+
+msgid "Hibernate"
+msgstr ""
+
+msgid "Do you want to hibernate?"
+msgstr ""
 #~ msgid "Default"
 #~ msgstr "Default"
 

--- a/resources/normal/base/lang/ja_JP/tintin.po
+++ b/resources/normal/base/lang/ja_JP/tintin.po
@@ -3473,6 +3473,12 @@ msgstr "削岩機"
 msgid "Gentle"
 msgstr "おだやか"
 
+
+msgid "Hibernate"
+msgstr ""
+
+msgid "Do you want to hibernate?"
+msgstr ""
 #~ msgid "Scaled"
 #~ msgstr "拡大"
 

--- a/resources/normal/base/lang/nl_NL/tintin.po
+++ b/resources/normal/base/lang/nl_NL/tintin.po
@@ -3495,6 +3495,12 @@ msgstr "Jackhammer"
 msgid "Gentle"
 msgstr "Gentle"
 
+
+msgid "Hibernate"
+msgstr ""
+
+msgid "Do you want to hibernate?"
+msgstr ""
 #~ msgid "Default"
 #~ msgstr "Default"
 

--- a/resources/normal/base/lang/pl_PL/tintin.po
+++ b/resources/normal/base/lang/pl_PL/tintin.po
@@ -3495,6 +3495,12 @@ msgstr "Młot pneumatyczny"
 msgid "Gentle"
 msgstr "Delikatny"
 
+
+msgid "Hibernate"
+msgstr ""
+
+msgid "Do you want to hibernate?"
+msgstr ""
 #~ msgid "Default"
 #~ msgstr "Domyślna"
 

--- a/resources/normal/base/lang/pt_PT/tintin.po
+++ b/resources/normal/base/lang/pt_PT/tintin.po
@@ -3498,6 +3498,12 @@ msgstr "Britadeira"
 msgid "Gentle"
 msgstr "Suave"
 
+
+msgid "Hibernate"
+msgstr ""
+
+msgid "Do you want to hibernate?"
+msgstr ""
 #~ msgid "Default"
 #~ msgstr "Padrão"
 

--- a/resources/normal/base/lang/ru_RU/tintin.po
+++ b/resources/normal/base/lang/ru_RU/tintin.po
@@ -3496,6 +3496,12 @@ msgstr "Jackhammer"
 msgid "Gentle"
 msgstr "Gentle"
 
+
+msgid "Hibernate"
+msgstr ""
+
+msgid "Do you want to hibernate?"
+msgstr ""
 #~ msgid "Default"
 #~ msgstr "Default"
 

--- a/resources/normal/base/lang/uk-UA/tintin.po
+++ b/resources/normal/base/lang/uk-UA/tintin.po
@@ -3495,6 +3495,12 @@ msgstr "Відбійний молот"
 msgid "Gentle"
 msgstr "Ніжно"
 
+
+msgid "Hibernate"
+msgstr ""
+
+msgid "Do you want to hibernate?"
+msgstr ""
 #~ msgid "Default"
 #~ msgstr "За замовчуванням"
 

--- a/resources/normal/base/lang/zh_CN/tintin.po
+++ b/resources/normal/base/lang/zh_CN/tintin.po
@@ -3455,6 +3455,12 @@ msgstr "钻孔机"
 msgid "Gentle"
 msgstr "Gentle"
 
+
+msgid "Hibernate"
+msgstr ""
+
+msgid "Do you want to hibernate?"
+msgstr ""
 #~ msgid "Default"
 #~ msgstr "Default"
 

--- a/src/fw/Kconfig
+++ b/src/fw/Kconfig
@@ -55,6 +55,15 @@ config MMAP_RESOURCES
       Serve read-only system resources as direct pointers into
       memory-mapped flash instead of copying them out.
 
+config HIBERNATE
+    bool "Hibernate"
+    default y
+    depends on SOC_SF32LB52
+    help
+      Add a hibernate quick-launch toggle and settings menu item that
+      puts the watch into an RTC-preserving low-power state. Only
+      supported on SF32LB52-based watches.
+
 endmenu
 
 choice

--- a/src/fw/apps/system/settings/system.c
+++ b/src/fw/apps/system/settings/system.c
@@ -150,6 +150,9 @@ typedef enum {
   SystemMenuItemStationaryToggle,
   SystemMenuItemDebugging,
   SystemMenuItemShutDown,
+#ifdef CONFIG_HIBERNATE
+  SystemMenuItemHibernate,
+#endif
   SystemMenuItemFactoryReset,
   SystemMenuItem_Count,
 } SystemMenuItem;
@@ -160,6 +163,9 @@ static const char *s_item_titles[SystemMenuItem_Count] = {
   [SystemMenuItemStationaryToggle] = i18n_noop("Stand-By Mode"),
   [SystemMenuItemDebugging]     = i18n_noop("Debugging"),
   [SystemMenuItemShutDown]      = i18n_noop("Shut Down"),
+#ifdef CONFIG_HIBERNATE
+  [SystemMenuItemHibernate]     = i18n_noop("Hibernate"),
+#endif
   [SystemMenuItemFactoryReset]  = i18n_noop("Factory Reset"),
 };
 
@@ -1270,6 +1276,22 @@ static void prv_shutdown_click_provider(void *context) {
   window_single_click_subscribe(BUTTON_ID_BACK, prv_shutdown_back_cb);
 }
 
+#ifdef CONFIG_HIBERNATE
+static void prv_hibernate_confirm_cb(ClickRecognizerRef recognizer, void *context) {
+  actionable_dialog_pop((ActionableDialog *) context);
+  battery_ui_handle_mcu_shutdown();
+}
+
+static void prv_hibernate_back_cb(ClickRecognizerRef recognizer, void *context) {
+  actionable_dialog_pop((ActionableDialog *) context);
+}
+
+static void prv_hibernate_click_provider(void *context) {
+  window_single_click_subscribe(BUTTON_ID_SELECT, prv_hibernate_confirm_cb);
+  window_single_click_subscribe(BUTTON_ID_BACK, prv_hibernate_back_cb);
+}
+#endif
+
 static void prv_shutdown_cb(void* data) {
   ActionableDialog *a_dialog = actionable_dialog_create("Shutdown");
   Dialog *dialog = actionable_dialog_get_dialog(a_dialog);
@@ -1287,6 +1309,25 @@ static void prv_shutdown_cb(void* data) {
   actionable_dialog_push(a_dialog, modal_manager_get_window_stack(ModalPriorityGeneric));
 }
 
+#ifdef CONFIG_HIBERNATE
+static void prv_hibernate_cb(void* data) {
+  ActionableDialog *a_dialog = actionable_dialog_create("Hibernate");
+  Dialog *dialog = actionable_dialog_get_dialog(a_dialog);
+
+  actionable_dialog_set_action_bar_type(a_dialog, DialogActionBarConfirm, NULL);
+  actionable_dialog_set_click_config_provider(a_dialog, prv_hibernate_click_provider);
+
+  dialog_set_text_color(dialog, GColorWhite);
+  dialog_set_background_color(dialog, GColorCobaltBlue);
+  dialog_set_text(dialog, i18n_get("Do you want to hibernate?", a_dialog));
+  dialog_set_icon(dialog, RESOURCE_ID_GENERIC_QUESTION_LARGE);
+
+  i18n_free_all(a_dialog);
+
+  actionable_dialog_push(a_dialog, modal_manager_get_window_stack(ModalPriorityGeneric));
+}
+#endif
+
 static void prv_deinit_cb(SettingsCallbacks *context) {
   SettingsSystemData *data = (SettingsSystemData *) context;
   i18n_free_all(data);
@@ -1302,6 +1343,9 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
       subtitle = stationary_get_enabled() ? i18n_get("On", data) : i18n_get("Off", data);
       break;
     case SystemMenuItemShutDown:
+#ifdef CONFIG_HIBERNATE
+    case SystemMenuItemHibernate:
+#endif
     case SystemMenuItemInformation:
     case SystemMenuItemCertification:
     case SystemMenuItemDebugging:
@@ -1334,6 +1378,11 @@ static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
     case SystemMenuItemShutDown:
       launcher_task_add_callback(prv_shutdown_cb, 0);
       break;
+#ifdef CONFIG_HIBERNATE
+    case SystemMenuItemHibernate:
+      launcher_task_add_callback(prv_hibernate_cb, 0);
+      break;
+#endif
     case SystemMenuItemDebugging:
       prv_debugging_interstitial_trigger(data);
       break;

--- a/src/fw/apps/system/toggle/hibernate.c
+++ b/src/fw/apps/system/toggle/hibernate.c
@@ -1,0 +1,67 @@
+/* SPDX-FileCopyrightText: 2025 The PebbleOS Contributors */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "hibernate.h"
+
+#include "applib/app.h"
+#include "applib/ui/dialogs/actionable_dialog.h"
+#include "applib/ui/dialogs/dialog.h"
+#include "kernel/event_loop.h"
+
+#ifdef CONFIG_HIBERNATE
+
+#include "process_management/app_manager.h"
+#include "pbl/services/i18n/i18n.h"
+#include "resource/resource_ids.auto.h"
+#include "shell/normal/battery_ui.h"
+
+static void prv_do_shutdown(void *data) {
+  battery_ui_handle_mcu_shutdown();
+}
+
+static void prv_shutdown_confirm_cb(ClickRecognizerRef recognizer, void *context) {
+  actionable_dialog_pop((ActionableDialog *)context);
+  launcher_task_add_callback(prv_do_shutdown, NULL);
+}
+
+static void prv_shutdown_back_cb(ClickRecognizerRef recognizer, void *context) {
+  actionable_dialog_pop((ActionableDialog *)context);
+}
+
+static void prv_shutdown_click_provider(void *context) {
+  window_single_click_subscribe(BUTTON_ID_SELECT, prv_shutdown_confirm_cb);
+  window_single_click_subscribe(BUTTON_ID_BACK, prv_shutdown_back_cb);
+}
+
+static void prv_main(void) {
+  ActionableDialog *a_dialog = actionable_dialog_create("Hibernate");
+  Dialog *dialog = actionable_dialog_get_dialog(a_dialog);
+
+  actionable_dialog_set_action_bar_type(a_dialog, DialogActionBarConfirm, NULL);
+  actionable_dialog_set_click_config_provider(a_dialog, prv_shutdown_click_provider);
+
+  dialog_set_text_color(dialog, GColorWhite);
+  dialog_set_background_color(dialog, GColorCobaltBlue);
+  /// Confirmation message shown in the Hibernate Quick Launch dialog.
+  dialog_set_text(dialog, i18n_get("Do you want to hibernate?", a_dialog));
+  dialog_set_icon(dialog, RESOURCE_ID_GENERIC_QUESTION_LARGE);
+
+  i18n_free_all(a_dialog);
+
+  app_actionable_dialog_push(a_dialog);
+  app_event_loop();
+}
+
+const PebbleProcessMd *hibernate_toggle_get_app_info(void) {
+  static const PebbleProcessMdSystem s_app_info = {
+    .common = {
+      .main_func = &prv_main,
+      .uuid = HIBERNATE_TOGGLE_UUID,
+      .visibility = ProcessVisibilityQuickLaunch,
+    },
+    /// Name of the Hibernate Quick Launch option shown in Quick Launch settings.
+    .name = i18n_noop("Hibernate"),
+  };
+  return &s_app_info.common;
+}
+#endif

--- a/src/fw/apps/system/toggle/hibernate.h
+++ b/src/fw/apps/system/toggle/hibernate.h
@@ -1,0 +1,13 @@
+/* SPDX-FileCopyrightText: 2025 The PebbleOS Contributors */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include "process_management/app_manager.h"
+
+#ifdef CONFIG_HIBERNATE
+#define HIBERNATE_TOGGLE_UUID {0x8b, 0x9a, 0x7c, 0x3e, 0x45, 0xd1, 0x4f, 0x89, \
+                                0xb2, 0x56, 0xee, 0xcc, 0xdd, 0xbb, 0xaa, 0x01}
+
+const PebbleProcessMd *hibernate_toggle_get_app_info(void);
+#endif

--- a/src/fw/kernel/util/standby.c
+++ b/src/fw/kernel/util/standby.c
@@ -5,6 +5,9 @@
 
 #include <pbl/drivers/display/display.h>
 #include <pbl/drivers/pmic.h>
+#ifdef CONFIG_HIBERNATE
+#include "bf0_hal_pmu.h"
+#endif
 #include "system/bootbits.h"
 #include <pbl/logging/logging.h>
 #include "system/reset.h"
@@ -37,3 +40,37 @@ NORETURN enter_standby(RebootReasonCode reason) {
 
   prv_enter_standby();
 }
+
+#ifdef CONFIG_HIBERNATE
+NORETURN enter_mcu_shutdown(RebootReasonCode reason) {
+  PBL_LOG_ALWAYS("Preparing to enter MCU shutdown.");
+
+  RebootReason reboot_reason = { reason, 0 };
+  reboot_reason_set(&reboot_reason);
+
+  display_clear();
+  display_set_enabled(false);
+
+  system_reset_prepare();
+  reboot_reason_set_restarted_safely();
+
+  // Hibernate keeps the RTC/backup domain powered, so the time is preserved.
+  // The watch wakes only from the back key (PA34) and cold-boots from there.
+
+  // Use the low-power 10 kHz clock for the wake counter: it draws less
+  // current and gives a big enough range for multi-second debounces.
+  HAL_PMU_LpCLockSelect(PMU_LPCLK_RC10);
+
+  // Disable all wakeup sources, then enable only the back key on wakeup pin 0.
+  hwp_pmuc->WER = 0;
+  // ~2 s debounce at 10 kHz (20000 cycles) to keep the hold time short while
+  // still ignoring brief accidental presses.
+  hwp_pmuc->WKUP_CNT = 0x00004E20;
+  HAL_PMU_SelectWakeupPin(0, 10);    // PA34 (OBELIX back key)
+  HAL_PMU_EnablePinWakeup(0, 1);     // low-level, active low
+
+  HAL_PMU_EnterHibernate();
+
+  PBL_CROAK("MCU shutdown returned unexpectedly.");
+}
+#endif

--- a/src/fw/kernel/util/standby.h
+++ b/src/fw/kernel/util/standby.h
@@ -12,3 +12,12 @@ NORETURN
 void
 #endif
 enter_standby(RebootReasonCode reason);
+
+#ifdef CONFIG_HIBERNATE
+#if !UNITTEST
+NORETURN
+#else
+void
+#endif
+enter_mcu_shutdown(RebootReasonCode reason);
+#endif

--- a/src/fw/shell/normal/battery_ui.h
+++ b/src/fw/shell/normal/battery_ui.h
@@ -22,6 +22,14 @@ void battery_ui_handle_state_change_event(PreciseBatteryChargeState new_state);
 //! entered once the watch is unplugged.
 void battery_ui_handle_shut_down(void);
 
+//! Shut down the watch using MCU hibernate instead of PMIC ship mode.
+//!
+//! This preserves the RTC and any backup state; the device wakes on button
+//! press and cold-boots normally.
+#ifdef CONFIG_HIBERNATE
+void battery_ui_handle_mcu_shutdown(void);
+#endif
+
 //! Show the 'battery charging' modal dialog
 void battery_ui_display_plugged(void);
 

--- a/src/fw/shell/normal/battery_ui_fsm.c
+++ b/src/fw/shell/normal/battery_ui_fsm.c
@@ -267,6 +267,14 @@ void battery_ui_handle_shut_down(void) {
   }
 }
 
+#ifdef CONFIG_HIBERNATE
+void battery_ui_handle_mcu_shutdown(void) {
+  // Hibernate the MCU while keeping the RTC/backup domain alive so the
+  // clock is preserved. The watch wakes on button press and cold-boots.
+  enter_mcu_shutdown(RebootReasonCode_ShutdownMenuItem);
+}
+#endif
+
 void battery_ui_reset_fsm_for_tests(void) {
   s_state = BatteryGood;
   s_warning_points_index = -1;

--- a/src/fw/shell/normal/system_app_registry_list.json
+++ b/src/fw/shell/normal/system_app_registry_list.json
@@ -660,6 +660,12 @@
       "md_fn": "airplane_mode_toggle_get_app_info"
     },
     {
+      "id": -101,
+      "enum": "HIBERNATE_TOGGLE",
+      "md_fn": "hibernate_toggle_get_app_info",
+      "ifdefs": ["CONFIG_HIBERNATE"]
+    },
+    {
       "id": -97,
       "enum": "SPORTS",
       "md_fn": "sports_app_get_info"

--- a/tests/fw/shell/normal/test_battery_ui_fsm.c
+++ b/tests/fw/shell/normal/test_battery_ui_fsm.c
@@ -57,6 +57,12 @@ void enter_standby(RebootReasonCode reason) {
   s_entered_standby = true;
 }
 
+#ifdef CONFIG_HIBERNATE
+void enter_mcu_shutdown(RebootReasonCode reason) {
+  // no-op stub; hibernate shutdown is tested separately.
+}
+#endif
+
 bool do_not_disturb_is_active(void) {
   return s_dnd_on;
 }


### PR DESCRIPTION
Adds a new "Hibernate" quick-launch toggle and a matching entry in the system settings menu. When confirmed, the watch enters an RTC-preserving MCU hibernate instead of a full power-off (shipping mode).

## Notes
- This feature only works for the new SF32LB52 SoC driven watches (PT2, PR2). Other watches will not show this new functionality/entries.
- This is a re-implementation of https://github.com/coredevices/PebbleOS/pull/1290 which was closed without an explanation
- Implements https://github.com/coredevices/PebbleOS/issues/1211

## Behaviour
- A "Hibernate" quick-launch app can be launched from the Quick Launch  settings.
- Selecting it shows a confirmation dialog: "Do you want to hibernate?".
- Pressing SELECT hibernates the MCU; pressing BACK cancels.
- A "Hibernate" option is also added to the system settings menu, underneath the "Shutdown" entry.

## Wake-up
- Hibernate keeps the RTC / backup domain powered, so the clock is  preserved.
- The wake source is the back key (PA34) only.
- A ~2 s key press is configured to avoid accidental wake-ups.
- When the back key is pressed the device cold-boots and resumes.

## Impact
- Normal shutdown through `enter_standby()` is unchanged; `enter_mcu_shutdown()` is used only for the new hibernate path.

## TODO 
- [ ] first merge https://github.com/coredevices/SiFli-SDK/pull/7, then update the submodule reference
- [ ] CHange the SiFli-SDK submodule back to pebbleos
- [ ] The function namings (`enter_standby()` vs. `enter_mcu_shutdown()`) are rater confusing. Should we rename them?