### PR TITLE
sdk: honour the platform's MAX_APP_BINARY_SIZE when injecting metadata

### DIFF
--- a/sdk/tools/inject_metadata.py
+++ b/sdk/tools/inject_metadata.py
@@ -46,10 +46,15 @@ PROCESS_INFO_VISIBILITY_SHOWN_ON_COMMUNICATION = 1 << 2
 PROCESS_INFO_ALLOW_JS = 1 << 3
 PROCESS_INFO_HAS_WORKER = 1 << 4
 
-# Max app size, including the struct and reloc table
+# Max app size, including the struct and reloc table. Fallback for callers that pass no limit; the
+# build passes the platform's MAX_APP_BINARY_SIZE from tools/pebble_sdk_platform.py.
 # Note that even if the app is smaller than this, it still may be too big, as it needs to share this
 # space with applib/ which changes in size from release to release.
 MAX_APP_BINARY_SIZE = 0x10000
+
+# PebbleProcessInfo.load_size and .virtual_size are uint16_t, so neither can exceed this whatever
+# the platform allows for the total. Only the reloc table, stored past load_size, can use the rest.
+MAX_PROCESS_INFO_SIZE_FIELD = 0xFFFF
 
 # This number is a rough estimate, but should not be less than the available space.
 # Currently, app_state uses up a small part of the app space.
@@ -77,7 +82,10 @@ def inject_metadata(
     timestamp,
     allow_js=False,
     has_worker=False,
+    max_binary_size=None,
 ):
