### PR TITLE
fw/board: use stereo mic capture in MFG builds

### DIFF
--- a/src/fw/board/boards/board_getafix.c
+++ b/src/fw/board/boards/board_getafix.c
@@ -537,8 +537,13 @@ static const MicDevice mic_device = {
     },
     .pdm_dma_irq = DMAC1_CH5_IRQn,
     .pdm_irq = PDM1_IRQn,
-    .pdm_irq_priority = 5, 
+    .pdm_irq_priority = 5,
+#ifdef CONFIG_MFG
+    // MFG mic test needs stereo capture to verify both microphones
+    .channels = 2,
+#else
     .channels = 1,
+#endif
     .sample_rate = 16000,
     .channel_depth = 16,
 };

--- a/src/fw/board/boards/board_obelix.c
+++ b/src/fw/board/boards/board_obelix.c
@@ -615,8 +615,13 @@ static const MicDevice mic_device = {
     },
     .pdm_dma_irq = DMAC1_CH5_IRQn,
     .pdm_irq = PDM1_IRQn,
-    .pdm_irq_priority = 5, 
+    .pdm_irq_priority = 5,
+#ifdef CONFIG_MFG
+    // MFG mic test needs stereo capture to verify both microphones
+    .channels = 2,
+#else
     .channels = 1,
+#endif
     .sample_rate = 16000,
     .channel_depth = 16,
 };


### PR DESCRIPTION
Commit b8867af60 ("fw/drivers/mic/sf32lb52: switch to mono capture", FIRM-1798) flipped obelix and getafix to mono PDM capture to shrink the voice-session heap footprint, but the MFG mic tests still assume stereo interleaved data: they de-interleave the recording and play back each microphone separately. With mono capture, playback skips every other sample (2x speed, distorted voice) and the second microphone is never captured at all.

This keeps mono capture for normal builds and restores stereo capture in MFG builds (`#ifdef CONFIG_MFG`), where both microphones must be verified on the factory line.

Verified: obelix@pvt MFG PRF, getafix@dvt2 MFG PRF, and obelix@pvt normal builds all compile cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)