### PR TITLE
fw/services: fix analytics heartbeat never reaching companion app

### DIFF
--- a/src/fw/services/analytics/native.c
+++ b/src/fw/services/analytics/native.c
@@ -307,7 +307,7 @@ void pbl_analytics__native_heartbeat(void) {
     Uuid system_uuid = UUID_SYSTEM;
 
     s_dls_session = dls_create(DlsSystemTagAnalyticsNativeHeartbeat, DATA_LOGGING_BYTE_ARRAY,
-                               sizeof(struct native_heartbeat_record), false, false, &system_uuid);
+                               sizeof(struct native_heartbeat_record), true, false, &system_uuid);
     PBL_ASSERTN(s_dls_session != NULL);
   }
 

--- a/src/fw/services/data_logging/dls_endpoint.c
+++ b/src/fw/services/data_logging/dls_endpoint.c
@@ -223,7 +223,7 @@ static void dls_endpoint_print_message(uint8_t *message, int num_bytes) {
 
 bool dls_endpoint_open_session(DataLoggingSession *session) {
   CommSession *comm_session = comm_session_get_system_session();
-  if (!session) {
+  if (!comm_session) {
     return false;
   }
 


### PR DESCRIPTION
## Summary

  Analytics heartbeat records (DataLogging tag 87) were never received by
  the CoreApp due to two bugs that compound each other:

  - **Bug 1** (`dls_endpoint.c:226`): `dls_endpoint_open_session()` checks
    `!session` (the `DataLoggingSession` parameter, never NULL) instead of
    `!comm_session` (the BLE session, which can be NULL). When called with a
    NULL CommSession the OpenSession packet is silently dropped and the
    session is left stuck in `DataLoggingSessionCommStateOpening`.

  - **Bug 2** (`native.c:310`): The heartbeat DLS session is created with
    `buffered=false`, which provides no automatic retry on failure. Buffered
    sessions (e.g. tag 81 / Steps) retry every 5 minutes and recover
    automatically; non-buffered sessions do not.

  Together: Bug 1 causes the initial OpenSession to fail, Bug 2 prevents
  recovery. The result is that the companion app never receives a tag 87
  session, regardless of how long the watch runs or how many times it
  reboots.

  ## Test plan

  - [ ] Build and flash firmware onto an obelix board
  - [ ] Confirm tag 87 OpenSession appears in CoreApp verbose log within
    the first heartbeat interval after pairing
  - [ ] Confirm recovery after a BLE disconnect/reconnect cycle
  - [ ] Confirm no regression on tags 81-85 (Steps, Sleep, HR)

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
