### PR TITLE
drivers/speaker: apply volume before un-muting the DAC path

### DIFF
--- a/src/fw/drivers/speaker/sf32lb52/audec.c
+++ b/src/fw/drivers/speaker/sf32lb52/audec.c
@@ -392,7 +392,10 @@ void audec_start(AudioDevice* audio_device, AudioTransCB cb) {
 
     HAL_AUDCODEC_Config_DACPath(haudcodec, 1);
     HAL_AUDCODEC_Config_Analog_DACPath(haudcodec->Init.dac_cfg.dac_clk);
-    HAL_AUDCODEC_Config_DACPath(haudcodec, 0);
+    // Volume 0 muted the path in prv_apply_volume(); don't reopen it.
+    if (state->volume != 0) {
+        HAL_AUDCODEC_Config_DACPath(haudcodec, 0);
+    }
 
     hwp_audcodec->DAC_CH0_CFG_EXT &= ~AUDCODEC_DAC_CH0_CFG_EXT_RAMP_EN_Msk;
     hwp_audcodec->DAC_CH1_CFG_EXT &= ~AUDCODEC_DAC_CH1_CFG_EXT_RAMP_EN_Msk;

--- a/src/fw/drivers/speaker/sf32lb52/audec.c
+++ b/src/fw/drivers/speaker/sf32lb52/audec.c
@@ -383,6 +383,10 @@ void audec_start(AudioDevice* audio_device, AudioTransCB cb) {
     HAL_NVIC_EnableIRQ(audio_device->audec_dma_irq);
     state->tx_instanc = HAL_AUDCODEC_DAC_CH0;
 
+    // Digital gain must be programmed before the DAC path opens, otherwise
+    // startup transients escape at the codec's default 0 dB gain.
+    prv_apply_volume(audio_device);
+
     /* enable AUDCODEC at last*/
     __HAL_AUDCODEC_DAC_ENABLE(haudcodec);
 
@@ -392,8 +396,6 @@ void audec_start(AudioDevice* audio_device, AudioTransCB cb) {
 
     hwp_audcodec->DAC_CH0_CFG_EXT &= ~AUDCODEC_DAC_CH0_CFG_EXT_RAMP_EN_Msk;
     hwp_audcodec->DAC_CH1_CFG_EXT &= ~AUDCODEC_DAC_CH1_CFG_EXT_RAMP_EN_Msk;
-
-    prv_apply_volume(audio_device);
 }
 
 uint32_t audec_write(AudioDevice* audio_device, void *writeBuf, uint32_t size) {


### PR DESCRIPTION
I was adding hourly "POST success" beep into my [Nostalgic Commander](https://apps.repebble.com/nostalgic-commander_d19443a35c6240ccaca492f5) watchface, and I noticed that on lower volume settings it's not just BOOOOOOP, it's BE-BOOOOP. Some investigation revealed that the driver applied volume gain AFTER sound has already started playing. This PR fixes the bug.