### PR TITLE
include: cleanup typos

### DIFF
--- a/include/bluetooth/bluetooth_types.h
+++ b/include/bluetooth/bluetooth_types.h
@@ -14,7 +14,7 @@ typedef enum {
   //! The operation was successful.
   BTErrnoOK = 0,
 
-  //! Connection established succesfully.
+  //! Connection established successfully.
   BTErrnoConnected = BTErrnoOK,
 
   //! One or more parameters were invalid.
@@ -228,7 +228,7 @@ typedef struct __attribute__((__packed__)) BTDeviceInternal {
 _Static_assert(sizeof(BTDeviceInternal) == sizeof(BTDevice),
                "BTDeviceInternal should be equal in size to BTDevice");
 
-//! Opaque data structure representing an advertisment report and optional
+//! Opaque data structure representing an advertisement report and optional
 //! scan response. Use the ble_ad... functions to query its contents.
 struct BLEAdData;
 
@@ -248,10 +248,10 @@ struct BLEAdData;
 #define LL_CONN_INTV_MAX_SLOTS (3200) // 1.25ms / slot
 #define LL_SUPERVISION_TIMEOUT_MIN_MS (100)
 
-//! Advertisment and scan response data
+//! Advertisement and scan response data
 //! @internal Exported as forward struct
 typedef struct BLEAdData {
-  //! Lengths of the raw advertisment data
+  //! Lengths of the raw advertisement data
   uint8_t ad_data_length;
 
   //! Lengths of the raw scan response data

--- a/include/bluetooth/bonding_sync.h
+++ b/include/bluetooth/bonding_sync.h
@@ -51,7 +51,7 @@ void bt_driver_handle_host_added_cccd(const BleCCCD *cccd);
 //! Called by the FW when a CCCD entry is removed.
 void bt_driver_handle_host_removed_cccd(const BleCCCD *cccd);
 
-//! Called by the BT driver after succesfully pairing a new device.
+//! Called by the BT driver after successfully pairing a new device.
 //! @param bonding The newly created bonding.
 //! @param addr The address that is used to refer to the connection. This is used to associate
 //! the bonding with the GAPLEConnection.

--- a/include/bluetooth/pebble_pairing_service.h
+++ b/include/bluetooth/pebble_pairing_service.h
@@ -206,7 +206,7 @@ _Static_assert(sizeof(PebblePairingServiceConnectivityStatus) <= 20, "Larger tha
 
 typedef struct GAPLEConnection GAPLEConnection;
 
-//! Signals to the Pebble GATT service that status change has occured (pairing, encryption, ...),
+//! Signals to the Pebble GATT service that status change has occurred (pairing, encryption, ...),
 //! allowing it to notify any BLE devices that are subscribed to connectivity status updates of the
 //! change.
 //! @param connection The connection for which the status was changed.

--- a/include/pbl/drivers/flash.h
+++ b/include/pbl/drivers/flash.h
@@ -28,7 +28,7 @@ void flash_init(void);
 void flash_stop(void);
 
 /**
- * Retreieve the first 3 bytes of the flash's device id. This ID
+ * Retrieve the first 3 bytes of the flash's device id. This ID
  * should remain fixed across all chips.
  */
 uint32_t flash_whoami(void);

--- a/include/pbl/drivers/mic.h
+++ b/include/pbl/drivers/mic.h
@@ -18,7 +18,7 @@ typedef void (*MicDataHandlerCB)(int16_t *samples, size_t sample_count, void *co
 //! Initialize microphone driver. Should be called on boot
 void mic_init(MicDevice *this);
 
-//! Set the mic volume.  This must be called afer mic_init, and not while the mic is running.
+//! Set the mic volume.  This must be called after mic_init, and not while the mic is running.
 void mic_set_volume(MicDevice *this, uint16_t volume);
 
 //! Start the microphone. The driver will fill the specified buffer with up to the specified size

--- a/include/pbl/drivers/qemu/qemu_serial.h
+++ b/include/pbl/drivers/qemu/qemu_serial.h
@@ -50,7 +50,7 @@ typedef struct PACKED {
 
 // QemuProtocol_Compass
 typedef struct PACKED {
-  uint32_t magnetic_heading;      // 0x10000 represents 360 degress
+  uint32_t magnetic_heading;      // 0x10000 represents 360 degrees
   CompassStatus calib_status:8;   // CompassStatus enum
 } QemuProtocolCompassHeader;
 

--- a/include/pbl/drivers/rng.h
+++ b/include/pbl/drivers/rng.h
@@ -7,5 +7,5 @@
 #include <stdbool.h>
 
 //! @param rand_out Storage for the 32-bit random number generated
-//! @return True if a random number was succesfully generated
+//! @return True if a random number was successfully generated
 bool rng_rand(uint32_t *rand_out);

--- a/include/pbl/drivers/rtc.h
+++ b/include/pbl/drivers/rtc.h
@@ -25,11 +25,11 @@ typedef uint64_t RtcTicks;
 void rtc_init(void);
 
 //! Calibrate the RTC driver using the given crystal frequency (in mHz).
-//! This is a seperate step because rtc_init needs to run incredibly early in the startup process
+//! This is a separate step because rtc_init needs to run incredibly early in the startup process
 //! and the manufacturing registry won't be initialized yet.
 void rtc_calibrate_frequency(uint32_t frequency);
 
-//! Initialize any timers the RTC driver may need. This is a seperate step than rtc_init because
+//! Initialize any timers the RTC driver may need. This is a separate step than rtc_init because
 //! rtc_init needs to run incredibly early in the startup process and at that time the timer
 //! system won't be initialized yet.
 void rtc_init_timers(void);

--- a/include/pbl/drivers/uart.h
+++ b/include/pbl/drivers/uart.h
@@ -54,7 +54,7 @@ void uart_set_baud_rate(UARTDevice *dev, uint32_t baud_rate);
 //! @note This cannot be set at the same time as a raw interrupt handler
 void uart_set_rx_interrupt_handler(UARTDevice *dev, UARTRXInterruptHandler irq_handler);
 
-//! Sets a transmit IRQ handler for the device which is called whenenver we send a byte (within an
+//! Sets a transmit IRQ handler for the device which is called whenever we send a byte (within an
 //! ISR)
 //! @note This cannot be set at the same time as a raw interrupt handler
 void uart_set_tx_interrupt_handler(UARTDevice *dev, UARTTXInterruptHandler irq_handler);

--- a/include/pbl/logging/log_hashing.h
+++ b/include/pbl/logging/log_hashing.h
@@ -13,7 +13,7 @@
  * isn't compiled into the final firmware binary image.
  *
  * Token format:
- *   The token is acually a packed uint32_t. The format is as follows:
+ *   The token is actually a packed uint32_t. The format is as follows:
  *   31-29: num fmt conversions  [0-7]
  *   28-26: string index 2       [0-7], 1 based. 0 if no second string. 1-7 otherwise
  *   25-23: string index 1       [0-7], 1 based. 0 if no first string. 1-7 otherwise

--- a/include/pbl/services/activity/insights_settings.h
+++ b/include/pbl/services/activity/insights_settings.h
@@ -41,7 +41,7 @@ typedef struct PACKED ActivitySummarySettings {
   int8_t below_avg_threshold;           //!< Values less than this are counted as above avg
                                         //!< In relation to 100% (eg 93% would be -7)
   int8_t fail_threshold;                //!< Values less than this are counted as fail
-                                        //!< In releastion to 100% (e.g. 55% would be -45)
+                                        //!< In relation to 100% (e.g. 55% would be -45)
 
   union {
     struct PACKED {

--- a/include/pbl/services/activity/kraepelin/kraepelin_algorithm.h
+++ b/include/pbl/services/activity/kraepelin/kraepelin_algorithm.h
@@ -39,7 +39,7 @@ typedef enum {
   // A restful period, these will always be inside of a ActivityType_Sleep session
   KAlgActivityType_RestfulSleep,
 
-  // A "sigificant" length walk
+  // A "significant" length walk
   KAlgActivityType_Walk,
 
   // A run

--- a/include/pbl/services/activity/workout_service.h
+++ b/include/pbl/services/activity/workout_service.h
@@ -42,7 +42,7 @@ bool workout_service_is_workout_ongoing(void);
 bool workout_service_is_workout_type_supported(ActivitySessionType type);
 
 //! Start a new workout
-//! This stops / saves all onoing automatically detected activity sessions
+//! This stops / saves all ongoing automatically detected activity sessions
 //! All workouts must eventually get stopped
 bool workout_service_start_workout(ActivitySessionType type);
 

--- a/include/pbl/services/alarms/alarm.h
+++ b/include/pbl/services/alarms/alarm.h
@@ -29,7 +29,7 @@ typedef int AlarmId; //! A unique ID that can be used to refer to each configure
 typedef enum AlarmKind {
   ALARM_KIND_EVERYDAY = 0, // Alarms of this type will happen each day
   ALARM_KIND_WEEKENDS,     // Alarms of this type will happen Monday - Friday
-  ALARM_KIND_WEEKDAYS,     // Alarms of this type happen Saturaday and Sunday
+  ALARM_KIND_WEEKDAYS,     // Alarms of this type happen Saturday and Sunday
   ALARM_KIND_JUST_ONCE,    // Alarms of this type will happen next time the specified time occurs
   ALARM_KIND_CUSTOM,       // Alarms of this type happen on specified days
 } AlarmKind;
@@ -122,7 +122,7 @@ void alarm_set_enabled(AlarmId id, bool enable);
 void alarm_delete(AlarmId id);
 
 //! @param id The alarm that is being queried
-//! @return True if the alarm exists and is not disabled, Flase otherwise
+//! @return True if the alarm exists and is not disabled, False otherwise
 bool alarm_get_enabled(AlarmId id);
 
 //! @param id The alarm that should be deleted

--- a/include/pbl/services/animation_service.h
+++ b/include/pbl/services/animation_service.h
@@ -16,6 +16,6 @@ void animation_service_timer_schedule(uint32_t ms);
 //! Acknowledge that we received an event sent by the animation timer
 void animation_service_timer_event_received(void);
 
-//! Destroy the animation resoures used by the given task. Called by the process_manager when a
+//! Destroy the animation resources used by the given task. Called by the process_manager when a
 // process exits
 void animation_service_cleanup(PebbleTask task);

--- a/include/pbl/services/battery/battery_state.h
+++ b/include/pbl/services/battery/battery_state.h
@@ -39,7 +39,7 @@ typedef struct {
   //! The battery percentage 0-100
   uint8_t pct;
   //! WARNING: This maps to @see battery_charge_controller_thinks_we_are_charging as opposed to
-  //! the user-facing defintion of whether we're charging (100% battery).
+  //! the user-facing definition of whether we're charging (100% battery).
   bool is_charging;
   bool is_plugged;
 } PreciseBatteryChargeState;

--- a/include/pbl/services/blob_db/api.h
+++ b/include/pbl/services/blob_db/api.h
@@ -54,17 +54,17 @@ typedef void (*BlobDBInitImpl)(void);
 
 //! Implements the insert API. Note that this function should be blocking.
 //! \param key a pointer to the key data
-//! \param key_len the lenght of the key, in bytes
+//! \param key_len the length of the key, in bytes
 //! \param val a pointer to the value data
 //! \param val_len the length of the value, in bytes
-//! \returns S_SUCCESS if the key/val pair was succesfully inserted
+//! \returns S_SUCCESS if the key/val pair was successfully inserted
 //! and an error code otherwise (See \ref StatusCode)
 typedef status_t (*BlobDBInsertImpl)
     (const uint8_t *key, int key_len, const uint8_t *val, int val_len);
 
 //! Implements the get length API.
 //! \param key a pointer to the key data
-//! \param key_len the lenght of the key, in bytes
+//! \param key_len the length of the key, in bytes
 //! \returns the length in bytes of the value for key on success
 //! and an error code otherwise (See \ref StatusCode)
 typedef int (*BlobDBGetLenImpl)
@@ -72,24 +72,24 @@ typedef int (*BlobDBGetLenImpl)
 
 //! Implements the read API. Note that this function should be blocking.
 //! \param key a pointer to the key data
-//! \param key_len the lenght of the key, in bytes
+//! \param key_len the length of the key, in bytes
 //! \param[out] val_out a pointer to a buffer of size val_len
 //! \param val_len the length of the value to be copied, in bytes
-//! \returns S_SUCCESS if the value for key was succesfully read,
+//! \returns S_SUCCESS if the value for key was successfully read,
 //! and an error code otherwise (See \ref StatusCode)
 typedef status_t (*BlobDBReadImpl)
     (const uint8_t *key, int key_len, uint8_t *val_out, int val_len);
 
 //! Implements the delete API. Note that this function should be blocking.
 //! \param key a pointer to the key data
-//! \param key_len the lenght of the key, in bytes
-//! \returns S_SUCCESS if the key/val pair was succesfully deleted
+//! \param key_len the length of the key, in bytes
+//! \returns S_SUCCESS if the key/val pair was successfully deleted
 //! and an error code otherwise (See \ref StatusCode)
 typedef status_t (*BlobDBDeleteImpl)
     (const uint8_t *key, int key_len);
 
 //! Implements the flush API. Note that this function should be blocking.
-//! \returns S_SUCCESS if all key/val pairs were succesfully deleted
+//! \returns S_SUCCESS if all key/val pairs were successfully deleted
 //! and an error code otherwise (See \ref StatusCode)
 typedef status_t (*BlobDBFlushImpl)(void);
 
@@ -106,7 +106,7 @@ typedef BlobDBDirtyItem *(*BlobDBGetDirtyListImpl)(void);
 
 //! Implements the MarkSynced API.
 //! \param key a pointer to the key data
-//! \param key_len the lenght of the key, in bytes
+//! \param key_len the length of the key, in bytes
 //! \returns S_SUCCESS if the item was marked synced, an error code otherwise
 typedef status_t (*BlobDBMarkSyncedImpl)(const uint8_t *key, int key_len);
 
@@ -143,7 +143,7 @@ void blob_db_get_dirty_dbs(uint8_t *ids, uint8_t *num_ids);
 //! See \ref BlobDBReadImpl
 //! \param db_id the ID of the blob DB
 //! \param key a pointer to the key data
-//! \param key_len the lenght of the key, in bytes
+//! \param key_len the length of the key, in bytes
 //! \param val a pointer to the value data
 //! \param val_len the length of the value, in bytes
 status_t blob_db_insert(BlobDBId db_id,
@@ -153,14 +153,14 @@ status_t blob_db_insert(BlobDBId db_id,
 //! See \ref BlobDBGetLenImpl
 //! \param db_id the ID of the blob DB
 //! \param key a pointer to the key data
-//! \param key_len the lenght of the key, in bytes
+//! \param key_len the length of the key, in bytes
 int blob_db_get_len(BlobDBId db_id,
     const uint8_t *key, int key_len);
 
 //! Get the value of length val_len for a given key
 //! \param db_id the ID of the blob DB
 //! \param key a pointer to the key data
-//! \param key_len the lenght of the key, in bytes
+//! \param key_len the length of the key, in bytes
 //! \param val_out a buffer to store the value data
 //! \param val_len the length of the value, in bytes
 //! See \ref BlobDBReadImpl
@@ -170,7 +170,7 @@ status_t blob_db_read(BlobDBId db_id,
 //! Delete the key/val pair in a blob DB for a given key
 //! \param db_id the ID of the blob DB
 //! \param key a pointer to the key data
-//! \param key_len the lenght of the key, in bytes
+//! \param key_len the length of the key, in bytes
 //! See \ref BlobDBDeleteImpl
 status_t blob_db_delete(BlobDBId db_id,
     const uint8_t *key, int key_len);
@@ -191,6 +191,6 @@ BlobDBDirtyItem *blob_db_get_dirty_list(BlobDBId db_id);
 //! \note This API is used upon receiving an ACK from the phone during sync
 //! \param db_id the ID of the blob DB
 //! \param key a pointer to the key data
-//! \param key_len the lenght of the key, in bytes
+//! \param key_len the length of the key, in bytes
 //! \see BlobDBMarkSyncedImpl
 status_t blob_db_mark_synced(BlobDBId db_id, uint8_t *key, int key_len);

--- a/include/pbl/services/bluetooth/bluetooth_ctl.h
+++ b/include/pbl/services/bluetooth/bluetooth_ctl.h
@@ -35,5 +35,5 @@ void bt_ctl_set_enabled(bool enabled);
 //! Sets the override mode used to stop and start the bluetooth independent of the airplane mode.
 void bt_ctl_set_override_mode(BtCtlModeOverride override);
 
-//! Reset bluetoosh using sequential calls to comm_stop() and comm_start()
+//! Reset bluetooth using sequential calls to comm_stop() and comm_start()
 void bt_ctl_reset_bluetooth(void);

--- a/include/pbl/services/bluetooth/bluetooth_persistent_storage.h
+++ b/include/pbl/services/bluetooth/bluetooth_persistent_storage.h
@@ -80,7 +80,7 @@ bool bt_persistent_storage_has_ble_ancs_bonding(void);
 bool bt_persistent_storage_has_active_ble_gateway_bonding(void);
 
 //! Runs the callback for each BLE pairing
-//! The callback is NOT allowed to aquire the bt_lock() (or we could deadlock).
+//! The callback is NOT allowed to acquire the bt_lock() (or we could deadlock).
 void bt_persistent_storage_for_each_ble_pairing(BtPersistBondingDBEachBLE cb, void *context);
 
 //! Registers all the existing BLE bondings with the BT driver lib.

--- a/include/pbl/services/comm_session/session_send_buffer.h
+++ b/include/pbl/services/comm_session/session_send_buffer.h
@@ -25,7 +25,7 @@ size_t comm_session_send_buffer_get_max_payload_length(const CommSession *sessio
 //! the function returns with `true`, the amount of space (or more) is guaranteed to be available.
 //! @param timeout_ms The maximum duration to wait for the send buffer to become available with the
 //! required number of bytes of free space.
-//! @return True if the "writer access" was sucessfully acquired, false otherwise.
+//! @return True if the "writer access" was successfully acquired, false otherwise.
 SendBuffer * comm_session_send_buffer_begin_write(CommSession *session, uint16_t endpoint_id,
                                                   size_t required_free_length,
                                                   uint32_t timeout_ms);

--- a/include/pbl/services/contacts/attributes_address.h
+++ b/include/pbl/services/contacts/attributes_address.h
@@ -55,8 +55,8 @@ size_t attributes_address_get_buffer_size(uint8_t num_attributes,
                                           const uint8_t *attributes_per_address,
                                           size_t required_size_for_strings);
 
-//! Initializes an AttrbuteList and AddressList
-//! @param attr_list          The AttrbuteList to initialize
+//! Initializes an AttributeList and AddressList
+//! @param attr_list          The AttributeList to initialize
 //! @param addr_list          The AddressList to initialize
 //! @param buffer             The buffer to hold the list of attributes and address
 //! @param num_attributes     number of attributes
@@ -71,7 +71,7 @@ void attributes_address_init(AttributeList *attr_list,
                              const uint8_t *attributes_per_address);
 
 //! Fills an AttributeList and AddressList from serialized data
-//! @param attr_list          The AttrbuteList to fill
+//! @param attr_list          The AttributeList to fill
 //! @param addr_list          The AddressList to fill
 //! @param buffer             The buffer which holds the list of attributes and address
 //! @param buf_end            A pointer to the end of the buffer
@@ -89,7 +89,7 @@ size_t attributes_address_get_serialized_payload_size(AttributeList *list,
                                                       AddressList *addr_list);
 
 //! Serializes an attribute list and address list into a buffer
-//! @param attr_list          The AttrbuteList to serialize
+//! @param attr_list          The AttributeList to serialize
 //! @param addr_list          The AddressList to serialize
 //! @param buffer a pointer to the buffer to write to
 //! @param buffer_size the size of the buffer in bytes

--- a/include/pbl/services/data_logging/dls_list.h
+++ b/include/pbl/services/data_logging/dls_list.h
@@ -27,7 +27,7 @@ void dls_list_insert_session(DataLoggingSession *logging_session);
 
 //! Creates a new DataLoggingSession object that is only initialized with the parameters given. The
 //! session will only be initialized with the given parameters. The .storage and .comm members must
-//! be seperately initialized. Also, the resulting object will need to be added to the list of
+//! be separately initialized. Also, the resulting object will need to be added to the list of
 //! sessions using one of dls_list_add_new_session and dls_list_insert_session. May return NULL if
 //! we've created too many sessions.
 DataLoggingSession *dls_list_create_session(uint32_t tag, DataLoggingItemType type, uint16_t size,

--- a/include/pbl/services/filesystem/pfs.h
+++ b/include/pbl/services/filesystem/pfs.h
@@ -76,7 +76,7 @@ typedef struct {
 //!    committed until the pfs_close is called. Until this time, pfs_open of the
 //!    'name' will return a hdl to the original file. This way there is always a
 //!    valid version of the file which can be read & the caller can copy parts
-//!    of the orginal file in hunks rather than allocating a lot of RAM.
+//!    of the original file in hunks rather than allocating a lot of RAM.
 //!
 //!   OP_FLAG_SKIP_HDR_CRC_CHECK - For files which are not accessed frequently,
 //!    it is a good idea to sanity check the on-flash header CRCs to make sure

--- a/include/pbl/services/hrm/hrm_manager.h
+++ b/include/pbl/services/hrm/hrm_manager.h
@@ -114,9 +114,9 @@ bool sys_hrm_manager_set_update_interval(HRMSessionRef session, uint32_t update_
 //! @param[in] session the HRMSessionRef returned by sys_hrm_manager_app_subscribe
 //! @param[out] app_id if not NULL, the app_id belonging to this subscription is returned here
 //! @param[out] update_interval_s if not NULL, the requested update interval is returned here
-//! @param[out] expire_s if not NULL, the number of seconds that this subcription will expire in
+//! @param[out] expire_s if not NULL, the number of seconds that this subscription will expire in
 //! @param[out] features if not NULL, the features of this subscription are returned here
-//! @return true if succss, false if subscription was not found
+//! @return true if successful, false if subscription was not found
 bool sys_hrm_manager_get_subscription_info(HRMSessionRef session, AppInstallId *app_id,
                                            uint32_t *update_interval_s, uint16_t *expire_s,
                                            HRMFeature *features);

--- a/include/pbl/services/new_timer/new_timer.h
+++ b/include/pbl/services/new_timer/new_timer.h
@@ -17,7 +17,7 @@
 //! callback to send an event to another thread with evented_timer.h. In the future these other
 //! threads will probably use their own TaskTimerManager instances instead and this thread will
 //! will get a whole lot less busy and reserved for only high priority work. At that time this
-//! thread will probably get renamed something like KernelHighPriortity.
+//! thread will probably get renamed something like KernelHighPriority.
 
 typedef void (*NewTimerCallback)(void *data);
 
@@ -49,7 +49,7 @@ TimerID new_timer_create(void);
 //! @param[in] cb pointer to the user's callback procedure
 //! @param[in] cb_data reference data for the callback
 //! @param[in] flags one or more TIMER_START_FLAG_.* flags
-//! @return True if succesful, false if timer was not rescheduled. Note that it will never return
+//! @return True if successful, false if timer was not rescheduled. Note that it will never return
 //!     false if none of the FAIL_IF_* flags are set.
 bool new_timer_start(TimerID timer, uint32_t timeout_ms, NewTimerCallback cb, void *cb_data, 
                      uint32_t flags);

--- a/include/pbl/services/notifications/ancs/ancs_item.h
+++ b/include/pbl/services/notifications/ancs/ancs_item.h
@@ -13,7 +13,7 @@
 //! @param app_attributes ANCS App attributes (namely, the display name)
 //! @param app_metadata The icon and color associated with the app
 //! @param notif_prefs iOS notification prefs for this notification
-//! @param timestamp Time the notification occured
+//! @param timestamp Time the notification occurred
 //! @param properties Additional ANCS properties (category, flags, etc)
 //! @return The newly created timeline item
 TimelineItem *ancs_item_create_and_populate(ANCSAttribute *notif_attributes[],

--- a/include/pbl/services/persist.h
+++ b/include/pbl/services/persist.h
@@ -39,7 +39,7 @@ void persist_service_unlock_store(SettingsFile *store);
 //! Call during each process's startup.
 void persist_service_client_open(const Uuid *uuid);
 
-//! Call once after proces exits to clean it up.
+//! Call once after process exits to clean it up.
 void persist_service_client_close(const Uuid *uuid);
 
 //! Deletes the app's persist file.

--- a/include/pbl/services/protobuf_log/protobuf_log_test.h
+++ b/include/pbl/services/protobuf_log/protobuf_log_test.h
@@ -9,7 +9,7 @@
 #include <stdint.h>
 
 // ---------------------------------------------------------------------------------------------
-// Decode an encoded payload with measurementsets. Used for debugging and unit tests.
+// Decode an encoded payload with MeasurementSets. Used for debugging and unit tests.
 // @param[in] encoded_buf pointer to encoded data
 // @param[in] encoded_buf_size size of encoded data
 // @param[out] payload_sender_type returned payload sender type string

--- a/include/pbl/services/put_bytes/put_bytes_storage.h
+++ b/include/pbl/services/put_bytes/put_bytes_storage.h
@@ -58,7 +58,7 @@ uint32_t pb_storage_calculate_crc(PutBytesStorage *storage, PutBytesCrcType crc_
 //! @param object_type the type of putbyte object we're about to store
 //! @param total_size the size of the incoming object, in bytes
 //! @param append_offset if != 0, this means we are continuing a PB operation that previously failed
-//!                      for some reason. The incomming writes will start at this offset
+//!                      for some reason. The incoming writes will start at this offset
 //! @param info additional information about the data (see PutBytesStorageInfo).
 bool pb_storage_init(PutBytesStorage *storage, PutBytesObjectType object_type,
                      uint32_t total_size, PutBytesStorageInfo *info, uint32_t append_offset);
@@ -66,7 +66,7 @@ bool pb_storage_init(PutBytesStorage *storage, PutBytesObjectType object_type,
 //! Deinitialize and free a storage struct after a transaction is over
 //! @param storage a pointer-to-pointer to where the reference to the storage is currently held
 //! @param is_success whether the putbyte transfer succeeded or not
-//! @note if putbytes is unsuccesful, the data will be deleted
+//! @note if putbytes is unsuccessful, the data will be deleted
 void pb_storage_deinit(PutBytesStorage *storage, bool is_success);
 
 //! Some types of storage allow the state of a partial installation to be recovered (today, just

--- a/include/pbl/services/regular_timer.h
+++ b/include/pbl/services/regular_timer.h
@@ -35,7 +35,7 @@ void regular_timer_add_multiminute_callback(RegularTimerInfo* cb, uint16_t minut
 
 //! Remove a callback already registered for either seconds or minutes.
 //! WARNING: If you call this from your callback procedure, you are NOT allowed to free up the memory used for
-//!  the RegulartTimerInfo structure until after your callback exits!
+//!  the RegularTimerInfo structure until after your callback exits!
 //! @return true iff the timer was successfully stopped (false may indicate no timer was
 //!  scheduled at all or the cb is currently executing)
 bool regular_timer_remove_callback(RegularTimerInfo* cb);

--- a/include/pbl/services/settings/settings_file.h
+++ b/include/pbl/services/settings/settings_file.h
@@ -9,19 +9,19 @@
 
 // Deleted records have their key stick around for at least DELETED_LIFETIME
 // before they can be garbage collected from the file in which they are
-// contained, that way they have time to propegate to all devices we end up
-// syncronizing with. For more information, refer to the sync protocol proposal:
+// contained, that way they have time to propagate to all devices we end up
+// synchronizing with. For more information, refer to the sync protocol proposal:
 // https://pebbletechnology.atlassian.net/wiki/pages/viewpage.action?pageId=26837564
 //
 // FIXME: See PBL-18945
 #define DELETED_LIFETIME (0 * SECONDS_PER_DAY)
 
 //! A SettingsFile is just a simple binary key-value store. Keys can be strings,
-//! uint32_ts, or arbitrary bytes. Values are similarilly flexible. All
+//! uint32_ts, or arbitrary bytes. Values are similarly flexible. All
 //! operations are atomic, so a reboot in the middle of changing the value for a
 //! key will always either complete, returning the new value upon reboot, or
 //! will just return the old value.
-//! It also supports bidirection syncronization between the phone & watch,
+//! It also supports bidirectional syncronization between the phone & watch,
 //! using timestamps to resolve conflicts.
 //! Note that although all operations are atomic, they are not thread-safe. If
 //! you will be accessing a SettingsFile from multiple threads, make sure you
@@ -156,7 +156,7 @@ typedef struct {
 //! Callback used for using settings_file_each.
 //! The bool returned is used to control the iteration.
 //! - If a callback returns true, the iteration continues
-//! - If a callback returns false, the ieration stops.
+//! - If a callback returns false, the iteration stops.
 typedef bool (*SettingsFileEachCallback)(SettingsFile *file,
                                          SettingsRecordInfo *info,
                                          void *context);

--- a/include/pbl/services/stationary.h
+++ b/include/pbl/services/stationary.h
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 
 //! Set up a timer that will check the position of the watch every minute to see
-//! if any motion has occured
+//! if any motion has occurred
 void stationary_init(void);
 
 //! Stationary mode should only be enabled when the user settings allow for it and when

--- a/include/pbl/services/timeline/attributes_actions.h
+++ b/include/pbl/services/timeline/attributes_actions.h
@@ -42,8 +42,8 @@ size_t attributes_actions_get_required_buffer_size(uint8_t num_attributes,
 size_t attributes_actions_get_buffer_size(AttributeList *attr_list,
                                           TimelineItemActionGroup *action_group);
 
-//! Initializes an AttrbuteList and ActionGroup
-//! @param attr_list          The AttrbuteList to initialize
+//! Initializes an AttributeList and ActionGroup
+//! @param attr_list          The AttributeList to initialize
 //! @param action_group       The ActionGroup to initialize
 //! @param buffer             The buffer to hold the list of attributes and actions
 //! @param num_attributes     number of attributes
@@ -58,7 +58,7 @@ void attributes_actions_init(AttributeList *attr_list,
                              const uint8_t *attributes_per_action);
 
 //! Fills an AttributeList and ActionGroup from serialized data
-//! @param attr_list          The AttrbuteList to fill
+//! @param attr_list          The AttributeList to fill
 //! @param action_group       The ActionGroup to fill
 //! @param buffer             The buffer which holds the list of attributes and actions
 //! @param buf_end            A pointer to the end of the buffer
@@ -76,7 +76,7 @@ size_t attributes_actions_get_serialized_payload_size(AttributeList *list,
                                                       TimelineItemActionGroup *action_group);
 
 //! Serializes an attribute list and action group into a buffer
-//! @param attr_list          The AttrbuteList to serialize
+//! @param attr_list          The AttributeList to serialize
 //! @param action_group       The ActionGroup to serialize
 //! @param buffer a pointer to the buffer to write to
 //! @param buffer_size the size of the buffer in bytes

--- a/include/pbl/services/timeline/calendar.h
+++ b/include/pbl/services/timeline/calendar.h
@@ -9,7 +9,7 @@
 //! The states are:
 //! - "no calendar events ongoing"
 //! - "one or more calendar events ongoing"
-//! Not every calendar event start / stop produces an event, but every transition is guarenteed
+//! Not every calendar event start / stop produces an event, but every transition is guaranteed
 //! to put an event.
 
 

--- a/include/pbl/services/timeline/layout_layer.h
+++ b/include/pbl/services/timeline/layout_layer.h
@@ -21,13 +21,13 @@ typedef enum {
 //! LayoutLayers depart from traditional Layers in a few meaningful way.
 //! 1) LayoutLayers are modulated by a "mode", which is the context in which the LayoutLayer
 //! is displayed. Examples of modes are the "card" mode which displays detailed pin info
-//! and the "minimzed" mode which is used to display a "toast" like mode of a pin.
+//! and the "minimized" mode which is used to display a "toast" like mode of a pin.
 //! 2) LayoutLayers expose three more generic APIs:
 //! \ref layout_get_size which returns the size of the
 //! content within the layout as well as a generic constructor/destructor:
 //!  \ref layout_create / \ref layout_destroy.
 //! 3) LayoutLayers are constructed from a set of Attributes which they are meant to display.
-//! 4) Sub-types of LayoutLayer are instanciated by summoning the correct type ID rather than by
+//! 4) Sub-types of LayoutLayer are instantiated by summoning the correct type ID rather than by
 //! calling a specialized constructor / destructor as per the Layer API.
 
 //! LayoutIds identify the type of a LayoutLayer. They are passed to the constructor to

--- a/include/pbl/services/timeline/timeline.h
+++ b/include/pbl/services/timeline/timeline.h
@@ -46,7 +46,7 @@ bool timeline_exists(Uuid *id);
 //! Enables bulk action mode for ancs actions to avoid filling the event queue
 void timeline_enable_ancs_bulk_action_mode(bool enable);
 
-//! Returns whether or not bulk actoin mode is enabled for ancs actions
+//! Returns whether or not bulk action mode is enabled for ancs actions
 bool timeline_is_bulk_ancs_action_mode_enabled(void);
 
 //! invokes a timelineitem's action. This can end up triggering a bluetooth message.

--- a/include/pbl/services/timezone_database.h
+++ b/include/pbl/services/timezone_database.h
@@ -29,7 +29,7 @@ typedef struct {
   char ds_label;
   //! Which day of the week this rule is observed.
   //! 0-indexed, starting with Sunday (ie Monday is 1, Tuesday is 2...).
-  //! A value of 255 indiciates that this rule applies to any day of the week.
+  //! A value of 255 indicates that this rule applies to any day of the week.
   uint8_t wday;
   //! A bitset of flags, see DSTRuleFlags.
   uint8_t flag;
@@ -56,7 +56,7 @@ int timezone_database_get_region_count(void);
 //! the .dst_start and .dst_end members in tz_info uninitialized.
 //!
 //! @param region_id The region ID to look up
-//! @param[out] tz_info The TimezoneInfo strcuture to populate with the region
+//! @param[out] tz_info The TimezoneInfo structure to populate with the region
 bool timezone_database_load_region_info(uint16_t region_id, TimezoneInfo *tz_info);
 
 //! Load a timezone name for a given region ID.

--- a/include/pbl/util/circular_buffer.h
+++ b/include/pbl/util/circular_buffer.h
@@ -48,7 +48,7 @@ uint16_t circular_buffer_write_prepare(CircularBuffer *buffer, uint8_t **data_ou
 //! To be used after circular_buffer_write_prepare(), to make the CircularBuffer update the length
 //! of the data it contains.
 //! @param buffer The circular buffer that was written to.
-//! @param written_length The length that has just been writted at the pointer provided by
+//! @param written_length The length that has just been written at the pointer provided by
 //! circular_buffer_write_prepare().
 void circular_buffer_write_finish(CircularBuffer *buffer, uint16_t written_length);
 
@@ -57,10 +57,10 @@ void circular_buffer_write_finish(CircularBuffer *buffer, uint16_t written_lengt
 //!
 //! If the circular buffer wraps in the middle of the requested data, this function call will return true but will
 //! provide fewer bytes that requested. When this happens, the length_out parameter will be set to a value smaller
-//! than length. A second read call can be made with the remaining smaller length to retreive the rest.
+//! than length. A second read call can be made with the remaining smaller length to retrieve the rest.
 //!
 //! The reason this read doesn't consume is to avoid having to copy out the data. The data_out pointer should be
-//! stable until you explicitely ask for it to be consumed with circular_buffer_consume.
+//! stable until you explicitly ask for it to be consumed with circular_buffer_consume.
 //!
 //! @param buffer The buffer to read from
 //! @param length How many bytes to read

--- a/include/pbl/util/heap.h
+++ b/include/pbl/util/heap.h
@@ -30,9 +30,9 @@ typedef struct Heap {
   HeapInfo_t *begin;
   HeapInfo_t *end;
 
-  //! Number of allocated bytes, including beginers
+  //! Number of allocated bytes, including beginners
   unsigned int current_size;
-  //! Peak number of allocated bytes, including beginers
+  //! Peak number of allocated bytes, including beginners
   unsigned int high_water_mark;
 
   HeapLockImpl lock_impl;
@@ -68,7 +68,7 @@ void heap_set_corruption_handler(Heap *heap, CorruptionHandler corruption_handle
 
 //! Allocate a fragment of memory on the given heap. Tries to avoid
 //! fragmentation by obtaining memory requests larger than LARGE_SIZE from the
-//! endo of the buffer, while small fragments are taken from the start of the
+//! end of the buffer, while small fragments are taken from the start of the
 //! buffer.
 //! @note heap_init() must be called prior to using heap_malloc().
 //! @param heap The heap to allocate from

--- a/include/pbl/util/list.h
+++ b/include/pbl/util/list.h
@@ -15,7 +15,7 @@ typedef struct __attribute__((packed)) ListNode {
 typedef bool (*ListFilterCallback)(ListNode *found_node, void *data);
 
 //! - If a callback returns true, the iteration continues
-//! - If a callback returns false, the ieration stops.
+//! - If a callback returns false, the iteration stops.
 typedef bool (*ListForEachCallback)(ListNode *node, void *context);
 
 #define LIST_NODE_NULL { .next = NULL, .prev = NULL }

--- a/include/pbl/util/math.h
+++ b/include/pbl/util/math.h
@@ -57,7 +57,7 @@ int ceil_log_two(uint32_t n);
 int32_t integer_sqrt(int64_t x);
 
 /*
- * The -Wtype-limits flag generated an error with the previous IS_SIGNED maco.
+ * The -Wtype-limits flag generated an error with the previous IS_SIGNED macro.
  * If an unsigned number was passed in the macro would check if the unsigned number was less than 0.
  */
 //! Determine whether a variable is signed or not.
@@ -88,7 +88,7 @@ static inline int distance_to_mod_boundary(int32_t i, uint16_t n) {
 }
 
 /**
- * Compute the next backoff interval using a bounded binary expoential backoff formula.
+ * Compute the next backoff interval using a bounded binary exponential backoff formula.
  *
  * @param[in,out] attempt The number of retries performed so far. This count will be incremented by the function.
  * @param[in] initial_value The inital backoff interval. Subsequent backoff attempts will be this number multiplied by a power of 2.

--- a/include/pbl/util/math_fixed.h
+++ b/include/pbl/util/math_fixed.h
@@ -145,7 +145,7 @@ static __inline__ Fixed_S64_32 Fixed_S64_32_sub(Fixed_S64_32 a, Fixed_S64_32 b) 
 ////////////////////////////////////////////////////////////////
 /// Mixed operations
 ////////////////////////////////////////////////////////////////
-// This function muliples a Fixed_S16_3 and Fixed_S32_16 and returns result in Fixed_S16_3 format
+// This function multiplies a Fixed_S16_3 and Fixed_S32_16 and returns result in Fixed_S16_3 format
 static __inline__ Fixed_S16_3 Fixed_S16_3_S32_16_mul(Fixed_S16_3 a, Fixed_S32_16 b) {
   return Fixed_S16_3( a.raw_value * b.raw_value >> FIXED_S32_16_PRECISION );
 }

--- a/include/pbl/util/slist.h
+++ b/include/pbl/util/slist.h
@@ -13,7 +13,7 @@ typedef struct SingleListNode {
 typedef bool (*SingleListFilterCallback)(SingleListNode *found_node, void *data);
 
 //! - If a callback returns true, the iteration continues
-//! - If a callback returns false, the ieration stops.
+//! - If a callback returns false, the iteration stops.
 typedef bool (*SingleListForEachCallback)(SingleListNode *node, void *context);
 
 #define SINGLE_LIST_NODE_NULL { .next = NULL }


### PR DESCRIPTION
Took a pass with cSpell, but sending them in a few batches instead of a big "treewide" one so it's still reviewable.