### PR TITLE
ci: nightly firmware builds published to eng-dash

### DIFF
--- a/.github/actions/publish-engdash/action.yml
+++ b/.github/actions/publish-engdash/action.yml
@@ -1,0 +1,84 @@
+name: Publish firmware to eng-dash
+description: >
+  Upload firmware release files to the eng-dash OTA ingest endpoint.
+  pbz files are published before elfs, since elfs attach to the artifact
+  rows their pbz creates.
+
+inputs:
+  version:
+    description: Firmware version the files were built as (git describe)
+    required: true
+  track:
+    description: CI track the build auto-deploys to (internal or nightly)
+    required: false
+    default: internal
+  token:
+    description: eng-dash OTA ingest token
+    required: true
+  path:
+    description: Directory containing the release files
+    required: false
+    default: release
+
+runs:
+  using: composite
+  steps:
+    - name: Publish
+      shell: bash
+      env:
+        ENGDASH_URL: https://dash.repebble.com/api/ota/releases/upload
+        ENGDASH_TOKEN: ${{ inputs.token }}
+        VERSION: ${{ inputs.version }}
+        TRACK: ${{ inputs.track }}
+        REVISION: ${{ github.sha }}
+        FILES: ${{ inputs.path }}
+      run: |
+        set -o pipefail
+
+        publish() {
+          file="$1"
+          body=$(jq -n \
+            --arg version "$VERSION" \
+            --arg revision "$REVISION" \
+            --arg track "$TRACK" \
+            --arg filename "$(basename "$file")" \
+            --arg sha256 "$(sha256sum "$file" | cut -d' ' -f1)" \
+            '{version: $version, revision: $revision, track: $track, filename: $filename, sha256: $sha256}')
+
+          for _ in 1 2; do
+            resp=$(curl -sS --fail-with-body -X POST \
+              -H "Authorization: Bearer $ENGDASH_TOKEN" \
+              -H "Content-Type: application/json" \
+              --data "$body" "$ENGDASH_URL") || {
+              echo "::error::$file: $resp" >&2
+              return 1
+            }
+            case "$(echo "$resp" | jq -r .status)" in
+              uploaded|ignored)
+                echo "$file: $(echo "$resp" | jq -c .)"
+                return 0
+                ;;
+              upload_required)
+                curl -sS --fail -X PUT --upload-file "$file" \
+                  "$(echo "$resp" | jq -r .upload_url)" || {
+                  echo "::error::$file: artifact upload failed" >&2
+                  return 1
+                }
+                ;;
+              *)
+                echo "::error::$file: unexpected response: $resp" >&2
+                return 1
+                ;;
+            esac
+          done
+
+          echo "::error::$file: not ingested after upload" >&2
+          return 1
+        }
+
+        for file in "$FILES"/normal_*.pbz; do
+          publish "$file"
+        done
+        for file in "$FILES"/firmware_*.elf; do
+          publish "$file"
+        done

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      should-build: ${{ github.event_name == 'push' || steps.filter.outputs.src == 'true' }}
+      should-build: ${{ github.event_name != 'pull_request' || steps.filter.outputs.src == 'true' }}
     steps:
       - uses: dorny/paths-filter@v4
         if: github.event_name == 'pull_request'
@@ -141,7 +141,7 @@ jobs:
           echo "BUILD_ID=$(readelf -n build/pebbleos.elf | sed -n -e 's/^.*Build ID: //p')" >> "$GITHUB_OUTPUT"
 
       - name: Upload log hash dictionary
