### PR TITLE
fw/drivers: fix OTP security register write cache coherency

### DIFF
--- a/src/fw/drivers/otp/otp_flash.c
+++ b/src/fw/drivers/otp/otp_flash.c
@@ -1,6 +1,8 @@
 /* SPDX-FileCopyrightText: 2025 Core Devices LLC */
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include <string.h>
+
 #include <pbl/drivers/otp.h>
 #include <pbl/drivers/flash.h>
 
@@ -102,6 +104,11 @@ OtpWriteResult otp_write_slot(const uint8_t index, const char *value) {
     if (ret != S_SUCCESS) {
       return OtpWriteFailCorrupt;
     }
+  }
+
+  existing_val = otp_get_slot(index);
+  if ((existing_val == NULL) || (memcmp(existing_val, value, len + 1) != 0)) {
+    return OtpWriteFailCorrupt;
   }
 
   return OtpWriteSuccess;

--- a/src/fw/drivers/sf32lb52/qspi.c
+++ b/src/fw/drivers/sf32lb52/qspi.c
@@ -363,6 +363,11 @@ status_t qspi_flash_write_security_register(QSPIFlash *dev, uint32_t addr, uint8
     return res;
   }
 
+  uintptr_t flush_addr = (uintptr_t)&val;
+  size_t flush_size = sizeof(val);
+  dcache_align(&flush_addr, &flush_size);
+  dcache_flush((const void *)flush_addr, flush_size);
+
   portENTER_CRITICAL();
   res = HAL_QSPI_WRITE_OTP(hflash, addr, &val, 1);
   portEXIT_CRITICAL();


### PR DESCRIPTION
## Problem

Factory serial-number provisioning on getafix is broken since MF package v13: after step 2.2 all mfginfo-tool steps report OK, but the watch shows an empty serial in the MFG PRF Device Info menu (locked units) or the dummy `XXXXXXXXXXXX` (unlocked units). Last working package was v12.

## Root cause

`qspi_flash_write_security_register()` passes a single stack byte (`&val`) to `HAL_QSPI_WRITE_OTP()`, which fetches the data over DMA (`HAL_FLASH_DMA_START`). Since fa8677e73 ("third_party/hal_sifli/sf32lb52: shrink HPSYS RAM MPU region to .ramfunc") the KernelBG stack lives in cacheable HPSYS SRAM, so the DMA reads stale SRAM behind the D-cache and the flash programs garbage while the HAL reports success. 4bde4ee00 fixed the same coherency break for array writes (`prv_write_nor`) but missed the OTP path. Erase/lock/read are command/FIFO-based (no DMA data phase), which is why the blank check passes, the tool prints OK, and the lock succeeds — permanently locking corrupt serials.

Timeline match: fa8677e73 landed between v4.9.171 (MF v12, last good) and v4.11.0 (MF v13, first bad). Confirmed the production v4.11.0 prf_mfg binary places the KernelBG stack at 0x20028b00 (cacheable, outside DTCM) by extracting the xTaskCreateStatic literal pool from the shipped hex.

The HAL's internal `mpu_dcache_clean()` in `HAL_DMA_Start` is compiled out (`PSRAM_CACHE_WB` undefined) and only covers PSRAM addresses anyway.

## Fix

- Flush the source byte's cache line before `HAL_QSPI_WRITE_OTP`, mirroring 4bde4ee00.
- Read back and verify OTP slot contents after writing in `otp_write_slot()`, so silently ignored programs (e.g. already-locked register) fail loudly instead of returning success.

## Impact / follow-ups

- Units burned+locked with v13–v18 MF packages have security register 1 locked forever with corrupt/blank serials — needs factory triage (`flash sec info` / `flash sec read 0x1020`).
- mfginfo-tool should also read back and verify before locking (separate mfgtools PR).
- Factory-parity test build (pebbleos-docker:v6, release.yml flags) sent to factory for validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)