### PR TITLE
fw/services/battery: add optional fuel gauge diagnostic logging

### DIFF
--- a/src/fw/services/battery/Kconfig
+++ b/src/fw/services/battery/Kconfig
@@ -33,6 +33,25 @@ config BATTERY_WARNING_SECOND_PERCENT
       Battery percentage for the second warning. A value of 0 uses the
       default time-based threshold of 12 hours remaining.
 
+config BATTERY_GAUGE_DIAG_LOG
+    bool "Periodic fuel gauge diagnostic logging"
+    default n
+    help
+      Log a structured line with the raw fuel gauge inputs and outputs
+      (SOC, voltage, current, temperature, TTE/TTF, charger state) at a
+      fixed interval, regardless of charge activity. Intended for
+      validating state-of-charge estimation on development devices, for
+      example under charge regimes that never reach full. Off for
+      production builds.
+
+config BATTERY_GAUGE_DIAG_LOG_INTERVAL_S
+    int "Fuel gauge diagnostic log interval (seconds)"
+    depends on BATTERY_GAUGE_DIAG_LOG
+    range 60 3600
+    default 900
+    help
+      Interval between fuel gauge diagnostic log lines.
+
 module = SERVICE_BATTERY
 module-str = Battery
 source "subsys/logging/Kconfig.template.log_level"

--- a/src/fw/services/battery/nrf_fuel_gauge/battery_state.c
+++ b/src/fw/services/battery/nrf_fuel_gauge/battery_state.c
@@ -85,6 +85,9 @@ static void prv_track_soc_min(void) {
 static uint32_t s_last_tte;
 static uint32_t s_last_ttf;
 static RtcTicks s_last_log;
+#if defined(CONFIG_BATTERY_GAUGE_DIAG_LOG)
+static RtcTicks s_last_diag_log;
+#endif
 static bool s_charger_enabled;
 
 #if FUEL_GAUGE_STATEFUL
@@ -420,6 +423,17 @@ static void prv_update_state(void *force_update) {
     prv_battery_state_put_change_event(s_last_battery_charge_state);
     s_last_log = now;
   }
+
+#if defined(CONFIG_BATTERY_GAUGE_DIAG_LOG)
+  if ((now - s_last_diag_log) / RTC_TICKS_HZ >= CONFIG_BATTERY_GAUGE_DIAG_LOG_INTERVAL_S) {
+    s_last_diag_log = now;
+    PBL_LOG_INFO("gauge diag: soc_cpct=%" PRIu32 " v_mv=%" PRId32 " i_ua=%" PRId32
+            " t_mc=%" PRId32 " tte_s=%" PRIu32 " ttf_s=%" PRIu32 " state=%s",
+            s_last_soc_cpct, constants.v_mv, constants.i_ua, constants.t_mc, s_last_tte,
+            s_last_ttf,
+            is_charging ? "charging" : (is_plugged ? "plugged" : "unplugged"));
+  }
+#endif
 
   // Enable battery charging after fuel gauge state has been updated for the first time
   if (!s_charger_enabled) {


### PR DESCRIPTION
Validating state-of-charge estimation needs a uniform record of what the fuel gauge was told and what it concluded. The existing battery log fires on percent changes and while charging, so it is dense during a charge and silent for hours otherwise. This adds an evenly spaced one, off unless a build asks for it.

`BATTERY_GAUGE_DIAG_LOG` gates a single structured line carrying the raw inputs and outputs together: SOC in centi-percent, voltage, current, temperature, time-to-empty and time-to-full, and whether the charger is unplugged, plugged or charging. `BATTERY_GAUGE_DIAG_LOG_INTERVAL_S` sets the cadence, 60 to 3600 seconds, default 900. Everything logged is already in hand at that point in `prv_update_state`, so nothing new is measured and no driver changes are needed.

The flag defaults to off and the block compiles out with it, so production builds are byte-identical to today.

Motivated by the review discussion on coredevices/PebbleOS#1841. Answering whether reported SOC drifts when a battery never reaches full needs voltage sampled alongside SOC on a fixed interval, from a watch actually living under a charge limit, which is what this produces. Running on my Pebble Time 2 since 2026-08-11 with the charge limit at 55%.

Written with AI assistance (Claude).

---

Aside: I am currently available for firmware contracting or full-time work. Contact: adrian@pascu.be.