-        if: ${{ github.event_name == 'push' && github.repository == 'coredevices/PebbleOS' }}
+        if: ${{ github.event_name != 'pull_request' && github.repository == 'coredevices/PebbleOS' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.LOG_HASH_BUCKET_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.LOG_HASH_BUCKET_SECRET }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,56 @@
+name: Nightly
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+jobs:
+  build-firmware:
+    if: ${{ github.repository == 'coredevices/PebbleOS' }}
+    uses: ./.github/workflows/build-firmware.yml
+    secrets: inherit
+
+  publish:
+    runs-on: ubuntu-24.04
+    needs: build-firmware
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Fetch tags
+        run: git fetch --tags --force
+
+      - name: Get version
+        id: version
+        run: |
+          if git describe --exact-match >/dev/null 2>&1; then
+            echo "::notice::$(git describe) is a tagged release, nothing to publish"
+            echo "SKIP=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "VERSION=$(git describe)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download artifacts
+        if: ${{ !steps.version.outputs.SKIP }}
+        uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+
+      - name: Collect release files
+        if: ${{ !steps.version.outputs.SKIP }}
+        run: |
+          mkdir release
+          find artifacts -type f -exec cp {} release/ \;
+          ls -l release
+
+      - name: Publish nightly to eng-dash
+        if: ${{ !steps.version.outputs.SKIP }}
+        uses: ./.github/actions/publish-engdash
+        with:
+          version: ${{ steps.version.outputs.VERSION }}
+          track: nightly
+          token: ${{ secrets.ENGDASH_OTA_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,8 +6,30 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-firmware:
+  check:
     if: ${{ github.repository == 'coredevices/PebbleOS' }}
+    runs-on: ubuntu-24.04
+    outputs:
+      changed: ${{ steps.last.outputs.CHANGED }}
+    steps:
+      - name: Compare with the last nightly
+        id: last
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          last=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow nightly.yml \
+            --branch "$GITHUB_REF_NAME" --status success --limit 1 --json headSha \
+            --jq '.[0].headSha // empty')
+          if [ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ] && [ "$last" = "$GITHUB_SHA" ]; then
+            echo "::notice::$GITHUB_SHA already built by the last nightly, skipping"
+            echo "CHANGED=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "CHANGED=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-firmware:
+    needs: check
+    if: ${{ needs.check.outputs.changed == 'true' }}
     uses: ./.github/workflows/build-firmware.yml
     secrets: inherit
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
       TAG: ${{ github.ref_name }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
       - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
@@ -55,56 +58,7 @@ jobs:
 
       - name: Publish release to eng-dash
         if: ${{ github.repository == 'coredevices/PebbleOS' }}
-        env:
-          ENGDASH_URL: https://dash.repebble.com/api/ota/releases/upload
-          ENGDASH_TOKEN: ${{ secrets.ENGDASH_OTA_TOKEN }}
-        run: |
-          set -o pipefail
-
-          publish() {
-            file="$1"
-            body=$(jq -n \
-              --arg version "$TAG" \
-              --arg revision "${{ github.sha }}" \
-              --arg filename "$(basename "$file")" \
-              --arg sha256 "$(sha256sum "$file" | cut -d' ' -f1)" \
-              '{version: $version, revision: $revision, filename: $filename, sha256: $sha256}')
-
-            for _ in 1 2; do
-              resp=$(curl -sS --fail-with-body -X POST \
-                -H "Authorization: Bearer $ENGDASH_TOKEN" \
-                -H "Content-Type: application/json" \
-                --data "$body" "$ENGDASH_URL") || {
-                echo "::error::$file: $resp" >&2
-                return 1
-              }
-              case "$(echo "$resp" | jq -r .status)" in
-                uploaded|ignored)
-                  echo "$file: $(echo "$resp" | jq -c .)"
-                  return 0
-                  ;;
-                upload_required)
-                  curl -sS --fail -X PUT --upload-file "$file" \
-                    "$(echo "$resp" | jq -r .upload_url)" || {
-                    echo "::error::$file: artifact upload failed" >&2
-                    return 1
-                  }
-                  ;;
-                *)
-                  echo "::error::$file: unexpected response: $resp" >&2
-                  return 1
-                  ;;
-              esac
-            done
-
-            echo "::error::$file: not ingested after upload" >&2
-            return 1
-          }
-
-          # pbz first: elfs attach to the artifact rows pbzs create
-          for file in release/normal_*.pbz; do
-            publish "$file"
-          done
-          for file in release/firmware_*.elf; do
-            publish "$file"
-          done
+        uses: ./.github/actions/publish-engdash
+        with:
+          version: ${{ env.TAG }}
+          token: ${{ secrets.ENGDASH_OTA_TOKEN }}


### PR DESCRIPTION
Adds a scheduled nightly build that publishes `main` to a new `nightly` OTA track on eng-dash.

- `.github/actions/publish-engdash`: the upload loop from `release.yml`, factored into a composite action with a `track` input (default `internal`).
- `nightly.yml`: runs `build-firmware.yml` at 06:00 UTC (or on `workflow_dispatch`), then publishes the merged bundles + elfs with `track: nightly`. Version is `git describe` at the built commit; if HEAD is exactly a tag the release workflow already covers it, so publishing is skipped. A `check` job also skips the whole build when HEAD matches the last successful nightly (manual runs always build).
- `build-firmware.yml`: builds on any non-PR event (so `schedule` via `workflow_call` works) and uploads loghash dictionaries for those builds too, so logs from nightly devices can be dehashed.

Depends on coredevices/eng-dash#58 (migrations `007_fw_tracks.sql`/`008_device_tracks.sql` + upload endpoint `track` field) being deployed first; until then the server rejects `track: nightly` and the publish step fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)