### PR TITLE
fw/services/weather: expose default-location forecast to apps via weather_service_peek()

### DIFF
--- a/include/pbl/services/weather/weather_service.h
+++ b/include/pbl/services/weather/weather_service.h
@@ -11,6 +11,7 @@
 //! changed events should use the PEBBLE_WEATHER_CHANGED_EVENT (see events.h)
 
 #include "pbl/services/blob_db/weather_db.h"
+#include "pbl/services/weather/weather_snapshot_types.h"
 #include "pbl/services/weather/weather_types.h"
 #include "pbl/util/list.h"
 #include "util/time/time.h"
@@ -76,3 +77,11 @@ void weather_service_locations_list_destroy(WeatherDataListNode *head);
 
 //! Returns whether or not the phone has weather support
 bool weather_service_supported_by_phone(void);
+
+//! Fills snapshot_out with a pointer-free copy of the default location's
+//! forecast, the same data weather_service_create_default_forecast() would
+//! return, but safe to pass across the syscall boundary directly.
+//! @param snapshot_out Pointer to a WeatherServiceSnapshot to fill in
+//! @return true if weather data was available and snapshot_out was filled
+//! in, false (with snapshot_out zeroed) if no forecast is available
+bool weather_service_get_snapshot(WeatherServiceSnapshot *snapshot_out);

--- a/include/pbl/services/weather/weather_snapshot_types.h
+++ b/include/pbl/services/weather/weather_snapshot_types.h
@@ -1,0 +1,53 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+//! App-facing weather snapshot types.
+//!
+//! Kept deliberately separate from weather_service.h / weather_types.h:
+//! weather_types.h transitively includes a per-platform auto-generated
+//! resource header (for TimelineResourceId) that isn't resolvable by the SDK
+//! export tool's limited parse environment, so nothing in this header's
+//! include chain may depend on it.
+
+#include "util/time/time.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define WEATHER_SNAPSHOT_MAX_PHRASE_LEN (32)
+
+//! Weather icon category. Numerically mirrors WeatherType (see
+//! src/fw/services/weather/weather_type_tuples.def, the source of truth for
+//! these IDs) without depending on its header - if weather_type_tuples.def
+//! ever changes, update this to match.
+typedef enum {
+  WeatherSnapshotIcon_PartlyCloudy = 0,
+  WeatherSnapshotIcon_CloudyDay = 1,
+  WeatherSnapshotIcon_LightSnow = 2,
+  WeatherSnapshotIcon_LightRain = 3,
+  WeatherSnapshotIcon_HeavyRain = 4,
+  WeatherSnapshotIcon_HeavySnow = 5,
+  WeatherSnapshotIcon_Generic = 6,
+  WeatherSnapshotIcon_Sun = 7,
+  WeatherSnapshotIcon_RainAndSnow = 8,
+  WeatherSnapshotIcon_Unknown = 255,
+} WeatherSnapshotIcon;
+
+//! A pointer-free snapshot of the default location's forecast, safe to hand
+//! directly to apps: unlike WeatherLocationForecast, none of its fields are
+//! heap pointers only valid in kernel context.
+typedef struct WeatherServiceSnapshot {
+  bool has_data;
+  bool is_current_location;
+  int current_temp;
+  int today_high;
+  int today_low;
+  WeatherSnapshotIcon current_weather_type;
+  char current_weather_phrase[WEATHER_SNAPSHOT_MAX_PHRASE_LEN];
+  int tomorrow_high;
+  int tomorrow_low;
+  WeatherSnapshotIcon tomorrow_weather_type;
+  time_t time_updated_utc;
+} WeatherServiceSnapshot;

--- a/src/fw/applib/weather_service_app.c
+++ b/src/fw/applib/weather_service_app.c
@@ -1,0 +1,10 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "weather_service_app.h"
+
+#include "syscall/syscall.h"
+
+bool weather_service_peek(WeatherServiceSnapshot *snapshot_out) {
+  return sys_weather_get_snapshot(snapshot_out);
+}

