### PR TITLE
qa: keep private hardware tests out of PebbleOS

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -25,6 +25,9 @@ jobs:
               - 'boards/**'
               - 'platform/**'
               - 'resources/**'
+              # Release-suite-only PRs still need an exact-commit firmware artifact so the hardware
+              # run can prove the catalog and the firmware together before merge.
+              - 'qa/**'
               - 'sdk/**'
               - 'src/**'
               - 'stored_apps/**'

--- a/.github/workflows/release-qa.yml
+++ b/.github/workflows/release-qa.yml
@@ -58,6 +58,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ github.event.workflow_run.id || inputs.run_id }}
         run: |
+          sha=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}" --jq .head_sha)
+          echo "pebbleos_sha=${sha}" >> "$GITHUB_OUTPUT"
           # Merged dual-slot bundles are uploaded as firmware-<board> (no _slot suffix);
           # none = Build Firmware skipped its builds (e.g. docs-only PR).
           if gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts?per_page=100" \
@@ -73,10 +75,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.UNICORN_DISPATCH_TOKEN }}
           RUN_ID: ${{ github.event.workflow_run.id || inputs.run_id }}
+          PEBBLEOS_QA_REF: ${{ steps.check.outputs.pebbleos_sha }}
         run: |
           if [ -z "${GH_TOKEN:-}" ]; then
             echo "::warning::UNICORN_DISPATCH_TOKEN not set, skipping"
             exit 0
           fi
           gh workflow run one-off-pebbleos-test.yml -R coredevices/unicorn \
-            -f to_pbz_run_id="${RUN_ID}"
+            -f to_pbz_run_id="${RUN_ID}" \
+            -f pebbleos_qa_ref="${PEBBLEOS_QA_REF}"

--- a/.github/workflows/release-qa.yml
+++ b/.github/workflows/release-qa.yml
@@ -1,4 +1,4 @@
-name: Release QA
+name: release-hw-android-obelix
 
 on:
   workflow_run:
@@ -22,14 +22,15 @@ on:
         required: false
         default: ""
 
-run-name: Release QA (${{ github.event.workflow_run.head_branch || format('run {0}', inputs.run_id) }})
+run-name: release-hw-android-obelix (${{ github.event.workflow_run.head_branch || format('run {0}', inputs.run_id) }})
 
 concurrency:
-  group: release-qa-${{ github.event.workflow_run.head_repository.full_name || 'manual' }}-${{ github.event.workflow_run.head_branch || inputs.run_id }}
+  group: release-hw-android-obelix-${{ github.event.workflow_run.head_repository.full_name || 'manual' }}-${{ github.event.workflow_run.head_branch || inputs.run_id }}
   cancel-in-progress: true
 
 jobs:
   dispatch-unicorn:
+    name: Dispatch release-hw-android-obelix
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
@@ -82,7 +83,7 @@ jobs:
             echo "FOUND=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Dispatch coredevices/unicorn one-off-pebbleos-test
+      - name: Dispatch release-hw-android-obelix to Unicorn
         if: steps.check.outputs.FOUND == 'true'
         env:
           GH_TOKEN: ${{ secrets.UNICORN_DISPATCH_TOKEN }}
@@ -100,6 +101,7 @@ jobs:
           # fine-grained dispatch token intentionally has Actions access but not Contents access,
           # so that preflight fails even though the REST workflow-dispatch permission is present.
           # Call the dispatch endpoint directly and pin every definition ref passed to Unicorn.
+          # one-off-pebbleos-test.yml is the compatibility API path for release-hw-android-obelix.
           gh api --method POST \
             "repos/coredevices/unicorn/actions/workflows/one-off-pebbleos-test.yml/dispatches" \
             -f ref="$UNICORN_REF" \

--- a/.github/workflows/release-qa.yml
+++ b/.github/workflows/release-qa.yml
@@ -9,6 +9,18 @@ on:
       run_id:
         description: "Build Firmware run id whose merged firmware artifacts are tested"
         required: true
