### PR TITLE
applib/recognizer: read nav gates and ticks through syscalls

### DIFF
--- a/src/fw/applib/ui/menu_layer.c
+++ b/src/fw/applib/ui/menu_layer.c
@@ -35,6 +35,7 @@
 #include "applib/ui/scroll_layer_private.h"
 #include "kernel/pebble_tasks.h"
 #include "pbl/drivers/rtc.h"
+#include "syscall/syscall.h"
 
 // The per-task touch-nav state lives in the app state (app task) or the modal manager (KernelMain).
 // Forward-declared here to avoid pulling those heavy kernel/app headers into this applib module.
@@ -1802,7 +1803,7 @@ void menu_layer_touch_handle_tap(MenuLayer *menu_layer, GPoint point_on_screen) 
     return;
   }
 
-  const RtcTicks now = rtc_get_ticks();
+  const RtcTicks now = sys_get_ticks();
   const RtcTicks window_ticks = (RtcTicks)DOUBLE_TAP_WINDOW_MS * RTC_TICKS_HZ / 1000;
 
   // Priority 1 — fast double tap: a second tap within the window after a tap-select activates the

--- a/src/fw/applib/ui/recognizer/pan.c
+++ b/src/fw/applib/ui/recognizer/pan.c
@@ -8,6 +8,7 @@
 
 #include "pbl/drivers/rtc.h"
 #include "pbl/util/math.h"
+#include "syscall/syscall.h"
 
 #include <string.h>
 
