### PR TITLE
nimble: pre-generate SC keypair after host sync

### DIFF
--- a/src/bluetooth-fw/nimble/init.c
+++ b/src/bluetooth-fw/nimble/init.c
@@ -8,6 +8,7 @@
 #include <comm/bt_lock.h>
 #include <host/ble_hs.h>
 #include <host/ble_hs_stop.h>
+#include <host/ble_sm.h>
 #include <host/util/util.h>
 #include <kernel/pebble_tasks.h>
 #include <nimble/nimble_port.h>
@@ -52,10 +53,26 @@ typedef enum {
 // with the vendor's ble_hs_enabled_state (Stopped<->OFF, Started<->ON).
 static DriverState s_driver_state = DriverStateStopped;
 
+// Pre-generate the SC ECDH keypair, which NimBLE otherwise creates lazily on
+// the first pairing after boot, deep in the L2CAP RX path on this task's small
+// stack. Generating it here keeps the expensive mbedtls P-256 computation off
+// the pairing hot path. The OOB output is a side product and is discarded.
+static void prv_pregenerate_sc_keys(void) {
+  struct ble_sm_sc_oob_data oob_data;
+
+  int rc = ble_sm_sc_oob_generate_data(&oob_data);
+  if (rc != 0) {
+    PBL_LOG_WRN("SC key pre-generation failed (0x%04x)", (uint16_t)rc);
+  } else {
+    PBL_LOG_DBG("SC keypair ready");
+  }
+}
+
 static void prv_sync_cb(void) {
   PBL_LOG_DBG("NimBLE host synchronized");
   xSemaphoreGive(s_host_started);
   bt_driver_handle_host_resynced();
+  prv_pregenerate_sc_keys();
 }
 
 static void prv_reset_cb(int reason) {


### PR DESCRIPTION
NimBLE generates the LE Secure Connections ECDH keypair lazily on the first pairing after boot, inside ble_sm_sc_public_key_rx() at the bottom of the L2CAP RX path. The mbedtls P-256 computation is deep and allocation-heavy, and running it on top of the RX call chain overflows the 5000-byte NimbleHost stack, corrupting the kernel heap and wedging the task in the allocator until the task watchdog reboots the watch. Seen during QA re-pairing on asterix, where repeated crashes within the boot-stable window dropped the watch into PRF.

Pre-generate the keypair right after the host syncs, using the public ble_sm_sc_oob_generate_data() helper, so pairing never runs the expensive keygen inline on the RX path. The discarded OOB rand/confirm output is a cheap side product (one HCI rand plus an AES-CMAC f4). Generation happens after the host-started semaphore is given so bt_driver_start() is not delayed.

Fixes FIRM-3726