### PR TITLE
treewide: drop getafix evt support

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -48,7 +48,6 @@ jobs:
           - asterix
           - obelix@dvt
           - obelix@pvt
-          - getafix@evt
           - getafix@dvt
           - getafix@dvt2
         slot:
@@ -93,7 +92,7 @@ jobs:
       - name: Set slot suffix
         id: slot_suffix
         run: |
-          NEEDS_SUFFIX="obelix_dvt obelix_pvt getafix_evt getafix_dvt getafix_dvt2"
+          NEEDS_SUFFIX="obelix_dvt obelix_pvt getafix_dvt getafix_dvt2"
 
           if echo $NEEDS_SUFFIX | grep -wq "${{ steps.artifact_board.outputs.NAME }}"; then
             echo "SLOT_SUFFIX=_slot${{ matrix.slot }}" >> "$GITHUB_OUTPUT"
@@ -145,7 +144,6 @@ jobs:
         board:
           - obelix_dvt
           - obelix_pvt
-          - getafix_evt
           - getafix_dvt
           - getafix_dvt2
 

--- a/.github/workflows/build-prf.yml
+++ b/.github/workflows/build-prf.yml
@@ -46,7 +46,6 @@ jobs:
           - asterix
           - obelix@dvt
           - obelix@pvt
-          - getafix@evt
           - getafix@dvt
           - getafix@dvt2
         mode:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
           - asterix
           - obelix@dvt
           - obelix@pvt
-          - getafix@evt
           - getafix@dvt
           - getafix@dvt2
 
@@ -113,7 +112,6 @@ jobs:
           - asterix
           - obelix@dvt
           - obelix@pvt
-          - getafix@evt
           - getafix@dvt
           - getafix@dvt2
         slot:
@@ -157,7 +155,7 @@ jobs:
       - name: Set slot suffix
         id: slot_suffix
         run: |
-          NEEDS_SUFFIX="obelix_dvt obelix_pvt getafix_evt getafix_dvt getafix_dvt2"
+          NEEDS_SUFFIX="obelix_dvt obelix_pvt getafix_dvt getafix_dvt2"
 
           if echo $NEEDS_SUFFIX | grep -wq "${{ steps.artifact_board.outputs.NAME }}"; then
             echo "SLOT_SUFFIX=_slot${{ matrix.slot }}" >> "$GITHUB_OUTPUT"
@@ -289,7 +287,7 @@ jobs:
 
       - name: Merge slot-specific pbz files
         run: |
-          NEEDS_MERGE="obelix_dvt obelix_pvt getafix_evt getafix_dvt getafix_dvt2"
+          NEEDS_MERGE="obelix_dvt obelix_pvt getafix_dvt getafix_dvt2"
 
           mkdir artifacts-merged
           for board in $NEEDS_MERGE; do

--- a/boards/getafix/Kconfig.evt
+++ b/boards/getafix/Kconfig.evt
@@ -1,6 +1,0 @@
-# SPDX-FileCopyrightText: 2026 Core Devices LLC
-# SPDX-License-Identifier: Apache-2.0
-
-config BOARD_GETAFIX_EVT
-    bool
-    default y

--- a/boards/getafix/defconfig.evt
+++ b/boards/getafix/defconfig.evt
@@ -1,4 +1,0 @@
-# getafix evt board revision configuration
-
-CONFIG_VIBE_AW8623X=y
-CONFIG_ACCEL_LIS2DW12_DISABLE_ADDR_PULLUP=y

--- a/boards/getafix/getafix.yml
+++ b/boards/getafix/getafix.yml
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 revisions:
-  - evt
   - dvt
   - dvt2
 

--- a/docs/development/options.md
+++ b/docs/development/options.md
@@ -10,7 +10,7 @@ using the (`--board`) flag followed by:
 
 :`asterix`: (Core Devices) Pebble 2 Duo
 :`obelix@bb2`, `obelix@dvt`, `obelix@pvt`: (Core Devices) Pebble Time 2
-:`getafix@evt`, `getafix@dvt`, `getafix@dvt2`: (Core Devices) Pebble Round 2
+:`getafix@dvt`, `getafix@dvt2`: (Core Devices) Pebble Round 2
 :`qemu_emery`, `qemu_flint`, `qemu_gabbro`: dedicated QEMU targets (see {doc}`qemu`)
 
 Keep in mind that some targets may not currently compile as-is.

