### PR TITLE
fw: fix app stack overflow crash loop that reverts watches to PRF (FIRM-3949)

### DIFF
--- a/src/fw/applib/graphics/text_resources.c
+++ b/src/fw/applib/graphics/text_resources.c
@@ -10,6 +10,7 @@
 #include "applib/fonts/fonts_private.h"
 #include "resource/resource_ids.auto.h"
 #include <pbl/logging/logging.h>
+#include <pbl/util/attributes.h>
 #include "system/passert.h"
 #include "system/profiler.h"
 #include "pbl/util/math.h"
@@ -349,10 +350,10 @@ static bool prv_load_glyph_bitmap(Codepoint codepoint, const FontResource *font_
   return true;
 }
 
-static const GlyphData *prv_get_glyph_metadata_from_spi(Codepoint codepoint,
-                                                        FontCache *font_cache,
-                                                        const FontResource *font_res,
-                                                        bool need_bitmap) {
+static ALWAYS_INLINE const GlyphData *prv_get_glyph_metadata_from_spi(Codepoint codepoint,
+                                                                      FontCache *font_cache,
+                                                                      const FontResource *font_res,
+                                                                      bool need_bitmap) {
   const uint32_t cache_key = prv_get_cache_key(font_res, codepoint);
   LineCacheData *cached = NULL;
 


### PR DESCRIPTION
35ff0d41 (v4.32.0) added a second call site for `prv_get_glyph_metadata_from_spi()`, which stopped GCC from inlining it into `prv_get_glyph_in_font()`. The glyph lookup path — the deepest consumer of the app stack (`graphics_draw_text` → `walk_line` → `text_resources_get_glyph` → resource/pfs syscalls) — grew from one 64-byte frame to 40 + 64 nested bytes. That +40 pushed near-limit watchfaces into the stack guard: the crashing app's SP was reconstructed at 16 bytes past where v4.31.1 would have left it.

Marking the function `ALWAYS_INLINE` restores the exact pre-4.32.0 64-byte frame (GCC overlaps the two inlined bodies' stack slots), and the merged function is 42 bytes *smaller* than the outlined pair. No behavior change; the base/extension rescue tests from 35ff0d41 still pass.
