### PR TITLE
fw/apps/prf: rescale obelix MFG ALS range for 99ms IT

### DIFF
--- a/src/fw/apps/prf/mfg_als.c
+++ b/src/fw/apps/prf/mfg_als.c
@@ -22,8 +22,8 @@
 
 // ALS pass/fail range (adjust these values based on your test requirements)
 #ifdef CONFIG_BOARD_OBELIX
-#define ALS_MIN_VALUE 100
-#define ALS_MAX_VALUE 250
+#define ALS_MIN_VALUE 600
+#define ALS_MAX_VALUE 1500
 #elif defined(CONFIG_BOARD_GETAFIX)
 #define ALS_MIN_VALUE 8500
 #define ALS_MAX_VALUE 11500


### PR DESCRIPTION
The W1160 integration time changed from 16.83 ms to 99 ms when the event-gated continuous sampling API landed (41df3a0bb, re-applied as 4be617c91), so raw counts for the same light level are now ~5.9x higher. The runtime dark/k-delta thresholds were retuned for the new regime (3989013c6, 39dff9efc), but the MFG ALS pass window was left at the old 100-250 counts, which now corresponds to ~6x dimmer light than intended — units that previously passed the lightbox station would now read ~6x higher and fail.

Scale the window linearly by the IT ratio (99 / 16.83 ≈ 5.88): 100 → 600, 250 → 1500.

Note: these values follow naive linear scaling and should be confirmed against production units in the actual lightbox, as was done for getafix (dd4758c8a).

Verified: obelix@pvt PRF variant builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)