### PR TITLE
ci: dual-slot QA firmware for getafix_dvt

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -137,6 +137,7 @@ jobs:
       matrix:
         board:
           - obelix@pvt
+          - getafix@dvt
           - getafix@dvt2
 
     steps:


### PR DESCRIPTION
Adds `getafix@dvt` to the `build-qa-firmware` matrix so PebbleOS main emits a dual-slot RELEASE PBZ (`qa-firmware-getafix_dvt`), matching `getafix@dvt2` and `obelix@pvt`.

The unicorn iOS+getafix daily release-QA (06:00 UTC) needs this dual-slot PBZ as the OTA "to": the per-commit `firmware-getafix_dvt` artifact is slot0-only and can't be OTA'd into the inactive slot. getafix_dvt is the board on the unicorn-mac-2 hardware rig.

Signed-off-by: Eric Migicovsky <eric@repebble.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)