### PR TITLE
Assorted triage fixes: two use-after-frees, blank notification window, speaker and RTC diagnosability

### DIFF
--- a/include/pbl/services/blob_db/sync.h
+++ b/include/pbl/services/blob_db/sync.h
@@ -20,6 +20,9 @@ typedef enum {
 
 typedef struct {
   ListNode node;
+  //! Unique, never reused. Deferred timer callbacks carry this instead of a
+  //! session pointer so they can detect a session that has already been freed.
+  uint32_t session_id;
   BlobDBSyncSessionState state;
   BlobDBId db_id;
   BlobDBDirtyItem *dirty_list;

--- a/src/fw/drivers/sf32lb52/rc10k.c
+++ b/src/fw/drivers/sf32lb52/rc10k.c
@@ -2,10 +2,13 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include <pbl/drivers/rtc.h>
+#include <pbl/logging/logging.h>
 #include "pbl/services/new_timer/new_timer.h"
 #include "system/passert.h"
 
 #include "bf0_hal.h"
+
+PBL_LOG_MODULE_DECLARE(driver_rtc_sf32lb, CONFIG_DRIVER_RTC_LOG_LEVEL);
 
 #define RC10K_DEFAULT_FREQ_HZ 10000UL
 #define RC10K_CAL_PERIOD_MS 15000U
@@ -16,7 +19,13 @@ static void prv_rc10k_cal_timer_cb(void *data) {
   uint8_t lp_cycle;
 
   lp_cycle = HAL_RC_CAL_GetLPCycle();
-  HAL_RC_CAL_update_reference_cycle_on_48M(lp_cycle);
+  // A dropped sample leaves the RTC running on a stale reference; the LCPU also
+  // drives RC calibration here, so losing the mailbox is expected but must not
+  // be silent - a run of these means the clock is drifting uncorrected.
+  const int rv = HAL_RC_CAL_update_reference_cycle_on_48M(lp_cycle);
+  if (rv != 0) {
+    PBL_LOG_WRN("RC10K calibration failed: %d", rv);
+  }
 }
 
 void rc10k_init(void) {

--- a/src/fw/popups/alarm_popup.c
+++ b/src/fw/popups/alarm_popup.c
@@ -317,6 +317,10 @@ static void prv_cleanup_alarm_popup(void *callback_context) {
 #ifdef CONFIG_SPEAKER
     prv_stop_sound();
 #endif
+    // The action bar owns a redraw timer armed on button press; it must be
+    // cancelled before the layer's memory goes away. actionable_dialog leaves
+    // custom action bars to their owner.
+    action_bar_layer_deinit(&s_alarm_popup_data->action_bar);
     gbitmap_destroy(s_alarm_popup_data->bitmap);
     gbitmap_destroy(s_alarm_popup_data->action_bar_snooze);
     gbitmap_destroy(s_alarm_popup_data->action_bar_dismiss);

--- a/src/fw/popups/notifications/notification_window.c
+++ b/src/fw/popups/notifications/notification_window.c
@@ -416,6 +416,10 @@ static void prv_show_peek_for_notification(NotificationWindowData *data, Uuid *i
   // get the current layout so we can get the color and icon
   LayoutLayer *layout = swap_layer_get_current_layout(&data->swap_layer);
   if (!layout) {
+    // The backing record couldn't be read, so there is nothing to peek at. The
+    // caller declines to push the window in this case; don't strand the layer.
+    peek_layer_destroy(data->peek_layer);
+    data->peek_layer = NULL;
     return;
   }
 
@@ -1086,6 +1090,13 @@ static void prv_window_appear(Window *window) {
     prv_pop_notification_window_after_delay(data, 0);
     return;
   }
+  if (!swap_layer_get_current_layout(&data->swap_layer)) {
+    // The entry is still listed but its record is gone, so there is nothing to
+    // draw. Self-pop rather than sit on an empty window.
+    PBL_LOG_WRN("Notification window has no layout; popping");
+    prv_pop_notification_window_after_delay(data, 0);
+    return;
+  }
   prv_setup_reminder_watchdog(data);
 
   prv_refresh_pop_timer(data);
@@ -1539,7 +1550,13 @@ static void prv_handle_notification_added_common(Uuid *id, NotificationType type
   if (is_new) {
     data->first_notif_loaded = false;
     prv_show_peek_for_notification(data, id, true /* is_first_notification */);
-    modal_window_push(&data->window, NOTIFICATION_PRIORITY, true /* animated */);
+    if (swap_layer_get_current_layout(&data->swap_layer)) {
+      modal_window_push(&data->window, NOTIFICATION_PRIORITY, true /* animated */);
+    } else {
+      // No layout means the backing record couldn't be read. Pushing anyway puts
+      // an empty window on screen (white, no vibe) that only Back can dismiss.
+      PBL_LOG_WRN("No layout for notification; not showing the window");
+    }
   } else if (in_view) {
     // Only focus the new notification if it becomes the new front of the list.
     // In DND mode notifications can get inserted into the middle of the list and we don't

--- a/src/fw/services/blob_db/sync.c
+++ b/src/fw/services/blob_db/sync.c
@@ -21,7 +21,25 @@ PBL_LOG_MODULE_DECLARE(service_blob_db, CONFIG_SERVICE_BLOB_DB_LOG_LEVEL);
 
 static BlobDBSyncSession *s_sync_sessions = NULL;
 
+//! Ids are handed out monotonically and never reused, so a stale id can never
+//! resolve to a different session that happens to reuse the same allocation.
+static uint32_t s_next_session_id = 1;
+
 static void prv_send_writeback(BlobDBSyncSession *session);
+
+static bool prv_session_uid_filter_callback(ListNode *node, void *data) {
+  BlobDBSyncSession *session = (BlobDBSyncSession *)node;
+  return session->session_id == (uint32_t)(uintptr_t)data;
+}
+
+//! The regular timers below hop to KernelBG before touching the session, and by
+//! then the sync may have finished or been cancelled and the session freed.
+//! Resolve the id against the live list instead of trusting a raw pointer.
+static BlobDBSyncSession *prv_find_live_session(void *session_id) {
+  return (BlobDBSyncSession *)list_find((ListNode *)s_sync_sessions,
+                                        prv_session_uid_filter_callback,
+                                        session_id);
+}
 
 static bool prv_session_id_filter_callback(ListNode *node, void *data) {
   BlobDBId db_id = (BlobDBId)data;
@@ -39,8 +57,12 @@ static bool prv_session_token_filter_callback(ListNode *node, void *data) {
 }
 
 static void prv_abandon_kernelbg_callback(void *data) {
+  BlobDBSyncSession *session = prv_find_live_session(data);
+  if (!session) {
+    // Sync finished or was cancelled between the timer firing and this callback
+    return;
+  }
   PBL_LOG_WRN("Blob DB Sync abandoned after extended timeout");
-  BlobDBSyncSession *session = data;
   blob_db_sync_cancel(session);
 }
 
@@ -49,7 +71,10 @@ static void prv_abandon_timer_callback(void *data) {
 }
 
 static void prv_timeout_kernelbg_callback(void *data) {
-  BlobDBSyncSession *session = data;
+  BlobDBSyncSession *session = prv_find_live_session(data);
+  if (!session) {
+    return;
+  }
 
   // Start the abandon timer if not already running
   if (!regular_timer_is_scheduled(&session->abandon_timer)) {
@@ -88,16 +113,22 @@ static void prv_send_writeback(BlobDBSyncSession *session) {
                                  dirty_item->key,
                                  dirty_item->key_len,
                                  item_buf, item_size);
-  if (PASSED(status)) {
-    regular_timer_add_multisecond_callback(&session->timeout_timer, SYNC_TIMEOUT_SECONDS);
-  } else if (status == E_DOES_NOT_EXIST) {
+  // Both blob_db_sync_next() and blob_db_sync_cancel() can free the session, so
+  // neither it nor dirty_item may be touched after calling them.
+  if (status == E_DOES_NOT_EXIST) {
     // item was removed
+    kernel_free(item_buf);
     blob_db_sync_next(session);
-  } else {
+    return;
+  } else if (!PASSED(status)) {
     // something went terribly wrong
     PBL_LOG_ERR("Failed to read blob DB during sync. Error code: 0x%"PRIx32, status);
+    kernel_free(item_buf);
     blob_db_sync_cancel(session);
+    return;
   }
+
+  regular_timer_add_multisecond_callback(&session->timeout_timer, SYNC_TIMEOUT_SECONDS);
 
   // only one writeback in flight at a time
   session->state = BlobDBSyncSessionStateWaitingForAck;
@@ -129,13 +160,18 @@ BlobDBSyncSession* prv_create_sync_session(BlobDBId db_id, BlobDBDirtyItem *dirt
   session->db_id = db_id;
   session->dirty_list = dirty_list;
   session->session_type = session_type;
+  session->session_id = s_next_session_id++;
+  if (s_next_session_id == 0) {
+    s_next_session_id = 1;  // 0 is reserved as "no session"
+  }
+  void *session_id_data = (void *)(uintptr_t)session->session_id;
   session->timeout_timer = (const RegularTimerInfo) {
     .cb = prv_timeout_timer_callback,
-    .cb_data = session,
+    .cb_data = session_id_data,
   };
   session->abandon_timer = (const RegularTimerInfo) {
     .cb = prv_abandon_timer_callback,
-    .cb_data = session,
+    .cb_data = session_id_data,
   };
   s_sync_sessions = (BlobDBSyncSession *)list_prepend((ListNode *)s_sync_sessions,
                                                       (ListNode *)session);

--- a/src/fw/services/notifications/alerts_preferences.c
+++ b/src/fw/services/notifications/alerts_preferences.c
@@ -359,6 +359,11 @@ void alerts_preferences_init(void) {
   prv_migrate_legacy_first_use_settings(&file);
   prv_migrate_vibe_intensity_to_vibe_scores(&file);
   prv_ensure_valid_vibe_scores();
+  // RESTORE_PREF writes straight into the globals, bypassing the setter that
+  // clamps this, so an out-of-range stored value has to be caught here.
+  if (s_speaker_volume > 100) {
+    s_speaker_volume = 100;
+  }
   prv_save_changed_vibe_scores_to_file(&file, orig_vibe_score_notifications,
                                        orig_vibe_score_incoming_calls,
                                        orig_vibe_score_alarms,

--- a/src/fw/services/speaker/speaker_service.c
+++ b/src/fw/services/speaker/speaker_service.c
@@ -98,6 +98,13 @@ static SpeakerServiceState s_state;
 // Serializes public APIs against prv_refill_bg (system task).
 static PebbleMutex *s_lock;
 
+//! Why playback is currently silent, cached so a muted watch logs once per change
+//! rather than on every sound.
+#define SPEAKER_SILENT (1 << 0)
+#define SPEAKER_SILENT_BY_MUTE (1 << 1)
+#define SPEAKER_SILENT_BY_DND (1 << 2)
+static uint8_t s_silence_reasons;
+
 //! Analytics: time-weighted average volume, reset on heartbeat.
 static uint64_t s_volume_time_product_sum;     // Sum of (volume_pct × time_ms)
 static RtcTicks s_last_volume_sample_ticks;    // Timestamp of last sample
@@ -155,14 +162,45 @@ void speaker_service_init(void) {
   s_state.owner_task = PebbleTask_Unknown;
   s_state.initialized = true;
 
+  s_silence_reasons = 0;
   s_volume_time_product_sum = 0;
   s_last_volume_sample_ticks = 0;
   s_last_sampled_volume_pct = 0;
   s_total_speaker_on_time_ms = 0;
 }
 
+//! Silent playback looks identical to broken hardware from the outside, so record
+//! which setting silenced it. Logs only when the reason changes: this runs on every
+//! sound, and a muted watch would otherwise flood the log.
+static void prv_log_silence(uint8_t vol, uint8_t effective_vol) {
+  uint8_t reasons = 0;
+
+  if (effective_vol == 0) {
+    reasons = SPEAKER_SILENT;
+    if (alerts_preferences_get_speaker_muted()) {
+      reasons |= SPEAKER_SILENT_BY_MUTE;
+    }
+    if (alerts_preferences_dnd_get_mute_speaker() && do_not_disturb_is_active()) {
+      reasons |= SPEAKER_SILENT_BY_DND;
+    }
+  }
+
+  if (reasons == s_silence_reasons) {
+    return;
+  }
+  s_silence_reasons = reasons;
+
+  if (reasons != 0) {
+    PBL_LOG_INFO("Playing silently: vol=%"PRIu8" cap=%"PRIu8" mute=%d quiet_time_mute=%d", vol,
+                 alerts_preferences_get_speaker_volume(),
+                 (reasons & SPEAKER_SILENT_BY_MUTE) != 0, (reasons & SPEAKER_SILENT_BY_DND) != 0);
+  }
+}
+
 static void prv_start_audio(uint8_t vol) {
   const uint8_t effective_vol = prv_effective_volume(vol);
+
+  prv_log_silence(vol, effective_vol);
 
   PBL_ANALYTICS_TIMER_START(speaker_on_time_ms);
   PBL_ANALYTICS_ADD(speaker_play_count, 1);

--- a/tests/fw/services/blob_db/test_blob_db_sync.c
+++ b/tests/fw/services/blob_db/test_blob_db_sync.c
@@ -277,6 +277,89 @@ void test_blob_db_sync__sync_while_syncing(void) {
   prv_generate_responses_from_phone();
 }
 
+static BlobDBSyncSession *prv_start_sync_with_two_keys(void) {
+  char *keys[] = { "key1", "key2" };
+  int key_len = strlen(keys[0]);
+  char *values[] = { "val1", "val2" };
+  int value_len = strlen(values[0]);
+
+  for (int i = 0; i < ARRAY_LENGTH(keys); ++i) {
+    blob_db_insert(BlobDBIdTest, (uint8_t *)keys[i], key_len, (uint8_t *)values[i], value_len);
+  }
+
+  cl_assert(blob_db_sync_db(BlobDBIdTest) == S_SUCCESS);
+  BlobDBSyncSession *session = blob_db_sync_get_session_for_id(BlobDBIdTest);
+  cl_assert(session != NULL);
+  return session;
+}
+
+// The regular timers fire on the timer task and hop to KernelBG before touching
+// the session. If the sync completes or is cancelled in that window the session
+// is freed, so the deferred half must detect that instead of dereferencing it.
+void test_blob_db_sync__stale_timeout_callback_after_cancel(void) {
+  BlobDBSyncSession *session = prv_start_sync_with_two_keys();
+
+  // Drop the harness' pending phone response; exercise the timeout path alone.
+  fake_system_task_callbacks_cleanup();
+
+  fake_regular_timer_trigger(&session->timeout_timer);
+  cl_assert_equal_i(fake_system_task_count_callbacks(), 1);
+
+  blob_db_sync_cancel(session);
+  cl_assert(blob_db_sync_get_session_for_id(BlobDBIdTest) == NULL);
+
+  s_num_writebacks = 0;
+  fake_system_task_callbacks_invoke_pending();
+
+  // The stale callback must not resurrect the session or send anything.
+  cl_assert_equal_i(s_num_writebacks, 0);
+  cl_assert(blob_db_sync_get_session_for_id(BlobDBIdTest) == NULL);
+}
+
+void test_blob_db_sync__stale_abandon_callback_after_cancel(void) {
+  // Keep the phone silent: a response would complete the sync and disarm the
+  // abandon timer before we can exercise it.
+  s_num_until_timeout = 1;
+  s_num_writebacks = 1;
+
+  BlobDBSyncSession *session = prv_start_sync_with_two_keys();
+  cl_assert_equal_i(fake_system_task_count_callbacks(), 0);
+
+  // A timeout schedules the abandon timer.
+  fake_regular_timer_trigger(&session->timeout_timer);
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert(regular_timer_is_scheduled(&session->abandon_timer));
+  fake_regular_timer_trigger(&session->abandon_timer);
+  cl_assert_equal_i(fake_system_task_count_callbacks(), 1);
+
+  // Session goes away before the abandon callback runs; it must not free twice.
+  blob_db_sync_cancel(session);
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert(blob_db_sync_get_session_for_id(BlobDBIdTest) == NULL);
+}
+
+// A stale id must never resolve to a *different* session that happened to reuse
+// the freed allocation.
+void test_blob_db_sync__stale_callback_does_not_match_new_session(void) {
+  BlobDBSyncSession *session = prv_start_sync_with_two_keys();
+  const uint32_t first_id = session->session_id;
+
+  fake_system_task_callbacks_cleanup();
+  fake_regular_timer_trigger(&session->timeout_timer);
+  blob_db_sync_cancel(session);
+
+  // A fresh session for the same db, potentially at the same address.
+  BlobDBSyncSession *new_session = prv_start_sync_with_two_keys();
+  cl_assert(new_session->session_id != first_id);
+
+  s_num_writebacks = 0;
+  fake_system_task_callbacks_invoke_pending();
+
+  // The new session syncs to completion; the stale timeout must not have
+  // driven it (which would double-send the first item).
+  cl_assert_equal_i(s_num_writebacks, 2);
+}
+
 static void prv_fill_stop_return_session(BlobDBId id) {
   char *keys[] = { "key1", "key2", "key3", "key4", "key5" };
   int key_len = strlen(keys[0]);


### PR DESCRIPTION
Five fixes surfaced while triaging the Linear queue. Each one is independently
useful and independently revertable; nothing here depends on anything else.

### Use-after-free fixes (both from coredumps)

**`fw/popups`: deinit the alarm popup's action bar before freeing it.** The
popup `task_free`s a struct embedding a custom `ActionBarLayer` without ever
calling `action_bar_layer_deinit`, so the layer's press-animation redraw timer
stayed armed against freed memory and fired into `prv_timed_redraw` with a
poisoned context. Every other custom action bar user already deinits on
teardown; this was the only outlier. Seen in the coredump on FIRM-3404.

**`fw/services/blob_db`: don't use sync sessions after they are freed.** Two
paths. `prv_send_writeback` fell through into the send after calling
`blob_db_sync_next`/`blob_db_sync_cancel` on a failed read, both of which can
free the session, then wrote into freed memory and sent a writeback built from
a freed dirty item. Separately, the timeout and abandon regular timers hop to
KernelBG carrying a raw session pointer; the session can complete or be
cancelled in that window, leaving the deferred half to touch freed memory and,
for the abandon callback, free it twice. Sessions now carry a monotonic
never-reused id resolved against the live list, so a stale id cannot alias a
new session that reuses the allocation. Consistent with the crash on FIRM-3569,
whose coredump asserted in `blob_db_sync_cancel` freeing a bogus heap pointer.
Adds three regression tests, verified to fail against the pre-fix behaviour.

### Correctness

**`fw/popups/notifications`: don't show a notification with no layout.** When
the backing record can't be read (evicted storage entry, already-deleted
reminder), the layout handler returns NULL and the swap layer ends up with no
children — but the modal window was pushed regardless, putting an empty window
on screen. White, because `Window` defaults its background to `GColorWhite` and
this one never overrides it; silent, because the vibe path bails out when it
can't resolve the current notification; and dismissable only by Back or the pop
timeout. Push only once a layout is present, let a window that loses its layout
pop itself on appear, and destroy the peek layer on that path instead of
stranding it. Covers FIRM-3214, FIRM-3704 and FIRM-3641.

### Diagnosability

**`fw/services`: say which setting silenced the speaker.** Playback at effective
volume 0 is indistinguishable from broken audio hardware from the outside.
Three reports (FIRM-3417, FIRM-3731, FIRM-3792) were triaged toward a speaker
or PA fault — one close to an RMA — when the cause was a persisted setting: a
zero volume cap, Sounds & Haptics mute, or Quiet Time's separate mute-speaker
toggle while DND is active. Log which one applies when a play starts silent.

The flash log level defaults to INFO, so the line has to be INFO to be captured
at all. Playback starts run on every notification and alarm, so it fires only
when the set of reasons changes — an unconditional INFO would flood the log on
a muted watch and push out the surrounding context that makes a report useful.
Tracking the reasons rather than a bare "was silent" flag keeps a change of
cause visible, and clears the memo on the first audible play so a later re-mute
reports again.

Also clamps the restored speaker volume, which `RESTORE_PREF` writes straight
into the global, bypassing the setter that clamps it (the same gap fixed for
the ambient light threshold in FIRM-2841); out-of-range can currently only make
audio louder, so that part is correctness rather than a fix.

**`fw/drivers/sf32lb52`: log RC10K calibration failures.** The 15-second
calibration timer discarded its result and the file had no logging at all. A
dropped sample leaves the RTC on a stale reference, and one documented failure
is losing the calibration mailbox to the LCPU — which also runs RC calibration
where LXT is disabled, so contention is expected rather than exceptional. Makes
a run of failures visible in a log capture. Context for FIRM-3428; does not by
itself correct the drift.

### Testing

`./waf build` clean on obelix@pvt; `./waf test` 324/324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
