### PR TITLE
fw/apps/alarms: Keep backlight on during alarm popup

### DIFF
--- a/src/fw/popups/alarm_popup.c
+++ b/src/fw/popups/alarm_popup.c
@@ -315,6 +315,7 @@ static void prv_cleanup_alarm_popup(void *callback_context) {
 #ifdef CONFIG_SPEAKER
     prv_stop_sound();
 #endif
+    light_enable(false);
     // The action bar owns a redraw timer armed on button press; it must be
     // cancelled before the layer's memory goes away. actionable_dialog leaves
     // custom action bars to their owner.
@@ -384,5 +385,5 @@ void alarm_popup_push_window(PebbleAlarmClockEvent *event) {
   }
 #endif
 
-  light_enable_interaction();
+  light_enable(true);
 }


### PR DESCRIPTION
This PR changes the behaviour of the system alarm popup to force the backlight on while the alarm popup has yet to be dismissed rather than use the user-configured backlight timeout. The motivation behind this change stems from one of my human limitations that haunts me every morning:

_My eyes take a few seconds to "turn on" when I wake up, I guess, so it's less than ideal when I can no longer see which button is Snooze and which is Dismiss on my alarm once I realize what is going on._

This PR is a bit opinionated in its nature, so perhaps it cannot be accepted without user configurability. That said, adding configuration options to the mobile app is a bit out of my area of familiarity with the codebase (right now), so I'm hoping this is not too crazy of a change to require that (which may take me a few days to implement).