### PR TITLE
ci: pass --ref main when dispatching release-QA (fine-grained PAT fix)

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -225,7 +225,10 @@ jobs:
           fi
           # to_pbz_run_id = this Build Firmware run (its qa-firmware-<board> artifact is the "to").
           # coreapp_run_id omitted -> unicorn uses the most recently tagged coreapp release.
-          gh workflow run one-off-pebbleos-test.yml -R coredevices/unicorn \
+          # --ref main is required: without it gh resolves the default branch via a GraphQL query
+          # (repository.defaultBranchRef) that fine-grained PATs can't access, so the run fails even
+          # with Actions:write. Passing the ref uses the REST dispatch endpoint, which the token has.
+          gh workflow run one-off-pebbleos-test.yml -R coredevices/unicorn --ref main \
             -f to_pbz_run_id=${{ github.run_id }}
 
   build-firmware-status:


### PR DESCRIPTION
Fixes the `dispatch-release-qa` failure seen on the first run:

```
unable to determine default branch for coredevices/unicorn:
GraphQL: Resource not accessible by personal access token (repository.defaultBranchRef)
```

`gh workflow run` **without** `--ref` resolves the default branch via a **GraphQL** query (`repository.defaultBranchRef`), and **fine-grained PATs can't use that query** — so it fails even though `UNICORN_DISPATCH_TOKEN` is correctly scoped (`coredevices/unicorn`, Actions: Read/Write, Metadata: Read).

Passing **`--ref main`** skips the default-branch lookup and uses the REST workflow-dispatch endpoint, which the token *can* use. One-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)