--- a/src/fw/applib/weather_service_app.h
+++ b/src/fw/applib/weather_service_app.h
@@ -1,0 +1,31 @@
+/* SPDX-FileCopyrightText: 2026 Core Devices LLC */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#pragma once
+
+#include "pbl/services/weather/weather_snapshot_types.h"
+
+//! @addtogroup Foundation
+//! @{
+//!   @addtogroup EventService
+//!   @{
+//!     @addtogroup WeatherService
+//!
+//! \brief Reads the phone-synced weather forecast for the default location
+//!
+//! Exposes the same forecast data the system Weather app displays - synced
+//! from the phone in the background - directly to third-party apps, with no
+//! AppMessage/PebbleKit JS round-trip required.
+//! @{
+
+//! Reads a snapshot of the phone-synced weather forecast for the default
+//! (usually current) location.
+//! @param snapshot_out Pointer to a \ref WeatherServiceSnapshot to fill in
+//! @return true if weather data was available and snapshot_out was filled
+//! in, false if no forecast is available yet (e.g. the phone hasn't synced
+//! any weather data)
+bool weather_service_peek(WeatherServiceSnapshot *snapshot_out);
+
+//!     @} // end addtogroup WeatherService
+//!   @} // end addtogroup EventService
+//! @} // end addtogroup Foundation

--- a/src/fw/process_management/pebble_process_info.h
+++ b/src/fw/process_management/pebble_process_info.h
@@ -172,9 +172,10 @@ typedef enum {
 // sdk.major:0x5 .minor:0x68 -- Expose gesture recognizer API (tap/pan/swipe + window attach/detach) to apps (rev 107)
 // sdk.major:0x5 .minor:0x69 -- Add app_touch_navigation_enable() opt-in for third-party touch nav (rev 108)
 // sdk.major:0x5 .minor:0x6a -- Add HRV sampling API (health_service_set_hrv_sample_period) (rev 109)
+// sdk.major:0x5 .minor:0x6b -- Add weather_service_peek() for direct app access to the phone-synced default-location forecast (rev 110)
 
 #define PROCESS_INFO_CURRENT_SDK_VERSION_MAJOR 0x5
-#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x6a
+#define PROCESS_INFO_CURRENT_SDK_VERSION_MINOR 0x6b
 
 // The first SDK to ship with 2.x APIs
 #define PROCESS_INFO_FIRST_2X_SDK_VERSION_MAJOR 0x4

--- a/src/fw/services/weather/weather_service.c
+++ b/src/fw/services/weather/weather_service.c
@@ -13,8 +13,10 @@
 #include "pbl/services/blob_db/watch_app_prefs_db.h"
 #include "pbl/services/blob_db/weather_db.h"
 #include "pbl/services/weather/weather_types.h"
+#include "syscall/syscall_internal.h"
 #include <pbl/logging/logging.h>
 #include "system/passert.h"
+#include <string.h>
 
 PBL_LOG_MODULE_DEFINE(service_weather, CONFIG_SERVICE_WEATHER_LOG_LEVEL);
 
@@ -222,6 +224,40 @@ void weather_service_destroy_default_forecast(WeatherLocationForecast *forecast)
     task_free(forecast->current_weather_phrase);
     task_free(forecast);
   }
