### PR TITLE
fw/services/touch: release an active touch before subscribe's reset

### DIFF
--- a/src/fw/applib/touch_service.c
+++ b/src/fw/applib/touch_service.c
@@ -83,6 +83,8 @@ void touch_service_subscribe(TouchServiceHandler handler, void *context) {
   }
   state->raw_handler = handler;
   state->raw_context = context;
+  // End any in-progress gesture before the reset zeroes the last coordinates: a finger that is still down must get its Liftoff synthesized here, or the eventual lift reports FingerUp against the already-reset state and emits nothing -- the Touchdown's backlight hold leaks.
+  sys_touch_release_active();
   sys_touch_reset();
   sys_touch_set_raw_subscribed(handler != NULL);
   prv_update_subscription(state);

--- a/src/fw/services/touch/touch.c
+++ b/src/fw/services/touch/touch.c
@@ -179,6 +179,10 @@ DEFINE_SYSCALL(void, sys_touch_reset, void) {
   touch_reset();
 }
 
+DEFINE_SYSCALL(void, sys_touch_release_active, void) {
+  touch_release_active();
+}
+
 void touch_set_backlight_enabled(bool enabled) {
   mutex_lock(s_touch_mutex);
   if (enabled && !s_backlight_subscribed) {

--- a/src/fw/syscall/syscall.h
+++ b/src/fw/syscall/syscall.h
@@ -218,6 +218,9 @@ bool sys_pebblekit_is_connected_debounced(void);
 bool sys_touch_service_is_enabled(void);
 void sys_touch_reset(void);
 
+// ! Synthesize a Liftoff for an in-progress touch (a no-op when no finger is down), without ! clearing the last coordinates. Used by subscribers that tear down or reclaim the touch slot ! mid-gesture, so the gesture ends cleanly instead of leaking its backlight hold.
+void sys_touch_release_active(void);
+
 //! Read the system and app-twin touch-navigation gates. The dispatcher runs on the app task,
 //! which is unprivileged for third-party apps, so these reads cannot touch the service's mutex
 //! and statics directly. Not exported to the SDK.

--- a/tests/fw/applib/test_touch_service.c
+++ b/tests/fw/applib/test_touch_service.c
@@ -53,8 +53,17 @@ TouchServiceState *kernel_applib_get_touch_service_state(void) {
 }
 
 static int s_touch_reset_count;
+static int s_touch_reset_seq;
+static int s_touch_release_seq;
+// Global sequence position shared by the ordering probes.
+static int s_seq;
 void sys_touch_reset(void) {
   s_touch_reset_count++;
+  s_touch_reset_seq = ++s_seq;
+}
+
+void sys_touch_release_active(void) {
+  s_touch_release_seq = ++s_seq;
 }
 
 static bool s_raw_subscribed;
@@ -97,7 +106,6 @@ static void prv_raw_handler(const TouchEvent *event, void *context) {
 }
 
 // Ordering probes: record the global sequence position at which each fires.
-static int s_seq;
 static int s_system_seq;
 static int s_raw_seq;
 
@@ -228,8 +236,7 @@ void test_touch_service__subscription_created_once(void) {
   cl_assert_equal_i(s_unsubscribe_count, 1);
 }
 
-// touch_service_unsubscribe with only the system slot occupied is a no-op on
-// the subscription and never clears the system slot.
+// touch_service_unsubscribe with only the system slot occupied is a no-op on the subscription and never clears the system slot.
 void test_touch_service__unsubscribe_keeps_system_slot(void) {
   touch_service_set_system_handler(prv_system_handler, &s_system_marker);
   cl_assert_equal_i(s_subscribe_count, 1);
@@ -238,4 +245,17 @@ void test_touch_service__unsubscribe_keeps_system_slot(void) {
   cl_assert(s_state.system_handler == prv_system_handler);
   cl_assert(s_state.subscribed);
   cl_assert_equal_i(s_unsubscribe_count, 0);
+}
+
+// Subscribing (re)claims the raw slot and resets the kernel touch state so a previous window's gesture cannot leak into this one. The reset must release an active touch first: with a finger down, a bare reset swallows the gesture's Liftoff (the eventual lift reports FingerUp against the already-reset FingerUp state and emits nothing), so the Touchdown's backlight hold leaks.
+void test_touch_service__subscribe_releases_active_touch_before_reset(void) {
+  s_seq = 0;
+  s_touch_release_seq = 0;
+  s_touch_reset_seq = 0;
+
+  touch_service_subscribe(prv_raw_handler, &s_raw_marker);
+
+  cl_assert(s_touch_release_seq > 0);
+  cl_assert(s_touch_reset_seq > 0);
+  cl_assert(s_touch_release_seq < s_touch_reset_seq);
 }


### PR DESCRIPTION
Draft — still validating on hardware.

A third oddity from the same touch experiments: drags occasionally hiccupped or truncated around window transitions that re-claim the touch slot (the weather forecast list does this on appear, after a popping child unsubscribes in its unload), and I also saw the stuck-backlight variant of the same thing.

touch_service_subscribe resets the kernel touch state to claim a clean slot, and a window appearing while a finger is down can hit that reset mid-gesture. The bare reset wipes the state to FingerUp without synthesising a Liftoff, so the gesture's eventual physical lift reports FingerUp against already-FingerUp state and emits nothing — the Touchdown's backlight hold leaks until a later full gesture rebalances it, and any motion before the lift manufactures a spurious mid-gesture Touchdown.

This synthesises the Liftoff before the reset (the sequence touch_service_set_globally_enabled(false) performs), via a new sys_touch_release_active syscall — a no-op when no finger is down.

Ordering covered by test_touch_service__subscribe_releases_active_touch_before_reset in tests/fw/applib/test_touch_service.c; full unit suite green.