### PR TITLE
fw/applib/ui: tune animation pacing for gabbro's 21 Hz display

### DIFF
--- a/src/fw/applib/ui/animation.c
+++ b/src/fw/applib/ui/animation.c
@@ -1065,7 +1065,7 @@ void animation_private_state_init(AnimationState *state) {
     // To aid for debugging, let's start each task off at a different handle offset. Eventually they
     // will collide but it is not required that each task have globally unique handles
     .next_handle = pebble_task_get_current() * 100000000,
-    .last_delay_ms = ANIMATION_TARGET_FRAME_INTERVAL_MS,
+    .last_delay_ms = ANIMATION_RENDER_FRAME_INTERVAL_MS,
     .last_frame_time_ms = prv_get_ms_since_system_start()
   };
 
@@ -1136,10 +1136,10 @@ void animation_private_timer_callback(void *context) {
 
   // Frame rate control:
   const int32_t frame_interval_ms = serial_distance32(state->aux->last_frame_time_ms, now);
-  const int32_t error_ms = frame_interval_ms - ANIMATION_TARGET_FRAME_INTERVAL_MS;
+  const int32_t error_ms = frame_interval_ms - ANIMATION_RENDER_FRAME_INTERVAL_MS;
   const int32_t theoretic_delay_ms = state->aux->last_delay_ms - error_ms;
   const uint32_t delay_ms = CLIP(theoretic_delay_ms, (int32_t) 0,
-                                (int32_t) ANIMATION_TARGET_FRAME_INTERVAL_MS);
+                                (int32_t) ANIMATION_RENDER_FRAME_INTERVAL_MS);
 
   prv_reschedule_timer(state, delay_ms);
   state->aux->last_delay_ms = delay_ms;

--- a/src/fw/applib/ui/animation.h
+++ b/src/fw/applib/ui/animation.h
@@ -67,8 +67,27 @@ typedef struct ImmutableAnimation ImmutableAnimation;
 
 //! @internal
 //! aimed to duration of a single frame
+//! Animation durations are derived from this, so it defines the design speed
+//! of animations
+#if defined(CONFIG_PLATFORM_GABBRO)
+//! Slightly quicker than the 33 ms design value: gabbro's ~21 Hz display
+//! shows fewer, larger motion steps, which read as sluggish at design speed
+#define ANIMATION_TARGET_FRAME_INTERVAL_MS 28
+#else
 //! 1000ms / 30 Hz
 #define ANIMATION_TARGET_FRAME_INTERVAL_MS 33
+#endif
+
+//! @internal
+//! interval at which the animation service schedules frames
+#if defined(CONFIG_PLATFORM_GABBRO)
+//! Gabbro's display (Sharp LS013B7DD02) is spec-limited to ~21 Hz full-frame
+//! updates; scheduling frames faster than the panel can show them produces
+//! uneven, coalesced updates
+#define ANIMATION_RENDER_FRAME_INTERVAL_MS 48
+#else
+#define ANIMATION_RENDER_FRAME_INTERVAL_MS ANIMATION_TARGET_FRAME_INTERVAL_MS
+#endif
 
 
 //! The type used to represent how far an animation has progressed. This is passed to the


### PR DESCRIPTION
Gabbro's Sharp LS013B7DD02 panel is spec-limited to ~21 Hz full-frame updates (BCK max 0.758 MHz, vertical period min 46.7 ms), while the animation service schedules frames at 30 Hz. A full-frame LCDC transfer takes ~47 ms on the wire and the framebuffer is converted in place, so rendering cannot overlap the flush: every other animation tick lands mid-transfer and gets coalesced into a single deferred render. Motion advances in uneven 1-2 frame steps, which reads as choppiness compared to obelix (whose panel refreshes at its 30 Hz spec).

Two changes, both gabbro-only:

- Introduce ANIMATION_RENDER_FRAME_INTERVAL_MS, the interval at which the animation service schedules frames, set to 48 ms (~21 Hz) on gabbro and equal to ANIMATION_TARGET_FRAME_INTERVAL_MS elsewhere. Sampling animations at the rate the panel can actually show them gives even motion steps instead of coalesced, uneven ones.

- Trim ANIMATION_TARGET_FRAME_INTERVAL_MS, the base all animation durations are derived from, to 28 ms. At ~21 Hz an animation shows fewer, larger motion steps, and design-speed durations read as sluggish; slightly shorter durations restore the snappy feel.

Relates to FIRM-3324.