### PR TITLE
fw: close battery-triage telemetry blind spots (heartbeat record v3)

### DIFF
--- a/include/pbl/services/analytics/analytics.def
+++ b/include/pbl/services/analytics/analytics.def
@@ -142,3 +142,6 @@ PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(i2c_transfer_error_count)
 PBL_ANALYTICS_METRIC_DEFINE_TIMER(ble_conn_itvl_other_time_ms)
 // Bitmask of driver init failures this boot, see pbl_analytics_drv_init_fail_flag.
 PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(drv_init_fail_flags)
+// Lowest SOC observed since the previous heartbeat; hourly snapshots miss
+// brief deep discharges (brownout-depth dips).
+PBL_ANALYTICS_METRIC_DEFINE_SCALED_UNSIGNED(battery_soc_pct_min, 100)

--- a/include/pbl/services/analytics/analytics.def
+++ b/include/pbl/services/analytics/analytics.def
@@ -132,3 +132,13 @@ PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(accel_stream_recovery_count)
 // Counted once per boot, on the first heartbeat, when the previous reboot
 // reason is in the error family (RebootReasonCode_Watchdog and above).
 PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(unexpected_reboot_count)
+// Battery temperature (mC at the fuel gauge); 0 on platforms without a
+// temperature source.
+PBL_ANALYTICS_METRIC_DEFINE_SCALED_SIGNED(battery_temp_c, 1000)
+PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(i2c_transfer_error_count)
+// Connected time at an interval outside every entry of the desired-params
+// table (e.g. a central-imposed 7.5 ms interval); previously misbucketed
+// into ble_conn_itvl_max_time_ms.
+PBL_ANALYTICS_METRIC_DEFINE_TIMER(ble_conn_itvl_other_time_ms)
+// Bitmask of driver init failures this boot, see pbl_analytics_drv_init_fail_flag.
+PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(drv_init_fail_flags)

--- a/include/pbl/services/analytics/analytics.def
+++ b/include/pbl/services/analytics/analytics.def
@@ -128,3 +128,7 @@ PBL_ANALYTICS_METRIC_DEFINE_TIMER(connectivity_expected_time_ms)
 // one at latency 3 despite ~4x the radio duty; track latency-0 time directly.
 PBL_ANALYTICS_METRIC_DEFINE_TIMER(ble_conn_slave_lat0_time_ms)
 PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(ble_conn_param_update_count)
+PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(accel_stream_recovery_count)
+// Counted once per boot, on the first heartbeat, when the previous reboot
+// reason is in the error family (RebootReasonCode_Watchdog and above).
+PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(unexpected_reboot_count)

--- a/include/pbl/services/analytics/analytics.def
+++ b/include/pbl/services/analytics/analytics.def
@@ -122,3 +122,9 @@ PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(app_tick_timer_second_subscribed)
 // Connectivity
 PBL_ANALYTICS_METRIC_DEFINE_TIMER(connectivity_connected_time_ms)
 PBL_ANALYTICS_METRIC_DEFINE_TIMER(connectivity_expected_time_ms)
+
+// Appended in record version 3. The conn-interval time buckets classify by
+// interval only, so a link stuck at slave latency 0 is indistinguishable from
+// one at latency 3 despite ~4x the radio duty; track latency-0 time directly.
+PBL_ANALYTICS_METRIC_DEFINE_TIMER(ble_conn_slave_lat0_time_ms)
+PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(ble_conn_param_update_count)

--- a/include/pbl/services/analytics/analytics.h
+++ b/include/pbl/services/analytics/analytics.h
@@ -30,6 +30,12 @@ enum pbl_analytics_key {
   PBL_ANALYTICS_KEY_COUNT,
 };
 
