### PR TITLE
fw/music: only accept touch taps on the action bar

### DIFF
--- a/src/fw/applib/ui/recognizer/touch_nav.c
+++ b/src/fw/applib/ui/recognizer/touch_nav.c
@@ -179,18 +179,22 @@ void touch_nav_set_action_bar(TouchNavState *state, const GRect *frame, uint8_t 
   }
 }
 
-ButtonId touch_nav_action_bar_zone_button(const TouchNavActionBar *bar, GPoint point) {
-  // No bar (or a degenerate frame) / a tap outside the bar is a plain SELECT.
+ButtonId touch_nav_action_bar_zone_button(const TouchNavActionBar *bar, GPoint point,
+                                          bool require_icon_zone) {
+  // The fallback for any tap that does not land on an icon zone: a plain SELECT normally, or no
+  // button at all for a window that only accepts taps on the bar's icons.
+  const ButtonId fallback = require_icon_zone ? NUM_BUTTONS : BUTTON_ID_SELECT;
+  // No bar (or a degenerate frame) / a tap outside the bar.
   if (!bar->present || bar->frame.size.h <= 0 || !grect_contains_point(&bar->frame, &point)) {
-    return BUTTON_ID_SELECT;
+    return fallback;
   }
   // Split the bar vertically into three equal zones with half-open bounds: top = UP, middle =
   // SELECT, bottom = DOWN. zone i maps to icon bit i and to button (BUTTON_ID_UP + i).
   int zone = (point.y - bar->frame.origin.y) * 3 / bar->frame.size.h;
   zone = CLIP(zone, 0, 2);
   if (!(bar->icon_mask & (1 << zone))) {
-    // The zone has no icon: fall back to SELECT.
-    return BUTTON_ID_SELECT;
+    // The zone has no icon.
+    return fallback;
   }
   return (ButtonId)(BUTTON_ID_UP + zone);
 }
@@ -437,9 +441,14 @@ static void prv_recognizer_event(const Recognizer *recognizer, RecognizerEvent e
           prv_emit_click(state, prv_swipe_button(dir));
         } else if (recognizer == state->tap) {
           // Route the tap into the action-bar UP/SELECT/DOWN zone if the tap point is inside a
-          // present bar; otherwise (no bar, or a tap outside it) this is a plain SELECT.
+          // present bar; otherwise (no bar, or a tap outside it) this is a plain SELECT -- unless
+          // the top window requires taps to land on an action-bar icon zone.
+          const bool require_icon_zone =
+              state->ops->top_tap_requires_action_bar &&
+              state->ops->top_tap_requires_action_bar(state->ops->ctx);
           const GPoint tap_point = tap_recognizer_get_tap_point((Recognizer *)recognizer);
-          prv_emit_click(state, touch_nav_action_bar_zone_button(&state->action_bar, tap_point));
+          prv_emit_click(state, touch_nav_action_bar_zone_button(&state->action_bar, tap_point,
+                                                                require_icon_zone));
         }
       }
       break;