+      unicorn_ref:
+        description: "Unicorn workflow ref (manual integration testing only)"
+        required: false
+        default: "main"
+      coreapp_run_id:
+        description: "CoreApp Build Android run id (manual integration testing only)"
+        required: false
+        default: ""
+      coreapp_qa_ref:
+        description: "CoreApp qa/release ref (manual integration testing only)"
+        required: false
+        default: ""
 
 run-name: Release QA (${{ github.event.workflow_run.head_branch || format('run {0}', inputs.run_id) }})
 
@@ -76,11 +88,22 @@ jobs:
           GH_TOKEN: ${{ secrets.UNICORN_DISPATCH_TOKEN }}
           RUN_ID: ${{ github.event.workflow_run.id || inputs.run_id }}
           PEBBLEOS_QA_REF: ${{ steps.check.outputs.pebbleos_sha }}
+          UNICORN_REF: ${{ inputs.unicorn_ref || 'main' }}
+          COREAPP_RUN_ID: ${{ inputs.coreapp_run_id }}
+          COREAPP_QA_REF: ${{ inputs.coreapp_qa_ref }}
         run: |
           if [ -z "${GH_TOKEN:-}" ]; then
             echo "::warning::UNICORN_DISPATCH_TOKEN not set, skipping"
             exit 0
           fi
-          gh workflow run one-off-pebbleos-test.yml -R coredevices/unicorn \
-            -f to_pbz_run_id="${RUN_ID}" \
-            -f pebbleos_qa_ref="${PEBBLEOS_QA_REF}"
+          # `gh workflow run` first queries repository.defaultBranchRef through GraphQL. The
+          # fine-grained dispatch token intentionally has Actions access but not Contents access,
+          # so that preflight fails even though the REST workflow-dispatch permission is present.
+          # Call the dispatch endpoint directly and pin every definition ref passed to Unicorn.
+          gh api --method POST \
+            "repos/coredevices/unicorn/actions/workflows/one-off-pebbleos-test.yml/dispatches" \
+            -f ref="$UNICORN_REF" \
+            -f "inputs[to_pbz_run_id]=$RUN_ID" \
+            -f "inputs[pebbleos_qa_ref]=$PEBBLEOS_QA_REF" \
+            -f "inputs[coreapp_run_id]=$COREAPP_RUN_ID" \
+            -f "inputs[coreapp_qa_ref]=$COREAPP_QA_REF"

--- a/docs/development/release_qa.md
+++ b/docs/development/release_qa.md
@@ -1,0 +1,56 @@
+# Release QA on real hardware
+
+PebbleOS release QA installs a shipping-style dual-slot firmware artifact on a real watch, pairs it
+with a real phone, upgrades through CoreApp's production sideload path, and then exercises the
+firmware over Pebble Protocol. The executable catalog lives in
+`qa/release/suites/android-obelix.json`; this page describes exactly what it covers and where each
+piece is maintained.
+
+## Ownership
+
+| Concern | Owner | Location |
+|---|---|---|
+| Ordered test catalog and required watch behavior | PebbleOS | `qa/release/suites/` |
+| Watch input and assertions | PebbleOS | `qa/release/watch/` |
+| Phone navigation and UI selectors | CoreApp | `qa/release/capabilities.json` and `qa/release/capabilities/` |
+| Artifact staging, physical devices, sidecar, logs and JUnit | Unicorn | `qa-release/` |
+
+The catalog refers to phone behavior only by logical capability ID. This prevents a PebbleOS test
+from embedding CoreApp screen structure, while keeping the full end-to-end order visible beside the
+firmware it qualifies.
+
+## Android + obelix release suite
+
+Before the catalog runs, Unicorn erases the watch, installs the fixed debug PRF, clears phone and
+Bluetooth state, installs the selected CoreApp APK, onboards and pairs, discovers the default
+"from" firmware, installs the selected PebbleOS dual-slot PBZ through CoreApp, reconnects over
+Pebble Protocol, and verifies the target version.
+
+The catalog then performs these tests in order:
+
+1. Open Bluetooth, Notifications, and System menus and prove each screen renders.
+2. Open Health and record its rendered step-count screen. Physical step detection is out of scope.
+3. Install Stride through CoreApp, start it from Watchfaces, and prove a face replaces the menu.
+4. Install Weather Land and prove its date and temperature slot render after phone data arrives.
+5. Install Transit and prove it renders a Caltrain/Palo Alto schedule.
+6. Verify the installed watchface and app are synchronized back into the CoreApp locker.
+7. Select the test vibe, post CoreApp's own test notification, and prove it appears on the watch.
+8. Select and verify the Cloud Only speech-recognition option.
+9. Submit a real QA bug report containing the run marker so eng-dash can associate it with the run.
+10. Read and capture the final firmware version.
+
+After the catalog, Unicorn pulls the firmware log over BLE and publishes per-step JUnit, phone
+video, screenshots, CoreApp logcat, sidecar logs, and the dehashed watch log.
+
+## Pull-request testing
+
+An unmerged change is tested without copying definitions into Unicorn:
+
+1. Build the PebbleOS PR to get its merged dual-slot `firmware-obelix_pvt` artifact.
+2. Build the CoreApp PR to get its `app-release` APK.
+3. Dispatch Unicorn's `one-off-pebbleos-test` from its integration branch with both run IDs and both
+   source SHAs. Unicorn checks out each catalog at the exact SHA that produced its artifact.
+
+The recommended merge order is Unicorn executor first, CoreApp capabilities second, and PebbleOS
+catalog last. Older artifact commits without both catalogs continue through Unicorn's legacy flow
+during the migration window.

