### PR TITLE
fw/apps/launcher: honor the user's Text Size preference in the main menu

### DIFF
--- a/src/fw/apps/system/launcher/default/app_glance_settings.c
+++ b/src/fw/apps/system/launcher/default/app_glance_settings.c
@@ -20,15 +20,41 @@
 #include "pbl/services/notifications/do_not_disturb.h"
 #include "system/passert.h"
 #include "pbl/util/attributes.h"
+#include "pbl/util/math.h"
 #include "pbl/util/size.h"
 #include "pbl/util/string.h"
 #include "pbl/util/struct.h"
 
 #include <stdio.h>
 
-// These dimensions are separate defines so we can use them to statically define the battery points
-#define BATTERY_SILHOUETTE_ICON_WIDTH (16)
-#define BATTERY_SILHOUETTE_ICON_HEIGHT (9)
+typedef struct {
+  int16_t width;
+  int16_t height;
+} IconSize;
+
+static const IconSize s_battery_silhouette_icon_size[NumPreferredContentSizes] = {
+  //! @note this is the same as Medium until Small is designed
+  [PreferredContentSizeSmall] = { .width = 12, .height = 7 },
+  [PreferredContentSizeMedium] = { .width = 16, .height = 9 },
+  [PreferredContentSizeLarge] = { .width = 16, .height = 9 },
+  [PreferredContentSizeExtraLarge] = { .width = 21, .height = 12 },
+};
+
+static IconSize prv_get_battery_silhouette_icon_size(void) {
+  return s_battery_silhouette_icon_size[launcher_menu_layer_get_clamped_content_size()];
+}
+
+static const IconSize s_charging_icon_size[NumPreferredContentSizes] = {
+  //! @note this is the same as Medium until Small is designed
+  [PreferredContentSizeSmall] = { .width = 5, .height = 7 },
+  [PreferredContentSizeMedium] = { .width = 7, .height = 9 },
+  [PreferredContentSizeLarge] = { .width = 7, .height = 9 },
+  [PreferredContentSizeExtraLarge] = { .width = 9, .height = 12 },
+};
+
+static IconSize prv_get_charging_icon_size(void) {
+  return s_charging_icon_size[launcher_menu_layer_get_clamped_content_size()];
+}
 
 typedef struct LauncherAppGlanceSettingsState {
   BatteryChargeState battery_charge_state;
@@ -45,7 +71,6 @@ typedef struct LauncherAppGlanceSettings {
   char battery_percent_text[5]; //!< longest string is "100%" (4 characters + 1 for NULL terminator)
   KinoReel *icon;
   uint32_t icon_resource_id;
-  KinoReel *charging_indicator_icon;
   uint8_t subtitle_font_height;
   LauncherAppGlanceSettingsState glance_state;
   EventServiceInfo battery_state_event_info;
@@ -76,19 +101,56 @@ static void prv_charging_icon_node_draw_cb(GContext *ctx, const GRect *rect,
   LauncherAppGlanceSettings *settings_glance =
       launcher_app_glance_structured_get_data(structured_glance);
 
-  KinoReel *charging_indicator_icon = NULL_SAFE_FIELD_ACCESS(settings_glance,
-                                                             charging_indicator_icon, NULL);
-  PBL_ASSERTN(charging_indicator_icon);
+  const IconSize icon_size = prv_get_charging_icon_size();
+  const int16_t w = icon_size.width;
+  const int16_t h = icon_size.height;
 
+  if (render) {
+    const GColor bolt_color =
+        launcher_app_glance_structured_get_highlight_color(structured_glance);
+    graphics_context_set_fill_color(ctx, bolt_color);
 
-  if (render && charging_indicator_icon) {
-    launcher_app_glance_structured_draw_icon(structured_glance, ctx, charging_indicator_icon,
-                                             rect->origin);
+    // Minimum 1px crossbar height keeps the bolt recognizable at small sizes.
+    const int16_t bar_height = MAX((int16_t)1, (int16_t)ROUND(h, 9));
+    const int16_t bar_top = (int16_t)ROUND(h * 4, 9);
+    const int16_t bar_bottom = bar_top + bar_height;
+
+    const int16_t apex_left = (int16_t)ROUND(w * 4, 7);
+    const int16_t apex_right = (int16_t)ROUND(w * 5, 7);
+    const int16_t upper_right_at_bar = apex_left;
+    for (int16_t y = 0; y < bar_top; y++) {
+      const int16_t x0 = (int16_t)ROUND(apex_left * (bar_top - y), bar_top);
+      const int16_t x1 =
+          MAX((int16_t)(x0 + 1),
+              (int16_t)ROUND(apex_right * (bar_top - y) + upper_right_at_bar * y, bar_top));
+      graphics_fill_rect(ctx, &GRect(rect->origin.x + x0, rect->origin.y + y, x1 - x0, 1));
+    }
+
+    graphics_fill_rect(ctx, &GRect(rect->origin.x, rect->origin.y + bar_top, w, bar_height));
+
+    const int16_t lower_left_at_bar = (int16_t)ROUND(w * 3, 7);
+    const int16_t lower_right_at_bar = (int16_t)ROUND(w * 6, 7);
+    const int16_t bottom_point = (int16_t)ROUND(w * 5, 14);  // 2.5/7, kept as a 14ths fraction
+    const int16_t rows_below = h - bar_bottom;
+    for (int16_t i = 0; i < rows_below; i++) {
+      int16_t x0, x1;
+      if (rows_below > 1) {
+        const int16_t denom = rows_below - 1;
+        x0 = (int16_t)ROUND(lower_left_at_bar * (denom - i) + bottom_point * i, denom);
+        x1 = MAX((int16_t)(x0 + 1),
+                 (int16_t)ROUND(lower_right_at_bar * (denom - i) + (bottom_point + 1) * i,
+                                denom));
+      } else {
+        x0 = bottom_point;
+        x1 = bottom_point + 1;
+      }
+      graphics_fill_rect(ctx, &GRect(rect->origin.x + x0, rect->origin.y + bar_bottom + i,
+                                     x1 - x0, 1));
+    }
   }
 
   if (size_out) {
-    *size_out = GSize(kino_reel_get_size(charging_indicator_icon).w,
-                      settings_glance->subtitle_font_height);
+    *size_out = GSize(w, settings_glance->subtitle_font_height);
   }
 }
 
@@ -99,24 +161,23 @@ static void prv_battery_icon_node_draw_cb(GContext *ctx, const GRect *rect,
   LauncherAppGlanceSettings *settings_glance =
       launcher_app_glance_structured_get_data(structured_glance);
 
-  const GSize battery_silhouette_icon_size = GSize(BATTERY_SILHOUETTE_ICON_WIDTH,
-                                                   BATTERY_SILHOUETTE_ICON_HEIGHT);
+  const IconSize icon_size = prv_get_battery_silhouette_icon_size();
+  const GSize battery_silhouette_icon_size = GSize(icon_size.width, icon_size.height);
 
   if (render) {
-    // This points array is static to help conserve stack usage
-    static const GPoint s_battery_silhouette_path_points[] = {
+    const GPoint battery_silhouette_path_points[] = {
       {0, 0},
-      {BATTERY_SILHOUETTE_ICON_WIDTH - 1, 0},
-      {BATTERY_SILHOUETTE_ICON_WIDTH - 1, 1},
-      {BATTERY_SILHOUETTE_ICON_WIDTH + 1, 2},
-      {BATTERY_SILHOUETTE_ICON_WIDTH + 1, BATTERY_SILHOUETTE_ICON_HEIGHT - 3},
-      {BATTERY_SILHOUETTE_ICON_WIDTH - 1, BATTERY_SILHOUETTE_ICON_HEIGHT - 3},
-      {BATTERY_SILHOUETTE_ICON_WIDTH - 1, BATTERY_SILHOUETTE_ICON_HEIGHT - 1},
-      {0, BATTERY_SILHOUETTE_ICON_HEIGHT - 1},
+      {icon_size.width - 1, 0},
+      {icon_size.width - 1, 1},
+      {icon_size.width + 1, 2},
+      {icon_size.width + 1, icon_size.height - 3},
+      {icon_size.width - 1, icon_size.height - 3},
+      {icon_size.width - 1, icon_size.height - 1},
+      {0, icon_size.height - 1},
     };
     GPath battery_silhouette_path = (GPath) {
-      .num_points = ARRAY_LENGTH(s_battery_silhouette_path_points),
-      .points = (GPoint *)s_battery_silhouette_path_points,
+      .num_points = ARRAY_LENGTH(battery_silhouette_path_points),
+      .points = (GPoint *)battery_silhouette_path_points,
       .offset = rect->origin,
     };
 
@@ -206,16 +267,14 @@ static GTextNode *prv_create_subtitle_node(LauncherAppGlanceStructured *structur
                                            vertically_centered_battery_percent_text_node);
   }
 
-#if PBL_DISPLAY_HEIGHT >= 200
-  const int16_t subtitle_icon_offset_y = 5;
-#else
-  const int16_t subtitle_icon_offset_y = 2;
-#endif
+  const IconSize battery_icon_size = prv_get_battery_silhouette_icon_size();
+  const int16_t battery_icon_offset_y =
+      (settings_glance->subtitle_font_height - battery_icon_size.height) / 2;
 
   GTextNodeCustom *battery_icon_node =
       graphics_text_node_create_custom(prv_battery_icon_node_draw_cb, structured_glance);
   // Push the battery icon down to center it properly
-  battery_icon_node->node.offset.y += subtitle_icon_offset_y;
+  battery_icon_node->node.offset.y += battery_icon_offset_y;
 
   // Achieves the design spec'd 6 px horizontal spacing b/w the battery icon and charging icon
   battery_icon_node->node.margin.w = 7;
@@ -225,10 +284,12 @@ static GTextNode *prv_create_subtitle_node(LauncherAppGlanceStructured *structur
                                          vertically_centered_battery_icon_node);
 
   if (settings_glance->glance_state.battery_charge_state.is_plugged) {
+    const int16_t charging_icon_offset_y =
+        (settings_glance->subtitle_font_height - prv_get_charging_icon_size().height) / 2;
     GTextNodeCustom *charging_icon_node =
         graphics_text_node_create_custom(prv_charging_icon_node_draw_cb, structured_glance);
     // Push the charging icon down to center it properly
-    charging_icon_node->node.offset.y += subtitle_icon_offset_y;
+    charging_icon_node->node.offset.y += charging_icon_offset_y;
     GTextNode *vertically_centered_charging_icon_node =
         prv_wrap_text_node_in_vertically_centered_container(&charging_icon_node->node);
     graphics_text_node_container_add_child(&horizontal_container_node->container,
@@ -250,7 +311,6 @@ static void prv_destructor(LauncherAppGlanceStructured *structured_glance) {
     event_service_client_unsubscribe(&settings_glance->hrm_sharing_event_info);
 #endif
     kino_reel_destroy(settings_glance->icon);
-    kino_reel_destroy(settings_glance->charging_indicator_icon);
   }
   app_free(settings_glance);
 }
@@ -389,13 +449,9 @@ LauncherAppGlance *launcher_app_glance_settings_create(const AppMenuNode *node) 
   strncpy(settings_glance->title, node->name, title_size);
   settings_glance->title[title_size - 1] = '\0';
 
-  // Load the charging indicator icon
-  settings_glance->charging_indicator_icon =
-      kino_reel_create_with_resource(RESOURCE_ID_BATTERY_CHARGING_ICON);
-
   // Cache the subtitle font height for simplifying layout calculations
   settings_glance->subtitle_font_height =
-      fonts_get_font_height(fonts_get_system_font(LAUNCHER_MENU_LAYER_SUBTITLE_FONT));
+      fonts_get_font_height(launcher_menu_layer_get_subtitle_font());
 
   const bool should_consider_slices = false;
   LauncherAppGlanceStructured *structured_glance =

--- a/src/fw/apps/system/launcher/default/app_glance_structured.c
+++ b/src/fw/apps/system/launcher/default/app_glance_structured.c
@@ -535,8 +535,8 @@ LauncherAppGlanceStructured *launcher_app_glance_structured_create(
   structured_glance->icon_max_size = LAUNCHER_APP_GLANCE_STRUCTURED_ICON_MAX_SIZE;
   structured_glance->icon_horizontal_margin =
       LAUNCHER_APP_GLANCE_STRUCTURED_ICON_HORIZONTAL_MARGIN;
-  structured_glance->title_font = fonts_get_system_font(LAUNCHER_MENU_LAYER_TITLE_FONT);
-  structured_glance->subtitle_font = fonts_get_system_font(LAUNCHER_MENU_LAYER_SUBTITLE_FONT);
+  structured_glance->title_font = launcher_menu_layer_get_title_font();
+  structured_glance->subtitle_font = launcher_menu_layer_get_subtitle_font();
   KinoReel *glance_impl = kino_reel_custom_create(&s_launcher_app_glance_structured_reel_impl,
                                                   structured_glance);
   // Now that we've setup the structured glance's fields, initialize the LauncherAppGlance

--- a/src/fw/apps/system/launcher/default/menu_layer.c
+++ b/src/fw/apps/system/launcher/default/menu_layer.c
@@ -14,11 +14,79 @@
 #include "pbl/services/timeline/timeline_resources.h"
 #include "system/passert.h"
 #include "shell/prefs.h"
+#include "shell/system_theme.h"
 #include "pbl/util/attributes.h"
 #include "pbl/util/struct.h"
 
 #define LAUNCHER_MENU_LAYER_CONTENT_INDICATOR_LAYER_HEIGHT (32)
 #define LAUNCHER_MENU_LAYER_GENERIC_APP_ICON (RESOURCE_ID_MENU_LAYER_GENERIC_WATCHAPP_ICON)
+
+PreferredContentSize launcher_menu_layer_get_clamped_content_size(void) {
+  const PreferredContentSize content_size = system_theme_get_content_size();
+  return (content_size < NumPreferredContentSizes) ? content_size : PreferredContentSizeDefault;
+}
+
+static const struct {
+  const char *title_font_key;
+  const char *subtitle_font_key;
+} s_launcher_fonts[NumPreferredContentSizes] = {
+  //! @note this is the same as Medium until Small is designed
+  [PreferredContentSizeSmall] = {
+    .title_font_key = FONT_KEY_GOTHIC_18_BOLD,
+    .subtitle_font_key = FONT_KEY_GOTHIC_14,
+  },
+  [PreferredContentSizeMedium] = {
+    .title_font_key = FONT_KEY_GOTHIC_18_BOLD,
+    .subtitle_font_key = FONT_KEY_GOTHIC_14,
+  },
+  [PreferredContentSizeLarge] = {
+    .title_font_key = FONT_KEY_GOTHIC_24_BOLD,
+    .subtitle_font_key = FONT_KEY_GOTHIC_18,
+  },
+  [PreferredContentSizeExtraLarge] = {
+    .title_font_key = FONT_KEY_GOTHIC_28_BOLD,
+    .subtitle_font_key = FONT_KEY_GOTHIC_24,
+  },
+};
+
+GFont launcher_menu_layer_get_title_font(void) {
+  const PreferredContentSize content_size = launcher_menu_layer_get_clamped_content_size();
+  return fonts_get_system_font(s_launcher_fonts[content_size].title_font_key);
+}
+
+GFont launcher_menu_layer_get_subtitle_font(void) {
+  const PreferredContentSize content_size = launcher_menu_layer_get_clamped_content_size();
+  return fonts_get_system_font(s_launcher_fonts[content_size].subtitle_font_key);
+}
+
+static const struct {
+  int16_t rect_cell_height;
+  int16_t round_focused_cell_height;
+  int16_t round_unfocused_cell_height;
+} s_launcher_cell_dimensions[NumPreferredContentSizes] = {
+  //! @note this is the same as Medium until Small is designed
+  [PreferredContentSizeSmall] = {
+    .rect_cell_height = 42,
+    .round_focused_cell_height = 52,
+    .round_unfocused_cell_height = 38,
+  },
+  [PreferredContentSizeMedium] = {
+    .rect_cell_height = 42,
+    .round_focused_cell_height = 52,
+    .round_unfocused_cell_height = 38,
+  },
+  [PreferredContentSizeLarge] = {
+    .rect_cell_height = 50,
+    .round_focused_cell_height = 55,
+    .round_unfocused_cell_height = 45,
+  },
+  [PreferredContentSizeExtraLarge] = {
+    .rect_cell_height = 60,
+    // Round always shows 5 fixed rows, so focused + 4*unfocused must fit the 260px display.
+    .round_focused_cell_height = 57,
+    .round_unfocused_cell_height = 47,
+  },
+};
 
 ////////////////////////////
 // Misc. callbacks/helpers
@@ -124,12 +192,13 @@ static void prv_menu_layer_draw_row(GContext* ctx, const Layer *cell_layer, Menu
 
 static int16_t prv_menu_layer_get_cell_height(PBL_UNUSED MenuLayer *menu_layer,
                                               PBL_UNUSED MenuIndex *cell_index, PBL_UNUSED void *context) {
+  const PreferredContentSize content_size = launcher_menu_layer_get_clamped_content_size();
 #if PBL_RECT
-  return LAUNCHER_MENU_LAYER_CELL_RECT_CELL_HEIGHT;
+  return s_launcher_cell_dimensions[content_size].rect_cell_height;
 #elif PBL_ROUND
   return menu_layer_is_index_selected(menu_layer, cell_index) ?
-      LAUNCHER_MENU_LAYER_CELL_ROUND_FOCUSED_CELL_HEIGHT :
-      LAUNCHER_MENU_LAYER_CELL_ROUND_UNFOCUSED_CELL_HEIGHT;
+      s_launcher_cell_dimensions[content_size].round_focused_cell_height :
+      s_launcher_cell_dimensions[content_size].round_unfocused_cell_height;
 #else
 #error "Unknown display shape type"
 #endif
@@ -180,8 +249,8 @@ void launcher_menu_layer_init(LauncherMenuLayer *launcher_menu_layer,
   // LAUNCHER_MENU_LAYER_NUM_VISIBLE_ROWS in launcher_menu_layer_private.h is valid
   const GRect frame = DISP_FRAME;
 
-  launcher_menu_layer->title_font = fonts_get_system_font(LAUNCHER_MENU_LAYER_TITLE_FONT);
-  launcher_menu_layer->subtitle_font = fonts_get_system_font(LAUNCHER_MENU_LAYER_SUBTITLE_FONT);
+  launcher_menu_layer->title_font = launcher_menu_layer_get_title_font();
+  launcher_menu_layer->subtitle_font = launcher_menu_layer_get_subtitle_font();
 
   Layer *container_layer = &launcher_menu_layer->container_layer;
   layer_init(container_layer, &frame);
@@ -190,10 +259,11 @@ void launcher_menu_layer_init(LauncherMenuLayer *launcher_menu_layer,
 
   GRect menu_layer_frame = frame;
 #if PBL_ROUND
+  const PreferredContentSize content_size = launcher_menu_layer_get_clamped_content_size();
   const int top_bottom_inset =
-      (frame.size.h - LAUNCHER_MENU_LAYER_CELL_ROUND_FOCUSED_CELL_HEIGHT -
+      (frame.size.h - s_launcher_cell_dimensions[content_size].round_focused_cell_height -
           (2 * LAUNCHER_MENU_LAYER_NUM_UNFOCUSED_ROWS_PER_SIDE *
-           LAUNCHER_MENU_LAYER_CELL_ROUND_UNFOCUSED_CELL_HEIGHT)) / 2;
+           s_launcher_cell_dimensions[content_size].round_unfocused_cell_height)) / 2;
   const GEdgeInsets menu_layer_frame_insets = GEdgeInsets(top_bottom_inset, 0);
   menu_layer_frame = grect_inset(menu_layer_frame, menu_layer_frame_insets);
 #endif

--- a/src/fw/apps/system/launcher/default/menu_layer.h
+++ b/src/fw/apps/system/launcher/default/menu_layer.h
@@ -5,18 +5,9 @@
 
 #include "app_glance_service.h"
 
+#include "applib/preferred_content_size.h"
 #include "process_management/app_menu_data_source.h"
 #include "board/display.h"
-
-// Use display height to determine launcher fonts: larger displays use larger fonts
-#if PBL_DISPLAY_HEIGHT >= 200
-#define LAUNCHER_MENU_LAYER_TITLE_FONT (FONT_KEY_GOTHIC_24_BOLD)
-#define LAUNCHER_MENU_LAYER_SUBTITLE_FONT (FONT_KEY_GOTHIC_18)
-#else
-#define LAUNCHER_MENU_LAYER_TITLE_FONT (FONT_KEY_GOTHIC_18_BOLD)
-#define LAUNCHER_MENU_LAYER_SUBTITLE_FONT (FONT_KEY_GOTHIC_14)
-#endif
-
 
 typedef struct LauncherMenuLayer {
   Layer container_layer;
@@ -37,6 +28,13 @@ typedef struct LauncherMenuLayerSelectionState {
   int16_t scroll_offset_y;
   uint16_t row_index;
 } LauncherMenuLayerSelectionState;
+
+//! Resolves the launcher's title/subtitle fonts for the user's current text size preference.
+GFont launcher_menu_layer_get_title_font(void);
+GFont launcher_menu_layer_get_subtitle_font(void);
+
+//! system_theme_get_content_size(), clamped to a valid PreferredContentSize.
+PreferredContentSize launcher_menu_layer_get_clamped_content_size(void);
 
 void launcher_menu_layer_init(LauncherMenuLayer *launcher_menu_layer,
                               AppMenuDataSource *data_source);

--- a/src/fw/apps/system/launcher/default/menu_layer_private.h
+++ b/src/fw/apps/system/launcher/default/menu_layer_private.h
@@ -6,20 +6,9 @@
 #include "pbl/util/math.h"
 #include "board/display.h"
 
-// Use display height to determine launcher cell height: larger displays use taller cells
-#if PBL_DISPLAY_HEIGHT >= 200
-#define LAUNCHER_MENU_LAYER_CELL_RECT_CELL_HEIGHT (50)
-#else
-#define LAUNCHER_MENU_LAYER_CELL_RECT_CELL_HEIGHT (42)
-#endif
-
-#if PBL_ROUND && PBL_DISPLAY_HEIGHT >= 200
-#define LAUNCHER_MENU_LAYER_CELL_ROUND_FOCUSED_CELL_HEIGHT (55)
-#define LAUNCHER_MENU_LAYER_CELL_ROUND_UNFOCUSED_CELL_HEIGHT (45)
-#else
-#define LAUNCHER_MENU_LAYER_CELL_ROUND_FOCUSED_CELL_HEIGHT (52)
-#define LAUNCHER_MENU_LAYER_CELL_ROUND_UNFOCUSED_CELL_HEIGHT (38)
-#endif
+// Smallest tier's row height, used only to size the glance cache (app_glance_service.c) for the
+// worst case. Not the actual rendered height - keep in sync with s_launcher_cell_dimensions.
+#define LAUNCHER_MENU_LAYER_CELL_RECT_CELL_HEIGHT_MIN (42)
 
 #if PBL_ROUND && PBL_DISPLAY_HEIGHT >= 200
 //! Two "unfocused" cells above and below one centered "focused" cell (5 total for larger display)
@@ -31,5 +20,5 @@
 #define LAUNCHER_MENU_LAYER_NUM_VISIBLE_ROWS (3)
 #else
 #define LAUNCHER_MENU_LAYER_NUM_VISIBLE_ROWS \
-    (DIVIDE_CEIL(DISP_ROWS, LAUNCHER_MENU_LAYER_CELL_RECT_CELL_HEIGHT))
+    (DIVIDE_CEIL(DISP_ROWS, LAUNCHER_MENU_LAYER_CELL_RECT_CELL_HEIGHT_MIN))
 #endif


### PR DESCRIPTION
Refs #1911.

  Builds on #1912: that PR switched the Settings menu, Bluetooth submenu, and several other
  system screens over to the Text Size preference (`textStyle` pref,
  `system_theme_get_content_size()`). The main menu (the app list, "Launcher") wasn't included
  there; it uses a completely separate rendering path (`apps/system/launcher/default/`), not any
  of the shared `menu_layer_system_cells.c` mechanisms.
  
  This PR (main menu): fonts, cell height, glance cache
  size, and the battery/charging icons in the Settings glance tile now follow the user's
  preference too, instead of fixed per-display-size values.

  **No new setting needed:** the launcher reads the same `textStyle` value that #1912 already
  exposed under "Settings → Display → Text Size" (Smaller/Default/Larger). Users who already know
  that setting now see its effect in the main menu too, without any new menu entry appearing
  anywhere.

  ### What changes

  1. **Fonts** (`menu_layer.c`): title/subtitle font per content-size tier instead of a fixed
     `#if PBL_DISPLAY_HEIGHT >= 200` macro. Medium/Large match today's exact look (no visible
     change without an active user choice); Small mirrors Medium (matching the convention in
     `system_theme.c`: "same as Medium until Small is designed"); ExtraLarge is newly designed
     (`GOTHIC_28_BOLD`/`GOTHIC_24`, one Gothic size step above Large).

  2. **Cell height** (Rect + Round): dynamic in the same way. Round displays always show a fixed
     5 rows at once; the ExtraLarge values were chosen so the total still fits the display at that
     fixed row count.

  3. **Glance cache size** (`app_glance_service.c`/`menu_layer_private.h`): the launcher keeps a
     small LRU cache of the most recently drawn "glance" objects (title/icon/subtitle per app row)
     so it doesn't have to rebuild them on every scroll frame. The cache size (2 × number of
     visible rows) was previously computed at compile time for rect displays from the static
     platform-default cell height. Since cell height can now be *smaller* than that default
     depending on the chosen tier (e.g. "Smaller"), more rows can fit on screen at once than the
     old compile-time estimate assumed, so the cache would have been undersized for that case.
     Fix: the calculation now uses the smallest possible cell height across all tiers (worst case
     = most visible rows), regardless of which tier the user has selected.

     Two things about this that came up during review and were deliberately left as-is:
     - The cache size remains a fixed compile-time constant and does not adapt to the selected
       tier at runtime. It's sized to be large enough for every tier up front. At larger tiers
       (fewer visible rows) the cache ends up somewhat bigger than strictly necessary, but the
       entries are small enough (one list node plus a handful of font/layout fields) that this
       doesn't matter.
     - An undersized cache would not have been a safety issue anyway (verified:
       `prv_glance_cache_put()` always evicts the oldest entry first if needed before adding a new
       one, so the counter can never exceed capacity). The only effect of too small a size would
       have been more cache churn while scrolling (glances rebuilt more often instead of reused),
       not a crash risk.

     Round displays are unaffected: the number of visible rows (5 or 3) is a fixed layout choice
     there, independent of cell height.

  4. **Battery/charging icon in the Settings glance tile**: both now scale too. The charging icon
     used to be a fixed 7x9px bitmap; it's now redrawn as a small vector shape.

  ### Why third-party apps are unaffected

  Unlike #1912, all of the launcher code here is purely internal system code. No watchapp can
  reach these functions or headers.

  ### Validation

  - Rect (`obelix@pvt`, physical device): tested at all three tiers, including the
    battery/charging icon while actually charging.
  - Round (`qemu_gabbro`, QEMU + `pebble-tool`): all four tiers including ExtraLarge, charging
    simulated, clean layout confirmed.
  - `./pbl test`: the full suite passes.

  ### Known limitations / deliberately out of scope for this PR

  - The ExtraLarge values are a first pass, not a final design.
  - The cell-height/font discrepancy between the launcher and Settings at "Large" (pre-existing,
    arose independently) is deliberately not part of this PR, since changing it would affect the
    whole system, not just the launcher.
  - The remaining ~20 screens (Health, Workout, Music, ...) are unchanged, as described in #1911.
