### PR TITLE
activity: store detailed heart data for workouts and sleep

### DIFF
--- a/include/pbl/services/activity/activity.h
+++ b/include/pbl/services/activity/activity.h
@@ -410,6 +410,12 @@ uint8_t activity_prefs_heart_get_zone3_threshold(void);
 //! Return true if the HRM is enabled, false if not
 bool activity_prefs_heart_rate_is_enabled(void);
 
+//! Return true when detailed heart-rate logging during detected overnight sleep is enabled.
+bool activity_prefs_enhanced_overnight_hr_logging_is_enabled(void);
+
+//! Enable or disable detailed heart-rate logging during detected overnight sleep.
+void activity_prefs_set_enhanced_overnight_hr_logging_enabled(bool enabled);
+
 #ifdef CONFIG_HRM
 //! Get the HRM measurement interval setting
 //! @return the current HRMonitoringInterval value

--- a/include/pbl/services/activity/activity_private.h
+++ b/include/pbl/services/activity/activity_private.h
@@ -273,6 +273,25 @@ typedef struct PACKED {
   };
 } ActivitySessionDataLoggingRecord;
 
+// Versioned, fixed-size record used to persist the high-resolution heart-rate detail of a
+// manually started Workout. workout_id is the corresponding ActivitySession start_utc, which
+// lets the companion associate the samples with the existing workout rather than inventing a
+// second workout.
+#define WORKOUT_HEART_RATE_LOGGING_VERSION 1
+
+typedef struct PACKED {
+  uint32_t workout_id;
+  uint32_t sequence;
+  uint32_t timestamp_utc;
+  uint8_t bpm;
+  int8_t quality;
+  uint8_t flags;
+  uint8_t version;
+} WorkoutHeartRateDataLoggingRecord;
+
+#define WORKOUT_HEART_RATE_FLAG_ACTIVE (1 << 0)
+#define WORKOUT_HEART_RATE_FLAG_COMPLETE (1 << 1)
+
 // -----------------------------------------------------------------------------------------
 // Globals
 

--- a/include/pbl/services/activity/activity_private.h
+++ b/include/pbl/services/activity/activity_private.h
@@ -292,6 +292,24 @@ typedef struct PACKED {
 #define WORKOUT_HEART_RATE_FLAG_ACTIVE (1 << 0)
 #define WORKOUT_HEART_RATE_FLAG_COMPLETE (1 << 1)
 
+// A compact, versioned raw PPI item. The upper nibble stores the version and the lower nibble
+// stores flags, keeping one accepted interval at 16 bytes and allowing several values per second.
+typedef struct PACKED {
+  uint32_t workout_id;
+  uint32_t sequence;
+  uint32_t timestamp_utc;
+  uint16_t ppi_ms;
+  int8_t quality;
+  uint8_t flags_and_version;
+} WorkoutPpiDataLoggingRecord;
+_Static_assert(sizeof(WorkoutPpiDataLoggingRecord) == 16,
+               "Workout PPI DataLogging record must remain wire-compatible");
+
+#define WORKOUT_PPI_LOGGING_VERSION 1
+#define WORKOUT_PPI_VERSION_SHIFT 4
+#define WORKOUT_PPI_FLAG_ACTIVE (1 << 0)
+#define WORKOUT_PPI_FLAG_COMPLETE (1 << 1)
+
 // -----------------------------------------------------------------------------------------
 // Globals
 

--- a/include/pbl/services/data_logging/data_logging_service.h
+++ b/include/pbl/services/data_logging/data_logging_service.h
@@ -31,6 +31,9 @@ typedef enum {
   // High-resolution heart-rate detail captured by the built-in Workout service. The matching
   // activity-session record remains the authoritative workout summary.
   DlsSystemTagWorkoutHeartRate = 88,
+  // Accepted PPI/RR intervals from the Time 2 HRV algorithm while a built-in Workout is active.
+  // These are raw algorithm outputs, not precomputed HRV metrics.
+  DlsSystemTagWorkoutPpi = 89,
 } DlsSystemTag;
 
 //! Init the data logging service. Called by the system at boot time.

--- a/include/pbl/services/data_logging/data_logging_service.h
+++ b/include/pbl/services/data_logging/data_logging_service.h
@@ -34,6 +34,9 @@ typedef enum {
   // Accepted PPI/RR intervals from the Time 2 HRV algorithm while a built-in Workout is active.
   // These are raw algorithm outputs, not precomputed HRV metrics.
   DlsSystemTagWorkoutPpi = 89,
+  // High-resolution sleep-capture records. One compact, versioned stream carries accepted PPI,
+  // BPM/quality, 30-second motion summaries, and session completion diagnostics.
+  DlsSystemTagSleepCapture = 90,
 } DlsSystemTag;
 
 //! Init the data logging service. Called by the system at boot time.

--- a/include/pbl/services/data_logging/data_logging_service.h
+++ b/include/pbl/services/data_logging/data_logging_service.h
@@ -28,6 +28,9 @@ typedef enum {
   DlsSystemTagProtobufLogSession = 85,
   DlsSystemTagMemfaultChunksSession = 86,
   DlsSystemTagAnalyticsNativeHeartbeat = 87,
+  // High-resolution heart-rate detail captured by the built-in Workout service. The matching
+  // activity-session record remains the authoritative workout summary.
+  DlsSystemTagWorkoutHeartRate = 88,
 } DlsSystemTag;
 
 //! Init the data logging service. Called by the system at boot time.

--- a/src/fw/apps/system/settings/health.c
+++ b/src/fw/apps/system/settings/health.c
@@ -41,6 +41,9 @@ enum SettingsHealthItem {
     SettingsHealthHRMonitoringInterval,
     SettingsHealthHRActivityTracking,
 #endif
+#ifdef CONFIG_HRM_HRV
+    SettingsHealthEnhancedOvernightHRLogging,
+#endif
     NumSettingsHealthItems
 };
 
@@ -118,6 +121,14 @@ static void prv_draw_row_cb(SettingsCallbacks *context, GContext *ctx,
             break;
         }
 #endif
+#ifdef CONFIG_HRM_HRV
+        case SettingsHealthEnhancedOvernightHRLogging: {
+            title = i18n_noop("Sleep HR Logging");
+            subtitle = activity_prefs_enhanced_overnight_hr_logging_is_enabled()
+                ? i18n_noop("On (more battery)") : i18n_noop("Off");
+            break;
+        }
+#endif
         default:
             WTF;
     }
