### PR TITLE
Four independent bug fixes: workout pin, alarm snooze, stale app cache, weather DST

### DIFF
--- a/src/fw/apps/system/weather/expanded_view.c
+++ b/src/fw/apps/system/weather/expanded_view.c
@@ -99,8 +99,9 @@ static int prv_sunset_minutes(int16_t lat_e2, int16_t lon_e2, int16_t utc_off_mi
   const int N = lt.tm_yday + 1;                    // day of year 1..366
   // The LOCATION's UTC offset when the phone synced one (v4.1) — so a saved city's
   // sunset reads in that city's local clock; otherwise the watch's own offset.
+  // tm_gmtoff, not time_get_gmtoffset(): the latter excludes DST while lt does not.
   const int tz_min = (utc_off_min != INT16_MIN) ? utc_off_min
-                                                : (time_get_gmtoffset() / 60);
+                                                : (lt.tm_gmtoff / 60);
 
   const int b_cdeg = (36000 * (N - 81)) / 365;     // B = (360/365)*(N-81), deg*100
   const int32_t sinB  = sin_lookup(prv_angle_from_cdeg(b_cdeg));

--- a/src/fw/apps/system/weather/weather.c
+++ b/src/fw/apps/system/weather/weather.c
@@ -135,8 +135,10 @@ static int prv_location_local_hour(const WxDsForecast *ds) {
   if (!lt) return -1;
   int hour = lt->tm_hour;
   if (ds && ds->utc_offset_min != INT16_MIN) {
+    // tm_gmtoff, not time_get_gmtoffset(): the latter excludes DST while lt does not, which
+    // would skew the location's hour by the DST adjustment for half the year.
     int mins = lt->tm_hour * 60 + lt->tm_min
-             - (int)(time_get_gmtoffset() / 60) + ds->utc_offset_min;
+             - (int)(lt->tm_gmtoff / 60) + ds->utc_offset_min;
     mins = ((mins % 1440) + 1440) % 1440;
     hour = mins / 60;
   }

--- a/src/fw/process_management/process_manager.c
+++ b/src/fw/process_management/process_manager.c
@@ -27,6 +27,7 @@
 #include "pbl/services/filesystem/pfs.h"
 #include "pbl/services/system_task.h"
 #include "pbl/services/app_cache.h"
+#include "pbl/services/blob_db/app_db.h"
 #include "pbl/services/data_logging/data_logging_service.h"
 #include "pbl/services/persist.h"
 #include "pbl/services/voice/voice.h"
@@ -228,6 +229,24 @@ static bool prv_needs_fetch(AppInstallId id, const PebbleProcessMd **md, bool is
   }
 
   *md = app_install_get_md(id, is_worker);
+
+  // The cache is keyed on the install ID alone, and IDs are recycled. An entry orphaned by a
+  // previous install leaves a stale binary at this ID, whose metadata comes from its own header --
+  // so without this check we would silently launch the wrong app. Drop it and fetch the real one.
+  AppDBEntry entry;
+  if (*md && (app_db_get_app_entry_for_install_id(id, &entry) == S_SUCCESS) &&
+      !uuid_equal(&(*md)->uuid, &entry.uuid)) {
+    char cached_uuid[UUID_STRING_BUFFER_LENGTH];
+    char expected_uuid[UUID_STRING_BUFFER_LENGTH];
+    uuid_to_string(&(*md)->uuid, cached_uuid);
+    uuid_to_string(&entry.uuid, expected_uuid);
+    PBL_LOG_WRN("Stale app cache entry for id %" PRId32 ": cached %s, expected %s. Refetching.",
+                id, cached_uuid, expected_uuid);
+    app_install_release_md(*md);
+    *md = NULL;
+    app_cache_remove_entry(id);
+    return true;
+  }
 
   return false;
 }

--- a/src/fw/services/alarms/alarm.c
+++ b/src/fw/services/alarms/alarm.c
@@ -107,7 +107,7 @@ static bool prv_reload_alarms(SettingsFile *file);
 static bool prv_alarm_get_config(SettingsFile *file, AlarmId id, AlarmConfig* config_out);
 static void prv_alarm_set_config(SettingsFile *file, AlarmId id, const AlarmConfig* config);
 static void prv_cron_callback(CronJob *job, void* data);
-static void prv_snooze_alarm(int snooze_delay_s);
+static void prv_snooze_alarm(int snooze_delay_s, bool user_initiated);
 static bool prv_set_alarm_kind_op(AlarmId id, AlarmConfig *config, void *context);
 static bool prv_set_alarm_custom_op(AlarmId id, AlarmConfig *config, void *context);
 
@@ -414,7 +414,7 @@ static void prv_process_most_recent_alarm(void) {
     if (!trigger) {
       // Not triggering an event, increment to signify elapsed time and snooze
       s_smart_snooze_counter++;
-      prv_snooze_alarm(SMART_ALARM_SNOOZE_DELAY_S);
+      prv_snooze_alarm(SMART_ALARM_SNOOZE_DELAY_S, false /* user_initiated */);
       return;
     }
   }
@@ -1011,8 +1011,11 @@ cleanup:
   return rv;
 }
 