--- a/src/fw/applib/ui/recognizer/touch_nav.h
+++ b/src/fw/applib/ui/recognizer/touch_nav.h
@@ -111,6 +111,8 @@ typedef struct TouchNavOps {
   bool (*is_animating)(void *ctx);
   //! @return true if the top window overrides the back button.
   bool (*top_overrides_back)(void *ctx);
+  //! @return true if the top window only accepts taps on action-bar icon zones.
+  bool (*top_tap_requires_action_bar)(void *ctx);
   //! @return true if the top window has the touch bridge disabled.
   bool (*top_bridge_disabled)(void *ctx);
   //! Pop the top window (BACK on a window without a back handler).
@@ -217,9 +219,12 @@ void touch_nav_set_action_bar(TouchNavState *state, const GRect *frame, uint8_t 
 //! Resolve a tap at \a point against the action-bar snapshot \a bar. Returns the zoned button when
 //! the bar is present and the point is inside its frame: the frame is split vertically into three
 //! equal zones (top = UP, middle = SELECT, bottom = DOWN). A zone whose icon bit is clear, a point
-//! outside the frame, or an absent snapshot all fall back to \ref BUTTON_ID_SELECT. Swipes are not
-//! zoned; only taps consult this.
-ButtonId touch_nav_action_bar_zone_button(const TouchNavActionBar *bar, GPoint point);
+//! outside the frame, or an absent snapshot all fall back to \ref BUTTON_ID_SELECT -- unless
+//! \a require_icon_zone is set (the top window's touch_tap_requires_action_bar exception), in which
+//! case every fallback returns NUM_BUTTONS so no button is synthesized. Swipes are not zoned; only
+//! taps consult this.
+ButtonId touch_nav_action_bar_zone_button(const TouchNavActionBar *bar, GPoint point,
+                                          bool require_icon_zone);
 
 //! Register a Tier-1 widget node under the given registry. Dedup-by-address (a re-add WARNs and is
 //! a no-op). Robust to a node zeroed by the widget's *_init. \a ops and \a widget are the migrated

--- a/src/fw/applib/ui/window.c
+++ b/src/fw/applib/ui/window.c
@@ -236,6 +236,13 @@ void window_set_touch_bridge_disabled(Window *window, bool disabled) {
   window->touch_bridge_disabled = disabled;
 }
 
+void window_set_touch_tap_requires_action_bar(Window *window, bool requires_action_bar) {
+  if (!window || (requires_action_bar == window->touch_tap_requires_action_bar)) {
+    return;
+  }
+  window->touch_tap_requires_action_bar = requires_action_bar;
+}
+
 static ClickManager* prv_get_current_click_manager(void) {
   return window_manager_get_window_click_manager(window_manager_get_top_window());
 }

--- a/src/fw/applib/ui/window.h
+++ b/src/fw/applib/ui/window.h
@@ -117,6 +117,12 @@ typedef struct Window {
   bool touch_bridge_disabled:1;
 
   //! @internal
+  //! If set, the touch-nav bridge only synthesizes a button for a tap landing on an action-bar
+  //! icon zone; a tap anywhere else is dropped instead of falling back to SELECT. Swipes are
+  //! unaffected. @see \ref window_set_touch_tap_requires_action_bar()
+  bool touch_tap_requires_action_bar:1;
+
+  //! @internal
   //! If a click config provider was changed while the window was covered by a modal,
   //! this flag is used to indicate that it should be called when uncovered.
   bool is_waiting_for_click_config:1;
@@ -409,6 +415,14 @@ void window_detach_recognizer(Window *window, Recognizer *recognizer);
 //! @param window \ref Window to configure
 //! @param disabled true to disable the bridge for this window
 void window_set_touch_bridge_disabled(Window *window, bool disabled);
+
+//! Restrict the touch-navigation bridge's tap handling for a window to action-bar icon zones:
+//! a tap outside the bar (or on a zone without an icon) is dropped instead of synthesizing
+//! SELECT. Swipe navigation is unaffected. Used by windows whose SELECT action is too easy to
+//! trigger with an accidental screen touch (e.g. the Music app's play/pause).
+//! @param window \ref Window to configure
+//! @param requires_action_bar true to drop taps that miss the action-bar icon zones
+void window_set_touch_tap_requires_action_bar(Window *window, bool requires_action_bar);
 
 //! Get the recognizers attached to a window
 //! @param window \ref Window from which to get recognizers

--- a/src/fw/apps/system/music.c
+++ b/src/fw/apps/system/music.c
@@ -1538,6 +1538,9 @@ static void prv_push_window(MusicAppData *data) {
   window_init(window, WINDOW_NAME("Music"));
   window_set_user_data(window, data);
   window_set_status_bar_icon(window, (GBitmap*)&s_status_icon_music_bitmap);
+  // Play/pause is too easy to hit by accident: only taps on the action-bar icons count here, so a
+  // stray touch on the album art / track info does not toggle playback. Swipe nav still works.
+  window_set_touch_tap_requires_action_bar(window, true);
 
   const bool animated = true;
   app_window_stack_push(window, animated);

--- a/src/fw/kernel/ui/modals/modal_manager.c
+++ b/src/fw/kernel/ui/modals/modal_manager.c
@@ -125,6 +125,11 @@ static bool prv_modal_touch_nav_top_overrides_back(void *ctx) {
   return window && window->overrides_back_button;
 }
 
+static bool prv_modal_touch_nav_top_tap_requires_action_bar(void *ctx) {
+  Window *window = prv_get_visible_focused_window();
+  return window && window->touch_tap_requires_action_bar;
+}
+
 static bool prv_modal_touch_nav_top_bridge_disabled(void *ctx) {
   Window *window = prv_get_visible_focused_window();
   // No focused modal window: keep the modal twin inert. The button path is
@@ -157,6 +162,7 @@ static void prv_modal_touch_nav_idle_refresh(void *ctx) {
 static const TouchNavOps s_modal_touch_nav_ops = {
   .is_animating = prv_modal_touch_nav_is_animating,
   .top_overrides_back = prv_modal_touch_nav_top_overrides_back,
+  .top_tap_requires_action_bar = prv_modal_touch_nav_top_tap_requires_action_bar,
   .top_bridge_disabled = prv_modal_touch_nav_top_bridge_disabled,
   .pop_top = prv_modal_touch_nav_pop_top,
   .emit_button = prv_modal_touch_nav_emit_button,

--- a/src/fw/process_state/app_state/app_state.c
+++ b/src/fw/process_state/app_state/app_state.c
@@ -201,6 +201,11 @@ static bool prv_app_touch_nav_top_overrides_back(void *ctx) {
   return top && top->overrides_back_button;
 }
 
+static bool prv_app_touch_nav_top_tap_requires_action_bar(void *ctx) {
+  Window *top = app_window_stack_get_top_window();
+  return top && top->touch_tap_requires_action_bar;
+}
+
 static bool prv_app_touch_nav_top_bridge_disabled(void *ctx) {
   Window *top = app_window_stack_get_top_window();
   const bool window_opt_out = top && top->touch_bridge_disabled;
@@ -226,6 +231,7 @@ static void prv_app_touch_nav_emit_button(void *ctx, ButtonId button) {
 static const TouchNavOps s_app_touch_nav_ops = {
   .is_animating = prv_app_touch_nav_is_animating,
   .top_overrides_back = prv_app_touch_nav_top_overrides_back,
+  .top_tap_requires_action_bar = prv_app_touch_nav_top_tap_requires_action_bar,
   .top_bridge_disabled = prv_app_touch_nav_top_bridge_disabled,
   .pop_top = prv_app_touch_nav_pop_top,
   .emit_button = prv_app_touch_nav_emit_button,

--- a/tests/fw/ui/recognizer/test_touch_nav.c
+++ b/tests/fw/ui/recognizer/test_touch_nav.c
@@ -78,6 +78,7 @@ typedef struct FakeOps {
   bool animating;
   bool overrides_back;
   bool bridge_disabled;         // the top window opted out (window_set_touch_bridge_disabled)
+  bool tap_requires_action_bar; // the top window only accepts taps on action-bar icon zones
   bool app_has_raw_subscriber;  // the app installed its own raw touch subscriber
   int pop_count;
   int idle_refresh_count;
@@ -94,6 +95,9 @@ static bool prv_top_bridge_disabled(void *ctx) {
   // app_state.c's top_bridge_disabled op does.
   const FakeOps *f = ctx;
   return touch_nav_app_bridge_disabled(f->bridge_disabled, f->app_has_raw_subscriber);
+}
+static bool prv_top_tap_requires_action_bar(void *ctx) {
+  return ((FakeOps *)ctx)->tap_requires_action_bar;
 }
 static void prv_pop_top(void *ctx) { ((FakeOps *)ctx)->pop_count++; }
 static void prv_idle_refresh(void *ctx) { ((FakeOps *)ctx)->idle_refresh_count++; }
@@ -141,6 +145,7 @@ void test_touch_nav__initialize(void) {
   s_ops = (TouchNavOps){
     .is_animating = prv_is_animating,
     .top_overrides_back = prv_top_overrides_back,
+    .top_tap_requires_action_bar = prv_top_tap_requires_action_bar,
     .top_bridge_disabled = prv_top_bridge_disabled,
     .pop_top = prv_pop_top,
     .emit_button = prv_emit_button,
@@ -794,14 +799,14 @@ void test_touch_nav__action_bar_zone_math(void) {
     .present = true,
   };
   // Top zone -> UP.
-  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 20)), BUTTON_ID_UP);
-  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 49)), BUTTON_ID_UP);
+  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 20), false), BUTTON_ID_UP);
+  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 49), false), BUTTON_ID_UP);
   // Middle zone -> SELECT (half-open boundary at 50).
-  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 50)), BUTTON_ID_SELECT);
-  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 79)), BUTTON_ID_SELECT);
+  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 50), false), BUTTON_ID_SELECT);
+  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 79), false), BUTTON_ID_SELECT);
   // Bottom zone -> DOWN (half-open boundary at 80; last pixel 109 inside).
