### PR TITLE
mbedtls: enable NIST optimized reduction for P-256

### DIFF
--- a/third_party/mbedtls/include/pebble_mbedtls_config.h
+++ b/third_party/mbedtls/include/pebble_mbedtls_config.h
@@ -31,7 +31,10 @@ void kernel_free(void *ptr);
 #define MBEDTLS_ECP_DP_SECP256R1_ENABLED
 #define MBEDTLS_ECDH_C
 
-/* Favor small flash/RAM footprint over ECC speed. */
+/* Favor small flash/RAM footprint over ECC speed, but keep the NIST fast
+ * reduction: the generic division-based path makes one P-256 point multiply
+ * slow enough to trip the task watchdog. */
+#define MBEDTLS_ECP_NIST_OPTIM
 #define MBEDTLS_ECP_WINDOW_SIZE 2
 #define MBEDTLS_ECP_FIXED_POINT_OPTIM 0
 


### PR DESCRIPTION
Without MBEDTLS_ECP_NIST_OPTIM, every P-256 field reduction goes through mbedtls_mpi_mod_mpi -> mbedtls_mpi_div_mpi, a heap-allocating multi-limb division. A single point multiply performs tens of thousands of such reductions, so the LE Secure Connections ECDH operations (lazy keygen on first pairing, and the DHKey computation on every SC pairing) run CPU-bound for over six seconds on the NimbleHost task.

NimbleHost runs at priority 3, above KernelBackground (priority 1). KernelBackground's watchdog bit is only fed on its behalf while it is idle with an empty queue, so whenever pairing coincides with queued system-task work the 6 s task watchdog window expires and the watch reboots: "Watchdog: Bits 0x81, Mask 0x83" with the stuck task parked in xQueueGenericReceive. The FIRM-3726 coredump caught the keygen mid-flight inside mbedtls_mpi_div_mpi with every other task idle.

The NIST fast reduction replaces the division with a few fixed-width additions (and removes the per-reduction heap churn), bringing P-256 operations down to well under the watchdog window on all NimBLE boards (asterix, obelix, getafix).

Fixes FIRM-3726