+    if max_binary_size is None:
+        max_binary_size = MAX_APP_BINARY_SIZE
 
     if target_binary[-4:] != ".bin":
         raise Exception(
@@ -245,7 +253,7 @@ def inject_metadata(
 
     with open(target_binary, "r+b") as f:
         total_app_image_size = app_load_size + (len(reloc_entries) * 4)
-        if total_app_image_size > MAX_APP_BINARY_SIZE:
+        if total_app_image_size > max_binary_size:
             raise Exception(
                 "App image size is %u (app %u relocation table %u). Must be smaller "
                 "than %u bytes"
@@ -253,8 +261,17 @@ def inject_metadata(
                     total_app_image_size,
                     app_load_size,
                     len(reloc_entries) * 4,
-                    MAX_APP_BINARY_SIZE,
+                    max_binary_size,
                 )
+            )
+
+        # Checked here so the pack() below cannot raise a bare struct.error.
+        if app_load_size > MAX_PROCESS_INFO_SIZE_FIELD:
+            raise Exception(
+                "App load size is %u bytes. The loaded image must be %u bytes or smaller, "
+                "because PebbleProcessInfo.load_size is a uint16_t. The relocation table is "
+                "stored past the loaded image and does not count towards this."
+                % (app_load_size, MAX_PROCESS_INFO_SIZE_FIELD)
             )
 
         def read_value_at_offset(offset, format_str, size):
@@ -273,6 +290,14 @@ def inject_metadata(
             app_flags = app_flags | PROCESS_INFO_HAS_WORKER
 
         app_virtual_size = get_virtual_size(target_elf)
+
+        # Same uint16_t ceiling as load_size, on the .text + .data + .bss total this time.
+        if app_virtual_size > MAX_PROCESS_INFO_SIZE_FIELD:
+            raise Exception(
+                "App virtual size is %u bytes (.text + .data + .bss). Must be %u bytes or "
+                "smaller, because PebbleProcessInfo.virtual_size is a uint16_t."
+                % (app_virtual_size, MAX_PROCESS_INFO_SIZE_FIELD)
+            )
 
         struct_changes = {
             "load_size": app_load_size,

--- a/sdk/waftools/process_elf.py
+++ b/sdk/waftools/process_elf.py
@@ -39,5 +39,7 @@ def generate_bin_file(task_gen, bin_type, elf_file, has_pkjs, has_worker):
         timestamp=task_gen.bld.env.TIMESTAMP,
         has_pkjs=has_pkjs,
         has_worker=has_worker,
+        # Read now: bld.env is only this platform's ConfigSet during the caller's loop.
+        max_binary_size=task_gen.bld.env.PLATFORM["MAX_APP_BINARY_SIZE"],
     )
     return bin_file

--- a/tools/waf/pebble_sdk_gcc.py
+++ b/tools/waf/pebble_sdk_gcc.py
@@ -137,6 +137,7 @@ def gen_inject_metadata_rule(
     timestamp,
     has_pkjs,
     has_worker,
+    max_binary_size=None,
 ):
     """
     Copy from src_bin_file to dst_bin_file and inject the correct meta-data into the
@@ -149,6 +150,7 @@ def gen_inject_metadata_rule(
     :param timestamp: the timestamp of the project build
     :param has_pkjs: boolean for whether the project contains code using PebbleKit JS
     :param has_worker: boolean for whether the project has a worker binary
+    :param max_binary_size: the platform's maximum app image size, or None for the default
     """
 
     def inject_data_rule(task):
@@ -175,6 +177,7 @@ def gen_inject_metadata_rule(
             timestamp,
             allow_js=has_pkjs,
             has_worker=has_worker,
+            max_binary_size=max_binary_size,
         )
 
     sources = [src_bin_file, elf_file]


### PR DESCRIPTION
## Summary

`tools/pebble_sdk_platform.py` gives emery and gabbro a `MAX_APP_BINARY_SIZE` of `0x20000`, but `sdk/tools/inject_metadata.py` carried its own module-scope `MAX_APP_BINARY_SIZE = 0x10000` and nothing ever passed the platform's value in. `inject_metadata()` took no platform argument and its caller supplied none, so every platform was held to 64 KB regardless of what its config declared. An emery or gabbro app past that failed with `App image size is N (app N relocation table N). Must be smaller than 65536 bytes`, while the memory report printed a few lines earlier in the same build said `128.0KB` — `sdk/waftools/report_memory_usage.py` does read `env.PLATFORM`, so the two halves of the build disagreed with each other.

This threads the platform's limit through `generate_bin_file` -> `gen_inject_metadata_rule` -> `inject_metadata`, defaulting to the old constant so callers that pass nothing are unaffected. The value is read in `generate_bin_file` rather than inside the rule closure: `bld.env` only holds the platform's ConfigSet while `process_bundle.py`'s per-platform loop is running, and the rule does not run until later. This matches the two pre-existing eager reads in the same function (`BUILD_DIR`, `TIMESTAMP`).

Raising the total exposes a second ceiling that was previously unreachable. `PebbleProcessInfo.load_size` and `.virtual_size` are `uint16_t`, so neither can exceed 65535 however large the platform's total allows — only the relocation table, stored past `load_size`, can use the space above 64 KB. Both fields are now range-checked with a message naming the limit that was hit. This also covers a latent case in the old code: the check was `total > MAX_APP_BINARY_SIZE`, so a total of exactly 65536 passed and then died in `pack("<H", ...)` with a bare `struct.error` and no indication of the cause.

Scope notes:

- This does not give emery/gabbro 128 KB of application memory, and is not intended to. `virtual_size` still caps static footprint at 65535 on every platform; widening that would need a `PROCESS_INFO_CURRENT_STRUCT_VERSION` bump and matching changes in the mobile bundle parsers. The space this opens up is usable only by an oversized relocation table.
- `apps/stored/wscript_build` also calls `gen_inject_metadata_rule` without a `max_binary_size` and so keeps the 64 KB default. Left alone deliberately — it is the firmware build rather than the SDK, and stored apps are far below either limit. Happy to follow up if you would prefer it consistent.
- `src/fw/services/process_management/app_storage.c`'s `APP_MAX_SIZE = 0x10000` is checked against `virtual_size`, which is `uint16_t` and so can never reach `0x10000`. The check is unreachable either way and is untouched here.

No new API surface, so the `docs/development/sdk_export.md` process does not apply. `sdk/wscript_build` already bundles all three modified files, so no export list needed updating.

## Testing

- A 15700-entry pointer array builds on emery and gabbro to a 126932 byte image (`load_size` 64132, 15700 relocation entries, 96.8% of the 128 KB ceiling). It installs in the emery emulator and reports all 15700 pointers correctly relocated at runtime, confirming the firmware loads a relocation table this far past 64 KB. The same app fails on an unpatched SDK at 65536.
- Older platforms are unchanged. Building the same project against the stock and patched SDK produces byte-identical app *and* worker binaries for aplite, basalt, chalk, diorite, emery, flint and gabbro — 28 binaries, once the per-build `resource_timestamp` is masked.
- basalt, chalk, diorite and flint still reject an oversized image at exactly 65536. aplite still fails earlier at link time on its 24 KB `APP` region, unchanged.
- The new `virtual_size` guard was exercised in passing: an intermediate build hit 66060 bytes and reported the field and its limit, where the unpatched SDK raised `struct.error`.
- `ruff format --check` clean on all three files; `gitlint` clean against the repo's `.gitlint`.
