### PR TITLE
gitlint: ignore Dependabot commits

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -5,9 +5,14 @@ ignore-merge-commits=false
 ignore-fixup-commits=false
 ignore-fixup-amend-commits=false
 ignore-squash-commits=false
+regex-style-search=True
+
+[ignore-by-author-name]
+regex=(?i)dependabot
+ignore=all
 
 [title-match-regex]
-regex=[a-z0-9/]+: .*
+regex=^[a-z0-9/]+: .*
 
 [title-max-length]
 line-length=100


### PR DESCRIPTION
Dependabot commits cannot satisfy our author/signoff gitlint rules (bot author name, noreply email domain, signoff under a different identity) and their auto-generated bodies exceed the line-length limit, so the `lint` job fails on every Dependabot PR (e.g. #1920).

Exempt commits authored by Dependabot from all gitlint rules via `ignore-by-author-name`; other commits are still fully checked. Also opts in to `regex-style-search` to silence the gitlint I4 deprecation warning, anchoring `title-match-regex` so its semantics are unchanged.

Verified locally by replaying the #1920 Dependabot commit through gitlint (passes, no warnings) and confirming non-Dependabot commits still fail on rule violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)