### PR TITLE
fw/drivers/pmic/npm1300: fix truncated battery current and temperature readings

### DIFF
--- a/src/fw/drivers/pmic/npm1300.c
+++ b/src/fw/drivers/pmic/npm1300.c
@@ -587,8 +587,8 @@ int battery_get_constants(BatteryConstants *constants) {
   }
 
   raw = (msb << NPM1300_ADC_MSB_SHIFT) |
-        ((lsb & PmicRegisters_ADC_ADCGP0RESULTLSBS_VBATRESULTLSB_MSK) >>
-         PmicRegisters_ADC_ADCGP0RESULTLSBS_VBATRESULTLSB_POS);
+        ((lsb >> PmicRegisters_ADC_ADCGP0RESULTLSBS_VBATRESULTLSB_POS) &
+         PmicRegisters_ADC_ADCGP0RESULTLSBS_VBATRESULTLSB_MSK);
 
   constants->v_mv = (int32_t)(raw * NPM1300_ADC_VFS_VBAT_MV) / NPM1300_BCHARGER_ADC_BITS_RESOLUTION;
 
@@ -616,8 +616,8 @@ int battery_get_constants(BatteryConstants *constants) {
   }
 
   raw = (msb << NPM1300_ADC_MSB_SHIFT) |
-        ((lsb & PmicRegisters_ADC_ADCGP1RESULTLSBS_VBAT2RESULTLSB_MSK) >>
-         PmicRegisters_ADC_ADCGP1RESULTLSBS_VBAT2RESULTLSB_POS);
+        ((lsb >> PmicRegisters_ADC_ADCGP1RESULTLSBS_VBAT2RESULTLSB_POS) &
+         PmicRegisters_ADC_ADCGP1RESULTLSBS_VBAT2RESULTLSB_MSK);
 
   constants->i_ua = ((int32_t)raw * full_scale_ua) / NPM1300_BCHARGER_ADC_BITS_RESOLUTION;
 
@@ -645,8 +645,8 @@ int battery_get_constants(BatteryConstants *constants) {
   }
 
   raw = (lsb << NPM1300_ADC_MSB_SHIFT) |
-        ((msb & PmicRegisters_ADC_ADCGP0RESULTLSBS_NTCRESULTLSB_MSK) >>
-         PmicRegisters_ADC_ADCGP0RESULTLSBS_NTCRESULTLSB_POS);
+        ((msb >> PmicRegisters_ADC_ADCGP0RESULTLSBS_NTCRESULTLSB_POS) &
+         PmicRegisters_ADC_ADCGP0RESULTLSBS_NTCRESULTLSB_MSK);
 
   // Ref: PS v1.2 Section 7.1.4: Battery temperature (Kelvin)
   float log_result = logf((1024.f / (float)raw) - 1.0f);


### PR DESCRIPTION
The PMIC's ADC readings are 10 bits wide: 8 bits in one register and 2 more in a shared register. The code combined them with `(reg & MSK) >> POS`, which throws the 2 extra bits away whenever `POS` is not zero, so battery current and temperature only ever had a quarter of their real resolution. This changes the read to `(reg >> POS) & MSK`, which keeps them.

The bit positions in the existing constants match the nPM1300 spec (§7.1.10.18, §7.1.10.23, [mirror](https://download.mikroe.com/documents/datasheets/nPM1300_datasheet.pdf)), and the new form is how Nordic's own drivers read these fields ([npmx](https://github.com/nordicsemi/npmx/blob/4da2753cf47b7fb2cd4443e518eb7b9aaca6fe2f/adk/npm1300.h#L3695-L3696), [Zephyr](https://github.com/zephyrproject-rtos/zephyr/blob/51e6cbddba8e27395958f306abb949c824f0dba0/drivers/sensor/nordic/npm1300_charger/npm1300_charger.c#L179-L182)). Voltage was already read correctly because its `POS` is zero. It moves to the same form so all three reads look alike.

Resolution improvement on the Pebble Time 2:

- battery current: 876 µA to 219 µA
- temperature: 0.41 °C to 0.10 °C, which also stops it reading slightly high

The old behaviour is visible in logs from my watch: every battery current value maps back to an ADC count divisible by four, while voltage uses all counts. That only happens if the two low bits never make it through. The charger's overtemperature cutoff is not affected, it lives in the PMIC hardware rather than in this code path.

> [!NOTE]
> Checked against the datasheet, Nordic's drivers, and the logs above, but not yet run on hardware. I will flash my Pebble Time 2 on 2026-08-14 and report the before and after here. Nordic's [FAQ](https://devzone.nordicsemi.com/nordic/nordic-blog/b/blog/posts/frequently-asked-questions-for-the-npm1300-and-npm1304) notes the current measurement is not accurate below 5 mA, so this restores resolution rather than making tiny readings exact.

Written with AI assistance (Claude).

---

Aside: I am currently available for firmware contracting or full-time work. Contact: adrian@pascu.be.
