### PR TITLE
fw: enable touch navigation by default behind a gesture-armed interaction session

### DIFF
--- a/include/pbl/services/analytics/analytics.def
+++ b/include/pbl/services/analytics/analytics.def
@@ -145,3 +145,6 @@ PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(drv_init_fail_flags)
 // Lowest SOC observed since the previous heartbeat; hourly snapshots miss
 // brief deep discharges (brownout-depth dips).
 PBL_ANALYTICS_METRIC_DEFINE_SCALED_UNSIGNED(battery_soc_pct_min, 100)
+// Touchdowns latched non-navigational by the interaction session gate
+// (unarmed contact on the idle watchface): the accidental-touch measure.
+PBL_ANALYTICS_METRIC_DEFINE_UNSIGNED(touch_gated_touchdown_count)

--- a/include/pbl/services/touch/touch.h
+++ b/include/pbl/services/touch/touch.h
@@ -48,7 +48,10 @@ bool touch_app_nav_active(void);
 //! Mark whether the app twin's nav dispatcher is installed.
 void touch_set_app_nav_active(bool active);
 
-//! @return true if at least one subscriber is currently registered for touch events.
+//! @return true if at least one task holds an explicit raw touch subscription
+//! (touch_service_subscribe). Nav twins, the backlight subscription, and the
+//! system hold do not count; the event loop composes those separately when
+//! deciding whether the backlight follows a touch.
 bool touch_has_app_subscribers(void);
 
 //! Globally enable or disable touch. When disabled:
@@ -84,27 +87,13 @@ void touch_reset(void);
 //! finger is currently down. Reused by the master-pref-off transaction.
 void touch_release_active(void);
 
-//! Outcome of the wake-gate decision made on a Touchdown.
+//! Outcome of the session-gate decision made on a Touchdown.
 typedef struct TouchWakeGateResult {
-  //! true when the touch must not drive navigation at all: the screen is (and
-  //! stays) dark — a DnD-suppressed touch, or a screen-off touch when nothing
-  //! drives the backlight (gesture-wake mode).
+  //! true when the touch must not drive navigation: the interaction session
+  //! (touch_session_is_active) was inactive at Touchdown — unarmed contact on
+  //! the idle watchface.
   bool latch;
-  //! true when this Touchdown turned the screen on: the gesture must not tap
-  //! or swipe (it targeted the wake, not the UI), but a follow-on drag is
-  //! deliberate, now-visible input and may pan.
-  bool wake;
 } TouchWakeGateResult;
-
-//! Pure wake-gate decision, factored out so it is unit-testable independently
-//! of the kernel event loop. Given the backlight state sampled around the
-//! touch-driven wake, decide whether this Touchdown is non-navigational.
-//! @param backlight_driven whether a subscriber ties the backlight to touch
-//! @param dnd whether DnD suppresses the touch backlight for this touch
-//! @param before light_is_on() sampled before the touch-driven wake
-//! @param after light_is_on() sampled after the touch-driven wake
-TouchWakeGateResult touch_wake_gate_on_touchdown(bool backlight_driven, bool dnd, bool before,
-                                                 bool after);
 
 //! Stamp non_navigational onto a touch event, latching the Touchdown decision
 //! across the whole gesture. @p gate is only consulted on a Touchdown event;

