### PR TITLE
applib/ui: touch scrolling affordances (scrollbar overlay + edge overscroll)

### DIFF
--- a/src/fw/applib/ui/menu_layer.c
+++ b/src/fw/applib/ui/menu_layer.c
@@ -20,6 +20,7 @@
 #include "shell/system_theme.h"
 #include <pbl/logging/logging.h>
 #include "system/passert.h"
+#include "pbl/util/attributes.h"
 #include "pbl/util/math.h"
 #include "pbl/util/size.h"
 #include "vibes.h"
@@ -60,13 +61,155 @@ static bool prv_cancel_selection_animation(MenuLayer *menu_layer);
 // Inside the MenuLayer's update_proc (Layer drawing callback), it will call out to its client for each row
 // that needs to be drawn, until all visible rows have been drawn.
 
+//! How long the scrollbar overlay stays visible after the last touch scroll movement.
+#define MENU_LAYER_SCROLLBAR_HIDE_TIMEOUT_MS 1000
+#define MENU_LAYER_SCROLLBAR_WIDTH 3
+#define MENU_LAYER_SCROLLBAR_MARGIN 2
+#define MENU_LAYER_SCROLLBAR_MIN_THUMB_HEIGHT 8
+
+static void prv_scrollbar_cancel_hide_timer(MenuLayer *menu_layer) {
+  if (menu_layer->scrollbar_hide_timer) {
+    app_timer_cancel(menu_layer->scrollbar_hide_timer);
+    menu_layer->scrollbar_hide_timer = NULL;
+  }
+}
+
+#ifdef CONFIG_TOUCH
+static void prv_scrollbar_hide_timer_cb(void *data) {
+  MenuLayer *menu_layer = data;
+  menu_layer->scrollbar_hide_timer = NULL;
+  menu_layer->scrollbar_visible = false;
+  layer_mark_dirty(&menu_layer->scroll_layer.layer);
+}
+
+//! Shows the scrollbar overlay and (re)arms the timer that hides it again. Called only from the
+//! touch scrolling paths: button scrolling steps the selection and doesn't need the position cue.
+static void prv_scrollbar_kick(MenuLayer *menu_layer) {
+  if (menu_layer->scrollbar_hidden || process_manager_compiled_with_legacy2_sdk()) {
+    return;
+  }
+  const int16_t frame_h = menu_layer->scroll_layer.layer.frame.size.h;
+  const int16_t content_h = scroll_layer_get_content_size(&menu_layer->scroll_layer).h;
+  if (content_h <= frame_h) {
+    return;
+  }
+  menu_layer->scrollbar_visible = true;
+  if (!menu_layer->scrollbar_hide_timer ||
+      !app_timer_reschedule(menu_layer->scrollbar_hide_timer,
+                            MENU_LAYER_SCROLLBAR_HIDE_TIMEOUT_MS)) {
+    menu_layer->scrollbar_hide_timer = app_timer_register(
+        MENU_LAYER_SCROLLBAR_HIDE_TIMEOUT_MS, prv_scrollbar_hide_timer_cb, menu_layer);
+  }
+}
+#endif  // CONFIG_TOUCH
+
+#if PBL_ROUND
+//! Curved scrollbar (Wear OS style): the track is an arc hugging the bezel, spanning
+//! ±30° around the 3 o'clock position.
+#define MENU_LAYER_SCROLLBAR_TRACK_SWEEP DEG_TO_TRIGANGLE(60)
+#define MENU_LAYER_SCROLLBAR_MIN_THUMB_SWEEP DEG_TO_TRIGANGLE(10)
+
+//! Thumb start/end angles for the curved scrollbar; false if the content doesn't scroll.
+T_STATIC bool prv_scrollbar_thumb_angles(MenuLayer *menu_layer, int16_t content_top_y,
+                                         int32_t *angle_start, int32_t *angle_end) {
+  const GSize frame_size = menu_layer->scroll_layer.layer.frame.size;
+  const int16_t content_h = scroll_layer_get_content_size(&menu_layer->scroll_layer).h;
+  const int16_t scrollable_h = content_h - frame_size.h;
+  if (scrollable_h <= 0) {
+    return false;
+  }
+  const int32_t track_sweep = MENU_LAYER_SCROLLBAR_TRACK_SWEEP;
+  const int32_t thumb_sweep = CLIP((track_sweep * frame_size.h) / content_h,
+                                   MENU_LAYER_SCROLLBAR_MIN_THUMB_SWEEP, track_sweep);
+  // Center-focused menus over-scroll past the ends (offset clipping disabled); clamp to the track.
+  const int32_t progress_y = CLIP(content_top_y, 0, scrollable_h);
+  const int32_t track_start = DEG_TO_TRIGANGLE(90) - (track_sweep / 2);
+  *angle_start = track_start + (((track_sweep - thumb_sweep) * progress_y) / scrollable_h);
+  *angle_end = *angle_start + thumb_sweep;
+  return true;
+}
+
+//! Fills an arc band with rounded end caps (graphics_fill_radial ends are cut flat).
+static void prv_scrollbar_fill_capped_arc(GContext *ctx, GPoint center, uint16_t radius_outer,
+                                          uint16_t thickness, int32_t angle_start,
+                                          int32_t angle_end) {
+  graphics_fill_radial_internal(ctx, center, radius_outer - thickness, radius_outer,
+                                angle_start, angle_end);
+  const int32_t radius_mid = radius_outer - (thickness / 2);
+  const int32_t angles[2] = { angle_start, angle_end };
+  for (size_t i = 0; i < ARRAY_LENGTH(angles); i++) {
+    const GPoint cap = GPoint(
+        center.x + (int16_t)((radius_mid * sin_lookup(angles[i])) / TRIG_MAX_RATIO),
+        center.y - (int16_t)((radius_mid * cos_lookup(angles[i])) / TRIG_MAX_RATIO));
+    graphics_fill_circle(ctx, cap, thickness / 2);
+  }
+}
+
+static void prv_scrollbar_draw(MenuLayer *menu_layer, GContext *ctx, int16_t content_top_y) {
+  int32_t angle_start, angle_end;
+  if (!prv_scrollbar_thumb_angles(menu_layer, content_top_y, &angle_start, &angle_end)) {
+    return;
+  }
+  const GSize frame_size = menu_layer->scroll_layer.layer.frame.size;
+  // Drawing happens in content space: the viewport center is offset by content_top_y.
+  const GPoint center = GPoint(frame_size.w / 2, content_top_y + (frame_size.h / 2));
+  const uint16_t radius_outer =
+      (MIN(frame_size.w, frame_size.h) / 2) - MENU_LAYER_SCROLLBAR_MARGIN;
+  // 1px halo around the thumb (rounded caps included) so it stays visible over both normal and
+  // highlighted cells
+  graphics_context_set_fill_color(ctx, menu_layer->normal_colors[MenuLayerColorBackground]);
+  prv_scrollbar_fill_capped_arc(ctx, center, radius_outer + 1, MENU_LAYER_SCROLLBAR_WIDTH + 2,
+                                angle_start, angle_end);
+  graphics_context_set_fill_color(ctx, menu_layer->normal_colors[MenuLayerColorForeground]);
+  prv_scrollbar_fill_capped_arc(ctx, center, radius_outer, MENU_LAYER_SCROLLBAR_WIDTH,
+                                angle_start, angle_end);
+}
+#else
+//! Scrollbar thumb rect in content-space coordinates (the space menu_layer_update_proc draws in).
+T_STATIC GRect prv_scrollbar_thumb_rect(MenuLayer *menu_layer, int16_t content_top_y) {
+  const GSize frame_size = menu_layer->scroll_layer.layer.frame.size;
+  const int16_t content_h = scroll_layer_get_content_size(&menu_layer->scroll_layer).h;
+  const int16_t scrollable_h = content_h - frame_size.h;
+  const int16_t track_h = frame_size.h - (2 * MENU_LAYER_SCROLLBAR_MARGIN);
+  if (scrollable_h <= 0 || track_h <= MENU_LAYER_SCROLLBAR_MIN_THUMB_HEIGHT) {
+    return GRectZero;
+  }
+  const int16_t thumb_h = CLIP((int16_t)(((int32_t)track_h * frame_size.h) / content_h),
+                               MENU_LAYER_SCROLLBAR_MIN_THUMB_HEIGHT, track_h);
+  // Center-focused menus over-scroll past the ends (offset clipping disabled); clamp to the track.
+  const int16_t progress_y = CLIP(content_top_y, 0, scrollable_h);
+  const int16_t thumb_y = MENU_LAYER_SCROLLBAR_MARGIN +
+      (((int32_t)(track_h - thumb_h) * progress_y) / scrollable_h);
+  return GRect(frame_size.w - MENU_LAYER_SCROLLBAR_MARGIN - MENU_LAYER_SCROLLBAR_WIDTH,
+               content_top_y + thumb_y, MENU_LAYER_SCROLLBAR_WIDTH, thumb_h);
+}
+
+static void prv_scrollbar_draw(MenuLayer *menu_layer, GContext *ctx, int16_t content_top_y) {
+  const GRect thumb = prv_scrollbar_thumb_rect(menu_layer, content_top_y);
+  if (grect_is_empty(&thumb)) {
+    return;
+  }
+  // 1px halo around the thumb so it stays visible over both normal and highlighted cells
+  const GRect halo = grect_inset_internal(thumb, -1, -1);
+  graphics_context_set_fill_color(ctx, menu_layer->normal_colors[MenuLayerColorBackground]);
+  graphics_fill_round_rect(ctx, &halo, 2, GCornersAll);
+  graphics_context_set_fill_color(ctx, menu_layer->normal_colors[MenuLayerColorForeground]);
+  graphics_fill_round_rect(ctx, &thumb, 1, GCornersAll);
+}
+#endif  // PBL_ROUND
+
 static void prv_menu_scroll_offset_changed_handler(ScrollLayer *scroll_layer,
                                                    MenuLayer *menu_layer) {
 #ifdef CONFIG_TOUCH
-  // During an inertial coast on a carousel the row crossing the centre becomes the selection live,
-  // one row at a time, exactly as during a finger pan (same selection_will_change contract).
-  if (menu_layer->touch_fling_active && menu_layer->center_focused) {
-    prv_menu_touch_track_center_row(menu_layer);
+  if (menu_layer->touch_fling_active) {
+    // Keep the scrollbar alive while an inertial coast drives the offset.
+    prv_scrollbar_kick(menu_layer);
+    // During an inertial coast on a carousel the row crossing the centre becomes the selection
+    // live, one row at a time, exactly as during a finger pan (same selection_will_change
+    // contract).
+    if (menu_layer->center_focused) {
+      prv_menu_touch_track_center_row(menu_layer);
+    }
   }
 #endif
 }
@@ -754,6 +897,10 @@ void menu_layer_update_proc(Layer *scroll_content_layer, GContext* ctx) {
   menu_layer->cache.cursor = render_iter->new_cache;
 
   task_free(render_iter);
+
+  if (menu_layer->scrollbar_visible) {
+    prv_scrollbar_draw(menu_layer, ctx, content_top_y);
+  }
 }
 
 void menu_layer_init_scroll_layer_callbacks(MenuLayer *menu_layer) {
@@ -825,6 +972,7 @@ void menu_layer_deinit(MenuLayer *menu_layer) {
   prv_menu_touch_nav_deregister(menu_layer);
 #endif
   prv_cancel_selection_animation(menu_layer);
+  prv_scrollbar_cancel_hide_timer(menu_layer);
   layer_deinit(&menu_layer->inverter.layer);
   scroll_layer_deinit(&menu_layer->scroll_layer);
 }
@@ -1495,6 +1643,18 @@ void menu_layer_set_center_focused(MenuLayer *menu_layer, bool center_focused) {
   menu_layer_update_caches(menu_layer);
 }
 
+void menu_layer_set_scrollbar_hidden(MenuLayer *menu_layer, bool hidden) {
+  if (!menu_layer) {
+    return;
+  }
+  menu_layer->scrollbar_hidden = hidden;
+  if (hidden && menu_layer->scrollbar_visible) {
+    prv_scrollbar_cancel_hide_timer(menu_layer);
+    menu_layer->scrollbar_visible = false;
+    layer_mark_dirty(&menu_layer->scroll_layer.layer);
+  }
+}
+
 void menu_layer_set_tap_select_only(MenuLayer *menu_layer, bool tap_select_only) {
   if (!menu_layer) {
     return;
@@ -1800,6 +1960,7 @@ void menu_layer_touch_handle_touchdown(MenuLayer *menu_layer) {
 void menu_layer_touch_handle_pan_update(MenuLayer *menu_layer, GPoint base,
                                         GPoint delta_since_start) {
   const int16_t new_y = prv_menu_touch_clamp_offset_y(menu_layer, base.y + delta_since_start.y);
+  prv_scrollbar_kick(menu_layer);
   scroll_layer_set_content_offset(&menu_layer->scroll_layer, GPoint(0, new_y), false);
   if (menu_layer->center_focused) {
     prv_menu_touch_track_center_row(menu_layer);
@@ -1836,6 +1997,7 @@ static void prv_menu_touch_fling(MenuLayer *menu_layer, int16_t released_y, int3
 void menu_layer_touch_handle_snap(MenuLayer *menu_layer, GPoint base, GPoint final_delta,
                                   GPoint velocity) {
   const int16_t new_y = prv_menu_touch_clamp_offset_y(menu_layer, base.y + final_delta.y);
+  prv_scrollbar_kick(menu_layer);
   const int32_t v = CLIP((int32_t)velocity.y, -TOUCH_FLING_MAX_VELOCITY_PX_S,
                          TOUCH_FLING_MAX_VELOCITY_PX_S);
   if (ABS(v) >= TOUCH_FLING_MIN_VELOCITY_PX_S) {

--- a/src/fw/applib/ui/menu_layer.c
+++ b/src/fw/applib/ui/menu_layer.c
@@ -46,6 +46,7 @@ struct TouchNavState *modal_manager_get_touch_nav_state(void);
 static void prv_menu_touch_nav_register(MenuLayer *menu_layer);
 static void prv_menu_touch_nav_deregister(MenuLayer *menu_layer);
 static void prv_menu_touch_track_center_row(MenuLayer *menu_layer);
+static void prv_menu_update_overscroll_stretch(MenuLayer *menu_layer);
 #endif
 
 //! @return True if there was an animation to cancel, false otherwise
@@ -201,6 +202,7 @@ static void prv_scrollbar_draw(MenuLayer *menu_layer, GContext *ctx, int16_t con
 static void prv_menu_scroll_offset_changed_handler(ScrollLayer *scroll_layer,
                                                    MenuLayer *menu_layer) {
 #ifdef CONFIG_TOUCH
+  prv_menu_update_overscroll_stretch(menu_layer);
   if (menu_layer->touch_fling_active) {
     // Keep the scrollbar alive while an inertial coast drives the offset.
     prv_scrollbar_kick(menu_layer);
@@ -837,6 +839,13 @@ void menu_layer_update_proc(Layer *scroll_content_layer, GContext* ctx) {
 
   if (!process_manager_compiled_with_legacy2_sdk()) {
     prv_draw_background(menu_layer, ctx, &menu_layer->scroll_layer.layer, false);
+  }
+
+  if (menu_layer->overscroll_stretched) {
+    // The overscroll-stretched selection background: cells paint over their own part, so only
+    // the gap beyond the content edge shows it.
+    graphics_context_set_fill_color(ctx, menu_layer->highlight_colors[MenuLayerColorBackground]);
+    graphics_fill_rect(ctx, &menu_layer->inverter.layer.frame);
   }
 
   MenuRenderIterator *render_iter = applib_type_malloc(MenuRenderIterator);
@@ -1777,6 +1786,51 @@ static int16_t prv_menu_touch_clamp_offset_y(MenuLayer *menu_layer, int16_t y) {
   int16_t min_y, max_y;
   prv_menu_touch_offset_bounds(menu_layer, &min_y, &max_y);
   return CLIP(y, min_y, max_y);
+}
+
+//! Derive the overscroll highlight stretch from the current (possibly rubber-banded) offset:
+//! with the edge row selected, the selection background extends to the viewport edge so the
+//! exposed gap reads as the selected cell stretching -- the touch counterpart of the
+//! blocked-button selection bounce -- and never paints over a neighbouring row (the neighbours
+//! moved away with the content). Purely offset-derived, so the live pan, the release
+//! spring-back, and a cancelled gesture all keep it in sync for free.
+static void prv_menu_update_overscroll_stretch(MenuLayer *menu_layer) {
+  GRect frame = (GRect) {
+    .origin = { 0, menu_layer->selection.y },
+    .size = { menu_layer->scroll_layer.layer.frame.size.w, menu_layer->selection.h },
+  };
+  bool stretched = false;
+  if (!menu_layer->center_focused && !menu_layer->selection_animation_disabled &&
+      !process_manager_compiled_with_legacy2_sdk()) {
+    const int16_t frame_h = menu_layer->scroll_layer.layer.frame.size.h;
+    const int16_t content_h = scroll_layer_get_content_size(&menu_layer->scroll_layer).h;
+    const int16_t min_y = MIN((int16_t)(frame_h - content_h), (int16_t)0);
+    const int16_t offset_y = scroll_layer_get_content_offset(&menu_layer->scroll_layer).y;
+    if (content_h > frame_h && offset_y > 0 && menu_layer->selection.y == 0) {
+      // Pulled past the top with the first cell selected: extend up to the viewport top.
+      frame.origin.y = (int16_t)-offset_y;
+      frame.size.h += offset_y;
+      stretched = true;
+    } else if (content_h > frame_h && offset_y < min_y &&
+               prv_menu_index_is_last_index(menu_layer, &menu_layer->selection.index)) {
+      // Pulled past the bottom with the last cell selected: extend down to the viewport bottom
+      // (covering the bottom padding on the way).
+      frame.size.h = (int16_t)(frame_h - offset_y) - frame.origin.y;
+      stretched = true;
+    }
+  }
+  if (!stretched && !menu_layer->overscroll_stretched) {
+    return;  // never disturb the inverter (selection animations own it) unless we stretched it
+  }
+  if (stretched && !menu_layer->overscroll_stretched) {
+    prv_cancel_selection_animation(menu_layer);  // the pull owns the highlight now
+  }
+  menu_layer->overscroll_stretched = stretched;
+  if (!grect_equal(&menu_layer->inverter.layer.frame, &frame)) {
+    menu_layer->inverter.layer.frame = frame;
+    menu_layer->inverter.layer.bounds.size = frame.size;
+    layer_mark_dirty(&menu_layer->inverter.layer);
+  }
 }
 
 typedef struct MenuHitTestIterator {

--- a/src/fw/applib/ui/menu_layer.c
+++ b/src/fw/applib/ui/menu_layer.c
@@ -1758,19 +1758,24 @@ bool menu_layer_touch_is_gesture_target(const MenuLayer *menu_layer) {
 // ---------------------------------------------------------------------------------------------
 // Coordinate helpers and hit-test
 
-static int16_t prv_menu_touch_clamp_offset_y(MenuLayer *menu_layer, int16_t y) {
+static void prv_menu_touch_offset_bounds(MenuLayer *menu_layer, int16_t *min_y, int16_t *max_y) {
   // Coarse bounds: [min(frame_h - content_h, 0), 0]. With content shorter than the viewport the
   // lower bound is 0 (via the min()). center_focused widens both ends by half a frame so the first
   // and last rows can reach the centre (the scroll layer itself does not clip in that mode).
   const int16_t frame_h = menu_layer->scroll_layer.layer.frame.size.h;
   const int16_t content_h = scroll_layer_get_content_size(&menu_layer->scroll_layer).h;
-  int16_t min_y = MIN((int16_t)(frame_h - content_h), (int16_t)0);
-  int16_t max_y = 0;
+  *min_y = MIN((int16_t)(frame_h - content_h), (int16_t)0);
+  *max_y = 0;
   if (menu_layer->center_focused) {
     const int16_t widen = frame_h / 2;
-    min_y -= widen;
-    max_y += widen;
+    *min_y -= widen;
+    *max_y += widen;
   }
+}
+
+static int16_t prv_menu_touch_clamp_offset_y(MenuLayer *menu_layer, int16_t y) {
+  int16_t min_y, max_y;
+  prv_menu_touch_offset_bounds(menu_layer, &min_y, &max_y);
   return CLIP(y, min_y, max_y);
 }
 
@@ -1959,13 +1964,29 @@ void menu_layer_touch_handle_touchdown(MenuLayer *menu_layer) {
 
 void menu_layer_touch_handle_pan_update(MenuLayer *menu_layer, GPoint base,
                                         GPoint delta_since_start) {
-  const int16_t new_y = prv_menu_touch_clamp_offset_y(menu_layer, base.y + delta_since_start.y);
+  int16_t min_y, max_y;
+  prv_menu_touch_offset_bounds(menu_layer, &min_y, &max_y);
+  const int32_t raw_y = (int32_t)base.y + delta_since_start.y;
+  const int16_t frame_h = menu_layer->scroll_layer.layer.frame.size.h;
+  // Past an edge the pan rubber-bands: the excess is damped instead of hard-clamped. Content
+  // that fits the frame keeps the hard clamp (nothing to scroll, nothing to bounce).
+  const bool scrollable = scroll_layer_get_content_size(&menu_layer->scroll_layer).h > frame_h;
+  const int16_t new_y = scrollable
+      ? scroll_layer_touch_overscroll_damp(raw_y, min_y, max_y, frame_h)
+      : (int16_t)CLIP(raw_y, min_y, max_y);
   prv_scrollbar_kick(menu_layer);
-  scroll_layer_set_content_offset(&menu_layer->scroll_layer, GPoint(0, new_y), false);
+  scroll_layer_touch_set_content_offset_overscrolled(&menu_layer->scroll_layer, new_y);
   if (menu_layer->center_focused) {
     prv_menu_touch_track_center_row(menu_layer);
   }
   // Plain menus: selection intentionally NOT touched — a pan scrolls, a tap selects.
+}
+
+static void prv_menu_touch_spring_back_stopped(Animation *animation, bool finished,
+                                               void *context) {
+  (void)animation;
+  (void)finished;
+  scroll_layer_touch_fling_cleanup(&((MenuLayer *)context)->scroll_layer);
 }
 
 static void prv_menu_touch_fling_stopped(Animation *animation, bool finished, void *context) {
@@ -1998,6 +2019,16 @@ void menu_layer_touch_handle_snap(MenuLayer *menu_layer, GPoint base, GPoint fin
                                   GPoint velocity) {
   const int16_t new_y = prv_menu_touch_clamp_offset_y(menu_layer, base.y + final_delta.y);
   prv_scrollbar_kick(menu_layer);
+  const int16_t current_y = scroll_layer_get_content_offset(&menu_layer->scroll_layer).y;
+  if (!menu_layer->center_focused &&
+      current_y != prv_menu_touch_clamp_offset_y(menu_layer, current_y)) {
+    // Rubber-banded past an edge: glide back to it regardless of velocity (a coast from out of
+    // bounds would be clipped to the edge on its first frame by the standard animation setter).
+    // Center-focused menus don't take this path: their settle-to-center below glides them back.
+    scroll_layer_touch_overscroll_spring_back(&menu_layer->scroll_layer, new_y,
+                                              prv_menu_touch_spring_back_stopped, menu_layer);
+    return;
+  }
   const int32_t v = CLIP((int32_t)velocity.y, -TOUCH_FLING_MAX_VELOCITY_PX_S,
                          TOUCH_FLING_MAX_VELOCITY_PX_S);
   if (ABS(v) >= TOUCH_FLING_MIN_VELOCITY_PX_S) {
@@ -2025,8 +2056,14 @@ void menu_layer_touch_handle_snap(MenuLayer *menu_layer, GPoint base, GPoint fin
 
 void menu_layer_touch_handle_cancel(MenuLayer *menu_layer) {
   if (!menu_layer->center_focused) {
-    // The selection never moved during the pan and the content is already settled, so a cancelled
-    // pan has nothing to do.
+    // The selection never moved during the pan and the content is already settled; only a
+    // rubber-banded offset needs restoring -- instantly, since a cancel is a handover that must
+    // not leave an animation running.
+    const int16_t y = scroll_layer_get_content_offset(&menu_layer->scroll_layer).y;
+    const int16_t clamped_y = prv_menu_touch_clamp_offset_y(menu_layer, y);
+    if (y != clamped_y) {
+      scroll_layer_set_content_offset(&menu_layer->scroll_layer, GPoint(0, clamped_y), false);
+    }
     return;
   }
   // A cancel means something else took over (gesture steal, window change): leave the carousel in

--- a/src/fw/applib/ui/menu_layer.c
+++ b/src/fw/applib/ui/menu_layer.c
@@ -65,7 +65,7 @@ static bool prv_cancel_selection_animation(MenuLayer *menu_layer);
 //! How long the scrollbar overlay stays visible after the last touch scroll movement.
 #define MENU_LAYER_SCROLLBAR_HIDE_TIMEOUT_MS 1000
 #define MENU_LAYER_SCROLLBAR_WIDTH 3
-#define MENU_LAYER_SCROLLBAR_MARGIN 2
+#define MENU_LAYER_SCROLLBAR_MARGIN 1
 #define MENU_LAYER_SCROLLBAR_MIN_THUMB_HEIGHT 8
 
 static void prv_scrollbar_cancel_hide_timer(MenuLayer *menu_layer) {
@@ -146,21 +146,34 @@ static void prv_scrollbar_fill_capped_arc(GContext *ctx, GPoint center, uint16_t
   }
 }
 
+//! The subdued color of the full-length track behind the thumb: the gray nearer the menu's
+//! background, so the track reads as a guide while the foreground-colored thumb pops.
+static GColor prv_scrollbar_track_color(MenuLayer *menu_layer) {
+  const GColor bg = menu_layer->normal_colors[MenuLayerColorBackground];
+  const int luminance = bg.r + bg.g + bg.b;  // 2-bit channels, 0..9
+  return (luminance >= 5) ? GColorLightGray : GColorDarkGray;
+}
+
 static void prv_scrollbar_draw(MenuLayer *menu_layer, GContext *ctx, int16_t content_top_y) {
   int32_t angle_start, angle_end;
   if (!prv_scrollbar_thumb_angles(menu_layer, content_top_y, &angle_start, &angle_end)) {
     return;
   }
-  const GSize frame_size = menu_layer->scroll_layer.layer.frame.size;
-  // Drawing happens in content space: the viewport center is offset by content_top_y.
-  const GPoint center = GPoint(frame_size.w / 2, content_top_y + (frame_size.h / 2));
-  const uint16_t radius_outer =
-      (MIN(frame_size.w, frame_size.h) / 2) - MENU_LAYER_SCROLLBAR_MARGIN;
-  // 1px halo around the thumb (rounded caps included) so it stays visible over both normal and
-  // highlighted cells
-  graphics_context_set_fill_color(ctx, menu_layer->normal_colors[MenuLayerColorBackground]);
-  prv_scrollbar_fill_capped_arc(ctx, center, radius_outer + 1, MENU_LAYER_SCROLLBAR_WIDTH + 2,
-                                angle_start, angle_end);
+  // The arc hugs the physical display circle, not the menu frame: a menu inset by a status bar
+  // would otherwise float the arc well into the content. Map the display centre into the content
+  // space this proc draws in (content_top_y cancels the scroll offset; the global frame supplies
+  // the menu's position on screen).
+  GRect global_frame;
+  layer_get_global_frame(&menu_layer->scroll_layer.layer, &global_frame);
+  const GPoint center = GPoint((DISP_COLS / 2) - global_frame.origin.x,
+                               content_top_y + ((DISP_ROWS / 2) - global_frame.origin.y));
+  const uint16_t radius_outer = (MIN(DISP_COLS, DISP_ROWS) / 2) - MENU_LAYER_SCROLLBAR_MARGIN;
+  // The full track first, subdued, so the thumb reads as a position within it; the track also
+  // provides the contrast backing for the thumb, so no halo is needed.
+  const int32_t track_start = DEG_TO_TRIGANGLE(90) - (MENU_LAYER_SCROLLBAR_TRACK_SWEEP / 2);
+  graphics_context_set_fill_color(ctx, prv_scrollbar_track_color(menu_layer));
+  prv_scrollbar_fill_capped_arc(ctx, center, radius_outer, MENU_LAYER_SCROLLBAR_WIDTH,
+                                track_start, track_start + MENU_LAYER_SCROLLBAR_TRACK_SWEEP);
   graphics_context_set_fill_color(ctx, menu_layer->normal_colors[MenuLayerColorForeground]);
   prv_scrollbar_fill_capped_arc(ctx, center, radius_outer, MENU_LAYER_SCROLLBAR_WIDTH,
                                 angle_start, angle_end);

--- a/src/fw/applib/ui/menu_layer.c
+++ b/src/fw/applib/ui/menu_layer.c
@@ -47,6 +47,8 @@ static void prv_menu_touch_nav_register(MenuLayer *menu_layer);
 static void prv_menu_touch_nav_deregister(MenuLayer *menu_layer);
 static void prv_menu_touch_track_center_row(MenuLayer *menu_layer);
 static void prv_menu_update_overscroll_stretch(MenuLayer *menu_layer);
+static void prv_menu_touch_pin_center_highlight(MenuLayer *menu_layer);
+static void prv_menu_touch_update_center_pin(MenuLayer *menu_layer);
 #endif
 
 //! @return True if there was an animation to cancel, false otherwise
@@ -224,8 +226,12 @@ static void prv_menu_scroll_offset_changed_handler(ScrollLayer *scroll_layer,
     // contract).
     if (menu_layer->center_focused) {
       prv_menu_touch_track_center_row(menu_layer);
+      menu_layer->touch_center_pin = true;
     }
   }
+  // Re-derive the pinned centre highlight after any offset change (coast frames, the
+  // settle-to-center glide, and a cancel's instant re-centre alike).
+  prv_menu_touch_update_center_pin(menu_layer);
 #endif
 }
 
@@ -1478,6 +1484,8 @@ static void prv_apply_selection_change(MenuLayer *menu_layer, MenuRowAlign scrol
   // move invalidates the double-tap window, so a stale recorded row cannot be activated (or, if it
   // was deleted, passed out-of-range to select_click). The tap handler re-arms after this returns.
   menu_layer->double_tap_armed = false;
+  // The selection (and its animations) own the highlight again.
+  menu_layer->touch_center_pin = false;
 #endif
   if (menu_layer->center_focused && animated) {
     prv_schedule_center_focus_animation(menu_layer, up, prev_selection, was_animating);
@@ -1782,16 +1790,23 @@ bool menu_layer_touch_is_gesture_target(const MenuLayer *menu_layer) {
 
 static void prv_menu_touch_offset_bounds(MenuLayer *menu_layer, int16_t *min_y, int16_t *max_y) {
   // Coarse bounds: [min(frame_h - content_h, 0), 0]. With content shorter than the viewport the
-  // lower bound is 0 (via the min()). center_focused widens both ends by half a frame so the first
-  // and last rows can reach the centre (the scroll layer itself does not clip in that mode).
+  // lower bound is 0 (via the min()). center_focused widens both ends so the first and last rows
+  // can reach the centre (the scroll layer itself does not clip in that mode): exactly to the
+  // terminal row's centred rest offset when it is the selection -- the case whenever these
+  // bounds actually clamp, so free travel ends where a button step would rest -- and coarsely by
+  // half a frame otherwise (mid-list, where the bounds are not in play).
   const int16_t frame_h = menu_layer->scroll_layer.layer.frame.size.h;
   const int16_t content_h = scroll_layer_get_content_size(&menu_layer->scroll_layer).h;
   *min_y = MIN((int16_t)(frame_h - content_h), (int16_t)0);
   *max_y = 0;
   if (menu_layer->center_focused) {
-    const int16_t widen = frame_h / 2;
-    *min_y -= widen;
-    *max_y += widen;
+    const int16_t sel_rest_y = (int16_t)((frame_h - menu_layer->selection.h) / 2);
+    *max_y = prv_menu_index_is_first_index(menu_layer, &menu_layer->selection.index)
+        ? sel_rest_y
+        : (int16_t)(frame_h / 2);
+    *min_y = prv_menu_index_is_last_index(menu_layer, &menu_layer->selection.index)
+        ? (int16_t)(sel_rest_y - menu_layer->selection.y)
+        : (int16_t)(*min_y - (frame_h / 2));
   }
 }
 
@@ -2005,6 +2020,53 @@ static void prv_menu_touch_settle_to_center(MenuLayer *menu_layer, bool animated
 // ---------------------------------------------------------------------------------------------
 // Gesture handlers (also the unit-test entry surface)
 
+//! While a touch gesture (pan, coast, or the settle that follows) drives a carousel, the
+//! selection highlight is pinned to the viewport centre: rows slide through the fixed box, the
+//! way button steps look, instead of the box travelling with the selected row and jumping at
+//! every crossing. The pin releases itself lazily: the moment the pinned frame coincides with
+//! the settled selection's own frame (the row reached the centre), the highlight is back in its
+//! normal selection-owned state.
+static void prv_menu_touch_update_center_pin(MenuLayer *menu_layer) {
+  if (!menu_layer->touch_center_pin) {
+    return;
+  }
+  const GSize frame_size = menu_layer->scroll_layer.layer.frame.size;
+  const int16_t offset_y = scroll_layer_get_content_offset(&menu_layer->scroll_layer).y;
+  int16_t pinned_y = (int16_t)(-offset_y + ((frame_size.h - menu_layer->selection.h) / 2));
+  // Past the ends there is no next row to transit to: the box glues to the terminal row and
+  // moves together with the rubber-banded pull instead of hovering over the exposed gap. (In
+  // transit near a terminal row the inequality points the other way, so this never engages.)
+  if ((pinned_y < menu_layer->selection.y &&
+       prv_menu_index_is_first_index(menu_layer, &menu_layer->selection.index)) ||
+      (pinned_y > menu_layer->selection.y &&
+       prv_menu_index_is_last_index(menu_layer, &menu_layer->selection.index))) {
+    pinned_y = menu_layer->selection.y;
+  }
+  const GRect pinned = (GRect) {
+    .origin = { 0, pinned_y },
+    .size = { frame_size.w, menu_layer->selection.h },
+  };
+  if (pinned.origin.y == menu_layer->selection.y) {
+    // At rest: the selected row is centred, so the pinned frame and the natural frame are one.
+    menu_layer->touch_center_pin = false;
+  }
+  if (!grect_equal(&menu_layer->inverter.layer.frame, &pinned)) {
+    menu_layer->inverter.layer.frame = pinned;
+    menu_layer->inverter.layer.bounds.size = pinned.size;
+    layer_mark_dirty(&menu_layer->inverter.layer);
+  }
+}
+
+static void prv_menu_touch_pin_center_highlight(MenuLayer *menu_layer) {
+  if (!menu_layer->touch_center_pin) {
+    // Taking the highlight over also stops a running selection (bump) animation from fighting
+    // the pin.
+    prv_cancel_selection_animation(menu_layer);
+    menu_layer->touch_center_pin = true;
+  }
+  prv_menu_touch_update_center_pin(menu_layer);
+}
+
 void menu_layer_touch_handle_touchdown(MenuLayer *menu_layer) {
   // Finger down while the content is coasting: catch it. The tap this gesture may become is then a
   // stop, not a select. The flag is ASSIGNED (never OR-ed) so it always reflects this gesture: a
@@ -2045,6 +2107,7 @@ void menu_layer_touch_handle_pan_update(MenuLayer *menu_layer, GPoint base,
   scroll_layer_touch_set_content_offset_overscrolled(&menu_layer->scroll_layer, new_y);
   if (menu_layer->center_focused) {
     prv_menu_touch_track_center_row(menu_layer);
+    prv_menu_touch_pin_center_highlight(menu_layer);
   }
   // Plain menus: selection intentionally NOT touched — a pan scrolls, a tap selects.
 }

--- a/src/fw/applib/ui/menu_layer.h
+++ b/src/fw/applib/ui/menu_layer.h
@@ -505,6 +505,13 @@ typedef struct MenuLayer {
   //! into \ref touch_fling_active's byte.
   bool overscroll_stretched:1;
 
+  //! @internal
+  //! True while a touch gesture (pan, coast, or the settle that follows) pins a center-focused
+  //! menu's selection highlight to the viewport centre, so rows slide through the fixed box the
+  //! way button steps look. Cleared lazily when the settling row lands in the box. Packs into
+  //! \ref touch_fling_active's byte.
+  bool touch_center_pin:1;
+
   //! Add some padding to keep track of the \ref MenuLayer size budget.
   //! As long as the size stays within this budget, 2.x apps can safely use the 3.x MenuLayer type.
   //! The actual size check is generated from applib_malloc.json, not asserted here.

--- a/src/fw/applib/ui/menu_layer.h
+++ b/src/fw/applib/ui/menu_layer.h
@@ -428,6 +428,12 @@ typedef struct MenuLayer {
   MenuIndex last_selected_index;
 
   //! @internal
+  //! Timer that hides the transient scrollbar overlay shortly after scrolling stops. Carved from
+  //! \ref padding (4-byte aligned here, like \ref touch_nav_node) so \c sizeof(MenuLayer) stays
+  //! within the fixed applib-malloc budget.
+  AppTimer *scrollbar_hide_timer;
+
+  //! @internal
   //! If true, there will be padding after the bottom item in the menu
   //! Defaults to 'true'
   bool pad_bottom:1;
@@ -483,10 +489,20 @@ typedef struct MenuLayer {
   //! \ref menu_layer_set_tap_select_only. Packs into \ref touch_fling_active's byte.
   bool tap_select_only:1;
 
+  //! If true, the transient scrollbar overlay is never shown. See
+  //! \ref menu_layer_set_scrollbar_hidden. Packs into \ref touch_fling_active's byte.
+  bool scrollbar_hidden:1;
+
+  //! @internal
+  //! True while the scrollbar overlay is drawn: set while a touch gesture (pan or inertial coast)
+  //! scrolls the content, cleared when \ref scrollbar_hide_timer fires. Packs into
+  //! \ref touch_fling_active's byte.
+  bool scrollbar_visible:1;
+
   //! Add some padding to keep track of the \ref MenuLayer size budget.
   //! As long as the size stays within this budget, 2.x apps can safely use the 3.x MenuLayer type.
   //! The actual size check is generated from applib_malloc.json, not asserted here.
-  uint8_t padding[19];
+  uint8_t padding[15];
 } MenuLayer;
 
 //! Padding used below the last item in pixels
@@ -693,6 +709,15 @@ bool menu_layer_get_center_focused(MenuLayer *menu_layer);
 //! @param center_focused true = enable the mode, false = disable it.
 //! @see \ref menu_layer_get_center_focused
 void menu_layer_set_center_focused(MenuLayer *menu_layer, bool center_focused);
+
+//! Controls whether the \ref MenuLayer shows a transient scrollbar overlay while touch scrolling
+//! (default: shown). The scrollbar appears while a touch gesture (pan or inertial coast) scrolls
+//! content taller than the frame, and hides again shortly after the movement stops. Button
+//! scrolling never shows it. On rectangular displays it is a straight bar on the right edge; on
+//! round displays it is an arc hugging the display edge. Only available on touch-capable builds.
+//! @param menu_layer The menu layer for which to set the scrollbar visibility.
+//! @param hidden true = never show the scrollbar, false (default) = show it while scrolling.
+void menu_layer_set_scrollbar_hidden(MenuLayer *menu_layer, bool hidden);
 
 //! @internal
 //! On a plain (non-center-focused) menu a touch tap on a not-selected row selects it and activates

--- a/src/fw/applib/ui/menu_layer.h
+++ b/src/fw/applib/ui/menu_layer.h
@@ -499,6 +499,12 @@ typedef struct MenuLayer {
   //! \ref touch_fling_active's byte.
   bool scrollbar_visible:1;
 
+  //! @internal
+  //! True while a touch overscroll stretches the selection background to the viewport edge.
+  //! Derived purely from the (rubber-banded) scroll offset in the offset-changed handler. Packs
+  //! into \ref touch_fling_active's byte.
+  bool overscroll_stretched:1;
+
   //! Add some padding to keep track of the \ref MenuLayer size budget.
   //! As long as the size stays within this budget, 2.x apps can safely use the 3.x MenuLayer type.
   //! The actual size check is generated from applib_malloc.json, not asserted here.

--- a/src/fw/applib/ui/menu_layer_private.h
+++ b/src/fw/applib/ui/menu_layer_private.h
@@ -50,7 +50,8 @@ bool menu_layer_touch_find_row_at_content_y(MenuLayer *menu_layer, int16_t conte
 //! carousel the catch glides into the nearest row centre instead of dead-stopping off-grid.
 void menu_layer_touch_handle_touchdown(MenuLayer *menu_layer);
 
-//! Live scroll during a pan: move the content to \a base + \a delta_since_start, coarsely clamped.
+//! Live scroll during a pan: move the content to \a base + \a delta_since_start; past the coarse
+//! bounds it rubber-bands (damped overscroll) instead of hard-clamping, springing back on liftoff.
 //! On a plain menu the selection index is intentionally left unchanged. On a center-focused menu
 //! the focus stays pinned at the viewport centre: the row crossing the centre becomes the
 //! selection live, through the full selection_will_change contract (veto/redirect honoured).

--- a/src/fw/applib/ui/scroll_layer.c
+++ b/src/fw/applib/ui/scroll_layer.c
@@ -153,8 +153,20 @@ static int16_t prv_scroll_touch_clamp_offset_y(ScrollLayer *scroll_layer, int16_
 
 void scroll_layer_touch_handle_pan_update(ScrollLayer *scroll_layer, GPoint base,
                                           GPoint delta_since_start) {
-  const int16_t new_y = prv_scroll_touch_clamp_offset_y(scroll_layer, base.y + delta_since_start.y);
-  scroll_layer_set_content_offset(scroll_layer, GPoint(0, new_y), false);
+  const int32_t raw_y = (int32_t)base.y + delta_since_start.y;
+  const int16_t frame_h = scroll_layer->layer.frame.size.h;
+  const int16_t content_h = scroll_layer_get_content_size(scroll_layer).h;
+  // Paging layers keep the hard clamp (rubber-banding would fight page alignment); so does
+  // content that fits the frame (nothing to scroll, nothing to bounce).
+  if (scroll_layer_get_paging(scroll_layer) || content_h <= frame_h) {
+    const int16_t clamped_y = prv_scroll_touch_clamp_offset_y(
+        scroll_layer, (int16_t)CLIP(raw_y, INT16_MIN, INT16_MAX));
+    scroll_layer_set_content_offset(scroll_layer, GPoint(0, clamped_y), false);
+    return;
+  }
+  const int16_t min_y = MIN((int16_t)(frame_h - content_h), (int16_t)0);
+  const int16_t new_y = scroll_layer_touch_overscroll_damp(raw_y, min_y, 0, frame_h);
+  scroll_layer_touch_set_content_offset_overscrolled(scroll_layer, new_y);
 }
 
 static void prv_scroll_touch_fling_stopped(Animation *animation, bool finished, void *context) {
@@ -167,6 +179,14 @@ void scroll_layer_touch_handle_snap(ScrollLayer *scroll_layer, GPoint base, GPoi
                                     GPoint velocity) {
   const int16_t released_y = prv_scroll_touch_clamp_offset_y(scroll_layer,
                                                              base.y + final_delta.y);
+  const int16_t current_y = scroll_layer_get_content_offset(scroll_layer).y;
+  if (current_y != prv_scroll_touch_clamp_offset_y(scroll_layer, current_y)) {
+    // Rubber-banded past an edge: glide back to it regardless of velocity (a coast from out of
+    // bounds would be clipped to the edge on its first frame by the standard animation setter).
+    scroll_layer_touch_overscroll_spring_back(scroll_layer, released_y,
+                                              prv_scroll_touch_fling_stopped, scroll_layer);
+    return;
+  }
   // Coast: project where the finger's velocity carries the content and decelerate there. The
   // coast starts from the current (last throttled) offset, so the unthrottled residual is
   // absorbed into the animation instead of jumping instantly at liftoff. Paging keeps its snap
@@ -234,6 +254,14 @@ void scroll_layer_touch_handle_touchdown(ScrollLayer *scroll_layer) {
   }
   // A fling caught before its first frame never ran its stopped handler; restore explicitly.
   scroll_layer_touch_fling_cleanup(scroll_layer);
+  // A catch mid-spring-back must not freeze the content out of bounds (a tap never settles it):
+  // restart the glide; a pan taking over unschedules it with the base latched.
+  const int16_t y = scroll_layer_get_content_offset(scroll_layer).y;
+  const int16_t clamped_y = prv_scroll_touch_clamp_offset_y(scroll_layer, y);
+  if (y != clamped_y) {
+    scroll_layer_touch_overscroll_spring_back(scroll_layer, clamped_y,
+                                              prv_scroll_touch_fling_stopped, scroll_layer);
+  }
 }
 
 static void prv_scroll_ops_touchdown(void *w) {
@@ -260,8 +288,14 @@ static void prv_scroll_ops_pan_snap(void *w, GPoint base, GPoint final_delta, GP
 }
 
 static void prv_scroll_ops_pan_cancel(void *w) {
-  // The content is already settled from the last Updated; a cancelled pan has nothing to undo.
-  (void)w;
+  // The content is already settled from the last Updated; only a rubber-banded offset needs
+  // restoring -- instantly, since a cancel is a handover that must not leave an animation running.
+  ScrollLayer *scroll_layer = w;
+  const int16_t y = scroll_layer_get_content_offset(scroll_layer).y;
+  const int16_t clamped_y = prv_scroll_touch_clamp_offset_y(scroll_layer, y);
+  if (y != clamped_y) {
+    scroll_layer_set_content_offset(scroll_layer, GPoint(0, clamped_y), false);
+  }
 }
 
 static void prv_scroll_ops_swipe(void *w, SwipeDirection dir) {
@@ -466,6 +500,98 @@ void scroll_layer_set_content_offset(ScrollLayer *scroll_layer, GPoint offset, b
 }
 
 #ifdef CONFIG_TOUCH
+//! Apply a touch-overscrolled content offset, bypassing the clamp that
+//! prv_scroll_layer_set_content_offset_internal applies when offset clipping is enabled (the
+//! clamp would swallow the rubber-band excess every frame).
+static void prv_set_content_offset_overscrolled_internal(ScrollLayer *scroll_layer,
+                                                         GPoint offset) {
+  GRect bounds = scroll_layer->content_sublayer.bounds;
+  const GPoint old_offset = bounds.origin;
+  bounds.origin = offset;
+  if (gpoint_equal(&old_offset, &bounds.origin)) {
+    scroll_layer_update_content_indicator(scroll_layer);
+    return;
+  }
+  layer_set_bounds(&scroll_layer->content_sublayer, &bounds);
+  scroll_layer_update_content_indicator(scroll_layer);
+  if (scroll_layer->callbacks.content_offset_changed_handler) {
+    scroll_layer->callbacks.content_offset_changed_handler(scroll_layer,
+                                                           get_callback_context(scroll_layer));
+  }
+}
+
+//! Animation impl for the overscroll spring-back: same shape as
+//! s_content_offset_animation_impl but with the unclamped setter, so intermediate out-of-bounds
+//! frames glide instead of being clipped to the edge on the first frame.
+static const PropertyAnimationImplementation s_overscroll_offset_animation_impl = {
+  .base = {
+    .update = (AnimationUpdateImplementation) property_animation_update_gpoint,
+  },
+  .accessors = {
+    .setter = { .grect =
+        (const GRectSetter) (void *) prv_set_content_offset_overscrolled_internal, },
+    .getter = { .grect = (const GRectGetter) (void *) scroll_layer_get_content_offset, },
+  },
+};
+
+int16_t scroll_layer_touch_overscroll_damp(int32_t raw_y, int16_t min_y, int16_t max_y,
+                                           int16_t frame_h) {
+  int32_t excess;
+  int16_t edge, sign;
+  if (raw_y > max_y) {
+    excess = raw_y - max_y;
+    edge = max_y;
+    sign = 1;
+  } else if (raw_y < min_y) {
+    excess = min_y - raw_y;
+    edge = min_y;
+    sign = -1;
+  } else {
+    return (int16_t)raw_y;
+  }
+  // Asymptotic rubber band: the content follows at half the finger's speed at first and
+  // saturates at ~1/6 of the frame height.
+  const int32_t max_over = MAX(frame_h / 6, 1);
+  const int32_t damped = (excess * max_over) / (excess + (2 * max_over));
+  return (int16_t)(edge + (sign * damped));
+}
+
+void scroll_layer_touch_set_content_offset_overscrolled(ScrollLayer *scroll_layer, int16_t y) {
+  Animation *animation = property_animation_get_animation(scroll_layer->animation);
+  if (animation && animation_is_scheduled(animation)) {
+    animation_unschedule(animation);
+  }
+  prv_set_content_offset_overscrolled_internal(scroll_layer, GPoint(0, y));
+}
+
+void scroll_layer_touch_overscroll_spring_back(ScrollLayer *scroll_layer, int16_t target_y,
+                                               AnimationStoppedHandler stopped,
+                                               void *stopped_context) {
+  const GPoint target = GPoint(0, target_y);
+  Animation *animation = property_animation_get_animation(scroll_layer->animation);
+  if (animation) {
+    if (animation_is_scheduled(animation)) {
+      animation_unschedule(animation);
+    }
+    property_animation_init(scroll_layer->animation, &s_overscroll_offset_animation_impl,
+                            scroll_layer, NULL, (void *)&target);
+  } else {
+    scroll_layer->animation = property_animation_create(&s_overscroll_offset_animation_impl,
+                                                        scroll_layer, NULL, (void *)&target);
+    if (!scroll_layer->animation) {
+      // No animation available: land on the edge instantly rather than staying out of bounds.
+      prv_set_content_offset_overscrolled_internal(scroll_layer, target);
+      return;
+    }
+    animation = property_animation_get_animation(scroll_layer->animation);
+    animation_set_auto_destroy(animation, false);
+  }
+  animation_set_duration(animation, TOUCH_OVERSCROLL_SPRING_BACK_MS);
+  animation_set_curve(animation, AnimationCurveEaseOut);
+  animation_set_handlers(animation, (AnimationHandlers) { .stopped = stopped }, stopped_context);
+  animation_schedule(animation);
+}
+
 // Cubic ease-out in AnimationProgress space: f(t) = 1 - (1 - t)^3. Compared to the stock
 // quadratic EaseOut it brakes harder early and glides out longer, so a fast coast tapers off
 // instead of stopping dead.

--- a/src/fw/applib/ui/scroll_layer_private.h
+++ b/src/fw/applib/ui/scroll_layer_private.h
@@ -19,8 +19,10 @@
 //! restore the shared animation's fling defaults.
 void scroll_layer_touch_handle_touchdown(ScrollLayer *scroll_layer);
 
-//! Live scroll during a pan: move the content to \a base + \a delta_since_start on the y axis,
-//! clamped to [min(frame_h - content_h, 0), 0].
+//! Live scroll during a pan: move the content to \a base + \a delta_since_start on the y axis.
+//! Within [min(frame_h - content_h, 0), 0] the content follows 1:1; past an edge it rubber-bands
+//! (damped overscroll, see \ref scroll_layer_touch_overscroll_damp). Paging layers keep the hard
+//! clamp.
 void scroll_layer_touch_handle_pan_update(ScrollLayer *scroll_layer, GPoint base,
                                           GPoint delta_since_start);
 
@@ -42,6 +44,31 @@ void scroll_layer_touch_handle_snap(ScrollLayer *scroll_layer, GPoint base, GPoi
 #define TOUCH_FLING_MIN_DURATION_MS 100
 #define TOUCH_FLING_MAX_DURATION_MS (3 * TOUCH_FLING_TAU_MS)
 #define TOUCH_FLING_MIN_DISTANCE_PX 3
+
+//! How long the animated return from a rubber-band overscroll takes.
+#define TOUCH_OVERSCROLL_SPRING_BACK_MS 200
+
+//! Rubber-band overscroll mapping for a held pan: offsets inside [min_y, max_y] pass through;
+//! beyond an edge the excess is damped asymptotically (half the finger's speed at first,
+//! saturating at ~1/6 of \a frame_h), so the content can be pulled a little past the edge.
+//! \a raw_y is 32-bit so callers can pass base + delta unclamped.
+int16_t scroll_layer_touch_overscroll_damp(int32_t raw_y, int16_t min_y, int16_t max_y,
+                                           int16_t frame_h);
+
+//! @internal
+//! Set the content offset to \a y without the [min, 0] clamp of the regular setter (which would
+//! swallow a rubber-banded offset every frame). Unschedules a running scroll animation, like the
+//! non-animated regular setter. Touch pan updates only.
+void scroll_layer_touch_set_content_offset_overscrolled(ScrollLayer *scroll_layer, int16_t y);
+
+//! @internal
+//! Animated glide from a rubber-banded offset back to \a target_y (the edge). Runs on the shared
+//! scroll animation with an unclamped setter -- the standard animation would clip its very first
+//! out-of-bounds frame to the edge and snap. \a stopped runs when the glide ends (finished or
+//! unscheduled) and MUST call scroll_layer_touch_fling_cleanup(), like a fling's stopped handler.
+void scroll_layer_touch_overscroll_spring_back(ScrollLayer *scroll_layer, int16_t target_y,
+                                               AnimationStoppedHandler stopped,
+                                               void *stopped_context);
 
 //! @internal
 //! Start an inertial coast on the shared scroll animation toward \a target_y (already clamped by

--- a/tests/fw/ui/test_action_menu_layer.c
+++ b/tests/fw/ui/test_action_menu_layer.c
@@ -20,6 +20,7 @@
 // Stubs
 /////////////////////
 #include "stubs_app_state.h"
+#include "stubs_app_timer.h"
 #include "stubs_click.h"
 #include "stubs_fonts.h"
 #include "stubs_graphics.h"

--- a/tests/fw/ui/test_menu_layer.c
+++ b/tests/fw/ui/test_menu_layer.c
@@ -1207,13 +1207,14 @@ void test_menu_layer__touch_clamp_center_focused_widens(void) {
   menu_layer_reload_data(&l);
   const int16_t frame_h = l.scroll_layer.layer.frame.size.h;
   const int16_t content_h = scroll_layer_get_content_size(&l.scroll_layer).h;
-  const int16_t widened_max = frame_h / 2;
+  // With the first row selected the top bound is its exact centred rest offset; the selection is
+  // not the last row, so the bottom bound keeps the coarse half-frame widen.
+  const int16_t widened_max = (int16_t)((frame_h - 44) / 2);
   const int16_t widened_min =
       MIN((int16_t)(frame_h - content_h), (int16_t)0) - (int16_t)(frame_h / 2);
 
-  // center_focused widens the coarse bounds by frame_h/2 (=90), so a positive offset up to +90
-  // scrolls freely where a normal menu would stop at 0; past the widened edge the pan
-  // rubber-bands by the shared damp mapping instead of hard-clamping.
+  // center_focused widens the bounds so the terminal rows can reach the centre; past the widened
+  // edge the pan rubber-bands by the shared damp mapping instead of hard-clamping.
   menu_layer_touch_handle_pan_update(&l, GPoint(0, 0), GPoint(0, 300));
   cl_assert_equal_i(scroll_layer_get_content_offset(&l.scroll_layer).y,
                     scroll_layer_touch_overscroll_damp(300, widened_min, widened_max, frame_h));

--- a/tests/fw/ui/test_menu_layer.c
+++ b/tests/fw/ui/test_menu_layer.c
@@ -2152,3 +2152,102 @@ void test_menu_layer__overscroll_cancel_restores_instantly(void) {
   cl_assert(!anim || !animation_is_scheduled(anim));
   menu_layer_deinit(&l);
 }
+
+// Overscroll highlight stretch
+//////////////////////
+
+void test_menu_layer__overscroll_stretch_fills_gap_at_top(void) {
+  MenuLayer l;
+  prv_init_scrollbar_menu(&l);
+  const int16_t cell_h = l.selection.h;
+  cl_assert_equal_i(l.selection.y, 0);  // first row selected
+
+  // Pulling past the top rubber-bands the offset; the selection background extends up to the
+  // viewport top so the exposed gap reads as the selected cell stretching.
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, 0), GPoint(0, 50));
+  const int16_t offset_y = scroll_layer_get_content_offset(&l.scroll_layer).y;
+  cl_assert(offset_y > 0);
+  cl_assert(l.overscroll_stretched);
+  cl_assert_equal_i(l.inverter.layer.frame.origin.y, -offset_y);
+  cl_assert_equal_i(l.inverter.layer.frame.size.h, cell_h + offset_y);
+
+  // Tracking the finger back into range restores the natural frame and clears the flag.
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, 0), GPoint(0, -10));
+  cl_assert(!l.overscroll_stretched);
+  cl_assert_equal_i(l.inverter.layer.frame.origin.y, 0);
+  cl_assert_equal_i(l.inverter.layer.frame.size.h, cell_h);
+  menu_layer_deinit(&l);
+}
+
+void test_menu_layer__overscroll_stretch_only_with_edge_row_selected(void) {
+  MenuLayer l;
+  prv_init_scrollbar_menu(&l);
+  menu_layer_set_selected_index(&l, MenuIndex(0, 5), MenuRowAlignTop, false);
+  const int16_t base_y = scroll_layer_get_content_offset(&l.scroll_layer).y;
+  const GRect before = l.inverter.layer.frame;
+
+  // The offset still rubber-bands past the top, but with a mid-list row selected the highlight
+  // is left alone.
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, base_y), GPoint(0, -base_y + 50));
+  cl_assert(scroll_layer_get_content_offset(&l.scroll_layer).y > 0);
+  cl_assert(!l.overscroll_stretched);
+  cl_assert(grect_equal(&l.inverter.layer.frame, &before));
+  menu_layer_deinit(&l);
+}
+
+void test_menu_layer__overscroll_stretch_fills_gap_at_bottom(void) {
+  MenuLayer l;
+  prv_init_scrollbar_menu(&l);
+  const int16_t frame_h = 168;
+  const int16_t min_y = (int16_t)(frame_h - scroll_layer_get_content_size(&l.scroll_layer).h);
+  menu_layer_set_selected_index(&l, MenuIndex(0, 9), MenuRowAlignCenter, false);
+  cl_assert_equal_i(scroll_layer_get_content_offset(&l.scroll_layer).y, min_y);
+
+  // Pulling past the bottom: the highlight extends down to the viewport bottom (covering the
+  // bottom padding on the way), anchored at the cell's top.
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, min_y), GPoint(0, -50));
+  const int16_t offset_y = scroll_layer_get_content_offset(&l.scroll_layer).y;
+  cl_assert(offset_y < min_y);
+  cl_assert(l.overscroll_stretched);
+  cl_assert_equal_i(l.inverter.layer.frame.origin.y, l.selection.y);
+  cl_assert_equal_i(l.inverter.layer.frame.origin.y + l.inverter.layer.frame.size.h,
+                    frame_h - offset_y);  // content-space viewport bottom
+  menu_layer_deinit(&l);
+}
+
+void test_menu_layer__overscroll_stretch_follows_spring_back(void) {
+  MenuLayer l;
+  prv_init_scrollbar_menu(&l);
+  const int16_t cell_h = l.selection.h;
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, 0), GPoint(0, 50));
+  cl_assert(l.overscroll_stretched);
+
+  // Liftoff schedules the offset spring-back toward the edge; the stretch is offset-derived, so
+  // each animation frame shrinks it, and reaching the edge restores the natural frame.
+  menu_layer_touch_handle_snap(&l, GPoint(0, 0), GPoint(0, 50), GPoint(0, 0));
+  cl_assert(animation_is_scheduled(property_animation_get_animation(l.scroll_layer.animation)));
+  cl_assert_equal_i(s_anim_to.y, 0);
+  scroll_layer_touch_set_content_offset_overscrolled(&l.scroll_layer, 5);  // a mid-glide frame
+  cl_assert(l.overscroll_stretched);
+  cl_assert_equal_i(l.inverter.layer.frame.origin.y, -5);
+  scroll_layer_touch_set_content_offset_overscrolled(&l.scroll_layer, 0);  // the glide lands on the edge
+  cl_assert(!l.overscroll_stretched);
+  cl_assert_equal_i(l.inverter.layer.frame.origin.y, 0);
+  cl_assert_equal_i(l.inverter.layer.frame.size.h, cell_h);
+  menu_layer_deinit(&l);
+}
+
+void test_menu_layer__overscroll_stretch_resets_on_cancel(void) {
+  MenuLayer l;
+  prv_init_scrollbar_menu(&l);
+  const int16_t cell_h = l.selection.h;
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, 0), GPoint(0, 50));
+  cl_assert(l.overscroll_stretched);
+
+  // A cancelled gesture restores the offset instantly, and the stretch follows.
+  menu_layer_touch_handle_cancel(&l);
+  cl_assert_equal_i(scroll_layer_get_content_offset(&l.scroll_layer).y, 0);
+  cl_assert(!l.overscroll_stretched);
+  cl_assert_equal_i(l.inverter.layer.frame.size.h, cell_h);
+  menu_layer_deinit(&l);
+}

--- a/tests/fw/ui/test_menu_layer.c
+++ b/tests/fw/ui/test_menu_layer.c
@@ -2100,3 +2100,55 @@ void test_menu_layer__scrollbar_thumb_rect_geometry(void) {
   cl_assert_equal_i(r.origin.y, -40 + 2);
   menu_layer_deinit(&l);
 }
+
+// Overscroll (rubber band)
+//////////////////////
+
+void test_menu_layer__overscroll_pan_rubber_bands_past_top(void) {
+  MenuLayer l;
+  prv_init_scrollbar_menu(&l);
+  const int16_t frame_h = 168;
+  const int16_t content_h = scroll_layer_get_content_size(&l.scroll_layer).h;
+  cl_assert(content_h > frame_h);
+  const int16_t min_y = (int16_t)(frame_h - content_h);
+
+  // A pull past the top follows the shared damp mapping: some movement, but less than the finger.
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, 0), GPoint(0, 50));
+  const int16_t y = scroll_layer_get_content_offset(&l.scroll_layer).y;
+  cl_assert_equal_i(y, scroll_layer_touch_overscroll_damp(50, min_y, 0, frame_h));
+  cl_assert(y > 0);
+  cl_assert(y < 50);
+  menu_layer_deinit(&l);
+}
+
+void test_menu_layer__overscroll_snap_springs_back_to_edge(void) {
+  MenuLayer l;
+  prv_init_scrollbar_menu(&l);
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, 0), GPoint(0, 50));
+  const int16_t overscrolled_y = scroll_layer_get_content_offset(&l.scroll_layer).y;
+  cl_assert(overscrolled_y > 0);
+
+  // Liftoff (even a fast one) glides back to the edge instead of coasting or snapping.
+  menu_layer_touch_handle_snap(&l, GPoint(0, 0), GPoint(0, 50), GPoint(0, 2000));
+  Animation *anim = property_animation_get_animation(l.scroll_layer.animation);
+  cl_assert(anim != NULL);
+  cl_assert(animation_is_scheduled(anim));
+  cl_assert_equal_i(s_anim_to.y, 0);
+  cl_assert(!l.touch_fling_active);  // a spring-back is not a coast
+  // The glide starts from the rubber-banded offset; nothing snapped yet.
+  cl_assert_equal_i(scroll_layer_get_content_offset(&l.scroll_layer).y, overscrolled_y);
+  menu_layer_deinit(&l);
+}
+
+void test_menu_layer__overscroll_cancel_restores_instantly(void) {
+  MenuLayer l;
+  prv_init_scrollbar_menu(&l);
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, 0), GPoint(0, 50));
+  cl_assert(scroll_layer_get_content_offset(&l.scroll_layer).y > 0);
+
+  menu_layer_touch_handle_cancel(&l);
+  cl_assert_equal_i(scroll_layer_get_content_offset(&l.scroll_layer).y, 0);
+  Animation *anim = property_animation_get_animation(l.scroll_layer.animation);
+  cl_assert(!anim || !animation_is_scheduled(anim));
+  menu_layer_deinit(&l);
+}

--- a/tests/fw/ui/test_menu_layer.c
+++ b/tests/fw/ui/test_menu_layer.c
@@ -1963,3 +1963,133 @@ void test_menu_layer__touch_catch_center_focused_settles_to_row(void) {
   cl_assert(animation_is_scheduled(anim));
   cl_assert_equal_i(s_anim_to.y, -108);
 }
+
+// Scrollbar overlay
+//////////////////////
+
+GRect prv_scrollbar_thumb_rect(MenuLayer *menu_layer, int16_t content_top_y);
+
+static void prv_init_scrollbar_menu(MenuLayer *l) {
+  menu_layer_init(l, &GRect(0, 0, 144, 168));
+  menu_layer_set_callbacks(l, NULL, &(MenuLayerCallbacks){
+      .draw_row = prv_draw_row,
+      .get_num_rows = prv_get_num_rows,
+  });
+}
+
+void test_menu_layer__scrollbar_shows_on_touch_pan_and_times_out(void) {
+  MenuLayer l;
+  prv_init_scrollbar_menu(&l);
+  cl_assert(!l.scrollbar_visible);
+  cl_assert(l.scrollbar_hide_timer == NULL);
+
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, 0), GPoint(0, -40));
+  cl_assert(l.scrollbar_visible);
+  cl_assert(l.scrollbar_hide_timer != NULL);
+  cl_assert(fake_app_timer_is_scheduled(l.scrollbar_hide_timer));
+
+  cl_assert(app_timer_trigger(l.scrollbar_hide_timer));
+  cl_assert(!l.scrollbar_visible);
+  cl_assert(l.scrollbar_hide_timer == NULL);
+  menu_layer_deinit(&l);
+}
+
+void test_menu_layer__scrollbar_not_shown_on_button_scroll(void) {
+  MenuLayer l;
+  prv_init_scrollbar_menu(&l);
+  // Button scrolling moves the offset through the selection, not a touch gesture
+  menu_layer_set_selected_index(&l, MenuIndex(0, 5), MenuRowAlignTop, false);
+  cl_assert(scroll_layer_get_content_offset(&l.scroll_layer).y < 0);
+  cl_assert(!l.scrollbar_visible);
+  cl_assert(l.scrollbar_hide_timer == NULL);
+  menu_layer_deinit(&l);
+}
+
+void test_menu_layer__scrollbar_not_shown_when_content_fits(void) {
+  s_num_rows = 2;
+  MenuLayer l;
+  prv_init_scrollbar_menu(&l);
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, 0), GPoint(0, -40));
+  cl_assert(!l.scrollbar_visible);
+  cl_assert(l.scrollbar_hide_timer == NULL);
+  menu_layer_deinit(&l);
+}
+
+void test_menu_layer__scrollbar_rearms_timer_while_scrolling(void) {
+  MenuLayer l;
+  prv_init_scrollbar_menu(&l);
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, 0), GPoint(0, -40));
+  AppTimer *timer = l.scrollbar_hide_timer;
+  cl_assert(timer != NULL);
+  // A further pan movement reschedules the same timer instead of registering a new one
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, 0), GPoint(0, -60));
+  cl_assert(l.scrollbar_hide_timer == timer);
+  cl_assert(l.scrollbar_visible);
+  menu_layer_deinit(&l);
+}
+
+void test_menu_layer__scrollbar_kept_alive_by_fling_coast(void) {
+  MenuLayer l;
+  prv_init_scrollbar_menu(&l);
+  // Fast liftoff schedules an inertial coast and shows the scrollbar
+  menu_layer_touch_handle_snap(&l, GPoint(0, -40), GPoint(0, -60), GPoint(0, -500));
+  cl_assert(l.touch_fling_active);
+  cl_assert(l.scrollbar_visible);
+
+  // Even if the hide timer fires mid-coast, the next coast frame re-shows and re-arms it
+  cl_assert(app_timer_trigger(l.scrollbar_hide_timer));
+  cl_assert(!l.scrollbar_visible);
+  prv_scroll_layer_set_content_offset_internal(&l.scroll_layer, GPoint(0, -120));
+  cl_assert(l.scrollbar_visible);
+  cl_assert(l.scrollbar_hide_timer != NULL);
+  menu_layer_deinit(&l);
+}
+
+void test_menu_layer__scrollbar_set_hidden(void) {
+  MenuLayer l;
+  prv_init_scrollbar_menu(&l);
+  menu_layer_set_scrollbar_hidden(&l, true);
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, 0), GPoint(0, -40));
+  cl_assert(!l.scrollbar_visible);
+  cl_assert(l.scrollbar_hide_timer == NULL);
+
+  // Re-enabling shows it on the next touch scroll; hiding while visible clears it immediately
+  menu_layer_set_scrollbar_hidden(&l, false);
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, -40), GPoint(0, -20));
+  cl_assert(l.scrollbar_visible);
+  AppTimer *timer = l.scrollbar_hide_timer;
+  cl_assert(timer != NULL);
+  menu_layer_set_scrollbar_hidden(&l, true);
+  cl_assert(!l.scrollbar_visible);
+  cl_assert(l.scrollbar_hide_timer == NULL);
+  cl_assert(!fake_app_timer_is_scheduled(timer));
+  menu_layer_deinit(&l);
+}
+
+void test_menu_layer__scrollbar_thumb_rect_geometry(void) {
+  MenuLayer l;
+  prv_init_scrollbar_menu(&l);
+  const int16_t frame_w = 144;
+  const int16_t frame_h = 168;
+  const int16_t content_h = scroll_layer_get_content_size(&l.scroll_layer).h;
+  cl_assert(content_h > frame_h);
+  const int16_t scrollable_h = content_h - frame_h;
+  const int16_t track_h = frame_h - 4;
+  const int16_t thumb_h = (int16_t)(((int32_t)track_h * frame_h) / content_h);
+
+  // Top of the list: thumb rests at the top track margin
+  GRect r = prv_scrollbar_thumb_rect(&l, 0);
+  cl_assert_equal_i(r.origin.x, frame_w - 5);
+  cl_assert_equal_i(r.size.w, 3);
+  cl_assert_equal_i(r.origin.y, 2);
+  cl_assert_equal_i(r.size.h, thumb_h);
+
+  // Bottom of the list: thumb ends at the bottom track margin (content-space coordinates)
+  r = prv_scrollbar_thumb_rect(&l, scrollable_h);
+  cl_assert_equal_i(r.origin.y + r.size.h, scrollable_h + frame_h - 2);
+
+  // Center-focused over-scroll past the top clamps the thumb to the track
+  r = prv_scrollbar_thumb_rect(&l, -40);
+  cl_assert_equal_i(r.origin.y, -40 + 2);
+  menu_layer_deinit(&l);
+}

--- a/tests/fw/ui/test_menu_layer.c
+++ b/tests/fw/ui/test_menu_layer.c
@@ -16,6 +16,7 @@
 #include "applib/ui/animation_private.h"
 #include "applib/ui/property_animation_private.h"
 
+#include "fake_app_timer.h"
 #include "fake_rtc.h"
 #include "pbl/drivers/rtc.h"
 
@@ -179,6 +180,7 @@ bool animation_set_handlers(Animation *animation, AnimationHandlers callbacks, v
 
 void test_menu_layer__initialize(void) {
   s_num_rows = 10;
+  fake_app_timer_init();
   fake_rtc_init(0, 0);
   s_anim_to = GPointZero;
   s_anim_handlers = (AnimationHandlers) { 0 };
@@ -192,6 +194,7 @@ void test_menu_layer__initialize(void) {
 }
 
 void test_menu_layer__cleanup(void) {
+  fake_app_timer_deinit();
 }
 
 static void prv_draw_row(GContext* ctx,

--- a/tests/fw/ui/test_menu_layer.c
+++ b/tests/fw/ui/test_menu_layer.c
@@ -1205,20 +1205,27 @@ void test_menu_layer__touch_clamp_center_focused_widens(void) {
   menu_layer_set_center_focused(&l, true);
   prv_set_touch_callbacks(&l);
   menu_layer_reload_data(&l);
-  // center_focused widens the clamp by frame_h/2 (=90), so a positive offset up to +90 is allowed
-  // where a normal menu would clamp at 0.
-  menu_layer_touch_handle_pan_update(&l, GPoint(0, 0), GPoint(0, 300));
-  cl_assert_equal_i(scroll_layer_get_content_offset(&l.scroll_layer).y, 90);
-
-  // The widen is symmetric: it also lowers the min bound by frame_h/2. A large negative pan reaches
-  // min(frame_h - content_h, 0) - frame_h/2; dropping the min_y widen would stop it at the un-widened
-  // min, so this pins the lower-bound widen the +90 case alone leaves untested.
   const int16_t frame_h = l.scroll_layer.layer.frame.size.h;
   const int16_t content_h = scroll_layer_get_content_size(&l.scroll_layer).h;
-  const int16_t expected_min = MIN((int16_t)(frame_h - content_h), (int16_t)0) - (int16_t)(frame_h / 2);
+  const int16_t widened_max = frame_h / 2;
+  const int16_t widened_min =
+      MIN((int16_t)(frame_h - content_h), (int16_t)0) - (int16_t)(frame_h / 2);
+
+  // center_focused widens the coarse bounds by frame_h/2 (=90), so a positive offset up to +90
+  // scrolls freely where a normal menu would stop at 0; past the widened edge the pan
+  // rubber-bands by the shared damp mapping instead of hard-clamping.
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, 0), GPoint(0, 300));
+  cl_assert_equal_i(scroll_layer_get_content_offset(&l.scroll_layer).y,
+                    scroll_layer_touch_overscroll_damp(300, widened_min, widened_max, frame_h));
+  cl_assert(scroll_layer_get_content_offset(&l.scroll_layer).y > widened_max);
+
+  // The widen is symmetric: the min bound is lowered by frame_h/2 too, and the rubber band hangs
+  // off the widened min; dropping the min_y widen would damp from the un-widened min instead.
   scroll_layer_set_content_offset(&l.scroll_layer, GPoint(0, 0), false);
   menu_layer_touch_handle_pan_update(&l, GPoint(0, 0), GPoint(0, -3000));
-  cl_assert_equal_i(scroll_layer_get_content_offset(&l.scroll_layer).y, expected_min);
+  cl_assert_equal_i(scroll_layer_get_content_offset(&l.scroll_layer).y,
+                    scroll_layer_touch_overscroll_damp(-3000, widened_min, widened_max, frame_h));
+  cl_assert(scroll_layer_get_content_offset(&l.scroll_layer).y < widened_min);
 }
 
 // ---- Criterion 6: a cancelled pan leaves the selection alone and fires no client callback ----

--- a/tests/fw/ui/test_menu_layer.c
+++ b/tests/fw/ui/test_menu_layer.c
@@ -2081,23 +2081,23 @@ void test_menu_layer__scrollbar_thumb_rect_geometry(void) {
   const int16_t content_h = scroll_layer_get_content_size(&l.scroll_layer).h;
   cl_assert(content_h > frame_h);
   const int16_t scrollable_h = content_h - frame_h;
-  const int16_t track_h = frame_h - 4;
+  const int16_t track_h = frame_h - 2;  // 1px margin at each end
   const int16_t thumb_h = (int16_t)(((int32_t)track_h * frame_h) / content_h);
 
   // Top of the list: thumb rests at the top track margin
   GRect r = prv_scrollbar_thumb_rect(&l, 0);
-  cl_assert_equal_i(r.origin.x, frame_w - 5);
+  cl_assert_equal_i(r.origin.x, frame_w - 4);  // 1px margin + 3px thumb
   cl_assert_equal_i(r.size.w, 3);
-  cl_assert_equal_i(r.origin.y, 2);
+  cl_assert_equal_i(r.origin.y, 1);
   cl_assert_equal_i(r.size.h, thumb_h);
 
   // Bottom of the list: thumb ends at the bottom track margin (content-space coordinates)
   r = prv_scrollbar_thumb_rect(&l, scrollable_h);
-  cl_assert_equal_i(r.origin.y + r.size.h, scrollable_h + frame_h - 2);
+  cl_assert_equal_i(r.origin.y + r.size.h, scrollable_h + frame_h - 1);
 
   // Center-focused over-scroll past the top clamps the thumb to the track
   r = prv_scrollbar_thumb_rect(&l, -40);
-  cl_assert_equal_i(r.origin.y, -40 + 2);
+  cl_assert_equal_i(r.origin.y, -40 + 1);
   menu_layer_deinit(&l);
 }
 

--- a/tests/fw/ui/test_menu_layer.c
+++ b/tests/fw/ui/test_menu_layer.c
@@ -2252,3 +2252,85 @@ void test_menu_layer__overscroll_stretch_resets_on_cancel(void) {
   cl_assert_equal_i(l.inverter.layer.frame.size.h, cell_h);
   menu_layer_deinit(&l);
 }
+
+// Center-focused highlight pin during touch scrolling
+//////////////////////
+
+void test_menu_layer__touch_center_pin_holds_highlight_during_pan(void) {
+  MenuLayer l;
+  const int16_t frame_h = 180;
+  menu_layer_init(&l, &GRect(0, 0, 144, frame_h));
+  menu_layer_set_center_focused(&l, true);
+  prv_set_touch_callbacks(&l);
+  menu_layer_reload_data(&l);
+  const int16_t centered_pad = (frame_h - 44) / 2;  // 68: row 0 centred offset
+
+  // Mid-pan the highlight is pinned to the viewport centre, not to the selected row.
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, centered_pad), GPoint(0, -30));
+  const int16_t offset_y = scroll_layer_get_content_offset(&l.scroll_layer).y;
+  cl_assert_equal_i(offset_y, centered_pad - 30);
+  cl_assert(l.touch_center_pin);
+  cl_assert_equal_i(l.inverter.layer.frame.origin.y, -offset_y + centered_pad);
+  cl_assert(l.inverter.layer.frame.origin.y != l.selection.y);  // row 0 is mid-transit
+
+  // A centre crossing re-selects the row underneath but the box does not move with it.
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, centered_pad), GPoint(0, -188));
+  const int16_t offset2_y = scroll_layer_get_content_offset(&l.scroll_layer).y;
+  cl_assert(menu_layer_get_selected_index(&l).row > 0);
+  cl_assert(l.touch_center_pin);
+  cl_assert_equal_i(l.inverter.layer.frame.origin.y, -offset2_y + centered_pad);
+}
+
+void test_menu_layer__touch_center_pin_releases_when_row_lands(void) {
+  MenuLayer l;
+  const int16_t frame_h = 180;
+  menu_layer_init(&l, &GRect(0, 0, 144, frame_h));
+  menu_layer_set_center_focused(&l, true);
+  prv_set_touch_callbacks(&l);
+  menu_layer_reload_data(&l);
+  const int16_t centered_pad = (frame_h - 44) / 2;
+
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, centered_pad), GPoint(0, -188));
+  cl_assert(l.touch_center_pin);
+  const uint16_t row = menu_layer_get_selected_index(&l).row;
+
+  // The settle glide's final frame centres the selected row exactly: the pin releases and the
+  // highlight is back on the row's own frame.
+  const int16_t settled_y = (int16_t)(centered_pad - (44 * row));
+  prv_scroll_layer_set_content_offset_internal(&l.scroll_layer, GPoint(0, settled_y));
+  cl_assert(!l.touch_center_pin);
+  cl_assert_equal_i(l.inverter.layer.frame.origin.y, l.selection.y);
+  cl_assert_equal_i(l.inverter.layer.frame.size.h, l.selection.h);
+}
+
+void test_menu_layer__touch_center_pin_cleared_by_button_step(void) {
+  MenuLayer l;
+  menu_layer_init(&l, &GRect(0, 0, 144, 180));
+  menu_layer_set_center_focused(&l, true);
+  prv_set_touch_callbacks(&l);
+  menu_layer_reload_data(&l);
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, 68), GPoint(0, -30));
+  cl_assert(l.touch_center_pin);
+
+  // A button step hands the highlight back to the selection and its own animations.
+  menu_down_click_handler(NULL, &l);
+  cl_assert(!l.touch_center_pin);
+}
+
+void test_menu_layer__touch_center_pin_moves_with_row_past_the_edge(void) {
+  MenuLayer l;
+  const int16_t frame_h = 180;
+  menu_layer_init(&l, &GRect(0, 0, 144, frame_h));
+  menu_layer_set_center_focused(&l, true);
+  prv_set_touch_callbacks(&l);
+  menu_layer_reload_data(&l);
+  const int16_t rest_y = (frame_h - 44) / 2;  // row 0 centred
+
+  // Pulling past the first row's centred rest rubber-bands the offset; the box has no next row
+  // to transit to, so it glues to the row and moves together with the pull.
+  menu_layer_touch_handle_pan_update(&l, GPoint(0, rest_y), GPoint(0, 50));
+  cl_assert(scroll_layer_get_content_offset(&l.scroll_layer).y > rest_y);
+  cl_assert_equal_i(menu_layer_get_selected_index(&l).row, 0);
+  cl_assert_equal_i(l.inverter.layer.frame.origin.y, l.selection.y);
+  cl_assert_equal_i(l.inverter.layer.frame.size.h, l.selection.h);
+}

--- a/tests/fw/ui/test_scroll_layer_touch.c
+++ b/tests/fw/ui/test_scroll_layer_touch.c
@@ -216,13 +216,20 @@ void test_scroll_layer_touch__pan_drags_content_1to1_and_clamps(void) {
   scroll_layer_touch_handle_pan_update(&sl, GPoint(0, -120), GPoint(0, -80));
   cl_assert_equal_i(scroll_layer_get_content_offset(&sl).y, -200);
 
-  // Clamp at the bottom: a huge negative delta stops at min(frame_h - content_h, 0) = -600.
+  // Past the bottom edge (min(frame_h - content_h, 0) = -600) a huge delta only rubber-bands a
+  // damped amount beyond it, matching the shared damp mapping.
   scroll_layer_touch_handle_pan_update(&sl, GPoint(0, 0), GPoint(0, -5000));
-  cl_assert_equal_i(scroll_layer_get_content_offset(&sl).y, -600);
+  cl_assert_equal_i(scroll_layer_get_content_offset(&sl).y,
+                    scroll_layer_touch_overscroll_damp(-5000, -600, 0, 300));
+  cl_assert(scroll_layer_get_content_offset(&sl).y < -600);
+  cl_assert(scroll_layer_get_content_offset(&sl).y >= -600 - (300 / 6));
 
-  // Clamp at the top: a positive delta cannot pull the content past 0.
+  // Same at the top: a positive delta rubber-bands past 0 instead of pulling the content freely.
   scroll_layer_touch_handle_pan_update(&sl, GPoint(0, -100), GPoint(0, 5000));
-  cl_assert_equal_i(scroll_layer_get_content_offset(&sl).y, 0);
+  cl_assert_equal_i(scroll_layer_get_content_offset(&sl).y,
+                    scroll_layer_touch_overscroll_damp(4900, -600, 0, 300));
+  cl_assert(scroll_layer_get_content_offset(&sl).y > 0);
+  cl_assert(scroll_layer_get_content_offset(&sl).y <= 300 / 6);
 
   scroll_layer_deinit(&sl);
 }

--- a/tests/fw/ui/test_scroll_layer_touch.c
+++ b/tests/fw/ui/test_scroll_layer_touch.c
@@ -672,3 +672,62 @@ void test_scroll_layer_touch__fling_cleanup_is_idempotent(void) {
   cl_assert_equal_i(animation_get_duration(anim, false, false), ANIMATION_DEFAULT_DURATION_MS);
   scroll_layer_deinit(&sl);
 }
+
+// ---------------------------------------------------------------------------------------------
+// Rubber-band overscroll: the shared damp mapping is well-behaved, liftoff springs back, and a
+// catch mid-spring-back restarts the glide instead of freezing out of bounds.
+
+void test_scroll_layer_touch__overscroll_damp_mapping(void) {
+  // In range: identity, edges included.
+  cl_assert_equal_i(scroll_layer_touch_overscroll_damp(-100, -600, 0, 300), -100);
+  cl_assert_equal_i(scroll_layer_touch_overscroll_damp(0, -600, 0, 300), 0);
+  cl_assert_equal_i(scroll_layer_touch_overscroll_damp(-600, -600, 0, 300), -600);
+
+  // Past an edge: strictly beyond it, monotonic, saturating at ~frame_h/6.
+  const int16_t max_over = 300 / 6;
+  const int16_t small = scroll_layer_touch_overscroll_damp(40, -600, 0, 300);
+  const int16_t large = scroll_layer_touch_overscroll_damp(4000, -600, 0, 300);
+  cl_assert(small > 0);
+  cl_assert(large > small);
+  cl_assert(large <= max_over);
+
+  // Symmetric on the bottom edge.
+  cl_assert_equal_i(scroll_layer_touch_overscroll_damp(-600 - 40, -600, 0, 300),
+                    (int16_t)(-600 - small));
+}
+
+void test_scroll_layer_touch__snap_from_overscroll_springs_back(void) {
+  ScrollLayer sl;
+  prv_make_tall_scroll(&sl, GRect(0, 0, 200, 300), 900);
+  // Drag past the top edge: rubber-banded positive offset.
+  scroll_layer_touch_handle_pan_update(&sl, GPoint(0, 0), GPoint(0, 200));
+  const int16_t overscrolled_y = scroll_layer_get_content_offset(&sl).y;
+  cl_assert(overscrolled_y > 0);
+  cl_assert_equal_i(overscrolled_y, scroll_layer_touch_overscroll_damp(200, -600, 0, 300));
+
+  // Liftoff (even a fast one) glides back to the edge instead of coasting or snapping.
+  scroll_layer_touch_handle_snap(&sl, GPoint(0, 0), GPoint(0, 200), GPoint(0, 2000));
+  Animation *anim = property_animation_get_animation(sl.animation);
+  cl_assert(anim != NULL);
+  cl_assert(animation_is_scheduled(anim));
+  cl_assert_equal_i(s_anim_to.y, 0);
+  // The glide starts from the rubber-banded offset; nothing snapped yet.
+  cl_assert_equal_i(scroll_layer_get_content_offset(&sl).y, overscrolled_y);
+  scroll_layer_deinit(&sl);
+}
+
+void test_scroll_layer_touch__touchdown_mid_spring_back_restarts_glide(void) {
+  ScrollLayer sl;
+  prv_make_tall_scroll(&sl, GRect(0, 0, 200, 300), 900);
+  scroll_layer_touch_handle_pan_update(&sl, GPoint(0, 0), GPoint(0, 200));
+  scroll_layer_touch_handle_snap(&sl, GPoint(0, 0), GPoint(0, 200), GPoint(0, 0));
+
+  // A finger down catches (stops) the glide; the content must not freeze out of bounds, so a
+  // new glide toward the edge is scheduled immediately.
+  scroll_layer_touch_handle_touchdown(&sl);
+  Animation *anim = property_animation_get_animation(sl.animation);
+  cl_assert(anim != NULL);
+  cl_assert(animation_is_scheduled(anim));
+  cl_assert_equal_i(s_anim_to.y, 0);
+  scroll_layer_deinit(&sl);
+}


### PR DESCRIPTION
Two affordances that touch scrolling was missing in menus, in three self-contained pairs of commits (feature + tests each):

## Transient scrollbar overlay

`MenuLayer` shows a small scrollbar while a touch gesture (pan or inertial coast) scrolls content taller than the frame, and hides it one second after the movement stops. Button scrolling never shows it (the selection already communicates position there).

- Rect displays: 3px thumb + 1px halo on the right edge, proportional height, position clamped to the track.
- Round displays: a curved arc hugging the bezel (Wear OS style), ±30° around 3 o'clock, drawn with rounded end caps via `graphics_fill_radial` + cap circles. The full-length track is drawn behind the thumb in a subdued gray (picked by the menu background's luminance), so the thumb reads as a position within the range.
- State is carved from the existing `MenuLayer` padding (an `AppTimer *` plus flag bits), so `sizeof(MenuLayer)` and the applib-malloc budget are unchanged. Legacy2 apps excluded; `menu_layer_set_scrollbar_hidden()` opts out.

