### PR TITLE
Revert "fw/services/analytics: use buffered DLS session for native heartbeat"

### DIFF
--- a/src/fw/services/analytics/native.c
+++ b/src/fw/services/analytics/native.c
@@ -307,7 +307,7 @@ void pbl_analytics__native_heartbeat(void) {
     Uuid system_uuid = UUID_SYSTEM;
 
     s_dls_session = dls_create(DlsSystemTagAnalyticsNativeHeartbeat, DATA_LOGGING_BYTE_ARRAY,
-                               sizeof(struct native_heartbeat_record), true, false, &system_uuid);
+                               sizeof(struct native_heartbeat_record), false, false, &system_uuid);
     PBL_ASSERTN(s_dls_session != NULL);
   }
 


### PR DESCRIPTION
This reverts commit bebc13477b0e8e2716b376275a9f403a7e8c56ee.

Fix #1919.

Tested this patch on top of v4.36.0 and it appears to work, no hourly reboot. Without it I get a consistent hourly reboot. See #1919.

So as I understand it bebc13477b0e8e2716b376275a9f403a7e8c56ee from ~#1919~ #1853 flipped the watch's native heartbeat analytics DLS session from unbuffered to buffered. The buffered ones are limited to 300 bytes (DLS_SESSION_MAX_BUFFERED_ITEM_SIZE), while the unbuffered ones are limited to 656/646 bytes (COMM_MAX_OUTBOUND_PAYLOAD_SIZE). The watch analytics size is dictated by analytics.def and is now around 570 bytes. So making it buffered hits the 300 byte limit when it tries to create the DLS session, which happens on an hourly timer, and it crashes on this assert:

https://github.com/coredevices/PebbleOS/blob/3889b0bba9fd24422bbdb997d03578186ae5fb91/src/fw/services/analytics/native.c#L311

I'm pretty new to this, so I could be getting things mixed up here, but I think that's roughly it.

There seem to be some benefits to using buffered sessions though, but that will require a bit more work.