### PR TITLE
phone_call: don't count an ongoing call an iOS phone never started

### DIFF
--- a/src/fw/services/phone_call/service.c
+++ b/src/fw/services/phone_call/service.c
@@ -9,6 +9,7 @@
 #include "popups/phone_ui.h"
 #include "pbl/services/analytics/analytics.h"
 #include "pbl/services/comm_session/session.h"
+#include "pbl/services/comm_session/session_remote_os.h"
 #include "pbl/services/phone_pp.h"
 #include "pbl/services/system_task.h"
 #include "pbl/services/notifications/alerts.h"
@@ -44,6 +45,10 @@ static bool s_mobile_app_is_connected;
 // We can't expect iOS to reliably send us phone call events, so we must poll for the current
 // status of the phone call
 static TimerID s_call_watchdog = TIMER_INVALID_ID;
+
+// What the mobile app said it runs on. A call over PP does not mean Android: an
+// iOS companion sends calls that way too, and cannot act on what we send back.
+static RemoteOS s_phone_os = RemoteOSUnknown;
 
 
 static void prv_handle_call_end(bool disconnected);
@@ -88,15 +93,23 @@ static void prv_cancel_call_watchdog(void) {
   pp_get_phone_state_set_enabled(false);
 }
 
+// iOS gives no third-party app a way to answer or end a carrier call, so the
+// answer and hangup we send over PP reach an app that can do nothing with them.
+// Acting as though they worked is what leaves the watch counting the seconds of
+// a call that is still ringing.
+static bool prv_phone_cannot_act_on_calls(void) {
+  return (s_phone_os == RemoteOSiOS);
+}
+
 static bool prv_should_show_ongoing_call_ui(void) {
-  // We only want to show the ongoing call UI on Android
-  return (s_call_source == PhoneCallSource_PP);
+  // Not on iOS, whichever way the call reached us: see prv_phone_cannot_act_on_calls
+  return (s_call_source == PhoneCallSource_PP) && !prv_phone_cannot_act_on_calls();
 }
 
 // hangup != decline. Decline == reject incomming call, Hangup == stop in progress call
 static bool prv_can_hangup(void) {
   // We can't hangup with iOS
-  return !prv_call_is_ancs();
+  return !prv_call_is_ancs() && !prv_phone_cannot_act_on_calls();
 }
 
 // Handles the common things when we hide an incoming call
@@ -257,12 +270,21 @@ T_STATIC void prv_handle_phone_event(PebbleEvent *e, void *context) {
   phone_call_util_destroy_caller(event.caller);
 }
 