## Rubber-band overscroll with spring-back

A held pan past the scroll bounds pulls the content a little further with asymptotic damping (half the finger's speed at first, saturating at ~1/6 of the frame height); liftoff glides back to the edge in 200ms, and a cancelled gesture restores it instantly. The spring-back runs on an unclamped animation setter so it glides instead of snapping. Paging layers and content that fits the frame keep the hard clamp; center-focused menus damp past their widened bounds and return through their existing settle-to-center.

## Selection stretch at the edges

When the edge row is the selected one, the pull extends its selection background across the exposed gap to the viewport edge — the touch counterpart of the blocked-button highlight bounce, without ever painting over a neighbouring row (the neighbours move away with the content). The stretch is derived purely from the rubber-banded offset in the offset-changed handler, so the live pan, every spring-back frame, and cancel stay in sync with no extra animation state (one flag bit; struct size unchanged).

## Testing

- Full unit test suite passes; 18 new tests cover the scrollbar lifecycle/geometry (rect + thumb math), damp mapping, pan/snap/cancel overscroll on both Tier-1 widgets, and the stretch geometry/contract.
- Validated interactively on QEMU: `qemu_emery` (rect + touch: swipe vs. buttons, stretch at both edges), `qemu_gabbro` (round arc scrollbar over the carousel), `qemu_flint` (non-touch: no scrollbar, button behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
