### PR TITLE
apps/music: replay now-playing updates dropped during transition

### DIFF
--- a/src/fw/apps/system/music.c
+++ b/src/fw/apps/system/music.c
@@ -357,6 +357,7 @@ static Animation *prv_create_bounceback_animation(MusicAppData *data) {
 }
 
 static void prv_update_track_progress(MusicAppData *data);
+static void prv_update_now_playing(MusicAppData *data);
 
 static void prv_flip_animated_text(Animation *animation, bool finished, void *context) {
   MusicAppData *data = context;
@@ -401,6 +402,17 @@ static Animation *prv_create_cassette_animation(MusicAppData *data) {
   return sequence;
 }
 
+static void prv_transition_stopped(Animation *animation, bool finished, void *context) {
+  MusicAppData *data = context;
+  data->transition = NULL;
+  if (!finished) {
+    return;
+  }
+  // Now-playing updates that arrive while the transition is scheduled are
+  // dropped; re-check so the latest track is not lost.
+  prv_update_now_playing(data);
+}
+
 static void prv_trigger_track_change_animation(MusicAppData *data) {
   // Animation structure:
   // - Master animation
@@ -426,6 +438,9 @@ static void prv_trigger_track_change_animation(MusicAppData *data) {
 
   Animation *complete;
   complete = animation_sequence_create(scroll_up, bounceback, NULL);
+  animation_set_handlers(complete, (AnimationHandlers) {
+      .stopped = prv_transition_stopped,
+  }, data);
   data->transition = complete;
   animation_schedule(complete);
 }


### PR DESCRIPTION
## Problem

Quickly double-skipping tracks (easy since touch tap-to-skip in v4.33.1) can leave the Music app showing the *intermediate* track's title/artist instead of the final track's, until the next metadata event arrives (FIRM-3900).

## Root cause

`prv_trigger_track_change_animation()` drops any `NowPlayingChanged` event that arrives while the transition is still scheduled, with no replay. The displayed `title_buffer`/`artist_buffer` are only refreshed at the flip point mid-animation (`prv_flip_animated_text`), so an update landing in the post-flip half of the ~286 ms transition (~143 ms window) is silently lost: the app keeps showing whatever the cache held at flip time. The phone sends updates in the correct order — this is purely a watch-side render race.

## Fix

Add a `.stopped` handler on the full transition sequence that clears `data->transition` and re-runs `prv_update_now_playing()`. If a track update was swallowed mid-flight, the re-check re-triggers the flip animation, so a fast double-skip renders as two consecutive flips landing on the correct final track.

## Verification

Reproduced in QEMU (`qemu_emery`) using `tools/qemu_album_art_bridge.py` as a scripted Android phone, sending two track changes 200 ms apart while the Music app is open:

- **Before:** phone on track 3 ("Über den Wolken" — Reinhard Mey), watch stuck displaying track 2 ("The Continuing Story…" — The Verbose) indefinitely; only the track length showed track 3's value.
- **After (identical timing):** watch settles on track 3's title and artist, stable across repeated screenshots.

Fixes FIRM-3900

🤖 Generated with [Claude Code](https://claude.com/claude-code)