-static void prv_snooze_alarm(int snooze_delay_s) {
+static void prv_snooze_alarm(int snooze_delay_s, bool user_initiated) {
   prv_clear_snooze_timer();
+  // Set before arming the timer: a stale snooze callback queued on KernelBG cannot be cancelled by
+  // new_timer_stop(), and would consume the flag if it ran while the timer was armed without it.
+  s_user_snoozed = user_initiated;
   PBL_LOG_INFO("Snoozing for %d minutes", snooze_delay_s / SECONDS_PER_MINUTE);
   bool success = new_timer_start(s_snooze_timer_id, snooze_delay_s * MS_PER_SECOND,
                                  prv_snooze_timer_callback, NULL, 0 /* flags*/);
@@ -1021,9 +1024,7 @@ static void prv_snooze_alarm(int snooze_delay_s) {
 
 // ----------------------------------------------------------------------------------------------
 void alarm_set_snooze_alarm(void) {
-  prv_snooze_alarm(s_snooze_delay_m * SECONDS_PER_MINUTE);
-  // Set after prv_snooze_alarm(): clearing the previous timer resets the flag.
-  s_user_snoozed = true;
+  prv_snooze_alarm(s_snooze_delay_m * SECONDS_PER_MINUTE, true /* user_initiated */);
 }
 
 // ----------------------------------------------------------------------------------------------
@@ -1137,13 +1138,19 @@ void alarm_handle_clock_change(void) {
     return;
   }
 
+  // Deferred until after the settings file is closed: prv_alarm_operation() opens it itself, and
+  // opening it twice croaks.
+  AlarmId record_alarm_id = ALARM_INVALID_ID;
+
   // If there's an active alarm (e.g., currently snoozing), we need to handle it carefully.
   // For smart alarms near their deadline, we should trigger them before clearing state.
   if (s_most_recent_alarm_id != ALARM_INVALID_ID) {
     bool should_force_trigger = false;
 
-    // Only consider force-triggering for smart alarms that are in their smart snooze window
-    if (s_most_recent_alarm_config.is_smart && s_smart_snooze_counter > 0) {
+    // Only consider force-triggering for smart alarms that are in their smart snooze window.
+    // A user snooze is an explicit deadline and must survive any clock change; force-triggering
+    // here would clear it and re-fire the alarm immediately.
+    if (s_most_recent_alarm_config.is_smart && s_smart_snooze_counter > 0 && !s_user_snoozed) {
       // Check if we've used up most of our smart snooze attempts (within last 2 minutes)
       if (s_smart_snooze_counter >= (SMART_ALARM_MAX_SMART_SNOOZE - 2)) {
         should_force_trigger = true;
@@ -1175,7 +1182,7 @@ void alarm_handle_clock_change(void) {
       prv_put_alarm_event();
       if (!s_most_recent_alarm_recorded) {
         s_most_recent_alarm_recorded = true;
-        prv_alarm_operation(s_most_recent_alarm_id, prv_record_alarm_op, NULL);
+        record_alarm_id = s_most_recent_alarm_id;
       }
       PBL_LOG_INFO("Clock change during alarm %u, triggered alarm", s_most_recent_alarm_id);
       // The alarm is now firing; stop the smart-snooze loop.
@@ -1210,6 +1217,10 @@ void alarm_handle_clock_change(void) {
   prv_reload_alarms(&file);
 
   prv_file_close_and_unlock(&file);
+
+  if (record_alarm_id != ALARM_INVALID_ID) {
+    prv_alarm_operation(record_alarm_id, prv_record_alarm_op, NULL);
+  }
 }
 
 // ----------------------------------------------------------------------------------------------

--- a/src/fw/shell/normal/shell_event_loop.c
+++ b/src/fw/shell/normal/shell_event_loop.c
@@ -175,20 +175,9 @@ void shell_event_loop_handle_event(PebbleEvent *e) {
       // When a workout is stopped it will return to it's normal position after the
       // default timeout.
       PebbleWorkoutEvent *workout_e = &e->workout;
-      bool can_expire = true;
-      switch (workout_e->type) {
-        case PebbleWorkoutEvent_Started:
-        case PebbleWorkoutEvent_Paused:
-          can_expire = false;
-          break;
-        case PebbleWorkoutEvent_Stopped:
-          can_expire = true;
-          break;
-        case PebbleWorkoutEvent_FrontendOpened:
-        case PebbleWorkoutEvent_FrontendClosed:
-          break;
-      }
-      app_install_mark_prioritized(APP_ID_WORKOUT, can_expire);
+      // Derive the pin from the workout state rather than the event type: closing the app while
+      // the workout keeps running must not downgrade the pin to an expiring one.
+      app_install_mark_prioritized(APP_ID_WORKOUT, !workout_service_is_workout_ongoing());
       workout_service_workout_event_handler(workout_e);
       return;
     }

--- a/src/fw/util/time/time.h
+++ b/src/fw/util/time/time.h
@@ -73,7 +73,8 @@ struct tm {
   int tm_yday;    /*!< Days in year.[0-365] */
   int tm_isdst;   /*!< DST. [-1/0/1] */
 
-  int tm_gmtoff;  /*!< Seconds east of UTC */
+  int tm_gmtoff;  /*!< Total seconds east of UTC, DST included. tm_isdst is an indicator only --
+                       never add it to this value. */
   char tm_zone[TZ_LEN]; /*!< Timezone abbreviation */
 };
 

--- a/tests/fw/test_alarm_smart.c
+++ b/tests/fw/test_alarm_smart.c
@@ -277,6 +277,73 @@ void test_alarm_smart__user_snooze_fires_after_delay(void) {
   cl_assert_equal_i(s_num_alarm_events_put, 3);
 }
 
+void test_alarm_smart__user_snooze_survives_clock_change(void) {
+  AlarmId id;
+  id = alarm_create(&(AlarmInfo) { .hour = 10, .minute = 30, .kind = ALARM_KIND_EVERYDAY, .is_smart = true });
+  prv_assert_alarm_config(id, 10, 30, false, ALARM_KIND_EVERYDAY, s_every_day_schedule);
+
+  // Stay asleep so the sleep poll runs and drives up the smart snooze counter
+  s_sleep_state = ActivitySleepStateRestfulSleep;
+  s_sleep_state_seconds = 0;
+  s_rand = 4;
+
+  prv_set_time(s_current_day, 10, 0);
+  cron_service_wakeup();
+  cl_assert_equal_i(s_num_alarm_events_put, 0);
+
+  const int num_checks = 6;
+  for (int i = 0; i < num_checks; i++) {
+    s_sleep_state_seconds = (i + 1) * 5 * SECONDS_PER_MINUTE;
+    s_last_vmc = (i == 5);
+    prv_set_time(s_current_day, 10, i * 5);
+    stub_new_timer_invoke(1);
+  }
+  // The alarm has now fired at the end of the smart window
+  cl_assert_equal_i(s_num_alarm_events_put, 1);
+
+  // The user snoozes it, then a clock change arrives (phone time sync, DST, RTC correction)
+  alarm_set_snooze_alarm();
+  alarm_handle_clock_change();
+
+  // The snooze must survive: no immediate re-fire
+  cl_assert_equal_i(s_num_alarm_events_put, 1);
+
+  // ...and it still fires after exactly the configured delay
+  prv_set_time(s_current_day, 10, 25 + alarm_get_snooze_delay());
+  stub_new_timer_invoke(1);
+  cl_assert_equal_i(s_num_alarm_events_put, 2);
+}
+
+void test_alarm_smart__clock_change_still_force_triggers_sleep_poll(void) {
+  // Guards the FIRM-3127 fix: with no user snooze pending, a clock change during the smart
+  // window must still force the alarm to fire rather than silently dropping it.
+  AlarmId id;
+  id = alarm_create(&(AlarmInfo) { .hour = 10, .minute = 30, .kind = ALARM_KIND_EVERYDAY, .is_smart = true });
+  prv_assert_alarm_config(id, 10, 30, false, ALARM_KIND_EVERYDAY, s_every_day_schedule);
+
+  s_sleep_state = ActivitySleepStateRestfulSleep;
+  s_sleep_state_seconds = 0;
+  s_rand = 4;
+
+  prv_set_time(s_current_day, 10, 0);
+  cron_service_wakeup();
+  cl_assert_equal_i(s_num_alarm_events_put, 0);
+
+  // A couple of sleep polls, so the smart snooze counter is non-zero but the alarm has not fired
+  for (int i = 0; i < 2; i++) {
+    s_sleep_state_seconds = (i + 1) * 5 * SECONDS_PER_MINUTE;
+    s_last_vmc = 0;
+    prv_set_time(s_current_day, 10, i * 5);
+    stub_new_timer_invoke(1);
+  }
+  cl_assert_equal_i(s_num_alarm_events_put, 0);
+
+  // Clock change lands inside the smart window with no user snooze pending
+  prv_set_time(s_current_day, 10, 35);
+  alarm_handle_clock_change();
+  cl_assert_equal_i(s_num_alarm_events_put, 1);
+}
+
 void test_alarm_smart__across_midnight_boundary(void) {
   prv_set_time(s_sunday, 22, 0);
 

--- a/tests/fw/test_app_manager.c
+++ b/tests/fw/test_app_manager.c
@@ -18,6 +18,7 @@
 #include "process_management/process_manager.h"
 #include "pbl/services/vibe_pattern.h"
 #include "resource/resource_ids.auto.h"
+#include "pbl/services/blob_db/app_db.h"
 #include "pbl/util/heap.h"
 
 // Fakes
@@ -199,6 +200,14 @@ bool app_install_id_from_app_db(AppInstallId id) {
 
 bool app_cache_entry_exists(AppInstallId app_id) {
   return true;
+}
+
+status_t app_cache_remove_entry(AppInstallId app_id) {
+  return S_SUCCESS;
+}
+
+status_t app_db_get_app_entry_for_install_id(AppInstallId app_id, AppDBEntry *entry) {
+  return E_DOES_NOT_EXIST;
 }
 
 const PebbleProcessMd* app_fetch_ui_get_app_info(void) {

--- a/tests/fw/test_process_manager.c
+++ b/tests/fw/test_process_manager.c
@@ -6,6 +6,7 @@
 #include "process_management/process_manager.h"
 #include "process_management/app_install_manager.h"
 #include "process_management/pebble_process_info.h"
+#include "pbl/services/blob_db/app_db.h"
 #include "pbl/util/size.h"
 
 // Stubs
@@ -161,6 +162,13 @@ const PebbleProcessMd *app_install_get_md(AppInstallId id, bool worker) {
 void app_install_release_md(const PebbleProcessMd *md) {
 }
 
+static status_t s_app_db_get_app_entry_for_install_id__result;
+static AppDBEntry s_app_db_get_app_entry_for_install_id__entry;
+status_t app_db_get_app_entry_for_install_id(AppInstallId app_id, AppDBEntry *entry) {
+  *entry = s_app_db_get_app_entry_for_install_id__entry;
+  return s_app_db_get_app_entry_for_install_id__result;
+}
+
 static int s_process_metadata_get_res_bank_num__result;
 int process_metadata_get_res_bank_num(const PebbleProcessMd *md) {
   return s_process_metadata_get_res_bank_num__result;
@@ -179,6 +187,8 @@ void event_reset_from_process_queue(PebbleTask task) { cl_fail("unexpected"); }
 
 void test_process_manager__initialize(void) {
   s_app_install_get_md__result = NULL;
+  s_app_db_get_app_entry_for_install_id__result = E_DOES_NOT_EXIST;
+  s_app_db_get_app_entry_for_install_id__entry = (AppDBEntry){};
   s_process_metadata_get_res_bank_num__result = 123;
   s_app_manager_launch_new_app__callcount = 0;
   s_app_manager_launch_new_app__config = (__typeof__(s_app_manager_launch_new_app__config)){};
@@ -190,5 +200,44 @@ void test_process_manager__check_SDK_compatible(void) {
     // skipping 0, since it's INSTALL_ID_INVALID
     cl_assert_equal_b(process_manager_check_SDK_compatible(i + 1), s_test_cases[i].should_pass);
   }
+}
+
+static const Uuid s_uuid_a = {0x9c, 0x40, 0xa7, 0x79, 0x00, 0x11, 0x22, 0x33,
+                              0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb};
+static const Uuid s_uuid_b = {0x49, 0x82, 0x77, 0x22, 0x00, 0x11, 0x22, 0x33,
+                              0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb};
+
+//! The app cache is keyed on the install ID alone and IDs get recycled, so a cache entry orphaned
+//! by a previous install leaves a stale binary at that ID. Launching must notice and refetch
+//! rather than silently running the wrong app.
+void test_process_manager__stale_cache_entry_is_refetched(void) {
+  static PebbleProcessMdFlash s_stale_md = { .common = { .uuid = {0} } };
+  s_stale_md.common.uuid = s_uuid_b;
+  s_app_install_get_md__result = (PebbleProcessMd *)&s_stale_md;
+
+  // app_db says install ID 1 should be uuid A, but the cached binary is uuid B
+  s_app_db_get_app_entry_for_install_id__entry.uuid = s_uuid_a;
+  s_app_db_get_app_entry_for_install_id__result = S_SUCCESS;
+
+  process_manager_launch_process(&(ProcessLaunchConfig) { .id = 1 });
+
+  cl_assert(s_event_put__event != NULL);
+  cl_assert_equal_i(s_event_put__event->type, PEBBLE_APP_FETCH_REQUEST_EVENT);
+  cl_assert_equal_i(s_event_put__event->app_fetch_request.id, 1);
+  cl_assert_equal_i(s_app_manager_launch_new_app__callcount, 0);
+}
+
+void test_process_manager__matching_cache_entry_launches(void) {
+  static PebbleProcessMdFlash s_good_md = { .common = { .uuid = {0} } };
+  s_good_md.common.uuid = s_uuid_a;
+  s_app_install_get_md__result = (PebbleProcessMd *)&s_good_md;
+
+  s_app_db_get_app_entry_for_install_id__entry.uuid = s_uuid_a;
+  s_app_db_get_app_entry_for_install_id__result = S_SUCCESS;
+
+  process_manager_launch_process(&(ProcessLaunchConfig) { .id = 1 });
+
+  cl_assert(s_event_put__event == NULL);
+  cl_assert_equal_i(s_app_manager_launch_new_app__callcount, 1);
 }
 


### PR DESCRIPTION
Four unrelated, independently reviewable fixes found while triaging assigned Todo issues. Each is a separate commit; nothing depends on anything else here.

### `fw/shell` — workout app unpins mid-workout (FIRM-1859)

The launcher pin was derived from the workout *event type*, and `FrontendOpened`/`FrontendClosed` fell through the switch on the `can_expire = true` initializer. Since `app_install_mark_prioritized()` overwrites the stored flag unconditionally, closing the workout app while the workout kept running downgraded the permanent pin to one expiring after five minutes.

Pause and resume both emit `PebbleWorkoutEvent_Paused`, which re-set the permanent pin — matching the reported "pausing and resuming re-pins it, then it unpins again later".

Now derived from `workout_service_is_workout_ongoing()`. Correct for `Stopped` too: the service posts the event before clearing `current_workout`, and the event drains on KernelMain afterwards, so the post-workout grace period is preserved.

### `fw/services/alarms` — snooze cancelled by a clock change (FIRM-4089)

`alarm_handle_clock_change()` force-triggers a smart alarm inside its smart-snooze window and then clears the snooze timer. It never checked `s_user_snoozed`, so a clock change during a user's 10-minute snooze destroyed it and re-rang the alarm immediately. A user snooze is an explicit deadline and must survive any clock change; the force trigger exists only to rescue the internal sleep poll.

Reachable in normal use on SF32LB52 boards, where the RTC calibration cycle emits `PEBBLE_SET_TIME_EVENT` every 60 s — a post-wake correction landing shortly after the alarm woke the watch is enough.

Two related fixes in the same commit:

- `s_user_snoozed` is now set inside `prv_snooze_alarm()` *before* the timer is armed. It was set afterwards, leaving a window where a snooze callback already queued on KernelBG — which `new_timer_stop()` cannot cancel — would consume the flag and re-enter the sleep poll, replacing the configured delay with the 60 s smart poll interval.
- **Pre-existing crash:** the force-trigger path called `prv_alarm_operation()` while `alarm_handle_clock_change()` still held the settings file open. `prv_alarm_operation()` opens it itself, and opening it twice hits `PBL_CROAK("Settings file is already open!")`. This fires whenever a clock change force-triggers a smart alarm that hasn't rung yet — the FIRM-3127 scenario — and was never exercised by a test. Writing the regression test surfaced it. The call is now deferred until after the file is closed.

### `fw/process_management` — wrong app launches from a recycled install ID (FIRM-4073)

`app_cache_entry_exists()` is keyed on the `AppInstallId` alone, and IDs are recycled: `app_db_init()` recomputes the next ID as max+1 over surviving records on every boot, skipping tombstones. A cache entry orphaned by an earlier uninstall therefore leaves a stale binary at an ID a later install reuses.

`prv_needs_fetch()` saw the hit and never requested a fetch, and `app_install_get_md()` reads `PebbleProcessInfo` out of the cached binary's own header — so the watch launched the *previous* app under the new app's ID. `app_cache_app_launched()` then refreshed the stale entry's `last_launch`, protecting it from eviction. Self-perpetuating.

Now the metadata UUID is compared against the app_db entry and the cache entry is dropped on mismatch, falling through to a normal fetch. An already-poisoned watch heals on the next launch attempt instead of needing a factory reset.

### `fw/apps/weather` — local-hour math drops DST

`prv_location_local_hour()` and `prv_sunset_minutes()` build a wall clock from `localtime()`, whose `tm_gmtoff` includes DST, then subtract `time_get_gmtoffset()`, which does not. During DST both were an hour off — wrong hourly UV reading, wrong sunrise/sunset whenever the watch's own offset was used.

Now uses `lt->tm_gmtoff`. Also documents the `tm_gmtoff` contract in `time.h`, which still described it as plain "seconds east of UTC" — the ambiguity behind FIRM-2872, where a third-party app added `tm_isdst` on top of it. (That report is an app bug, not a firmware one; no functional change here for it.)

## Testing

- `./pbl test` — green. Four new cases: `test_alarm_smart__user_snooze_survives_clock_change`, `test_alarm_smart__clock_change_still_force_triggers_sleep_poll` (guards the FIRM-3127 behaviour), `test_process_manager__stale_cache_entry_is_refetched`, `test_process_manager__matching_cache_entry_launches`.
- `./pbl build` on `qemu_emery` — all five changed sources compile clean.
- Not built for obelix, which is the board most of these reports come from. The changes are board-independent, but worth a second build before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)