-  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 80)), BUTTON_ID_DOWN);
-  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 109)), BUTTON_ID_DOWN);
+  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 80), false), BUTTON_ID_DOWN);
+  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 109), false), BUTTON_ID_DOWN);
 }
 
 // A zone whose icon bit is clear falls back to SELECT even though the point is in that zone.
@@ -812,9 +817,9 @@ void test_touch_nav__action_bar_zone_without_icon_is_select(void) {
     .present = true,
   };
   // UP zone has no icon -> SELECT.
-  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 30)), BUTTON_ID_SELECT);
+  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 30), false), BUTTON_ID_SELECT);
   // DOWN zone still has its icon.
-  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 95)), BUTTON_ID_DOWN);
+  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 95), false), BUTTON_ID_DOWN);
 }
 
 // A tap outside the bar frame, or on an absent snapshot, is a plain SELECT.
@@ -825,12 +830,12 @@ void test_touch_nav__action_bar_outside_and_absent_are_select(void) {
     .present = true,
   };
   // Left of the bar (x < 100) -> SELECT.
-  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(50, 30)), BUTTON_ID_SELECT);
+  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(50, 30), false), BUTTON_ID_SELECT);
   // Above the bar (y < 20) -> SELECT.
-  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 10)), BUTTON_ID_SELECT);
+  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 10), false), BUTTON_ID_SELECT);
   // Absent snapshot -> SELECT regardless of the point.
   const TouchNavActionBar absent = { .present = false };
