### PR TITLE
docs: fix dead links and CI

### DIFF
--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -7,6 +7,10 @@
 name: Docs Link Check
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/docs-linkcheck.yml
+      - docs/
   schedule:
     - cron: "0 6 * * 1"
   workflow_dispatch:

--- a/docs/architecture/activity/index.md
+++ b/docs/architecture/activity/index.md
@@ -45,7 +45,7 @@ The logic used to pull out and identify the stepping signal from the spectral de
 
 VMC, or Vector Magnitude Counts, is a measure of the overall amount of movement in the watch over time. When the watch is perfectly still, the VMC will be 0 and greater amounts of movement result in higher VMC numbers. Running, for example results in a higher VMC than walking. 
 
-The VMC computation in Pebble Health was developed in conjunction with the Stanford Wearables lab and has been calibrated to match the VMC numbers produced by the [Actigraph](http://www.actigraphcorp.com/product-category/activity-monitors/) wrist-worn device. The Actigraph is commonly used today for medical research studies. The Stanford Wearables lab will be publishing the VMC computation used in the Pebble Health algorithm and this transparency of the algorithm will enable the Pebble to be used for medical research studies as well. 
+The VMC computation in Pebble Health was developed in conjunction with the Stanford Wearables lab and has been calibrated to match the VMC numbers produced by the [Actigraph](https://ametris.com/actigraph-leap) wrist-worn device. The Actigraph is commonly used today for medical research studies. The Stanford Wearables lab will be publishing the VMC computation used in the Pebble Health algorithm and this transparency of the algorithm will enable the Pebble to be used for medical research studies as well. 
 
 VMC is computed using the formula below. Before the accelerometer readings are incorporated into this computation however, each axis’ signal is run through a bandpass filter with a design of 0.25Hz to 1.75Hz.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,7 @@ html_theme_options = {
 # Sites that are alive but block automated requests
 linkcheck_ignore = [
     r"https?://reveng\.sourceforge\.net/.*",
+    r"https://https://www\.itu\.int/rec/T-REC-X\.25-199610-I/en",
 ]
 
 # -- Options for myst_parser extension -----------------------------------------

--- a/docs/reference/pulse2/flash-imaging.md
+++ b/docs/reference/pulse2/flash-imaging.md
@@ -26,7 +26,7 @@ high-latency links.
   maintain a minimal, fixed-size amount of state.
 
 > The idempotence of writing to flash is leveraged in the design of this
-> protocol to effectively implement a [Selective Repeat ARQ](http://en.wikipedia.org/wiki/Selective_Repeat_ARQ)
+> protocol to effectively implement a [Selective Repeat ARQ](https://en.wikipedia.org/wiki/Selective_Repeat_ARQ)
 > with an unlimited window size without requiring the server to keep
 > track of which frames are missing. Any Write Data command to the same
 > location in flash can be repeated any number of times with no ill

--- a/docs/reference/pulse2/pulse2.md
+++ b/docs/reference/pulse2/pulse2.md
@@ -28,7 +28,7 @@ retransmissions into the application protocols in an ad-hoc manner,
 poorly. This has made the design and implementation of prompt and file
 transfer protocols more complex than necessary, and no attempt has yet
 been made to tunnel Pebble Protocol over PULSE. It's the [waterbed
-theory](http://wiki.c2.com/?WaterbedTheory) at work.
+theory](https://wiki.c2.com/?WaterbedTheory) at work.
 
 Adding support for reliable, ordered delivery of datagrams will allow
 for any application to make use of reliable service simply by requesting
@@ -102,12 +102,12 @@ Flag sequences constitute and empty frame, which is silently discarded.
 The Protocol field is used as prescribed by RFC 1661, Section 2. PPP
 assigned protocol numbers and their respective assigned protocols should
 be used wherever it makes sense. Custom protocols must not be assigned
-protocol numbers which overlap any [existing PPP assigned protocol](http://www.iana.org/assignments/ppp-numbers/ppp-numbers.xhtml).
+protocol numbers which overlap any [existing PPP assigned protocol](https://www.iana.org/assignments/ppp-numbers/ppp-numbers.xhtml).
 
 #### Frame Check Sequence field
 
 The Frame Check Sequence is transmitted least significant octet first.
-The check sequence is calculated using the [CRC-32](http://reveng.sourceforge.net/crc-catalogue/all.htm#crc.cat.crc-32)
+The check sequence is calculated using the [CRC-32](https://reveng.sourceforge.net/crc-catalogue/all.htm#crc.cat.crc-32)
 checksum. The parameters of the CRC algorithm are:
 
     width=32 poly=0x04c11db7 init=0xffffffff refin=true refout=true
@@ -412,6 +412,6 @@ Useful Links
 - [RFC 3772 - Point-to-Point Protocol (PPP) Vendor Protocol](https://tools.ietf.org/html/rfc3772)
 - [PPP Consistent Overhead Byte Stuffing (COBS)](https://tools.ietf.org/html/draft-ietf-pppext-cobs)
 - [ITU-T Recommendation X.25](https://www.itu.int/rec/T-REC-X.25-199610-I/en)
-- [Digital Data Communications Message Protocol](http://www.ibiblio.org/pub/historic-linux/early-ports/Mips/doc/DEC/ddcmp-4.1.txt)
+- [Digital Data Communications Message Protocol](https://www.ibiblio.org/pub/historic-linux/early-ports/Mips/doc/DEC/ddcmp-4.1.txt)
 
 <!-- vim: set tw=72: -->

--- a/docs/reference/pulse2/pulse2.md
+++ b/docs/reference/pulse2/pulse2.md
@@ -66,7 +66,7 @@ Link Layer
 ----------
 
 The link layer, in a nutshell, is PPP with custom framing. The entirety
-of [RFC 1661](https://tools.ietf.org/html/rfc1661) is normative, except
+of [RFC 1661](https://datatracker.ietf.org/doc/html/rfc1661) is normative, except
 as noted in this document.
 
 ### Encapsulation
@@ -102,7 +102,7 @@ Flag sequences constitute and empty frame, which is silently discarded.
 The Protocol field is used as prescribed by RFC 1661, Section 2. PPP
 assigned protocol numbers and their respective assigned protocols should
 be used wherever it makes sense. Custom protocols must not be assigned
-protocol numbers which overlap any [existing PPP assigned protocol](https://www.iana.org/assignments/ppp-numbers/ppp-numbers.xhtml).
+protocol numbers which overlap any [existing PPP assigned protocol](https://www.iana.org/assignments/ppp-numbers).
 
 #### Frame Check Sequence field
 
@@ -404,13 +404,13 @@ Useful Links
   which includes a draft of this documentation along with a lot of
   notes about the design decisions.
 - [Python implementation of PULSEv2](https://github.com/coredevices/PebbleOS/tree/main/tools/libs/pulse2)
-- [RFC 1661 - The Point to Point Protocol (PPP)](https://tools.ietf.org/html/rfc1661)
-- [RFC 1662 - PPP in HDLC-like Framing](https://tools.ietf.org/html/rfc1662)
-- [RFC 1663 - PPP Reliable Transmission](https://tools.ietf.org/html/rfc1663)
-- [RFC 1570 - PPP LCP Extensions](https://tools.ietf.org/html/rfc1570)
-- [RFC 2153 - PPP Vendor Extensions](https://tools.ietf.org/html/rfc2153)
-- [RFC 3772 - Point-to-Point Protocol (PPP) Vendor Protocol](https://tools.ietf.org/html/rfc3772)
-- [PPP Consistent Overhead Byte Stuffing (COBS)](https://tools.ietf.org/html/draft-ietf-pppext-cobs)
+- [RFC 1661 - The Point to Point Protocol (PPP)](https://datatracker.ietf.org/doc/html/rfc1661)
+- [RFC 1662 - PPP in HDLC-like Framing](https://datatracker.ietf.org/doc/html/rfc1662)
+- [RFC 1663 - PPP Reliable Transmission](https://datatracker.ietf.org/doc/html/rfc1663)
+- [RFC 1570 - PPP LCP Extensions](https://datatracker.ietf.org/doc/html/rfc1570)
+- [RFC 2153 - PPP Vendor Extensions](https://datatracker.ietf.org/doc/html/rfc2153)
+- [RFC 3772 - Point-to-Point Protocol (PPP) Vendor Protocol](https://datatracker.ietf.org/doc/html/rfc3772)
+- [PPP Consistent Overhead Byte Stuffing (COBS)](https://datatracker.ietf.org/doc/html/draft-ietf-pppext-cobs)
 - [ITU-T Recommendation X.25](https://www.itu.int/rec/T-REC-X.25-199610-I/en)
 - [Digital Data Communications Message Protocol](https://www.ibiblio.org/pub/historic-linux/early-ports/Mips/doc/DEC/ddcmp-4.1.txt)
 


### PR DESCRIPTION
Noticed this since I got a build failure on my fork. Originally was going to filter the job, but decided to just fix the link and make sure any PR that touches the docs runs the CI.

Could add a badge to the README for visibility, but I didn't think that would be too helpful in catching the failing job.