### PR TITLE
fw: inject button presses and swipes over pebble protocol

### DIFF
--- a/include/pbl/services/touch/touch.h
+++ b/include/pbl/services/touch/touch.h
@@ -104,3 +104,33 @@ void touch_wake_gate_stamp(TouchEvent *event, TouchWakeGateResult gate);
 //! incoming touch coordinates are mirrored to match the rotated framebuffer
 //! before being dispatched to subscribers.
 void touch_set_rotated(bool rotated);
+
+//! Phase of an injected gesture. Stated explicitly rather than inferred from the finger state:
+//! a mid-path sample and a fresh touchdown are both "finger down", so if the service had to guess,
+//! a gesture that lost the sensor (a reset, or touch switched off) could have its next sample
+//! taken as the start of a new one, halfway along the path.
+typedef enum TouchInjectPhase {
+  TouchInjectPhase_Begin,  //!< Touchdown, claiming the sensor
+  TouchInjectPhase_Move,   //!< Position update; requires the gesture to still own the sensor
+  TouchInjectPhase_End,    //!< Liftoff, releasing the sensor
+} TouchInjectPhase;
+
+//! Inject a synthetic touch sample, as if a finger had produced it. Intended for automated input
+//! (the remote input endpoint, console commands), not for drivers.
+//!
+//! @p x and @p y are the coordinates the UI observes: the left-hand mode mirror is not applied,
+//! so callers never restate the rotation themselves.
+//!
+//! Injection is deliberate interaction, so a Begin arms the interaction session the same way a
+//! button press does; without that, contact on the idle watchface is dropped as unarmed.
+//!
+//! The sensor is owned by whoever puts a finger down first: a Begin is refused while a physical
+//! finger is down, and physical samples are ignored until the injected gesture ends. A Move or End
+//! is refused unless the gesture still owns the sensor, so a caller learns it was interrupted
+//! instead of silently starting a second gesture.
+//! @return false if the sample was dropped
+bool touch_handle_injected_update(TouchInjectPhase phase, int16_t x, int16_t y);
+
+//! @return false when a new injected gesture would be refused: touch is globally disabled, or a
+//! physical finger currently owns the sensor.
+bool touch_injection_is_available(void);

--- a/include/pbl/services/touch/touch_session.h
+++ b/include/pbl/services/touch/touch_session.h
@@ -21,6 +21,8 @@
 typedef enum TouchSessionArmSource {
   TouchSessionArmSource_WakeGesture,
   TouchSessionArmSource_Button,
+  //! A synthetic touch injected for automated input; deliberate by construction.
+  TouchSessionArmSource_Injected,
 } TouchSessionArmSource;
 
 //! Open (or re-open) the session: deliberate interaction observed.

--- a/src/fw/applib/ui/recognizer/swipe.c
+++ b/src/fw/applib/ui/recognizer/swipe.c
@@ -12,19 +12,13 @@
 
 #include <string.h>
 
-// Minimum travel (component-wise, on the major axis) from the touchdown point for a path to count
-// as a swipe. A shorter flick is treated as a tap or noise. Value from the reference PT2 touch-nav
-// gesture spec.
-#define SWIPE_MIN_LENGTH_PX (30)
+// SWIPE_MIN_LENGTH_PX and SWIPE_MAX_DURATION_MS live in swipe.h: synthetic gesture generators size
+// their paths from the same limits this recognizer enforces.
 
 // Once the major-axis travel exceeds this, the path is committed enough that we start enforcing
 // straightness: any further wandering on the minor axis fails the swipe early. The drag threshold
 // value comes from the reference PT2 touch-nav gesture spec.
 #define SWIPE_STRAIGHTNESS_MIN_PX (10)
-
-// Maximum touchdown-to-liftoff duration for a swipe; a slower drag is a pan, not a flick. Value
-// from the reference PT2 touch-nav gesture spec.
-#define SWIPE_MAX_DURATION_MS (300)
 
 // Number of most-recent position samples retained for the velocity estimate.
 #define SWIPE_VELOCITY_SAMPLE_COUNT (3)

--- a/src/fw/applib/ui/recognizer/swipe.h
+++ b/src/fw/applib/ui/recognizer/swipe.h
@@ -17,6 +17,17 @@
 
 typedef struct SwipeRecognizerData SwipeRecognizerData;
 
