### PR TITLE
ci: grant pull-requests read to reusable workflow callers

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 6 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   check:
     if: ${{ github.repository == 'coredevices/PebbleOS' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - v*
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   build-firmware:
     uses: ./.github/workflows/build-firmware.yml


### PR DESCRIPTION
The build-* reusable workflows request `pull-requests: read` for their paths filter jobs. A caller that does not declare permissions only passes on the repository default (none for pull-requests), so the Nightly run https://github.com/coredevices/PebbleOS/actions/runs/33173871276 aborted at startup with:

> The nested job 'changes-firmware' is requesting 'pull-requests: read', but is only allowed 'pull-requests: none'.

Declare the permissions at workflow level in both Nightly and Release, which call the same reusable workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)