+//! Bits for the drv_init_fail_flags metric. Only the first heartbeat after
+//! boot carries them.
+enum pbl_analytics_drv_init_fail_flag {
+  PBL_ANALYTICS_DRV_INIT_FAIL_HRM = 1U << 0U,
+};
+
 void pbl_analytics_init(void);
 
 void sys_pbl_analytics_set_signed(enum pbl_analytics_key key, int32_t signed_value);

--- a/src/fw/comm/ble/gap_le_connect_params.c
+++ b/src/fw/comm/ble/gap_le_connect_params.c
@@ -107,6 +107,7 @@ static void prv_analytics_stop_conn_interval_timers(void) {
   PBL_ANALYTICS_TIMER_STOP(ble_conn_itvl_min_time_ms);
   PBL_ANALYTICS_TIMER_STOP(ble_conn_itvl_mid_time_ms);
   PBL_ANALYTICS_TIMER_STOP(ble_conn_itvl_max_time_ms);
+  PBL_ANALYTICS_TIMER_STOP(ble_conn_slave_lat0_time_ms);
 }
 
 //! Classify the actual connection interval into a ResponseTimeState based on
@@ -124,7 +125,8 @@ static ResponseTimeState prv_classify_conn_interval(uint16_t conn_interval_1_25m
   return ResponseTimeMax;
 }
 
