### PR TITLE
drivers/touch/cst816: take the i2c lock around the hardware reset

### DIFF
--- a/src/fw/drivers/touch/cst816/cst816.c
+++ b/src/fw/drivers/touch/cst816/cst816.c
@@ -223,6 +223,8 @@ static bool cst816_fw_update(void) {
 }
 
 static void cst816_hw_reset(void) {
+  // Toggling the reset pin must not race an in-flight I2C transfer on another task: a chip hit by reset mid-byte stops ACKing and corrupts the transfer (touch_sensor_set_enabled is reachable synchronously from arbitrary tasks while the system task services IRQ-driven reads). Take the same per-transfer lock prv_read_data/prv_write_data use. No caller holds it already -- the only lock-takers are those two, neither of which resets -- so this cannot self-deadlock.
+  mutex_lock(s_i2c_lock);
 #ifdef RESET_PIN_CTRLBY_NPM1300
   NPM1300_OPS.gpio_set(Npm1300_Gpio2, 0);
   psleep(CST816_RESET_CYCLE_TIME);
@@ -234,6 +236,7 @@ static void cst816_hw_reset(void) {
   gpio_output_set(&CST816->reset, false);
   psleep(CST816_POR_DELAY_TIME);
 #endif
+  mutex_unlock(s_i2c_lock);
 }
 
 void touch_sensor_init(void) {


### PR DESCRIPTION
Draft — still validating on hardware.

The vaguest of the failures I saw while playing with touch a few weeks ago: very occasional glitched or dropped touch input, never reproducible on demand. Looking at the driver, there is a real unsynchronised window for it.

cst816_hw_reset toggles the chip's reset pin with no synchronisation against the bus: touch_sensor_set_enabled is reached synchronously from arbitrary tasks (subscribe/unsubscribe callbacks, the backlight and system-hold toggles) and calls the reset as its first statement, while the system task may be mid-transfer inside prv_read_data clocking the same chip. A chip hit by reset mid-byte stops ACKing and corrupts the in-flight transfer.

This takes s_i2c_lock inside cst816_hw_reset — the same per-transfer lock the read/write paths use. No caller holds it already (the only lock-takers are prv_read_data and prv_write_data, neither of which resets), so the acquisition cannot self-deadlock, and the bootmode/fw-update sequences keep their existing per-operation interleaving.

No unit test: the driver has no test target (it sits on real I2C, GPIO and EXTI) and the race is a cross-task timing window against hardware. Validated by call-site audit and a full firmware build.