@@ -134,7 +135,7 @@ static void prv_handle_touch_event(Recognizer *recognizer, const TouchEvent *tou
   switch (touch_event->type) {
     case TouchEvent_Touchdown: {
       const GPoint point = GPoint(touch_event->x, touch_event->y);
-      const RtcTicks now = rtc_get_ticks();
+      const RtcTicks now = sys_get_ticks();
       data->state.touch_down_point = point;
       data->state.start_point = point;
       data->state.prev_point = point;
@@ -147,7 +148,7 @@ static void prv_handle_touch_event(Recognizer *recognizer, const TouchEvent *tou
 
     case TouchEvent_PositionUpdate: {
       const GPoint point = GPoint(touch_event->x, touch_event->y);
-      const RtcTicks now = rtc_get_ticks();
+      const RtcTicks now = sys_get_ticks();
       prv_record_sample(data, point, now);
       // prev_point lags one event behind last_point so delta_since_prev is the delta between the
       // two most-recent events.

--- a/src/fw/applib/ui/recognizer/swipe.c
+++ b/src/fw/applib/ui/recognizer/swipe.c
@@ -8,6 +8,7 @@
 
 #include "pbl/drivers/rtc.h"
 #include "pbl/util/math.h"
+#include "syscall/syscall.h"
 
 #include <string.h>
 
@@ -71,7 +72,7 @@ static uint32_t prv_ticks_to_ms(RtcTicks ticks) {
 }
 
 static uint32_t prv_touch_duration_ms(const SwipeRecognizerData *data) {
-  return prv_ticks_to_ms(rtc_get_ticks() - data->state.touch_down_ticks);
+  return prv_ticks_to_ms(sys_get_ticks() - data->state.touch_down_ticks);
 }
 
 static void prv_record_sample(SwipeRecognizerData *data, GPoint point, RtcTicks ticks) {
@@ -132,7 +133,7 @@ static void prv_handle_touch_event(Recognizer *recognizer, const TouchEvent *tou
   switch (touch_event->type) {
     case TouchEvent_Touchdown: {
       const GPoint point = GPoint(touch_event->x, touch_event->y);
-      const RtcTicks now = rtc_get_ticks();
+      const RtcTicks now = sys_get_ticks();
       data->state.touch_down_point = point;
       data->state.last_point = point;
       data->state.touch_down_ticks = now;
@@ -145,7 +146,7 @@ static void prv_handle_touch_event(Recognizer *recognizer, const TouchEvent *tou
 
     case TouchEvent_PositionUpdate: {
       const GPoint point = GPoint(touch_event->x, touch_event->y);
-      prv_record_sample(data, point, rtc_get_ticks());
+      prv_record_sample(data, point, sys_get_ticks());
       data->state.last_point = point;
 
       const GPoint total_delta = gpoint_sub(point, data->state.touch_down_point);

--- a/src/fw/applib/ui/recognizer/tap.c
+++ b/src/fw/applib/ui/recognizer/tap.c
@@ -8,6 +8,7 @@
 
 #include "pbl/drivers/rtc.h"
 #include "pbl/util/math.h"
+#include "syscall/syscall.h"
 
 #include <string.h>
 
@@ -57,7 +58,7 @@ static bool prv_moved_too_far(const TapRecognizerData *data, const TouchEvent *t
 }
 
 static uint32_t prv_touch_duration_ms(const TapRecognizerData *data) {
-  const RtcTicks elapsed = rtc_get_ticks() - data->state.touch_down_ticks;
+  const RtcTicks elapsed = sys_get_ticks() - data->state.touch_down_ticks;
   return (uint32_t)((elapsed * MS_PER_SECOND) / RTC_TICKS_HZ);
 }
 
@@ -71,7 +72,7 @@ static void prv_handle_touch_event(Recognizer *recognizer, const TouchEvent *tou
       // refined by later position updates.
       data->state.touch_down_point = GPoint(touch_event->x, touch_event->y);
       data->state.tap_point = data->state.touch_down_point;
-      data->state.touch_down_ticks = rtc_get_ticks();
+      data->state.touch_down_ticks = sys_get_ticks();
       data->state.fingers_down = 1;
       break;
 

--- a/src/fw/applib/ui/recognizer/touch_nav.c
+++ b/src/fw/applib/ui/recognizer/touch_nav.c
@@ -17,6 +17,7 @@
 #include "pbl/services/touch/touch.h"
 #include "pbl/util/math.h"
 #include "pbl/util/size.h"
+#include "syscall/syscall.h"
 #include "system/passert.h"
 
 #include <stddef.h>
@@ -267,7 +268,7 @@ static void prv_widget_recognizer_event(const Recognizer *recognizer, Recognizer
       break;
     case RecognizerEvent_Updated:
       if (!state->declined && recognizer == state->widget_pan) {
-        const RtcTicks now = rtc_get_ticks();
+        const RtcTicks now = sys_get_ticks();
         const RtcTicks min_ticks =
             (RtcTicks)TOUCH_NAV_WIDGET_PAN_UPDATE_MIN_INTERVAL_MS * RTC_TICKS_HZ / 1000;
         if (now - state->last_update_ticks >= min_ticks) {
@@ -456,7 +457,7 @@ void touch_nav_dispatch(const TouchEvent *touch_event, void *context) {
   // activated, no route is resolved, and the bridge synthesizes nothing. System nav covers the
   // kernel twin and participating apps; app-nav-active covers an opted-in app riding the master
   // pref alone.
-  if (!touch_nav_enabled() && !touch_app_nav_active()) {
+  if (!sys_touch_nav_enabled() && !sys_touch_app_nav_active()) {
     return;
   }
 

--- a/src/fw/services/touch/touch.c
+++ b/src/fw/services/touch/touch.c
@@ -151,6 +151,14 @@ DEFINE_SYSCALL(bool, sys_touch_service_is_enabled, void) {
   return touch_service_is_globally_enabled();
 }
 
+DEFINE_SYSCALL(bool, sys_touch_nav_enabled, void) {
+  return touch_nav_enabled();
+}
+
+DEFINE_SYSCALL(bool, sys_touch_app_nav_active, void) {
+  return touch_app_nav_active();
+}
+
 DEFINE_SYSCALL(void, sys_touch_set_raw_subscribed, bool subscribed) {
   const PebbleTask task = pebble_task_get_current();
   mutex_lock(s_touch_mutex);

--- a/src/fw/syscall/syscall.h
+++ b/src/fw/syscall/syscall.h
@@ -218,6 +218,12 @@ bool sys_pebblekit_is_connected_debounced(void);
 bool sys_touch_service_is_enabled(void);
 void sys_touch_reset(void);
 
+//! Read the system and app-twin touch-navigation gates. The dispatcher runs on the app task,
+//! which is unprivileged for third-party apps, so these reads cannot touch the service's mutex
+//! and statics directly. Not exported to the SDK.
+bool sys_touch_nav_enabled(void);
+bool sys_touch_app_nav_active(void);
+
 //! Mark whether the calling task has a live raw-slot touch subscription
 //! (touch_service_subscribe). Drives touch_has_app_subscribers(); the shared
 //! per-task event-service subscription cannot distinguish the raw slot from

--- a/tests/fw/services/timeline/test_swap_layer_touch.c
+++ b/tests/fw/services/timeline/test_swap_layer_touch.c
@@ -86,8 +86,8 @@ void window_multi_click_subscribe(ButtonId button_id, uint8_t min_clicks, uint8_
 // the master gate; the recognizer manager needs a couple of window/layer collaborators to link.
 
 static bool s_nav_enabled = true;
-bool touch_nav_enabled(void) { return s_nav_enabled; }
-bool touch_app_nav_active(void) { return false; }
+bool sys_touch_nav_enabled(void) { return s_nav_enabled; }
+bool sys_touch_app_nav_active(void) { return false; }
 
 static TouchNavState s_touch_nav_state;
 struct TouchNavState *app_state_get_touch_nav_state(void) { return &s_touch_nav_state; }

--- a/tests/fw/ui/recognizer/test_touch_nav.c
+++ b/tests/fw/ui/recognizer/test_touch_nav.c
@@ -65,11 +65,11 @@ Layer *layer_find_layer_containing_point(const Layer *node, const GPoint *point)
 
 static bool s_nav_enabled;
 
-bool touch_nav_enabled(void) {
+bool sys_touch_nav_enabled(void) {
   return s_nav_enabled;
 }
 
-bool touch_app_nav_active(void) { return false; }
+bool sys_touch_app_nav_active(void) { return false; }
 
 // ---------------------------------------------------------------------------------------------
 // Fake TouchNavOps, recording every effect.

--- a/tests/fw/ui/test_action_menu_layer.c
+++ b/tests/fw/ui/test_action_menu_layer.c
@@ -40,8 +40,8 @@
 // window/layer collaborators to link.
 
 static bool s_nav_enabled = true;
-bool touch_nav_enabled(void) { return s_nav_enabled; }
-bool touch_app_nav_active(void) { return false; }
+bool sys_touch_nav_enabled(void) { return s_nav_enabled; }
+bool sys_touch_app_nav_active(void) { return false; }
 
 static TouchNavState s_touch_nav_state;
 struct TouchNavState *app_state_get_touch_nav_state(void) { return &s_touch_nav_state; }

--- a/tests/fw/ui/test_menu_layer.c
+++ b/tests/fw/ui/test_menu_layer.c
@@ -36,8 +36,8 @@
 // through these accessors; the recognizer manager needs a few window/layer collaborators to link.
 
 static bool s_nav_enabled = true;
-bool touch_nav_enabled(void) { return s_nav_enabled; }
-bool touch_app_nav_active(void) { return false; }
+bool sys_touch_nav_enabled(void) { return s_nav_enabled; }
+bool sys_touch_app_nav_active(void) { return false; }
 
 static TouchNavState s_touch_nav_state;
 struct TouchNavState *app_state_get_touch_nav_state(void) { return &s_touch_nav_state; }

--- a/tests/fw/ui/test_modal_touch_nav.c
+++ b/tests/fw/ui/test_modal_touch_nav.c
@@ -158,8 +158,8 @@ void app_click_config_setup_with_window(ClickManager *click_manager, struct Wind
 }
 
 // Touch-nav collaborators for the kernel twin.
-bool touch_nav_enabled(void) { return s_nav_enabled; }
-bool touch_app_nav_active(void) { return false; }
+bool sys_touch_nav_enabled(void) { return s_nav_enabled; }
+bool sys_touch_app_nav_active(void) { return false; }
 
 void touch_service_set_system_handler(TouchServiceHandler handler, void *context) {
   s_kernel_handler = handler;

--- a/tests/fw/ui/test_scroll_layer_touch.c
+++ b/tests/fw/ui/test_scroll_layer_touch.c
@@ -34,8 +34,8 @@
 // through these accessors; the recognizer manager needs a few window/layer collaborators to link.
 
 static bool s_nav_enabled = true;
-bool touch_nav_enabled(void) { return s_nav_enabled; }
-bool touch_app_nav_active(void) { return false; }
+bool sys_touch_nav_enabled(void) { return s_nav_enabled; }
+bool sys_touch_app_nav_active(void) { return false; }
 
 static TouchNavState s_touch_nav_state;
 struct TouchNavState *app_state_get_touch_nav_state(void) { return &s_touch_nav_state; }


### PR DESCRIPTION
Third-party apps that call `app_touch_navigation_enable(true)` are killed on their first touch, as reported in #1865. The custom-recognizer route documented in `docs/reference/recognizers.md` is unusable for the same reason.

## Root cause

`touch_nav_dispatch()` lives in `applib/` and runs on the app task, which is unprivileged for third-party apps: `prv_init_from_info_common()` sets `is_unprivileged = true` on every app loaded from its `PebbleProcessInfo` header. Its first statement read the touch service's nav gates directly, taking the kernel-owned mutex over kernel-owned statics:

```
PC 0x120ffa68 -> touch_nav_enabled    src/fw/services/touch/touch.c:86
LR 0x12142e83 -> touch_nav_dispatch   src/fw/applib/ui/recognizer/touch_nav.c:459
```

(symbolized against the `firmware_obelix_pvt_v4.33.1_slot0.elf` release artifact; the DVT artifact resolves the same addresses to two functions with no call relationship, which is what identifies PVT as the right one)

Built-in system apps are constructed from a static `PebbleProcessMd` where the flag stays false, so they are privileged and never hit this. That is why the whole system UI scrolls by touch while only third-party apps die.

The recognizers had the same problem one level down. `tap.c`, `pan.c`, `swipe.c` and the `menu_layer` double-tap window all called `rtc_get_ticks()`, which reaches `xTaskGetTickCount()`. That fault only surfaces once the first one is fixed:

```
PC 0x120d428e -> xTaskGetTickCount    FreeRTOS tasks.c:1777
LR 0x1203d771 -> rtc_get_ticks        src/fw/drivers/rtc/sf32lb.c:223
```

## Fix

Two new syscalls, `sys_touch_nav_enabled()` and `sys_touch_app_nav_active()`, mirroring the existing `sys_touch_service_is_enabled()` right next to them, plus nine `rtc_get_ticks()` call sites routed through the existing `sys_get_ticks()`.

No central registration is involved: `DEFINE_SYSCALL` emits a self-contained trampoline into its own `.syscall_text.<name>` section.

Six unit tests stubbed `touch_nav_enabled` / `touch_app_nav_active` under their old names and are renamed to match. `fake_rtc.c` already provides `sys_get_ticks()`, so the tick change needed no test changes.

## Why the recognizer route was inert

`recognizer_manager_handle_touch_event()` has exactly two call sites, `touch_nav.c:496` and `:527`, both downstream of the faulting line. So there was no reachable state for a third-party app: without the opt-in the recognizers were never fed, and with it the dispatcher faulted before it could feed them. `window_attach_recognizer()` and `window_set_touch_bridge_disabled()` become usable again with this change.

## Verification

- `./pbl test` green.
- QEMU `pebble-emery`, third-party app calling `app_touch_navigation_enable(true)`: tap on a plain `Layer` window opens the next window, vertical swipe scrolls a `MenuLayer` at pixel granularity, double-tap selects a row. No `App fault!` across the sequence; before the change the first touch was fatal.
- Obelix PVT hardware running `v4.33.1` plus this patch: touch works in the same app.

One thing I could not characterize: a horizontal swipe produced no BACK on QEMU. There is no baseline to compare against, since the app died on the first touch before this change, so I am not claiming it as either working or regressed.