+//! Minimum travel (component-wise, on the major axis) from the touchdown point for a path to count
+//! as a swipe. A shorter flick is treated as a tap or noise. Value from the reference PT2 touch-nav
+//! gesture spec. Exposed so synthetic gesture generators size their paths from the same number the
+//! recognizer enforces.
+#define SWIPE_MIN_LENGTH_PX (30)
+
+//! Maximum touchdown-to-liftoff duration for a swipe; a slower drag is a pan, not a flick. Value
+//! from the reference PT2 touch-nav gesture spec. Exposed alongside the minimum length so a
+//! synthetic generator cannot produce a path this recognizer is bound to reject.
+#define SWIPE_MAX_DURATION_MS (300)
+
 //! Swipe direction, also used as a bitmask when configuring which directions a swipe recognizer
 //! accepts. Screen coordinates grow downward, so a positive y delta is a downward swipe.
 typedef enum SwipeDirection {

--- a/src/fw/console/prompt_commands.c
+++ b/src/fw/console/prompt_commands.c
@@ -18,6 +18,7 @@
 #include "logging/logging_private.h"
 #include "kernel/pbl_malloc.h"
 #include "kernel/pebble_tasks.h"
+#include "kernel/remote_input.h"
 #include "kernel/util/delay.h"
 #include "kernel/util/factory_reset.h"
 #include "kernel/util/sleep.h"
@@ -51,8 +52,6 @@
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
-
-static TimerID s_console_button_timer = TIMER_INVALID_ID;
 
 static void prv_pfs_stress_callback(void *data) {
   pfs_remove_files(NULL);
@@ -723,50 +722,6 @@ void command_boot_bit_set(const char* bit, const char* value) {
   prompt_send_response("OK bit assigned");
 }
 
-typedef struct {
-  ButtonId button_id;
-  bool button_is_held_down;
-  uint32_t num_presses_remaining;
-  uint32_t hold_down_time_ms;
-  uint32_t delay_between_presses_ms;
-} ButtonPressNewTimerContext;
-
-// This is a callback to only be used in conjunction with command_button_press() and
-// command_button_press_multiple()
-static void command_button_press_callback(void *cb_data) {
-  ButtonPressNewTimerContext *context = cb_data;
-
-  const bool button_is_held_down = context->button_is_held_down;
-  // Choose the next event type to emit and the next timeout based on the current button state
-  PebbleEventType next_event_type = button_is_held_down ? PEBBLE_BUTTON_UP_EVENT :
-                                                          PEBBLE_BUTTON_DOWN_EVENT;
-  const uint32_t next_timeout_ms = button_is_held_down ? context->delay_between_presses_ms :
-                                                         context->hold_down_time_ms;
-
-  // Add the next button event to the queue
-  PebbleEvent next_button_event = {
-    .type = next_event_type,
-    .button.button_id = context->button_id,
-  };
-  event_put(&next_button_event);
-
-  // Decrement the number of presses remaining if the button is currently held down (because we
-  // just pushed it up by adding that event)
-  if (button_is_held_down) {
-    context->num_presses_remaining--;
-  }
-
-  if (context->num_presses_remaining > 0) {
-    // Toggle the state of the button
-    context->button_is_held_down = !button_is_held_down;
-    // Restart the timer
-    new_timer_start(s_console_button_timer, next_timeout_ms, command_button_press_callback,
-                    context, 0 /* flags */);
-  } else {
-    kernel_free(context);
-  }
-}
-
 static bool prv_convert_and_validate_timeout_value(const char *timeout_string,
                                                    uint32_t default_value,
                                                    uint32_t *result) {
@@ -802,8 +757,6 @@ static void prv_button_press_multiple(const char *button_index, const char *pres
     goto error;
   }
 
-  const ButtonId button_id = (ButtonId)button;
-
   uint32_t num_presses = 1;
   // If presses is NULL, default to 1; otherwise convert the char string to an integer
   if (presses) {
@@ -831,44 +784,19 @@ static void prv_button_press_multiple(const char *button_index, const char *pres
     goto error;
   }
 
-  // Initialize timer on first use
-  if (s_console_button_timer == TIMER_INVALID_ID) {
-    s_console_button_timer = new_timer_create();
+  // The press sequence itself is synthesized by the shared input injection service, so the console
+  // and the remote input endpoint drive buttons through exactly one implementation.
+  switch (remote_input_button_press((ButtonId)button, num_presses, hold_down_timeout_ms,
+                                    delay_between_presses_timeout_ms)) {
+    case RemoteInputResult_Ok:
+      prompt_send_response("OK");
+      return;
+    case RemoteInputResult_Busy:
+      prompt_send_response("BUSY");
+      return;
+    case RemoteInputResult_Invalid:
+      break;
   }
-
-  // If the callback is already scheduled, notify busy and exit
-  if (new_timer_scheduled(s_console_button_timer, NULL)) {
-    prompt_send_response("BUSY");
-    return;
-  }
-
-  // Construct our new_timer context, will be freed in command_button_press_callback()
-  ButtonPressNewTimerContext *new_timer_context = kernel_malloc(sizeof(ButtonPressNewTimerContext));
-  if (!new_timer_context) {
-    goto error;
-  }
-  *new_timer_context = (ButtonPressNewTimerContext) {
-    .button_id = button_id,
-    .button_is_held_down = false,
-    .num_presses_remaining = num_presses,
-    .hold_down_time_ms = hold_down_timeout_ms,
-    .delay_between_presses_ms = delay_between_presses_timeout_ms,
-  };
-
-  // In order to avoid race conditions between button events and timers being registered, drive the
-  // entire multi click sequence in new_timers. The callback will re-register this timer as needed
-  // for each subsequent click event in the sequence.
-  const bool timer_started = new_timer_start(s_console_button_timer, 0,
-                                             command_button_press_callback, new_timer_context,
-                                             0 /* flags */);
-
-  if (!timer_started) {
-    kernel_free(new_timer_context);
-    goto error;
-  }
-
-  prompt_send_response("OK");
-  return;
 
   error:
     prompt_send_response("ERROR");
@@ -888,24 +816,11 @@ void command_button_press_multiple(const char *button_index, const char *num_pre
   prv_button_press_multiple(button_index, num_presses, hold_down_time_ms, delay_between_presses_ms);
 }
 
-static void prv_button_press_short_launcher_task_cb(void *data) {
-  uintptr_t button = (uintptr_t)data;
-  PebbleEvent e = {
-    .type = PEBBLE_BUTTON_DOWN_EVENT,
-    .button.button_id = button
-  };
-  event_put(&e);
-  e = (PebbleEvent) {
-    .type = PEBBLE_BUTTON_UP_EVENT,
-    .button.button_id = button
-  };
-  event_put(&e);
-}
-
-void command_button_press_short(const char* button_index) {
-  uintptr_t button = (uintptr_t)atoi(button_index);
-  launcher_task_add_callback(prv_button_press_short_launcher_task_cb, (void *)button);
-  prompt_send_response("OK");
+void command_button_press_short(const char *button_index) {
+  // Back-to-back down/up, as this command has always meant. Routing it through the shared service
+  // gives it the button validation and single-flight check it never had, and keeps it from racing
+  // a sequence started by the console or the remote input endpoint.
+  prv_button_press_multiple(button_index, "1", "0", "0");
 }
 
 void command_factory_reset(void) {

--- a/src/fw/kernel/remote_input.c
+++ b/src/fw/kernel/remote_input.c
@@ -90,6 +90,23 @@ static RemoteInputResult prv_claim_timer(void) {
   return RemoteInputResult_Ok;
 }
 
+// Admits one sequence and fires its first callback immediately. Rolls the claim back if the timer
+// cannot start, so a failed request never leaves the service stuck reporting Busy.
+static RemoteInputResult prv_start_sequence(NewTimerCallback cb, void *context) {
+  mutex_lock(s_input_lock);
+  const RemoteInputResult claimed = prv_claim_timer();
+  mutex_unlock(s_input_lock);
+  if (claimed != RemoteInputResult_Ok) {
+    return claimed;
+  }
+  // Past this point the claim is ours: no other caller can be admitted, so no lock is needed.
+  if (!new_timer_start(s_input_timer, 0, cb, context, 0 /* flags */)) {
+    prv_sequence_finished();
+    return RemoteInputResult_Invalid;
+  }
+  return RemoteInputResult_Ok;
+}
+
 // ---------------------------------------------------------------------------------------------
 // Buttons
 
@@ -143,17 +160,8 @@ RemoteInputResult remote_input_button_press(ButtonId button, uint32_t presses, u
     // and leaving the button stuck down.
     return RemoteInputResult_Ok;
   }
-  mutex_lock(s_input_lock);
-  const RemoteInputResult claimed = prv_claim_timer();
-  mutex_unlock(s_input_lock);
-  if (claimed != RemoteInputResult_Ok) {
-    return claimed;
-  }
-  // Past this point the claim is ours: no other caller can be admitted, so the rest needs no lock.
-
   ButtonPressContext *context = kernel_malloc(sizeof(ButtonPressContext));
   if (!context) {
-    prv_sequence_finished();
     return RemoteInputResult_Invalid;
   }
   *context = (ButtonPressContext){
@@ -166,12 +174,11 @@ RemoteInputResult remote_input_button_press(ButtonId button, uint32_t presses, u
 
   // Drive the whole sequence from timer callbacks so the button events can't race the timers that
   // separate them.
-  if (!new_timer_start(s_input_timer, 0, prv_button_timer_cb, context, 0 /* flags */)) {
+  const RemoteInputResult result = prv_start_sequence(prv_button_timer_cb, context);
+  if (result != RemoteInputResult_Ok) {
     kernel_free(context);
-    prv_sequence_finished();
-    return RemoteInputResult_Invalid;
   }
-  return RemoteInputResult_Ok;
+  return result;
 }
 
 RemoteInputResult remote_input_button_set(uint8_t buttons) {
@@ -288,12 +295,6 @@ RemoteInputResult remote_input_swipe(RemoteInputSwipeDirection direction, uint16
   if (!touch_injection_is_available()) {
     return RemoteInputResult_Invalid;
   }
-  mutex_lock(s_input_lock);
-  const RemoteInputResult claimed = prv_claim_timer();
-  mutex_unlock(s_input_lock);
-  if (claimed != RemoteInputResult_Ok) {
-    return claimed;
-  }
 
   const bool vertical =
       (direction == RemoteInputSwipeDirection_Up) || (direction == RemoteInputSwipeDirection_Down);
@@ -312,7 +313,6 @@ RemoteInputResult remote_input_swipe(RemoteInputSwipeDirection direction, uint16
 
   SwipeContext *context = kernel_malloc(sizeof(SwipeContext));
   if (!context) {
-    prv_sequence_finished();
     return RemoteInputResult_Invalid;
   }
   *context = (SwipeContext){
@@ -330,12 +330,11 @@ RemoteInputResult remote_input_swipe(RemoteInputSwipeDirection direction, uint16
     .finger_down = false,
   };
 
-  if (!new_timer_start(s_input_timer, 0, prv_swipe_timer_cb, context, 0 /* flags */)) {
+  const RemoteInputResult result = prv_start_sequence(prv_swipe_timer_cb, context);
+  if (result != RemoteInputResult_Ok) {
     kernel_free(context);
-    prv_sequence_finished();
-    return RemoteInputResult_Invalid;
   }
-  return RemoteInputResult_Ok;
+  return result;
 }
 
 #else  // !CONFIG_SERVICE_TOUCH

--- a/src/fw/kernel/remote_input.c
+++ b/src/fw/kernel/remote_input.c
@@ -1,0 +1,400 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "kernel/remote_input.h"
+
+#include "kernel/events.h"
+#include "kernel/pbl_malloc.h"
+#include <pbl/drivers/display/display.h>
+#include <pbl/logging/logging.h>
+#include "pbl/services/comm_session/session.h"
+#include "pbl/os/mutex.h"
+#include "pbl/services/new_timer/new_timer.h"
+#include "pbl/util/attributes.h"
+#include "pbl/util/math.h"
+#include "util/net.h"
+
+#if defined(CONFIG_SERVICE_TOUCH)
+#include "applib/ui/recognizer/swipe.h"
+#include "pbl/services/touch/touch.h"
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define REMOTE_INPUT_ENDPOINT 0xf00d
+
+// Buttons and swipes share one timer, so injected input is single-flight: a swipe can never land
+// halfway through a button press, and either one reports Busy while the other runs.
+static TimerID s_input_timer = TIMER_INVALID_ID;
+
+// Buttons currently held down by remote_input_button_set(). Bit x is ButtonId x. Nothing releases
+// these but another call, so a held chord outlives the session that asked for it.
+static uint8_t s_held_buttons;
+
+// Set from the moment a sequence is admitted until its last callback frees the context. The
+// timer's own scheduled state cannot stand in for this: NewTimer clears the expiry before running
+// a callback, so a timer reports unscheduled for the whole time its callback is executing, and a
+// request arriving in that window would be admitted and then have its timer stolen when the
+// running callback rearms.
+static bool s_sequence_active;
+
+// Serializes admission. Two controllers are exposed -- the serial console and the endpoint, on
+// different tasks -- so without this both can read the state as idle, both be told Ok, and the
+// second start of the shared timer replace the first callback, leaking its context.
+static PebbleMutex *s_input_lock;
+
+void remote_input_init(void) {
+  s_input_lock = mutex_create();
+}
+
+static void prv_sequence_finished(void) {
+  mutex_lock(s_input_lock);
+  s_sequence_active = false;
+  mutex_unlock(s_input_lock);
+}
+
+// Caller must hold s_input_lock.
+static RemoteInputResult prv_claim_timer(void) {
+  // A held button is a level rather than a sequence, but a press interleaved with one would emit
+  // transitions the UI reads as chord edges. Keep the two mutually exclusive.
+  if ((s_held_buttons != 0) || s_sequence_active) {
+    return RemoteInputResult_Busy;
+  }
+  if (s_input_timer == TIMER_INVALID_ID) {
+    s_input_timer = new_timer_create();
+    if (s_input_timer == TIMER_INVALID_ID) {
+      return RemoteInputResult_Invalid;
+    }
+  }
+  s_sequence_active = true;
+  return RemoteInputResult_Ok;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Buttons
+
+static void prv_put_button_event(ButtonId button, bool down) {
+  PebbleEvent event = {
+    .type = down ? PEBBLE_BUTTON_DOWN_EVENT : PEBBLE_BUTTON_UP_EVENT,
+    .button.button_id = button,
+  };
+  event_put(&event);
+}
+
+typedef struct ButtonPressContext {
+  ButtonId button_id;
+  bool button_is_held_down;
+  // 32-bit: the console has always accepted counts and timeouts this wide, and narrowing them here
+  // would silently shorten a long hold while still reporting OK.
+  uint32_t presses_remaining;
+  uint32_t hold_ms;
+  uint32_t gap_ms;
+} ButtonPressContext;
+
+static void prv_button_timer_cb(void *cb_data) {
+  ButtonPressContext *context = cb_data;
+
+  const bool was_held_down = context->button_is_held_down;
+  // Emit the transition opposite to the current state, then wait out whichever interval that
+  // transition starts: a press is followed by the hold time, a release by the inter-press gap.
+  prv_put_button_event(context->button_id, !was_held_down);
+
+  if (was_held_down) {
+    context->presses_remaining--;
+  }
+
+  if (context->presses_remaining > 0) {
+    context->button_is_held_down = !was_held_down;
+    new_timer_start(s_input_timer, was_held_down ? context->gap_ms : context->hold_ms,
+                    prv_button_timer_cb, context, 0 /* flags */);
+  } else {
+    kernel_free(context);
+    prv_sequence_finished();
+  }
+}
+
+RemoteInputResult remote_input_button_press(ButtonId button, uint32_t presses, uint32_t hold_ms,
+                                            uint32_t gap_ms) {
+  if (button >= NUM_BUTTONS) {
+    return RemoteInputResult_Invalid;
+  }
+  if (presses == 0) {
+    // Nothing to do. Returning early also keeps the timer chain from emitting a lone BUTTON_DOWN
+    // and leaving the button stuck down.
+    return RemoteInputResult_Ok;
+  }
+  mutex_lock(s_input_lock);
+  const RemoteInputResult claimed = prv_claim_timer();
+  mutex_unlock(s_input_lock);
+  if (claimed != RemoteInputResult_Ok) {
+    return claimed;
+  }
+  // Past this point the claim is ours: no other caller can be admitted, so the rest needs no lock.
+
+  ButtonPressContext *context = kernel_malloc(sizeof(ButtonPressContext));
+  if (!context) {
+    prv_sequence_finished();
+    return RemoteInputResult_Invalid;
+  }
+  *context = (ButtonPressContext){
+    .button_id = button,
+    .button_is_held_down = false,
+    .presses_remaining = presses,
+    .hold_ms = hold_ms,
+    .gap_ms = gap_ms,
+  };
+
+  // Drive the whole sequence from timer callbacks so the button events can't race the timers that
+  // separate them.
+  if (!new_timer_start(s_input_timer, 0, prv_button_timer_cb, context, 0 /* flags */)) {
+    kernel_free(context);
+    prv_sequence_finished();
+    return RemoteInputResult_Invalid;
+  }
+  return RemoteInputResult_Ok;
+}
+
+RemoteInputResult remote_input_button_set(uint8_t buttons) {
+  if (buttons >= (1u << NUM_BUTTONS)) {
+    return RemoteInputResult_Invalid;
+  }
+  // Deliberately not prv_claim_timer(): that reports Busy while buttons are held, which would
+  // make the held state impossible to release.
+  mutex_lock(s_input_lock);
+  if (s_sequence_active) {
+    mutex_unlock(s_input_lock);
+    return RemoteInputResult_Busy;
+  }
+
+  const uint8_t released = s_held_buttons & ~buttons;
+  const uint8_t pressed = buttons & ~s_held_buttons;
+  s_held_buttons = buttons;
+  // Emit outside the lock: the events go to a queue and nothing here needs the mask to stay put.
+  mutex_unlock(s_input_lock);
+
+  // Release before pressing, so a mask that swaps one button for another never has more buttons
+  // held at once than the caller asked for.
+  for (ButtonId id = 0; id < NUM_BUTTONS; id++) {
+    if (released & (1u << id)) {
+      prv_put_button_event(id, false /* down */);
+    }
+  }
+  for (ButtonId id = 0; id < NUM_BUTTONS; id++) {
+    if (pressed & (1u << id)) {
+      prv_put_button_event(id, true /* down */);
+    }
+  }
+  return RemoteInputResult_Ok;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Swipes
+
+#if defined(CONFIG_SERVICE_TOUCH)
+
+// Number of position updates streamed between touchdown and liftoff. The swipe recognizer only
+// keeps the newest 3 samples for its velocity estimate, so a handful is plenty.
+#define REMOTE_INPUT_SWIPE_STEPS 5
+
+// Fraction of the travelled axis the finger covers, as numerator/denominator (60%). Must clear the
+// recognizer's minimum length on every board.
+#define REMOTE_INPUT_SWIPE_TRAVEL_NUM 3
+#define REMOTE_INPUT_SWIPE_TRAVEL_DEN 5
+
+_Static_assert((MIN(DISP_COLS, DISP_ROWS) * REMOTE_INPUT_SWIPE_TRAVEL_NUM) /
+                   REMOTE_INPUT_SWIPE_TRAVEL_DEN >= SWIPE_MIN_LENGTH_PX,
+               "swipe travel is below the swipe recognizer's minimum length");
+
+typedef struct SwipeContext {
+  int16_t x;
+  int16_t y;
+  int16_t step_dx;
+  int16_t step_dy;
+  uint8_t steps_remaining;
+  uint16_t step_ms;
+  bool finger_down;
+} SwipeContext;
+
+static bool prv_swipe_emit(TouchInjectPhase phase, int16_t x, int16_t y) {
+  // The injection entry point takes the coordinates the UI observes, so left-hand mode, the
+  // interaction session and physical-touch arbitration are all the touch service's business.
+  return touch_handle_injected_update(phase, x, y);
+}
+
+static void prv_swipe_timer_cb(void *cb_data) {
+  SwipeContext *context = cb_data;
+
+  bool emitted;
+  if (!context->finger_down) {
+    context->finger_down = true;
+    emitted = prv_swipe_emit(TouchInjectPhase_Begin, context->x, context->y);
+  } else if (context->steps_remaining > 0) {
+    context->steps_remaining--;
+    context->x += context->step_dx;
+    context->y += context->step_dy;
+    emitted = prv_swipe_emit(TouchInjectPhase_Move, context->x, context->y);
+  } else {
+    prv_swipe_emit(TouchInjectPhase_End, context->x, context->y);
+    kernel_free(context);
+    prv_sequence_finished();
+    return;
+  }
+
+  if (!emitted) {
+    // Ownership was lost mid-path: touch switched off, or the service reset under us. The service
+    // refuses a Move from a gesture that no longer owns the sensor, so this is where we find out;
+    // carrying on would strand a half-finished path.
+    kernel_free(context);
+    prv_sequence_finished();
+    return;
+  }
+
+  new_timer_start(s_input_timer, context->step_ms, prv_swipe_timer_cb, context, 0 /* flags */);
+}
+
+RemoteInputResult remote_input_swipe(RemoteInputSwipeDirection direction, uint16_t duration_ms) {
+  if (direction >= RemoteInputSwipeDirectionCount) {
+    return RemoteInputResult_Invalid;
+  }
+  // The recognizer reads a slower contact as a pan, so a longer request could never become a
+  // swipe. Say so rather than acknowledging a gesture that is bound to be rejected.
+  if (duration_ms > SWIPE_MAX_DURATION_MS) {
+    return RemoteInputResult_Invalid;
+  }
+  // Likewise for a swipe the touch service would silently drop: touch switched off, or a physical
+  // finger already on the screen.
+  if (!touch_injection_is_available()) {
+    return RemoteInputResult_Invalid;
+  }
+  mutex_lock(s_input_lock);
+  const RemoteInputResult claimed = prv_claim_timer();
+  mutex_unlock(s_input_lock);
+  if (claimed != RemoteInputResult_Ok) {
+    return claimed;
+  }
+
+  const bool vertical =
+      (direction == RemoteInputSwipeDirection_Up) || (direction == RemoteInputSwipeDirection_Down);
+  const int16_t axis = vertical ? DISP_ROWS : DISP_COLS;
+  const int16_t travel =
+      (int16_t)((axis * REMOTE_INPUT_SWIPE_TRAVEL_NUM) / REMOTE_INPUT_SWIPE_TRAVEL_DEN);
+  // The finger starts on the far side of centre and travels towards the named direction.
+  const int16_t sign = ((direction == RemoteInputSwipeDirection_Up) ||
+                        (direction == RemoteInputSwipeDirection_Left))
+                           ? -1
+                           : 1;
+  const int16_t half = (int16_t)(travel / 2);
+  // Round the per-step delta away from zero so the accumulated path never falls short of `travel`.
+  const int16_t step = (int16_t)(sign * ((travel + REMOTE_INPUT_SWIPE_STEPS - 1) /
+                                         REMOTE_INPUT_SWIPE_STEPS));
+
+  SwipeContext *context = kernel_malloc(sizeof(SwipeContext));
+  if (!context) {
+    prv_sequence_finished();
+    return RemoteInputResult_Invalid;
+  }
+  *context = (SwipeContext){
+    .x = (int16_t)(DISP_COLS / 2 - (vertical ? 0 : sign * half)),
+    .y = (int16_t)(DISP_ROWS / 2 - (vertical ? sign * half : 0)),
+    .step_dx = vertical ? 0 : step,
+    .step_dy = vertical ? step : 0,
+    .steps_remaining = REMOTE_INPUT_SWIPE_STEPS,
+    // The touchdown-to-liftoff time covers the position updates plus the liftoff that follows
+    // them. At least 1ms per step, or the chained timers never separate the velocity samples.
+    .step_ms = MAX(1, duration_ms / (REMOTE_INPUT_SWIPE_STEPS + 1)),
+    .finger_down = false,
+  };
+
+  if (!new_timer_start(s_input_timer, 0, prv_swipe_timer_cb, context, 0 /* flags */)) {
+    kernel_free(context);
+    prv_sequence_finished();
+    return RemoteInputResult_Invalid;
+  }
+  return RemoteInputResult_Ok;
+}
+
+#else  // !CONFIG_SERVICE_TOUCH
+
+RemoteInputResult remote_input_swipe(RemoteInputSwipeDirection direction, uint16_t duration_ms) {
+  return RemoteInputResult_Invalid;
+}
+
+#endif  // CONFIG_SERVICE_TOUCH
+
+// ---------------------------------------------------------------------------------------------
+// Pebble protocol endpoint
+
+typedef enum RemoteInputCommand {
+  RemoteInputCommand_Button = 0x00,
+  RemoteInputCommand_Swipe = 0x01,
+  RemoteInputCommand_ButtonSet = 0x02,
+} RemoteInputCommand;
+
+typedef struct PACKED RemoteInputButtonMsg {
+  uint8_t command;
+  uint8_t button_id;
+  uint8_t presses;
+  uint16_t hold_ms;
+  uint16_t gap_ms;
+} RemoteInputButtonMsg;
+
+typedef struct PACKED RemoteInputButtonSetMsg {
+  uint8_t command;
+  uint8_t buttons;
+} RemoteInputButtonSetMsg;
+
+typedef struct PACKED RemoteInputSwipeMsg {
+  uint8_t command;
+  uint8_t direction;
+  uint16_t duration_ms;
+} RemoteInputSwipeMsg;
+
+typedef struct PACKED RemoteInputAck {
+  uint8_t command;
+  uint8_t status;
+} RemoteInputAck;
+
+void remote_input_protocol_msg_callback(CommSession *session, const uint8_t *data, size_t length) {
+  RemoteInputResult result = RemoteInputResult_Invalid;
+  uint8_t command = 0xff;
+
+  if (length >= 1) {
+    command = data[0];
+    switch (command) {
+      case RemoteInputCommand_Button:
+        if (length >= sizeof(RemoteInputButtonMsg)) {
+          const RemoteInputButtonMsg *msg = (const RemoteInputButtonMsg *)data;
+          result = remote_input_button_press((ButtonId)msg->button_id, msg->presses,
+                                             ntohs(msg->hold_ms), ntohs(msg->gap_ms));
+        }
+        break;
+      case RemoteInputCommand_ButtonSet:
+        if (length >= sizeof(RemoteInputButtonSetMsg)) {
+          const RemoteInputButtonSetMsg *msg = (const RemoteInputButtonSetMsg *)data;
+          result = remote_input_button_set(msg->buttons);
+        }
+        break;
+      case RemoteInputCommand_Swipe:
+        if (length >= sizeof(RemoteInputSwipeMsg)) {
+          const RemoteInputSwipeMsg *msg = (const RemoteInputSwipeMsg *)data;
+          const uint16_t duration_ms = ntohs(msg->duration_ms);
+          result = remote_input_swipe(
+              (RemoteInputSwipeDirection)msg->direction,
+              (duration_ms > 0) ? duration_ms : REMOTE_INPUT_SWIPE_DEFAULT_DURATION_MS);
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  PBL_LOG_DBG("Remote input: cmd %u -> %u", command, result);
+
+  const RemoteInputAck ack = {
+    .command = command,
+    .status = (uint8_t)result,
+  };
+  comm_session_send_data(session, REMOTE_INPUT_ENDPOINT, (const uint8_t *)&ack, sizeof(ack),
+                         COMM_SESSION_DEFAULT_TIMEOUT);
+}

--- a/src/fw/kernel/remote_input.c
+++ b/src/fw/kernel/remote_input.c
@@ -263,7 +263,9 @@ static void prv_swipe_timer_cb(void *cb_data) {
   if (!emitted) {
     // Ownership was lost mid-path: touch switched off, or the service reset under us. The service
     // refuses a Move from a gesture that no longer owns the sensor, so this is where we find out;
-    // carrying on would strand a half-finished path.
+    // carrying on would strand a half-finished path. The caller was already told Ok, so leave a
+    // trace of the abort.
+    PBL_LOG_DBG("Remote input: swipe aborted, injection refused");
     kernel_free(context);
     prv_sequence_finished();
     return;
@@ -320,8 +322,11 @@ RemoteInputResult remote_input_swipe(RemoteInputSwipeDirection direction, uint16
     .step_dy = vertical ? step : 0,
     .steps_remaining = REMOTE_INPUT_SWIPE_STEPS,
     // The touchdown-to-liftoff time covers the position updates plus the liftoff that follows
-    // them. At least 1ms per step, or the chained timers never separate the velocity samples.
-    .step_ms = MAX(1, duration_ms / (REMOTE_INPUT_SWIPE_STEPS + 1)),
+    // them. One divisor step beyond that count keeps the scheduled path strictly inside the
+    // requested duration: the recognizer measures the gesture in wall-clock time, so a path
+    // timed to land exactly on SWIPE_MAX_DURATION_MS would be rejected by any dispatch latency
+    // at all. At least 1ms per step, or the chained timers never separate the velocity samples.
+    .step_ms = MAX(1, duration_ms / (REMOTE_INPUT_SWIPE_STEPS + 2)),
     .finger_down = false,
   };
 

--- a/src/fw/kernel/remote_input.c
+++ b/src/fw/kernel/remote_input.c
@@ -3,6 +3,7 @@
 
 #include "kernel/remote_input.h"
 
+#include "applib/event_service_client.h"
 #include "kernel/events.h"
 #include "kernel/pbl_malloc.h"
 #include <pbl/drivers/display/display.h>
@@ -28,8 +29,8 @@
 // halfway through a button press, and either one reports Busy while the other runs.
 static TimerID s_input_timer = TIMER_INVALID_ID;
 
-// Buttons currently held down by remote_input_button_set(). Bit x is ButtonId x. Nothing releases
-// these but another call, so a held chord outlives the session that asked for it.
+// Buttons currently held down by remote_input_button_set(). Bit x is ButtonId x. Released by
+// another call, or when the phone's session closes.
 static uint8_t s_held_buttons;
 
 // Set from the moment a sequence is admitted until its last callback frees the context. The
@@ -44,8 +45,26 @@ static bool s_sequence_active;
 // second start of the shared timer replace the first callback, leaking its context.
 static PebbleMutex *s_input_lock;
 
+static void prv_comm_session_event_handler(PebbleEvent *e, void *context) {
+  const PebbleCommSessionEvent *event = &e->bluetooth.comm_session_event;
+  if (!event->is_system || event->is_open) {
+    return;
+  }
+  // A held button is a level with no timeout, and only the phone's session can release it. When
+  // that session closes, release here: otherwise the hold -- and the Busy it imposes on every
+  // other injected input -- outlives its controller for good.
+  remote_input_button_set(0);
+}
+
 void remote_input_init(void) {
   s_input_lock = mutex_create();
+
+  static EventServiceInfo s_comm_session_event_info;
+  s_comm_session_event_info = (EventServiceInfo){
+    .type = PEBBLE_COMM_SESSION_EVENT,
+    .handler = prv_comm_session_event_handler,
+  };
+  event_service_client_subscribe(&s_comm_session_event_info);
 }
 
 static void prv_sequence_finished(void) {

--- a/src/fw/kernel/remote_input.h
+++ b/src/fw/kernel/remote_input.h
@@ -1,0 +1,62 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include <pbl/drivers/button_id.h>
+#include "pbl/services/comm_session/session.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+//! Result of an injected input request. Doubles as the status byte of the
+//! remote input endpoint's ack.
+typedef enum RemoteInputResult {
+  RemoteInputResult_Ok = 0,
+  RemoteInputResult_Busy = 1,     //!< another injected sequence is still running
+  RemoteInputResult_Invalid = 2,  //!< bad arguments, or unsupported on this board
+} RemoteInputResult;
+
+//! Logical swipe direction, resolved to a touch path by the watch.
+typedef enum RemoteInputSwipeDirection {
+  RemoteInputSwipeDirection_Up = 0,
+  RemoteInputSwipeDirection_Down = 1,
+  RemoteInputSwipeDirection_Left = 2,
+  RemoteInputSwipeDirection_Right = 3,
+  RemoteInputSwipeDirectionCount,
+} RemoteInputSwipeDirection;
+
+//! Default swipe duration, comfortably inside the swipe recognizer's limit.
+#define REMOTE_INPUT_SWIPE_DEFAULT_DURATION_MS 150
+
+//! Initialize the injected input service.
+void remote_input_init(void);
+
+//! Synthesize button presses, as if the button had been pressed by hand.
+//! @param button The button to press
+//! @param presses Number of press/release pairs. 0 is a no-op success.
+//! @param hold_ms How long each press is held down
+//! @param gap_ms Delay between successive presses
+RemoteInputResult remote_input_button_press(ButtonId button, uint32_t presses, uint32_t hold_ms,
+                                            uint32_t gap_ms);
+
+//! Hold down exactly the given set of buttons, releasing any others that were held. Bit x of
+//! @p buttons is ButtonId x, so a mask with two bits set holds a chord, and 0 releases everything.
+//!
+//! Unlike remote_input_button_press() this leaves the buttons down: nothing releases them but a
+//! later call, so a caller that disconnects mid-hold leaves the watch holding a button.
+//!
+//! Reports Busy while a press or swipe sequence is running, and those report Busy while any
+//! button is held here.
+//! @param buttons Bitmask of buttons to hold down
+RemoteInputResult remote_input_button_set(uint8_t buttons);
+
+//! Synthesize a straight swipe across the middle of the screen. Injected through the touch
+//! service, so @p direction is always the direction the UI sees, whatever the display rotation.
+//! @param direction Which way the finger travels
+//! @param duration_ms Touchdown-to-liftoff duration. Anything above the swipe recognizer's
+//!        maximum is Invalid: the recognizer would read it as a pan and never report a swipe.
+RemoteInputResult remote_input_swipe(RemoteInputSwipeDirection direction, uint16_t duration_ms);
+
+//! Remote input endpoint handler. Answers every message with a {command, RemoteInputResult} ack.
+void remote_input_protocol_msg_callback(CommSession *session, const uint8_t *data, size_t length);

--- a/src/fw/kernel/remote_input.h
+++ b/src/fw/kernel/remote_input.h
@@ -43,8 +43,9 @@ RemoteInputResult remote_input_button_press(ButtonId button, uint32_t presses, u
 //! Hold down exactly the given set of buttons, releasing any others that were held. Bit x of
 //! @p buttons is ButtonId x, so a mask with two bits set holds a chord, and 0 releases everything.
 //!
-//! Unlike remote_input_button_press() this leaves the buttons down: nothing releases them but a
-//! later call, so a caller that disconnects mid-hold leaves the watch holding a button.
+//! Unlike remote_input_button_press() this leaves the buttons down until a later call changes the
+//! mask, or the phone's session closes: a caller that disconnects mid-hold must not leave the
+//! watch holding a button forever.
 //!
 //! Reports Busy while a press or swipe sequence is running, and those report Busy while any
 //! button is held here.

--- a/src/fw/services/comm_session/protocol_endpoints_table.json
+++ b/src/fw/services/comm_session/protocol_endpoints_table.json
@@ -27,7 +27,8 @@
     [ 2003,  "0x07d3", "private", "reset_protocol_msg_callback", null, null ],
     [ 5001,  "0x1389", "private", "factory_registry_protocol_msg_callback", null, null ],
     [ 9000,  "0x2328", "private", "get_bytes_protocol_msg_callback", null, null ],
-    [ 48879, "0xbeef", "private", null, "g_put_bytes_receiver_impl", null ]
+    [ 48879, "0xbeef", "private", null, "g_put_bytes_receiver_impl", null ],
+    [ 61453, "0xf00d", "private", "remote_input_protocol_msg_callback", null, null ]
   ],
   "normal_fw_only": [
     [ 11,    "0x000b", "private", "clock_protocol_msg_callback", null, null ],

--- a/src/fw/services/services_common/service.c
+++ b/src/fw/services/services_common/service.c
@@ -52,7 +52,9 @@ void services_common_init(void) {
 
   bt_ctl_init();
 
-#ifdef CONFIG_TOUCH
+#ifdef CONFIG_SERVICE_TOUCH
+  // Gate on the same symbol that compiles touch.c and its consumers (e.g. the remote input
+  // endpoint), so no configuration can reach the touch service before touch_init() has run.
   touch_init();
 #endif
 

--- a/src/fw/services/services_common/service.c
+++ b/src/fw/services/services_common/service.c
@@ -20,6 +20,7 @@
 #include "pbl/services/firmware_update.h"
 #include "pbl/services/hrm/hrm_manager.h"
 #include "pbl/services/light.h"
+#include "kernel/remote_input.h"
 #include "pbl/services/poll_remote.h"
 #include "pbl/services/put_bytes/put_bytes.h"
 #include "pbl/services/shared_prf_storage/shared_prf_storage.h"
@@ -46,6 +47,8 @@ void services_common_init(void) {
   comm_session_app_session_capabilities_init();
 #endif
   comm_session_init();
+
+  remote_input_init();
 
   bt_ctl_init();
 

--- a/src/fw/services/touch/Kconfig
+++ b/src/fw/services/touch/Kconfig
@@ -3,7 +3,8 @@
 
 config SERVICE_TOUCH
     bool "Touch"
-    default y if TOUCH
+    depends on TOUCH
+    default y
     help
       Touch event service. Requires a touch driver (CONFIG_TOUCH).
 

--- a/src/fw/services/touch/touch.c
+++ b/src/fw/services/touch/touch.c
@@ -3,9 +3,11 @@
 
 #include "pbl/services/touch/touch.h"
 #include "pbl/services/touch/touch_event.h"
+#include "pbl/services/touch/touch_session.h"
 
 #include <pbl/drivers/display/display.h>
 #include <pbl/drivers/touch/touch_sensor.h>
+#include "kernel/event_loop.h"
 #include "kernel/events.h"
 #include "kernel/pebble_tasks.h"
 #include "pbl/services/event_service.h"
@@ -36,6 +38,9 @@ static bool s_nav_enabled = false;
 static bool s_app_nav_active = false;
 static bool s_globally_enabled = true;
 static bool s_rotated = false;
+//! Set while an injected gesture owns the sensor, between its touchdown and liftoff. Physical
+//! samples are ignored for its duration so the synthetic path cannot be corrupted mid-swipe.
+static bool s_injecting = false;
 
 static void prv_apply_rotation(int16_t *x, int16_t *y) {
   if (s_rotated) {
@@ -237,15 +242,28 @@ static void prv_put_gesture_event(GestureEventType gesture, int16_t x, int16_t y
   event_put(&e);
 }
 
-void touch_handle_update(TouchState touch_state, int16_t x, int16_t y) {
+static void prv_arm_session_cb(void *unused) {
+  // touch_session is KernelMain-only, and injection runs off a timer callback.
+  touch_session_arm(TouchSessionArmSource_Injected);
+}
+
+static bool prv_handle_update(TouchState touch_state, int16_t x, int16_t y, bool injected) {
   mutex_lock(s_touch_mutex);
 
   if (!s_globally_enabled) {
     mutex_unlock(s_touch_mutex);
-    return;
+    return false;
   }
 
-  prv_apply_rotation(&x, &y);
+  if (injected) {
+    // Injected coordinates are already the ones the UI observes, so no rotation is applied.
+  } else {
+    if (s_injecting) {
+      mutex_unlock(s_touch_mutex);
+      return false;
+    }
+    prv_apply_rotation(&x, &y);
+  }
 
   if (s_touch_state != touch_state) {
     s_touch_state = touch_state;
@@ -261,7 +279,7 @@ void touch_handle_update(TouchState touch_state, int16_t x, int16_t y) {
       PBL_LOG_DBG("Touch: Liftoff");
       prv_put_touch_event(TouchEvent_Liftoff, x, y);
     }
-    return;
+    return true;
   }
 
   if (touch_state == TouchState_FingerDown && (x != s_last_x || y != s_last_y)) {
@@ -271,16 +289,72 @@ void touch_handle_update(TouchState touch_state, int16_t x, int16_t y) {
 
     PBL_LOG_DBG("Touch: Position Update @ (%" PRId16 ", %" PRId16 ")", x, y);
     prv_put_touch_event(TouchEvent_PositionUpdate, x, y);
-    return;
+    return true;
   }
 
   mutex_unlock(s_touch_mutex);
+  return true;
+}
+
+void touch_handle_update(TouchState touch_state, int16_t x, int16_t y) {
+  prv_handle_update(touch_state, x, y, false /* injected */);
+}
+
+bool touch_handle_injected_update(TouchInjectPhase phase, int16_t x, int16_t y) {
+  mutex_lock(s_touch_mutex);
+  if (!s_globally_enabled) {
+    mutex_unlock(s_touch_mutex);
+    return false;
+  }
+  if (phase == TouchInjectPhase_Begin) {
+    // Whoever puts a finger down first owns the sensor until the gesture ends.
+    if (s_injecting || (s_touch_state == TouchState_FingerDown)) {
+      mutex_unlock(s_touch_mutex);
+      return false;
+    }
+    s_injecting = true;
+  } else if (!s_injecting) {
+    // The gesture lost the sensor (reset, or touch switched off and back on). Refusing here is
+    // what lets the caller abort, rather than having this sample taken as a new touchdown from
+    // the middle of its path.
+    mutex_unlock(s_touch_mutex);
+    return false;
+  } else if (phase == TouchInjectPhase_End) {
+    s_injecting = false;
+  }
+  const bool starting = (phase == TouchInjectPhase_Begin);
+  mutex_unlock(s_touch_mutex);
+
+  if (starting) {
+    // Arm before the touchdown is queued: both land on KernelMain in order, so the gate sees an
+    // armed session rather than dropping the gesture as unarmed idle-watchface contact.
+    launcher_task_add_callback(prv_arm_session_cb, NULL);
+  }
+
+  const TouchState touch_state =
+      (phase == TouchInjectPhase_End) ? TouchState_FingerUp : TouchState_FingerDown;
+  return prv_handle_update(touch_state, x, y, true /* injected */);
+}
+
+bool touch_injection_is_available(void) {
+  mutex_lock(s_touch_mutex);
+  const bool available =
+      s_globally_enabled && (s_injecting || (s_touch_state != TouchState_FingerDown));
+  mutex_unlock(s_touch_mutex);
+  return available;
 }
 
 void touch_handle_gesture(TouchGesture gesture, int16_t x, int16_t y) {
   mutex_lock(s_touch_mutex);
 
   if (!s_globally_enabled) {
+    mutex_unlock(s_touch_mutex);
+    return;
+  }
+
+  // Drivers report gestures alongside the raw samples they are derived from, so a real finger
+  // landing mid-injection would otherwise reach subscribers even though its samples do not.
+  if (s_injecting) {
     mutex_unlock(s_touch_mutex);
     return;
   }
@@ -310,6 +384,9 @@ void touch_reset(void) {
   s_touch_state = TouchState_FingerUp;
   s_last_x = 0;
   s_last_y = 0;
+  // Ownership ends with the finger it belonged to; leaving it set would block physical touch for
+  // good, since the injected liftoff that would clear it can no longer arrive.
+  s_injecting = false;
   mutex_unlock(s_touch_mutex);
 }
 
@@ -319,6 +396,8 @@ void touch_release_active(void) {
   const int16_t x = s_last_x;
   const int16_t y = s_last_y;
   s_touch_state = TouchState_FingerUp;
+  // The gesture is over however it was owned; see touch_reset().
+  s_injecting = false;
   mutex_unlock(s_touch_mutex);
 
   if (was_down) {
@@ -341,3 +420,4 @@ void touch_set_rotated(bool rotated) {
   s_rotated = rotated;
   mutex_unlock(s_touch_mutex);
 }
+

--- a/src/fw/services/touch/touch.c
+++ b/src/fw/services/touch/touch.c
@@ -247,57 +247,46 @@ static void prv_arm_session_cb(void *unused) {
   touch_session_arm(TouchSessionArmSource_Injected);
 }
 
-static bool prv_handle_update(TouchState touch_state, int16_t x, int16_t y, bool injected) {
-  mutex_lock(s_touch_mutex);
-
-  if (!s_globally_enabled) {
-    mutex_unlock(s_touch_mutex);
-    return false;
-  }
-
-  if (injected) {
-    // Injected coordinates are already the ones the UI observes, so no rotation is applied.
-  } else {
-    if (s_injecting) {
-      mutex_unlock(s_touch_mutex);
-      return false;
-    }
-    prv_apply_rotation(&x, &y);
-  }
-
+//! Applies one sample's state transition and queues the matching events.
+//! Caller must hold s_touch_mutex. The events are queued with the lock held so a concurrent
+//! sample cannot interleave between a transition and the event it produced.
+static void prv_apply_update(TouchState touch_state, int16_t x, int16_t y, bool injected) {
   if (s_touch_state != touch_state) {
     s_touch_state = touch_state;
     s_last_x = x;
     s_last_y = y;
-    mutex_unlock(s_touch_mutex);
 
     if (touch_state == TouchState_FingerDown) {
-      PBL_ANALYTICS_ADD(touch_event_count, 1);
+      if (!injected) {
+        // Synthetic contact must not read as user engagement.
+        PBL_ANALYTICS_ADD(touch_event_count, 1);
+      }
       PBL_LOG_DBG("Touch: Touchdown @ (%" PRId16 ", %" PRId16 ")", x, y);
       prv_put_touch_event(TouchEvent_Touchdown, x, y);
     } else {
       PBL_LOG_DBG("Touch: Liftoff");
       prv_put_touch_event(TouchEvent_Liftoff, x, y);
     }
-    return true;
+    return;
   }
 
   if (touch_state == TouchState_FingerDown && (x != s_last_x || y != s_last_y)) {
     s_last_x = x;
     s_last_y = y;
-    mutex_unlock(s_touch_mutex);
-
     PBL_LOG_DBG("Touch: Position Update @ (%" PRId16 ", %" PRId16 ")", x, y);
     prv_put_touch_event(TouchEvent_PositionUpdate, x, y);
-    return true;
   }
-
-  mutex_unlock(s_touch_mutex);
-  return true;
 }
 
 void touch_handle_update(TouchState touch_state, int16_t x, int16_t y) {
-  prv_handle_update(touch_state, x, y, false /* injected */);
+  mutex_lock(s_touch_mutex);
+  if (!s_globally_enabled || s_injecting) {
+    mutex_unlock(s_touch_mutex);
+    return;
+  }
+  prv_apply_rotation(&x, &y);
+  prv_apply_update(touch_state, x, y, false /* injected */);
+  mutex_unlock(s_touch_mutex);
 }
 
 bool touch_handle_injected_update(TouchInjectPhase phase, int16_t x, int16_t y) {
@@ -313,6 +302,9 @@ bool touch_handle_injected_update(TouchInjectPhase phase, int16_t x, int16_t y) 
       return false;
     }
     s_injecting = true;
+    // Arm before the touchdown is queued: both land on KernelMain in order, so the gate sees an
+    // armed session rather than dropping the gesture as unarmed idle-watchface contact.
+    launcher_task_add_callback(prv_arm_session_cb, NULL);
   } else if (!s_injecting) {
     // The gesture lost the sensor (reset, or touch switched off and back on). Refusing here is
     // what lets the caller abort, rather than having this sample taken as a new touchdown from
@@ -322,18 +314,15 @@ bool touch_handle_injected_update(TouchInjectPhase phase, int16_t x, int16_t y) 
   } else if (phase == TouchInjectPhase_End) {
     s_injecting = false;
   }
-  const bool starting = (phase == TouchInjectPhase_Begin);
-  mutex_unlock(s_touch_mutex);
 
-  if (starting) {
-    // Arm before the touchdown is queued: both land on KernelMain in order, so the gate sees an
-    // armed session rather than dropping the gesture as unarmed idle-watchface contact.
-    launcher_task_add_callback(prv_arm_session_cb, NULL);
-  }
-
+  // Injected coordinates are already the ones the UI observes, so no rotation is applied. The
+  // sample is applied under the same lock hold as the arbitration above: dropping the lock in
+  // between would let a physical sample or a reset interleave and garble the event stream.
   const TouchState touch_state =
       (phase == TouchInjectPhase_End) ? TouchState_FingerUp : TouchState_FingerDown;
-  return prv_handle_update(touch_state, x, y, true /* injected */);
+  prv_apply_update(touch_state, x, y, true /* injected */);
+  mutex_unlock(s_touch_mutex);
+  return true;
 }
 
 bool touch_injection_is_available(void) {
@@ -420,4 +409,3 @@ void touch_set_rotated(bool rotated) {
   s_rotated = rotated;
   mutex_unlock(s_touch_mutex);
 }
-

--- a/tests/fw/kernel/test_remote_input.c
+++ b/tests/fw/kernel/test_remote_input.c
@@ -1,0 +1,418 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "kernel/remote_input.h"
+
+#include "applib/ui/recognizer/swipe.h"
+#include <pbl/drivers/display/display.h>
+#include "kernel/events.h"
+#include "pbl/services/touch/touch.h"
+#include "pbl/util/math.h"
+#include "pbl/util/size.h"
+
+#include <string.h>
+
+#include "clar.h"
+
+// Stubs
+///////////////////////////////////////////////////////////////////////////////
+#include "stubs_logging.h"
+#include "stubs_mutex.h"
+#include "stubs_passert.h"
+
+#include "fake_pbl_malloc.h"
+#include "fake_new_timer.h"
+
+#define MAX_RECORDED 32
+
+static PebbleEvent s_events[MAX_RECORDED];
+static int s_event_count;
+
+void event_put(PebbleEvent *event) {
+  cl_assert(s_event_count < MAX_RECORDED);
+  s_events[s_event_count++] = *event;
+}
+
+typedef struct RecordedTouch {
+  TouchState state;
+  int16_t x;
+  int16_t y;
+} RecordedTouch;
+
+static RecordedTouch s_touches[MAX_RECORDED];
+static int s_touch_count;
+static bool s_injection_available;
+//! Whether a sample is accepted once the gesture is under way, as opposed to whether a new one may
+//! start; the touch service can withdraw the sensor mid-path.
+static bool s_injection_accepts;
+
+bool touch_handle_injected_update(TouchInjectPhase phase, int16_t x, int16_t y) {
+  if (!s_injection_accepts) {
+    return false;
+  }
+  cl_assert(s_touch_count < MAX_RECORDED);
+  const TouchState state =
+      (phase == TouchInjectPhase_End) ? TouchState_FingerUp : TouchState_FingerDown;
+  s_touches[s_touch_count++] = (RecordedTouch){.state = state, .x = x, .y = y};
+  return true;
+}
+
+bool touch_injection_is_available(void) {
+  return s_injection_available;
+}
+
+static uint8_t s_ack[8];
+static int s_ack_length;
+static int s_ack_count;
+
+bool comm_session_send_data(CommSession *session, uint16_t endpoint_id, const uint8_t *data,
+                           size_t length, uint32_t timeout_ms) {
+  cl_assert(length <= sizeof(s_ack));
+  memcpy(s_ack, data, length);
+  s_ack_length = length;
+  s_ack_count++;
+  return true;
+}
+
+// Helpers
+///////////////////////////////////////////////////////////////////////////////
+
+// The service creates exactly one timer, and the fake hands out ids from 1.
+#define INPUT_TIMER_ID 1
+
+//! Run the injected sequence to completion, so the test sees what the rest of the system would.
+static void prv_run_sequence(void) {
+  for (int i = 0; i < MAX_RECORDED; i++) {
+    if (!stub_new_timer_is_scheduled(INPUT_TIMER_ID)) {
+      return;
+    }
+    stub_new_timer_fire(INPUT_TIMER_ID);
+  }
+  cl_fail("injected sequence never finished");
+}
+
+//! Injected coordinates are the ones the UI observes; left-hand mode is the touch service's
+//! business (see test_touch), so these read the samples straight back.
+static int16_t prv_observed_y(int i) {
+  return s_touches[i].y;
+}
+
+static int16_t prv_observed_x(int i) {
+  return s_touches[i].x;
+}
+
+// Tests
+///////////////////////////////////////////////////////////////////////////////
+
+void test_remote_input__initialize(void) {
+  remote_input_init();
+  s_event_count = 0;
+  s_touch_count = 0;
+  s_ack_count = 0;
+  s_ack_length = 0;
+  s_injection_available = true;
+  s_injection_accepts = true;
+}
+
+void test_remote_input__cleanup(void) {
+  prv_run_sequence();
+  // Held buttons are module state that would otherwise leak into the next test.
+  remote_input_button_set(0);
+}
+
+void test_remote_input__button_press_emits_down_then_up(void) {
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_press(BUTTON_ID_SELECT, 1, 50, 0));
+  prv_run_sequence();
+
+  cl_assert_equal_i(2, s_event_count);
+  cl_assert_equal_i(PEBBLE_BUTTON_DOWN_EVENT, s_events[0].type);
+  cl_assert_equal_i(BUTTON_ID_SELECT, s_events[0].button.button_id);
+  cl_assert_equal_i(PEBBLE_BUTTON_UP_EVENT, s_events[1].type);
+  cl_assert_equal_i(BUTTON_ID_SELECT, s_events[1].button.button_id);
+}
+
+void test_remote_input__button_press_repeats(void) {
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_press(BUTTON_ID_UP, 3, 20, 10));
+  prv_run_sequence();
+
+  cl_assert_equal_i(6, s_event_count);
+  for (int i = 0; i < s_event_count; i++) {
+    cl_assert_equal_i(BUTTON_ID_UP, s_events[i].button.button_id);
+    cl_assert_equal_i((i % 2 == 0) ? PEBBLE_BUTTON_DOWN_EVENT : PEBBLE_BUTTON_UP_EVENT,
+                      s_events[i].type);
+  }
+}
+
+void test_remote_input__button_hold_time_separates_down_from_up(void) {
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_press(BUTTON_ID_BACK, 1, 700, 0));
+
+  // First callback presses the button, and must schedule the release a full hold time later,
+  // otherwise a "long press" would be indistinguishable from a short one.
+  stub_new_timer_fire(INPUT_TIMER_ID);
+  cl_assert_equal_i(PEBBLE_BUTTON_DOWN_EVENT, s_events[0].type);
+  cl_assert_equal_i(700, stub_new_timer_timeout(INPUT_TIMER_ID));
+}
+
+void test_remote_input__zero_presses_leaves_no_button_held(void) {
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_press(BUTTON_ID_SELECT, 0, 20, 0));
+  prv_run_sequence();
+  cl_assert_equal_i(0, s_event_count);
+}
+
+void test_remote_input__rejects_unknown_button(void) {
+  cl_assert_equal_i(RemoteInputResult_Invalid,
+                    remote_input_button_press(NUM_BUTTONS, 1, 20, 0));
+  cl_assert_equal_i(0, s_event_count);
+}
+
+void test_remote_input__second_request_is_busy(void) {
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_press(BUTTON_ID_SELECT, 1, 20, 0));
+  cl_assert_equal_i(RemoteInputResult_Busy, remote_input_button_press(BUTTON_ID_UP, 1, 20, 0));
+  // Swipes share the timer, so they are single-flight against button presses too.
+  cl_assert_equal_i(RemoteInputResult_Busy,
+                    remote_input_swipe(RemoteInputSwipeDirection_Up, 150));
+
+  prv_run_sequence();
+
+  // ...and the next request is accepted once the sequence has drained.
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_press(BUTTON_ID_UP, 1, 20, 0));
+}
+
+void test_remote_input__button_set_holds_until_released(void) {
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_set(1 << BUTTON_ID_SELECT));
+
+  // The button goes down and stays down: no timer runs it back up.
+  cl_assert_equal_i(1, s_event_count);
+  cl_assert_equal_i(PEBBLE_BUTTON_DOWN_EVENT, s_events[0].type);
+  cl_assert_equal_i(BUTTON_ID_SELECT, s_events[0].button.button_id);
+  cl_assert(!stub_new_timer_is_scheduled(INPUT_TIMER_ID));
+
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_set(0));
+  cl_assert_equal_i(2, s_event_count);
+  cl_assert_equal_i(PEBBLE_BUTTON_UP_EVENT, s_events[1].type);
+  cl_assert_equal_i(BUTTON_ID_SELECT, s_events[1].button.button_id);
+}
+
+void test_remote_input__button_set_holds_a_chord(void) {
+  cl_assert_equal_i(RemoteInputResult_Ok,
+                    remote_input_button_set((1 << BUTTON_ID_BACK) | (1 << BUTTON_ID_SELECT)));
+
+  cl_assert_equal_i(2, s_event_count);
+  cl_assert_equal_i(PEBBLE_BUTTON_DOWN_EVENT, s_events[0].type);
+  cl_assert_equal_i(BUTTON_ID_BACK, s_events[0].button.button_id);
+  cl_assert_equal_i(PEBBLE_BUTTON_DOWN_EVENT, s_events[1].type);
+  cl_assert_equal_i(BUTTON_ID_SELECT, s_events[1].button.button_id);
+
+  // Releasing one leaves the other held.
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_set(1 << BUTTON_ID_SELECT));
+  cl_assert_equal_i(3, s_event_count);
+  cl_assert_equal_i(PEBBLE_BUTTON_UP_EVENT, s_events[2].type);
+  cl_assert_equal_i(BUTTON_ID_BACK, s_events[2].button.button_id);
+}
+
+void test_remote_input__button_set_only_emits_changes(void) {
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_set(1 << BUTTON_ID_UP));
+  cl_assert_equal_i(1, s_event_count);
+
+  // Re-asserting the same mask is a no-op, not a second press.
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_set(1 << BUTTON_ID_UP));
+  cl_assert_equal_i(1, s_event_count);
+}
+
+void test_remote_input__button_set_releases_before_pressing(void) {
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_set(1 << BUTTON_ID_UP));
+  // Swapping one held button for another must not hold both at once, even momentarily.
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_set(1 << BUTTON_ID_DOWN));
+
+  cl_assert_equal_i(3, s_event_count);
+  cl_assert_equal_i(PEBBLE_BUTTON_UP_EVENT, s_events[1].type);
+  cl_assert_equal_i(BUTTON_ID_UP, s_events[1].button.button_id);
+  cl_assert_equal_i(PEBBLE_BUTTON_DOWN_EVENT, s_events[2].type);
+  cl_assert_equal_i(BUTTON_ID_DOWN, s_events[2].button.button_id);
+}
+
+void test_remote_input__button_set_rejects_unknown_buttons(void) {
+  cl_assert_equal_i(RemoteInputResult_Invalid, remote_input_button_set(1 << NUM_BUTTONS));
+  cl_assert_equal_i(0, s_event_count);
+}
+
+void test_remote_input__held_buttons_block_sequences(void) {
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_set(1 << BUTTON_ID_BACK));
+
+  cl_assert_equal_i(RemoteInputResult_Busy, remote_input_button_press(BUTTON_ID_UP, 1, 20, 0));
+  cl_assert_equal_i(RemoteInputResult_Busy,
+                    remote_input_swipe(RemoteInputSwipeDirection_Up, 150));
+
+  // Releasing the hold lets sequences through again.
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_set(0));
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_press(BUTTON_ID_UP, 1, 20, 0));
+}
+
+void test_remote_input__running_sequence_blocks_button_set(void) {
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_press(BUTTON_ID_SELECT, 1, 20, 0));
+  cl_assert_equal_i(RemoteInputResult_Busy, remote_input_button_set(1 << BUTTON_ID_BACK));
+
+  prv_run_sequence();
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_set(1 << BUTTON_ID_BACK));
+}
+
+void test_remote_input__endpoint_acks_a_button_set_command(void) {
+  const uint8_t msg[] = {0x02, (1 << BUTTON_ID_BACK) | (1 << BUTTON_ID_SELECT)};
+  remote_input_protocol_msg_callback(NULL, msg, sizeof(msg));
+
+  cl_assert_equal_i(1, s_ack_count);
+  cl_assert_equal_i(2, s_ack_length);
+  cl_assert_equal_i(0x02, s_ack[0]);
+  cl_assert_equal_i(RemoteInputResult_Ok, s_ack[1]);
+  cl_assert_equal_i(2, s_event_count);
+}
+
+void test_remote_input__swipe_up_travels_up_in_a_straight_line(void) {
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_swipe(RemoteInputSwipeDirection_Up, 150));
+  prv_run_sequence();
+
+  // Touchdown, the position updates, then liftoff.
+  cl_assert(s_touch_count >= 4);
+  cl_assert_equal_i(TouchState_FingerDown, s_touches[0].state);
+  cl_assert_equal_i(TouchState_FingerUp, s_touches[s_touch_count - 1].state);
+
+  const int last_down = s_touch_count - 2;
+  for (int i = 1; i <= last_down; i++) {
+    cl_assert_equal_i(TouchState_FingerDown, s_touches[i].state);
+    // Straight: the swipe recognizer fails a path that wanders off the major axis.
+    cl_assert_equal_i(prv_observed_x(0), prv_observed_x(i));
+    // Monotonically upward, so the direction can't be ambiguous.
+    cl_assert(prv_observed_y(i) < prv_observed_y(i - 1));
+  }
+
+  // Long enough for the recognizer's 30px minimum.
+  cl_assert(prv_observed_y(0) - prv_observed_y(last_down) >= 30);
+}
+
+void test_remote_input__swipe_right_travels_right(void) {
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_swipe(RemoteInputSwipeDirection_Right, 150));
+  prv_run_sequence();
+
+  const int last_down = s_touch_count - 2;
+  cl_assert_equal_i(prv_observed_y(0), prv_observed_y(last_down));
+  cl_assert(prv_observed_x(last_down) - prv_observed_x(0) >= 30);
+}
+
+void test_remote_input__swipe_left_travels_left(void) {
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_swipe(RemoteInputSwipeDirection_Left, 150));
+  prv_run_sequence();
+
+  const int last_down = s_touch_count - 2;
+  cl_assert_equal_i(prv_observed_y(0), prv_observed_y(last_down));
+  cl_assert(prv_observed_x(0) - prv_observed_x(last_down) >= 30);
+}
+
+void test_remote_input__swipe_down_travels_down(void) {
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_swipe(RemoteInputSwipeDirection_Down, 150));
+  prv_run_sequence();
+
+  const int last_down = s_touch_count - 2;
+  cl_assert_equal_i(prv_observed_x(0), prv_observed_x(last_down));
+  cl_assert(prv_observed_y(last_down) - prv_observed_y(0) >= 30);
+}
+
+void test_remote_input__swipe_rejected_when_injection_unavailable(void) {
+  // Touch off, or a real finger already on the screen: report it rather than acknowledging a
+  // gesture the touch service would drop on the floor.
+  s_injection_available = false;
+  cl_assert_equal_i(RemoteInputResult_Invalid,
+                    remote_input_swipe(RemoteInputSwipeDirection_Up, 150));
+  cl_assert_equal_i(0, s_touch_count);
+}
+
+void test_remote_input__rejects_swipe_slower_than_the_recognizer_allows(void) {
+  // Above the recognizer's maximum the path is a pan; acknowledging it would promise a swipe that
+  // can never be reported.
+  cl_assert_equal_i(RemoteInputResult_Invalid,
+                    remote_input_swipe(RemoteInputSwipeDirection_Up, SWIPE_MAX_DURATION_MS + 1));
+  cl_assert_equal_i(0, s_touch_count);
+
+  cl_assert_equal_i(RemoteInputResult_Ok,
+                    remote_input_swipe(RemoteInputSwipeDirection_Up, SWIPE_MAX_DURATION_MS));
+}
+
+void test_remote_input__swipe_aborts_when_injection_is_refused(void) {
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_swipe(RemoteInputSwipeDirection_Up, 150));
+  // Touchdown lands, then the touch service takes the sensor away mid-path.
+  stub_new_timer_fire(INPUT_TIMER_ID);
+  cl_assert_equal_i(1, s_touch_count);
+  s_injection_accepts = false;
+  stub_new_timer_fire(INPUT_TIMER_ID);
+
+  // The sequence stops instead of leaving a half-finished path behind, and frees its claim so the
+  // next request is not stuck reporting Busy.
+  cl_assert(!stub_new_timer_is_scheduled(INPUT_TIMER_ID));
+  s_injection_accepts = true;
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_press(BUTTON_ID_UP, 1, 20, 0));
+}
+
+void test_remote_input__swipe_stays_on_screen(void) {
+  const RemoteInputSwipeDirection directions[] = {
+    RemoteInputSwipeDirection_Up, RemoteInputSwipeDirection_Down,
+    RemoteInputSwipeDirection_Left, RemoteInputSwipeDirection_Right,
+  };
+  for (unsigned d = 0; d < ARRAY_LENGTH(directions); d++) {
+    s_touch_count = 0;
+    cl_assert_equal_i(RemoteInputResult_Ok, remote_input_swipe(directions[d], 150));
+    prv_run_sequence();
+    for (int i = 0; i < s_touch_count; i++) {
+      cl_assert(s_touches[i].x >= 0 && s_touches[i].x < DISP_COLS);
+      cl_assert(s_touches[i].y >= 0 && s_touches[i].y < DISP_ROWS);
+    }
+  }
+}
+
+void test_remote_input__rejects_unknown_swipe_direction(void) {
+  cl_assert_equal_i(RemoteInputResult_Invalid,
+                    remote_input_swipe(RemoteInputSwipeDirectionCount, 150));
+  cl_assert_equal_i(0, s_touch_count);
+}
+
+void test_remote_input__endpoint_acks_a_button_command(void) {
+  // command=button, button=down, presses=2, hold=0x0032, gap=0x000a
+  const uint8_t msg[] = {0x00, 0x03, 0x02, 0x00, 0x32, 0x00, 0x0a};
+  remote_input_protocol_msg_callback(NULL, msg, sizeof(msg));
+
+  cl_assert_equal_i(1, s_ack_count);
+  cl_assert_equal_i(2, s_ack_length);
+  cl_assert_equal_i(0x00, s_ack[0]);
+  cl_assert_equal_i(RemoteInputResult_Ok, s_ack[1]);
+
+  prv_run_sequence();
+  cl_assert_equal_i(4, s_event_count);
+  cl_assert_equal_i(BUTTON_ID_DOWN, s_events[0].button.button_id);
+}
+
+void test_remote_input__endpoint_acks_a_swipe_command(void) {
+  // command=swipe, direction=left, duration=0 (watch default)
+  const uint8_t msg[] = {0x01, 0x02, 0x00, 0x00};
+  remote_input_protocol_msg_callback(NULL, msg, sizeof(msg));
+
+  cl_assert_equal_i(RemoteInputResult_Ok, s_ack[1]);
+  prv_run_sequence();
+
+  const int last_down = s_touch_count - 2;
+  cl_assert(prv_observed_x(0) - prv_observed_x(last_down) >= 30);
+}
+
+void test_remote_input__endpoint_rejects_malformed_messages(void) {
+  const uint8_t truncated[] = {0x00, 0x03};
+  remote_input_protocol_msg_callback(NULL, truncated, sizeof(truncated));
+  cl_assert_equal_i(RemoteInputResult_Invalid, s_ack[1]);
+
+  const uint8_t unknown_command[] = {0x7f, 0x00, 0x00, 0x00};
+  remote_input_protocol_msg_callback(NULL, unknown_command, sizeof(unknown_command));
+  cl_assert_equal_i(0x7f, s_ack[0]);
+  cl_assert_equal_i(RemoteInputResult_Invalid, s_ack[1]);
+
+  remote_input_protocol_msg_callback(NULL, unknown_command, 0);
+  cl_assert_equal_i(RemoteInputResult_Invalid, s_ack[1]);
+
+  cl_assert_equal_i(0, s_event_count);
+  cl_assert_equal_i(0, s_touch_count);
+}

--- a/tests/fw/kernel/test_remote_input.c
+++ b/tests/fw/kernel/test_remote_input.c
@@ -377,6 +377,25 @@ void test_remote_input__rejects_swipe_slower_than_the_recognizer_allows(void) {
                     remote_input_swipe(RemoteInputSwipeDirection_Up, SWIPE_MAX_DURATION_MS));
 }
 
+void test_remote_input__cap_duration_swipe_stays_inside_the_recognizer_window(void) {
+  cl_assert_equal_i(RemoteInputResult_Ok,
+                    remote_input_swipe(RemoteInputSwipeDirection_Up, SWIPE_MAX_DURATION_MS));
+
+  // Touchdown fires immediately; sum what the rest of the path is scheduled to take.
+  stub_new_timer_fire(INPUT_TIMER_ID);
+  uint32_t scheduled_ms = 0;
+  while (stub_new_timer_is_scheduled(INPUT_TIMER_ID)) {
+    scheduled_ms += stub_new_timer_timeout(INPUT_TIMER_ID);
+    stub_new_timer_fire(INPUT_TIMER_ID);
+  }
+
+  // The recognizer measures touchdown-to-liftoff in wall-clock time and rejects anything past the
+  // maximum, so a path scheduled to land exactly on it would fail under any dispatch latency. A
+  // swipe that was acknowledged Ok must leave headroom.
+  cl_assert_equal_i(TouchState_FingerUp, s_touches[s_touch_count - 1].state);
+  cl_assert(scheduled_ms < SWIPE_MAX_DURATION_MS);
+}
+
 void test_remote_input__swipe_aborts_when_injection_is_refused(void) {
   cl_assert_equal_i(RemoteInputResult_Ok, remote_input_swipe(RemoteInputSwipeDirection_Up, 150));
   // Touchdown lands, then the touch service takes the sensor away mid-path.

--- a/tests/fw/kernel/test_remote_input.c
+++ b/tests/fw/kernel/test_remote_input.c
@@ -3,6 +3,7 @@
 
 #include "kernel/remote_input.h"
 
+#include "applib/event_service_client.h"
 #include "applib/ui/recognizer/swipe.h"
 #include <pbl/drivers/display/display.h>
 #include "kernel/events.h"
@@ -31,6 +32,26 @@ static int s_event_count;
 void event_put(PebbleEvent *event) {
   cl_assert(s_event_count < MAX_RECORDED);
   s_events[s_event_count++] = *event;
+}
+
+static EventServiceInfo *s_comm_session_subscription;
+
+void event_service_client_subscribe(EventServiceInfo *service_info) {
+  cl_assert_equal_i(PEBBLE_COMM_SESSION_EVENT, service_info->type);
+  s_comm_session_subscription = service_info;
+}
+
+//! Delivers a comm session open/close event the way the event service would.
+static void prv_put_comm_session_event(bool is_open, bool is_system) {
+  cl_assert(s_comm_session_subscription != NULL);
+  PebbleEvent event = {
+    .type = PEBBLE_COMM_SESSION_EVENT,
+    .bluetooth.comm_session_event = {
+      .is_open = is_open,
+      .is_system = is_system,
+    },
+  };
+  s_comm_session_subscription->handler(&event, s_comm_session_subscription->context);
 }
 
 typedef struct RecordedTouch {
@@ -245,6 +266,26 @@ void test_remote_input__held_buttons_block_sequences(void) {
 
   // Releasing the hold lets sequences through again.
   cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_set(0));
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_press(BUTTON_ID_UP, 1, 20, 0));
+}
+
+void test_remote_input__session_close_releases_held_buttons(void) {
+  cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_set(1 << BUTTON_ID_BACK));
+  cl_assert_equal_i(1, s_event_count);
+
+  // Sessions opening, or a third-party app session closing, leave the hold alone: only the phone
+  // (system) session can have asked for it.
+  prv_put_comm_session_event(true /* is_open */, true /* is_system */);
+  prv_put_comm_session_event(false /* is_open */, false /* is_system */);
+  cl_assert_equal_i(1, s_event_count);
+
+  // The phone's session closing releases the hold: nothing else ever could have.
+  prv_put_comm_session_event(false /* is_open */, true /* is_system */);
+  cl_assert_equal_i(2, s_event_count);
+  cl_assert_equal_i(PEBBLE_BUTTON_UP_EVENT, s_events[1].type);
+  cl_assert_equal_i(BUTTON_ID_BACK, s_events[1].button.button_id);
+
+  // ...and injected sequences are admitted again.
   cl_assert_equal_i(RemoteInputResult_Ok, remote_input_button_press(BUTTON_ID_UP, 1, 20, 0));
 }
 

--- a/tests/fw/kernel/wscript_build
+++ b/tests/fw/kernel/wscript_build
@@ -5,3 +5,8 @@ clar(ctx,
         " src/fw/kernel/util/interval_timer.c"
         " tests/fakes/fake_rtc.c",
     test_sources_ant_glob="test_interval_timer.c")
+
+clar(ctx,
+    sources_ant_glob = " src/fw/kernel/remote_input.c",
+    test_sources_ant_glob="test_remote_input.c",
+    defines=["CONFIG_SERVICE_TOUCH"])

--- a/tests/fw/services/test_touch.c
+++ b/tests/fw/services/test_touch.c
@@ -3,11 +3,14 @@
 
 #include "clar.h"
 
+#include "kernel/event_loop.h"
 #include "kernel/events.h"
 #include "kernel/pebble_tasks.h"
+#include <pbl/drivers/display/display.h>
 #include "pbl/services/event_service.h"
 #include "pbl/services/touch/touch.h"
 #include "pbl/services/touch/touch_event.h"
+#include "pbl/services/touch/touch_session.h"
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -42,6 +45,20 @@ void event_service_init(PebbleEventType type, EventServiceAddSubscriberCallback 
   s_remove_subscriber_cb = remove_cb;
 }
 
+static int s_session_arm_count;
+static TouchSessionArmSource s_last_arm_source;
+
+void touch_session_arm(TouchSessionArmSource source) {
+  s_session_arm_count++;
+  s_last_arm_source = source;
+}
+
+// touch.c hands the arm to KernelMain because touch_session is KernelMain-only. Run it inline so
+// the test observes the arm in the same order the event loop would.
+void launcher_task_add_callback(CallbackEventCallback callback, void *data) {
+  callback(data);
+}
+
 static int s_touch_sensor_enable_count;
 static int s_touch_sensor_disable_count;
 static bool s_touch_sensor_enabled;
@@ -63,6 +80,7 @@ void test_touch__initialize(void) {
   s_touch_sensor_enable_count = 0;
   s_touch_sensor_disable_count = 0;
   s_touch_sensor_enabled = false;
+  s_session_arm_count = 0;
   touch_init();
   touch_reset();
   // Make sure the global kill switch is reset between tests — it's a module
@@ -433,6 +451,144 @@ void test_touch__toggle_off_without_finger_no_liftoff(void) {
   touch_service_set_globally_enabled(false);
   cl_assert_equal_i(fake_event_get_count(), 0);
   touch_service_set_globally_enabled(true);
+}
+
+void test_touch__injected_touch_arms_the_session(void) {
+  // Injection is deliberate interaction: without arming, contact on the idle watchface is dropped
+  // as unarmed and the whole gesture goes nowhere.
+  touch_handle_injected_update(TouchInjectPhase_Begin, 10, 20);
+  cl_assert_equal_i(s_session_arm_count, 1);
+  cl_assert_equal_i(s_last_arm_source, TouchSessionArmSource_Injected);
+  prv_assert_touch_event(TouchEvent_Touchdown, 10, 20);
+
+  // Only the touchdown arms; position updates do not re-arm.
+  touch_handle_injected_update(TouchInjectPhase_Move, 10, 40);
+  cl_assert_equal_i(s_session_arm_count, 1);
+
+  touch_handle_injected_update(TouchInjectPhase_End, 10, 40);
+}
+
+void test_touch__injected_coordinates_skip_rotation(void) {
+  touch_set_rotated(true);
+  // Injected coordinates are the ones the UI observes, so left-hand mode must not mirror them
+  // again: the caller states the direction it wants and the service takes it at its word.
+  touch_handle_injected_update(TouchInjectPhase_Begin, 10, 20);
+  prv_assert_touch_event(TouchEvent_Touchdown, 10, 20);
+
+  touch_handle_injected_update(TouchInjectPhase_End, 10, 20);
+  touch_set_rotated(false);
+}
+
+void test_touch__physical_touch_is_still_rotated(void) {
+  touch_set_rotated(true);
+  touch_handle_update(TouchState_FingerDown, 10, 20);
+  // Mirrored against the display bounds, unlike the injected path above.
+  prv_assert_touch_event(TouchEvent_Touchdown, DISP_COLS - 1 - 10, DISP_ROWS - 1 - 20);
+
+  touch_handle_update(TouchState_FingerUp, 10, 20);
+  touch_set_rotated(false);
+}
+
+void test_touch__injection_refused_while_a_finger_is_down(void) {
+  touch_handle_update(TouchState_FingerDown, 10, 20);
+  cl_assert(!touch_injection_is_available());
+
+  // The physical gesture owns the sensor; injection must not hijack it mid-touch.
+  fake_event_reset_count();
+  cl_assert(!touch_handle_injected_update(TouchInjectPhase_Begin, 90, 90));
+  cl_assert_equal_i(fake_event_get_count(), 0);
+
+  touch_handle_update(TouchState_FingerUp, 10, 20);
+  cl_assert(touch_injection_is_available());
+}
+
+void test_touch__physical_touch_ignored_during_injection(void) {
+  cl_assert(touch_handle_injected_update(TouchInjectPhase_Begin, 10, 20));
+
+  // A real finger arriving mid-swipe would otherwise drag the synthetic path off course.
+  fake_event_reset_count();
+  touch_handle_update(TouchState_FingerDown, 90, 90);
+  cl_assert_equal_i(fake_event_get_count(), 0);
+
+  // The injected gesture still owns the sensor and can finish.
+  cl_assert(touch_handle_injected_update(TouchInjectPhase_End, 10, 20));
+  prv_assert_touch_event(TouchEvent_Liftoff, 10, 20);
+}
+
+void test_touch__injection_unavailable_when_globally_disabled(void) {
+  touch_service_set_globally_enabled(false);
+  cl_assert(!touch_injection_is_available());
+  cl_assert(!touch_handle_injected_update(TouchInjectPhase_Begin, 10, 20));
+  cl_assert_equal_i(fake_event_get_count(), 0);
+
+  touch_service_set_globally_enabled(true);
+}
+
+void test_touch__disable_during_injection_releases_ownership(void) {
+  cl_assert(touch_handle_injected_update(TouchInjectPhase_Begin, 10, 20));
+
+  // Turning touch off mid-gesture ends it. The injected liftoff that would normally clear
+  // ownership is itself dropped while disabled, so the release has to happen here or the sensor
+  // stays owned by a gesture that can never finish.
+  touch_service_set_globally_enabled(false);
+  touch_service_set_globally_enabled(true);
+
+  cl_assert(touch_injection_is_available());
+
+  // Physical touch works again...
+  fake_event_reset_count();
+  touch_handle_update(TouchState_FingerDown, 30, 40);
+  prv_assert_touch_event(TouchEvent_Touchdown, 30, 40);
+  touch_handle_update(TouchState_FingerUp, 30, 40);
+
+  // ...and the next injected gesture still arms the session rather than assuming it already owns
+  // the sensor.
+  s_session_arm_count = 0;
+  cl_assert(touch_handle_injected_update(TouchInjectPhase_Begin, 10, 20));
+  cl_assert_equal_i(s_session_arm_count, 1);
+  touch_handle_injected_update(TouchInjectPhase_End, 10, 20);
+}
+
+void test_touch__reset_releases_injection_ownership(void) {
+  cl_assert(touch_handle_injected_update(TouchInjectPhase_Begin, 10, 20));
+  touch_reset();
+
+  cl_assert(touch_injection_is_available());
+  fake_event_reset_count();
+  touch_handle_update(TouchState_FingerDown, 30, 40);
+  prv_assert_touch_event(TouchEvent_Touchdown, 30, 40);
+  touch_handle_update(TouchState_FingerUp, 30, 40);
+}
+
+void test_touch__gesture_suppressed_during_injection(void) {
+  cl_assert(touch_handle_injected_update(TouchInjectPhase_Begin, 10, 20));
+
+  // Drivers report gestures next to the raw samples they came from; letting one through would
+  // break the exclusive ownership the injected path is promised.
+  fake_event_reset_count();
+  touch_handle_gesture(TouchGesture_Tap, 90, 90);
+  cl_assert_equal_i(fake_event_get_count(), 0);
+
+  touch_handle_injected_update(TouchInjectPhase_End, 10, 20);
+}
+
+void test_touch__reset_mid_gesture_refuses_continuation(void) {
+  cl_assert(touch_handle_injected_update(TouchInjectPhase_Begin, 10, 20));
+  // Anything that forces the finger state up mid-gesture takes the sensor away -- an app calling
+  // touch_service_subscribe() reaches touch_reset() this way.
+  touch_reset();
+
+  // The rest of the path must be refused rather than taken as a fresh touchdown from the middle of
+  // the gesture, which is what a phase-less API would have to guess at.
+  fake_event_reset_count();
+  cl_assert(!touch_handle_injected_update(TouchInjectPhase_Move, 10, 40));
+  cl_assert(!touch_handle_injected_update(TouchInjectPhase_End, 10, 40));
+  cl_assert_equal_i(fake_event_get_count(), 0);
+
+  // A brand new gesture is still fine.
+  cl_assert(touch_handle_injected_update(TouchInjectPhase_Begin, 50, 60));
+  prv_assert_touch_event(TouchEvent_Touchdown, 50, 60);
+  touch_handle_injected_update(TouchInjectPhase_End, 50, 60);
 }
 
 void test_touch__event_abi_unchanged(void) {

--- a/tools/libs/pebble-commander/pebble/commander/_commands/clicks.py
+++ b/tools/libs/pebble-commander/pebble/commander/_commands/clicks.py
@@ -1,7 +1,25 @@
 # SPDX-FileCopyrightText: 2024 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
+import time
+
 from .. import PebbleCommander, exceptions
+
+# Injected input is single-flight on the watch: a click that arrives while an
+# earlier sequence is still draining (or a remote controller holds a button)
+# answers BUSY. Wait it out instead of failing the caller's script.
+BUSY_RETRIES = 50
+BUSY_RETRY_DELAY_S = 0.1
+
+
+def _send_click_command(cmdr, command):
+    for _ in range(BUSY_RETRIES):
+        ret = cmdr.send_prompt_command(command)
+        if not ret[0].startswith("BUSY"):
+            break
+        time.sleep(BUSY_RETRY_DELAY_S)
+    if not ret[0].startswith("OK"):
+        raise exceptions.PromptResponseError(ret)
 
 
 @PebbleCommander.command()
@@ -10,9 +28,7 @@ def click_short(cmdr, button):
     button = int(str(button), 0)
     if not 0 <= button <= 3:
         raise exceptions.ParameterError("button out of range: %d" % button)
-    ret = cmdr.send_prompt_command("click short %d" % button)
-    if not ret[0].startswith("OK"):
-        raise exceptions.PromptResponseError(ret)
+    _send_click_command(cmdr, "click short %d" % button)
 
 
 @PebbleCommander.command()
@@ -39,10 +55,9 @@ def click_multiple(cmdr, button, count=1, hold_ms=20, delay_ms=0):
         raise exceptions.ParameterError("hold_ms out of range: %d" % hold_ms)
     if delay_ms < 0:
         raise exceptions.ParameterError("delay_ms out of range: %d" % delay_ms)
-    ret = cmdr.send_prompt_command(
+    _send_click_command(
+        cmdr,
         "click multiple {button:d} {count:d} {hold_ms:d} {delay_ms:d}".format(
             **locals()
-        )
+        ),
     )
-    if not ret[0].startswith("OK"):
-        raise exceptions.PromptResponseError(ret)


### PR DESCRIPTION
Adds a Pebble Protocol endpoint that presses buttons and swipes on the watch, so a connected phone (or anything that can reach the watch over the protocol) can drive the UI for automated testing. Until now that needed a serial console, which needs physical access.

## The endpoint

`0xf00d`, three commands, each answered with a `{command, status}` ack so a harness can tell an accepted command from a rejected one (`Ok` / `Busy` / `Invalid`):

| command | payload | what it does |
|---|---|---|
| `0x00` button | `button, presses, hold_ms, gap_ms` | press/release pairs; a long press is a longer hold |
| `0x02` button set | `buttons` bitmask | hold exactly this set down — one bit is an open-ended press, two bits a chord, empty releases |
| `0x01` swipe | `direction, duration_ms` | straight path across the middle of the screen |

No phone-app changes are needed to use it: the dev connection already relays raw Pebble Protocol both ways, so a test machine can reach the endpoint through it over `adb forward`.

## Notes for review

**Injected input is single-flight**, tracked by an explicit flag under a mutex. The timer's scheduled state cannot express either half of that — NewTimer clears the expiry *before* running a callback, so a timer reports unscheduled for as long as its callback is executing, and a request arriving in that window would be admitted and then have its timer stolen when the running callback rearmed. The lock matters because two controllers are exposed (the console and the endpoint) on different tasks. Held buttons and sequences are mutually exclusive, so a sequence can never interleave with a hold and emit transitions the UI would read as chord edges.

**Touch injection moved into the touch service.** The swipe generator originally read the rotation state out of the service and restated the left-hand-mode mirror itself. `touch_handle_injected_update()` takes the coordinates the UI observes and keeps rotation, the enable check, and physical-touch arbitration where they belong. It also arms the interaction session, which injected contact needs: without it, a swipe on the idle watchface is dropped as unarmed and goes nowhere.

**Consolidation.** The console's button-press machinery moved into the shared service, so `click`, `click short`, `click multiple` and the endpoint all drive buttons through one implementation — `prompt_commands.c` loses ~99 lines. `click short` was the last place synthesizing button events by hand and had no button validation at all.

**Known limitation:** nothing releases a held button but a later call, so a caller that disconnects mid-hold leaves the watch holding it. This is deliberate — an auto-release timer was considered and rejected. Scoping holds to the owning comm session would be the principled fix if this becomes a problem in practice.

**Injection phases are explicit.** `touch_handle_injected_update()` takes Begin/Move/End rather than a finger state, because a mid-path sample and a fresh touchdown are otherwise indistinguishable: a gesture that lost the sensor would have its next sample taken as the start of a new one, halfway along its path.

## Testing

- `./pbl test` — 329/329. Each of the four commits builds and lints independently.
- New coverage: press/hold/gap sequencing, chords, no-op re-assert, release-before-press, both `Busy` directions, all four swipe path directions, mid-path abort, duration cap; and in the touch service, session arming, rotation bypass, physical/injected arbitration both ways, and ownership release on reset and on the global kill switch.
- Live on QEMU driven from the Android app over the dev connection: all four buttons verified by their on-screen effect, all four swipe directions, key-repeat from a held button, chords, and `Ok`/`Busy`/`Invalid` acks.

Left swipe is worth knowing about: it maps to `SELECT`, but `MenuLayer` deliberately ignores it, so it only does anything in bridged windows — verified by starting playback from the Music app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