+T_STATIC void prv_handle_remote_app_info_event(PebbleEvent *e, void *context) {
+  s_phone_os = e->bluetooth.app_info_event.os;
+}
+
 T_STATIC void prv_handle_mobile_app_event(PebbleEvent *e, void *context) {
   if (!e->bluetooth.comm_session_event.is_system) {
     return;
   }
 
   s_mobile_app_is_connected = e->bluetooth.comm_session_event.is_open;
+  if (!s_mobile_app_is_connected) {
+    // The next app to connect need not be the same one, and its version
+    // response can arrive after the first call it sends us.
+    s_phone_os = RemoteOSUnknown;
+  }
   if (!s_mobile_app_is_connected && (s_call_source != PhoneCallSource_ANCS)) {
     prv_handle_call_end(true /* disconnected */);
   }
@@ -291,6 +313,13 @@ void phone_call_service_init() {
     .handler = prv_handle_mobile_app_event,
   };
   event_service_client_subscribe(&mobile_app_event_info);
+
+  static EventServiceInfo app_info_event_info;
+  app_info_event_info = (EventServiceInfo) {
+    .type = PEBBLE_REMOTE_APP_INFO_EVENT,
+    .handler = prv_handle_remote_app_info_event,
+  };
+  event_service_client_subscribe(&app_info_event_info);
 
   static EventServiceInfo ancs_disconnected_event_info;
   ancs_disconnected_event_info = (EventServiceInfo) {

--- a/tests/fw/services/test_phone_call.c
+++ b/tests/fw/services/test_phone_call.c
@@ -12,6 +12,7 @@
 extern T_STATIC void prv_handle_phone_event(PebbleEvent *e, void *context);
 extern T_STATIC void prv_handle_mobile_app_event(PebbleEvent *e, void *context);
 extern T_STATIC void prv_handle_ancs_disconnected_event(PebbleEvent *e, void *context);
+extern T_STATIC void prv_handle_remote_app_info_event(PebbleEvent *e, void *context);
 
 
 ///////////////////////////////////////////////////////////
@@ -44,9 +45,11 @@ void pp_get_phone_state_set_enabled(bool enabled) {}
 
 // Phone UI stubs that allow us to track what phone_call.c is doing
 static PhoneEventType s_last_phone_ui_event;
+static bool s_last_show_ongoing_call_ui;
 void phone_ui_handle_incoming_call(PebblePhoneCaller *caller, bool show_ongoing_call_ui,
                                    PhoneCallSource source) {
   s_last_phone_ui_event = PhoneEventType_Incoming;
+  s_last_show_ongoing_call_ui = show_ongoing_call_ui;
 }
 
 void phone_ui_handle_outgoing_call(PebblePhoneCaller *caller) {
@@ -110,6 +113,18 @@ static void prv_put_phone_event(PhoneEventType type, PhoneCallSource source,
     }
   };
   prv_handle_phone_event(&phone_event, NULL);
+}
+
+static void prv_put_remote_app_info_event(RemoteOS os) {
+  PebbleEvent app_info_event = {
+    .type = PEBBLE_REMOTE_APP_INFO_EVENT,
+    .bluetooth = {
+      .app_info_event = {
+        .os = os,
+      }
+    }
+  };
+  prv_handle_remote_app_info_event(&app_info_event, NULL);
 }
 
 static void prv_put_incoming_call_event(PhoneCallSource source, bool app_connected) {
@@ -269,4 +284,37 @@ void test_phone_call__ancs_hide(void) {
 
   prv_call_hide(ANCS_CALL_UID);
   ASSERT_LAST_EVENT(PhoneEventType_Hide);
+}
+
+void test_phone_call__pp_incoming_from_android_shows_the_ongoing_call_ui(void) {
+  prv_put_remote_app_info_event(RemoteOSAndroid);
+
+  prv_put_incoming_call_event(PhoneCallSource_PP, true);
+
+  cl_assert_equal_i(s_last_phone_ui_event, PhoneEventType_Incoming);
+  cl_assert_equal_b(s_last_show_ongoing_call_ui, true);
+}
+
+void test_phone_call__pp_incoming_from_ios_does_not(void) {
+  // An iOS companion sends calls over PP as well, and can neither answer nor
+  // end one, so counting the call would be counting a phone still ringing.
+  prv_put_remote_app_info_event(RemoteOSiOS);
+
+  prv_put_incoming_call_event(PhoneCallSource_PP, true);
+
+  cl_assert_equal_i(s_last_phone_ui_event, PhoneEventType_Incoming);
+  cl_assert_equal_b(s_last_show_ongoing_call_ui, false);
+}
+
+void test_phone_call__pp_incoming_after_the_ios_app_went_away(void) {
+  prv_put_remote_app_info_event(RemoteOSiOS);
+  prv_put_comm_session_event(false /* app_connected */);
+  prv_call_end();
+  s_last_phone_ui_event = PhoneEventType_Invalid;
+
+  // A call from whoever connected next, arriving before its version response.
+  prv_put_incoming_call_event(PhoneCallSource_PP, true);
+
+  cl_assert_equal_i(s_last_phone_ui_event, PhoneEventType_Incoming);
+  cl_assert_equal_b(s_last_show_ongoing_call_ui, true);
 }


### PR DESCRIPTION
## What

A call that arrives over Pebble Protocol is taken to mean the phone is Android, so answering one starts the call-duration timer and offers a hangup:

```c
static bool prv_should_show_ongoing_call_ui(void) {
  // We only want to show the ongoing call UI on Android
  return (s_call_source == PhoneCallSource_PP);
}
```

An iOS companion sends calls the same way. iOS gives no third-party app a way to answer or end a carrier call, so the answer and the hangup we send back over PP reach an app that can do nothing with them — and the watch is left counting the seconds of a call that is still ringing on the phone.

This remembers what the mobile app said it runs on (`PEBBLE_REMOTE_APP_INFO_EVENT`, the same event `music_endpoint_handle_mobile_app_info_event` already keys off) and treats iOS-over-PP the way iOS-over-ANCS is already treated: accept-and-dismiss, no duration timer, no hangup. Android is unchanged.

## How I checked it

Two host tests in `tests/fw/services/test_phone_call.c`, driving the same PP incoming call once after an Android app-info event and once after an iOS one, and asserting on the `show_ongoing_call_ui` argument the service passes to `phone_ui_handle_incoming_call`. Reverting the `prv_should_show_ongoing_call_ui` hunk fails only the iOS case, so the tests do pin the change.

Then on `qemu_emery`, with a companion that speaks Pebble Protocol over the emulator's port and announces its OS in its PhoneVersion response. Same incoming call each time, answered with the UP button:

| firmware | phone announces | screen 3–25 s after answering |
| --- | --- | --- |
| `main` (70ed290ff) | iOS | `0:02` … `0:24`, counting up |
| this branch | iOS | "Call Accepted", popup closes after 3 s |
| this branch | Android | `0:02` … `0:24`, counting up |

The last row is the same binary as the middle one, so the only thing that moved is what the phone said it was.

## Note

I have not reproduced this against a real iPhone and a real carrier call — I have no iOS companion that sends calls over PP to hand you. The reasoning above is from the firmware's own code and from what iOS permits a third-party app to do; the emulator rows show the branch behaves as intended, not that an iPhone triggers it in the wild.
