### PR TITLE
fw/apps/prf: lower MFG speaker test volume on obelix

### DIFF
--- a/src/fw/apps/prf/mfg_speaker_obelix.c
+++ b/src/fw/apps/prf/mfg_speaker_obelix.c
@@ -35,7 +35,7 @@ static void prv_audio_trans_handler(uint32_t *free_size) {
 
 static void prv_play_audio(void) {
   audio_start(AUDIO, prv_audio_trans_handler);
-  audio_set_volume(AUDIO, 100);
+  audio_set_volume(AUDIO, 30);
 }
 
 static void prv_result_confirmed(ClickRecognizerRef recognizer, void *context) {


### PR DESCRIPTION
The MFG speaker test played a full-scale square wave at maximum volume (100, i.e. 0 dB attenuation), which is excessively loud on the factory line. Lower it to 30 (~-25 dB with the codec driver's linear volume mapping), still clearly audible for the pass/fail check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)