### PR TITLE
applib/touch: let watchfaces ride an already-powered touch sensor

### DIFF
--- a/src/fw/applib/touch_service.c
+++ b/src/fw/applib/touch_service.c
@@ -14,16 +14,14 @@
 #include "system/passert.h"
 
 //! @return the per-task touch service state, or NULL if the current task is
-//! not permitted to use the touch service (e.g. background workers, or
-//! watchfaces). Callers must no-op when this returns NULL.
+//! not permitted to use the touch service (e.g. background workers). Callers
+//! must no-op when this returns NULL. Watchfaces reach the raw slot through
+//! here; the system slot is gated separately in
+//! touch_service_set_system_handler().
 static TouchServiceState *prv_get_state(void) {
   PebbleTask task = pebble_task_get_current();
   switch (task) {
     case PebbleTask_App:
-      // Touch is reserved for watchapps; watchfaces must not consume it.
-      if (sys_app_is_watchface()) {
-        return NULL;
-      }
       return app_state_get_touch_service_state();
     case PebbleTask_KernelMain:
       return kernel_applib_get_touch_service_state();
@@ -67,6 +65,11 @@ static void prv_update_subscription(TouchServiceState *state) {
 }
 
 void touch_service_set_system_handler(TouchServiceHandler handler, void *context) {
+  // The Tier-2 bridge is a watchapp feature: a watchface drives its own UI from
+  // raw touch.
+  if ((pebble_task_get_current() == PebbleTask_App) && sys_app_is_watchface()) {
+    return;
+  }
   TouchServiceState *state = prv_get_state();
   if (!state) {
     return;

--- a/src/fw/services/touch/touch.c
+++ b/src/fw/services/touch/touch.c
@@ -8,6 +8,7 @@
 #include <pbl/drivers/touch/touch_sensor.h>
 #include "kernel/events.h"
 #include "kernel/pebble_tasks.h"
+#include "process_management/app_manager.h"
 #include "pbl/services/event_service.h"
 #include "pbl/services/analytics/analytics.h"
 #include "syscall/syscall.h"
@@ -30,6 +31,13 @@ static uint8_t s_subscriber_count = 0;
 //! system-slot handlers share the same per-task event-service subscription, so
 //! raw subscribers cannot be derived from s_subscriber_count.
 static uint8_t s_raw_subscriber_tasks = 0;
+//! Subset of s_subscriber_count that must never power the sensor: a watchface
+//! rides whatever a system holder already keeps on and powers nothing itself.
+static uint8_t s_passive_subscriber_count = 0;
+//! Bitmask by PebbleTask of the subscriptions counted in
+//! s_passive_subscriber_count, so the remove path unwinds the same accounting
+//! the add path chose (the task may no longer be a watchface by then).
+static uint8_t s_passive_subscriber_tasks = 0;
 static bool s_backlight_subscribed = false;
 static bool s_system_hold_subscribed = false;
 static bool s_nav_enabled = false;
@@ -44,21 +52,40 @@ static void prv_apply_rotation(int16_t *x, int16_t *y) {
   }
 }
 
+//! Subscribers that power the sensor. A passive subscriber is delivered
+//! whatever the sensor already produces but never turns it on.
+static uint8_t prv_powering_subscriber_count(void) {
+  return s_subscriber_count - s_passive_subscriber_count;
+}
+
 static void prv_add_subscriber_cb(PebbleTask task) {
   mutex_lock(s_touch_mutex);
+  const bool passive = (task == PebbleTask_App) && app_manager_is_watchface_running();
+  if (passive) {
+    s_passive_subscriber_tasks |= (uint8_t)(1u << task);
+    s_passive_subscriber_count++;
+  }
+  s_subscriber_count++;
   // Honor the global kill switch: when touch is globally disabled, track the
   // subscriber count but don't power up the sensor.
-  if (++s_subscriber_count == 1 && s_globally_enabled) {
+  if (!passive && prv_powering_subscriber_count() == 1 && s_globally_enabled) {
     touch_sensor_set_enabled(true);
   }
-  PBL_LOG_DBG("Touch: subscriber added, count=%" PRIu8, s_subscriber_count);
+  PBL_LOG_DBG("Touch: subscriber added, count=%" PRIu8 " (passive=%" PRIu8 ")",
+              s_subscriber_count, s_passive_subscriber_count);
   mutex_unlock(s_touch_mutex);
 }
 
 static void prv_remove_subscriber_cb(PebbleTask task) {
   mutex_lock(s_touch_mutex);
   PBL_ASSERTN(s_subscriber_count > 0);
-  if (--s_subscriber_count == 0 && s_globally_enabled) {
+  const bool passive = (s_passive_subscriber_tasks & (1u << task)) != 0;
+  if (passive) {
+    s_passive_subscriber_tasks &= (uint8_t)~(1u << task);
+    s_passive_subscriber_count--;
+  }
+  s_subscriber_count--;
+  if (!passive && prv_powering_subscriber_count() == 0 && s_globally_enabled) {
     touch_sensor_set_enabled(false);
   }
   // An app whose shared touch subscription disappears (task exit, or both
@@ -126,7 +153,9 @@ void touch_service_set_globally_enabled(bool enabled) {
     return;
   }
   s_globally_enabled = enabled;
-  const bool sensor_enabled = enabled && (s_subscriber_count > 0);
+  // Passive subscribers never power the sensor, so re-enabling the kill switch
+  // must not turn it on for a watchface that is the only one left subscribed.
+  const bool sensor_enabled = enabled && (prv_powering_subscriber_count() > 0);
   mutex_unlock(s_touch_mutex);
 
   touch_sensor_set_enabled(sensor_enabled);

--- a/tests/fw/services/test_touch.c
+++ b/tests/fw/services/test_touch.c
@@ -23,6 +23,13 @@
 
 void kernel_free(void *p) {}
 
+// A watchface subscription is passive: it never powers the sensor. Tests drive
+// this directly to cover both sides of that decision.
+static bool s_watchface_running;
+bool app_manager_is_watchface_running(void) {
+  return s_watchface_running;
+}
+
 // Declared in syscall/syscall.h; in the test build DEFINE_SYSCALL is a plain function.
 void sys_touch_set_raw_subscribed(bool subscribed);
 
@@ -73,6 +80,7 @@ void test_touch__initialize(void) {
   // The raw-slot mark is a module static; clear the App task's bit between tests.
   s_current_task = PebbleTask_App;
   sys_touch_set_raw_subscribed(false);
+  s_watchface_running = false;
 }
 
 void test_touch__cleanup(void) {
@@ -192,6 +200,62 @@ void test_touch__backlight_and_app_share_sensor(void) {
   s_remove_subscriber_cb(PebbleTask_App);
   cl_assert_equal_i(s_touch_sensor_disable_count, 1);
   cl_assert(!s_touch_sensor_enabled);
+}
+
+void test_touch__watchface_subscription_never_powers_sensor(void) {
+  s_watchface_running = true;
+
+  // Alone, a watchface subscription leaves the sensor off: it rides what a
+  // system holder already powers and powers nothing itself.
+  s_add_subscriber_cb(PebbleTask_App);
+  cl_assert_equal_i(s_touch_sensor_enable_count, 0);
+  cl_assert(!s_touch_sensor_enabled);
+
+  s_remove_subscriber_cb(PebbleTask_App);
+  cl_assert_equal_i(s_touch_sensor_disable_count, 0);
+
+  // Accounting unwound: a watchapp subscribing afterwards still powers it.
+  s_watchface_running = false;
+  s_add_subscriber_cb(PebbleTask_App);
+  cl_assert_equal_i(s_touch_sensor_enable_count, 1);
+  cl_assert(s_touch_sensor_enabled);
+}
+
+void test_touch__watchface_follows_system_holder(void) {
+  touch_set_backlight_enabled(true);
+  cl_assert_equal_i(s_touch_sensor_enable_count, 1);
+
+  s_watchface_running = true;
+  s_add_subscriber_cb(PebbleTask_App);
+  cl_assert_equal_i(s_touch_sensor_enable_count, 1);
+  cl_assert(s_touch_sensor_enabled);
+
+  // The holder leaving powers the sensor down even though the watchface is
+  // still subscribed: it cannot keep the sensor alive on its own.
+  touch_set_backlight_enabled(false);
+  cl_assert_equal_i(s_touch_sensor_disable_count, 1);
+  cl_assert(!s_touch_sensor_enabled);
+
+  s_remove_subscriber_cb(PebbleTask_App);
+  cl_assert_equal_i(s_touch_sensor_disable_count, 1);
+}
+
+void test_touch__global_reenable_ignores_passive_subscribers(void) {
+  s_watchface_running = true;
+  s_add_subscriber_cb(PebbleTask_App);
+  cl_assert(!s_touch_sensor_enabled);
+
+  // Cycling the master kill switch must not power the sensor for a watchface:
+  // this path re-derives the sensor state from the subscribers and has to use
+  // the powering count, not the total.
+  touch_service_set_globally_enabled(false);
+  touch_service_set_globally_enabled(true);
+  cl_assert(!s_touch_sensor_enabled);
+  cl_assert_equal_i(s_touch_sensor_enable_count, 0);
+
+  // The subscriber counts are module statics in touch.c and survive between
+  // tests, so balance the add.
+  s_remove_subscriber_cb(PebbleTask_App);
 }
 
 void test_touch__has_app_subscribers_app(void) {


### PR DESCRIPTION
Watchfaces cannot read touch at all: `prv_get_state()` returns NULL for them, so `touch_service_subscribe()` is a no-op and the sensor is never powered on their behalf (the early return precedes `sys_touch_set_raw_subscribed()`).

This lets a watchface subscribe to raw touch, but only in a way that cannot cost anything.

## The guarantee

A watchface subscription is **passive**: it is counted in `s_subscriber_count` but excluded from the count that powers the sensor. It is delivered whatever the sensor already produces and never turns it on.

So a watchface reads touch exactly when something else already keeps the sensor up, and reads nothing otherwise:

| Wake on touch | Touch navigation | Watchface |
|---|---|---|
| Off | Off | receives nothing, sensor stays off |
| Tap / Double Tap | Off | receives |
| Off | On | receives |

Verified on obelix PVT hardware with a watchface calling `touch_service_subscribe()`, toggling both prefs.

The point is that this is structural rather than a convention: the code cannot power the sensor for a watchface, so there is no configuration in which the feature costs battery. On a watch where either pref is on, the CST816 already runs continuously (`touch_set_backlight_enabled` and `touch_set_system_hold` each take a permanent hold), and a watchface subscription only joins the existing refcount.

## Scope, and what to look at

This touches the sensor refcount, which is shared by every touch user (the backlight holder, the nav hold, all apps), so it deserves a careful read rather than a glance at the line count:

- `prv_add_subscriber_cb` / `prv_remove_subscriber_cb` now split the count. The passive decision is recorded per task in `s_passive_subscriber_tasks` rather than recomputed on removal, because by the time the subscription dies the task may no longer be the running watchface, and the remove path has to unwind the accounting the add path chose.
- `touch_service_set_globally_enabled()` re-derives the sensor state from the subscribers, so it takes the powering count too. Otherwise cycling the master Touch pref would power the sensor up for a watchface that is the only subscriber left.
- `touch.c` now includes `process_management/app_manager.h`. `touch_session.c` already does this, so there is precedent, but it is a service reaching into process management.

Three tests cover the accounting: a watchface alone never powers the sensor and the count unwinds so a later watchapp still does; a system holder leaving powers the sensor down even though the watchface is still subscribed; and cycling the global kill switch does not power it up for a passive subscriber.

## What is deliberately not changed

The system slot stays gated for watchfaces, so the Tier-2 button bridge remains a watchapp feature: a watchface drives its own UI from raw touch rather than having buttons synthesized under it. Whether watchfaces should be able to opt into the bridge is a separate question, and a separate PR.

The interaction session is untouched, so on an unarmed idle watchface the events still carry `non_navigational`. That is what lets a watchface ignore a pocket touch rather than act on it, and it is a better tool for that than a blanket block.