-static void prv_analytics_update_conn_interval(uint16_t conn_interval_1_25ms) {
+static void prv_analytics_update_conn_params(uint16_t conn_interval_1_25ms,
+                                             uint16_t slave_latency_events) {
   prv_analytics_stop_conn_interval_timers();
 
   switch (prv_classify_conn_interval(conn_interval_1_25ms)) {
@@ -139,6 +141,12 @@ static void prv_analytics_update_conn_interval(uint16_t conn_interval_1_25ms) {
       break;
     default:
       break;
+  }
+
+  // Interval buckets alone cannot distinguish a link that never got its slave
+  // latency applied (~Nx the connection-event duty at the same interval).
+  if (slave_latency_events == 0U) {
+    PBL_ANALYTICS_TIMER_START(ble_conn_slave_lat0_time_ms);
   }
 }
 
@@ -328,7 +336,8 @@ void bt_driver_handle_le_conn_params_update_event(const BleConnectionUpdateCompl
   const bool local_is_master = connection->local_is_master;
   if (!local_is_master) {
      bluetooth_analytics_handle_connection_params_update(params);
-     prv_analytics_update_conn_interval(params->conn_interval_1_25ms);
+     prv_analytics_update_conn_params(params->conn_interval_1_25ms, params->slave_latency_events);
+     PBL_ANALYTICS_ADD(ble_conn_param_update_count, 1);
   }
 
   prv_evaluate(connection, desired_state);

--- a/src/fw/comm/ble/gap_le_connect_params.c
+++ b/src/fw/comm/ble/gap_le_connect_params.c
@@ -107,6 +107,7 @@ static void prv_analytics_stop_conn_interval_timers(void) {
   PBL_ANALYTICS_TIMER_STOP(ble_conn_itvl_min_time_ms);
   PBL_ANALYTICS_TIMER_STOP(ble_conn_itvl_mid_time_ms);
   PBL_ANALYTICS_TIMER_STOP(ble_conn_itvl_max_time_ms);
+  PBL_ANALYTICS_TIMER_STOP(ble_conn_itvl_other_time_ms);
   PBL_ANALYTICS_TIMER_STOP(ble_conn_slave_lat0_time_ms);
 }
 
@@ -121,8 +122,8 @@ static ResponseTimeState prv_classify_conn_interval(uint16_t conn_interval_1_25m
       return (ResponseTimeState)state;
     }
   }
-  // Outside all known ranges, assume Max (slowest)
-  return ResponseTimeMax;
+  // Outside all known ranges (only used for analytics bucketing)
+  return ResponseTimeInvalid;
 }
 
 static void prv_analytics_update_conn_params(uint16_t conn_interval_1_25ms,
@@ -140,6 +141,7 @@ static void prv_analytics_update_conn_params(uint16_t conn_interval_1_25ms,
       PBL_ANALYTICS_TIMER_START(ble_conn_itvl_max_time_ms);
       break;
     default:
+      PBL_ANALYTICS_TIMER_START(ble_conn_itvl_other_time_ms);
       break;
   }
 

--- a/src/fw/drivers/hrm/gh3x2x.c
+++ b/src/fw/drivers/hrm/gh3x2x.c
@@ -6,6 +6,7 @@
 #include <pbl/drivers/hrm.h>
 #include "board/board.h"
 #include "kernel/util/sleep.h"
+#include "pbl/services/analytics/analytics.h"
 #include <pbl/logging/logging.h>
 
 #ifdef HRM_USE_GH3X2X
@@ -478,6 +479,7 @@ void hrm_init(HRMDevice *dev) {
   ret = Gh3x2xDemoInit();
   if (ret != 0) {
     PBL_LOG_ERR("GH3X2X failed to initialize");
+    PBL_ANALYTICS_ADD(drv_init_fail_flags, PBL_ANALYTICS_DRV_INIT_FAIL_HRM);
     return;
   }
 #else

--- a/src/fw/drivers/i2c/common.c
+++ b/src/fw/drivers/i2c/common.c
@@ -7,6 +7,7 @@
 
 #include "board/board.h"
 #include "debug/power_tracking.h"
+#include "pbl/services/analytics/analytics.h"
 #include <pbl/drivers/gpio.h>
 #include <pbl/drivers/rtc.h>
 #include "FreeRTOS.h"
@@ -242,6 +243,7 @@ static bool prv_do_transfer_locked(I2CBus *bus, I2CTransferDirection direction, 
           (bus->state->transfer_event == I2CTransferEvent_Error)) {
         if (bus->state->transfer_event == I2CTransferEvent_Error) {
           PBL_LOG_ERR("I2C Error on bus %s", bus->name);
+          PBL_ANALYTICS_ADD(i2c_transfer_error_count, 1);
         }
         complete = true;
         result = (bus->state->transfer_event == I2CTransferEvent_TransferComplete);
@@ -270,6 +272,7 @@ static bool prv_do_transfer_locked(I2CBus *bus, I2CTransferDirection direction, 
       i2c_hal_abort_transfer(bus);
       complete = true;
       PBL_LOG_ERR("Transfer timed out on bus %s", bus->name);
+      PBL_ANALYTICS_ADD(i2c_transfer_error_count, 1);
       break;
     }
   } while (!complete);

--- a/src/fw/drivers/imu/lis2dw12/lis2dw12.c
+++ b/src/fw/drivers/imu/lis2dw12/lis2dw12.c
@@ -7,6 +7,7 @@
 #include <pbl/drivers/i2c.h>
 #include <pbl/drivers/rtc.h>
 #include <pbl/drivers/gpio.h>
+#include "pbl/services/analytics/analytics.h"
 #include "pbl/services/imu/units.h"
 #include "pbl/services/regular_timer.h"
 #include <pbl/logging/logging.h>
@@ -509,6 +510,7 @@ static void prv_lis2dw12_recover(void) {
   uint8_t val;
 
   LIS2DW12->state->num_recoveries++;
+  PBL_ANALYTICS_ADD(accel_stream_recovery_count, 1);
   PBL_LOG_WRN("Recovering accel stream (count %" PRIu32 ")",
           LIS2DW12->state->num_recoveries);
 

--- a/src/fw/drivers/imu/lsm6dso/lsm6dso.c
+++ b/src/fw/drivers/imu/lsm6dso/lsm6dso.c
@@ -7,6 +7,7 @@
 #include <pbl/drivers/i2c.h>
 #include <pbl/drivers/rtc.h>
 #include <pbl/drivers/gpio.h>
+#include "pbl/services/analytics/analytics.h"
 #include "pbl/services/imu/units.h"
 #include "pbl/services/regular_timer.h"
 #include <pbl/logging/logging.h>
@@ -612,6 +613,7 @@ static void prv_lsm6dso_recover(void) {
   uint8_t val;
 
   LSM6DSO->state->num_recoveries++;
+  PBL_ANALYTICS_ADD(accel_stream_recovery_count, 1);
   PBL_LOG_WRN("Recovering accel stream (count %" PRIu32 ")",
           LSM6DSO->state->num_recoveries);
 

--- a/src/fw/services/analytics/analytics.c
+++ b/src/fw/services/analytics/analytics.c
@@ -74,9 +74,18 @@ static const struct pbl_analytics_backend_ops *s_backend_ops[] = {
 };
 
 static void prv_heartbeat_system_task_cb(void *data) {
+  static bool s_reboot_reason_counted = false;
+
   PBL_ANALYTICS_SET_STRING(fw_version, TINTIN_METADATA.version_tag);
   PBL_ANALYTICS_SET_UNSIGNED(last_reboot_reason, reboot_reason_get_last_reboot_reason());
   PBL_ANALYTICS_SET_UNSIGNED(uptime_s, time_get_uptime_seconds());
+
+  if (!s_reboot_reason_counted) {
+    s_reboot_reason_counted = true;
+    if (reboot_reason_get_last_reboot_reason() >= RebootReasonCode_Watchdog) {
+      PBL_ANALYTICS_ADD(unexpected_reboot_count, 1);
+    }
+  }
 
   pbl_analytics_external_collect_battery();
   pbl_analytics_external_collect_cpu_stats();

--- a/src/fw/services/analytics/native.c
+++ b/src/fw/services/analytics/native.c
@@ -19,7 +19,7 @@
 
 PBL_LOG_MODULE_DEFINE(service_analytics, CONFIG_SERVICE_ANALYTICS_LOG_LEVEL);
 
-#define NATIVE_HEARTBEAT_RECORD_VERSION 2
+#define NATIVE_HEARTBEAT_RECORD_VERSION 3
 
 /* Heartbeat record logged to DLS */
 struct PACKED native_heartbeat_record {

--- a/src/fw/services/battery/nrf_fuel_gauge/battery_state.c
+++ b/src/fw/services/battery/nrf_fuel_gauge/battery_state.c
@@ -70,8 +70,18 @@ static uint64_t prv_ref_time;
 static int32_t s_last_voltage_mv;
 static int32_t s_last_temp_mc;
 static uint32_t s_last_soc_cpct;
+static uint32_t s_soc_cpct_min = UINT32_MAX;
 static int32_t s_analytics_last_voltage_mv;
 static uint32_t s_analytics_last_cpct;
+
+//! Track the lowest SOC seen since the last heartbeat: hourly snapshots miss
+//! brief deep discharges, which matter when correlating battery behavior with
+//! brownout-cleared states.
+static void prv_track_soc_min(void) {
+  if (s_last_soc_cpct < s_soc_cpct_min) {
+    s_soc_cpct_min = s_last_soc_cpct;
+  }
+}
 static uint32_t s_last_tte;
 static uint32_t s_last_ttf;
 static RtcTicks s_last_log;
@@ -362,6 +372,7 @@ static void prv_update_state(void *force_update) {
 
   pct_int = (uint8_t)ceilf(pct);
   s_last_soc_cpct = (uint32_t)(pct * 100.0f);
+  prv_track_soc_min();
   if (pct_int != s_last_battery_charge_state.pct) {
     s_last_battery_charge_state.pct = pct_int;
     s_last_battery_charge_state.charge_percent = (uint32_t)(pct * RATIO32_MAX) / 100U;
@@ -510,6 +521,7 @@ void battery_state_init(void) {
   prv_ref_time = rtc_get_ticks();
 
   s_last_soc_cpct = (uint32_t)(pct * 100.0f);
+  prv_track_soc_min();
   s_last_battery_charge_state.pct = (uint8_t)ceilf(pct);
   s_last_battery_charge_state.charge_percent = (uint32_t)(pct * RATIO32_MAX) / 100U;
 
@@ -595,6 +607,10 @@ void pbl_analytics_external_collect_battery(void) {
   PBL_ANALYTICS_SET_UNSIGNED(battery_voltage, battery_mv);
   PBL_ANALYTICS_SET_SIGNED(battery_voltage_delta, d_mv);
   PBL_ANALYTICS_SET_SIGNED(battery_temp_c, s_last_temp_mc);
+  PBL_ANALYTICS_SET_UNSIGNED(battery_soc_pct_min,
+                             s_soc_cpct_min < battery_soc_cpct ? s_soc_cpct_min
+                                                               : battery_soc_cpct);
+  s_soc_cpct_min = battery_soc_cpct;
   s_analytics_last_voltage_mv = battery_mv;
 
   d_soc_cpct = MAX((int32_t)s_analytics_last_cpct - (int32_t)battery_soc_cpct, 0);

--- a/src/fw/services/battery/nrf_fuel_gauge/battery_state.c
+++ b/src/fw/services/battery/nrf_fuel_gauge/battery_state.c
@@ -594,6 +594,7 @@ void pbl_analytics_external_collect_battery(void) {
   d_mv = battery_mv - s_analytics_last_voltage_mv;
   PBL_ANALYTICS_SET_UNSIGNED(battery_voltage, battery_mv);
   PBL_ANALYTICS_SET_SIGNED(battery_voltage_delta, d_mv);
+  PBL_ANALYTICS_SET_SIGNED(battery_temp_c, s_last_temp_mc);
   s_analytics_last_voltage_mv = battery_mv;
 
   d_soc_cpct = MAX((int32_t)s_analytics_last_cpct - (int32_t)battery_soc_cpct, 0);


### PR DESCRIPTION
## Context

The v4.30.1 battery-regression investigation (FIRM-3716) repeatedly hit the same wall: affected devices show a flat drain adder that is invisible to every existing heartbeat metric. This PR closes the blind spots that were identified, appending 9 metrics to the native heartbeat record and bumping `NATIVE_HEARTBEAT_RECORD_VERSION` 2 → 3. All fields are appended at the end so existing offsets are untouched.

## Commits

- **fw/comm/ble: track slave-latency-0 time and conn param update churn** — the `ble_conn_itvl_*` buckets classify by interval only, so a link whose slave latency never took effect (several times the connection-event duty) reads identically to a healthy one. Adds `ble_conn_slave_lat0_time_ms` and `ble_conn_param_update_count`.
- **fw/services/analytics: count accel stream recoveries and unexpected reboots** — both IMU drivers already count stream recoveries internally but never export them (`accel_stream_recovery_count`); `unexpected_reboot_count` counts error-family reboot reasons once per boot.
- **fw/services/analytics: add battery temp, i2c error, and driver health metrics** — `battery_temp_c` (first thermal telemetry), `i2c_transfer_error_count` (bus health), `ble_conn_itvl_other_time_ms` (out-of-table intervals such as central-imposed 7.5 ms were silently misbucketed into `ble_conn_itvl_max_time_ms`), and `drv_init_fail_flags` (silent driver init failures; wired for the GH3X2X HRM, which can fail init and sit unmanaged with no trace beyond a log line).
- **fw/services/battery: report the within-heartbeat SOC minimum** — `battery_soc_pct_min` catches brownout-depth dips that hourly snapshots miss; during triage, several devices' drain normalized right after such dips.

Since the record is a versioned packed blob, consumers of the heartbeat need their schema extended for the appended fields before the new data becomes visible; that change is being handled separately.

## Verification

- obelix@bb2 and asterix builds green (covers both IMU drivers and the packed-record static asserts)
- full `./pbl test` suite green
- gitlint clean on all commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)