--- a/docs/development/release_qa.md
+++ b/docs/development/release_qa.md
@@ -1,9 +1,10 @@
-# Release QA on real hardware
+# `release-hw-android-obelix`
 
-PebbleOS release QA installs a shipping-style dual-slot firmware artifact on a real watch, pairs it
-with a real phone, upgrades through CoreApp's production sideload path, and then exercises the
-firmware over Pebble Protocol. The executable catalog lives in
-`qa/release/suites/android-obelix.json`; this page describes exactly what it covers and where each
+`release-hw-android-obelix` installs a shipping-style dual-slot firmware artifact on a real watch,
+pairs it with a real phone, upgrades through CoreApp's production sideload path, and then exercises
+the firmware over Pebble Protocol. The executable catalog lives in
+`qa/release/suites/android-obelix.json` (whose stable suite ID is
+`release-hw-android-obelix`); this page describes exactly what it covers and where each
 piece is maintained.
 
 ## Ownership
@@ -19,7 +20,7 @@ The catalog refers to phone behavior only by logical capability ID. This prevent
 from embedding CoreApp screen structure, while keeping the full end-to-end order visible beside the
 firmware it qualifies.
 
-## Android + obelix release suite
+## `release-hw-android-obelix` coverage
 
 Before the catalog runs, Unicorn erases the watch, installs the fixed debug PRF, clears phone and
 Bluetooth state, installs the selected CoreApp APK, onboards and pairs, discovers the default
@@ -48,10 +49,10 @@ An unmerged change is tested without copying definitions into Unicorn:
 
 1. Build the PebbleOS PR to get its merged dual-slot `firmware-obelix_pvt` artifact.
 2. Build the CoreApp PR to get its `app-release` APK.
-3. Manually dispatch PebbleOS `Release QA` from its integration branch with the Unicorn integration
-   ref, both run IDs, and the CoreApp source SHA. It resolves the PebbleOS SHA from the firmware run
-   and dispatches Unicorn through the same REST handoff used after merge. Unicorn checks out each
-   catalog at the exact SHA that produced its artifact.
+3. Manually dispatch PebbleOS `release-hw-android-obelix` from its integration branch with the
+   Unicorn integration ref, both run IDs, and the CoreApp source SHA. It resolves the PebbleOS SHA
+   from the firmware run and dispatches Unicorn through the same REST handoff used after merge.
+   Unicorn checks out each catalog at the exact SHA that produced its artifact.
 
 The recommended merge order is Unicorn executor first, CoreApp capabilities second, and PebbleOS
 catalog last. Older artifact commits without both catalogs continue through Unicorn's legacy flow

