### PR TITLE
fw/services/activity: release auto-activity HRM subscription on reset

### DIFF
--- a/include/pbl/services/activity/kraepelin/kraepelin_algorithm.h
+++ b/include/pbl/services/activity/kraepelin/kraepelin_algorithm.h
@@ -93,6 +93,10 @@ uint32_t kalg_state_size(void);
 //  statistics that are computed.
 bool kalg_init(KAlgState *state, KAlgStatsCallback stats_cb);
 
+// Release resources held by the state. Must be called before freeing it.
+// @param[in] state the state structure passed into kalg_init
+void kalg_deinit(KAlgState *state);
+
 // Analyze a set of accel samples
 // @param[in] state the state structure passed into kalg_init
 // @param[in] samples array of accel samples

--- a/src/fw/services/activity/kraepelin/activity_algorithm_kraepelin.c
+++ b/src/fw/services/activity/kraepelin/activity_algorithm_kraepelin.c
@@ -875,6 +875,7 @@ bool activity_algorithm_deinit(void) {
   PBL_ASSERTN(s_alg_state->k_state);
 
   mutex_destroy((PebbleMutex *)s_alg_state->mutex);
+  kalg_deinit(s_alg_state->k_state);
   kernel_free(s_alg_state->k_state);
 
   kernel_free(s_alg_state);

--- a/src/fw/services/activity/kraepelin/kraepelin_algorithm.c
+++ b/src/fw/services/activity/kraepelin/kraepelin_algorithm.c
@@ -383,17 +383,31 @@ static const char* prv_log_time(KAlgState *alg_state, time_t utc) {
 }
 
 // ----------------------------------------------------------------------------------------
-static void prv_reset_step_activity_state(KAlgStepActivityState *state) {
+// Drop the HRM subscription held by a step activity, if it has one. Safe to call on a state that
+// stays in progress: the next active minute re-subscribes.
+static void prv_release_step_activity_hrm(KAlgStepActivityState *state) {
 #ifdef CONFIG_HRM
   if (state->hrm_session != HRM_INVALID_SESSION_REF) {
     sys_hrm_manager_unsubscribe(state->hrm_session);
+    state->hrm_session = HRM_INVALID_SESSION_REF;
   }
 #endif
+}
+
+// ----------------------------------------------------------------------------------------
+static void prv_reset_step_activity_state(KAlgStepActivityState *state) {
+  prv_release_step_activity_hrm(state);
   *state = (KAlgStepActivityState) { };
 }
 
 // ----------------------------------------------------------------------------------------
 static void prv_reset_state(KAlgState *state) {
+  // Release the HRM unconditionally. The state reset below skips in-progress activities, but the
+  // subscription must not outlive the reset: a state machine that stops running can never reach
+  // prv_reset_step_activity_state, leaving the sensor pinned on until reboot.
+  prv_release_step_activity_hrm(&state->walk_state);
+  prv_release_step_activity_hrm(&state->run_state);
+
   // Only reset step activity states if they're not currently in progress to avoid
   // race conditions with the minute handler
   if (state->walk_state.start_time == KALG_START_TIME_NONE) {
@@ -1292,6 +1306,16 @@ bool kalg_init(KAlgState *state, KAlgStatsCallback stats_cb) {
 }
 
 
+// -----------------------------------------------------------------------------------------
+// Release resources held by the state. Must be called before the caller frees it, otherwise the
+// HRM subscriptions outlive the only references to them and pin the sensor on until reboot.
+void kalg_deinit(KAlgState *state) {
+  PBL_ASSERTN(state != NULL);
+  prv_release_step_activity_hrm(&state->walk_state);
+  prv_release_step_activity_hrm(&state->run_state);
+}
+
+
 // ------------------------------------------------------------------------------------
 uint32_t kalg_analyze_samples(KAlgState *state, AccelRawData *data, uint32_t num_samples,
                               uint32_t *consumed_samples) {
@@ -2021,12 +2045,20 @@ static void prv_step_activity_update(KAlgState *alg_state, KAlgStepActivityState
     uint32_t duration_secs = utc_now - state->start_time;
 
 #ifdef CONFIG_HRM
+    // Bound the subscription and re-arm it each active minute, so it lapses on its own if this
+    // state machine ever stops running. An activity survives k_max_inactive_minutes without
+    // reaching here, so the window has to comfortably exceed that.
+    const uint16_t hrm_expire_s = 10 * SECONDS_PER_MINUTE;
+
     // Make sure we have a couple active minutes in a row before enabling the HRM to save battery
     const unsigned min_duration_for_hrm = 3 * SECONDS_PER_MINUTE;
-    if (duration_secs >= min_duration_for_hrm && state->hrm_session == HRM_INVALID_SESSION_REF &&
-        activity_prefs_hrm_activity_tracking_is_enabled()) {
+    if (state->hrm_session != HRM_INVALID_SESSION_REF) {
+      sys_hrm_manager_set_update_interval(state->hrm_session, 1 /* update interval */,
+                                          hrm_expire_s);
+    } else if (duration_secs >= min_duration_for_hrm &&
+               activity_prefs_hrm_activity_tracking_is_enabled()) {
       state->hrm_session = hrm_manager_subscribe_with_callback(INSTALL_ID_INVALID,
-          1 /* update interval */, 0 /*expire_s*/, HRMFeature_BPM, prv_hrm_subscription_cb, NULL);
+          1 /* update interval */, hrm_expire_s, HRMFeature_BPM, prv_hrm_subscription_cb, NULL);
     }
 #endif
 

--- a/tests/fw/services/activity/test_activity_algorithm_kraepelin.c
+++ b/tests/fw/services/activity/test_activity_algorithm_kraepelin.c
@@ -251,6 +251,8 @@ bool kalg_init(KAlgState *state, KAlgStatsCallback stats_cb) {
   return true;
 }
 
+void kalg_deinit(KAlgState *state) {}
+
 uint32_t kalg_analyze_samples(KAlgState *state, AccelRawData *data, uint32_t num_samples,
                               uint32_t *consumed_samples) {
   *consumed_samples = 0;

--- a/tests/fw/services/activity/test_kraepelin_algorithm.c
+++ b/tests/fw/services/activity/test_kraepelin_algorithm.c
@@ -30,15 +30,34 @@
 #include "fake_rtc.h"
 
 HRMSessionRef s_hrm_next_session_ref = 1;
+int s_hrm_live_subscriptions = 0;
+uint16_t s_hrm_last_expire_s = 0;
+bool s_hrm_activity_tracking_enabled = true;
+
 HRMSessionRef hrm_manager_subscribe_with_callback(AppInstallId app_id, uint32_t update_interval_s,
                                                   uint16_t expire_s, HRMFeature features,
                                                   HRMSubscriberCallback callback, void *context) {
+  s_hrm_live_subscriptions++;
+  s_hrm_last_expire_s = expire_s;
   return s_hrm_next_session_ref++;
 }
 
 bool sys_hrm_manager_unsubscribe(HRMSessionRef session) {
   cl_assert(session < s_hrm_next_session_ref);
+  cl_assert(s_hrm_live_subscriptions > 0);
+  s_hrm_live_subscriptions--;
   return true;
+}
+
+bool sys_hrm_manager_set_update_interval(HRMSessionRef session, uint32_t update_interval_s,
+                                         uint16_t expire_s) {
+  cl_assert(session < s_hrm_next_session_ref);
+  s_hrm_last_expire_s = expire_s;
+  return true;
+}
+
+bool activity_prefs_hrm_activity_tracking_is_enabled(void) {
+  return s_hrm_activity_tracking_enabled;
 }
 
 #include <dirent.h>
@@ -2208,3 +2227,87 @@ void test_kraepelin_algorithm__sleep_stats(void) {
 }
 
 
+
+// ---------------------------------------------------------------------------------------
+// Feed active walking minutes, leaving the walk activity in progress.
+static void prv_feed_walk_minutes(int num_minutes) {
+  time_t now = rtc_get_time();
+  for (int i = 0; i < num_minutes; i++) {
+    kalg_activities_update(s_kalg_state, now, 80 /*steps*/, 7000 /*vmc*/, 0 /*orientation*/,
+                           true /*definitely_not_worn*/, 100 /*resting_calories*/,
+                           200 /*active_calories*/, 1000 /*distance_mm*/, false /*shutting_down*/,
+                           prv_activity_session_callback, NULL);
+    now += SECONDS_PER_MINUTE;
+    rtc_set_time(now);
+  }
+}
+
+// ---------------------------------------------------------------------------------------
+// The HRM subscription taken by an auto-detected activity must be released when activity
+// tracking is disabled, even though the activity itself stays in progress. Otherwise starting a
+// workout leaves a never-expiring 1-second subscription behind that pins the sensor on.
+void test_kraepelin_algorithm__hrm_released_when_tracking_disabled(void) {
+  s_kalg_state = kernel_zalloc(kalg_state_size());
+  kalg_init(s_kalg_state, prv_stats_cb);
+  s_hrm_live_subscriptions = 0;
+  s_num_captured_activity_sessions = 0;
+
+  // Walk long enough to pass the 3 minute threshold that arms the HRM
+  prv_feed_walk_minutes(5);
+  cl_assert_equal_i(s_hrm_live_subscriptions, 1);
+
+  // Starting a workout disables activity tracking while the walk is still in progress
+  kalg_enable_activity_tracking(s_kalg_state, false);
+  cl_assert_equal_i(s_hrm_live_subscriptions, 0);
+
+  kalg_deinit(s_kalg_state);
+  kernel_free(s_kalg_state);
+  s_kalg_state = NULL;
+}
+
+// ---------------------------------------------------------------------------------------
+// kalg_deinit must release a subscription held by an in-progress activity. The caller frees the
+// state right after, so anything left subscribed is orphaned in the manager until reboot.
+void test_kraepelin_algorithm__hrm_released_on_deinit(void) {
+  s_kalg_state = kernel_zalloc(kalg_state_size());
+  kalg_init(s_kalg_state, prv_stats_cb);
+  s_hrm_live_subscriptions = 0;
+  s_num_captured_activity_sessions = 0;
+
+  prv_feed_walk_minutes(5);
+  cl_assert_equal_i(s_hrm_live_subscriptions, 1);
+
+  kalg_deinit(s_kalg_state);
+  cl_assert_equal_i(s_hrm_live_subscriptions, 0);
+
+  kernel_free(s_kalg_state);
+  s_kalg_state = NULL;
+}
+
+// ---------------------------------------------------------------------------------------
+// The subscription is bounded and re-armed each active minute, so it lapses on its own if the
+// state machine ever stops running.
+void test_kraepelin_algorithm__hrm_subscription_is_bounded(void) {
+  s_kalg_state = kernel_zalloc(kalg_state_size());
+  kalg_init(s_kalg_state, prv_stats_cb);
+  s_hrm_live_subscriptions = 0;
+  s_hrm_last_expire_s = 0;
+  s_num_captured_activity_sessions = 0;
+
+  prv_feed_walk_minutes(5);
+  cl_assert_equal_i(s_hrm_live_subscriptions, 1);
+
+  // The window has to outlast the inactive-minute grace period, or an ongoing activity would
+  // lose its subscription mid-walk
+  cl_assert(s_hrm_last_expire_s > 7 * SECONDS_PER_MINUTE);
+
+  // Each further active minute re-arms it rather than subscribing again
+  s_hrm_last_expire_s = 0;
+  prv_feed_walk_minutes(1);
+  cl_assert_equal_i(s_hrm_live_subscriptions, 1);
+  cl_assert(s_hrm_last_expire_s > 7 * SECONDS_PER_MINUTE);
+
+  kalg_deinit(s_kalg_state);
+  kernel_free(s_kalg_state);
+  s_kalg_state = NULL;
+}

--- a/tests/fw/services/activity/wscript_build
+++ b/tests/fw/services/activity/wscript_build
@@ -61,7 +61,7 @@ clar(ctx,
          " tests/fw/services/activity/kraepelin_reference/helper_worker.c" \
          " tests/fw/services/activity/kraepelin_reference/ProjectK_worker.c" \
          " tests/fw/services/activity/kraepelin_reference/raw_stats.c",
-     defines=['DUMA_DISABLED'],  # DUMA false-positive
+     defines=['DUMA_DISABLED', 'CONFIG_HRM'],  # DUMA false-positive
      test_sources_ant_glob = "test_kraepelin_algorithm.c",
      override_includes=['dummy_board'])
 


### PR DESCRIPTION
The auto-activity detector takes its own HRM subscription after three minutes of a detected walk or run. It is registered with `INSTALL_ID_INVALID` and `expire_s = 0`, so nothing can reclaim it except `prv_reset_step_activity_state`.

Starting a workout disables activity tracking, which calls `prv_reset_state` — and that skips step activities still in progress, i.e. exactly the ones holding a subscription. The state machine is then gated off and can never reach the release site, so the subscription stays live at a one second interval and pins the sensor on. Charging frees the algorithm state outright without unsubscribing, orphaning the subscriber in the manager until reboot.

Changes:

- release the HRM in `prv_reset_state` whether or not the activity is in progress; the next active minute re-subscribes
- add `kalg_deinit` so the free path releases it too
- bound the subscription with an expiry that each active minute re-arms, so a state machine that stops running lapses on its own

Enabling `CONFIG_HRM` on the `test_kraepelin_algorithm` target was needed to cover this — the path was previously compiled out of that test.

Tested: 331/331 unit tests pass; the new tests fail without the fix. Firmware builds for `obelix@pvt`.

Fixes FIRM-3862