--- a/include/pebbleos/firmware_metadata.h
+++ b/include/pebbleos/firmware_metadata.h
@@ -102,8 +102,6 @@ _Static_assert(sizeof(struct FirmwareMetadata) == (sizeof(uint32_t) +
   #define FIRMWARE_METADATA_HW_PLATFORM (FirmwareMetadataPlatformPebbleObelixPVT)
 #elif defined(CONFIG_BOARD_OBELIX_BB2)
   #define FIRMWARE_METADATA_HW_PLATFORM (FirmwareMetadataPlatformPebbleObelixBigboard2)
-#elif defined(CONFIG_BOARD_GETAFIX_EVT)
-  #define FIRMWARE_METADATA_HW_PLATFORM (FirmwareMetadataPlatformPebbleGetafixEVT)
 #elif defined(CONFIG_BOARD_GETAFIX_DVT)
   #define FIRMWARE_METADATA_HW_PLATFORM (FirmwareMetadataPlatformPebbleGetafixDVT)
 #elif defined(CONFIG_BOARD_GETAFIX_DVT2)

--- a/src/fw/board/board_definitions.h
+++ b/src/fw/board/board_definitions.h
@@ -8,7 +8,7 @@
 #include "boards/board_asterix.h"
 #elif defined(CONFIG_BOARD_OBELIX_DVT) || defined(CONFIG_BOARD_OBELIX_PVT) || defined(CONFIG_BOARD_OBELIX_BB2)
 #include "boards/board_obelix.h"
-#elif defined(CONFIG_BOARD_GETAFIX_EVT) || defined(CONFIG_BOARD_GETAFIX_DVT) || defined(CONFIG_BOARD_GETAFIX_DVT2)
+#elif defined(CONFIG_BOARD_GETAFIX_DVT) || defined(CONFIG_BOARD_GETAFIX_DVT2)
 #include "boards/board_getafix.h"
 #elif defined(CONFIG_BOARD_QEMU_EMERY)
 #include "boards/board_qemu_emery.h"

--- a/src/fw/board/boards/board_getafix.c
+++ b/src/fw/board/boards/board_getafix.c
@@ -281,11 +281,7 @@ static const LIS2DW12Config s_lis2dw12_config = {
     .state = &s_lis2dw12_state,
     .i2c = {
         .bus = &s_i2c_bus_1,
-#ifdef CONFIG_BOARD_GETAFIX_EVT
-        .address = 0x18,
-#else
         .address = 0x19,
-#endif
     },
     .int1 = {
       .peripheral = hwp_gpio1,

--- a/src/fw/board/display.h
+++ b/src/fw/board/display.h
@@ -26,7 +26,7 @@ typedef struct {
 #include "displays/display_asterix.h"
 #elif defined(CONFIG_BOARD_OBELIX_DVT) || defined(CONFIG_BOARD_OBELIX_PVT) || defined(CONFIG_BOARD_OBELIX_BB2)
 #include "displays/display_obelix.h"
-#elif defined(CONFIG_BOARD_GETAFIX_EVT) || defined(CONFIG_BOARD_GETAFIX_DVT) || defined(CONFIG_BOARD_GETAFIX_DVT2)
+#elif defined(CONFIG_BOARD_GETAFIX_DVT) || defined(CONFIG_BOARD_GETAFIX_DVT2)
 #include "displays/display_getafix.h"
 #elif defined(CONFIG_BOARD_QEMU_EMERY)
 #include "displays/display_qemu_emery.h"

--- a/src/fw/board/splash.h
+++ b/src/fw/board/splash.h
@@ -5,7 +5,7 @@
 
 #if defined(CONFIG_BOARD_OBELIX_DVT) || defined(CONFIG_BOARD_OBELIX_PVT) || defined(CONFIG_BOARD_OBELIX_BB2)
 #include "splash/splash_obelix.xbm"
-#elif defined(CONFIG_BOARD_GETAFIX_EVT) || defined(CONFIG_BOARD_GETAFIX_DVT) || defined(CONFIG_BOARD_GETAFIX_DVT2)
+#elif defined(CONFIG_BOARD_GETAFIX_DVT) || defined(CONFIG_BOARD_GETAFIX_DVT2)
 #include "splash/splash_getafix.xbm"
 #elif defined(CONFIG_BOARD_QEMU_EMERY)
 #include "splash/splash_obelix.xbm"


### PR DESCRIPTION
Remove the `getafix@evt` board revision:

- Delete `boards/getafix/Kconfig.evt` and `defconfig.evt`, and drop `evt` from the revision manifest (`getafix.yml`), which removes the build target.
- Remove the `CONFIG_BOARD_GETAFIX_EVT` conditionals from `firmware_metadata.h`, board headers, and `board_getafix.c` (the EVT-only LIS2DW12 I2C address 0x18; DVT's 0x19 is now unconditional).
- Drop `getafix@evt`/`getafix_evt` from the CI matrices and slot-suffix/merge lists in `build-firmware.yml`, `build-prf.yml`, and `release.yml`.
- Remove the board from the docs target list.

`FirmwareMetadataPlatformPebbleGetafixEVT` is kept in the enum so the platform ID is not reused, matching how the obelix EVT removal was handled.

Verified: `getafix@evt` is now rejected at configure time and `getafix@dvt` still configures and builds successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)