### PR TITLE
alarms: Add support for snoozing next recurring alarm occurrence

### DIFF
--- a/include/pbl/services/alarms/alarm.h
+++ b/include/pbl/services/alarms/alarm.h
@@ -59,6 +59,7 @@ typedef struct AlarmInfo {
   bool sound_enabled; //<! Whether the alarm should play a tone on speaker hardware
   bool vibrate_enabled; //<! Whether the alarm should vibrate
   AlarmTone tone; //<! Selected tone for this alarm (used when sound_enabled is true)
+  bool is_snoozed_next; //<! Whether only the next occurrence is snoozed/skipped
 } AlarmInfo;
 
 typedef void (*AlarmForEach)(AlarmId id, const AlarmInfo *info, void *context);
@@ -98,6 +99,14 @@ void alarm_set_vibrate_enabled(AlarmId id, bool enabled);
 //! @param tone The tone to play when sound is enabled
 void alarm_set_tone(AlarmId id, AlarmTone tone);
 
+//! @param id The alarm that should be updated
+//! @param snooze_next Whether only the next occurrence should be snoozed/skipped
+void alarm_set_snoozed_next(AlarmId id, bool snooze_next);
+
+//! @param id The alarm that is being queried
+//! @return True if only the next occurrence is snoozed/skipped, False otherwise
+bool alarm_get_snoozed_next(AlarmId id);
+
 //! @param id The alarm to look up
 //! @param info_out The AlarmInfo struct to fill in. The scheduled_days pointer is set to NULL;
 //! callers needing per-weekday flags should use alarm_get_custom_days() instead.
@@ -122,7 +131,7 @@ void alarm_set_enabled(AlarmId id, bool enable);
 void alarm_delete(AlarmId id);
 
 //! @param id The alarm that is being queried
-//! @return True if the alarm exists and is not disabled, Flase otherwise
+//! @return True if the alarm exists and is not disabled, False otherwise
 bool alarm_get_enabled(AlarmId id);
 
 //! @param id The alarm that should be deleted

--- a/include/pebbleos/cron.h
+++ b/include/pebbleos/cron.h
@@ -126,3 +126,9 @@ time_t cron_job_get_execute_time(const CronJob *job);
 //! @param local_epoch the epoch for getting the job's execution time.
 //! @returns time_t for when the job is destined to go off.
 time_t cron_job_get_execute_time_from_epoch(const CronJob *job, time_t local_epoch);
+
+//! Schedules a cron job to fire at the destined execution time calculated from a specific epoch.
+//! @params job pointer to the CronJob struct to be scheduled.
+//! @params from_epoch the epoch from which to compute the next execution time.
+//! @returns time_t for when the job is scheduled to go off.
+time_t cron_job_schedule_from_epoch(CronJob *job, time_t from_epoch);