@@ -149,6 +160,12 @@ static void prv_select_click_cb(SettingsCallbacks *context, uint16_t row) {
         case SettingsHealthHRActivityTracking:
             activity_prefs_set_hrm_activity_tracking_enabled(
                 !activity_prefs_hrm_activity_tracking_is_enabled());
+            break;
+#endif
+#ifdef CONFIG_HRM_HRV
+        case SettingsHealthEnhancedOvernightHRLogging:
+            activity_prefs_set_enhanced_overnight_hr_logging_enabled(
+                !activity_prefs_enhanced_overnight_hr_logging_is_enabled());
             break;
 #endif
         default:

--- a/src/fw/services/activity/activity.c
+++ b/src/fw/services/activity/activity.c
@@ -43,12 +43,17 @@
 #include "pbl/services/activity/activity_calculators.h"
 #include "pbl/services/activity/activity_insights.h"
 #include "pbl/services/activity/activity_private.h"
+#include "sleep_capture.h"
 
 PBL_LOG_MODULE_DEFINE(service_activity, CONFIG_SERVICE_ACTIVITY_LOG_LEVEL);
 
 // Our globals
 static ActivityState s_activity_state;
 static bool s_activity_initialized = false;
+#ifdef CONFIG_HRM_HRV
+// Tracks the temporary overnight HRV feature request.
+static bool s_sleep_capture_hrv_requested = false;
+#endif
 
 // ------------------------------------------------------------------------------------------------
 ActivityState *activity_private_state(void) {
@@ -97,6 +102,28 @@ static uint32_t prv_get_hrm_period_sec(void) {
 // @param[in] now_ts number of seconds the system has been running (from time_get_uptime_seconds())
 static void prv_heart_rate_subscription_update(uint32_t now_ts) {
 #ifdef CONFIG_HRM
+  #ifdef CONFIG_HRM_HRV
+  if (sleep_capture_is_active()) {
+    if (!s_sleep_capture_hrv_requested) {
+      sys_hrm_manager_set_features(s_activity_state.hr.hrm_session,
+                                   HRMFeature_BPM | HRMFeature_HRV);
+      s_sleep_capture_hrv_requested = true;
+    }
+    // Keep the HRM manager's PPI path active.
+    sys_hrm_manager_set_update_interval(s_activity_state.hr.hrm_session, 1, 0 /* expire_sec */);
+    s_activity_state.hr.currently_sampling = true;
+    s_activity_state.hr.toggled_sampling_at_ts = now_ts;
+    return;
+  }
+  if (s_sleep_capture_hrv_requested) {
+    sys_hrm_manager_set_features(s_activity_state.hr.hrm_session, HRMFeature_BPM);
+    s_sleep_capture_hrv_requested = false;
+    // Resume the normal background-HR policy.
+    s_activity_state.hr.currently_sampling = false;
+    s_activity_state.hr.toggled_sampling_at_ts = now_ts;
+  }
+  #endif
+
   // If measurement interval is disabled, ensure we're not sampling and skip
   if (activity_prefs_get_hrm_measurement_interval() == HRMonitoringInterval_Disabled) {
     if (s_activity_state.hr.currently_sampling) {
@@ -167,6 +194,7 @@ static void prv_heart_rate_subscription_update(uint32_t now_ts) {
 #ifdef CONFIG_HRM
 T_STATIC void prv_hrm_subscription_cb(PebbleHRMEvent *hrm_event, void *context) {
   ACTIVITY_LOG_DEBUG("Got HR event: %d", (int) hrm_event->event_type);
+  sleep_capture_handle_hrm_event(hrm_event);
   if (hrm_event->event_type == HRMEvent_BPM) {
     ACTIVITY_LOG_DEBUG("HR bpm: %"PRIu8", qual: %"PRId8" ", hrm_event->bpm.bpm,
                        (int8_t) hrm_event->bpm.quality);
@@ -232,6 +260,9 @@ T_STATIC void prv_hrm_subscription_cb(PebbleHRMEvent *hrm_event, void *context) 
 // Init heart rate support
 static void prv_heart_rate_init(void) {
 #ifdef CONFIG_HRM
+  #ifdef CONFIG_HRM_HRV
+  s_sleep_capture_hrv_requested = false;
+  #endif
   // Subscribe to HRM data
   s_activity_state.hr.currently_sampling = false;
   s_activity_state.hr.toggled_sampling_at_ts = time_get_uptime_seconds();
@@ -253,6 +284,9 @@ static void prv_heart_rate_deinit(void) {
   sys_hrm_manager_unsubscribe(s_activity_state.hr.hrm_session);
   protobuf_log_session_delete(s_activity_state.hr.log_session);
   activity_metrics_prv_reset_hr_stats();
+  #ifdef CONFIG_HRM_HRV
+  s_sleep_capture_hrv_requested = false;
+  #endif
 #endif // CONFIG_HRM
 }
 
@@ -487,7 +521,9 @@ static void NOINLINE prv_update_storage(time_t utc_sec) {
 // We use NOINLINE to reduce the stack requirements during the minute handler (see PBL-38130)
 static void NOINLINE prv_process_minute_data_tail(time_t utc_sec) {
   bool need_history_update_event;
+  bool sleep_active;
   uint16_t cur_day_index;
+
   mutex_lock_recursive(s_activity_state.mutex);
   {
     cur_day_index = time_util_get_day(utc_sec);
@@ -495,6 +531,8 @@ static void NOINLINE prv_process_minute_data_tail(time_t utc_sec) {
 
     // Call the activity sessions minute handler
     activity_sessions_prv_minute_handler(utc_sec);
+    sleep_active = s_activity_state.sleep_data.cur_state == ActivitySleepStateLightSleep ||
+                   s_activity_state.sleep_data.cur_state == ActivitySleepStateRestfulSleep;
 
     // Update our backing store if necessary
     prv_update_storage(utc_sec);
@@ -518,9 +556,14 @@ static void NOINLINE prv_process_minute_data_tail(time_t utc_sec) {
       activity_insights_recalculate_stats();
     }
 
-    // Update the heart rate sampling period if necessary
-    prv_heart_rate_subscription_update(time_get_uptime_seconds());
   }
+  mutex_unlock_recursive(s_activity_state.mutex);
+
+  // DataLogging may allocate or close a session, so keep it outside the Activity-state mutex.
+  sleep_capture_minute_handler(utc_sec, activity_prefs_heart_rate_is_enabled(), sleep_active);
+
+  mutex_lock_recursive(s_activity_state.mutex);
+  prv_heart_rate_subscription_update(time_get_uptime_seconds());
   mutex_unlock_recursive(s_activity_state.mutex);
 
   // Send the history update event now if history has changed
@@ -738,6 +781,7 @@ static void prv_accel_cb(AccelRawData *data, uint32_t num_samples, uint64_t time
   if (vibes_get_vibe_strength() != VIBE_STRENGTH_OFF) {
     memset(data, 0, num_samples * sizeof(AccelRawData));
   }
+  sleep_capture_handle_accel(data, num_samples);
   // Have the algorithm process the samples from KernelBG
   activity_algorithm_handle_accel(data, num_samples, timestamp);
 
@@ -894,6 +938,9 @@ static void prv_stop_tracking_cb(void *context) {
     accel_session_delete(s_activity_state.accel_session);
     s_activity_state.accel_session = NULL;
   }
+
+  // Finish the local-first sleep stream before releasing the HRM subscription it depends on.
+  sleep_capture_deinit();
 
   // Close down heart rate support
   prv_heart_rate_deinit();

--- a/src/fw/services/activity/activity.c
+++ b/src/fw/services/activity/activity.c
@@ -560,7 +560,8 @@ static void NOINLINE prv_process_minute_data_tail(time_t utc_sec) {
   mutex_unlock_recursive(s_activity_state.mutex);
 
   // DataLogging may allocate or close a session, so keep it outside the Activity-state mutex.
-  sleep_capture_minute_handler(utc_sec, activity_prefs_heart_rate_is_enabled(), sleep_active);
+  sleep_capture_minute_handler(utc_sec, activity_prefs_heart_rate_is_enabled(), sleep_active,
+                               activity_prefs_enhanced_overnight_hr_logging_is_enabled());
 
   mutex_lock_recursive(s_activity_state.mutex);
   prv_heart_rate_subscription_update(time_get_uptime_seconds());

--- a/src/fw/services/activity/sleep_capture.c
+++ b/src/fw/services/activity/sleep_capture.c
@@ -3,6 +3,7 @@
 
 #include "sleep_capture.h"
 
+#include <pbl/drivers/rng.h>
 #include "pbl/services/data_logging/data_logging_service.h"
 #include "pbl/services/activity/activity_private.h"
 #include "util/time/time.h"
@@ -79,6 +80,14 @@ static bool prv_is_capture_window(time_t utc_sec) {
 
 static uint16_t prv_clamp_u16(uint32_t value) {
   return (value > UINT16_MAX) ? UINT16_MAX : (uint16_t)value;
+}
+
+static uint32_t prv_new_session_id(time_t now_utc) {
+  uint32_t session_id;
+  if (!rng_rand(&session_id) || session_id == 0) {
+    session_id = (uint32_t)now_utc;
+  }
+  return (session_id == 0) ? 1 : session_id;
 }
 
 static bool prv_log_record(SleepCaptureRecordType type, time_t timestamp_utc, uint16_t value,
@@ -174,7 +183,7 @@ static void prv_start_capture(time_t now_utc) {
 
   s_sleep_capture = (SleepCaptureState) {
     .active = true,
-    .session_id = (uint32_t)now_utc,
+    .session_id = prv_new_session_id(now_utc),
     .dls_session = session,
   };
   prv_reset_motion_epoch(now_utc - (now_utc % SLEEP_CAPTURE_EPOCH_SECONDS));
@@ -256,7 +265,8 @@ void sleep_capture_handle_accel(const AccelRawData *data, uint32_t num_samples) 
       const int32_t dy = (int32_t)data[i].y - s_sleep_capture.previous_accel.y;
       const int32_t dz = (int32_t)data[i].z - s_sleep_capture.previous_accel.z;
       // Store a compact, gravity-independent motion feature.
-      s_sleep_capture.motion_energy += (abs(dx) + abs(dy) + abs(dz)) >> 3;
+      const uint32_t energy = (abs(dx) + abs(dy) + abs(dz)) >> 3;
+      s_sleep_capture.motion_energy = MIN(UINT16_MAX, s_sleep_capture.motion_energy + energy);
     }
     s_sleep_capture.previous_accel = data[i];
     s_sleep_capture.has_previous_accel = true;

--- a/src/fw/services/activity/sleep_capture.c
+++ b/src/fw/services/activity/sleep_capture.c
@@ -1,0 +1,277 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "sleep_capture.h"
+
+#include "pbl/services/data_logging/data_logging_service.h"
+#include "pbl/services/activity/activity_private.h"
+#include "util/time/time.h"
+#include "util/units.h"
+
+#include <pbl/logging/logging.h>
+
+#include <stdlib.h>
+
+PBL_LOG_MODULE_DECLARE(service_activity, CONFIG_SERVICE_ACTIVITY_LOG_LEVEL);
+
+// Matches the existing overnight sleep window.
+#define SLEEP_CAPTURE_START_MINUTE (21 * MINUTES_PER_HOUR)
+#define SLEEP_CAPTURE_END_MINUTE   (12 * MINUTES_PER_HOUR)
+#define SLEEP_CAPTURE_EPOCH_SECONDS 30
+#define SLEEP_CAPTURE_BPM_PERIOD_SECONDS 30
+
+typedef enum {
+  SleepCaptureRecordType_Invalid = 0,
+  SleepCaptureRecordType_Ppi = 1,
+  SleepCaptureRecordType_Bpm = 2,
+  SleepCaptureRecordType_Motion = 3,
+  SleepCaptureRecordType_Session = 4,
+} SleepCaptureRecordType;
+
+// One resumable DataLogging stream for a complete night.
+typedef struct PACKED {
+  uint32_t session_id;
+  uint16_t sequence;
+  uint32_t timestamp_utc;
+  uint16_t value;
+  int8_t quality;
+  uint8_t type_flags;
+} SleepCaptureDataLoggingRecord;
+_Static_assert(sizeof(SleepCaptureDataLoggingRecord) == 14,
+               "Sleep capture DataLogging record must remain wire-compatible");
+
+#define SLEEP_CAPTURE_LOGGING_VERSION 1
+#define SLEEP_CAPTURE_TYPE_MASK 0x07
+#define SLEEP_CAPTURE_FLAG_COMPLETE (1 << 3)
+#define SLEEP_CAPTURE_FLAG_DROPPED (1 << 4)
+#define SLEEP_CAPTURE_VERSION_SHIFT 6
+#define SLEEP_CAPTURE_MOTION_QUALITY_UNKNOWN (-128)
+
+typedef struct {
+  bool active;
+  uint32_t session_id;
+  uint32_t next_sequence;
+  uint32_t dropped_records;
+  DataLoggingSession *dls_session;
+  bool storage_full;
+  bool reported_log_error;
+  time_t last_logged_bpm_utc;
+
+  time_t motion_epoch_start_utc;
+  uint32_t motion_energy;
+  uint16_t motion_sample_count;
+  AccelRawData previous_accel;
+  bool has_previous_accel;
+} SleepCaptureState;
+
+static SleepCaptureState s_sleep_capture;
+
+static uint8_t prv_type_flags(SleepCaptureRecordType type, uint8_t flags) {
+  return ((SLEEP_CAPTURE_LOGGING_VERSION << SLEEP_CAPTURE_VERSION_SHIFT) |
+          ((uint8_t)type & SLEEP_CAPTURE_TYPE_MASK) | flags);
+}
+
+static bool prv_is_capture_window(time_t utc_sec) {
+  const int minute_of_day = time_util_get_minute_of_day(utc_sec);
+  return (minute_of_day >= SLEEP_CAPTURE_START_MINUTE) ||
+         (minute_of_day < SLEEP_CAPTURE_END_MINUTE);
+}
+
+static uint16_t prv_clamp_u16(uint32_t value) {
+  return (value > UINT16_MAX) ? UINT16_MAX : (uint16_t)value;
+}
+
+static bool prv_log_record(SleepCaptureRecordType type, time_t timestamp_utc, uint16_t value,
+                           int8_t quality, uint8_t flags) {
+  if (!s_sleep_capture.active || !s_sleep_capture.dls_session) {
+    return false;
+  }
+  if (s_sleep_capture.storage_full && type != SleepCaptureRecordType_Session) {
+    ++s_sleep_capture.dropped_records;
+    return false;
+  }
+  if (s_sleep_capture.next_sequence > UINT16_MAX) {
+    ++s_sleep_capture.dropped_records;
+    s_sleep_capture.storage_full = true;
+    if (!s_sleep_capture.reported_log_error) {
+      s_sleep_capture.reported_log_error = true;
+      PBL_LOG_WRN("Sleep capture sequence capacity reached");
+    }
+    return false;
+  }
+
+  SleepCaptureDataLoggingRecord record = {
+    .session_id = s_sleep_capture.session_id,
+    // Leave sequence gaps visible when a write fails.
+    .sequence = (uint16_t)s_sleep_capture.next_sequence++,
+    .timestamp_utc = (uint32_t)timestamp_utc,
+    .value = value,
+    .quality = quality,
+    .type_flags = prv_type_flags(type, flags),
+  };
+  const DataLoggingResult result = dls_log(s_sleep_capture.dls_session, &record, 1);
+  if (result != DATA_LOGGING_SUCCESS) {
+    ++s_sleep_capture.dropped_records;
+    if (result == DATA_LOGGING_FULL) {
+      s_sleep_capture.storage_full = true;
+    }
+    if (!s_sleep_capture.reported_log_error) {
+      s_sleep_capture.reported_log_error = true;
+      PBL_LOG_WRN("Sleep capture log failed: %"PRIi32, (int32_t)result);
+    }
+    return false;
+  }
+  s_sleep_capture.reported_log_error = false;
+  return true;
+}
+
+static void prv_flush_motion_epoch(void) {
+  if (!s_sleep_capture.active || s_sleep_capture.motion_epoch_start_utc == 0 ||
+      s_sleep_capture.motion_sample_count == 0) {
+    return;
+  }
+
+  // Completeness identifies partial 30-second epochs.
+  const uint32_t expected_samples = SLEEP_CAPTURE_EPOCH_SECONDS * 25;
+  const uint32_t completeness = MIN(100,
+                                    (s_sleep_capture.motion_sample_count * 100) /
+                                        expected_samples);
+  prv_log_record(SleepCaptureRecordType_Motion, s_sleep_capture.motion_epoch_start_utc,
+                 prv_clamp_u16(s_sleep_capture.motion_energy), (int8_t)completeness, 0);
+}
+
+static void prv_reset_motion_epoch(time_t epoch_start_utc) {
+  s_sleep_capture.motion_epoch_start_utc = epoch_start_utc;
+  s_sleep_capture.motion_energy = 0;
+  s_sleep_capture.motion_sample_count = 0;
+}
+
+static void prv_finish_capture(time_t now_utc) {
+  if (!s_sleep_capture.active) {
+    return;
+  }
+
+  prv_flush_motion_epoch();
+  const uint8_t flags = SLEEP_CAPTURE_FLAG_COMPLETE |
+                        ((s_sleep_capture.dropped_records != 0) ? SLEEP_CAPTURE_FLAG_DROPPED : 0);
+  prv_log_record(SleepCaptureRecordType_Session, now_utc,
+                 prv_clamp_u16(s_sleep_capture.dropped_records),
+                 SLEEP_CAPTURE_MOTION_QUALITY_UNKNOWN, flags);
+  dls_finish(s_sleep_capture.dls_session);
+  s_sleep_capture = (SleepCaptureState) {};
+}
+
+static void prv_start_capture(time_t now_utc) {
+  const Uuid system_uuid = UUID_SYSTEM;
+  // Resume the flash stream after a reboot.
+  DataLoggingSession *session = dls_create(DlsSystemTagSleepCapture, DATA_LOGGING_BYTE_ARRAY,
+                                           sizeof(SleepCaptureDataLoggingRecord),
+                                           true /* buffered */, true /* resume */, &system_uuid);
+  if (!session) {
+    PBL_LOG_ERR("Unable to create sleep capture logging session");
+    return;
+  }
+
+  s_sleep_capture = (SleepCaptureState) {
+    .active = true,
+    .session_id = (uint32_t)now_utc,
+    .dls_session = session,
+  };
+  prv_reset_motion_epoch(now_utc - (now_utc % SLEEP_CAPTURE_EPOCH_SECONDS));
+  prv_log_record(SleepCaptureRecordType_Session, now_utc, 0,
+                 SLEEP_CAPTURE_MOTION_QUALITY_UNKNOWN, 0);
+  PBL_LOG_INFO("Sleep capture started");
+}
+
+void sleep_capture_minute_handler(uint32_t utc_sec, bool heart_rate_enabled, bool sleep_active) {
+#ifndef CONFIG_HRM_HRV
+  (void)utc_sec;
+  (void)heart_rate_enabled;
+  (void)sleep_active;
+#else
+  const time_t now_utc = (time_t)utc_sec;
+  const bool should_capture = heart_rate_enabled && sleep_active && prv_is_capture_window(now_utc);
+  if (should_capture && !s_sleep_capture.active) {
+    prv_start_capture(now_utc);
+  } else if (!should_capture && s_sleep_capture.active) {
+    prv_finish_capture(now_utc);
+  }
+#endif
+}
+
+bool sleep_capture_is_active(void) {
+#ifdef CONFIG_HRM_HRV
+  return s_sleep_capture.active;
+#else
+  return false;
+#endif
+}
+
+void sleep_capture_handle_hrm_event(const PebbleHRMEvent *event) {
+#ifdef CONFIG_HRM_HRV
+  if (!s_sleep_capture.active) {
+    return;
+  }
+
+  const time_t now_utc = rtc_get_time();
+  switch (event->event_type) {
+    case HRMEvent_HRV:
+      if (event->hrv.ppi_ms != 0) {
+        // The API exposes receipt UTC, not a millisecond event timestamp.
+        prv_log_record(SleepCaptureRecordType_Ppi, now_utc, event->hrv.ppi_ms,
+                       event->hrv.quality, 0);
+      }
+      break;
+    case HRMEvent_BPM:
+      if (now_utc - s_sleep_capture.last_logged_bpm_utc >= SLEEP_CAPTURE_BPM_PERIOD_SECONDS &&
+          prv_log_record(SleepCaptureRecordType_Bpm, now_utc, event->bpm.bpm,
+                         event->bpm.quality, 0)) {
+        s_sleep_capture.last_logged_bpm_utc = now_utc;
+      }
+      break;
+    default:
+      break;
+  }
+#else
+  (void)event;
+#endif
+}
+
+void sleep_capture_handle_accel(const AccelRawData *data, uint32_t num_samples) {
+#ifdef CONFIG_HRM_HRV
+  if (!s_sleep_capture.active || !data || num_samples == 0) {
+    return;
+  }
+
+  const time_t now_utc = rtc_get_time();
+  const time_t epoch_start = now_utc - (now_utc % SLEEP_CAPTURE_EPOCH_SECONDS);
+  if (epoch_start != s_sleep_capture.motion_epoch_start_utc) {
+    prv_flush_motion_epoch();
+    prv_reset_motion_epoch(epoch_start);
+  }
+
+  for (uint32_t i = 0; i < num_samples; ++i) {
+    if (s_sleep_capture.has_previous_accel) {
+      const int32_t dx = (int32_t)data[i].x - s_sleep_capture.previous_accel.x;
+      const int32_t dy = (int32_t)data[i].y - s_sleep_capture.previous_accel.y;
+      const int32_t dz = (int32_t)data[i].z - s_sleep_capture.previous_accel.z;
+      // Store a compact, gravity-independent motion feature.
+      s_sleep_capture.motion_energy += (abs(dx) + abs(dy) + abs(dz)) >> 3;
+    }
+    s_sleep_capture.previous_accel = data[i];
+    s_sleep_capture.has_previous_accel = true;
+    if (s_sleep_capture.motion_sample_count != UINT16_MAX) {
+      ++s_sleep_capture.motion_sample_count;
+    }
+  }
+#else
+  (void)data;
+  (void)num_samples;
+#endif
+}
+
+void sleep_capture_deinit(void) {
+#ifdef CONFIG_HRM_HRV
+  prv_finish_capture(rtc_get_time());
+#endif
+}

--- a/src/fw/services/activity/sleep_capture.c
+++ b/src/fw/services/activity/sleep_capture.c
@@ -192,14 +192,17 @@ static void prv_start_capture(time_t now_utc) {
   PBL_LOG_INFO("Sleep capture started");
 }
 
-void sleep_capture_minute_handler(uint32_t utc_sec, bool heart_rate_enabled, bool sleep_active) {
+void sleep_capture_minute_handler(uint32_t utc_sec, bool heart_rate_enabled, bool sleep_active,
+                                  bool enhanced_logging_enabled) {
 #ifndef CONFIG_HRM_HRV
   (void)utc_sec;
   (void)heart_rate_enabled;
   (void)sleep_active;
+  (void)enhanced_logging_enabled;
 #else
   const time_t now_utc = (time_t)utc_sec;
-  const bool should_capture = heart_rate_enabled && sleep_active && prv_is_capture_window(now_utc);
+  const bool should_capture = enhanced_logging_enabled && heart_rate_enabled && sleep_active &&
+                              prv_is_capture_window(now_utc);
   if (should_capture && !s_sleep_capture.active) {
     prv_start_capture(now_utc);
   } else if (!should_capture && s_sleep_capture.active) {

--- a/src/fw/services/activity/sleep_capture.h
+++ b/src/fw/services/activity/sleep_capture.h
@@ -10,7 +10,8 @@
 #include <stdint.h>
 
 //! Called once per minute by the Activity service.
-void sleep_capture_minute_handler(uint32_t utc_sec, bool heart_rate_enabled, bool sleep_active);
+void sleep_capture_minute_handler(uint32_t utc_sec, bool heart_rate_enabled, bool sleep_active,
+                                  bool enhanced_logging_enabled);
 
 //! True while the HRM subscription must include PPI collection.
 bool sleep_capture_is_active(void);

--- a/src/fw/services/activity/sleep_capture.h
+++ b/src/fw/services/activity/sleep_capture.h
@@ -1,0 +1,25 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include "kernel/events.h"
+#include "pbl/services/accel_manager_types.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+//! Called once per minute by the Activity service.
+void sleep_capture_minute_handler(uint32_t utc_sec, bool heart_rate_enabled, bool sleep_active);
+
+//! True while the HRM subscription must include PPI collection.
+bool sleep_capture_is_active(void);
+
+//! Store a BPM or accepted PPI event.
+void sleep_capture_handle_hrm_event(const PebbleHRMEvent *event);
+
+//! Summarize accelerometer data into 30-second epochs.
+void sleep_capture_handle_accel(const AccelRawData *data, uint32_t num_samples);
+
+//! Flush and close the active DataLogging stream.
+void sleep_capture_deinit(void);

--- a/src/fw/services/activity/workout_service.c
+++ b/src/fw/services/activity/workout_service.c
@@ -16,6 +16,7 @@
 #include "kernel/pbl_malloc.h"
 #include "pbl/services/evented_timer.h"
 #include "pbl/services/regular_timer.h"
+#include "pbl/services/system_task.h"
 #include <pbl/logging/logging.h>
 #include "system/passert.h"
 #include "util/time/time.h"
@@ -51,6 +52,12 @@ typedef struct CurrentWorkoutData {
   int32_t hr_samples_sum;
   int32_t hr_samples_count;
 
+  // The normal ActivitySession supplies the workout summary. This buffered DataLogging session
+  // retains the one-second sensor readings while the phone is absent.
+  DataLoggingSession *heart_rate_dls_session;
+  uint32_t next_heart_rate_sequence;
+  time_t last_logged_heart_rate_utc;
+
   // Step count total from the last HealthEventMovementUpdate
   int32_t last_event_step_count;
   time_t last_movement_event_time_ts;
@@ -73,6 +80,13 @@ typedef struct WorkoutServiceData {
 } WorkoutServiceData;
 
 static WorkoutServiceData s_workout_data;
+
+typedef struct WorkoutHeartRateDlsFinishData {
+  DataLoggingSession *session;
+  uint32_t workout_id;
+  uint32_t sequence;
+  time_t end_utc;
+} WorkoutHeartRateDlsFinishData;
 
 static void prv_lock(void) {
   mutex_lock_recursive(s_workout_data.s_workout_mutex);
@@ -127,6 +141,80 @@ static void prv_reset_hr_data(void) {
   s_workout_data.current_workout->current_bpm = 0;
   s_workout_data.current_workout->current_hr_zone = HRZone_Zone0;
   s_workout_data.current_workout->current_bpm_timestamp_ts = now_ts;
+}
+
+// ---------------------------------------------------------------------------------------
+static bool prv_ensure_workout_heart_rate_dls_session(CurrentWorkoutData *wrkt_data) {
+  if (wrkt_data->heart_rate_dls_session) {
+    return true;
+  }
+
+  // Workout start is initiated in the app task, where a system DataLogging buffer cannot be
+  // allocated. Health events are dispatched from the shell task, so create the buffered session
+  // lazily here and let the service own its kernel buffer.
+  const Uuid system_uuid = UUID_SYSTEM;
+  wrkt_data->heart_rate_dls_session = dls_create(
+      DlsSystemTagWorkoutHeartRate, DATA_LOGGING_BYTE_ARRAY,
+      sizeof(WorkoutHeartRateDataLoggingRecord), true /* buffered */, false /* resume */,
+      &system_uuid);
+  if (!wrkt_data->heart_rate_dls_session) {
+    PBL_LOG_WRN("Unable to create workout HR logging session");
+    return false;
+  }
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------------------
+static void prv_log_workout_heart_rate(CurrentWorkoutData *wrkt_data,
+                                       HealthEventHeartRateUpdateData *event) {
+  if (wrkt_data->paused || !prv_ensure_workout_heart_rate_dls_session(wrkt_data)) {
+    return;
+  }
+
+  const time_t now_utc = rtc_get_time();
+  // The workout subscription requests one update per second. If the lower-level source emits
+  // more than once in a second, keep one deterministic point rather than wasting flash.
+  if (now_utc == wrkt_data->last_logged_heart_rate_utc) {
+    return;
+  }
+
+  WorkoutHeartRateDataLoggingRecord record = {
+    .workout_id = (uint32_t)wrkt_data->start_utc,
+    .sequence = wrkt_data->next_heart_rate_sequence++,
+    .timestamp_utc = (uint32_t)now_utc,
+    .bpm = event->current_bpm,
+    .quality = event->quality,
+    .flags = WORKOUT_HEART_RATE_FLAG_ACTIVE,
+    .version = WORKOUT_HEART_RATE_LOGGING_VERSION,
+  };
+
+  DataLoggingResult result = dls_log(wrkt_data->heart_rate_dls_session, &record, 1);
+  if (result != DATA_LOGGING_SUCCESS) {
+    PBL_LOG_WRN("Workout HR log failed: %"PRIi32, (int32_t)result);
+    return;
+  }
+
+  wrkt_data->last_logged_heart_rate_utc = now_utc;
+}
+
+// ---------------------------------------------------------------------------------------
+static void prv_finish_workout_heart_rate_dls_session(void *data) {
+  WorkoutHeartRateDlsFinishData *finish_data = data;
+  WorkoutHeartRateDataLoggingRecord record = {
+    .workout_id = finish_data->workout_id,
+    .sequence = finish_data->sequence,
+    .timestamp_utc = (uint32_t)finish_data->end_utc,
+    .quality = -128, // terminal marker; not a sensor measurement
+    .flags = WORKOUT_HEART_RATE_FLAG_COMPLETE,
+    .version = WORKOUT_HEART_RATE_LOGGING_VERSION,
+  };
+  DataLoggingResult result = dls_log(finish_data->session, &record, 1);
+  if (result != DATA_LOGGING_SUCCESS) {
+    PBL_LOG_WRN("Workout HR completion log failed: %"PRIi32, (int32_t)result);
+  }
+  dls_finish(finish_data->session);
+  kernel_free(finish_data);
 }
 
 // ---------------------------------------------------------------------------------------
@@ -185,6 +273,7 @@ static void prv_handle_heart_rate_update(HealthEventHeartRateUpdateData *event) 
           wrkt_data->current_bpm_timestamp_ts - prev_bpm_timestamp_ts;
       wrkt_data->hr_samples_count++;
       wrkt_data->hr_samples_sum += event->current_bpm;
+      prv_log_workout_heart_rate(wrkt_data, event);
     }
   }
   return;
@@ -450,6 +539,7 @@ bool workout_service_stop_workout(void) {
   ActivitySession session_to_save;
   int32_t avg_hr_to_save = 0;
   int32_t hr_zone_time_s_to_save[HRZoneCount];
+  WorkoutHeartRateDlsFinishData *heart_rate_dls_finish_data = NULL;
 
   prv_lock();
   {
@@ -502,6 +592,15 @@ bool workout_service_stop_workout(void) {
     PBL_LOG_INFO("Stopping a workout with type: %d", wrkt->type);
     prv_put_event(PebbleWorkoutEvent_Stopped);
 
+    if (wrkt->heart_rate_dls_session) {
+      heart_rate_dls_finish_data = kernel_zalloc_check(sizeof(*heart_rate_dls_finish_data));
+      *heart_rate_dls_finish_data = (WorkoutHeartRateDlsFinishData) {
+        .session = wrkt->heart_rate_dls_session,
+        .workout_id = (uint32_t)wrkt->start_utc,
+        .sequence = wrkt->next_heart_rate_sequence,
+        .end_utc = rtc_get_time(),
+      };
+    }
     kernel_free(s_workout_data.current_workout);
     s_workout_data.current_workout = NULL;
   }
@@ -511,6 +610,16 @@ bool workout_service_stop_workout(void) {
     activity_sessions_prv_add_activity_session(&session_to_save);
     activity_insights_push_activity_session_notification(rtc_get_time(), &session_to_save,
                                                          avg_hr_to_save, hr_zone_time_s_to_save);
+  }
+
+  if (heart_rate_dls_finish_data) {
+    // Finish after releasing the workout mutex: buffered data is first flushed to flash and then
+    // handed to the existing companion DataLogging path. No Bluetooth connection is required.
+    if (!system_task_add_callback(prv_finish_workout_heart_rate_dls_session,
+                                  heart_rate_dls_finish_data)) {
+      PBL_LOG_WRN("Unable to finish workout HR logging session");
+      kernel_free(heart_rate_dls_finish_data);
+    }
   }
 
   return true;

--- a/src/fw/services/activity/workout_service.c
+++ b/src/fw/services/activity/workout_service.c
@@ -210,6 +210,15 @@ static void prv_finish_workout_heart_rate_dls_session(void *data) {
     .version = WORKOUT_HEART_RATE_LOGGING_VERSION,
   };
   DataLoggingResult result = dls_log(finish_data->session, &record, 1);
+  // Buffered sessions can temporarily be full while their preceding samples are being written
+  // from the System Task queue.  The completion marker is the companion's commit record: losing
+  // it would leave every otherwise valid detail point pending forever.  Requeue behind that
+  // writer rather than finishing the session without a marker.
+  if (result == DATA_LOGGING_BUSY &&
+      system_task_add_callback(prv_finish_workout_heart_rate_dls_session, finish_data)) {
+    PBL_LOG_WRN("Workout HR completion buffer busy; retrying");
+    return;
+  }
   if (result != DATA_LOGGING_SUCCESS) {
     PBL_LOG_WRN("Workout HR completion log failed: %"PRIi32, (int32_t)result);
   }

--- a/src/fw/services/activity/workout_service.c
+++ b/src/fw/services/activity/workout_service.c
@@ -58,6 +58,11 @@ typedef struct CurrentWorkoutData {
   uint32_t next_heart_rate_sequence;
   time_t last_logged_heart_rate_utc;
 
+  // PPI/RR intervals can arrive more than once in a second. Keep their own stream and sequence
+  // rather than downsampling or inferring them from the BPM stream.
+  DataLoggingSession *ppi_dls_session;
+  uint32_t next_ppi_sequence;
+
   // Step count total from the last HealthEventMovementUpdate
   int32_t last_event_step_count;
   time_t last_movement_event_time_ts;
@@ -87,6 +92,13 @@ typedef struct WorkoutHeartRateDlsFinishData {
   uint32_t sequence;
   time_t end_utc;
 } WorkoutHeartRateDlsFinishData;
+
+typedef struct WorkoutPpiDlsFinishData {
+  DataLoggingSession *session;
+  uint32_t workout_id;
+  uint32_t sequence;
+  time_t end_utc;
+} WorkoutPpiDlsFinishData;
 
 static void prv_lock(void) {
   mutex_lock_recursive(s_workout_data.s_workout_mutex);
@@ -165,6 +177,31 @@ static bool prv_ensure_workout_heart_rate_dls_session(CurrentWorkoutData *wrkt_d
   return true;
 }
 
+#ifdef CONFIG_HRM_HRV
+// ---------------------------------------------------------------------------------------
+static bool prv_ensure_workout_ppi_dls_session(CurrentWorkoutData *wrkt_data) {
+  if (wrkt_data->ppi_dls_session) {
+    return true;
+  }
+
+  // The HRV driver emits accepted PPI values on the shell task. Allocate the buffered system
+  // session lazily here, after a real interval exists, so a Workout with no valid PPI consumes no
+  // DataLogging storage and can still retain its normal ActivitySession summary.
+  const Uuid system_uuid = UUID_SYSTEM;
+  wrkt_data->ppi_dls_session = dls_create(
+      DlsSystemTagWorkoutPpi, DATA_LOGGING_BYTE_ARRAY,
+      sizeof(WorkoutPpiDataLoggingRecord), true /* buffered */, false /* resume */,
+      &system_uuid);
+  if (!wrkt_data->ppi_dls_session) {
+    PBL_LOG_WRN("Unable to create workout PPI logging session");
+    return false;
+  }
+
+  return true;
+}
+
+#endif  // CONFIG_HRM_HRV
+
 // ---------------------------------------------------------------------------------------
 static void prv_log_workout_heart_rate(CurrentWorkoutData *wrkt_data,
                                        HealthEventHeartRateUpdateData *event) {
@@ -198,6 +235,36 @@ static void prv_log_workout_heart_rate(CurrentWorkoutData *wrkt_data,
   wrkt_data->last_logged_heart_rate_utc = now_utc;
 }
 
+#ifdef CONFIG_HRM_HRV
+// ---------------------------------------------------------------------------------------
+static void prv_log_workout_ppi(CurrentWorkoutData *wrkt_data,
+                                 const HealthEventHRVUpdateData *event) {
+  if (wrkt_data->paused || event->ppi_ms == 0 || !prv_ensure_workout_ppi_dls_session(wrkt_data)) {
+    return;
+  }
+
+  // The firmware's HRV driver has already discarded invalid vendor results. Preserve every
+  // accepted non-zero PPI plus its quality; a companion must not manufacture missing intervals.
+  WorkoutPpiDataLoggingRecord record = {
+    .workout_id = (uint32_t)wrkt_data->start_utc,
+    .sequence = wrkt_data->next_ppi_sequence++,
+    .timestamp_utc = (uint32_t)rtc_get_time(),
+    .ppi_ms = event->ppi_ms,
+    .quality = event->quality,
+    .flags_and_version = (WORKOUT_PPI_LOGGING_VERSION << WORKOUT_PPI_VERSION_SHIFT) |
+        WORKOUT_PPI_FLAG_ACTIVE,
+  };
+
+  const DataLoggingResult result = dls_log(wrkt_data->ppi_dls_session, &record, 1);
+  if (result != DATA_LOGGING_SUCCESS) {
+    // A buffered DLS session retains data locally and reports BUSY only when its bounded RAM
+    // staging buffer is full. Do not reuse this sequence after a failed append: a future retry
+    // must never overwrite an interval the phone might already have received.
+    PBL_LOG_WRN("Workout PPI log failed: %"PRIi32, (int32_t)result);
+  }
+}
+#endif  // CONFIG_HRM_HRV
+
 // ---------------------------------------------------------------------------------------
 static void prv_finish_workout_heart_rate_dls_session(void *data) {
   WorkoutHeartRateDlsFinishData *finish_data = data;
@@ -221,6 +288,30 @@ static void prv_finish_workout_heart_rate_dls_session(void *data) {
   }
   if (result != DATA_LOGGING_SUCCESS) {
     PBL_LOG_WRN("Workout HR completion log failed: %"PRIi32, (int32_t)result);
+  }
+  dls_finish(finish_data->session);
+  kernel_free(finish_data);
+}
+
+// ---------------------------------------------------------------------------------------
+static void prv_finish_workout_ppi_dls_session(void *data) {
+  WorkoutPpiDlsFinishData *finish_data = data;
+  WorkoutPpiDataLoggingRecord record = {
+    .workout_id = finish_data->workout_id,
+    .sequence = finish_data->sequence,
+    .timestamp_utc = (uint32_t)finish_data->end_utc,
+    .quality = -128, // terminal marker; not a sensor measurement
+    .flags_and_version = (WORKOUT_PPI_LOGGING_VERSION << WORKOUT_PPI_VERSION_SHIFT) |
+        WORKOUT_PPI_FLAG_COMPLETE,
+  };
+  const DataLoggingResult result = dls_log(finish_data->session, &record, 1);
+  if (result == DATA_LOGGING_BUSY &&
+      system_task_add_callback(prv_finish_workout_ppi_dls_session, finish_data)) {
+    PBL_LOG_WRN("Workout PPI completion buffer busy; retrying");
+    return;
+  }
+  if (result != DATA_LOGGING_SUCCESS) {
+    PBL_LOG_WRN("Workout PPI completion log failed: %"PRIi32, (int32_t)result);
   }
   dls_finish(finish_data->session);
   kernel_free(finish_data);
@@ -289,6 +380,15 @@ static void prv_handle_heart_rate_update(HealthEventHeartRateUpdateData *event) 
 }
 
 // ---------------------------------------------------------------------------------------
+static void prv_handle_hrv_update(HealthEventHRVUpdateData *event) {
+#ifdef CONFIG_HRM_HRV
+  prv_log_workout_ppi(s_workout_data.current_workout, event);
+#else
+  (void)event;
+#endif
+}
+
+// ---------------------------------------------------------------------------------------
 bool workout_service_is_workout_type_supported(ActivitySessionType type) {
   return type == ActivitySessionType_Walk ||
          type == ActivitySessionType_Run ||
@@ -344,6 +444,8 @@ void workout_service_health_event_handler(PebbleHealthEvent *event) {
       prv_handle_movement_update(&event->data.movement_update);
     } else if (event->type == HealthEventHeartRateUpdate) {
       prv_handle_heart_rate_update(&event->data.heart_rate_update);
+    } else if (event->type == HealthEventHRVUpdate) {
+      prv_handle_hrv_update(&event->data.hrv_update);
     }
   }
 unlock:
@@ -431,8 +533,14 @@ void workout_service_frontend_closed(void) {
 
     if (hr_time_left > 0) {
       // Still some time left. Set a subscription with an expiration
-      s_workout_data.hrm_session =
-          sys_hrm_manager_app_subscribe(app_get_app_id(), 1, hr_time_left, HRMFeature_BPM);
+      s_workout_data.hrm_session = sys_hrm_manager_app_subscribe(
+          app_get_app_id(), 1, hr_time_left,
+#ifdef CONFIG_HRM_HRV
+          workout_service_is_workout_ongoing() ? (HRMFeature_BPM | HRMFeature_HRV) : HRMFeature_BPM
+#else
+          HRMFeature_BPM
+#endif
+      );
     } else {
       // No time left. Kill the subscription
       sys_hrm_manager_unsubscribe(s_workout_data.hrm_session);
@@ -492,6 +600,17 @@ bool workout_service_start_workout(ActivitySessionType type) {
 
     regular_timer_add_seconds_callback(&s_workout_data.second_timer);
 
+#ifdef CONFIG_HRM
+    // A normal Workout begins with the existing one-second BPM subscription. Add HRV only while
+    // the user is actively recording: this causes the optional Time 2 driver path to run and
+    // stops it again on Workout end, without changing idle or merely-open Workout battery use.
+    if (s_workout_data.hrm_session != HRM_INVALID_SESSION_REF) {
+#ifdef CONFIG_HRM_HRV
+      sys_hrm_manager_set_features(s_workout_data.hrm_session, HRMFeature_BPM | HRMFeature_HRV);
+#endif
+    }
+#endif
+
     // Finally tell our algorithm it should stop automatically tracking activities
     activity_algorithm_enable_activity_tracking(false /* disable */);
 
@@ -549,6 +668,7 @@ bool workout_service_stop_workout(void) {
   int32_t avg_hr_to_save = 0;
   int32_t hr_zone_time_s_to_save[HRZoneCount];
   WorkoutHeartRateDlsFinishData *heart_rate_dls_finish_data = NULL;
+  WorkoutPpiDlsFinishData *ppi_dls_finish_data = NULL;
 
   prv_lock();
   {
@@ -596,6 +716,10 @@ bool workout_service_stop_workout(void) {
     // the user's preferred rate within a bounded window, regardless of when the app actually exits.
     sys_hrm_manager_set_update_interval(s_workout_data.hrm_session, 1,
                                         WORKOUT_ENDED_HR_SUBSCRIPTION_TS_EXPIRE);
+#ifdef CONFIG_HRM_HRV
+    // Return to the existing BPM-only recovery behavior before releasing the Workout state.
+    sys_hrm_manager_set_features(s_workout_data.hrm_session, HRMFeature_BPM);
+#endif
 #endif // CONFIG_HRM
 
     PBL_LOG_INFO("Stopping a workout with type: %d", wrkt->type);
@@ -607,6 +731,15 @@ bool workout_service_stop_workout(void) {
         .session = wrkt->heart_rate_dls_session,
         .workout_id = (uint32_t)wrkt->start_utc,
         .sequence = wrkt->next_heart_rate_sequence,
+        .end_utc = rtc_get_time(),
+      };
+    }
+    if (wrkt->ppi_dls_session) {
+      ppi_dls_finish_data = kernel_zalloc_check(sizeof(*ppi_dls_finish_data));
+      *ppi_dls_finish_data = (WorkoutPpiDlsFinishData) {
+        .session = wrkt->ppi_dls_session,
+        .workout_id = (uint32_t)wrkt->start_utc,
+        .sequence = wrkt->next_ppi_sequence,
         .end_utc = rtc_get_time(),
       };
     }
@@ -628,6 +761,12 @@ bool workout_service_stop_workout(void) {
                                   heart_rate_dls_finish_data)) {
       PBL_LOG_WRN("Unable to finish workout HR logging session");
       kernel_free(heart_rate_dls_finish_data);
+    }
+  }
+  if (ppi_dls_finish_data) {
+    if (!system_task_add_callback(prv_finish_workout_ppi_dls_session, ppi_dls_finish_data)) {
+      PBL_LOG_WRN("Unable to finish workout PPI logging session");
+      kernel_free(ppi_dls_finish_data);
     }
   }
 

--- a/src/fw/services/activity/wscript_build
+++ b/src/fw/services/activity/wscript_build
@@ -12,6 +12,7 @@ sources = [
     'insights_settings.c',
     'kraepelin/activity_algorithm_kraepelin.c',
     'kraepelin/kraepelin_algorithm.c',
+    'sleep_capture.c',
     'workout_service.c',
 ]
 

--- a/src/fw/services/hrm/hrm_manager.c
+++ b/src/fw/services/hrm/hrm_manager.c
@@ -759,6 +759,10 @@ DEFINE_SYSCALL(bool, sys_hrm_manager_set_features, HRMSessionRef session, HRMFea
   HRMSubscriberState *state = prv_get_subscriber_state_from_ref(session);
   if (state) {
     state->features = features;
+    // The driver must restart when a live subscriber changes the requested feature mix (for
+    // example BPM-only to BPM + HRV during a Workout). Without this wake-up, the state changes
+    // only in RAM and the sensor can keep running with its old feature set indefinitely.
+    system_task_add_callback(prv_update_hrm_enable_system_cb, NULL);
     success = true;
   }
   mutex_unlock_recursive(s_manager_state.lock);

--- a/src/fw/shell/normal/prefs.c
+++ b/src/fw/shell/normal/prefs.c
@@ -272,6 +272,9 @@ static uint8_t s_alarms_app_opened = 0;
 #define PREF_KEY_ACTIVITY_HRM_PREFERENCES "hrmPreferences"
 static ActivityHRMSettings s_activity_hrm_preferences = ACTIVITY_HRM_DEFAULT_PREFERENCES;
 
+#define PREF_KEY_ACTIVITY_ENHANCED_OVERNIGHT_HR_LOGGING "enhancedOvernightHrLogging"
+static bool s_activity_enhanced_overnight_hr_logging_enabled = false;
+
 #define PREF_KEY_ACTIVITY_HEART_RATE_PREFERENCES "heartRatePreferences"
 static HeartRatePreferences s_activity_hr_preferences = ACTIVITY_HEART_RATE_DEFAULT_PREFERENCES;
 
@@ -743,6 +746,11 @@ static bool prv_set_s_activity_hrm_preferences(ActivityHRMSettings *new_settings
 #if BLE_HRM_SERVICE
   ble_hrm_handle_activity_prefs_heart_rate_is_enabled(new_settings->enabled);
 #endif // BLE_HRM_SERVICE
+  return true;
+}
+
+static bool prv_set_s_activity_enhanced_overnight_hr_logging_enabled(bool *enabled) {
+  s_activity_enhanced_overnight_hr_logging_enabled = *enabled;
   return true;
 }
 
@@ -1991,6 +1999,16 @@ uint8_t activity_prefs_heart_get_zone3_threshold(void) {
 
 bool activity_prefs_heart_rate_is_enabled(void) {
   return s_activity_hrm_preferences.enabled;
+}
+
+bool activity_prefs_enhanced_overnight_hr_logging_is_enabled(void) {
+  return s_activity_enhanced_overnight_hr_logging_enabled;
+}
+
+void activity_prefs_set_enhanced_overnight_hr_logging_enabled(bool enabled) {
+  if (s_activity_enhanced_overnight_hr_logging_enabled != enabled) {
+    prv_pref_set(PREF_KEY_ACTIVITY_ENHANCED_OVERNIGHT_HR_LOGGING, &enabled, sizeof(enabled));
+  }
 }
 
 #ifdef CONFIG_HRM

--- a/src/fw/shell/normal/prefs_values.h.inc
+++ b/src/fw/shell/normal/prefs_values.h.inc
@@ -47,6 +47,7 @@
   PREFS_MACRO(PREF_KEY_ACTIVITY_WORKOUT_APP_OPENED, s_activity_prefs_workout_app_opened)
   PREFS_MACRO(PREF_KEY_ALARMS_APP_OPENED, s_alarms_app_opened)
   PREFS_MACRO(PREF_KEY_ACTIVITY_HRM_PREFERENCES, s_activity_hrm_preferences)
+  PREFS_MACRO(PREF_KEY_ACTIVITY_ENHANCED_OVERNIGHT_HR_LOGGING, s_activity_enhanced_overnight_hr_logging_enabled)
   PREFS_MACRO(PREF_KEY_ACTIVITY_HEART_RATE_PREFERENCES, s_activity_hr_preferences)
   PREFS_MACRO(PREF_KEY_TIMELINE_SETTINGS_OPENED, s_timeline_settings_opened)
   PREFS_MACRO(PREF_KEY_TIMELINE_PEEK_ENABLED, s_timeline_peek_enabled)

--- a/tests/fw/services/activity/test_workout_service.c
+++ b/tests/fw/services/activity/test_workout_service.c
@@ -6,6 +6,7 @@
 #include "pbl/services/activity/activity.h"
 #include "pbl/services/activity/activity_calculators.h"
 #include "pbl/services/activity/workout_service.h"
+#include "pbl/services/data_logging/data_logging_service.h"
 #include "pbl/services/hrm/hrm_manager.h"
 #include "process_management/app_install_types.h"
 #include "util/time/time.h"
@@ -17,6 +18,7 @@
 #include "stubs_logging.h"
 #include "stubs_pbl_malloc.h"
 #include "stubs_regular_timer.h"
+#include "stubs_system_task.h"
 
 #include "fake_rtc.h"
 #include "fake_mutex.h"
@@ -78,6 +80,22 @@ uint8_t activity_prefs_heart_get_zone3_threshold(void) {
 AppInstallId app_get_app_id(void) {
   return 0;
 }
+
+// ---------------------------------------------------------------------------------------
+
+static DataLoggingSession *const s_data_logging_session = (DataLoggingSession *)1;
+
+DataLoggingSession *dls_create(uint32_t tag, DataLoggingItemType item_type, uint16_t item_size,
+                               bool buffered, bool resume, const Uuid *uuid) {
+  return s_data_logging_session;
+}
+
+DataLoggingResult dls_log(DataLoggingSession *logging_session, const void *data,
+                          uint32_t num_items) {
+  return DATA_LOGGING_SUCCESS;
+}
+
+void dls_finish(DataLoggingSession *logging_session) {}
 
 // ---------------------------------------------------------------------------------------
 

--- a/tests/fw/services/activity/wscript_build
+++ b/tests/fw/services/activity/wscript_build
@@ -15,6 +15,7 @@ clar(ctx,
          " src/fw/services/activity/activity_sessions.c" \
          " src/fw/services/activity/activity_calculators.c" \
          " src/fw/services/activity/hr_util.c" \
+         " src/fw/services/activity/sleep_capture.c" \
          " src/fw/services/filesystem/flash_translation.c" \
          " src/fw/services/filesystem/pfs.c" \
          " src/fw/services/settings/settings_file.c" \
@@ -26,7 +27,8 @@ clar(ctx,
          " src/fw/util/legacy_checksum.c" \
          " tests/fakes/fake_events.c" \
          " tests/fakes/fake_rtc.c" \
-         " tests/fakes/fake_spi_flash.c",
+         " tests/fakes/fake_spi_flash.c" \
+         " src/fw/drivers/rng/stubs.c",
      test_sources_ant_glob = "test_activity.c",
      override_includes=['dummy_board'],
      defines=["DUMA_DISABLED", "CAPABILITY_HAS_HEALTH_TRACKING=1",

--- a/tests/fw/services/test_hrm_manager.c
+++ b/tests/fw/services/test_hrm_manager.c
@@ -555,18 +555,27 @@ void test_hrm_manager__set_features(void) {
   const uint16_t expire_s = SECONDS_PER_MINUTE;
   const HRMSessionRef session_ref = sys_hrm_manager_app_subscribe(app_id, 1, expire_s,
                                                                   HRMFeature_BPM);
+  fake_system_task_callbacks_invoke_pending();
   HRMSubscriberState *state = prv_get_subscriber_state_from_ref(session_ref);
 
   // Starts off with BPM enabled
   cl_assert_equal_i(state->features, HRMFeature_BPM);
 
-  // Change to none
-  sys_hrm_manager_set_features(session_ref, 0);
-  cl_assert_equal_i(state->features, 0);
+  // Switching a live subscription must make the KernelBG task restart the sensor with the new
+  // feature set. This is what enables raw PPI during an already-running Workout.
+  const int initial_enable_count = s_hrm_state.enable_count;
+  cl_assert(sys_hrm_manager_set_features(session_ref, HRMFeature_BPM | HRMFeature_HRV));
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_i(state->features, HRMFeature_BPM | HRMFeature_HRV);
+  cl_assert_equal_i(s_hrm_state.features, HRMFeature_BPM | HRMFeature_HRV);
+  cl_assert_equal_i(s_hrm_state.enable_count, initial_enable_count + 1);
 
-  // Change to BPM
-  sys_hrm_manager_set_features(session_ref, HRMFeature_BPM);
+  // And it must likewise remove HRV at Workout end.
+  cl_assert(sys_hrm_manager_set_features(session_ref, HRMFeature_BPM));
+  fake_system_task_callbacks_invoke_pending();
   cl_assert_equal_i(state->features, HRMFeature_BPM);
+  cl_assert_equal_i(s_hrm_state.features, HRMFeature_BPM);
+  cl_assert_equal_i(s_hrm_state.enable_count, initial_enable_count + 2);
 }
 
 void test_hrm_manager__set_update_internal(void) {

--- a/tests/stubs/stubs_activity.h
+++ b/tests/stubs/stubs_activity.h
@@ -36,6 +36,10 @@ bool WEAK activity_prefs_heart_rate_is_enabled(void) {
   return true;
 }
 
+bool WEAK activity_prefs_enhanced_overnight_hr_logging_is_enabled(void) {
+  return false;
+}
+
 bool activity_get_metric_typical(ActivityMetric metric, DayInWeek day, int32_t *value_out) {
   return false;
 }


### PR DESCRIPTION
## Summary

This change saves detailed heart data during a built-in Workout and during detected sleep.

A user can start a Workout as usual. The watch keeps one heart-rate value each second. On watches that support HRV, it also keeps accepted pulse-to-pulse interval (PPI) values. The watch stores this data locally. It does not need a phone connection while the Workout runs.

During a detected overnight sleep period, the watch stores accepted PPI values, one heart-rate value every 30 seconds, and a 30-second motion summary. The normal activity session stays the main Workout summary. These new records add detail to that summary.

## Before this change

- Background heart-rate sampling used BPM only. The watch sampled at the user-selected interval: 10 minutes by default, 30 minutes, one hour, or disabled.
- Each background sampling run used a one-second sensor interval. It stopped after 60 seconds or after enough good readings.
- An open Workout requested BPM updates at a one-second interval.
- Workout readings updated the current BPM, heart-rate zones, and the average heart rate in the normal Workout summary.
- Valid BPM readings also entered the general heart-rate log. They were not a separate, clearly bounded Workout dataset.
- The watch did not keep raw PPI values.

## After this change

- The existing background heart-rate log and Workout summary behavior stays in place.
- An active Workout saves at most one BPM record per UTC second in a Workout-specific stream.
- On watches with HRV support, an active Workout also saves every accepted PPI value.
- The watch stores this detail locally and sends it through the normal DataLogging transfer.
- Detected overnight sleep also stores PPI values, a BPM value every 30 seconds, and 30-second motion summaries.

## What this enables

A companion or analysis tool can:

- Reconstruct the BPM timeline for one specific Workout, without paused time.
- Know when the full Workout dataset is complete.
- Use raw PPI data on supported watches for beat-to-beat and HRV analysis.
- Correlate overnight PPI, BPM, and motion with detected sleep.

This change records and transfers the new detail. It does not add a user-facing chart or insight by itself. A companion-side consumer must read these streams to present the data.

## Implementation

- Add three system DataLogging streams: Workout heart rate, Workout PPI, and sleep capture.
- Use versioned, fixed-size records. Each record has a session ID, sequence number, time, value, quality, and state flags.
- Add a final record when a Workout or sleep capture ends. The companion can use this record to know that a stream is complete.
- Keep the Workout PPI stream at its raw accepted values. The watch does not invent missing intervals or calculate new HRV values.
- Start the HRV sensor feature only during an active Workout or sleep capture. Return to BPM-only operation when it ends.
- Make the HRM manager refresh a live sensor subscription after its feature set changes.
- Resume the sleep stream after a reboot. Use a non-zero session ID and sequence gaps to keep replay safe.
- Add unit-test links and fakes for the new telemetry paths.

## User effect

- Workout detail stays on the watch until the normal DataLogging transfer can send it.
- Sleep detail can support later analysis without changing the existing activity summary.
- The change adds no public SDK API and no user interface.

## Validation

- Rebased onto current Core Devices main; the six commits apply without conflicts.
- Ran gitlint and git diff --check.
- Ran the full local QEMU test suite: ./waf test -k (pass).
- PR CI will also run the project container, QEMU tests, and firmware builds.