### PR TITLE
docs: add Dependabot package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,9 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+  - package-ecosystem: pip
+    directory: '/docs'
+    commit-message:
+      prefix: 'docs'
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Add Dependabot to update the `requirements.txt` versions, but only in thd `docs` folder.
Figured this would be less noisy than adding the root files as a start