### PR TITLE
tests: cleanup non-functional typos

### DIFF
--- a/tests/fakes/fake_GAPAPI.c
+++ b/tests/fakes/fake_GAPAPI.c
@@ -222,7 +222,7 @@ int GAP_LE_Cancel_Create_Connection(unsigned int BluetoothStackID) {
   return 0;
 }
 
-// Puts the event that the BT Controller will emit after a succesfull
+// Puts the event that the BT Controller will emit after a successful
 // GAP_LE_Cancel_Create_Connection call.
 void fake_gap_le_put_cancel_create_event(const BTDeviceInternal *device, bool is_master) {
   fake_gap_put_connection_event(HCI_ERROR_CODE_UNKNOWN_CONNECTION_IDENTIFIER,

--- a/tests/fixtures/activity/sleep_samples/pbl-25945.c
+++ b/tests/fixtures/activity/sleep_samples/pbl-25945.c
@@ -33,7 +33,7 @@ AlgDlsMinuteData *activity_sample_2015_09_30_23_04_00(int *len) {
   //> TEST_IN_DEEP_SLEEP_MAX 0
   //> TEST_WEIGHT 1.0
 
-  // list of: {steps, orientation, vmc, ligh}
+  // list of: {steps, orientation, vmc, light}
   static AlgDlsMinuteData samples[] = {
     { 11, 0x56, 990, 0x0},
     { 0, 0x47, 261, 0x0},

--- a/tests/fixtures/activity/sleep_samples/pbl-27896.c
+++ b/tests/fixtures/activity/sleep_samples/pbl-27896.c
@@ -33,7 +33,7 @@ AlgDlsMinuteData *activity_sample_2015_10_08_18_58_01(int *len) {
   //> TEST_IN_DEEP_SLEEP_MAX 0
   //> TEST_WEIGHT 1.0
 
-  // list of: {steps, orientation, vmc, ligh}
+  // list of: {steps, orientation, vmc, light}
   static AlgDlsMinuteData samples[] = {
     { 0, 0x55, 148, 0x0},
     { 8, 0x55, 374, 0x0},

--- a/tests/fixtures/activity/sleep_samples/pbl-27921.c
+++ b/tests/fixtures/activity/sleep_samples/pbl-27921.c
@@ -33,7 +33,7 @@ AlgDlsMinuteData *activity_sample_2015_10_08_12_35_00(int *len) {
   //> TEST_IN_DEEP_SLEEP_MAX 0
   //> TEST_WEIGHT 1.0
 
-  // list of: {steps, orientation, vmc, ligh}
+  // list of: {steps, orientation, vmc, light}
   static AlgDlsMinuteData samples[] = {
     { 0, 0x0, 0, 0x2},
     { 9, 0x7d, 1496, 0x0},

--- a/tests/fixtures/activity/sleep_samples/pbl-27937.c
+++ b/tests/fixtures/activity/sleep_samples/pbl-27937.c
@@ -30,7 +30,7 @@ AlgDlsMinuteData *activity_sample_2015_10_07_14_39_00(int *len) {
   //> TEST_IN_DEEP_SLEEP_MAX 0
   //> TEST_WEIGHT 1.0
 
-  // list of: {steps, orientation, vmc, ligh}
+  // list of: {steps, orientation, vmc, light}
   static AlgDlsMinuteData samples[] = {
     { 0, 0x72, 1836, 0x0},
     { 71, 0x5f, 4438, 0x0},

--- a/tests/fixtures/activity/sleep_samples/sleep_samples_v1.c
+++ b/tests/fixtures/activity/sleep_samples/sleep_samples_v1.c
@@ -2658,7 +2658,7 @@ AlgDlsMinuteData *activity_sample_sleep_v1_3(int *len) {
 
 // ----------------------------------------------------------------
 // Sample captured at: 2015-08-22 19:57:00 local, 2015-08-23 02:57:00 GMT
-// Accroding to misfit:
+// According to misfit:
 //  total sleep: 374 min
 //  deep: 200 min
 //  light: 174 min

--- a/tests/fw/applib/bluetooth/test_ble_ad_parse.c
+++ b/tests/fw/applib/bluetooth/test_ble_ad_parse.c
@@ -78,7 +78,7 @@ void test_ble_ad_parse__16_bit_uuid_and_device_name(void) {
   Uuid missing_uuid = bt_uuid_expand_16bit(0xabcd);
   cl_assert(!ble_ad_includes_service(s_ad_data, &missing_uuid));
 
-  // Test ble_ad_copy_service_uuids, destination array sized larged enough:
+  // Test ble_ad_copy_service_uuids, destination array sized enlarged enough:
   const uint8_t count = 4;
   Uuid copied_uuids[count];
   uint8_t found = ble_ad_copy_service_uuids(s_ad_data, copied_uuids, count);

--- a/tests/fw/comm/test_ams.c
+++ b/tests/fw/comm/test_ams.c
@@ -65,7 +65,7 @@ void launcher_task_add_callback(void (*callback)(void *data), void *data) {
   s_launcher_task_callback_data = data;
 }
 
-// Tests: Disover AMS
+// Tests: Discover AMS
 ///////////////////////////////////////////////////////////
 #define NUM_AMS_INSTANCES 2
 static BLECharacteristic s_characteristics[NUM_AMS_INSTANCES][NumAMSCharacteristic] = {

--- a/tests/fw/comm/test_gap_le_advert.c
+++ b/tests/fw/comm/test_gap_le_advert.c
@@ -74,7 +74,7 @@ void test_gap_le_advert__initialize(void) {
   s_unscheduled_completed = false;
 
   // This bypasses the work-around for the CC2564 advertising bug, that pauses the round-robinning
-  // through scheduled advertisment jobs:
+  // through scheduled advertisement jobs:
   s_is_connected_as_slave = true;
 
   regular_timer_init();

--- a/tests/fw/graphics/test_bitblt.c
+++ b/tests/fw/graphics/test_bitblt.c
@@ -229,7 +229,7 @@ void test_bitblt__8bit_comptint_blend(void) {
                                     GPointZero, GCompOpAssign, GColorWhite);
   }
 
-  // RGB value should be discarded later on adding them here might relveal bugs.
+  // RGB value should be discarded later on adding them here might reveal bugs.
   // .a is the important part
   GColor8 test_blend_colors[] = {
     (GColor8){.a = 0, .r = 3, .g = 2, .b = 1},

--- a/tests/fw/graphics/test_graphics_gpath.template.c
+++ b/tests/fw/graphics/test_graphics_gpath.template.c
@@ -435,7 +435,7 @@ void test_graphics_gpath_8bit__clipping_aa(void) {
   // NOTE: Expected result of this test is to have an antialiased stripe go through the screen,
   //         where antialiased edges are being nicely cut off on top and bottom of the stripe
   //         (antialiased gradient would dive into the stripe near screen edges), also top
-  //         left corner is intentinally ending just before screen cuts it out to verify that
+  //         left corner is intentionally ending just before screen cuts it out to verify that
   //         fractional anti-aliasing is not bleeding into row before (would occur as pixels on
   //         right side of the screen)
   cl_check(gbitmap_pbi_eq(&ctx.dest_bitmap,

--- a/tests/fw/services/activity/kraepelin_reference/LICENSE
+++ b/tests/fw/services/activity/kraepelin_reference/LICENSE
@@ -14,4 +14,4 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 This license is taken to apply to any other files in the Project Kraepelin
-Pebble App roject.
+Pebble App project.

--- a/tests/fw/services/activity/kraepelin_reference/constants_worker.h
+++ b/tests/fw/services/activity/kraepelin_reference/constants_worker.h
@@ -2,10 +2,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-/* +++++++++++++++ PERSISTANT STORAGE KEYS +++++++++++++++ */
+/* +++++++++++++++ PERSISTENT STORAGE KEYS +++++++++++++++ */
 
 // +++++++ RESERVED KEYS
-// REMEMBER!!! keys 1-20 are reserved for the actigraphy keys
+// REMEMBER!!! keys 1-20 are reserved for the actigraph keys
 
 // +++++++ intra-app messaging
 static const int16_t WORKER_START_FORE_APP_REASON_PERSIST_KEY = 120;
@@ -24,8 +24,8 @@ static const int16_t PK_VERSION_PERSIST_KEY = 183;
 
 
 // +++++++ Interaction Data
-static const int16_t PIRPS_B1_PERSIST_KEY = 190; // Patient Response Pesistant Storage, Block 1
-static const int16_t PIRPS_B2_PERSIST_KEY = 191; // Patient Response Pesistant Storage, Block 2
+static const int16_t PIRPS_B1_PERSIST_KEY = 190; // Patient Response Persistent Storage, Block 1
+static const int16_t PIRPS_B2_PERSIST_KEY = 191; // Patient Response Persistent Storage, Block 2
 
 
 // +++++++ Continuous Data
@@ -120,7 +120,7 @@ enum ActivityClassLearnFeatures {
 //   person said that they arose, AND the DAY to which these minutes
 //   are assigned is the one that the 16 hours ENDED ON.
 // uint16_t daily_arise_time_min;
-//   time when person said getitng up for the day, triggered by a sudden
+//   time when person said getting up for the day, triggered by a sudden
 //   increase in the number od steps
 //   counts
 

--- a/tests/fw/services/activity/kraepelin_reference/fourier.c
+++ b/tests/fw/services/activity/kraepelin_reference/fourier.c
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 This license is taken to apply to any other files in the Project Kraepelin
-Pebble App roject.
+Pebble App project.
 */
 
 
@@ -35,18 +35,18 @@ void fft_2radix_real(int16_t *d, int16_t dlenpwr){
   /* +++++++++++ REAL-VALUED, IN-PLACE, 2-RADIX FOURIER TRANSFORM +++++++++++
   *
   *   This implementation of the fourier transform is taken directly from
-  *   Henrik V. Sorensen's 1987 paper "Real-valued Fast Fourier Tranform
+  *   Henrik V. Sorensen's 1987 paper "Real-valued Fast Fourier Transform
   *   Algorithms" with slight modifications to allow use of Pebble's cos and
   *   sin lookup functions with input range of 0 to 2*pi angle scaled to
   *   0 to 65536 and output range of -1 to 1 scaled to -65535 to 65536. This
-  *   descretization introduces some discrepancies between the results of this
+  *   discretization introduces some discrepancies between the results of this
   *   function and the floating point equivalents that are not important for its
-  *   use here, but nonetheless documented in the accompaning Julia test code.
+  *   use here, but nonetheless documented in the accompanying Julia test code.
   *   INPUT
   *     d = input signal array pointer
   *     dlenpwr = the exponent of the array length, ie: array length = 2^dlenpwr
   *   OUTPUT
-  *     d = fourier tranformed array pointer, with array of real coefficents of form
+  *     d = fourier transformed array pointer, with array of real coefficients of form
   *       [Re(0), Re(1),..., Re(N/2-1), Re(N/2), Im(N/2-1),..., Im(1)]
   */
 

--- a/tests/fw/services/activity/kraepelin_reference/helper_worker.c
+++ b/tests/fw/services/activity/kraepelin_reference/helper_worker.c
@@ -15,7 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     This license is taken to apply to any other files in the Project Kraepelin
-    Pebble App roject.
+    Pebble App project.
 */
 
 // #include <pebble_worker.h>
@@ -136,7 +136,7 @@ void fft_mag(int16_t *d, int16_t dlenpwr){
   // NOTE! this function modifies the input array
   int16_t dlen = pow_int(2,dlenpwr);
 
-  // evaluate the fourier coefficent magnitude
+  // evaluate the fourier coefficient magnitude
   // NOTE: coeff @ index 0 and dlen/2 only have real components
   //    so their magnitude is exactly that
   for(int16_t i = 1; i < (dlen/2); i++){

--- a/tests/fw/services/activity/kraepelin_reference/raw_stats.c
+++ b/tests/fw/services/activity/kraepelin_reference/raw_stats.c
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 This license is taken to apply to any other files in the Project Kraepelin
-Pebble App roject.
+Pebble App project.
 */
 
 
@@ -71,7 +71,7 @@ static __inline__ sfxp fxp_mul(sfxp a, sfxp b){
   bf = (uint32_t) b; // ibid
 
   // have to add all the elements as unsigned types, because otherwise
-  // C will try to interpert the high bit of the low 32 bits of the fractional
+  // C will try to interpret the high bit of the low 32 bits of the fractional
   // segment as a sign, and cause substraction, when all we really want is to
   // assume all elements are positive, and then encode the sign as the highest
   // bit of var "si",
@@ -91,7 +91,7 @@ static __inline__ sfxp fxp_mul(sfxp a, sfxp b){
 }
 
 
-// we statically encode the coefficents because we only need this
+// we statically encode the coefficients because we only need this
 // filter to run fast. ALSO, MUST initialize to 0
 static sfxp yt[4][3] = {{0,0,0},{0,0,0},{0,0,0},{0,0,0}};
 static sfxp xt[5][3] = {{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0}};
@@ -134,8 +134,8 @@ void pim_filt_prime(int16_t *d, int16_t dlen, int16_t axis) {
 // // TEST : PASSED
 uint32_t pim_filt(int16_t *d, int16_t dlen, int16_t axis){
 // uint32_t pim_filt(int16_t *d, int16_t dlen, int16_t axis){
-  // we use a butterworth second order digital fitler with a bandpass
-  // design of 0.25 to 2 hz, with coefficents double *ca_d,double *cb_dof
+  // we use a butterworth second order digital filter with a bandpass
+  // design of 0.25 to 2 hz, with coefficients double *ca_d,double *cb_dof
 
   // and, we calculate all of these by multiplying by 100000x
   int32_t x1000_thres = 3750; // this is calibrated to pebble, 125 = 1G
@@ -188,8 +188,8 @@ uint32_t calc_scaled_vmc(uint32_t *pim_ary){
   // epoch.
   // INPUTS
   //   *pim_ary -> the actual array of cpm for each axis
-  //   oflw_scl -> dividing factor to reduce pim_ary so doesnt overflow
-  // PARAMTERS
+  //   oflw_scl -> dividing factor to reduce pim_ary so doesn't overflow
+  // PARAMETERS
   //   oflw_cap -> cap to prevent overflow when pim_ary[:].^2 is summed
   // OUTPUT
   //  @ return -> the sqrt of the scaled vmcpm
@@ -326,7 +326,7 @@ uint8_t compressed_stepc(uint32_t stepc, int16_t num_min){
   // This function simply takes in the number of steps in a given number of
   // minutes. Then, we calculate the maximum number of steps possible in num_min
   // given a max of 4hz running speed. Then, that max is turned in a scaling
-  // factor that the step count is premultiplied by, and then the squrt is taken
+  // factor that the step count is premultiplied by, and then the sqrt is taken
   uint32_t max_stepc = 4*60*num_min; // @ 4hz * 60secs * num_min
   return (uint8_t) isqrt( (stepc*65535)/max_stepc) ;
 }
@@ -343,7 +343,7 @@ void vm_accel(int16_t **d, int16_t *w, int16_t max_vm, int16_t dlen){
   /* EVALUATE THE VECTOR ACCELERATION MAGNITUDE, WRITE TO first array */
   // NOTE: we can look at the entire array, because we only write to
   // the first N_SMP_EPOCH, the remainder being 0's, which will
-  // evalulate to a vector mag of 0
+  // evaluate to a vector mag of 0
   for(int16_t i = 0; i < dlen; i++){
     // evaluate the vector mag of acceleration, write to work array w
     w[i] = (int16_t) isqrt( d[0][i]*d[0][i] + d[1][i]*d[1][i] + d[2][i]*d[2][i] );
@@ -358,7 +358,7 @@ void vm_accel_xy(int16_t **d, int16_t *w, int16_t max_vm, int16_t dlen){
   /* EVALUATE THE VECTOR ACCELERATION MAGNITUDE, WRITE TO first array */
   // NOTE: we can look at the entire array, because we only write to
   // the first N_SMP_EPOCH, the remainder being 0's, which will
-  // evalulate to a vector mag of 0
+  // evaluate to a vector mag of 0
   for(int16_t i = 0; i < dlen; i++){
     // evaluate the vector mag of acceleration, write to work array w
     w[i] = (int16_t) isqrt( d[0][i]*d[0][i] + d[1][i]*d[1][i]);
@@ -658,7 +658,7 @@ int16_t calc_stepc_5sec(int16_t *work_ary, int16_t dlen_smp, int16_t dlenpwr_ary
 // // TEST : PASSED
 // int32_t pim_filt(int16_t *d, int16_t dlen){
 //   /* This function calculates the pim of the given array, single axis
-//   * constuction and application of filters are contained with the function */
+//   * construction and application of filters are contained with the function */
 //   int32_t pim_local = 0;
 //
 //   /* calculate the filter */
@@ -682,8 +682,8 @@ int16_t calc_stepc_5sec(int16_t *work_ary, int16_t dlen_smp, int16_t dlenpwr_ary
 //   // epoch.
 //   // INPUTS
 //   //   *pim_ary -> the actual array of cpm for each axis
-//   //   oflw_scl -> dividing factor to reduce pim_ary so doesnt overflow
-//   // PARAMTERS
+//   //   oflw_scl -> dividing factor to reduce pim_ary so doesn't overflow
+//   // PARAMETERS
 //   //   oflw_cap -> cap to prevent overflow when pim_ary[:].^2 is summed
 //   // OUTPUT
 //   //  @ return -> the sqrt of the scaled vmcpm
@@ -792,7 +792,7 @@ int16_t calc_stepc_5sec(int16_t *work_ary, int16_t dlen_smp, int16_t dlenpwr_ary
 //   /* EVALUATE THE VECTOR ACCELERATION MAGNITUDE, WRITE TO first array */
 //   // NOTE: we can look at the entire array, because we only write to
 //   // the first N_SMP_EPOCH, the remainder being 0's, which will
-//   // evalulate to a vector mag of 0
+//   // evaluate to a vector mag of 0
 //   for(int16_t i = 0; i < dlen; i++){
 //     // evaluate the vector mag of acceleration, write to work array w
 //     w[i] = (int16_t) isqrt( d[0][i]*d[0][i] + d[1][i]*d[1][i] + d[2][i]*d[2][i] );
@@ -970,7 +970,7 @@ int16_t calc_stepc_5sec(int16_t *work_ary, int16_t dlen_smp, int16_t dlenpwr_ary
 // // TEST : PASSED
 // int32_t pim_filt(int16_t *d, int16_t dlen){
 //   /* This function calculates the pim of the given array, single axis
-//   * constuction and application of filters are contained with the function */
+//   * construction and application of filters are contained with the function */
 //   int32_t pim_local = 0;
 
 //   /* calculate the filter */

--- a/tests/fw/services/activity/test_kraepelin_algorithm.c
+++ b/tests/fw/services/activity/test_kraepelin_algorithm.c
@@ -2023,7 +2023,7 @@ static void prv_feed_activity_minutes(KAlgTestActivityMinute *samples, int sampl
 }
 
 // ---------------------------------------------------------------------------------------
-// Test that we correectly recognize walk and run activities
+// Test that we correctly recognize walk and run activities
 void test_kraepelin_algorithm__walks_and_runs(void) {
   const int k_minute_data_len = 60;
   const int k_minute_data_bytes = k_minute_data_len * sizeof(KAlgTestActivityMinute);

--- a/tests/fw/services/blob_db/test_reminder_db.c
+++ b/tests/fw/services/blob_db/test_reminder_db.c
@@ -253,7 +253,7 @@ void test_reminder_db__delete_parent(void) {
   prv_insert_default_reminders();
 
   const TimelineItemId *parent_id = &item1.header.parent_id;
-  // cnfirm the two are here
+  // confirm the two are here
   cl_assert(reminder_db_get_len((uint8_t *)&item1.header.id, sizeof(Uuid)) > 0);
   cl_assert(reminder_db_get_len((uint8_t *)&item2.header.id, sizeof(Uuid)) > 0);
   // remove the two that share a parent
@@ -288,7 +288,7 @@ void test_reminder_db__find_by_timestamp_title(void) {
   cl_assert_equal_b(reminder_db_find_by_timestamp_title(0, "nonexistent title", NULL, &reminder),
                     false);
 
-  // Test matching timstamp, but not title
+  // Test matching timestamp, but not title
   cl_assert_equal_b(reminder_db_find_by_timestamp_title(title_item1.header.timestamp,
       "nonexistent title", NULL, &reminder), false);
 

--- a/tests/fw/services/comm_session/test_session.c
+++ b/tests/fw/services/comm_session/test_session.c
@@ -242,7 +242,7 @@ void test_session__last_system_session_wins(void) {
   comm_session_close(system_session2, CommSessionCloseReason_UnderlyingDisconnection);
 
   // The transport's .close is supposed to call this.
-  // The stub in this test doens't, so clean up manually:
+  // The stub in this test doesn't, so clean up manually:
   comm_session_close(system_session, CommSessionCloseReason_UnderlyingDisconnection);
 }
 

--- a/tests/fw/services/comm_session/test_session_receive_router.c
+++ b/tests/fw/services/comm_session/test_session_receive_router.c
@@ -124,7 +124,7 @@ static void prv_set_connection_responsiveness(Transport *transport,
 
 }
 
-// Referenced from protocol_endppints_table.auto.h override header:
+// Referenced from protocol_endpoints_table.auto.h override header:
 ///////////////////////////////////////////////////////////
 
 typedef enum {

--- a/tests/fw/services/notifications/test_ancs_filtering.c
+++ b/tests/fw/services/notifications/test_ancs_filtering.c
@@ -126,7 +126,7 @@ void test_ancs_filtering__record_app_no_action_needed(void) {
 }
 
 void test_ancs_filtering__record_app_no_prefs_yet(void) {
-  // No existing prefs yet, we should instert all the defaults
+  // No existing prefs yet, we should insert all the defaults
   iOSNotifPrefs *existing_prefs = NULL;
 
   AttributeList attr_list = {

--- a/tests/fw/services/notifications/test_ancs_notifications.c
+++ b/tests/fw/services/notifications/test_ancs_notifications.c
@@ -136,7 +136,7 @@ void test_ancs_notifications__handle_phone_call_message(void) {
 
   ancs_notifications_handle_message(37, properties, notif_attributes, app_attributes);
 
-  // We just processed an incomming phone call event, there better be a phone event scheduled!
+  // We just processed an incoming phone call event, there better be a phone event scheduled!
   PebbleEvent event = fake_event_get_last();
 
   cl_assert_equal_i(event.type, PEBBLE_PHONE_EVENT);

--- a/tests/fw/services/protobuf_log/test_protobuf_log.c
+++ b/tests/fw/services/protobuf_log/test_protobuf_log.c
@@ -677,7 +677,7 @@ void test_protobuf_log__measurements_auto_flush(void) {
     values[i] = i * 3;
   }
 
-  // Create a session with an artifically small buffer size which will cause it to flush
+  // Create a session with an artificially small buffer size which will cause it to flush
   // automatically
   time_t start_time = rtc_get_time();
   ProtobufLogConfig log_config = {

--- a/tests/fw/services/test_hrm_manager.c
+++ b/tests/fw/services/test_hrm_manager.c
@@ -247,7 +247,7 @@ void test_hrm_manager__feature_change_restarts_sensor(void) {
   cl_assert_equal_b(hrm_is_enabled(HRM), false);
 }
 
-// When we cleanup after an app process, its subscription, if any, should get an expriration time
+// When we cleanup after an app process, its subscription, if any, should get an expiration time
 // placed on it
 void test_hrm_manager__app_cleanup(void) {
   stub_pebble_tasks_set_current(PebbleTask_App);

--- a/tests/fw/services/test_timezone_database.c
+++ b/tests/fw/services/test_timezone_database.c
@@ -35,7 +35,7 @@ void test_timezone_database__get_region_count(void) {
 }
 
 void test_timezone_database__find_region_by_name_simple(void) {
-  // Unforunately we don't really care what the resulting region ids are, we should
+  // Unfortunately we don't really care what the resulting region ids are, we should
   // just make sure the ones that exist are there and they're unique from each other.
 
   const int america_new_york_region = FIND_REGION("America/New_York");

--- a/tests/fw/test_alarm_common.h
+++ b/tests/fw/test_alarm_common.h
@@ -101,7 +101,7 @@ static int s_current_day = 0;
 static const int s_thursday = 1426118400;
 // Friday March 13, 2015, 00:00 UTC
 static const int s_friday = 1426204800;
-// Saturaday March 14, 2015, 00:00 UTC
+// Saturday March 14, 2015, 00:00 UTC
 static const int s_saturday = 1426291200;
 // Sunday March 15, 2015, 00:00 UTC
 static const int s_sunday = 1426377600;

--- a/tests/fw/test_app_run_state.c
+++ b/tests/fw/test_app_run_state.c
@@ -193,7 +193,7 @@ void test_app_run_state__send_update(void) {
 }
 
 void test_app_run_state__protocol_msg_callback(void) {
-  // Tests app_run_state_procotol_msg_callback which should take data
+  // Tests app_run_state_protocol_msg_callback which should take data
   // from a source and perform the appropriate command
   prv_set_remote_active();
   prv_set_remote_capability(CommSessionRunState);

--- a/tests/fw/test_text_layout.c
+++ b/tests/fw/test_text_layout.c
@@ -105,7 +105,7 @@ void test_text_layout__cache_vert_overflow(void) {
   cl_assert(layout.box.size.w == box.size.w);
   cl_assert_equal_i(layout.max_used_size.w, 4 * HORIZ_ADVANCE_PX);
 
-  cl_assert_equal_i(layout.max_used_size.h, 3 * FONT_HEIGHT); // 3 lines - one line extra being layed out so that it will clip ("Jr\nWho-\npper")
+  cl_assert_equal_i(layout.max_used_size.h, 3 * FONT_HEIGHT); // 3 lines - one line extra being laid out so that it will clip ("Jr\nWho-\npper")
 
   graphics_text_layout_get_max_used_size(&gcontext, "JR Whopper 123", font, box, GTextOverflowModeWordWrap, GTextAlignmentLeft, (void*)&layout);
 
@@ -126,7 +126,7 @@ void test_text_layout__cache_vert_overflow_first_line(void) {
     .alignment = GTextAlignmentLeft,
     .max_used_size = (GSize) { 0, 0 }
   };
-  // In all cases, the first line should be layed out (not truncated)
+  // In all cases, the first line should be laid out (not truncated)
 
   graphics_text_layout_get_max_used_size(&gcontext, "JR Whopper", font, box, GTextOverflowModeFill, GTextAlignmentLeft, (void*)&layout);
 
@@ -165,7 +165,7 @@ void test_text_layout__cache_vert_overflow_with_newline(void) {
   graphics_text_layout_get_max_used_size(&gcontext, "JR\n\nWhop", font, box, GTextOverflowModeTrailingEllipsis, GTextAlignmentLeft, (void*)&layout);
 
   cl_assert_equal_i(layout.box.size.w, box.size.w);
-  cl_assert_equal_i(layout.max_used_size.w, 2 * HORIZ_ADVANCE_PX); // only the JR, since Whop is not being layed out
+  cl_assert_equal_i(layout.max_used_size.w, 2 * HORIZ_ADVANCE_PX); // only the JR, since Whop is not being laid out
 
   cl_assert_equal_i(layout.max_used_size.h, 2 * FONT_HEIGHT); // Nothing - save for the first line - will be rendered below the box
 
@@ -174,14 +174,14 @@ void test_text_layout__cache_vert_overflow_with_newline(void) {
   cl_assert_equal_i(layout.box.size.w, box.size.w);
   cl_assert_equal_i(layout.max_used_size.w, 4 * HORIZ_ADVANCE_PX); // Includes Whop - as it may be partially rendered at the bottom of the box
 
-  cl_assert_equal_i(layout.max_used_size.h, 3 * FONT_HEIGHT); // The blank line before Whop is still being layed out, however, so it is still included in the height
+  cl_assert_equal_i(layout.max_used_size.h, 3 * FONT_HEIGHT); // The blank line before Whop is still being laid out, however, so it is still included in the height
 
   graphics_text_layout_get_max_used_size(&gcontext, "JR\n\n\nWhop", font, box, GTextOverflowModeWordWrap, GTextAlignmentLeft, (void*)&layout);
 
   cl_assert_equal_i(layout.box.size.w, box.size.w);
-  cl_assert_equal_i(layout.max_used_size.w, 2 * HORIZ_ADVANCE_PX); // Back to only JR - as the line being layed out from y=20-30px is empty (and the line from 30-40, Whop, is truncated as it can never appear)
+  cl_assert_equal_i(layout.max_used_size.w, 2 * HORIZ_ADVANCE_PX); // Back to only JR - as the line being laid out from y=20-30px is empty (and the line from 30-40, Whop, is truncated as it can never appear)
 
-  cl_assert_equal_i(layout.max_used_size.h, 3 * FONT_HEIGHT); // Same as above - the blank line is still layed out
+  cl_assert_equal_i(layout.max_used_size.h, 3 * FONT_HEIGHT); // Same as above - the blank line is still laid out
 
   graphics_text_layout_get_max_used_size(&gcontext, "JR\n\n\nWhop", font, box, GTextOverflowModeFill, GTextAlignmentLeft, (void*)&layout);
 
@@ -342,7 +342,7 @@ void test_text_layout__delta(void) {
   graphics_text_layout_get_max_used_size(&gcontext, "JR Whopper", font, box, GTextOverflowModeWordWrap, GTextAlignmentLeft, (void*)&layout);
   cl_assert(layout.box.size.w == box.size.w);
   cl_assert_equal_i(layout.max_used_size.w, 4 * HORIZ_ADVANCE_PX);
-  // 3 lines - one line extra being layed out so that it will clip ("Jr\nWho-\npper")
+  // 3 lines - one line extra being laid out so that it will clip ("Jr\nWho-\npper")
   cl_assert_equal_i(layout.max_used_size.h, 3 * (FONT_HEIGHT + FONT_LINE_DELTA));
 
   graphics_text_layout_get_max_used_size(&gcontext, "JR Whopper 123", font, box, GTextOverflowModeWordWrap, GTextAlignmentLeft, (void*)&layout);

--- a/tests/fw/ui/test_animation.c
+++ b/tests/fw/ui/test_animation.c
@@ -146,7 +146,7 @@ static uint64_t prv_now_ms(void) {
 static void prv_advance_by_ms_no_timers(uint64_t ms_delta) {
   uint64_t target_ms = prv_now_ms() + ms_delta;
 
-  // Comppensate for rounding errors
+  // Compensate for rounding errors
   uint64_t new_ticks = rtc_get_ticks() + (ms_delta * RTC_TICKS_HZ + 500 ) / 1000;
   uint64_t new_ms = (new_ticks * 1000 + RTC_TICKS_HZ / 2) / RTC_TICKS_HZ;
   if (new_ms == target_ms - 1) {
@@ -1113,7 +1113,7 @@ void test_animation__property_gcolor8(void) {
 
 // --------------------------------------------------------------------------------------
 // Test that the schedule/unschedule calls work correctly.
-// We should be able to unschedule an amimation parthway through
+// We should be able to unschedule an animation pathway through
 void test_animation__unschedule(void) {
 #ifdef TEST_INCLUDE_BASIC
   PropertyAnimation *prop_h;

--- a/tests/fw/ui/test_scroll_layer_touch.c
+++ b/tests/fw/ui/test_scroll_layer_touch.c
@@ -184,7 +184,7 @@ void test_scroll_layer_touch__registered_and_deregistered(void) {
   cl_assert(s_touch_nav_state.scroll_head == NULL);
 }
 
-// Init->init without deinit stays a single entry (dedup by address); double deinit is a no-op.
+// Init->init without deinit stays a single entry (dedupe by address); double deinit is a no-op.
 void test_scroll_layer_touch__double_init_and_double_deinit(void) {
   prv_touch_nav_setup();
   ScrollLayer sl;

--- a/tests/fw/ui/test_window_stack.c
+++ b/tests/fw/ui/test_window_stack.c
@@ -520,7 +520,7 @@ void test_window_stack__insert_next(void) {
 
 // Description:
 // During the push of a window, we push another window in the load handler of
-// the window being pushed.  This causes the loading window to disappaer from
+// the window being pushed.  This causes the loading window to disappear from
 // the screen (before it even appeared) and become subverted by the new window.
 void test_window_stack__push_during_window_load(void) {
   Window *window = window_create();

--- a/tests/fw/util/test_ihex.c
+++ b/tests/fw/util/test_ihex.c
@@ -19,7 +19,7 @@ void test_ihex__initialize(void) {
 
 static void prv_assert_ihex(const char *expected) {
   int len = strlen(expected);
-  // Cehck that bytes aren't touched past the end of the record.
+  // Check that bytes aren't touched past the end of the record.
   for (int i=len; i < sizeof(s_result); ++i) {
     cl_assert_equal_i(0x20, s_result[i]);
   }

--- a/tests/libutil/test_math_fixed.c
+++ b/tests/libutil/test_math_fixed.c
@@ -217,7 +217,7 @@ void test_math_fixed__S16_3_rounding(void) {
 
   // This test shows how the in between fractional values evaluate to the fixed representation
   // Positive numbers round down to nearest fraction
-  // Negative numbers round up to neareset fraction
+  // Negative numbers round up to nearest fraction
   test_num = (int16_t)((float)-1.249 * (1 << FIXED_S16_3_PRECISION));
   num = (Fixed_S16_3){ .raw_value = test_num };
   cl_assert(num.integer == -2);
@@ -431,7 +431,7 @@ void test_math_fixed__S32_16_mul(void) {
   Fixed_S32_16 num1, num2;
   Fixed_S32_16 mul, mul_c;
 
-  // Test number muliplication
+  // Test number multiplication
   num1 = FIXED_S32_16_ONE;
   num2 = FIXED_S32_16_ONE;
   mul = Fixed_S32_16_mul(num1, num2);

--- a/tests/libutil/test_string.c
+++ b/tests/libutil/test_string.c
@@ -96,7 +96,7 @@ void test_string__test_itoa_int(void) {
 }
 
 void test_string__test_byte_stream_to_hex_string(void) {
-  char result_buf[256]; // arbitraily large
+  char result_buf[256]; // arbitrarily large
 
   const uint8_t byte_stream[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   const char *expected_result_fwd = "00010203040506070809";


### PR DESCRIPTION
Took a pass with cSpell, but sending them in a few batches instead of a big "treewide" one so it's still reviewable.