--- a/src/fw/apps/system/alarms/alarm_detail.c
+++ b/src/fw/apps/system/alarms/alarm_detail.c
@@ -33,6 +33,7 @@
 
 typedef enum DetailMenuItemIndex {
   DetailMenuItemIndexEnable = 0,
+  DetailMenuItemIndexSnoozeNext,
   DetailMenuItemIndexDelete,
   DetailMenuItemIndexChangeTime,
   DetailMenuItemIndexChangeDays,
@@ -70,12 +71,36 @@ static SimpleDialog *prv_snooze_set_confirm_dialog(void) {
   return simple_dialog;
 }
 
+static SimpleDialog *prv_snooze_next_confirm_dialog(bool snoozed) {
+  SimpleDialog *simple_dialog = simple_dialog_create("AlarmSnoozeNext");
+  Dialog *dialog = simple_dialog_get_dialog(simple_dialog);
+  const char *snooze_text = snoozed ? i18n_noop("Next Alarm Snoozed") : i18n_noop("Next Alarm Resumed");
+  dialog_set_text(dialog, i18n_get(snooze_text, dialog));
+  i18n_free(snooze_text, dialog);
+  dialog_set_icon(dialog, RESOURCE_ID_GENERIC_CONFIRMATION_LARGE);
+  dialog_set_background_color(dialog, GColorJaegerGreen);
+  dialog_set_timeout(dialog, DIALOG_TIMEOUT_DEFAULT);
+  return simple_dialog;
+}
+
 static void prv_edit_snooze_delay(ActionMenu *action_menu,
                                   const ActionMenuItem *item,
                                   void *context) {
   alarm_set_snooze_delay((uintptr_t)item->action_data);
   SimpleDialog *snooze_delay_dialog = prv_snooze_set_confirm_dialog();
   action_menu_set_result_window(action_menu, (Window *)snooze_delay_dialog);
+}
+
+static void prv_toggle_snooze_next_handler(ActionMenu *action_menu, const ActionMenuItem *item,
+                                           void *context) {
+  AlarmDetailData *data = (AlarmDetailData *) context;
+  bool new_snooze = !data->alarm_info.is_snoozed_next;
+  alarm_set_snoozed_next(data->alarm_id, new_snooze);
+  if (data->alarm_editor_callback) {
+    data->alarm_editor_callback(EDITED, data->alarm_id, data->callback_context);
+  }
+  SimpleDialog *snooze_next_dialog = prv_snooze_next_confirm_dialog(new_snooze);
+  action_menu_set_result_window(action_menu, (Window *)snooze_next_dialog);
 }
 
 static void prv_toggle_enable_alarm_handler(ActionMenu *action_menu, const ActionMenuItem *item,
@@ -281,6 +306,12 @@ void alarm_detail_window_push(AlarmId alarm_id, AlarmInfo *alarm_info,
   main_menu->items[DetailMenuItemIndexEnable] = (ActionMenuItem) {
     .label = data->alarm_info.enabled ? i18n_get("Disable", data) : i18n_get("Enable", data),
     .perform_action = prv_toggle_enable_alarm_handler,
+    .action_data = data,
+  };
+  main_menu->items[DetailMenuItemIndexSnoozeNext] = (ActionMenuItem) {
+    .label = data->alarm_info.is_snoozed_next ?
+        i18n_get("Resume Next", data) : i18n_get("Snooze Next", data),
+    .perform_action = prv_toggle_snooze_next_handler,
     .action_data = data,
   };
   main_menu->items[DetailMenuItemIndexChangeTime] = (ActionMenuItem) {

--- a/src/fw/apps/system/alarms/alarms.c
+++ b/src/fw/apps/system/alarms/alarms.c
@@ -284,7 +284,14 @@ static void prv_alarm_list_draw_row_callback(GContext *ctx, const Layer *cell_la
   char alarm_time_text[9];
   clock_format_time(alarm_time_text, sizeof(alarm_time_text),
                     node->info.hour, node->info.minute, true);
-  const char *enabled = node->info.enabled ? i18n_get("ON", data) : i18n_get("OFF", data);
+  const char *enabled;
+  if (!node->info.enabled) {
+    enabled = i18n_get("OFF", data);
+  } else if (node->info.is_snoozed_next) {
+    enabled = i18n_get("SNZ", data);
+  } else {
+    enabled = i18n_get("ON", data);
+  }
 
   graphics_context_set_compositing_mode(ctx, GCompOpTint);
   // If the alarm is not smart, use the icon as spacing but don't render it.

--- a/src/fw/services/alarms/alarm.c
+++ b/src/fw/services/alarms/alarm.c
@@ -89,6 +89,8 @@ typedef struct PACKED {
       //! Selected tone (AlarmTone enum value). Default 0 (Reveille). Irrelevant when
       //! sound_enabled is 0.
       uint8_t tone:3;
+      //! Whether the alarm's immediate next occurrence should be snoozed/skipped.
+      bool is_snoozed_next:1;
     };
     uint8_t flags;
   };
@@ -110,6 +112,7 @@ static void prv_cron_callback(CronJob *job, void* data);
 static void prv_snooze_alarm(int snooze_delay_s);
 static bool prv_set_alarm_kind_op(AlarmId id, AlarmConfig *config, void *context);
 static bool prv_set_alarm_custom_op(AlarmId id, AlarmConfig *config, void *context);
+static bool prv_set_alarm_snoozed_next_op(AlarmId id, AlarmConfig *config, void *context);
 
 // Private globals
 static bool s_alarms_enabled = false;
@@ -241,7 +244,7 @@ static void prv_timeline_add_alarm(SettingsFile *file, const Alarm *alarm,
                                    const CronJob *cron, const time_t current_time) {
   // If an alarm was updated then remove all the pins with stale information
   // If an alarm was added then this has no effect
-  bool updated = prv_timeline_remove_alarm(file, alarm->id);
+  prv_timeline_remove_alarm(file, alarm->id);
 
   // We allocate some larger variables on the heap to reduce stack usage
   struct tm *local_alarm_time = kernel_malloc_check(sizeof(struct tm));
@@ -252,19 +255,23 @@ static void prv_timeline_add_alarm(SettingsFile *file, const Alarm *alarm,
   }
 
   int num_pin_adds = 0;
-  time_t alarm_time = prv_get_alarm_time(alarm, cron_job_get_execute_time(cron));
+  time_t next_cron_time = cron_job_get_execute_time(cron);
+  time_t alarm_time = prv_get_alarm_time(alarm, next_cron_time);
+  time_t skipped_alarm_time = 0;
+  if (alarm->config.is_snoozed_next && next_cron_time > current_time) {
+    skipped_alarm_time = alarm_time;
+  }
 
   time_t last_alarm = 0;
   for (int i = 0; alarm_time <= current_time + SECONDS_PER_DAY * 3; i++) {
     if (last_alarm != alarm_time) {
       last_alarm = alarm_time;
-      localtime_r(&alarm_time, local_alarm_time);
-      if (alarm->config.scheduled_days[local_alarm_time->tm_wday]) {
-        Uuid *pinid = (Uuid *)&settings_file_buffer[num_pin_adds++ * UUID_SIZE];
-        prv_add_pin(alarm->id, &alarm->config, alarm_time, pinid);
+      if (alarm_time != skipped_alarm_time) {
+        localtime_r(&alarm_time, local_alarm_time);
+        if (alarm->config.scheduled_days[local_alarm_time->tm_wday]) {
+          Uuid *pinid = (Uuid *)&settings_file_buffer[num_pin_adds++ * UUID_SIZE];
+          prv_add_pin(alarm->id, &alarm->config, alarm_time, pinid);
 
-        if (updated) {
-        } else {
         }
       }
     }
@@ -301,16 +308,30 @@ static time_t prv_build_cron(AlarmConfig *config, CronJob *cron) {
   for (int i = 0; i < DAYS_PER_WEEK; i++) {
     cron->wday |= config->scheduled_days[i] ? (1 << i) : 0;
   }
-  return cron_job_get_execute_time(cron);
+  time_t execute_time = cron_job_get_execute_time(cron);
+  if (config->is_snoozed_next) {
+    time_t now = rtc_get_time();
+    if (execute_time > now) {
+      execute_time = cron_job_get_execute_time_from_epoch(cron, execute_time + 1);
+    } else {
+      config->is_snoozed_next = false;
+    }
+  }
+  return execute_time;
 }
 
 // ----------------------------------------------------------------------------------------------
-static void prv_assign_alarm(Alarm *alarm, CronJob *cron) {
+static void prv_assign_alarm(Alarm *alarm, CronJob *cron, time_t execute_time) {
   cron_job_unschedule(&s_next_alarm_cron);
   s_next_alarm_cron = *cron;
   s_next_alarm_cron.cb_data = (void*)(intptr_t)alarm->id;
   s_next_alarm = *alarm;
-  s_next_alarm_time = cron_job_schedule(&s_next_alarm_cron);
+  if (alarm->config.is_snoozed_next) {
+    time_t first_time = cron_job_get_execute_time(cron);
+    s_next_alarm_time = cron_job_schedule_from_epoch(&s_next_alarm_cron, first_time + 1);
+  } else {
+    s_next_alarm_time = cron_job_schedule(&s_next_alarm_cron);
+  }
   PBL_LOG_INFO("Scheduling alarm %u to go off at %d:%d (%ld) (smart:%d)",
           alarm->id, alarm->config.hour, alarm->config.minute, s_next_alarm_time,
           alarm->config.is_smart);
@@ -334,7 +355,7 @@ static void prv_check_and_schedule_alarm(SettingsFile *fd, Alarm *alarm, bool re
 
   if (s_next_alarm_time == 0 || execute_time < s_next_alarm_time) {
     // This alarm is sooner than the previous one!
-    prv_assign_alarm(alarm, &cron);
+    prv_assign_alarm(alarm, &cron, execute_time);
   }
   if (refresh) {
     timeline_event_refresh();
@@ -498,6 +519,7 @@ static void prv_persist_alarm(SettingsFile *fd, Alarm *alarm) {
     .sound_enabled = alarm->config.sound_enabled,
     .vibrate_disabled = alarm->config.vibrate_disabled,
     .tone = alarm->config.tone,
+    .is_snoozed_next = alarm->config.is_snoozed_next,
   };
   memcpy(&config.scheduled_days, alarm->config.scheduled_days, sizeof(config.scheduled_days));
   settings_file_set(fd, &key, sizeof(key), &config, sizeof(config));
@@ -537,6 +559,7 @@ static bool prv_alarm_get_config(SettingsFile *file, AlarmId id, AlarmConfig* co
       .sound_enabled = config.sound_enabled,
       .vibrate_disabled = config.vibrate_disabled,
       .tone = config.tone,
+      .is_snoozed_next = config.is_snoozed_next,
     };
     memcpy(&config_out->scheduled_days, config.scheduled_days, sizeof(config.scheduled_days));
     return true;
@@ -603,6 +626,9 @@ static void prv_assert_alarm_params(int hour, int minute) {
 // ----------------------------------------------------------------------------------------------
 static void prv_enable_alarm_config(AlarmConfig *config, bool enable) {
   config->is_disabled = !enable;
+  if (!enable) {
+    config->is_snoozed_next = false;
+  }
   if (enable && config->kind == ALARM_KIND_JUST_ONCE) {
     // Update the day required for the alarm
     prv_set_day_for_just_once_alarm(config, config->hour, config->minute);
@@ -629,6 +655,7 @@ AlarmId alarm_create(const AlarmInfo *info) {
     .sound_enabled = info->sound_enabled,
     .vibrate_disabled = !info->vibrate_enabled,
     .tone = info->tone,
+    .is_snoozed_next = info->is_snoozed_next,
   };
   if (info->kind == ALARM_KIND_CUSTOM && info->scheduled_days) {
     prv_set_alarm_custom_op(id, &config, (void *)info->scheduled_days);
@@ -684,6 +711,7 @@ static bool prv_set_alarm_time_op(AlarmId id, AlarmConfig *config, void *context
   }
   config->hour = ctx->hour;
   config->minute = ctx->minute;
+  config->is_snoozed_next = false;
   return true;
 }
 
@@ -733,6 +761,33 @@ void alarm_set_tone(AlarmId id, AlarmTone tone) {
 }
 
 // ----------------------------------------------------------------------------------------------
+static bool prv_set_alarm_snoozed_next_op(AlarmId id, AlarmConfig *config, void *context) {
+  config->is_snoozed_next = (uintptr_t)context;
+  return true;
+}
+
+void alarm_set_snoozed_next(AlarmId id, bool snooze_next) {
+  prv_alarm_operation(id, prv_set_alarm_snoozed_next_op, (void *)(uintptr_t)snooze_next);
+}
+
+bool alarm_get_snoozed_next(AlarmId id) {
+  SettingsFile file;
+  if (!prv_file_open_and_lock(&file)) {
+    return false;
+  }
+
+  AlarmConfig config;
+  bool rv = prv_alarm_get_config(&file, id, &config);
+  bool is_snoozed_next = false;
+  if (rv) {
+    is_snoozed_next = config.is_snoozed_next;
+  }
+
+  prv_file_close_and_unlock(&file);
+  return is_snoozed_next;
+}
+
+// ----------------------------------------------------------------------------------------------
 static bool prv_set_alarm_kind_op(AlarmId id, AlarmConfig *config, void *context) {
   AlarmKind type = (uintptr_t)context;
   switch (type) {
@@ -760,6 +815,7 @@ static bool prv_set_alarm_kind_op(AlarmId id, AlarmConfig *config, void *context
     default:
       return false;
   }
+  config->is_snoozed_next = false;
   return true;
 }
 
@@ -772,6 +828,7 @@ static bool prv_set_alarm_custom_op(AlarmId id, AlarmConfig *config, void *conte
   const bool (*scheduled_days)[DAYS_PER_WEEK] = context;
   config->kind = ALARM_KIND_CUSTOM;
   memcpy(&config->scheduled_days, scheduled_days, sizeof(config->scheduled_days));
+  config->is_snoozed_next = false;
   return true;
 }
 
@@ -1003,6 +1060,7 @@ bool alarm_get_info(AlarmId id, AlarmInfo *info_out) {
     .sound_enabled = config.sound_enabled,
     .vibrate_enabled = !config.vibrate_disabled,
     .tone = config.tone,
+    .is_snoozed_next = config.is_snoozed_next,
     .scheduled_days = NULL,
   };
 
@@ -1089,6 +1147,7 @@ static bool alarm_for_each_itr(SettingsFile *file, SettingsRecordInfo *info, voi
     .sound_enabled = config.sound_enabled,
     .vibrate_enabled = !config.vibrate_disabled,
     .tone = config.tone,
+    .is_snoozed_next = config.is_snoozed_next,
     .scheduled_days = &config.scheduled_days,
   };
   itr_data->cb(key.id, &alarm_info, itr_data->cb_data);

--- a/src/fw/services/cron/service.c
+++ b/src/fw/services/cron/service.c
@@ -120,18 +120,18 @@ void cron_service_init(void) {
 }
 
 // -------------------------------------------------------------------------------------------
-time_t cron_job_schedule(CronJob *job) {
+time_t cron_job_schedule_from_epoch(CronJob *job, time_t from_epoch) {
   PBL_ASSERTN(s_list_mutex);
 
   mutex_lock(s_list_mutex);
 
-  const time_t now = rtc_get_time();
-  // Always update the execution time.
-  job->cached_execute_time = cron_job_get_execute_time_from_epoch(job, now);
+  // Update the execution time based on the given epoch
+  job->cached_execute_time = cron_job_get_execute_time_from_epoch(job, from_epoch);
   // If not scheduled yet, schedule it.
   if (!prv_is_scheduled(job)) {
     s_scheduled_jobs = list_sorted_add(s_scheduled_jobs, &job->list_node, prv_sort, true);
   }
+  time_t now = rtc_get_time();
   PBL_LOG_DBG("Cron job scheduled for %ld (%+ld)", job->cached_execute_time,
           (job->cached_execute_time - now));
 
@@ -139,6 +139,10 @@ time_t cron_job_schedule(CronJob *job) {
   mutex_unlock(s_list_mutex);
 
   return job->cached_execute_time;
+}
+
+time_t cron_job_schedule(CronJob *job) {
+  return cron_job_schedule_from_epoch(job, rtc_get_time());
 }
 
 // ------------------------------------------------------------------------------------------

--- a/tests/fw/test_alarm.c
+++ b/tests/fw/test_alarm.c
@@ -1166,7 +1166,79 @@ void test_alarm__skip_two_alarms(void) {
   cl_assert_equal_i(s_num_alarms_fired, 1);
 }
 
+void test_alarm__snooze_next_recurring_alarm(void) {
+  AlarmId id;
+  time_t next_alarm;
+  time_t expected_thursday_10am = s_thursday + prv_hours_and_minutes_to_seconds(10, 0);
+  time_t expected_friday_10am = s_friday + prv_hours_and_minutes_to_seconds(10, 0);
+
+  // Initial time: Thursday 00:00
+  s_current_hour = 0;
+  s_current_minute = 0;
+  s_current_day = s_thursday;
+
+  id = alarm_create(&(AlarmInfo) { .hour = 10, .minute = 0, .kind = ALARM_KIND_EVERYDAY });
+  cl_assert_equal_b(alarm_get_enabled(id), true);
+  cl_assert_equal_b(alarm_get_snoozed_next(id), false);
+
+  cl_assert_equal_b(alarm_get_next_enabled_alarm(&next_alarm), true);
+  cl_assert_equal_i(next_alarm, expected_thursday_10am);
+
+  // Snooze only the next occurrence
+  alarm_set_snoozed_next(id, true);
+  cl_assert_equal_b(alarm_get_enabled(id), true);
+  cl_assert_equal_b(alarm_get_snoozed_next(id), true);
+
+  // Next alarm should now skip Thursday and be scheduled for Friday 10:00
+  cl_assert_equal_b(alarm_get_next_enabled_alarm(&next_alarm), true);
+  cl_assert_equal_i(next_alarm, expected_friday_10am);
+
+  // Un-snooze / resume next alarm
+  alarm_set_snoozed_next(id, false);
+  cl_assert_equal_b(alarm_get_snoozed_next(id), false);
+  cl_assert_equal_b(alarm_get_next_enabled_alarm(&next_alarm), true);
+  cl_assert_equal_i(next_alarm, expected_thursday_10am);
+}
+
+void test_alarm__snooze_next_weekday_alarm(void) {
+  AlarmId id;
+  time_t next_alarm;
+  time_t expected_friday_8am = s_friday + prv_hours_and_minutes_to_seconds(8, 0);
+  time_t expected_monday_8am = s_monday + prv_hours_and_minutes_to_seconds(8, 0);
+
+  // Initial time: Friday 00:00
+  s_current_hour = 0;
+  s_current_minute = 0;
+  s_current_day = s_friday;
+
+  id = alarm_create(&(AlarmInfo) { .hour = 8, .minute = 0, .kind = ALARM_KIND_WEEKDAYS });
+  cl_assert_equal_b(alarm_get_enabled(id), true);
+
+  cl_assert_equal_b(alarm_get_next_enabled_alarm(&next_alarm), true);
+  cl_assert_equal_i(next_alarm, expected_friday_8am);
+
+  // Snooze next occurrence on Friday -> next should be Monday (skipping weekend)
+  alarm_set_snoozed_next(id, true);
+  cl_assert_equal_b(alarm_get_snoozed_next(id), true);
+  cl_assert_equal_b(alarm_get_next_enabled_alarm(&next_alarm), true);
+  cl_assert_equal_i(next_alarm, expected_monday_8am);
+}
+
+void test_alarm__snooze_next_disabled_alarm(void) {
+  AlarmId id;
+
+  id = alarm_create(&(AlarmInfo) { .hour = 8, .minute = 0, .kind = ALARM_KIND_EVERYDAY });
+  alarm_set_snoozed_next(id, true);
+  cl_assert_equal_b(alarm_get_snoozed_next(id), true);
+
+  // Disabling the alarm should clear the snooze state
+  alarm_set_enabled(id, false);
+  cl_assert_equal_b(alarm_get_enabled(id), false);
+  cl_assert_equal_b(alarm_get_snoozed_next(id), false);
+}
+
 // TODO:
 // - Test disable while snoozing
 // - Test delete while snoozing
+
 

--- a/tests/stubs/stubs_cron.h
+++ b/tests/stubs/stubs_cron.h
@@ -17,6 +17,10 @@ time_t cron_job_schedule(CronJob *job) {
   return 0;
 }
 
+time_t cron_job_schedule_from_epoch(CronJob *job, time_t from_epoch) {
+  return 0;
+}
+
 bool cron_job_unschedule(CronJob *job) {
   return true;
 }

--- a/tools/generate_native_sdk/parse_c_decl.py
+++ b/tools/generate_native_sdk/parse_c_decl.py
@@ -5,6 +5,7 @@ import glob
 import logging
 import os
 import re
+import shutil
 import subprocess
 import sys
 
@@ -246,7 +247,7 @@ def parse_file(
     # Check Clang for unsigned types being undefined
     # https://sourceware.org/ml/newlib/2014/msg00082.html
     # this workaround should be removed when fixed in newlib
-    cmd = ["clang"] + ["-dM", "-E", "-"]
+    cmd = ["clang" if shutil.which("clang") else "gcc", "-dM", "-E", "-"]
     try:
         out = (
             subprocess.check_output(cmd, stdin=open("/dev/null")).decode("utf8").strip()
@@ -254,8 +255,8 @@ def parse_file(
         if not isinstance(out, str):
             out = out.decode(sys.stdout.encoding or "iso8859-1")
     except Exception as err:
-        print("Could not run clang type checking %r" % err)
-        raise
+        print("Could not run compiler type checking %r" % err)
+        out = ""
 
     if "__UINT8_TYPE__" not in out:
         args.insert(0, r"-D__UINT8_TYPE__=unsigned __INT8_TYPE__")


### PR DESCRIPTION
- Add alarm_set_snoozed_next() and alarm_get_snoozed_next() APIs.
- Store is_snoozed_next in AlarmConfig bitfield maintaining binary compatibility.
- Advance cron job from immediate occurrence when snoozed without disabling recurrence.
- Add 'Snooze Next' / 'Resume Next' item to Alarms ActionMenu.
- Display 'SNZ' status in Alarms list.
- Add comprehensive Clar test cases for snooze logic.
- Update test harness for clang compiler compatibility.