### PR TITLE
fw/services/hrm: stop unserved subscribers pinning the sensor on

### DIFF
--- a/include/pbl/services/hrm/hrm_manager_private.h
+++ b/include/pbl/services/hrm/hrm_manager_private.h
@@ -58,6 +58,12 @@ typedef struct HRMSubscriberState {
 // After this many consecutive hrm_enable failures, stop trying until reboot
 #define HRM_MAX_ENABLE_FAILURES 3
 
+// If the sensor has been on this long and a subscriber still hasn't received a Good-quality
+// reading, the subscriber is deferred to its next interval instead of holding the sensor on.
+// Comfortably above a normal serve cycle (spin-up plus a few seconds), far below the battery
+// impact threshold.
+#define HRM_MAX_UNSERVED_TIME_SEC 120
+
 struct HRMManagerState {
   PebbleRecursiveMutex *lock;
   ListNode *subscribers;
@@ -81,6 +87,9 @@ struct HRMManagerState {
   uint8_t enable_failure_count;    // counts consecutive hrm_enable failures, stops retrying after max
 
   HRMFeature enabled_features;     // feature union the sensor was last enabled with
+
+  RtcTicks sensor_on_since_ticks;  // tick count when the sensor was last turned on; 0 while off
+  bool unserved_timeout_logged;    // limits the unserved-timeout warning to once per on-stretch
 
   bool enabled_run_level;          // True if the current run_level (LowPower, Stationary,
                                    // Normal, etc.) allows the sensor to be turned on

--- a/src/fw/services/hrm/hrm_manager.c
+++ b/src/fw/services/hrm/hrm_manager.c
@@ -196,6 +196,14 @@ static void prv_update_hrm_enable_system_cb(void *unused) {
       int32_t remaining_ticks = INT32_MAX;
       const int32_t spin_up_ticks = (int32_t)milliseconds_to_ticks(
                                              HRM_SENSOR_SPIN_UP_SEC * MS_PER_SECOND);
+      const int64_t unserved_timeout_ticks = milliseconds_to_ticks(
+          HRM_MAX_UNSERVED_TIME_SEC * MS_PER_SECOND);
+      // True once the sensor has been on a full serve window without satisfying every
+      // subscriber. Only counts continuous on-time, so subscribers that went overdue while the
+      // sensor was forced off (charging, run level) still get served first.
+      const bool serve_window_expired =
+          hrm_is_enabled(HRM) && s_manager_state.sensor_on_since_ticks &&
+          ((int64_t)(cur_ticks - s_manager_state.sensor_on_since_ticks) > unserved_timeout_ticks);
 
       // Loop through each of the subscribers and figure out when the next one needs an update
       HRMSubscriberState *state = (HRMSubscriberState *) s_manager_state.subscribers;
@@ -205,16 +213,31 @@ static void prv_update_hrm_enable_system_cb(void *unused) {
           continue;
         }
         needed_features |= state->features;
+        const int64_t interval_ticks =
+            (int64_t)milliseconds_to_ticks(state->update_interval_s * MS_PER_SECOND);
         int64_t subscriber_age_ticks;
         if (state->last_valid_bpm_ticks) {
           subscriber_age_ticks = cur_ticks - state->last_valid_bpm_ticks;
         } else {
           // Never got an update yet
-          subscriber_age_ticks = milliseconds_to_ticks(state->update_interval_s * MS_PER_SECOND);
+          subscriber_age_ticks = interval_ticks;
+        }
+        if (serve_window_expired &&
+            ((state->last_valid_bpm_ticks == 0) ||
+             (subscriber_age_ticks >= interval_ticks + unserved_timeout_ticks))) {
+          // The sensor ran a whole serve window without producing a Good-quality reading for
+          // this subscriber. Mark it served so it waits out its interval instead of pinning the
+          // sensor on; short-interval (live HR) subscribers become due again immediately.
+          if (!s_manager_state.unserved_timeout_logged) {
+            PBL_LOG_WRN("HRM on for %ds without a valid reading, deferring subscribers",
+                        HRM_MAX_UNSERVED_TIME_SEC);
+            s_manager_state.unserved_timeout_logged = true;
+          }
+          state->last_valid_bpm_ticks = cur_ticks;
+          subscriber_age_ticks = 0;
         }
         int64_t subscriber_remaining_ticks =
-            (int64_t)milliseconds_to_ticks(state->update_interval_s * MS_PER_SECOND)
-            - subscriber_age_ticks - spin_up_ticks;
+            interval_ticks - subscriber_age_ticks - spin_up_ticks;
         subscriber_remaining_ticks = MAX(0, subscriber_remaining_ticks);
 
         remaining_ticks = MIN(remaining_ticks, subscriber_remaining_ticks);
@@ -274,6 +297,8 @@ static void prv_update_hrm_enable_system_cb(void *unused) {
         // Success - reset failure counter
         s_manager_state.enable_failure_count = 0;
         s_manager_state.enabled_features = needed_features;
+        s_manager_state.sensor_on_since_ticks = rtc_get_ticks();
+        s_manager_state.unserved_timeout_logged = false;
         // Don't need the re-enable timer to fire
         new_timer_stop(s_manager_state.update_enable_timer_id);
         // Track HRM on-time
@@ -285,6 +310,7 @@ static void prv_update_hrm_enable_system_cb(void *unused) {
       HRM_LOG("Turning off HR sensor");
       hrm_disable(HRM);
       s_manager_state.enabled_features = (HRMFeature)0;
+      s_manager_state.sensor_on_since_ticks = 0;
       // Stop tracking HRM on-time
       PBL_ANALYTICS_TIMER_STOP(hrm_on_time_ms);
 

--- a/tests/fw/services/test_hrm_manager.c
+++ b/tests/fw/services/test_hrm_manager.c
@@ -821,6 +821,66 @@ void test_hrm_manager__app_queue_full_drops_without_panic(void) {
   sys_hrm_manager_unsubscribe(session_ref);
 }
 
+// A subscriber the sensor cannot serve (quality never reaches Good) must not pin the sensor on
+// indefinitely: after HRM_MAX_UNSERVED_TIME_SEC it is deferred to its next interval.
+void test_hrm_manager__unserved_subscriber_timeout(void) {
+  HRMSessionRef session_ref = sys_hrm_manager_app_subscribe(1 /*app_id*/, 600 /*interval_s*/,
+                                                            0 /*expire_s*/, HRMFeature_BPM);
+  fake_system_task_callbacks_invoke_pending();
+
+  // Never served, so the sensor turns on right away
+  cl_assert_equal_b(hrm_is_enabled(HRM), true);
+
+  // Sub-Good readings don't serve the subscriber; the sensor stays on before the timeout
+  const HRMData poor_data = {
+    .features = HRMFeature_BPM,
+    .hrm_bpm = 70,
+    .hrm_quality = HRMQuality_Acceptable,
+  };
+  for (int i = 0; i < 2 * HRM_CHECK_SENSOR_DISABLE_COUNT; ++i) {
+    hrm_manager_new_data_cb(&poor_data);
+    fake_system_task_callbacks_invoke_pending();
+  }
+  cl_assert_equal_b(hrm_is_enabled(HRM), true);
+
+  // Once the serve window expires, the subscriber is deferred and the sensor powers off
+  prv_advance_time_ms((HRM_MAX_UNSERVED_TIME_SEC + 1) * MS_PER_SECOND);
+  for (int i = 0; i <= HRM_CHECK_SENSOR_DISABLE_COUNT; ++i) {
+    hrm_manager_new_data_cb(&poor_data);
+    fake_system_task_callbacks_invoke_pending();
+  }
+  cl_assert_equal_b(hrm_is_enabled(HRM), false);
+
+  // The re-enable timer waits out the subscriber's interval, not another immediate attempt
+  uint32_t timeout_ms = stub_new_timer_timeout(prv_get_timer_id());
+  cl_assert_equal_i(timeout_ms, (600 - HRM_SENSOR_SPIN_UP_SEC) * MS_PER_SECOND);
+
+  sys_hrm_manager_unsubscribe(session_ref);
+}
+
+// The unserved-subscriber timeout must not shut the sensor off under a short-interval (live HR)
+// subscriber: deferring it makes it due again immediately, so the sensor stays on.
+void test_hrm_manager__unserved_timeout_keeps_live_hr_on(void) {
+  HRMSessionRef session_ref = sys_hrm_manager_app_subscribe(1 /*app_id*/, 1 /*interval_s*/,
+                                                            0 /*expire_s*/, HRMFeature_BPM);
+  fake_system_task_callbacks_invoke_pending();
+  cl_assert_equal_b(hrm_is_enabled(HRM), true);
+
+  const HRMData poor_data = {
+    .features = HRMFeature_BPM,
+    .hrm_bpm = 70,
+    .hrm_quality = HRMQuality_Acceptable,
+  };
+  prv_advance_time_ms((HRM_MAX_UNSERVED_TIME_SEC + 1) * MS_PER_SECOND);
+  for (int i = 0; i <= HRM_CHECK_SENSOR_DISABLE_COUNT; ++i) {
+    hrm_manager_new_data_cb(&poor_data);
+    fake_system_task_callbacks_invoke_pending();
+  }
+  cl_assert_equal_b(hrm_is_enabled(HRM), true);
+
+  sys_hrm_manager_unsubscribe(session_ref);
+}
+
 // Test that OffWrist quality is delivered immediately without delay
 void test_hrm_manager__immediate_off_wrist(void) {
   stub_pebble_tasks_set_current(PebbleTask_KernelBackground);


### PR DESCRIPTION
The manager only considers a subscriber served once it receives a Good-or-better (or OffWrist) BPM sample. A subscriber the sensor cannot serve - poor contact, or the fresh state right after boot where every subscriber is treated as immediately due - would hold the sensor powered indefinitely. Telemetry from MOB-11575 shows a Pebble Time 2 running the sensor for 42 minutes straight after an OTA reboot, then burning ~4-7 min/hour for two days against a 30-minute measurement interval.

Track how long the sensor has been continuously on. Once it exceeds a full serve window (120 s) without producing a valid reading for a subscriber, stamp that subscriber as served so it defers to its next interval instead. Short-interval (live HR) subscribers become due again immediately, so workouts and BLE HR sharing are unaffected; only long-interval duty-cycled subscribers stop pinning the sensor. The gate counts continuous on-time only, so subscribers that went overdue while the sensor was forced off (charging, run level) still get served first.

Fixes MOB-11575