### PR TITLE
fw/services/activity: skip post-workout HR window when monitoring off

### DIFF
--- a/src/fw/services/activity/workout_service.c
+++ b/src/fw/services/activity/workout_service.c
@@ -320,6 +320,10 @@ void workout_service_frontend_closed(void) {
     } else if (s_workout_data.frontend_last_opened_ts >= s_workout_data.last_workout_end_ts) {
       // If the app was opened and closed without starting a workout, turn the HR sensor off
       hr_time_left = 0;
+    } else if (activity_prefs_get_hrm_measurement_interval() == HRMonitoringInterval_Disabled) {
+      // Background HR monitoring is off, so the user expects the sensor to run only while an
+      // activity is in progress. The workout is over, so skip the recovery window entirely.
+      hr_time_left = 0;
     } else {
       // We have ended a workout while the app was open. Make sure to keep the HR sensor on for at
       // least a little bit after the workout is finished

--- a/tests/fw/services/activity/test_workout_service.c
+++ b/tests/fw/services/activity/test_workout_service.c
@@ -75,6 +75,11 @@ uint8_t activity_prefs_heart_get_zone3_threshold(void) {
   return 172;
 }
 
+static HRMonitoringInterval s_hrm_measurement_interval;
+HRMonitoringInterval activity_prefs_get_hrm_measurement_interval(void) {
+  return s_hrm_measurement_interval;
+}
+
 AppInstallId app_get_app_id(void) {
   return 0;
 }
@@ -166,6 +171,7 @@ void test_workout_service__initialize(void) {
   s_total_step_count = 5000;
   s_hrm_expiration = 0;
   s_hrm_subscribed = false;
+  s_hrm_measurement_interval = HRMonitoringInterval_10Min;
   s_abandoned_workout_notification_sent = false;
 
   const bool assert_all_unlocked = true;
@@ -563,6 +569,54 @@ void test_workout_service__app_open_close_valid_workout(void) {
   workout_service_frontend_closed();
   cl_assert_equal_b(s_hrm_subscribed, true);
   cl_assert_equal_i(s_hrm_expiration, 8 * SECONDS_PER_MINUTE);
+}
+
+// ---------------------------------------------------------------------------------------
+// Same as above, but with background HR monitoring disabled. The user expects the sensor to run
+// only during an activity, so closing the app after a workout must turn it off immediately rather
+// than running the post-workout recovery window.
+void test_workout_service__app_open_close_valid_workout_hrm_disabled(void) {
+  s_hrm_measurement_interval = HRMonitoringInterval_Disabled;
+
+  // Put some time into the clock
+  prv_inc_time(1 * SECONDS_PER_MINUTE);
+
+  // Open the app, confirm that we are now subscribed with no end in sight
+  workout_service_frontend_opened();
+  cl_assert_equal_b(s_hrm_subscribed, true);
+  cl_assert_equal_i(s_hrm_expiration, 0);
+
+  prv_inc_time(1 * SECONDS_PER_MINUTE);
+  cl_assert(workout_service_start_workout(ActivitySessionType_Run));
+  // Workout of 120 seconds duration. Should be valid
+  prv_inc_time(2 * SECONDS_PER_MINUTE);
+  cl_assert(workout_service_stop_workout());
+
+  prv_inc_time(2 * SECONDS_PER_MINUTE);
+
+  workout_service_frontend_closed();
+  cl_assert_equal_b(s_hrm_subscribed, false);
+  cl_assert_equal_i(s_hrm_expiration, 0);
+}
+
+// ---------------------------------------------------------------------------------------
+// With background HR monitoring disabled, closing the app while a workout is still running must
+// still keep the sensor on -- an ongoing workout is exactly the "during an activity" case.
+void test_workout_service__app_open_close_active_workout_hrm_disabled(void) {
+  s_hrm_measurement_interval = HRMonitoringInterval_Disabled;
+
+  // Put some time into the clock
+  prv_inc_time(1 * SECONDS_PER_MINUTE);
+
+  workout_service_frontend_opened();
+  cl_assert_equal_b(s_hrm_subscribed, true);
+  cl_assert_equal_i(s_hrm_expiration, 0);
+
+  cl_assert(workout_service_start_workout(ActivitySessionType_Run));
+
+  workout_service_frontend_closed();
+  cl_assert_equal_b(s_hrm_subscribed, true);
+  cl_assert_equal_i(s_hrm_expiration, SECONDS_PER_HOUR);
 }
 
 // ---------------------------------------------------------------------------------------


### PR DESCRIPTION
The workout app keeps the HR sensor alive for a 10-minute recovery window after a workout ends, so it can capture the user's HR settling back to a normal level. That window was applied unconditionally, including for users who have set HR Monitoring to Disabled and therefore expect the sensor to run only while an activity is in progress.

Re-entering and leaving the workout app appeared to "fix" it, because the second exit takes the `frontend_last_opened_ts >= last_workout_end_ts` branch and unsubscribes immediately -- which is exactly the workaround users reported having to perform.

Skip the recovery window when the measurement interval is HRMonitoringInterval_Disabled, matching how activity.c already treats that value as "don't sample in the background". A workout that is still ongoing when the app closes keeps its subscription, since that is genuinely the "during an activity" case.

Fixes FIRM-4154