--- a/include/pbl/services/touch/touch_event.h
+++ b/include/pbl/services/touch/touch_event.h
@@ -16,18 +16,12 @@ typedef enum TouchEventType {
 //! Touch event data, carried directly in PebbleTouchEvent
 typedef struct TouchEvent {
   TouchEventType type:8;
-  //! true when the touch must not drive navigation at all: a DnD-suppressed
-  //! touch (the screen stayed dark), or a screen-off touch under gesture-based
-  //! wake. Latched on Touchdown and carried across the whole gesture.
+  //! true when the touch must not drive navigation: the interaction session
+  //! was inactive at Touchdown (unarmed contact on the idle watchface).
+  //! Latched on Touchdown and carried across the whole gesture.
   bool non_navigational;
   int16_t x;
   int16_t y;
-  //! true when this touch's Touchdown turned the screen on: the gesture must
-  //! not tap or swipe (it targeted the wake, not the UI), but a drag that
-  //! follows is deliberate, now-visible input and may pan. Latched on
-  //! Touchdown and carried across the whole gesture. Appended after y so the
-  //! x/y offsets stay app-ABI-compatible (see test_touch__event_abi_unchanged).
-  bool wake_touch;
 } TouchEvent;
 
 _Static_assert(sizeof(TouchEvent) <= 9, "TouchEvent must stay small; it rides inside PebbleEvent");

--- a/include/pbl/services/touch/touch_session.h
+++ b/include/pbl/services/touch/touch_session.h
@@ -1,0 +1,40 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include <stdbool.h>
+
+//! Interaction session gating raw touch navigation.
+//!
+//! Raw touchdowns only navigate (and hold the backlight) while the session is
+//! active. Deliberate interaction arms it: the backlight wake gesture or a
+//! button press. Use extends it; it expires after the backlight timeout, as if
+//! the light had come on — tracked as its own deadline because bright ambient
+//! (or DnD) keeps the actual backlight off. The idle watchface is the only
+//! guarded surface: any other foreground UI, a focused modal, or a lit
+//! backlight counts as active.
+//!
+//! All entry points run on KernelMain (event-loop handlers); the module is
+//! unlocked by design.
+
+typedef enum TouchSessionArmSource {
+  TouchSessionArmSource_WakeGesture,
+  TouchSessionArmSource_Button,
+} TouchSessionArmSource;
+
+//! Open (or re-open) the session: deliberate interaction observed.
+void touch_session_arm(TouchSessionArmSource source);
+
+//! Push the session deadline out, but only while the session is active --
+//! gated contact must not keep itself alive.
+void touch_session_extend(void);
+
+//! @return true while touch may navigate: within the armed deadline, the
+//! foreground UI is not a watchface, a focused modal is up, or the backlight
+//! is on. Always true in recovery firmware (mfg touch test).
+bool touch_session_is_active(void);
+
+//! Close the session deadline immediately. The environmental overrides in
+//! touch_session_is_active() still apply.
+void touch_session_reset(void);

--- a/src/fw/applib/ui/recognizer/touch_nav.c
+++ b/src/fw/applib/ui/recognizer/touch_nav.c
@@ -467,7 +467,7 @@ void touch_nav_dispatch(const TouchEvent *touch_event, void *context) {
     // (event-time), not cached from the last focus-change event. The dispatcher runs per touch
     // event, so a delayed/missed PEBBLE_APP_DID_CHANGE_FOCUS_EVENT cannot stale this decision.
     if (touch_event->non_navigational) {
-      // Gated (wake tap / DnD): skip routing and set_failed, keep the set Possible, and unwind any
+      // Session-gated: skip routing and set_failed, keep the set Possible, and unwind any
       // mid-gesture so a stuck recognizer does not linger. The next navigational Touchdown starts
       // fresh from its first event.
       state->counters.gated++;
@@ -523,18 +523,6 @@ void touch_nav_dispatch(const TouchEvent *touch_event, void *context) {
       prv_fail(state, state->widget_swipe);
     }
 
-    if (touch_event->wake_touch) {
-      // This Touchdown turned the screen on. The gesture must not tap or swipe (it targeted the
-      // wake, not the UI), but a drag that follows is deliberate, now-visible input: leave the
-      // pans alive so wake-and-scroll works as one gesture instead of demanding a second touch.
-      // On a Tier-2 route the bridge pan is already failed by the tier exclusion, so a wake
-      // gesture stays fully inert on button-emulation surfaces.
-      prv_fail(state, state->tap);
-      prv_fail(state, state->swipe);
-      prv_fail(state, state->widget_tap);
-      prv_fail(state, state->widget_swipe);
-      prv_log_push(state, TouchNavLog_Gated, 1 /* wake: pans allowed */);
-    }
   } else {
     recognizer_manager_handle_touch_event(touch_event, manager);
   }

--- a/src/fw/apps/system/settings/display.c
+++ b/src/fw/apps/system/settings/display.c
@@ -425,11 +425,7 @@ static void prv_backlight_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
 #ifdef CONFIG_TOUCH
     case SettingsBacklightTouchWake:
       title = i18n_noop("Wake on touch");
-      // Full touch navigation (master Touch + Touch Navigation) wakes on every touch, so this
-      // setting is superseded while both are on.
-      subtitle = (touch_is_globally_enabled() && touch_navigation_menu_is_enabled())
-                     ? i18n_noop("On (nav)")
-                     : s_touch_wake_labels[backlight_get_touch_wake()];
+      subtitle = s_touch_wake_labels[backlight_get_touch_wake()];
       break;
 #endif
     case SettingsBacklightAmbientSensor:

--- a/src/fw/kernel/event_loop.c
+++ b/src/fw/kernel/event_loop.c
@@ -61,6 +61,7 @@
 #include "pbl/services/system_task.h"
 #ifdef CONFIG_TOUCH
 #include "pbl/services/touch/touch.h"
+#include "pbl/services/touch/touch_session.h"
 #endif
 #include "pbl/services/vibe_pattern.h"
 #include "pbl/services/alarms/alarm.h"
@@ -212,6 +213,10 @@ static void launcher_handle_button_event(PebbleEvent* e) {
     }
 #endif // !defined(CONFIG_SHELL_SDK)
 
+#ifdef CONFIG_TOUCH
+    // Deliberate interaction: open the touch session so touch may navigate.
+    touch_session_arm(TouchSessionArmSource_Button);
+#endif
     light_button_pressed();
   } else if (e->type == PEBBLE_BUTTON_UP_EVENT) {
     if (button_id == BUTTON_ID_BACK) {
@@ -338,14 +343,6 @@ static NOINLINE void prv_minimal_event_handler(PebbleEvent* e) {
 #endif
 
     case PEBBLE_GESTURE_EVENT: {
-#ifdef CONFIG_TOUCH
-      // While an app is subscribed the touch event handler drives the
-      // backlight, so skip gesture-based wake to avoid a redundant trigger
-      // (and to keep double-tap from waking when only single-tap is wanted).
-      if (touch_has_app_subscribers()) {
-        return;
-      }
-#endif
       bool wake_on_gesture = false;
       switch (backlight_get_touch_wake()) {
         case BacklightTouchWake_Tap:
@@ -360,6 +357,11 @@ static NOINLINE void prv_minimal_event_handler(PebbleEvent* e) {
           break;
       }
       if (wake_on_gesture) {
+#ifdef CONFIG_TOUCH
+        // The wake gesture is the deliberate act that opens the touch session;
+        // arm even when DnD keeps the light off, so touch still works.
+        touch_session_arm(TouchSessionArmSource_WakeGesture);
+#endif
 #ifndef CONFIG_RECOVERY_FW
         const bool dnd_suppresses_backlight = do_not_disturb_is_active() &&
                                              !alerts_preferences_dnd_get_touch_backlight();

--- a/src/fw/kernel/event_loop.c
+++ b/src/fw/kernel/event_loop.c
@@ -331,6 +331,9 @@ static NOINLINE void prv_minimal_event_handler(PebbleEvent* e) {
           light_touch_down();
         }
         gate = (TouchWakeGateResult){.latch = !armed};
+        if (!armed) {
+          PBL_ANALYTICS_ADD(touch_gated_touchdown_count, 1);
+        }
         touch_session_extend();
       } else if (e->touch.event.type == TouchEvent_Liftoff) {
         light_touch_up();

--- a/src/fw/kernel/event_loop.c
+++ b/src/fw/kernel/event_loop.c
@@ -297,15 +297,25 @@ static NOINLINE void prv_minimal_event_handler(PebbleEvent* e) {
 
 #ifdef CONFIG_TOUCH
     case PEBBLE_TOUCH_EVENT: {
-      // For touch-subscribed apps, tie the backlight to the touch: on while a
-      // finger is down, timed out after liftoff. Release on liftoff ungated
-      // so the refcount can't leak if the app unsubscribed or DnD turned on mid-touch.
+      // Raw touches only navigate (and hold the backlight) while the
+      // interaction session is active; unarmed contact on the idle watchface
+      // stays fully inert. Release on liftoff ungated so the refcount can't
+      // leak if the session expired or touch was disabled mid-touch.
       TouchWakeGateResult gate = {0};
+      const bool is_modal_focused =
+          (modal_manager_get_enabled() &&
+           !(modal_manager_get_properties() & ModalProperty_Unfocused));
       if (e->touch.event.type == TouchEvent_Touchdown) {
-        // Wake gate: sample the backlight around the touch-driven wake so a
-        // wake tap can be told apart from navigation. before must come first.
-        const bool before = light_is_on();
-        const bool backlight_driven = touch_has_app_subscribers();
+        const bool armed = touch_session_is_active();
+        // Light follows touch only where something consumes the touch: the
+        // modal twin, a live app nav twin (system app under the nav pref, or
+        // an explicit opt-in), a raw-subscribed app, or the armed watchface
+        // (so touch keeps the woken screen lit). A third-party app that never
+        // subscribed to touch gets no touchdown light.
+        const bool backlight_driven =
+            (touch_nav_enabled() &&
+             (is_modal_focused || app_manager_is_watchface_running())) ||
+            touch_app_nav_active() || touch_has_app_subscribers();
         bool dnd_suppresses_backlight = false;
 #ifndef CONFIG_RECOVERY_FW
         dnd_suppresses_backlight =
@@ -315,19 +325,17 @@ static NOINLINE void prv_minimal_event_handler(PebbleEvent* e) {
         // global-off toggle (different queues, no global FIFO) must not grab an
         // unreleasable backlight hold once touch is disabled. Both the toggle
         // and this handler run on KernelMain, so the switch is already settled.
-        if (backlight_driven && !dnd_suppresses_backlight &&
+        // DnD only suppresses the light; an armed touch still navigates.
+        if (armed && backlight_driven && !dnd_suppresses_backlight &&
             touch_service_is_globally_enabled()) {
           light_touch_down();
         }
-        const bool after = light_is_on();
-        gate =
-            touch_wake_gate_on_touchdown(backlight_driven, dnd_suppresses_backlight, before, after);
+        gate = (TouchWakeGateResult){.latch = !armed};
+        touch_session_extend();
       } else if (e->touch.event.type == TouchEvent_Liftoff) {
         light_touch_up();
+        touch_session_extend();
       }
-      const bool is_modal_focused =
-          (modal_manager_get_enabled() &&
-           !(modal_manager_get_properties() & ModalProperty_Unfocused));
       if (compositor_is_animating() || is_modal_focused) {
         // Mask the app task while the compositor animates or a modal is focused. Otherwise a
         // gesture over a focused modal reaches both the kernel (modal) twin and the app twin

--- a/src/fw/services/touch/touch.c
+++ b/src/fw/services/touch/touch.c
@@ -109,13 +109,6 @@ void touch_set_app_nav_active(bool active) {
 }
 
 bool touch_has_app_subscribers(void) {
-  // Anything actively navigating by touch wants touch treated as active -- the
-  // screen wakes and stays lit on any touch: system nav (master pref AND the
-  // touch-navigation sub-pref) or an opted-in app driving nav under the master
-  // pref alone. Evaluated outside the lock (non-recursive mutex).
-  if (touch_nav_enabled() || touch_app_nav_active()) {
-    return true;
-  }
   mutex_lock(s_touch_mutex);
   // Only explicit raw-slot subscriptions (touch_service_subscribe) count as
   // app subscribers. The event-service count cannot be used: the nav twins'
@@ -326,36 +319,13 @@ void touch_release_active(void) {
   }
 }
 
-TouchWakeGateResult touch_wake_gate_on_touchdown(bool backlight_driven, bool dnd, bool before,
-                                                 bool after) {
-  if (!backlight_driven) {
-    // Nothing drives the backlight for this touch (gesture-wake mode): a touch
-    // that begins with the screen off can only be a wake attempt and must not
-    // act invisibly on the UI under the finger, so latch it non-navigational.
-    // With the screen on, it navigates.
-    return (TouchWakeGateResult){.latch = !before};
-  }
-  if (!before && after) {
-    // This Touchdown turned the screen on: block taps/swipes (the touch
-    // targeted the wake, not the UI) but let a follow-on drag pan, so
-    // wake-and-scroll works as one gesture.
-    return (TouchWakeGateResult){.wake = true};
-  }
-  // DnD suppressed the wake while the screen was off: still dark, fully
-  // non-navigational.
-  return (TouchWakeGateResult){.latch = (!before && dnd)};
-}
-
 static bool s_wake_gate_latch;
-static bool s_wake_gate_wake_latch;
 
 void touch_wake_gate_stamp(TouchEvent *event, TouchWakeGateResult gate) {
   if (event->type == TouchEvent_Touchdown) {
     s_wake_gate_latch = gate.latch;
-    s_wake_gate_wake_latch = gate.wake;
   }
   event->non_navigational = s_wake_gate_latch;
-  event->wake_touch = s_wake_gate_wake_latch;
 }
 
 void touch_set_rotated(bool rotated) {

--- a/src/fw/services/touch/touch_session.c
+++ b/src/fw/services/touch/touch_session.c
@@ -1,0 +1,63 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "pbl/services/touch/touch_session.h"
+
+#include <pbl/drivers/rtc.h>
+#include <pbl/logging/logging.h>
+#include "kernel/ui/modals/modal_manager.h"
+#include "pbl/services/light.h"
+#include "process_management/app_manager.h"
+#include "shell/prefs.h"
+
+PBL_LOG_MODULE_DECLARE(service_touch, CONFIG_SERVICE_TOUCH_LOG_LEVEL);
+
+//! The session lasts exactly as long as the backlight would stay on: arming
+//! behaves as if the light had come on, even when ALS or DnD kept it dark.
+//! Sampled per arm/extend so a pref change applies immediately.
+static RtcTicks prv_timeout_ticks(void) {
+  return ((RtcTicks)backlight_get_timeout_ms() * RTC_TICKS_HZ) / 1000;
+}
+
+static RtcTicks s_armed_until;
+
+void touch_session_arm(TouchSessionArmSource source) {
+  s_armed_until = rtc_get_ticks() + prv_timeout_ticks();
+  PBL_LOG_DBG("Touch session armed (source %d)", (int)source);
+}
+
+void touch_session_extend(void) {
+  if (touch_session_is_active()) {
+    s_armed_until = rtc_get_ticks() + prv_timeout_ticks();
+  }
+}
+
+bool touch_session_is_active(void) {
+#ifdef CONFIG_RECOVERY_FW
+  // PRF has no touch navigation; keep the mfg touch test's touch-follows-light
+  // behavior unconditional.
+  return true;
+#else
+  if (rtc_get_ticks() < s_armed_until) {
+    return true;
+  }
+  // Any UI the user deliberately entered is not guarded; only the idle
+  // watchface needs arming.
+  if (!app_manager_is_watchface_running()) {
+    return true;
+  }
+  // A focused modal just demanded attention (notification, alarm): the
+  // immediate touch response is intentional.
+  if (modal_manager_get_enabled() &&
+      !(modal_manager_get_properties() & ModalProperty_Unfocused)) {
+    return true;
+  }
+  // A lit backlight means something (button, shake, wake gesture) already
+  // signalled engagement.
+  return light_is_on();
+#endif
+}
+
+void touch_session_reset(void) {
+  s_armed_until = 0;
+}

--- a/src/fw/services/touch/wscript_build
+++ b/src/fw/services/touch/wscript_build
@@ -4,6 +4,7 @@
 sources = [
     'touch.c',
     'touch_nav_service.c',
+    'touch_session.c',
 ]
 
 bld.stlib(

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -95,7 +95,7 @@ static uint8_t s_backlight_touch_wake = BacklightTouchWake_DoubleTap;
 static bool s_touch_enabled = true;
 
 #define PREF_KEY_TOUCH_NAVIGATION_MENU "touchNavMenuEnabled"
-static bool s_touch_navigation_menu_enabled = false;
+static bool s_touch_navigation_menu_enabled = true;
 
 #define PREF_KEY_MOTION_SENSITIVITY "motionSensitivity"
 static uint8_t s_motion_sensitivity = 55; // Default to Medium

--- a/src/fw/shell/prefs.h
+++ b/src/fw/shell/prefs.h
@@ -117,9 +117,10 @@ void touch_set_globally_enabled(bool enable);
 // nothing system-side subscribes to touch. Only the wake-gesture pref, SDK
 // raw-touch apps, and third-party apps that explicitly opted in via
 // app_touch_navigation_enable() (they follow the master switch alone) still
-// consume the sensor. Defaults to off. Toggling either pref runs the
-// enable/disable transaction when the effective (ANDed) state changes and
-// re-evaluates the running app's twin otherwise.
+// consume the sensor. Defaults to on, gated by the interaction session
+// (touch_session_is_active). Toggling either pref runs the enable/disable
+// transaction when the effective (ANDed) state changes and re-evaluates the
+// running app's twin otherwise.
 bool touch_navigation_menu_is_enabled(void);
 void touch_set_navigation_menu_enabled(bool enable);
 

--- a/tests/fw/services/test_touch.c
+++ b/tests/fw/services/test_touch.c
@@ -256,24 +256,23 @@ void test_touch__has_app_subscribers_nav(void) {
   touch_set_backlight_enabled(true);
   cl_assert(!touch_has_app_subscribers());
 
-  // The nav gate reports app subscribers regardless of the actual subscriber
-  // set. The shell only raises it when nav is effectively on (master pref AND
-  // the touch-navigation sub-pref).
+  // The nav gate must NOT read as an app subscriber: the event loop composes
+  // nav state into its backlight decision itself (focus-aware), so a
+  // third-party app that never subscribed gets no touchdown light even with
+  // system nav on.
   touch_set_nav_enabled(true);
-  cl_assert(touch_has_app_subscribers());
-
-  // Back off, and with only the backlight hold it's false again.
-  touch_set_nav_enabled(false);
   cl_assert(!touch_has_app_subscribers());
+  touch_set_nav_enabled(false);
 
-  // Nav off + the nav system hold (on top of backlight): the hold must be
-  // excluded too, otherwise tap-to-wake is wrongly suppressed once the shell
-  // decouples the pref from the hold.
+  // Same for the app twin flag and the nav system hold.
+  touch_set_app_nav_active(true);
+  cl_assert(!touch_has_app_subscribers());
+  touch_set_app_nav_active(false);
   touch_set_system_hold(true);
   cl_assert(!touch_has_app_subscribers());
   touch_set_system_hold(false);
 
-  // Nav off + a real raw subscriber → true.
+  // A real raw subscriber → true.
   sys_touch_set_raw_subscribed(true);
   cl_assert(touch_has_app_subscribers());
 
@@ -388,54 +387,12 @@ void test_touch__global_disable_sleeps_unsubscribed_sensor(void) {
   touch_service_set_globally_enabled(true);
 }
 
-void test_touch__wake_gate_formula(void) {
-  // (before=F, after=T) -> woke the screen -> WAKE: taps/swipes blocked, a follow-on drag pans.
-  const TouchWakeGateResult woke = touch_wake_gate_on_touchdown(true, false, false, true);
-  cl_assert(!woke.latch);
-  cl_assert(woke.wake);
-  // Already on (T, T) -> navigation.
-  cl_assert(!touch_wake_gate_on_touchdown(true, false, true, true).latch);
-  cl_assert(!touch_wake_gate_on_touchdown(true, false, true, true).wake);
-  // Off and stayed off (F, F), no DnD (day/ALS) -> navigation.
-  cl_assert(!touch_wake_gate_on_touchdown(true, false, false, false).latch);
-  cl_assert(!touch_wake_gate_on_touchdown(true, false, false, false).wake);
-  // DnD suppressed the wake while off -> screen still dark -> full latch, not wake.
-  cl_assert(touch_wake_gate_on_touchdown(true, true, false, false).latch);
-  cl_assert(!touch_wake_gate_on_touchdown(true, true, false, false).wake);
-  // DnD but screen already on -> navigation.
-  cl_assert(!touch_wake_gate_on_touchdown(true, true, true, true).latch);
-}
-
-void test_touch__wake_gate_guard_matrix(void) {
-  // No backlight driver (gesture-wake mode): a touch that begins with the
-  // screen off can only be a wake attempt -- it must not act invisibly on the
-  // UI, so it latches non-navigational regardless of `after`/DnD.
-  cl_assert(touch_wake_gate_on_touchdown(false, false, false, false).latch);
-  cl_assert(touch_wake_gate_on_touchdown(false, false, false, true).latch);
-  cl_assert(touch_wake_gate_on_touchdown(false, true, false, false).latch);
-  // The gesture-wake latch is never the pan-allowing wake kind (the screen is dark).
-  cl_assert(!touch_wake_gate_on_touchdown(false, false, false, false).wake);
-  // Screen already on: the touch navigates.
-  cl_assert(!touch_wake_gate_on_touchdown(false, false, true, true).latch);
-  cl_assert(!touch_wake_gate_on_touchdown(false, true, true, true).latch);
-
-  // Driven, screen lit by this touch: the wake kind, not the full latch.
-  TouchWakeGateResult driven = touch_wake_gate_on_touchdown(true, false, false, true);
-  cl_assert(!driven.latch);
-  cl_assert(driven.wake);
-
-  // Driven, DnD (screen stayed dark): full latch == !before.
-  cl_assert(touch_wake_gate_on_touchdown(true, true, false, false).latch);
-  cl_assert(!touch_wake_gate_on_touchdown(true, true, true, true).latch);
-}
-
 void test_touch__wake_gate_latches_across_gesture(void) {
-  // A DnD-blocked Touchdown stamps non_navigational and latches it for the gesture.
-  TouchWakeGateResult blocked = touch_wake_gate_on_touchdown(true, true, false, false);
+  // A session-gated Touchdown stamps non_navigational and latches it for the gesture.
+  TouchWakeGateResult blocked = {.latch = true};
   TouchEvent td = {.type = TouchEvent_Touchdown};
   touch_wake_gate_stamp(&td, blocked);
   cl_assert(td.non_navigational);
-  cl_assert(!td.wake_touch);
 
   // PositionUpdate and Liftoff carry the latch, regardless of their gate arg.
   TouchEvent pu = {.type = TouchEvent_PositionUpdate};
@@ -447,7 +404,7 @@ void test_touch__wake_gate_latches_across_gesture(void) {
   cl_assert(lo.non_navigational);
 
   // A fresh navigational Touchdown clears the latch for the next gesture.
-  TouchWakeGateResult nav = touch_wake_gate_on_touchdown(true, false, false, false);
+  TouchWakeGateResult nav = {0};
   TouchEvent td2 = {.type = TouchEvent_Touchdown};
   touch_wake_gate_stamp(&td2, nav);
   cl_assert(!td2.non_navigational);
@@ -455,30 +412,6 @@ void test_touch__wake_gate_latches_across_gesture(void) {
   TouchEvent pu2 = {.type = TouchEvent_PositionUpdate};
   touch_wake_gate_stamp(&pu2, (TouchWakeGateResult){0});
   cl_assert(!pu2.non_navigational);
-}
-
-void test_touch__wake_gate_wake_kind_latches_across_gesture(void) {
-  // A screen-waking Touchdown stamps wake_touch (NOT non_navigational) and latches it.
-  TouchWakeGateResult woke = touch_wake_gate_on_touchdown(true, false, false, true);
-  TouchEvent td = {.type = TouchEvent_Touchdown};
-  touch_wake_gate_stamp(&td, woke);
-  cl_assert(!td.non_navigational);
-  cl_assert(td.wake_touch);
-
-  // The whole gesture carries the wake latch so the dispatcher's Touchdown decision holds.
-  TouchEvent pu = {.type = TouchEvent_PositionUpdate};
-  touch_wake_gate_stamp(&pu, (TouchWakeGateResult){0});
-  cl_assert(pu.wake_touch);
-
-  TouchEvent lo = {.type = TouchEvent_Liftoff};
-  touch_wake_gate_stamp(&lo, (TouchWakeGateResult){0});
-  cl_assert(lo.wake_touch);
-
-  // A fresh navigational Touchdown clears it.
-  TouchWakeGateResult nav = touch_wake_gate_on_touchdown(true, false, true, true);
-  TouchEvent td2 = {.type = TouchEvent_Touchdown};
-  touch_wake_gate_stamp(&td2, nav);
-  cl_assert(!td2.wake_touch);
 }
 
 void test_touch__toggle_off_with_finger_down_emits_liftoff(void) {
@@ -503,7 +436,7 @@ void test_touch__toggle_off_without_finger_no_liftoff(void) {
 }
 
 void test_touch__event_abi_unchanged(void) {
-  // The wake flag rides in the padding after type:8; x/y offsets and the
+  // non_navigational rides in the padding after type:8; x/y offsets and the
   // overall size must not move, keeping the SDK struct app-compatible.
   cl_assert_equal_i(offsetof(TouchEvent, x), 2);
   cl_assert_equal_i(offsetof(TouchEvent, y), 4);

--- a/tests/fw/services/test_touch_session.c
+++ b/tests/fw/services/test_touch_session.c
@@ -1,0 +1,176 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "clar.h"
+
+#include "kernel/ui/modals/modal_manager.h"
+#include "pbl/services/touch/touch_session.h"
+
+#include <stdbool.h>
+
+#include "fake_rtc.h"
+
+// Stubs
+#include "stubs_logging.h"
+
+// The session's environmental overrides; each test drives them directly.
+static bool s_watchface_running;
+bool app_manager_is_watchface_running(void) {
+  return s_watchface_running;
+}
+
+static bool s_modal_enabled;
+static ModalProperty s_modal_properties;
+bool modal_manager_get_enabled(void) {
+  return s_modal_enabled;
+}
+ModalProperty modal_manager_get_properties(void) {
+  return s_modal_properties;
+}
+
+static bool s_light_on;
+bool light_is_on(void) {
+  return s_light_on;
+}
+
+// The session deadline follows the backlight timeout pref, sampled per arm.
+static uint32_t s_backlight_timeout_ms;
+uint32_t backlight_get_timeout_ms(void) {
+  return s_backlight_timeout_ms;
+}
+
+#define MS_TO_TICKS(ms) (((ms) * (RtcTicks)RTC_TICKS_HZ) / 1000)
+#define TIMEOUT_TICKS MS_TO_TICKS(s_backlight_timeout_ms)
+
+// setup and teardown
+void test_touch_session__initialize(void) {
+  fake_rtc_init(1000 /* initial_ticks */, 0 /* initial_time */);
+  // Guarded posture: idle watchface, no modal, backlight off.
+  s_watchface_running = true;
+  s_modal_enabled = false;
+  s_modal_properties = ModalPropertyDefault;
+  s_light_on = false;
+  s_backlight_timeout_ms = 3000;
+  touch_session_reset();
+}
+
+void test_touch_session__cleanup(void) {
+}
+
+// tests
+void test_touch_session__inactive_by_default(void) {
+  cl_assert(!touch_session_is_active());
+}
+
+void test_touch_session__arm_activates_until_deadline(void) {
+  touch_session_arm(TouchSessionArmSource_WakeGesture);
+  cl_assert(touch_session_is_active());
+
+  fake_rtc_increment_ticks(TIMEOUT_TICKS - 1);
+  cl_assert(touch_session_is_active());
+
+  fake_rtc_increment_ticks(1);
+  cl_assert(!touch_session_is_active());
+}
+
+void test_touch_session__extend_pushes_deadline(void) {
+  touch_session_arm(TouchSessionArmSource_Button);
+
+  fake_rtc_increment_ticks(TIMEOUT_TICKS - 1);
+  touch_session_extend();
+
+  // Past the original deadline, still inside the extended one.
+  fake_rtc_increment_ticks(TIMEOUT_TICKS - 1);
+  cl_assert(touch_session_is_active());
+
+  fake_rtc_increment_ticks(1);
+  cl_assert(!touch_session_is_active());
+}
+
+void test_touch_session__extend_while_inactive_is_a_noop(void) {
+  // Gated contact must not keep the session alive, let alone open it.
+  touch_session_extend();
+  cl_assert(!touch_session_is_active());
+
+  // Same after an armed session has expired.
+  touch_session_arm(TouchSessionArmSource_WakeGesture);
+  fake_rtc_increment_ticks(TIMEOUT_TICKS);
+  touch_session_extend();
+  cl_assert(!touch_session_is_active());
+}
+
+void test_touch_session__non_watchface_is_active(void) {
+  s_watchface_running = false;
+  cl_assert(touch_session_is_active());
+}
+
+void test_touch_session__focused_modal_is_active(void) {
+  s_modal_enabled = true;
+  s_modal_properties = 0;  // focused
+  cl_assert(touch_session_is_active());
+}
+
+void test_touch_session__unfocused_modal_stays_guarded(void) {
+  s_modal_enabled = true;
+  s_modal_properties = ModalProperty_Unfocused;
+  cl_assert(!touch_session_is_active());
+}
+
+void test_touch_session__disabled_modal_stays_guarded(void) {
+  // Properties say focused, but the modal stack is disabled.
+  s_modal_enabled = false;
+  s_modal_properties = 0;
+  cl_assert(!touch_session_is_active());
+}
+
+void test_touch_session__lit_backlight_is_active(void) {
+  s_light_on = true;
+  cl_assert(touch_session_is_active());
+}
+
+void test_touch_session__extend_in_menu_arms_deadline(void) {
+  // Touching inside a menu (non-watchface => active) arms the deadline, so
+  // touch stays live briefly after backing out to the watchface.
+  s_watchface_running = false;
+  touch_session_extend();
+
+  s_watchface_running = true;
+  cl_assert(touch_session_is_active());
+
+  fake_rtc_increment_ticks(TIMEOUT_TICKS);
+  cl_assert(!touch_session_is_active());
+}
+
+void test_touch_session__reset_closes_deadline(void) {
+  touch_session_arm(TouchSessionArmSource_WakeGesture);
+  cl_assert(touch_session_is_active());
+
+  touch_session_reset();
+  cl_assert(!touch_session_is_active());
+}
+
+void test_touch_session__deadline_follows_backlight_timeout_pref(void) {
+  // The pref is sampled when the session is armed, not cached at init.
+  s_backlight_timeout_ms = 10000;
+  touch_session_arm(TouchSessionArmSource_WakeGesture);
+
+  fake_rtc_increment_ticks(MS_TO_TICKS(10000) - 1);
+  cl_assert(touch_session_is_active());
+  fake_rtc_increment_ticks(1);
+  cl_assert(!touch_session_is_active());
+
+  // A shortened pref applies from the next arm.
+  s_backlight_timeout_ms = 1000;
+  touch_session_arm(TouchSessionArmSource_Button);
+  fake_rtc_increment_ticks(MS_TO_TICKS(1000));
+  cl_assert(!touch_session_is_active());
+}
+
+void test_touch_session__reset_leaves_overrides(void) {
+  touch_session_arm(TouchSessionArmSource_Button);
+  touch_session_reset();
+
+  // Environmental overrides are not the deadline's business.
+  s_watchface_running = false;
+  cl_assert(touch_session_is_active());
+}

--- a/tests/fw/services/wscript_build
+++ b/tests/fw/services/wscript_build
@@ -470,6 +470,11 @@ clar(ctx,
     test_sources_ant_glob = "test_touch.c")
 
 clar(ctx,
+    sources_ant_glob = "src/fw/services/touch/touch_session.c" \
+        " tests/fakes/fake_rtc.c",
+    test_sources_ant_glob = "test_touch_session.c")
+
+clar(ctx,
     sources_ant_glob = \
         "src/fw/services/hrm/hrm_manager.c " \
         "lib/os/tick.c " \

--- a/tests/fw/ui/recognizer/test_touch_nav.c
+++ b/tests/fw/ui/recognizer/test_touch_nav.c
@@ -1016,52 +1016,6 @@ static void prv_register_fake_widget(TouchNavWidgetNode *node) {
   s_active_layer = &s_child_layer;
 }
 
-// A Touchdown that woke the screen (wake_touch stamped): the gesture must not tap or swipe, but a
-// follow-on drag is deliberate, now-visible input — the widget pan drives scrolling in the SAME
-// gesture instead of demanding a lift and re-touch.
-void test_touch_nav__wake_touchdown_pans_but_never_taps(void) {
-  static TouchNavWidgetNode node;
-  prv_register_fake_widget(&node);
-  s_widget.can_start_result = true;
-
-  const TouchEvent td = {.type = TouchEvent_Touchdown, .x = 50, .y = 150, .wake_touch = true};
-  touch_nav_dispatch(&td, &s_state);
-  cl_assert_equal_i(s_state.route, TouchNavRoute_Tier1);
-  // Taps and swipes are dead for this gesture, in both recognizer sets.
-  cl_assert_equal_i(prv_state(s_state.tap), RecognizerState_Failed);
-  cl_assert_equal_i(prv_state(s_state.swipe), RecognizerState_Failed);
-  cl_assert_equal_i(prv_state(s_state.widget_tap), RecognizerState_Failed);
-  cl_assert_equal_i(prv_state(s_state.widget_swipe), RecognizerState_Failed);
-  // The widget pan is alive and a drag drives the widget.
-  cl_assert(prv_state(s_state.widget_pan) != RecognizerState_Failed);
-  prv_advance_ms(20);
-  const TouchEvent pu = {.type = TouchEvent_PositionUpdate, .x = 50, .y = 100, .wake_touch = true};
-  touch_nav_dispatch(&pu, &s_state);
-  cl_assert_equal_i(s_widget.pan_started_calls, 1);
-  const TouchEvent lo = {.type = TouchEvent_Liftoff, .wake_touch = true};
-  touch_nav_dispatch(&lo, &s_state);
-  cl_assert_equal_i(s_widget.pan_snap_calls, 1);
-  cl_assert_equal_i(s_widget.tap_calls, 0);
-  cl_assert_equal_i(s_widget.swipe_calls, 0);
-  cl_assert_equal_i(s_fake.emit_count, 0);
-}
-
-// A stationary wake tap completes nothing anywhere: no widget tap, no bridge emulation.
-void test_touch_nav__wake_tap_is_inert(void) {
-  static TouchNavWidgetNode node;
-  prv_register_fake_widget(&node);
-  s_widget.can_start_result = true;
-
-  const TouchEvent td = {.type = TouchEvent_Touchdown, .x = 50, .y = 90, .wake_touch = true};
-  touch_nav_dispatch(&td, &s_state);
-  prv_advance_ms(30);
-  const TouchEvent lo = {.type = TouchEvent_Liftoff, .wake_touch = true};
-  touch_nav_dispatch(&lo, &s_state);
-  cl_assert_equal_i(s_widget.tap_calls, 0);
-  cl_assert_equal_i(s_fake.emit_count, 0);
-  cl_assert_equal_i(s_fake.pop_count, 0);
-}
-
 // can_start returning false declines the WHOLE gesture: no pan_started/get_base_offset, the unified
 // pan is NOT set_failed/cancelled, later events drive nothing and never re-latch, and `declined`
 // resets on the next Touchdown so a following can_start=true gesture drives the widget normally.


### PR DESCRIPTION
## What

Enables touch navigation by default, gated by a new **interaction session** so accidental contact costs nothing: raw touchdowns only navigate (and hold the backlight) after a deliberate act — the backlight wake gesture (double-tap/tap per the existing pref), a button press, a focused modal, or being in any UI other than the idle watchface. The session lasts the user's backlight timeout, tracked as its own deadline because bright ambient (or DnD) keeps the actual backlight off.

## Why

Power testing showed touch nav's only cost is backlight-on-touch. Fleet heartbeats (14 days, obelix + getafix) show **65–82% of touch contact never becomes a recognized gesture** (~2–14 contacts/hour of brushes, water, sleeves) — ungated, each of those would light the screen. The old wake gate keyed off `light_is_on()`, which the ALS keeps false in bright ambient, so every touchdown navigated ungated in daylight.

## Behavior changes

- Unarmed contact on the idle watchface is fully inert (no light, no navigation). The arming gesture itself can never act on the UI (the chip reports the tap's touch events before the gesture code).
- The touchdown light is focus-aware: a third-party app that never subscribed to touch gets no touchdown backlight (they're nav-inert unless they opt in via `app_touch_navigation_enable()`).
- DnD no longer latches touches non-navigational; it only suppresses the light.
- The wake-and-scroll pan continuation is gone (arming and navigating are separate gestures); `wake_touch` plumbing removed.
- Settings shows the real Double Tap/Tap/Off wake value again instead of "On (nav)".
- Default flip affects fresh installs only; a stored `touchNavMenuEnabled` pref is honored.

## Verification

- 325/325 unit suites, including a new `test_touch_session` suite (deadline, pref sampling, arming sources, environmental overrides).
- Builds: obelix@pvt, getafix@dvt2, qemu_gabbro.
- QEMU end-to-end: cold-watchface swipes/taps inert with the new `touch_gated_touchdown_count` analytics counter matching exactly; button-armed swipe not gated; `notif test` modal scrolls by swipe with `gated=0`; gating resumes after the timeout.
- On-device (obelix): double-tap arming, armed touch-holds-light, third-party app no-light rule.

## Deferred

- CST816 gesture-only IRQ mode while disarmed (register 0xFA) — power follow-up, needs bench validation of the vendor blobs.
- Palm code 0xAA handling in the driver.
- A visible arming affordance for bright ambient (armed state is currently invisible there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
