### PR TITLE
docs: document adb firmware sideloading on Android

### DIFF
--- a/docs/development/building_fw.md
+++ b/docs/development/building_fw.md
@@ -47,3 +47,21 @@ onto your sealed watch:
 The resulting `.pbz` file will be located in the `build/` directory. Transfer this file
 to the device paired to your watch, then, in the Pebble app, enable `Settings -> Show debug options`.
 Go back to the Devices tab, tap your watch, then `Firmware Update Debug -> Sideload FW`, and select the `.pbz` file.
+
+On Android, flashing repeatedly is better scripted over adb, which installs without asking. This route
+is open to an adb shell, which holds the `android.permission.DUMP` the broadcast requires,
+and it needs `Show debug options` on in the app. `$PBZ` is the file from `build/`:
+
+```shell
+adb push $PBZ /data/local/tmp/firmware.pbz
+adb shell am broadcast -a coredevices.pebble.SIDELOAD_FIRMWARE \
+    -n coredevices.coreapp/coredevices.pebble.firmware.FirmwareSideloadReceiver \
+    --es path /data/local/tmp/firmware.pbz
+```
+
+The app waits up to a minute for the watch to be connected, then starts the update and
+shows its progress on the watch card in the Devices tab.
+
+Not every Android version lets an app read `/data/local/tmp`. If the app reports the file
+as missing, create `/sdcard/Android/data/coredevices.coreapp/cache` and push it there
+instead.


### PR DESCRIPTION
The building firmware guide covers flashing over a debugger and the manual sideload, but not how to iterate on firmware from an Android phone without touching the phone UI. This documents the adb broadcast route next to the existing steps.

- The broadcast installs without asking, needs `Show debug options` on, and is gated on `android.permission.DUMP`, which an adb shell holds.
- The file is staged in `/data/local/tmp`, with the app's external cache directory as the fallback for Android versions that will not let the app read it.
- The receiver landed in coredevices/mobileapp#321.

Written with AI assistance (Claude), and the route exercised on a Pixel 6 with a Pebble Time 2.

---

Aside: I am currently available for firmware contracting or full-time work. Contact: adrian@pascu.be.
