### PR TITLE
applib/ui/layer: invalidate gesture latch on subtree removal

### DIFF
--- a/src/fw/applib/ui/layer.c
+++ b/src/fw/applib/ui/layer.c
@@ -373,6 +373,13 @@ void layer_remove_from_parent(Layer *child) {
   if (!child || child->parent == NULL) {
     return;
   }
+#ifdef CONFIG_TOUCH
+  // Must run while child->window is still set (cleared below). A subtree that leaves the
+  // tree mid-gesture must drop the recognizer manager's active-layer latch: the layers may
+  // be freed right after removal without a layer_deinit (e.g. the swap-layer layout path),
+  // leaving the latch dangling.
+  prv_invalidate_manager_active_layer(child);
+#endif
   if (child->parent->window) {
     window_schedule_render(child->parent->window);
   }

--- a/src/fw/services/timeline/notification_layout.c
+++ b/src/fw/services/timeline/notification_layout.c
@@ -617,6 +617,10 @@ static void prv_layout_destroy(LayoutLayer *layout) {
   NotificationLayout *notification_layout = (NotificationLayout *)layout;
   prv_destroy_view(notification_layout);
   kino_layer_deinit(&notification_layout->icon_layer);
+  // Every other layout deinits its base layer before freeing (see timeline_layout_deinit);
+  // skipping it leaks attached recognizers and frees a layer the touch system may still
+  // reference.
+  layer_deinit(&notification_layout->layout.layer);
   task_free(notification_layout);
 }
 

--- a/tests/stubs/stubs_layer.h
+++ b/tests/stubs/stubs_layer.h
@@ -11,6 +11,8 @@
 
 WEAK void layer_init(Layer *layer, const GRect *frame) { }
 
+WEAK void layer_deinit(Layer *layer) { }
+
 WEAK void layer_add_child(Layer *parent, Layer *child) { }
 
 WEAK void layer_mark_dirty(Layer *layer) { }


### PR DESCRIPTION
The touch recognizer manager latches the touched layer for the whole gesture and walks its parent chain on every touch event and on every layer_deinit. The deinit-time invalidation hook only runs while layer->window is still set, but layer_remove_from_parent clears the window recursively, so any remove-then-free teardown leaves the latch dangling with no hook ever firing.

The notification window hits exactly this: swap_layer_reload_data (re-layout when a new notification arrives) removes the old LayoutLayers from the tree and then destroys them, while a pan gesture latched on the old layout's layer is in flight. The notification layout destructor also frees its base layer without layer_deinit. The next layer_deinit of any still-attached layer then walks the freed chain and hard-faults.

Confirmed against the FIRM-3724 coredump: HardFault on KernelMain in layer_deinit's active-layer walk (ldr r3,[r3,#24] with r3=0x190019, r0=&s_modal_recognizer_manager just returned by
window_get_recognizer_manager, LR=layer_deinit+14), with manager->active_layer pointing into freed, reused heap, during a wake-touch pan on the notification card as a second notification triggered the re-layout.

Invalidate the latch in layer_remove_from_parent while the window is still reachable, covering every remove-then-free pattern, and deinit the notification layout's base layer like every other layout does.

Fixes FIRM-3724