### PR TITLE
fw/services: sync dndAutoDismiss quiet-time pref

### DIFF
--- a/src/fw/services/blob_db/settings_blob_db.c
+++ b/src/fw/services/blob_db/settings_blob_db.c
@@ -144,6 +144,7 @@ static const char *s_syncable_notif_prefs[] = {
   "notifBacklight",
   "dndMotionBacklight",
   "dndTouchBacklight",
+  "dndAutoDismiss",
 };
 
 static const size_t s_num_syncable_notif_prefs = ARRAY_LENGTH(s_syncable_notif_prefs);


### PR DESCRIPTION
## Problem

Quiet Time's "clear notification and return to watchface" toggle (Android app pref `dndAutoDismiss`) does nothing on the watch. Reported in [MOB-12749](https://linear.app/core-dev/issue/MOB-12749).

## Root cause

The phone writes the `dndAutoDismiss` pref into the watch's Settings BlobDB. `settings_blob_db_insert()` gates every write against a whitelist. `dndAutoDismiss` was **missing** from `s_syncable_notif_prefs` in `settings_blob_db.c`, even though it is a notifpref stored/reloaded exactly like its sibling `dndMotionBacklight` (see `alerts_preferences.c`). The write was rejected with `E_INVALID_OPERATION` and the value never landed, so the fully-implemented firmware feature (`notification_window.c` returns the notification to the watchface in Quiet Time) never received the setting.

## Fix

Add `"dndAutoDismiss"` to the notif-pref sync whitelist. One line — the app side is already correct.

## Test

Builds clean (`obelix_pvt`). Needs on-device verification: enable the Quiet Time auto-dismiss toggle in the Android app, confirm notifications now auto-return to the watchface during Quiet Time.

Fixes MOB-12749

🤖 Generated with [Claude Code](https://claude.com/claude-code)