### PR TITLE
Notification image support

### DIFF
--- a/include/pbl/services/comm_session/session_remote_version.h
+++ b/include/pbl/services/comm_session/session_remote_version.h
@@ -33,7 +33,8 @@ typedef struct PACKED {
       bool custom_vibe_pattern_support:1;
       uint8_t javascript_bytecode_version_appended: 1;
       bool imaging_support:1;  // Phone serves images (album art, ...) via the imaging endpoint
-      uint8_t more_padded_bits:3;
+      bool notification_image_support:1;  // Watch renders AttributeIdImageAspectRatio notifications
+      uint8_t more_padded_bits:2;
       bool continue_fw_install_across_disconnect_support: 1;
       bool blob_db_version_support: 1;
       bool settings_sync_support: 1;  // Phone supports Settings BlobDB sync

--- a/include/pbl/services/imaging.h
+++ b/include/pbl/services/imaging.h
@@ -9,6 +9,7 @@
 
 #include "kernel/events.h"
 #include "pbl/services/imaging_endpoint_types.h"
+#include "pbl/util/uuid.h"
 
 struct GBitmap;
 typedef struct CommSession CommSession;
@@ -32,6 +33,12 @@ bool imaging_is_type_supported(ImagingImageType image_type);
 //! returns false) if unsupported. The matching handler is invoked when the transfer completes.
 bool imaging_request_album_art(uint8_t token, ImagingFormat format, uint16_t width, uint16_t height,
                                const char *title, const char *artist);
+
+//! Ask the phone for the image it holds for timeline item `item_id`, at the given size/format.
+//! No-op (and returns false) if unsupported. The matching handler is invoked when the transfer
+//! completes.
+bool imaging_request_notification_image(uint8_t token, ImagingFormat format, uint16_t width,
+                                        uint16_t height, const Uuid *item_id);
 
 //! Endpoint receive callback (registered in protocol_endpoints_table.json).
 void imaging_protocol_msg_callback(CommSession *session, const uint8_t *msg, size_t length);

--- a/include/pbl/services/imaging_endpoint_types.h
+++ b/include/pbl/services/imaging_endpoint_types.h
@@ -24,7 +24,9 @@ typedef enum {
 //! What the image is for. Determines the type-specific parameters in the request tail.
 typedef enum {
   ImagingImageTypeAlbumArt = 0x00,
-  // Future: ImagingImageTypeNotification = 0x01, ...
+  ImagingImageTypeNotification = 0x01,
+
+  ImagingImageTypeCount,
 } ImagingImageType;
 
 //! Pixel encoding the watch is asking for (and that the response is packed in).
@@ -46,6 +48,8 @@ typedef struct PACKED {
   //   uint8_t title_len;  char title[title_len];
   //   uint8_t artist_len; char artist[artist_len];
   // The phone returns art for the named track (so it can't race a track change), or NO_IMAGE.
+  // For ImagingImageTypeNotification:
+  //   uint8_t item_id[16];  // the timeline item's UUID, as the phone keyed its cache
 } ImagingRequestHeader;
 
 //! Flags byte in an ImageResponse chunk.
@@ -57,6 +61,11 @@ typedef enum {
                                              //!< follow. The watch latches the type off for the
                                              //!< rest of the connection and stops requesting it.
 } ImagingResponseFlags;
+
+//! Bits 4-7 of a response's `flags` carry the ImagingImageType it answers. Several consumers can
+//! have a request outstanding at once, and the token alone doesn't say which one a response is for.
+#define IMAGING_RESPONSE_FLAG_TYPE_MASK (0xf0)
+#define IMAGING_RESPONSE_FLAG_TYPE_SHIFT (4)
 
 //! Phone -> Watch, chunked. `chunk_len` pixel bytes follow this header (after the image header on
 //! the first chunk).

--- a/include/pbl/services/notifications/notification_image.h
+++ b/include/pbl/services/notifications/notification_image.h
@@ -1,0 +1,48 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "pbl/util/uuid.h"
+
+struct GBitmap;
+
+//! Notification images need a colour display and enough RAM for the decoded bitmap, so only emery
+//! and gabbro qualify — the same bar as album art.
+#if defined(CONFIG_PLATFORM_EMERY) || defined(CONFIG_PLATFORM_GABBRO)
+#define NOTIFICATION_IMAGE_SUPPORTED 1
+#else
+#define NOTIFICATION_IMAGE_SUPPORTED 0
+#endif
+
+//! Single slot holding the phone-supplied image for the notification currently on screen. Only one
+//! notification card is ever focused, so one slot is the whole requirement.
+
+//! Create the lock. Call once at boot before any other function here.
+void notification_image_service_init(void);
+
+//! Claim the slot for `item_id` and write the imaging request token to `token_out`. Returns false
+//! if the slot is already this item's — whether the image is in flight, delivered, or the phone
+//! already said it has none — so callers can drive this straight from a redraw.
+bool notification_image_claim(const Uuid *item_id, uint8_t *token_out);
+
+//! The stored bitmap for `item_id`, or NULL. Ownership stays with the store, which is locked until
+//! the matching notification_image_unlock — call that even when this returns NULL.
+const struct GBitmap *notification_image_lock(const Uuid *item_id);
+
+void notification_image_unlock(void);
+
+//! True while a response for `item_id` is still outstanding, so the card can show a placeholder
+//! rather than an empty band — but stop once the phone has said it has no image.
+bool notification_image_is_pending(const Uuid *item_id);
+
+//! Take ownership of a delivered bitmap (NULL when the phone had no image). Ignores stale tokens.
+//! @return true if the slot resolved, so anything showing this notification needs to redraw — also
+//! when [bitmap] is NULL, which is what takes the pending placeholder back down.
+bool notification_image_store(uint8_t token, struct GBitmap *bitmap);
+
+//! Drop the slot and free the bitmap.
+void notification_image_clear(void);

--- a/include/pbl/services/timeline/attribute.h
+++ b/include/pbl/services/timeline/attribute.h
@@ -117,6 +117,11 @@ typedef enum {
   AttributeIdMuteExpiration = 50,
   //! (StringList) Notification filtering rules encoded as a byte array.
   AttributeIdNotificationFilteringRules = 51,
+  //! (uint8_t) The phone holds an image for this item, fetchable over the imaging endpoint
+  //! (ImagingImageTypeNotification, keyed by the item's UUID). The value is the image's
+  //! height/width in sixteenths, so the card can reserve a band of the right shape before the
+  //! pixels arrive. Absent or 0 means no image.
+  AttributeIdImageAspectRatio = 52,
   NumAttributeIds,
 } AttributeId;
 

--- a/include/pbl/services/timeline/notification_layout.h
+++ b/include/pbl/services/timeline/notification_layout.h
@@ -123,8 +123,16 @@ static const TimelineResourceId REMINDER_FALLBACK_ICON = TIMELINE_RESOURCE_NOTIF
     ((LAYOUT_TOP_BANNER_HEIGHT - NOTIFICATION_TINY_RESOURCE_HEIGHT) / 2) + \
       NOTIFICATION_TINY_RESOURCE_VERTICAL_OFFSET
 
+//! Bounds on the aspect a notification image band can reserve; the phone clamps to the same range.
+#define NOTIFICATION_IMAGE_MIN_ASPECT (4)   //!< 4:1 landscape
+#define NOTIFICATION_IMAGE_MAX_ASPECT (24)  //!< 2:3 portrait
+
 LayoutLayer *notification_layout_create(const LayoutLayerConfig *config);
 
 bool notification_layout_verify(bool existing_attributes[]);
+
+//! Size of the image band this layout reserves, or false if the item has no image. The requester
+//! and the renderer must agree on it, so it has one home.
+bool notification_layout_get_image_size(const LayoutLayer *layout, GSize *size_out);
 
 TimelineResourceId notification_layout_get_fallback_icon_id(TimelineItemType item_type);

--- a/src/fw/kernel/system_versions.c
+++ b/src/fw/kernel/system_versions.c
@@ -15,6 +15,7 @@
 #include "pbl/services/comm_session/session_remote_version.h"
 #include "pbl/services/i18n/i18n.h"
 #include "pbl/services/activity/insights_settings.h"
+#include "pbl/services/notifications/notification_image.h"
 #include "shell/system_app_ids.auto.h"
 #include "system/bootbits.h"
 #include <pbl/logging/logging.h>
@@ -141,6 +142,7 @@ static void prv_send_watch_versions(CommSession *session) {
   versions_msg.capabilities.custom_vibe_pattern_support = 1;
   versions_msg.capabilities.blob_db_version_support = 1;
   versions_msg.capabilities.weather_db_v4_support = 1;
+  versions_msg.capabilities.notification_image_support = NOTIFICATION_IMAGE_SUPPORTED;
   bt_local_id_copy_address(&versions_msg.device_address);
 
   versions_msg.system_resources_version = resource_get_system_version();

--- a/src/fw/popups/notifications/notification_window.c
+++ b/src/fw/popups/notifications/notification_window.c
@@ -23,6 +23,7 @@
 #include "kernel/pbl_malloc.h"
 #include "kernel/ui/modals/modal_manager.h"
 #include "pbl/os/mutex.h"
+#include "process_management/process_manager.h"
 #include "process_state/app_state/app_state.h"
 #include "resource/resource_ids.auto.h"
 #include "pbl/services/analytics/analytics.h"
@@ -40,7 +41,9 @@
 #include "pbl/services/notifications/alerts_preferences_private.h"
 #include "pbl/services/notifications/alerts_private.h"
 #include "pbl/services/notifications/ancs/ancs_filtering.h"
+#include "pbl/services/imaging.h"
 #include "pbl/services/notifications/do_not_disturb.h"
+#include "pbl/services/notifications/notification_image.h"
 #include "pbl/services/notifications/notification_storage.h"
 #include "pbl/services/notifications/notification_types.h"
 #include "pbl/services/notifications/notifications.h"
@@ -1151,6 +1154,7 @@ static void prv_window_unload(Window *window) {
   animation_unschedule(data->peek_animation);
 
   swap_layer_deinit(&data->swap_layer);
+  notification_image_clear();
   status_bar_layer_deinit(&data->status_layer);
   notifications_presented_list_deinit(prv_handle_presented_notif_deinit, NULL);
   gbitmap_deinit(&data->dnd_icon);
@@ -1166,12 +1170,49 @@ static void prv_window_unload(Window *window) {
 // Callback Handlers
 //////////////////////
 
+#if NOTIFICATION_IMAGE_SUPPORTED
+static void prv_redraw_current_layout(void *unused) {
+  LayoutLayer *layout = swap_layer_get_current_layout(&s_notification_window_data.swap_layer);
+  if (s_in_use && layout) {
+    layer_mark_dirty(&layout->layer);
+  }
+}
+
+static void prv_imaging_notification_received(uint8_t token, GBitmap *bitmap) {
+  if (!notification_image_store(token, bitmap) || !s_in_use) {
+    return;
+  }
+  // Delivery lands on KernelMain, which is where the modal renders; the notification history app
+  // owns its window on the App task and has to mark it dirty there.
+  if (s_notification_window_data.is_modal) {
+    prv_redraw_current_layout(NULL);
+  } else {
+    process_manager_send_callback_event_to_process(PebbleTask_App, prv_redraw_current_layout, NULL);
+  }
+}
+
+static void prv_maybe_request_notification_image(LayoutLayer *layout, TimelineItem *item) {
+  GSize size;
+  uint8_t token;
+  if (!notification_layout_get_image_size(layout, &size) ||
+      !imaging_is_type_supported(ImagingImageTypeNotification) ||
+      !notification_image_claim(&item->header.id, &token)) {
+    return;
+  }
+  imaging_request_notification_image(token, ImagingFormat4BitPalette, size.w, size.h,
+                                     &item->header.id);
+}
+#endif
+
 static void prv_layout_did_appear_handler(SwapLayer *swap_layer, LayoutLayer *layout,
                                           int8_t rel_change, void *context) {
   NotificationWindowData *data = context;
   TimelineItem *n = layout_get_context(layout);
   Uuid *id = &n->header.id;
   notifications_presented_list_set_current(id);
+#if NOTIFICATION_IMAGE_SUPPORTED
+  prv_maybe_request_notification_image(layout, n);
+#endif
   if (data->first_notif_loaded || !data->is_modal) {
     layer_set_hidden(&data->action_button_layer, !prv_should_provide_action_menu_for_item(data, n));
   }
@@ -1433,6 +1474,12 @@ void notification_window_focus_notification(Uuid *id, bool animated) {
 void notification_window_service_init(void) {
   s_notification_window_mutex = mutex_create();
   s_notification_window_data.pop_timer_id = EVENTED_TIMER_INVALID_ID;
+  // Unconditional: prv_window_unload clears the slot on every platform, so the lock has to exist
+  // even where images are never fetched.
+  notification_image_service_init();
+#if NOTIFICATION_IMAGE_SUPPORTED
+  imaging_register_handler(ImagingImageTypeNotification, prv_imaging_notification_received);
+#endif
 }
 
 

--- a/src/fw/services/imaging/imaging.c
+++ b/src/fw/services/imaging/imaging.c
@@ -20,16 +20,12 @@ static const uint16_t IMAGING_ENDPOINT = 0x35;
 #define IMAGING_MAX_DIM (300)
 #define IMAGING_PALETTE_ENTRIES (16)
 
-static ImagingReceivedHandler s_handlers[ImagingImageTypeAlbumArt + 1];
+static ImagingReceivedHandler s_handlers[ImagingImageTypeCount];
 
-//! Guards the request/latch state below: requests come in on the requesting task (e.g. the Music
-//! app) while responses are handled on KernelMain. The reassembly state (s_rx) is deliberately
-//! not covered — it is only ever touched on KernelMain (endpoint receiver and comm-session
-//! events).
+//! Guards the latch state below: requests come in on the requesting task (e.g. the Music app)
+//! while responses are handled on KernelMain. The reassembly state (s_rx) is deliberately not
+//! covered — it is only ever touched on KernelMain (endpoint receiver and comm-session events).
 static PebbleMutex *s_lock;
-
-// The response only carries the token, so remember which type the in-flight request was for.
-static ImagingImageType s_pending_type;
 
 // Image types the phone told us it can't serve (ImagingResponseFlagUnsupported), so we stop asking.
 // Latched per session: the connected phone doesn't change what it supports mid-connection, and a
@@ -67,10 +63,14 @@ void imaging_register_handler(ImagingImageType image_type, ImagingReceivedHandle
   }
 }
 
-static void prv_deliver(uint8_t token, GBitmap *bitmap) {
-  mutex_lock(s_lock);
-  const ImagingImageType type = s_pending_type;
-  mutex_unlock(s_lock);
+//! The type a response answers, from the top nibble of its flags byte. Zero — which is what a phone
+//! that doesn't set those bits sends — is album art. A value we don't know is left out of range so
+//! it routes nowhere rather than to the wrong consumer.
+static uint8_t prv_response_type(const ImagingResponseHeader *hdr) {
+  return (hdr->flags & IMAGING_RESPONSE_FLAG_TYPE_MASK) >> IMAGING_RESPONSE_FLAG_TYPE_SHIFT;
+}
+
+static void prv_deliver(uint8_t token, uint8_t type, GBitmap *bitmap) {
   ImagingReceivedHandler handler = (type < ARRAY_LENGTH(s_handlers)) ? s_handlers[type] : NULL;
   if (handler) {
     handler(token, bitmap);
@@ -128,10 +128,28 @@ bool imaging_request_album_art(uint8_t token, ImagingFormat format, uint16_t wid
   memcpy(cursor, artist, artist_len);
   cursor += artist_len;
 
-  mutex_lock(s_lock);
-  s_pending_type = ImagingImageTypeAlbumArt;
-  mutex_unlock(s_lock);
   comm_session_send_data(session, IMAGING_ENDPOINT, payload, cursor - payload,
+                         COMM_SESSION_DEFAULT_TIMEOUT);
+  return true;
+}
+
+bool imaging_request_notification_image(uint8_t token, ImagingFormat format, uint16_t width,
+                                        uint16_t height, const Uuid *item_id) {
+  if (!item_id || !imaging_is_type_supported(ImagingImageTypeNotification)) {
+    return false;
+  }
+  CommSession *session = comm_session_get_system_session();
+  uint8_t payload[sizeof(ImagingRequestHeader) + UUID_SIZE];
+  ImagingRequestHeader *hdr = (ImagingRequestHeader *)payload;
+  hdr->cmd = ImagingCmdIDRequest;
+  hdr->token = token;
+  hdr->image_type = ImagingImageTypeNotification;
+  hdr->format = format;
+  hdr->width = width;
+  hdr->height = height;
+  memcpy(payload + sizeof(*hdr), item_id, UUID_SIZE);
+
+  comm_session_send_data(session, IMAGING_ENDPOINT, payload, sizeof(payload),
                          COMM_SESSION_DEFAULT_TIMEOUT);
   return true;
 }
@@ -162,20 +180,24 @@ void imaging_protocol_msg_callback(CommSession *session, const uint8_t *msg, siz
   const uint8_t *cursor = msg + sizeof(*hdr);
   const uint8_t *msg_end = msg + length;
 
+  const uint8_t type = prv_response_type(hdr);
+
   if (hdr->flags & ImagingResponseFlagUnsupported) {
     // Phone can't serve this type: latch it off so we don't ask again this connection, and deliver
     // NULL so the current request resolves (the app treats it like "no image").
-    mutex_lock(s_lock);
-    s_unsupported_types |= (1u << s_pending_type);
-    mutex_unlock(s_lock);
+    if (type < ImagingImageTypeCount) {
+      mutex_lock(s_lock);
+      s_unsupported_types |= (1u << type);
+      mutex_unlock(s_lock);
+    }
     prv_rx_reset();
-    prv_deliver(hdr->token, NULL);
+    prv_deliver(hdr->token, type, NULL);
     return;
   }
 
   if (hdr->flags & ImagingResponseFlagNoImage) {
     prv_rx_reset();
-    prv_deliver(hdr->token, NULL);
+    prv_deliver(hdr->token, type, NULL);
     return;
   }
 
@@ -230,6 +252,8 @@ void imaging_protocol_msg_callback(CommSession *session, const uint8_t *msg, siz
   }
 
   if (!s_rx.active || s_rx.token != hdr->token) {
+    // ponytail: one reassembly slot, so two consumers fetching at once costs one of them a retry.
+    // Add a per-token slot array if that ever matters.
     prv_rx_reset();
     return;
   }
@@ -265,7 +289,7 @@ void imaging_protocol_msg_callback(CommSession *session, const uint8_t *msg, siz
     s_rx.pixels = NULL;
     s_rx.palette = NULL;
     prv_rx_reset();
-    prv_deliver(token, bmp);
+    prv_deliver(token, type, bmp);
   }
 }
 

--- a/src/fw/services/notifications/notification_image.c
+++ b/src/fw/services/notifications/notification_image.c
@@ -1,0 +1,94 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "pbl/services/notifications/notification_image.h"
+
+#include "applib/graphics/gtypes.h"
+#include "kernel/pbl_malloc.h"
+#include "pbl/os/mutex.h"
+
+//! Responses are delivered on KernelMain while the card that requested and renders the image runs
+//! on KernelMain (modal) or the App task (notification history), so the slot needs a lock. It is
+//! recursive because the renderer holds it across the blit to stop the bitmap being freed
+//! underneath it.
+static PebbleRecursiveMutex *s_lock;
+
+static Uuid s_item_id;
+static GBitmap *s_bitmap;
+static uint8_t s_token;
+static bool s_claimed;  //!< The slot belongs to s_item_id (in flight, delivered or empty).
+static bool s_pending;  //!< Waiting on a response for s_token.
+
+static void prv_free(GBitmap *bitmap) {
+  if (bitmap) {
+    kernel_free(bitmap->addr);
+    kernel_free(bitmap->palette);
+    kernel_free(bitmap);
+  }
+}
+
+void notification_image_service_init(void) {
+  s_lock = mutex_create_recursive();
+}
+
+bool notification_image_claim(const Uuid *item_id, uint8_t *token_out) {
+  if (!item_id || !token_out) {
+    return false;
+  }
+  mutex_lock_recursive(s_lock);
+  if (s_claimed && uuid_equal(&s_item_id, item_id)) {
+    mutex_unlock_recursive(s_lock);
+    return false;
+  }
+  prv_free(s_bitmap);
+  s_bitmap = NULL;
+  s_item_id = *item_id;
+  s_claimed = true;
+  s_pending = true;
+  *token_out = ++s_token;
+  mutex_unlock_recursive(s_lock);
+  return true;
+}
+
+const GBitmap *notification_image_lock(const Uuid *item_id) {
+  mutex_lock_recursive(s_lock);
+  // Held until notification_image_unlock so the bitmap can't be freed mid-draw.
+  if (!s_bitmap || !item_id || !s_claimed || !uuid_equal(&s_item_id, item_id)) {
+    return NULL;
+  }
+  return s_bitmap;
+}
+
+void notification_image_unlock(void) {
+  mutex_unlock_recursive(s_lock);
+}
+
+bool notification_image_is_pending(const Uuid *item_id) {
+  mutex_lock_recursive(s_lock);
+  const bool pending =
+      s_pending && s_claimed && item_id && uuid_equal(&s_item_id, item_id);
+  mutex_unlock_recursive(s_lock);
+  return pending;
+}
+
+bool notification_image_store(uint8_t token, GBitmap *bitmap) {
+  mutex_lock_recursive(s_lock);
+  if (!s_pending || token != s_token) {
+    mutex_unlock_recursive(s_lock);
+    prv_free(bitmap);
+    return false;
+  }
+  s_pending = false;
+  s_bitmap = bitmap;
+  mutex_unlock_recursive(s_lock);
+  return true;
+}
+
+void notification_image_clear(void) {
+  mutex_lock_recursive(s_lock);
+  prv_free(s_bitmap);
+  s_bitmap = NULL;
+  s_claimed = false;
+  s_pending = false;
+  mutex_unlock_recursive(s_lock);
+}

--- a/src/fw/services/notifications/wscript_build
+++ b/src/fw/services/notifications/wscript_build
@@ -13,6 +13,7 @@ sources = [
     'ancs/nexmo.c',
     'do_not_disturb.c',
     'do_not_disturb_toggle.c',
+    'notification_image.c',
     'notification_storage.c',
     'notifications.c',
 ]

--- a/src/fw/services/timeline/attribute.c
+++ b/src/fw/services/timeline/attribute.c
@@ -505,7 +505,9 @@ bool attribute_check_serialized_list(const uint8_t *cursor, const uint8_t *val_e
     cursor += attrib_hdr->length;
     if (cursor > val_end) {
       return false;
-    } else {
+    } else if (attrib_hdr->id < NumAttributeIds) {
+      // has_attribute is indexed by id, so a phone that knows an id this firmware doesn't must not
+      // reach the write.
       has_attribute[attrib_hdr->id] = true;
     }
   }

--- a/src/fw/services/timeline/attribute.c
+++ b/src/fw/services/timeline/attribute.c
@@ -71,6 +71,7 @@ static AttributeType prv_attribute_type(AttributeId id) {
     case AttributeIdMuteDayOfWeek:
     case AttributeIdHealthActivityType:
     case AttributeIdAlarmKind:
+    case AttributeIdImageAspectRatio:
       return AttributeTypeUint8;
     case AttributeIdIconTiny:
     case AttributeIdIconSmall:

--- a/src/fw/services/timeline/notification_layout.c
+++ b/src/fw/services/timeline/notification_layout.c
@@ -20,6 +20,7 @@
 #include "pbl/services/i18n/i18n.h"
 #include "pbl/services/blob_db/pin_db.h"
 #include "pbl/services/notifications/alerts_preferences_private.h"
+#include "pbl/services/notifications/notification_image.h"
 #include "pbl/services/timeline/timeline_resources.h"
 #include "shell/system_theme.h"
 #include "system/hexdump.h"
@@ -211,6 +212,128 @@ static bool prv_should_enlarge_emoji(NotificationLayout *layout) {
           prv_get_emoji_icon(layout) != INVALID_RESOURCE);
 }
 
+#if NOTIFICATION_IMAGE_SUPPORTED
+//! Space above and below the image band. Its own constant because body_padding is 0 for rect at
+//! the default content size, which leaves the image touching the body text.
+#define NOTIFICATION_IMAGE_PADDING (8)
+#define NOTIFICATION_IMAGE_CORNER_RADIUS (4)
+
+#if PBL_ROUND
+//! Round cards page in fixed steps and the usable width narrows towards the top and bottom of the
+//! circle, so the image takes a page of its own and sits centred in it.
+#define NOTIFICATION_IMAGE_CIRCLE_INSET (8)
+#define NOTIFICATION_IMAGE_RADIUS (DISP_ROWS / 2 - NOTIFICATION_IMAGE_CIRCLE_INSET)
+//! Centre of the page the image gets, which sits between the status bar and the paging arrow and so
+//! is a couple of pixels below the circle's own centre.
+#define NOTIFICATION_IMAGE_PAGE_CENTRE_Y (STATUS_BAR_LAYER_HEIGHT + LAYOUT_HEIGHT / 2)
+
+//! Whether a `width`-wide image of this aspect, centred in its page, clears the bezel.
+//!
+//! Checking the rectangle's own corners against the circle rather than bounding it by the inscribed
+//! square: a landscape photo is far wider than the square that fits the same circle, and photos are
+//! mostly landscape.
+static bool prv_image_fits_circle(int16_t width, uint8_t aspect) {
+  const int32_t half_w = width / 2;
+  const int32_t half_h = ((int32_t)width * aspect) / 32;
+  const int32_t dy = ABS(NOTIFICATION_IMAGE_PAGE_CENTRE_Y - DISP_ROWS / 2) + half_h;
+  const int32_t r = NOTIFICATION_IMAGE_RADIUS;
+  return (half_w * half_w) + (dy * dy) <= (r * r);
+}
+#endif
+
+//! Clamped height/width in sixteenths of the image the phone holds, or 0 for none. Clamping bounds
+//! the band a malformed attribute can reserve.
+static uint8_t prv_image_aspect(const NotificationLayout *layout) {
+  const uint8_t aspect =
+      attribute_get_uint8(layout->layout.attributes, AttributeIdImageAspectRatio, 0);
+  return aspect ? CLIP(aspect, NOTIFICATION_IMAGE_MIN_ASPECT, NOTIFICATION_IMAGE_MAX_ASPECT) : 0;
+}
+
+//! Size of the image itself for a content box `width` wide. Derived from the attribute rather than
+//! the bitmap, so the card's height is final before the pixels arrive and nothing reflows when they
+//! do — and so the requester and the renderer ask for the same thing.
+static GSize prv_image_size(const NotificationLayout *layout, int16_t width) {
+  const uint8_t aspect = prv_image_aspect(layout);
+  GSize size = { width, (width * aspect) / 16 };
+#if PBL_ROUND
+  // Shrink to the widest that still clears the bezel. Bounded by the content width, so this is a
+  // few dozen integer comparisons at most, and the result is cached with the node's size.
+  while (size.w > 0 && !prv_image_fits_circle(size.w, aspect)) {
+    size.w--;
+    size.h = (size.w * aspect) / 16;
+  }
+#endif
+  return size;
+}
+
+static void prv_image_node_callback(GContext *ctx, const GRect *box,
+                                    const GTextNodeDrawConfig *config, bool render,
+                                    GSize *size_out, void *user_data) {
+  NotificationLayout *layout = user_data;
+  const GSize image = prv_image_size(layout, box->size.w);
+  GSize band = { box->size.w, image.h };
+  GPoint origin = box->origin;
+
+#if PBL_ROUND
+  // Give the image a page to itself: a fixed-height band that straddled a page seam would be
+  // sliced in half, since paging only knows how to break text.
+  if (config && config->paging && config->page_frame->size.h > 0) {
+    const int16_t page_h = config->page_frame->size.h;
+    const int16_t page_y = config->origin_on_screen->y + box->origin.y -
+                           config->page_frame->origin.y;
+    const int16_t into_page = (page_y > 0) ? (page_y % page_h) : 0;
+    const int16_t skip = into_page ? (page_h - into_page) : 0;
+    band.h = skip + page_h;
+    origin.y += skip + (page_h - image.h) / 2;
+  }
+#endif
+  origin.x += (band.w - image.w) / 2;
+
+  if (render) {
+    const Uuid *item_id = &layout->info.item->header.id;
+    const GBitmap *bitmap = notification_image_lock(item_id);
+    if (bitmap) {
+      const GSize bitmap_size = bitmap->bounds.size;
+      const GRect dest = {
+        { origin.x + (image.w - bitmap_size.w) / 2,
+          origin.y + (image.h - bitmap_size.h) / 2 },
+        bitmap_size,
+      };
+      graphics_context_set_compositing_mode(ctx, GCompOpAssign);
+      graphics_draw_bitmap_in_rect(ctx, bitmap, &dest);
+    } else if (notification_image_is_pending(item_id)) {
+      // Still transferring: fill the reserved area so the card doesn't look broken. Once the phone
+      // answers NoImage this stops and the space is simply blank.
+      const GRect placeholder = { origin, image };
+      graphics_context_set_fill_color(ctx, GColorLightGray);
+      graphics_fill_round_rect(ctx, &placeholder, NOTIFICATION_IMAGE_CORNER_RADIUS, GCornersAll);
+    }
+    notification_image_unlock();
+  }
+  if (size_out) {
+    *size_out = band;
+  }
+}
+
+static GTextNode *prv_create_image_node(const LayoutLayer *layout_ref,
+                                        const LayoutNodeConstructorConfig *config) {
+  NotificationLayout *layout = (NotificationLayout *)layout_ref;
+  if (!prv_image_aspect(layout)) {
+    return NULL;
+  }
+  return &graphics_text_node_create_custom(prv_image_node_callback, layout)->node;
+}
+
+bool notification_layout_get_image_size(const LayoutLayer *layout_ref, GSize *size_out) {
+  const NotificationLayout *layout = (const NotificationLayout *)layout_ref;
+  if (!prv_image_aspect(layout)) {
+    return false;
+  }
+  *size_out = prv_image_size(layout, DISP_COLS - 2 * CARD_MARGIN);
+  return true;
+}
+#endif
+
 //! Creates a GTextNode view node representing the inner content of the notification
 //! @param layout NotificationLayout of the notification
 //! @param use_body_icon Whether to display a body icon. Currently used by Jumboji
@@ -291,6 +414,14 @@ static NOINLINE GTextNode *prv_create_view(NotificationLayout *layout, bool use_
     .heading_style_font = TextStyleFont_Header,
     .paragraph_style_font = TextStyleFont_Body,
   };
+#if NOTIFICATION_IMAGE_SUPPORTED
+  const LayoutNodeConstructorConfig image_config = {
+    .extent.node.type = LayoutNodeType_Constructor,
+    .constructor = prv_create_image_node,
+    .extent.offset.y = NOTIFICATION_IMAGE_PADDING,
+    .extent.margin.h = 2 * NOTIFICATION_IMAGE_PADDING,
+  };
+#endif
   const LayoutNodeConfig *reminder_timestamp_node_config = NULL;
   const LayoutNodeConfig *notification_timestamp_node_config = NULL;
   const LayoutNodeConfig *header_node_config = NULL;
@@ -316,6 +447,9 @@ static NOINLINE GTextNode *prv_create_view(NotificationLayout *layout, bool use_
     use_body_icon ? &body_icon_config.extent.node :
                     &body_config.text.extent.node,
     &headings_paragraphs_node.extent.node,
+#if NOTIFICATION_IMAGE_SUPPORTED
+    &image_config.extent.node,
+#endif
 #if PBL_RECT
     notification_timestamp_node_config,
 #endif

--- a/tests/fw/services/test_imaging.c
+++ b/tests/fw/services/test_imaging.c
@@ -66,6 +66,18 @@ static void prv_art_handler(uint8_t token, GBitmap *bitmap) {
   s_last_bitmap = bitmap;
 }
 
+static int s_notif_deliveries;
+
+static void prv_notif_handler(uint8_t token, GBitmap *bitmap) {
+  s_notif_deliveries++;
+  prv_free_last_bitmap();
+  s_last_bitmap = bitmap;
+}
+
+static uint8_t prv_typed(ImagingImageType type, uint8_t flags) {
+  return flags | (type << IMAGING_RESPONSE_FLAG_TYPE_SHIFT);
+}
+
 // Helpers
 ///////////////////////////////////////////////////////////
 
@@ -128,7 +140,9 @@ void test_imaging__initialize(void) {
   s_transport = fake_transport_create(TransportDestinationSystem, NULL, NULL);
   fake_transport_set_connected(s_transport, true);
   imaging_register_handler(ImagingImageTypeAlbumArt, prv_art_handler);
+  imaging_register_handler(ImagingImageTypeNotification, prv_notif_handler);
   s_deliveries = 0;
+  s_notif_deliveries = 0;
   s_last_token = 0;
   s_last_bitmap = NULL;
   // Reset any latched state left over from a previous test
@@ -302,6 +316,8 @@ void test_imaging__unsupported_latches_until_session_close(void) {
   cl_assert_equal_i(s_deliveries, 1);
   cl_assert(s_last_bitmap == NULL);
   cl_assert(!imaging_is_type_supported(ImagingImageTypeAlbumArt));
+  // Latching is per type
+  cl_assert(imaging_is_type_supported(ImagingImageTypeNotification));
 
   // Closing the system session clears the latch
   const PebbleCommSessionEvent closed_event = {
@@ -321,4 +337,63 @@ void test_imaging__request_payload_format(void) {
     6, 'A', 'r', 't', 'i', 's', 't',
   };
   fake_transport_assert_sent(s_transport, 0, 0x35, expected, sizeof(expected));
+}
+
+void test_imaging__notification_request_payload_format(void) {
+  const Uuid id = UuidMake(0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                           0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10);
+  cl_assert(imaging_request_notification_image(9, ImagingFormat4BitPalette, 180, 135, &id));
+  fake_comm_session_process_send_next();
+  const uint8_t expected[] = {
+    0x01, 9, 0x01, 0x02, 180, 0, 135, 0,
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+  };
+  fake_transport_assert_sent(s_transport, 0, 0x35, expected, sizeof(expected));
+}
+
+void test_imaging__response_routed_by_type(void) {
+  uint8_t buf[64];
+  const size_t len = prv_build_response(
+      buf, TEST_TOKEN,
+      prv_typed(ImagingImageTypeNotification,
+                ImagingResponseFlagFirst | ImagingResponseFlagLast),
+      0, sizeof(s_pixels), 4, 2, ImagingFormat4BitPalette,
+      s_palette, sizeof(s_palette), s_pixels, sizeof(s_pixels));
+  prv_receive(buf, len);
+  cl_assert_equal_i(s_notif_deliveries, 1);
+  cl_assert_equal_i(s_deliveries, 0);
+  cl_assert(s_last_bitmap != NULL);
+}
+
+void test_imaging__untyped_response_goes_to_album_art(void) {
+  // A phone that doesn't set the type bits only ever serves album art.
+  prv_receive_valid_image(TEST_TOKEN);
+  cl_assert_equal_i(s_deliveries, 1);
+  cl_assert_equal_i(s_notif_deliveries, 0);
+}
+
+void test_imaging__interleaved_requests_route_correctly(void) {
+  const Uuid id = UuidMake(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+  cl_assert(imaging_request_album_art(7, ImagingFormat4BitPalette, 166, 166, "Title", "Artist"));
+  cl_assert(imaging_request_notification_image(9, ImagingFormat4BitPalette, 180, 135, &id));
+  // The album art response arrives after the notification request was sent; it must still reach
+  // the album art handler.
+  prv_receive_valid_image(7);
+  cl_assert_equal_i(s_deliveries, 1);
+  cl_assert_equal_i(s_notif_deliveries, 0);
+}
+
+void test_imaging__unsupported_latches_per_type(void) {
+  // A response only ever follows a request, which always checks support first.
+  cl_assert(imaging_is_type_supported(ImagingImageTypeNotification));
+
+  uint8_t buf[32];
+  const size_t len = prv_build_response(
+      buf, TEST_TOKEN, prv_typed(ImagingImageTypeNotification, ImagingResponseFlagUnsupported),
+      0, 0, 0, 0, 0, NULL, 0, NULL, 0);
+  prv_receive(buf, len);
+  cl_assert_equal_i(s_notif_deliveries, 1);
+  cl_assert(!imaging_is_type_supported(ImagingImageTypeNotification));
+  cl_assert(imaging_is_type_supported(ImagingImageTypeAlbumArt));
 }

--- a/tests/fw/services/timeline/test_attribute.c
+++ b/tests/fw/services/timeline/test_attribute.c
@@ -358,6 +358,40 @@ void test_attribute__too_long_app_glance_subtitle_in_attribute_list(void) {
       "really really really really really really really really long su");
 }
 
+void test_attribute__image_aspect_ratio_deserializes(void) {
+  // An attribute whose type isn't recognised aborts the whole list, so a new id must be typed
+  // before anything after it survives.
+  static const uint8_t serialized[] = {
+    0x34,                     // AttributeIdImageAspectRatio
+    0x01, 0x00,
+    12,                       // 4:3
+    0x01,                     // AttributeIdTitle
+    0x04, 0x00,
+    'N', 'e', 'x', 't',
+  };
+  const uint8_t num_attributes = 2;
+  const uint8_t *end = serialized + sizeof(serialized);
+  const uint8_t *buffer_size_cursor = serialized;
+  const int32_t buffer_size =
+      attribute_get_buffer_size_for_serialized_attributes(num_attributes, &buffer_size_cursor, end);
+
+  Attribute attribute_buffer[num_attributes];
+  char attribute_data_buffer[buffer_size];
+  char *attribute_data_buffer_pointer = attribute_data_buffer;
+  AttributeList result = (AttributeList) {
+      .num_attributes = num_attributes,
+      .attributes = attribute_buffer,
+  };
+  const uint8_t *cursor = serialized;
+
+  cl_assert_equal_b(attribute_deserialize_list(&attribute_data_buffer_pointer,
+                                               attribute_data_buffer + buffer_size,
+                                               &cursor, end, result),
+                    true);
+  cl_assert_equal_i(attribute_get_uint8(&result, AttributeIdImageAspectRatio, 0), 12);
+  cl_assert_equal_s(attribute_get_string(&result, AttributeIdTitle, NULL), "Next");
+}
+
 void test_attribute__unknown_attribute_id_does_not_overflow(void) {
   // has_attribute is indexed by attribute id, so an id this firmware doesn't know must not be
   // written into it.

--- a/tests/fw/services/timeline/test_attribute.c
+++ b/tests/fw/services/timeline/test_attribute.c
@@ -357,3 +357,20 @@ void test_attribute__too_long_app_glance_subtitle_in_attribute_list(void) {
       "This is a really really really really really really really really really really really "
       "really really really really really really really really long su");
 }
+
+void test_attribute__unknown_attribute_id_does_not_overflow(void) {
+  // has_attribute is indexed by attribute id, so an id this firmware doesn't know must not be
+  // written into it.
+  static const uint8_t serialized[] = {
+    NumAttributeIds + 3,
+    0x01, 0x00,
+    1,
+  };
+  bool has_attribute[NumAttributeIds] = {0};
+  cl_assert_equal_b(attribute_check_serialized_list(serialized, serialized + sizeof(serialized), 1,
+                                                    has_attribute),
+                    true);
+  for (int i = 0; i < NumAttributeIds; i++) {
+    cl_assert_equal_b(has_attribute[i], false);
+  }
+}

--- a/tests/fw/ui/test_jumboji.c
+++ b/tests/fw/ui/test_jumboji.c
@@ -21,6 +21,7 @@
 #include "stubs_layer.h"
 #include "stubs_layout_node.h"
 #include "stubs_logging.h"
+#include "stubs_notification_image.h"
 #include "stubs_passert.h"
 #include "stubs_pbl_malloc.h"
 #include "stubs_pin_db.h"
@@ -29,6 +30,9 @@
 #include "stubs_text_node.h"
 #include "stubs_timeline_item.h"
 #include "stubs_timeline_resources.h"
+
+// Not in stubs_graphics.h: test_bitmap_layer.c defines its own.
+void graphics_draw_bitmap_in_rect(GContext *ctx, const GBitmap *src_bitmap, const GRect *rect) {}
 
 // Statics
 ////////////////////////////////////

--- a/tests/fw/ui/test_notification_window.c
+++ b/tests/fw/ui/test_notification_window.c
@@ -42,6 +42,7 @@
 #include "stubs_health_layout.h"
 #include "stubs_heap.h"
 #include "stubs_i18n.h"
+#include "stubs_imaging.h"
 #include "stubs_ios_notif_pref_db.h"
 #include "stubs_layer.h"
 #include "stubs_light.h"

--- a/tests/fw/ui/wscript_build
+++ b/tests/fw/ui/wscript_build
@@ -353,6 +353,7 @@ clar(ctx,
          " src/fw/apps/system/timeline/text_node.c"
          " src/fw/popups/notifications/notification_window.c"
          " src/fw/popups/notifications/notifications_presented_list.c"
+         " src/fw/services/notifications/notification_image.c"
          " src/fw/services/timeline/attribute.c"
          " src/fw/services/timeline/layout_layer.c"
          " src/fw/services/timeline/layout_node.c"

--- a/tests/stubs/stubs_imaging.h
+++ b/tests/stubs/stubs_imaging.h
@@ -16,3 +16,8 @@ bool WEAK imaging_request_album_art(uint8_t token, ImagingFormat format, uint16_
                                     uint16_t height, const char *title, const char *artist) {
   return false;
 }
+
+bool WEAK imaging_request_notification_image(uint8_t token, ImagingFormat format, uint16_t width,
+                                             uint16_t height, const Uuid *item_id) {
+  return false;
+}

--- a/tests/stubs/stubs_notification_image.h
+++ b/tests/stubs/stubs_notification_image.h
@@ -1,0 +1,29 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include "pbl/services/notifications/notification_image.h"
+#include "pbl/util/attributes.h"
+
+void WEAK notification_image_service_init(void) {}
+
+bool WEAK notification_image_claim(const Uuid *item_id, uint8_t *token_out) {
+  return false;
+}
+
+const struct GBitmap *WEAK notification_image_lock(const Uuid *item_id) {
+  return NULL;
+}
+
+void WEAK notification_image_unlock(void) {}
+
+bool WEAK notification_image_is_pending(const Uuid *item_id) {
+  return false;
+}
+
+bool WEAK notification_image_store(uint8_t token, struct GBitmap *bitmap) {
+  return false;
+}
+
+void WEAK notification_image_clear(void) {}

--- a/tests/stubs/stubs_text_node.h
+++ b/tests/stubs/stubs_text_node.h
@@ -20,3 +20,6 @@ bool graphics_text_node_container_add_child(GTextNodeContainer *parent, GTextNod
 GTextNodeText *graphics_text_node_create_text(size_t buffer_size) { return NULL; }
 
 GTextNodeHorizontal *graphics_text_node_create_horizontal(size_t max_nodes) { return NULL; }
+
+GTextNodeCustom *graphics_text_node_create_custom(GTextNodeDrawCallback callback,
+                                                  void *user_data) { return NULL; }


### PR DESCRIPTION
The phone (Android only) can now hold a photo for a timeline notification 
and serve it over the imaging endpoint, the same way the music app 
fetches album art.

A notification carrying one gains AttributeIdImageAspectRatio, the image's
height/width in sixteenths. The card reserves a band of exactly that shape and
requests the pixels with ImagingImageTypeNotification, keyed by the item's
UUID. Taking the shape from the attribute rather than the bitmap means the
card's height is final before the transfer completes, so nothing reflows when
the image lands; a placeholder fills the band until it does, and disappears if
the phone answers NoImage.

Rendering needs no new layout node: LayoutNodeType_Constructor already injects
an arbitrary GTextNode, and graphics_text_node_create_custom is documented for
exactly this. On round the band takes a page of its own, because paging only
knows how to break text and a fixed-height band could otherwise be sliced
across a seam, and the image is sized to the largest rectangle of its aspect
that clears the bezel at that position.

Serving a second image type means a response can no longer be routed by
remembering the type of the last request: the music app and the notification
modal can both have one outstanding. The type now rides in the spare bits of
the response's flags byte. Zero is album art, which is also what a phone
predating this sends, so nothing changes for it on the wire.

The phone only attaches the attribute when the watch advertises support for
it, so older firmware never receives an id it does not know.

Mobile changes here: 
https://github.com/coredevices/CoreApp/tree/steve/notif-images

Obelix screenshots:

<img width="200" height="228" alt="pebble_screenshot_2026-08-17_17-47-31" src="https://github.com/user-attachments/assets/034dc7f8-a817-4aff-bede-370a34069981" />
<img width="200" height="228" alt="pebble_screenshot_2026-08-17_17-47-02" src="https://github.com/user-attachments/assets/51b8958a-4cec-4190-8b1d-ce285c74c2d3" />
<img width="200" height="228" alt="pebble_screenshot_2026-08-17_17-45-44" src="https://github.com/user-attachments/assets/fe344c22-cc73-4e44-8c4e-cc816c9cb3e7" />

Getafix screenshots:

<img width="260" height="260" alt="pebble_screenshot_2026-08-17_17-49-35" src="https://github.com/user-attachments/assets/19032c5b-60c5-4552-abf2-264c559ba5d3" />
<img width="260" height="260" alt="pebble_screenshot_2026-08-17_17-48-43" src="https://github.com/user-attachments/assets/23b412bb-b3be-4a10-8fb8-20cb18980297" />
<img width="260" height="260" alt="pebble_screenshot_2026-08-17_17-48-32" src="https://github.com/user-attachments/assets/ce0e0165-6668-4c10-b03a-aadc396db49b" />