### PR TITLE
ci: lint commit messages on the unrebased PR history

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -12,9 +12,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Rebase onto target branch
-        uses: ./.github/actions/rebase
-
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
@@ -24,7 +21,9 @@ jobs:
         run: pip install gitlint
 
       - name: Run GitLint
-        run: gitlint --commits "origin/${GITHUB_BASE_REF}..HEAD"
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: gitlint --commits "origin/${GITHUB_BASE_REF}..${HEAD_SHA}"
 
   ruff:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
The compliance `lint` job rebased the PR head onto the target branch before running gitlint. A plain rebase linearizes history, silently dropping merge commits, so gitlint never saw them and PRs containing merge commits (e.g. #1846, "Merge branch 'coredevices:main' into main") passed compliance despite `ignore-merge-commits=false` in `.gitlint`.

Commit message linting does not need the rebased tree, so drop the rebase step and lint the range up to the true PR head (`github.event.pull_request.head.sha`) instead. Verified locally that gitlint on the unrebased range of #1846 flags its merge commit (missing `Signed-off-by`, title format). The `ruff` and `license` jobs keep the rebase, as they check file contents against up-to-date code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)