--- a/docs/development/release_qa.md
+++ b/docs/development/release_qa.md
@@ -48,8 +48,10 @@ An unmerged change is tested without copying definitions into Unicorn:
 
 1. Build the PebbleOS PR to get its merged dual-slot `firmware-obelix_pvt` artifact.
 2. Build the CoreApp PR to get its `app-release` APK.
-3. Dispatch Unicorn's `one-off-pebbleos-test` from its integration branch with both run IDs and both
-   source SHAs. Unicorn checks out each catalog at the exact SHA that produced its artifact.
+3. Manually dispatch PebbleOS `Release QA` from its integration branch with the Unicorn integration
+   ref, both run IDs, and the CoreApp source SHA. It resolves the PebbleOS SHA from the firmware run
+   and dispatches Unicorn through the same REST handoff used after merge. Unicorn checks out each
+   catalog at the exact SHA that produced its artifact.
 
 The recommended merge order is Unicorn executor first, CoreApp capabilities second, and PebbleOS
 catalog last. Older artifact commits without both catalogs continue through Unicorn's legacy flow

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,5 +1,8 @@
 # Running and writing tests
 
+This page covers host unit tests. The release firmware pass on real watches is cataloged separately
+in {doc}`release_qa`.
+
 Unit tests live under `tests/` and run on the host (not on device or QEMU),
 using a vendored copy of the [clar](https://github.com/clar-test/clar) test
 framework in `tools/clar/`. Code under test is compiled for the host together

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,6 +88,7 @@ development/getting_started.md
 development/options.md
 development/building_fw.md
 development/testing.md
+development/release_qa.md
 development/qemu.md
 development/debugging.md
 development/moddable.md

--- a/qa/release/README.md
+++ b/qa/release/README.md
@@ -1,0 +1,22 @@
+# PebbleOS release QA
+
+This directory is the source of truth for the release tests exercised against PebbleOS firmware on
+real hardware. PebbleOS owns the suite order, watch behavior, and watch-side assertions. CoreApp
+owns reusable phone capabilities and its UI selectors under `qa/release/` in the CoreApp repo.
+Unicorn supplies the hardware, artifact staging, Pebble Protocol sidecar, and result collection.
+
+`suites/android-obelix.json` deliberately references CoreApp by logical capability ID. It must not
+contain CoreApp selectors. Watch flows are small Maestro wrappers because Maestro provides the
+JavaScript HTTP bridge used to drive Unicorn's watch sidecar.
+
+To validate references using a checkout of Unicorn and CoreApp:
+
+```shell
+python3 ../unicorn/qa-release/bin/compose-release-suite.py \
+  --suite qa/release/suites/android-obelix.json \
+  --capabilities ../CoreApp/qa/release/capabilities.json --check
+```
+
+The production runner checks out this directory at the firmware artifact's exact commit and checks
+out CoreApp's capabilities at the APK artifact's exact commit. If either older commit predates the
+catalog, Unicorn uses its legacy monolithic flow during the migration window.

--- a/qa/release/README.md
+++ b/qa/release/README.md
@@ -1,12 +1,13 @@
-# PebbleOS release QA
+# `release-hw-android-obelix`
 
 This directory is the source of truth for the release tests exercised against PebbleOS firmware on
 real hardware. PebbleOS owns the suite order, watch behavior, and watch-side assertions. CoreApp
 owns reusable phone capabilities and its UI selectors under `qa/release/` in the CoreApp repo.
 Unicorn supplies the hardware, artifact staging, Pebble Protocol sidecar, and result collection.
 
-`suites/android-obelix.json` deliberately references CoreApp by logical capability ID. It must not
-contain CoreApp selectors. Watch flows are small Maestro wrappers because Maestro provides the
+`suites/android-obelix.json` has the stable suite ID `release-hw-android-obelix` and deliberately
+references CoreApp by logical capability ID. It must not contain CoreApp selectors. Watch flows are
+small Maestro wrappers because Maestro provides the
 JavaScript HTTP bridge used to drive Unicorn's watch sidecar.
 
 To validate references using a checkout of Unicorn and CoreApp:

--- a/qa/release/suites/android-obelix.json
+++ b/qa/release/suites/android-obelix.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "id": "pebbleos-release-a",
+  "platform": "android",
+  "board": "obelix_pvt",
+  "description": "Release firmware functional pass over Pebble Protocol on a real PT2 and Android phone.",
+  "steps": [
+    { "id": "watch-menus", "watch_flow": "watch/menus.yaml" },
+    { "id": "health", "watch_flow": "watch/health.yaml" },
+    { "id": "install-stride", "coreapp_capability": "store.install_stride" },
+    { "id": "run-stride", "watch_flow": "watch/stride.yaml" },
+    { "id": "install-weather-land", "coreapp_capability": "store.install_weather_land" },
+    { "id": "run-weather-land", "watch_flow": "watch/weather_land.yaml" },
+    { "id": "install-transit", "coreapp_capability": "store.install_transit" },
+    { "id": "run-transit", "watch_flow": "watch/transit.yaml" },
+    { "id": "locker-sync", "coreapp_capability": "locker.verify_release_apps" },
+    { "id": "post-notification", "coreapp_capability": "notifications.post_test" },
+    { "id": "receive-notification", "watch_flow": "watch/notification.yaml" },
+    { "id": "voice-model", "coreapp_capability": "speech.select_cloud_only" },
+    { "id": "bug-report", "coreapp_capability": "support.submit_qa_bug_report" },
+    { "id": "final-version", "watch_flow": "watch/final_version.yaml" }
+  ]
+}