-  cl_assert_equal_i(touch_nav_action_bar_zone_button(&absent, GPoint(120, 30)), BUTTON_ID_SELECT);
+  cl_assert_equal_i(touch_nav_action_bar_zone_button(&absent, GPoint(120, 30), false), BUTTON_ID_SELECT);
 }
 
 // Through the dispatcher: with a bar snapshot set, a tap inside a zone emulates that zone's button.
@@ -875,6 +880,48 @@ void test_touch_nav__action_bar_swipe_stays_fullscreen(void) {
   // Swipe up entirely within the bar's x-column. Vertical swipe maps by content-scroll, not zone.
   prv_swipe(120, 95, 120, 30);
   cl_assert_equal_i(s_fake.emit_count, 1);
+  cl_assert_equal_i(s_fake.last_emit, BUTTON_ID_DOWN);
+}
+
+// require_icon_zone (the Music-app exception): every SELECT fallback becomes NUM_BUTTONS, so only
+// a tap landing on an icon zone maps to a button.
+void test_touch_nav__action_bar_zone_math_require_icon_zone(void) {
+  const TouchNavActionBar bar = {
+    .frame = GRect(100, 20, 40, 90),
+    .icon_mask = 0x5,  // UP (bit0) + DOWN (bit2), no SELECT icon
+    .present = true,
+  };
+  // Icon zones still map.
+  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 30), true), BUTTON_ID_UP);
+  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 95), true), BUTTON_ID_DOWN);
+  // In-bar zone without an icon -> no button.
+  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(120, 65), true), NUM_BUTTONS);
+  // Outside the bar -> no button.
+  cl_assert_equal_i(touch_nav_action_bar_zone_button(&bar, GPoint(50, 65), true), NUM_BUTTONS);
+  // Absent snapshot -> no button.
+  const TouchNavActionBar absent = { .present = false };
+  cl_assert_equal_i(touch_nav_action_bar_zone_button(&absent, GPoint(120, 30), true), NUM_BUTTONS);
+}
+
+// Through the dispatcher: with the top window requiring action-bar taps, a tap off the bar emits
+// nothing, a tap on an icon zone still emits, and swipes are unaffected.
+void test_touch_nav__tap_requires_action_bar_through_dispatcher(void) {
+  s_fake.tap_requires_action_bar = true;
+  const GRect frame = GRect(100, 20, 40, 90);
+  touch_nav_set_action_bar(&s_state, &frame, 0x7);
+
+  // Tap outside the bar (the album-art area): dropped, no SELECT.
+  prv_tap(50, 65);
+  cl_assert_equal_i(s_fake.emit_count, 0);
+
+  // Tap on the SELECT icon zone: still emits.
+  prv_tap(120, 65);
+  cl_assert_equal_i(s_fake.emit_count, 1);
+  cl_assert_equal_i(s_fake.last_emit, BUTTON_ID_SELECT);
+
+  // Swipe up anywhere: still the full-screen content-scroll mapping.
+  prv_swipe(50, 90, 50, 20);
+  cl_assert_equal_i(s_fake.emit_count, 2);
   cl_assert_equal_i(s_fake.last_emit, BUTTON_ID_DOWN);
 }
 


### PR DESCRIPTION
## Summary

Fixes [FIRM-4063](https://linear.app/core-dev/issue/FIRM-4063/music-app-play-button-too-easily-triggered-by-touch): the play button was too easily triggered by touch in the Music app.

The Tier-2 touch bridge maps any tap outside the action bar to SELECT, so on touch watches (obelix/getafix) brushing the album art or track-info area toggled play/pause.

- `applib/ui`: new `window_set_touch_tap_requires_action_bar()` per-window exception — with it set, a tap only synthesizes a button when it lands on an action-bar icon zone; any other tap is dropped instead of falling back to SELECT. Swipes are unaffected. Wired for both the app and modal touch-nav twins.
- `fw/music`: the music window opts in.

## Testing

- Unit tests: new zone-math + dispatcher cases in `test_touch_nav` (icon-zone taps still map, off-bar/no-icon taps drop, swipes unaffected); `test_touch_nav`, `test_modal_touch_nav`, `test_music_{asterix,obelix,gabbro}`, `test_music_endpoint` all pass.
- QEMU (`qemu_emery`) with a simulated Android phone session feeding music metadata and logging watch-to-phone MusicControl packets:
  - taps on album art / track info emit **no** command (previously play/pause);
  - action-bar zone taps still emit PreviousTrack/NextTrack and SELECT (opened volume controls);
  - swipe-right still exits the app; physical buttons unchanged;
  - launcher tap behavior outside the music app unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)