### PR TITLE
ci: use actions/setup-python with caching

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -15,6 +15,11 @@ jobs:
       - name: Rebase onto target branch
         uses: ./.github/actions/rebase
 
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+
       - name: Install GitLint
         run: pip install gitlint
 
@@ -31,6 +36,11 @@ jobs:
 
       - name: Rebase onto target branch
         uses: ./.github/actions/rebase
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
 
       - name: Install ruff
         run: pip install ruff

--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: "docs/requirements.txt"
 
       - name: Install dependencies
         run: pip install -r docs/requirements.txt


### PR DESCRIPTION
Noticed it was only being used in the doc-linkscheck workflow, so used it consistently throughout the jobs, and used the built-in pip caching.

The `python-version` value of 3.13 was just based on the single use, and potentially could be unpinned to keep using the version shipped with the runner. Alternately at python verson file could live at the root for consitency.