+}
+
+bool weather_service_get_snapshot(WeatherServiceSnapshot *snapshot_out) {
+  *snapshot_out = (WeatherServiceSnapshot){ 0 };
+
+  WeatherLocationForecast *forecast = weather_service_create_default_forecast();
+  if (!forecast) {
+    return false;
+  }
+
+  snapshot_out->has_data = true;
+  snapshot_out->is_current_location = forecast->is_current_location;
+  snapshot_out->current_temp = forecast->current_temp;
+  snapshot_out->today_high = forecast->today_high;
+  snapshot_out->today_low = forecast->today_low;
+  snapshot_out->current_weather_type = (WeatherSnapshotIcon)forecast->current_weather_type;
+  if (forecast->current_weather_phrase) {
+    strncpy(snapshot_out->current_weather_phrase, forecast->current_weather_phrase,
+            sizeof(snapshot_out->current_weather_phrase) - 1);
+  }
+  snapshot_out->tomorrow_high = forecast->tomorrow_high;
+  snapshot_out->tomorrow_low = forecast->tomorrow_low;
+  snapshot_out->tomorrow_weather_type = (WeatherSnapshotIcon)forecast->tomorrow_weather_type;
+  snapshot_out->time_updated_utc = forecast->time_updated_utc;
+
+  weather_service_destroy_default_forecast(forecast);
+  return true;
+}
+
+DEFINE_SYSCALL(bool, sys_weather_get_snapshot, WeatherServiceSnapshot *snapshot_out) {
+  if (PRIVILEGE_WAS_ELEVATED) {
+    syscall_assert_userspace_buffer(snapshot_out, sizeof(*snapshot_out));
+  }
+  return weather_service_get_snapshot(snapshot_out);
 }
 
 static void prv_blobdb_event_handler(PebbleEvent *event, void *context) {

--- a/src/fw/syscall/syscall.h
+++ b/src/fw/syscall/syscall.h
@@ -30,6 +30,7 @@
 #include "pbl/services/evented_timer.h"
 #include "pbl/services/activity/activity.h"
 #include "pbl/services/app_glances/app_glance_service.h"
+#include "pbl/services/weather/weather_snapshot_types.h"
 
 #include "process_management/pebble_process_info.h"
 
@@ -189,6 +190,8 @@ bool sys_clock_is_24h_style(void);
 size_t sys_strftime(char* s, size_t maxsize, const char* format, const struct tm* tim_p, char *locale);
 
 BatteryChargeState sys_battery_get_charge_state(void);
+
+bool sys_weather_get_snapshot(WeatherServiceSnapshot *snapshot_out);
 
 bool sys_activity_get_metric(ActivityMetric metric, uint32_t history_len, int32_t *history);
 bool sys_activity_get_minute_history(HealthMinuteData *minute_data, uint32_t *num_records,

--- a/tools/generate_native_sdk/exported_symbols.json
+++ b/tools/generate_native_sdk/exported_symbols.json
@@ -4,7 +4,7 @@
               "You should also make sure you are obeying our API design guidelines:",
               "https://pebbletechnology.atlassian.net/wiki/display/DEV/SDK+API+Design+Guidelines"
             ],
-  "revision" : "109",
+  "revision" : "110",
   "version" : "2.0",
   "files": [
     "include/pbl/drivers/ambient_light.h",
@@ -135,7 +135,9 @@
     "fw/applib/voice/dictation_session.h",
     "fw/applib/ui/content_indicator.h",
     "fw/applib/rockyjs/rocky.h",
-    "fw/applib/unobstructed_area_service.h"
+    "fw/applib/unobstructed_area_service.h",
+    "fw/applib/weather_service_app.h",
+    "include/pbl/services/weather/weather_snapshot_types.h"
   ],
   "exports": [
     {
@@ -438,6 +440,30 @@
                   "type": "function",
                   "name": "battery_state_service_peek",
                   "addedRevision": "0"
+                }
+              ]
+            }, {
+              "type": "group",
+              "name": "WeatherService",
+              "appOnly": true,
+              "addedRevision": "110",
+              "exports": [
+                {
+                  "type": "define",
+                  "name": "WEATHER_SNAPSHOT_MAX_PHRASE_LEN",
+                  "addedRevision": "110"
+                }, {
+                  "type": "type",
+                  "name": "WeatherSnapshotIcon",
+                  "addedRevision": "110"
+                }, {
+                  "type": "type",
+                  "name": "WeatherServiceSnapshot",
+                  "addedRevision": "110"
+                }, {
+                  "type": "function",
+                  "name": "weather_service_peek",
+                  "addedRevision": "110"
                 }
               ]
             }, {


### PR DESCRIPTION
Third-party watchfaces have no way to read the weather data the phone already syncs to the watch - the only precedent is the old PebbleKit JS AppMessage convention, which needs a JS engine most native apps don't have. weather_service_create_default_forecast() already builds almost exactly the data we want, it just has never been exposed: WeatherLocationForecast owns raw location_name/current_weather_phrase pointers into kernel memory, which can't cross the syscall boundary as-is.

Add weather_service_get_snapshot(), which copies that forecast into a new pointer-free WeatherServiceSnapshot (fixed-size phrase buffer via strncpy), and wrap it in a DEFINE_SYSCALL following the buffer-passing pattern used by sys_activity_get_minute_history: validate the caller's buffer with syscall_assert_userspace_buffer() before writing into it. The public wrapper, weather_service_peek(), lives in a new src/fw/applib/weather_service_app.{c,h}, mirroring how battery_state_service.{c,h} wraps sys_battery_get_charge_state().

WeatherServiceSnapshot's icon fields use a new WeatherSnapshotIcon enum instead of WeatherType: weather_types.h transitively includes a per-platform auto-generated resource header (for TimelineResourceId) that the SDK export tool's parser can't resolve, which is why nothing building on it was exportable before. WeatherSnapshotIcon numerically mirrors WeatherType (see weather_type_tuples.def, still the source of truth for the IDs) without depending on its header.

Registers weather_service_peek(), WeatherServiceSnapshot, and WeatherSnapshotIcon in exported_symbols.json at rev 110 and bumps PROCESS_INFO_CURRENT_SDK_VERSION_MINOR to 0x6b per docs/development/sdk_export.md.

Fixes #555