### PR TITLE
fw/drivers/i2c: don't call NULL XferISR in sf32lb IRQ handler

### DIFF
--- a/src/fw/drivers/i2c/sf32lb.c
+++ b/src/fw/drivers/i2c/sf32lb.c
@@ -38,6 +38,10 @@ void i2c_irq_handler(I2CBus *bus) {
   I2CTransferEvent event;
   portBASE_TYPE woken;
 
+  if (hdl->XferISR == NULL) {
+    return;
+  }
+
   (void)hdl->XferISR(hdl, 0, 0);
 
   state = HAL_I2C_GetState(hdl);


### PR DESCRIPTION
## Summary

Fixes the obelix red-flash boot loop reported in FIRM-3696 (dup: FIRM-3682).

The SiFli HAL clears `hdl->XferISR` in its completion and error cleanup paths (`I2C_ITMasterCplt`/`I2C_ITError`), but an IRQ re-latched during that cleanup can still invoke `i2c_irq_handler` afterwards. The handler called `hdl->XferISR` unconditionally, jumping to address 0 and taking a HardFault — on a bus with a flaky peripheral (e.g. the AW2016 backlight controller erroring on i2c1), every recoverable I2C error became a reboot loop.

This mirrors the NULL guard the SDK's own `HAL_I2C_EV_IRQHandler` uses, with an early return so a spurious IRQ can't inject a false transfer event. No SR write is needed: the HAL cleanup already disabled the interrupt sources (`IER = 0`).

Verified against the FIRM-3696 coredump: ISR crash at `sf32lb.c:41` with frame #8 at `0x00000000`, reboot-marker LR `0x1211982b` = return address after the `XferISR` call, launcher thread parked mid-AW2016-write. Affects all SF32LB boards (obelix and getafix wire every I2C bus IRQ to this handler).

Fixes FIRM-3696

## Test plan

- `sf32lb.c` compiles cleanly for obelix@pvt (final link of this workspace fails on a pre-existing, unrelated `g_gbitmap_data_row_infos` undefined reference, identical on unmodified main)
- Not reproduced on hardware — the race needs a flaky I2C peripheral; the affected unit is pending RMA

🤖 Generated with [Claude Code](https://claude.com/claude-code)