--- a/qa/release/suites/android-obelix.json
+++ b/qa/release/suites/android-obelix.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
-  "id": "pebbleos-release-a",
+  "id": "release-hw-android-obelix",
   "platform": "android",
   "board": "obelix_pvt",
-  "description": "Release firmware functional pass over Pebble Protocol on a real PT2 and Android phone.",
+  "description": "release-hw-android-obelix: firmware functional pass over Pebble Protocol on a real PT2 and Android phone.",
   "steps": [
     { "id": "watch-menus", "watch_flow": "watch/menus.yaml" },
     { "id": "health", "watch_flow": "watch/health.yaml" },

--- a/qa/release/watch/final_version.yaml
+++ b/qa/release/watch/final_version.yaml
@@ -1,0 +1,3 @@
+appId: coredevices.coreapp
+---
+- runScript: scripts/final_version.js

--- a/qa/release/watch/health.yaml
+++ b/qa/release/watch/health.yaml
@@ -1,0 +1,3 @@
+appId: coredevices.coreapp
+---
+- runScript: scripts/health.js

--- a/qa/release/watch/menus.yaml
+++ b/qa/release/watch/menus.yaml
@@ -1,0 +1,4 @@
+appId: coredevices.coreapp
+---
+- runScript: scripts/browse_menus_pp.js
+- assertTrue: ${output.mBluetooth != '' && output.mNotifications != '' && output.mSystem != ''}

--- a/qa/release/watch/notification.yaml
+++ b/qa/release/watch/notification.yaml
@@ -1,0 +1,4 @@
+appId: coredevices.coreapp
+---
+- runScript: scripts/notification_pp.js
+- assertTrue: ${output.notifArrived == 'yes'}

--- a/qa/release/watch/scripts/browse_menus_pp.js
+++ b/qa/release/watch/scripts/browse_menus_pp.js
@@ -1,0 +1,17 @@
+// Release firmware has no readable window stack, so prove navigation by reading each screen.
+var W = 'http://127.0.0.1:8842';
+function open(name) {
+  http.get(W + '/tap?text=' + name);
+  return json(http.get(W + '/text').body).text.join(' | ');
+}
+http.get(W + '/home');
+open('Settings');
+output.mBluetooth = open('Bluetooth');
+http.get(W + '/screenshot?name=02-menu-bluetooth');
+http.get(W + '/press?button=back');
+output.mNotifications = open('Notifications');
+http.get(W + '/screenshot?name=02-menu-notifications');
+http.get(W + '/press?button=back');
+output.mSystem = open('System');
+http.get(W + '/screenshot?name=02-menu-system');
+http.get(W + '/press?button=back');

--- a/qa/release/watch/scripts/final_version.js
+++ b/qa/release/watch/scripts/final_version.js
@@ -1,0 +1,2 @@
+output.fwFinal = json(http.get('http://127.0.0.1:8842/version').body).tag;
+http.get('http://127.0.0.1:8842/screenshot?name=02-final');

--- a/qa/release/watch/scripts/health.js
+++ b/qa/release/watch/scripts/health.js
@@ -1,0 +1,7 @@
+// Proves the Health app renders. Step detection itself requires human motion or a shaker rig.
+var W = 'http://127.0.0.1:8842';
+http.get(W + '/home');
+http.get(W + '/tap?text=Health');
+output.healthText = json(http.get(W + '/text').body).text.join(' | ');
+http.get(W + '/screenshot?name=02-health');
+http.get(W + '/press?button=back');

--- a/qa/release/watch/scripts/notification_pp.js
+++ b/qa/release/watch/scripts/notification_pp.js
@@ -1,0 +1,11 @@
+// Prove CoreApp's test notification reached the watch by reading the watch screen.
+var W = 'http://127.0.0.1:8842';
+var seen = '', arrived = false;
+for (var i = 0; i < 20 && !arrived; i++) {
+  seen = json(http.get(W + '/text').body).text.join(' | ');
+  arrived = /test notification|test @/i.test(seen);
+}
+output.notifText = seen;
+output.notifArrived = arrived ? 'yes' : 'no';
+http.get(W + '/screenshot?name=02-notification');
+http.get(W + '/press?button=back');

--- a/qa/release/watch/scripts/stride_on_watch_pp.js
+++ b/qa/release/watch/scripts/stride_on_watch_pp.js
@@ -1,0 +1,15 @@
+// Start Stride and prove the Watchfaces menu was replaced by a rendered face.
+var W = 'http://127.0.0.1:8842';
+http.get(W + '/home');
+http.get(W + '/tap?text=Watchfaces');
+var tap = http.get(W + '/tap?text=Stride');
+output.strideInstalled = (tap.status == 200 && json(tap.body).ok) ? 'yes' : 'no';
+var seen = '';
+var rendered = false;
+for (var i = 0; i < 20 && !rendered; i++) {
+  seen = json(http.get(W + '/text').body).text.join(' | ');
+  rendered = seen != '' && !/Watchfaces/i.test(seen);
+}
+output.faceText = seen;
+output.faceRendered = rendered ? 'yes' : 'no';
+http.get(W + '/screenshot?name=02-stride-running');

--- a/qa/release/watch/scripts/transit_on_watch.js
+++ b/qa/release/watch/scripts/transit_on_watch.js
@@ -1,0 +1,14 @@
+// Start Transit and prove it renders a schedule for the hardware lab's deterministic location.
+var W = 'http://127.0.0.1:8842';
+function launch() { http.get(W + '/home'); http.get(W + '/tap?text=Transit'); }
+launch();
+var seen = '', ok = false, relaunches = 0;
+for (var i = 0; i < 30 && !ok; i++) {
+  seen = json(http.get(W + '/text').body).text.join(' | ');
+  if (/failed/i.test(seen) && relaunches < 2) { relaunches++; launch(); continue; }
+  ok = /Caltrain|Palo Alto/i.test(seen);
+}
+output.transitText = seen;
+output.transitCaltrain = ok ? 'yes' : 'no';
+http.get(W + '/screenshot?name=02-transit');
+http.get(W + '/press?button=back');

--- a/qa/release/watch/scripts/weatherland_on_watch.js
+++ b/qa/release/watch/scripts/weatherland_on_watch.js
@@ -1,0 +1,29 @@
+// Start Weather Land and prove that its date and temperature slot render after PebbleKit-JS data.
+var W = 'http://127.0.0.1:8842';
+function launch() {
+  http.get(W + '/home');
+  http.get(W + '/tap?text=Watchfaces');
+  http.get(W + '/tap?text=Weather');
+}
+function weatherRendered(arr) {
+  var joined = arr.join(' | ');
+  var hasDate = /\b(AUG|JAN|FEB|MAR|APR|MAY|JUN|JUL|SEP|OCT|NOV|DEC)\b/i.test(joined);
+  var hasTemp = arr.some(function (t) {
+    var s = t.trim();
+    return s.length >= 1 && s.length <= 3 && s.indexOf(':') < 0 && /[0-9]/.test(s) &&
+           !/(AUG|JAN|FEB|MAR|APR|MAY|JUN|JUL|SEP|OCT|NOV|DEC|THU|MON|TUE|WED|FRI|SAT|SUN)/i.test(s);
+  });
+  return hasDate && hasTemp;
+}
+launch();
+var seen = '', ok = false, relaunches = 0;
+for (var it = 0; it < 40 && !ok; it++) {
+  var reader = (it % 2 === 0) ? '' : '?reader=llm';
+  var body = json(http.get(W + '/text' + reader).body);
+  seen = body.text.join(' | ');
+  if (/failed/i.test(seen) && relaunches < 2) { relaunches++; launch(); continue; }
+  ok = weatherRendered(body.text);
+}
+output.weatherText = seen;
+output.weatherTemp = ok ? 'yes' : 'no';
+http.get(W + '/screenshot?name=02-weather-land');

--- a/qa/release/watch/stride.yaml
+++ b/qa/release/watch/stride.yaml
@@ -1,0 +1,5 @@
+appId: coredevices.coreapp
+---
+- runScript: scripts/stride_on_watch_pp.js
+- assertTrue: ${output.strideInstalled == 'yes'}
+- assertTrue: ${output.faceRendered == 'yes'}

--- a/qa/release/watch/transit.yaml
+++ b/qa/release/watch/transit.yaml
@@ -1,0 +1,4 @@
+appId: coredevices.coreapp
+---
+- runScript: scripts/transit_on_watch.js
+- assertTrue: ${output.transitCaltrain == 'yes'}

--- a/qa/release/watch/weather_land.yaml
+++ b/qa/release/watch/weather_land.yaml
@@ -1,0 +1,4 @@
+appId: coredevices.coreapp
+---
+- runScript: scripts/weatherland_on_watch.js
+- assertTrue: ${output.weatherTemp == 'yes'}


### PR DESCRIPTION
## Outcome

This PR is closed and should not be merged as an executable test catalog.

The release tests require the private Unicorn harness, CoreApp artifacts, and dedicated hardware, so contributors with only PebbleOS cannot run them. Executable suite ownership has therefore moved back to Unicorn.

The follow-up branch commit `6825789e0` removes the proposed PebbleOS catalog, watch flows, and test documentation. Its only remaining diff is the thin `release-hw-android-obelix` dispatch bridge:

- validate the exact firmware artifact run
- dispatch the private Unicorn workflow through the REST API
- pass only the exact `to_pbz_run_id`
- keep all executable test definitions out of PebbleOS

## Final ownership

- Unicorn: ordered release suite, watch flows, composer, hardware orchestration, evidence
- CoreApp: private phone capability registry and selectors
- PebbleOS: firmware build artifact and optional thin dispatch bridge only

Unicorn `main` commit `8ff118c` contains the self-contained executable suite. CoreApp #267 remains the companion capability PR; it has no dependency on this closed PR.

## Validation

- reduced PebbleOS branch diff contains one workflow file and no `qa/release` test definitions or release-test documentation
- workflow YAML parses and Actions lint passes
- live bridge run passed: https://github.com/coredevices/PebbleOS/actions/runs/33144183527
- it dispatched Unicorn `main` at `8ff118c`: https://github.com/coredevices/unicorn/actions/runs/33144188613
- the Unicorn Android job was correctly skipped because the preserved Android lane is paused
- final Codex review found no actionable defect in the reduced workflow
