### PR TITLE
Fix MFG speaker test volume on obelix (v4.9)

### DIFF
--- a/src/fw/apps/prf/mfg_speaker_obelix.c
+++ b/src/fw/apps/prf/mfg_speaker_obelix.c
@@ -33,7 +33,7 @@ static void prv_audio_trans_handler(uint32_t *free_size) {
 
 static void prv_play_audio(void) {
   audio_start(AUDIO, prv_audio_trans_handler);
-  audio_set_volume(AUDIO, 100);
+  audio_set_volume(AUDIO, 30);
 }
 
 static void prv_handle_init(void) {

--- a/src/fw/drivers/sf32lb52/audio/audec.c
+++ b/src/fw/drivers/sf32lb52/audio/audec.c
@@ -382,11 +382,13 @@ void audec_set_vol(AudioDevice* audio_device, int volume) {
         HAL_AUDCODEC_Mute_DACPath(haudcodec, 1);
     } else {
         HAL_AUDCODEC_Mute_DACPath(haudcodec, 0);
-        //convert to HAL decoder range (-36~54)*2
-        volume -= 36;
-        volume *= 2;
-        HAL_AUDCODEC_Config_DACPath_Volume(haudcodec, 0, volume);
-        HAL_AUDCODEC_Config_DACPath_Volume(haudcodec, 1, volume);
+        // Map 1..100 to -36..0 dB in the HAL's 0.5 dB units. Never apply positive
+        // digital gain: it clips full-scale content and overdrives the speaker.
+        int atten_half_db = ((MAX_VOLUME - volume) * 72) / MAX_VOLUME;
+        if ((HAL_AUDCODEC_Config_DACPath_Volume(haudcodec, 0, -atten_half_db) != HAL_OK) ||
+            (HAL_AUDCODEC_Config_DACPath_Volume(haudcodec, 1, -atten_half_db) != HAL_OK)) {
+            PBL_LOG_WRN("Failed to apply DAC volume (%d half-dB)", -atten_half_db);
+        }
     }
 }
 

--- a/src/fw/drivers/sf32lb52/audio/audec.c
+++ b/src/fw/drivers/sf32lb52/audio/audec.c
@@ -367,6 +367,9 @@ void audec_start(AudioDevice* audio_device, AudioTransCB cb) {
     HAL_AUDCODEC_Config_DACPath(haudcodec, 1);
     HAL_AUDCODEC_Config_Analog_DACPath(haudcodec->Init.dac_cfg.dac_clk);
     HAL_AUDCODEC_Config_DACPath(haudcodec, 0);
+
+    hwp_audcodec->DAC_CH0_CFG_EXT &= ~AUDCODEC_DAC_CH0_CFG_EXT_RAMP_EN_Msk;
+    hwp_audcodec->DAC_CH1_CFG_EXT &= ~AUDCODEC_DAC_CH1_CFG_EXT_RAMP_EN_Msk;
 }
 
 uint32_t audec_write(AudioDevice* audio_device, void *writeBuf, uint32_t size) {

--- a/src/fw/drivers/sf32lb52/audio/audec.c
+++ b/src/fw/drivers/sf32lb52/audio/audec.c
@@ -3,6 +3,7 @@
 
 #include "audio_definitions.h"
 #include "kernel/pbl_malloc.h"
+#include "mcu/cache.h"
 #include "system/passert.h"
 #include "system/logging.h"
 #include "util/misc.h"
@@ -319,10 +320,17 @@ bool audec_init(AudioDevice* audio_device) {
 
     if (haudcodec->buf[HAL_AUDCODEC_DAC_CH0] == NULL)
     {
-        haudcodec->buf[HAL_AUDCODEC_DAC_CH0] = kernel_malloc(haudcodec->bufSize);
+        // Over-allocate so the DMA buffer can start on a cache-line boundary.
+        // Each half is consumed by DMA while the CPU fills the other half;
+        // dcache_flush() of one half must not touch lines that belong to the
+        // half currently being DMA'd, so both halves need to be aligned.
+        const size_t cache_align = dcache_line_size();
+        state->raw_dac_buffer = kernel_malloc(haudcodec->bufSize + cache_align - 1U);
+        PBL_ASSERT(state->raw_dac_buffer, "allocated mem error");
+        haudcodec->buf[HAL_AUDCODEC_DAC_CH0] =
+            (uint8_t *)(((uintptr_t)state->raw_dac_buffer + cache_align - 1U) &
+                        ~(uintptr_t)(cache_align - 1U));
         memset(haudcodec->buf[HAL_AUDCODEC_DAC_CH0], 0, haudcodec->bufSize);
-        PBL_ASSERT(haudcodec->buf[HAL_AUDCODEC_DAC_CH0], "allocated mem error");
-
     }
     state->queue_buf[HAL_AUDCODEC_DAC_CH0] = haudcodec->buf[HAL_AUDCODEC_DAC_CH0];
     HAL_AUDCODEC_Config_TChanel(haudcodec, 0, &haudcodec->Init.dac_cfg);
@@ -345,6 +353,10 @@ void audec_start(AudioDevice* audio_device, AudioTransCB cb) {
     prv_bf0_audio_pll_config(audio_device, &codec_dac_clk_config[haudcodec->Init.samplerate_index]);
     HAL_AUDCODEC_Config_TChanel(haudcodec, 0, &haudcodec->Init.dac_cfg);
     HAL_NVIC_SetPriority(audio_device->audec_dma_irq, audio_device->irq_priority, 0);
+    // The buffer was memset() to zero by the CPU at init and is again at stop;
+    // those writes may still be sitting in D-cache. Push them to RAM so the
+    // codec DMA reads silence on the first transfer instead of stale memory.
+    dcache_flush(haudcodec->buf[HAL_AUDCODEC_DAC_CH0], haudcodec->bufSize);
     HAL_AUDCODEC_Transmit_DMA(haudcodec, haudcodec->buf[HAL_AUDCODEC_DAC_CH0], haudcodec->bufSize, HAL_AUDCODEC_DAC_CH0);
     HAL_NVIC_EnableIRQ(audio_device->audec_dma_irq);
     state->tx_instanc = HAL_AUDCODEC_DAC_CH0;
@@ -441,6 +453,11 @@ static void prv_dma_request_processing(AudioDeviceState* state) {
         PBL_ASSERT(bytes_copied == trans_size, "circ buffer read err");
         circular_buffer_consume(&state->circ_buffer, bytes_copied);
     }
+    // Codec DMA reads this half-buffer next time it wraps; flush the CPU-side
+    // writes (memset for underrun and circular_buffer_copy above) so the DAC
+    // doesn't replay stale RAM contents. We always flush a full half because
+    // any bytes we didn't touch were already memset() to silence.
+    dcache_flush(state->queue_buf[HAL_AUDCODEC_DAC_CH0], CFG_AUDIO_PLAYBACK_PIPE_SIZE);
     uint32_t free_size = circular_buffer_get_write_space_remaining(&state->circ_buffer);
     if(state->trans_cb && free_size >= CFG_AUDIO_PLAYBACK_PIPE_SIZE) {
         bool system_task_switch_context = false;

--- a/src/fw/drivers/sf32lb52/audio/audio_definitions.h
+++ b/src/fw/drivers/sf32lb52/audio/audio_definitions.h
@@ -36,9 +36,13 @@ typedef struct AudioState {
   uint8_t tx_instanc;
   bool    tx_rbf_enable;
   uint16_t tx_buffer_size;
-  uint8_t *circ_buffer_storage; 
+  uint8_t *circ_buffer_storage;
   CircularBuffer circ_buffer;
   AudioTransCB trans_cb;
+  //! Raw (unaligned) pointer returned by kernel_malloc for the AUDCODEC DAC
+  //! DMA buffer. haudcodec->buf[] is bumped up to a cache-line boundary so
+  //! dcache_flush() of one half can't touch the other half's lines.
+  uint8_t *raw_dac_buffer;
 } AudioDeviceState;
 
 typedef const struct AudioDevice {


### PR DESCRIPTION
## Summary

The obelix MFG speaker test sounded weak no matter what volume was requested. Root cause (confirmed on obelix_pvt hardware with a register dump): the DAC output gain ramp (`RAMP_EN`, enabled by `HAL_AUDCODEC_Config_TChanel`) prevented `ROUGH_VOL`/`FINE_VOL` writes from taking effect, so the DAC never reached the programmed gain. With the ramp disabled the volume latches directly and output is loud as expected.

Backports of the fixes already on `main`:

- **`1c062b384` — disable the DAC gain ramp.** The confirmed fix for the weak output; also removes the fade-in on playback start.
- **`32784e6ee` — attenuation-only volume mapping.** The old mapping turned 0-100 into `(vol - 36) * 2` half-dB (-36..+64 dB): volumes above 36 applied clipping digital gain, and above 90 the HAL silently rejected the out-of-range value. Now 1..100 maps linearly to -36..0 dB (0 still mutes) and HAL rejection logs a warning.
- **`0a372853e` — D-cache flushes on the AUDCODEC DMA buffer.** The codec DMA reads HPSYS SRAM directly while the CPU fills the buffer through the D-cache; without flushes the DAC can replay stale memory. Correctness fix for the same pipeline, included while we're here.
- **`d2eb349f2` — speaker test volume 30** (~-25 dB), matching main. Can be bumped independently if the factory line needs more.

The aging and mic MFG tests keep volume 100, matching main.

## Testing

Validated on an obelix_pvt unit: with these changes the test tone is loud at volume 100, and the register dump confirms the gain latches (`DAC_CH0_CFG` rough-vol = 6 → 0 dB, `RAMP_EN` clear). Still to confirm: the shipped volume of 30 is adequate for the factory pass/fail check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)