### PR TITLE
src/fw/applib: cleanup typos

### DIFF
--- a/src/fw/applib/app_focus_service.h
+++ b/src/fw/applib/app_focus_service.h
@@ -33,7 +33,7 @@ typedef void (*AppFocusHandler)(bool in_focus);
 //! 2) A notification comes in and the animation to show the notification starts. The will_focus
 //! handler is called with in_focus set to false.
 //! 3) The animation completes and the notification is in focus, with the app being completely
-//! covered. The did_focus hander is called with in_focus set to false.
+//! covered. The did_focus handler is called with in_focus set to false.
 //! 4) The notification is dismissed and the animation to return to the app starts. The will_focus
 //! handler is called with in_focus set to true.
 //! 5) The animation completes and the app is in focus. The did_focus handler is called with

--- a/src/fw/applib/app_message/app_message.h
+++ b/src/fw/applib/app_message/app_message.h
@@ -331,7 +331,7 @@ void app_message_deregister_callbacks(void);
 
 // -------- AppMessage Lifecycle ----------------------------------------------------------------------------------- //
 
-//! Programatically determine the inbox size maximum in the current configuration.
+//! Programmatically determine the inbox size maximum in the current configuration.
 //!
 //! \return The inbox size maximum on this firmware.
 //!
@@ -340,7 +340,7 @@ void app_message_deregister_callbacks(void);
 //!
 uint32_t app_message_inbox_size_maximum(void);
 
-//! Programatically determine the outbox size maximum in the current configuration.
+//! Programmatically determine the outbox size maximum in the current configuration.
 //!
 //! \return The outbox size maximum on this firmware.
 //!

--- a/src/fw/applib/app_smartstrap.h
+++ b/src/fw/applib/app_smartstrap.h
@@ -35,7 +35,7 @@
 
 //! Error values which may be returned from the smartstrap APIs.
 typedef enum {
-  //! No error occured.
+  //! No error occurred.
   SmartstrapResultOk = 0,
   //! Invalid function arguments were supplied.
   SmartstrapResultInvalidArgs,
@@ -48,7 +48,7 @@ typedef enum {
   SmartstrapResultServiceUnavailable,
   //! The smartstrap reported that it does not support the requested attribute.
   SmartstrapResultAttributeUnsupported,
-  //! A time-out occured during the request.
+  //! A time-out occurred during the request.
   SmartstrapResultTimeOut,
 } SmartstrapResult;
 
@@ -132,7 +132,7 @@ void app_smartstrap_set_timeout(uint16_t timeout_ms);
 //! @param attribute_id The AttributeId to create the attribute for.
 //! @param buffer_length The length of the internal buffer which will be used to store the read
 //! and write requests for this attribute.
-//! @returns The newly created SmartstrapAttribute or NULL if an internal error occured or if the
+//! @returns The newly created SmartstrapAttribute or NULL if an internal error occurred or if the
 //! specified length is greater than SMARTSTRAP_ATTRIBUTE_LENGTH_MAXIMUM.
 SmartstrapAttribute *app_smartstrap_attribute_create(SmartstrapServiceId service_id,
                                                      SmartstrapAttributeId attribute_id,

--- a/src/fw/applib/app_timer.c
+++ b/src/fw/applib/app_timer.c
@@ -9,7 +9,7 @@
 
 //! @file fw/applib/app_timer.c
 //!
-//! Surpise! All this is is a dumb wrapper around evented_timer!
+//! Surprise! All this is is a dumb wrapper around evented_timer!
 
 DEFINE_SYSCALL(AppTimer*, app_timer_register, uint32_t timeout_ms,
                                               AppTimerCallback callback,

--- a/src/fw/applib/applib_malloc.json
+++ b/src/fw/applib/applib_malloc.json
@@ -8,7 +8,7 @@
         "",
         "Types are defined below with the following parameters:                                  ",
         " name: The name of the type as it appears in our codebase. This type definition must    ",
-        "       be visibile in one of the headers in the headers list below.                     ",
+        "       be visible in one of the headers in the headers list below.                      ",
         " size_2x: The size in bytes that should be used for legacy2 apps                        ",
         " size_3x: The size in bytes that should be used for 3.x apps                            ",
         " size_3x_padding: The amount of padding to add directly to this particular struct.      ",

--- a/src/fw/applib/applib_resource_private.h
+++ b/src/fw/applib/applib_resource_private.h
@@ -33,7 +33,7 @@ bool applib_resource_munmap_all();
 //! @param offset The offset in bytes into the resource
 //! @param length The number of bytes to load
 //! @param used_aligned True, if you want this function to allocate 7 extra bytes if it cannot mmap
-//! @return NULL, if the resource coudln't be memory-mapped or allocated
+//! @return NULL, if the resource couldn't be memory-mapped or allocated
 void *applib_resource_mmap_or_load(ResAppNum app_num, uint32_t resource_id,
                                    size_t offset, size_t length, bool used_aligned);
 

--- a/src/fw/applib/bluetooth/ble_ad_parse.h
+++ b/src/fw/applib/bluetooth/ble_ad_parse.h
@@ -6,7 +6,7 @@
 #include <bluetooth/bluetooth_types.h>
 
 //! @file ble_ad_parse.h
-//! API to serialize and deserialize advertisment and scan response payloads.
+//! API to serialize and deserialize advertisement and scan response payloads.
 //!
 //! Inbound payloads, as received using the ble_scan.h public API, can be
 //! consumed/deserialized using the functions below.
@@ -68,7 +68,7 @@ bool ble_ad_get_tx_power_level(const BLEAdData *ad, int8_t *tx_power_level_out);
 size_t ble_ad_copy_local_name(const BLEAdData *ad,
                               char *buffer, size_t size);
 
-//! If the Local Name is present in the advertisment data, returns the number
+//! If the Local Name is present in the advertisement data, returns the number
 //! of bytes a C-string needs to be to hold the full name.
 //! @param ad The advertisement data
 //! @return The size of the Local Name in bytes, *including* zero terminator.
@@ -95,7 +95,7 @@ size_t ble_ad_copy_manufacturer_specific_data(const BLEAdData *ad,
                                               uint16_t *company_id_out,
                                               uint8_t *buffer, size_t size);
 
-//! Gets the size in bytes of Manufacturer Specific data in the advertisment.
+//! Gets the size in bytes of Manufacturer Specific data in the advertisement.
 //! @param ad The advertisement data
 //! @return The size of the data, in bytes. If the Manufacturer Specific data is
 //! not present, zero is returned.

--- a/src/fw/applib/bluetooth/ble_client.h
+++ b/src/fw/applib/bluetooth/ble_client.h
@@ -221,7 +221,7 @@ BTErrno ble_client_write_without_response(BLECharacteristic characteristic,
 //! @note Under the hood, this API writes to the Client Characteristic
 //! Configuration Descriptor's Notifications or Indications enabled/disabled
 //! bit.
-//! @return BTErrnoOK if the subscription request was sent sucessfully, or
+//! @return BTErrnoOK if the subscription request was sent successfully, or
 //! TODO...
 BTErrno ble_client_subscribe(BLECharacteristic characteristic,
                              BLESubscription subscription_type);

--- a/src/fw/applib/bluetooth/ble_ibeacon.h
+++ b/src/fw/applib/bluetooth/ble_ibeacon.h
@@ -32,7 +32,7 @@ typedef struct {
 
   //! The calibrated power of the iBeacon. This is the RSSI measured at 1 meter
   //! distance from the iBeacon. The iBeacon transmits this information in its
-  //! advertisment. Using this and the actual RSSI, the distance is estimated.
+  //! advertisement. Using this and the actual RSSI, the distance is estimated.
   int8_t calibrated_tx_power;
 } BLEiBeacon;
 
@@ -77,7 +77,7 @@ void ble_ibeacon_destroy(BLEiBeacon *ibeacon);
 //! @param rssi The RSSI of the advertisement
 //! @param[out] ibeacon_out Will contain the parsed iBeacon data if the call
 //! returns true.
-//! @return true if the data element was succesfully parsed as iBeacon,
+//! @return true if the data element was successfully parsed as iBeacon,
 //! false if the data element could not be parsed as iBeacon.
 bool ble_ibeacon_parse(const BLEAdData *ad, int8_t rssi,
                        BLEiBeacon *ibeacon_out);

--- a/src/fw/applib/bluetooth/ble_scan.h
+++ b/src/fw/applib/bluetooth/ble_scan.h
@@ -5,9 +5,9 @@
 
 #include <bluetooth/bluetooth_types.h>
 
-//! Callback that is called for each advertisment that is found while scanning
+//! Callback that is called for each advertisement that is found while scanning
 //! using ble_scan_start().
-//! @param device The device from which the advertisment originated.
+//! @param device The device from which the advertisement originated.
 //! @param rssi The RSSI (Received Signal Strength Indication) of the
 //! advertisement.
 //! @param advertisement_data The payload of the advertisement. When there was
@@ -25,7 +25,7 @@ typedef void (*BLEScanHandler)(BTDevice device,
 
 //! Start scanning for advertisements. Pebble will scan actively, meaning it
 //! will perform scan requests whenever the advertisement is scannable.
-//! @param handler The callback to handle the found advertisments. It must not
+//! @param handler The callback to handle the found advertisements. It must not
 //! be NULL.
 //! @return BTErrnoOK if scanning started successfully, BTErrnoInvalidParameter
 //! if the handler was invalid or BTErrnoInvalidState if scanning had already

--- a/src/fw/applib/bluetooth/ble_service.h
+++ b/src/fw/applib/bluetooth/ble_service.h
@@ -26,7 +26,7 @@ uint8_t ble_service_get_characteristics(BLEService service,
 //! @return The 128-bit Service UUID, or UUID_INVALID if the service reference
 //! was invalid.
 //! @note The returned UUID is always a 128-bit UUID, even if the device
-//! its interal GATT service database uses 16-bit or 32-bit Service UUIDs.
+//! its internal GATT service database uses 16-bit or 32-bit Service UUIDs.
 //! @see bt_uuid_expand_16bit for a macro that converts 16-bit UUIDs to 128-bit
 //! equivalents.
 //! @see bt_uuid_expand_32bit for a macro that converts 32-bit UUIDs to 128-bit

--- a/src/fw/applib/data_logging.h
+++ b/src/fw/applib/data_logging.h
@@ -112,10 +112,10 @@ void data_logging_finish(DataLoggingSessionRef logging_session);
 //! DATA_LOGGING_NOT_FOUND if the logging session is invalid
 //!
 //! @return
-//! DATA_LOGGING_CLOSED if the sesion is not active
+//! DATA_LOGGING_CLOSED if the session is not active
 //!
 //! @return
-//! DATA_LOGGING_BUSY if the sesion is not available for writing
+//! DATA_LOGGING_BUSY if the session is not available for writing
 //!
 //! @return
 //! DATA_LOGGING_INVALID_PARAMS if num_items is 0 or data is NULL

--- a/src/fw/applib/graphics/framebuffer.c
+++ b/src/fw/applib/graphics/framebuffer.c
@@ -2,8 +2,8 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 //! @file framebuffer.c
-//! Bitdepth independant routines for framebuffer.h
-//! Bitdepth depenedant routines can be found in the 1_bit & 8_bit folders in their
+//! Bitdepth independent routines for framebuffer.h
+//! Bitdepth dependant routines can be found in the 1_bit & 8_bit folders in their
 //! respective framebuffer.c files.
 
 #include "applib/graphics/framebuffer.h"

--- a/src/fw/applib/graphics/gbitmap.c
+++ b/src/fw/applib/graphics/gbitmap.c
@@ -132,7 +132,7 @@ void gbitmap_init_with_data(GBitmap *bitmap, const uint8_t *data) {
   bitmap->info.is_bitmap_heap_allocated = false;
 
   // Note that our container contains values for the origin, but we want to ignore them.
-  // This is because orginally we just serialized GBitmap to disk,
+  // This is because originally we just serialized GBitmap to disk,
   // but these fields don't really make sense for static images.
   // These origin fields are only used when reusing a byte buffer in a sub bitmap.
   // This allows us to have a shallow copy of a portion of a parent bitmap.

--- a/src/fw/applib/graphics/gbitmap_pbi.h
+++ b/src/fw/applib/graphics/gbitmap_pbi.h
@@ -30,7 +30,7 @@
 //!   (width by height) and the first bit of image data is the pixel at (0, 0),
 //!   then the bounds.size would be `GSize(29, 5)` and bounds.origin would be `GPoint(0, 0)`.
 //!   ![](gbitmap.png)
-//!   In the illustration each pixel is a representated as a square. The white
+//!   In the illustration each pixel is a represented as a square. The white
 //!   squares are the bits that are used, the gray squares are the padding bits, because
 //!   each row of image data has to be a multiple of 4 bytes (32 bits).
 //!   The numbers in the column in the left are the offsets (in bytes) from the `*addr`
@@ -41,7 +41,7 @@
 //!   ![](pixel_bit_values.png)
 //!
 //! - \ref GBitmapFormat8Bit "GBitmapFormat8Bit":
-//!   Each pixel in the bitmap is represented by 1 byte. The color value of that byte correspends to
+//!   Each pixel in the bitmap is represented by 1 byte. The color value of that byte corresponds to
 //!   a GColor.argb value.
 //!   There is no restriction on row_size_bytes / stride.
 //!

--- a/src/fw/applib/graphics/gbitmap_sequence.c
+++ b/src/fw/applib/graphics/gbitmap_sequence.c
@@ -274,7 +274,7 @@ bool gbitmap_sequence_update_bitmap_next_frame(GBitmapSequence *bitmap_sequence,
   const bool bitmap_supports_transparency = (bitmap_format != GBitmapFormat1Bit);
 
   // DISPOSE_OP_BACKGROUND sets the background to black with transparency (0x00)
-  // If we don't support tranparency, just do nothing.
+  // If we don't support transparency, just do nothing.
   if (bitmap_supports_transparency &&
       (png_decoder_data->last_dispose_op == APNG_DISPOSE_OP_BACKGROUND)) {
     const uint32_t y_origin = bitmap->bounds.origin.y + png_decoder_data->previous_yoffset;

--- a/src/fw/applib/graphics/gcolor_definitions.c
+++ b/src/fw/applib/graphics/gcolor_definitions.c
@@ -3,7 +3,7 @@
 
 #include "gtypes.h"
 
-//! This is used for performaing backward-compatibility conversions with 1-bit GColors.
+//! This is used for performing backward-compatibility conversions with 1-bit GColors.
 GColor8 get_native_color(GColor2 color) {
   switch (color) {
     case GColor2Black:

--- a/src/fw/applib/graphics/gcontext.h
+++ b/src/fw/applib/graphics/gcontext.h
@@ -218,8 +218,8 @@ void graphics_context_mask_destroy(GContext *ctx, GDrawMask *mask);
 GSize graphics_context_get_framebuffer_size(GContext *ctx);
 
 //! @internal
-//! Retreives the destination bitmap for the graphics context.
-//! @param ctx The graphics context to retreive the bitmap for.
+//! Retrieves the destination bitmap for the graphics context.
+//! @param ctx The graphics context to retrieve the bitmap for.
 GBitmap* graphics_context_get_bitmap(GContext* ctx);
 
 //! @internal

--- a/src/fw/applib/graphics/gdraw_command_image.h
+++ b/src/fw/applib/graphics/gdraw_command_image.h
@@ -60,7 +60,7 @@ bool gdraw_command_image_validate(GDrawCommandImage *image, size_t size);
 //! @param offset Offset from draw context origin to draw the image
 void gdraw_command_image_draw(GContext *ctx, GDrawCommandImage *image, GPoint offset);
 
-//! Draw an image after being processed by the passed in proccessor
+//! Draw an image after being processed by the passed in processor
 //! @param ctx The destination graphics context in which to draw
 //! @param image Image to draw
 //! @param offset Offset from draw context origin to draw the image

--- a/src/fw/applib/graphics/gdraw_command_list.h
+++ b/src/fw/applib/graphics/gdraw_command_list.h
@@ -109,7 +109,7 @@ size_t gdraw_command_list_get_data_size(GDrawCommandList *command_list);
 //! The order is guaranteed to be the definition order of the points
 //! @param command_list \ref GDrawCommandList from which to collect points
 //! @param is_precise true to convert to GPointPrecise, otherwise points are converted to GPoint
-//! @param num_points_out Optinal pointer to uint16_t to receive the num points
+//! @param num_points_out Optional pointer to uint16_t to receive the num points
 GPoint *gdraw_command_list_collect_points(GDrawCommandList *command_list, bool is_precise,
     uint16_t *num_points_out);
 

--- a/src/fw/applib/graphics/gpath.c
+++ b/src/fw/applib/graphics/gpath.c
@@ -33,7 +33,7 @@ void gpath_init(GPath *path, const GPathInfo *init) {
 
 GPath* gpath_create(const GPathInfo *init) {
   // Can't pad this out because the definition itself is exported. Even if we did pad it out so
-  // we can theoretically add members to the end of the struct, we'll still have to add compatibilty
+  // we can theoretically add members to the end of the struct, we'll still have to add compatibility
   // flags throughout here to check which size of struct the app is going to pass us through these
   // APIs.
   GPath* path = applib_malloc(sizeof(GPath));

--- a/src/fw/applib/graphics/gpath_builder.h
+++ b/src/fw/applib/graphics/gpath_builder.h
@@ -57,7 +57,7 @@ typedef struct {
 //! of points given
 //!
 //! @param max_points Size of the points buffer
-//! @return A pointer to GPathBuilder. NULL if object couldnt be created
+//! @return A pointer to GPathBuilder. NULL if object couldn't be created
 GPathBuilder *gpath_builder_create(uint32_t max_points);
 
 //! Destroys GPathBuilder previously created with gpath_builder_create()

--- a/src/fw/applib/graphics/graphics.c
+++ b/src/fw/applib/graphics/graphics.c
@@ -217,7 +217,7 @@ void graphics_fill_round_rect(GContext* ctx, const GRect *rect, uint16_t radius,
 
 #if PBL_COLOR
   if (ctx->draw_state.antialiased) {
-    // Antialiased (not suppported on 1-bit color)
+    // Antialiased (not supported on 1-bit color)
     prv_fill_rect_aa(ctx, rect, radius, corner_mask, ctx->draw_state.fill_color);
     return;
   }
@@ -415,7 +415,7 @@ void graphics_draw_round_rect(GContext* ctx, const GRect *rect, uint16_t radius)
         prv_draw_round_rect_aa_stroked(ctx, rect, radius, ctx->draw_state.stroke_width);
         return;
       } else {
-        // Antialiased and Stroke Width == 1 (not suppported on 1-bit color)
+        // Antialiased and Stroke Width == 1 (not supported on 1-bit color)
         // Note: stroke width == 2 is rounded down to stroke width of 1
         prv_draw_round_rect_aa(ctx, rect, radius);
         return;

--- a/src/fw/applib/graphics/graphics_bitmap.c
+++ b/src/fw/applib/graphics/graphics_bitmap.c
@@ -119,7 +119,7 @@ T_STATIC GColor get_bitmap_color(GBitmap *bmp, int x, int y) {
                      (format == GBitmapFormat2BitPalette) ||
                      (format == GBitmapFormat4BitPalette));
   if (palletized) {
-    // Look up color in pallete if palletized
+    // Look up color in palette if palletized
     const GColor *palette = bmp->palette;
     src_color = palette[cindex];
   }
@@ -175,7 +175,7 @@ void graphics_draw_rotated_bitmap(GContext* ctx, GBitmap *src, GPoint src_ic, in
       background = GColorWhite;
       break;
     default:
-      PBL_ASSERT(0, "unknown coposting mode %d", compositing_mode);
+      PBL_ASSERT(0, "unknown compositing mode %d", compositing_mode);
       return;
   }
 #endif
@@ -201,7 +201,7 @@ void graphics_draw_rotated_bitmap(GContext* ctx, GBitmap *src, GPoint src_ic, in
     const int32_t width = 2 * (max_width + 1);   // Add one more pixel in case on the edge
     const int32_t height = 2 * (max_height + 1); // Add one more pixel in case on the edge
 
-    // add two pixels just in case of rounding isssues
+    // add two pixels just in case of rounding issues
     const int32_t max_distance = integer_sqrt((width * width) + (height * height)) + 2;
     const int32_t min_x = src_ic.x - max_distance;
     const int32_t min_y = src_ic.y - max_distance;
@@ -301,7 +301,7 @@ void graphics_draw_rotated_bitmap(GContext* ctx, GBitmap *src, GPoint src_ic, in
             break;
           }
         }
-        /* FALLTHRU */
+        /* FALLTHROUGH */
         case GCompOpAssign:
         default:
           // Do assign by default

--- a/src/fw/applib/graphics/graphics_circle.c
+++ b/src/fw/applib/graphics/graphics_circle.c
@@ -69,7 +69,7 @@ static GPointPrecise prv_get_rotated_precise_point_for_ellipsis(GPointPrecise ce
     }
   }
 
-  // This algorthm operates on angle starting at our 90° mark, so we add 90°
+  // This algorithm operates on angle starting at our 90° mark, so we add 90°
   // and flip x/y coordinates (see last line of this function)
   angle = (angle + (TRIG_MAX_ANGLE / 4)) % TRIG_MAX_ANGLE;
 
@@ -169,7 +169,7 @@ static void prv_plot4(GBitmap *fb, GRect *clip_box, GPoint center, GPoint offset
    *        |
    *
    *    +  center point
-   *    -  x coordiante mirror line
+   *    -  x coordinate mirror line
    *    |  y coordinate mirror line
    *    x  given offset point
    *    xn mirrored points
@@ -199,7 +199,7 @@ static void prv_plot8(GBitmap *fb, GRect *clip_box, GPoint center, GPoint offset
    *   /  x5| x4 \
    *
    *    +  center point
-   *    -  x coordiante mirror line
+   *    -  x coordinate mirror line
    *    |  y coordinate mirror line
    *    /  45 degree mirror line
    *    \  135 degree mirror line
@@ -217,7 +217,7 @@ T_STATIC void graphics_circle_quadrant_draw_1px_aa(GContext* ctx, GPoint p, uint
                                                    GCornerMask quadrant) {
   /* This will draw antialiased circle with width of 1px, can be drawn in quadrants
    * Based on wu-xiang line drawing, will draw circle in two steps
-   * 1. Calculate point on the edge of eighth of the cricle and plot it around by mirroring
+   * 1. Calculate point on the edge of eighth of the circle and plot it around by mirroring
    *    - if point is matching pixel perfectly thats going to be on fully colored pixel
    *    - if theres fraction, two pixels will be colored accordingly
    * 2. Fill special case pixels (pixels that are between mirrored eighths)
@@ -225,7 +225,7 @@ T_STATIC void graphics_circle_quadrant_draw_1px_aa(GContext* ctx, GPoint p, uint
    *    - three pixels calculated for circle with radius > 6
    *    - two pixels calculated for circle with radius < 6
    *
-   * Theres also special case for the radius of 3, where algorithm couldnt stop at right
+   * Theres also special case for the radius of 3, where algorithm couldn't stop at right
    *   point and wasn't drawing two pixels on each quadrant
    *
    * Here's quadrant example:
@@ -245,7 +245,7 @@ T_STATIC void graphics_circle_quadrant_draw_1px_aa(GContext* ctx, GPoint p, uint
    *   x               -
    *
    *      |  original calculated pixels for plotting
-   *      -  mirrored eight of the circle (will mirror more of them if neccessary)
+   *      -  mirrored eight of the circle (will mirror more of them if necessary)
    *      o  special case pixels
    *      x  center of the circle
    */
@@ -292,7 +292,7 @@ T_STATIC void graphics_circle_quadrant_draw_1px_aa(GContext* ctx, GPoint p, uint
   // Note: magic numbers explained in main comment for this function
   int special_case_pixels = 3;
 
-  // Acommpanied by magic number 7 (not 6, we increased radius at beginning of this function)
+  // Accompanied by magic number 7 (not 6, we increased radius at beginning of this function)
   if (radius < 7) {
     // And sometimes magic number 2
     special_case_pixels = 2;
@@ -370,7 +370,7 @@ inline void prv_hline_quadrant(GCornerMask quadrant, GCornerMask desired, GConte
 
 static void prv_stroke_circle_quadrant_full(GContext* ctx, GPoint p, uint16_t radius,
                                             uint8_t stroke_width, GCornerMask quadrant) {
-  // This algorithm will draw stroked circle with vairable width (only odd numbers for now)
+  // This algorithm will draw stroked circle with variable width (only odd numbers for now)
   const uint8_t half_stroke_width = stroke_width / 2;
   const int16_t inner_radius = radius - half_stroke_width;
   const uint8_t outer_radius = radius + half_stroke_width;
@@ -425,7 +425,7 @@ static void prv_stroke_circle_quadrant_full_override_aa(GContext* ctx, GPoint p,
 }
 
 #if PBL_COLOR
-//! Draws anit-aliased stroked quadrant of a circle
+//! Draws antialiased stroked quadrant of a circle
 //! @internal
 T_STATIC void graphics_circle_quadrant_draw_stroked_aa(GContext* ctx, GPoint p, uint16_t radius,
                                                        uint8_t stroke_width, GCornerMask quadrant) {
@@ -450,7 +450,7 @@ void graphics_circle_quadrant_draw(GContext* ctx, GPoint p, uint16_t radius, GCo
       graphics_circle_quadrant_draw_stroked_aa(ctx, p, radius, stroke_width, quadrant);
       return;
     } else {
-      // Antialiased and Stroke Width == 1 (not suppported on 1-bit color)
+      // Antialiased and Stroke Width == 1 (not supported on 1-bit color)
       graphics_circle_quadrant_draw_1px_aa(ctx, p, radius, quadrant);
       return;
     }
@@ -507,7 +507,7 @@ void graphics_draw_circle(GContext* ctx, GPoint p, uint16_t radius) {
   }
 
   if (radius == 0) {
-    // Special case radius 0 to fill a circle with radius eqaul to half the stroke width
+    // Special case radius 0 to fill a circle with radius equal to half the stroke width
     // Backup the fill color and set that to the current stroke color since the fill color
     // is what is used for fill circle. Restore the fill color afterwards.
     GColor backup_fill_color = ctx->draw_state.fill_color;
@@ -853,7 +853,7 @@ static void prv_fill_oval_precise(GContext *ctx, GPointPrecise center,
                                                  radius_inner_x.raw_value, radius_inner_y.raw_value,
                                                  config.end_quadrant.angle);
 
-  // Swapping top/bottom offset points if neccesary
+  // Swapping top/bottom offset points if necessary
   if (start_top.y.raw_value > start_bottom.y.raw_value) {
     prv_swap_precise_points(&start_top, &start_bottom);
   } else if (start_top.y.raw_value == start_bottom.y.raw_value &&
@@ -870,15 +870,15 @@ static void prv_fill_oval_precise(GContext *ctx, GPointPrecise center,
     prv_swap_precise_points(&end_top, &end_bottom);
   }
 
-  // Range for scanline, since scanlines are mirred from the middle of the circle this is also
+  // Range for scanline, since scanlines are mirrored from the middle of the circle this is also
   //   indicated from the middle, therefore initialised with 0 (as middle) and
-  //   radius_y (as scalines are on y axis)
+  //   radius_y (as scanlines are on y axis)
   int draw_min = 0;
   int draw_max = radius_outer_y.integer;
 
   // Adjust to drawing_box offset
   int adjusted_center = center.y.integer + ctx->draw_state.drawing_box.origin.y;
-  // We add one to compenaste in case of odd line needs to be drawn
+  // We add one to compensate in case of odd line needs to be drawn
   int adjusted_top = adjusted_center - radius_outer_y.integer - 1;
   int adjusted_bottom = adjusted_center + radius_outer_y.integer + 1;
 
@@ -1198,7 +1198,7 @@ MOCKABLE void graphics_draw_arc_precise_internal(GContext *ctx, GPointPrecise ce
   center.x.raw_value -= center.x.raw_value % (FIXED_S16_3_ONE.raw_value / 2);
   center.y.raw_value -= center.y.raw_value % (FIXED_S16_3_ONE.raw_value / 2);
 
-  // To maintain compability we have to adjust from integral points where given point means
+  // To maintain compatibility we have to adjust from integral points where given point means
   //    center of the point
   center.x.raw_value += 4;
   center.y.raw_value += 4;
@@ -1256,7 +1256,7 @@ void graphics_draw_arc_internal(GContext *ctx, GPoint center, uint16_t radius, i
   // We're just casting this to precise points
   GPointPrecise fixed_center;
 
-  // GPointPreciseFromGPoint doesnt work for unit tests (!!!)
+  // GPointPreciseFromGPoint doesn't work for unit tests (!!!)
   fixed_center.x.integer = center.x;
   fixed_center.y.integer = center.y;
   fixed_center.x.fraction = 0;

--- a/src/fw/applib/graphics/graphics_line.c
+++ b/src/fw/applib/graphics/graphics_line.c
@@ -369,13 +369,13 @@ void prv_draw_stroked_line_precise(GContext* ctx, GPointPrecise p0, GPointPrecis
 
     ctx->draw_state.fill_color = ctx->draw_state.stroke_color;
 
-    // If so, draw a circle with corrseponding radius
+    // If so, draw a circle with corresponding radius
     graphics_fill_circle(ctx, GPoint(p0.x.integer, p0.y.integer), radius.integer);
 
     // Finish color hack
     ctx->draw_state.fill_color = temp_color;
 
-    // Return without drawing the line since its not neccessary
+    // Return without drawing the line since its not necessary
     return;
   }
 
@@ -391,7 +391,7 @@ void prv_draw_stroked_line_precise(GContext* ctx, GPointPrecise p0, GPointPrecis
   // To compensate for rounding errors we need to add half of the precision in specific places
   //   - we add on top if line is leaning backward
   //   - we add on bottom if line is leaning forward
-  //   - for lines with perfect horizontal or vertical lines this fix doesnt matter
+  //   - for lines with perfect horizontal or vertical lines this fix doesn't matter
   //       same applies to same starting/ending points
   bool delta_x_is_positive = ((p1.x.raw_value - p0.x.raw_value) >= 0);
   bool delta_y_is_positive = ((p1.y.raw_value - p0.y.raw_value) >= 0);
@@ -417,7 +417,7 @@ void prv_draw_stroked_line_precise(GContext* ctx, GPointPrecise p0, GPointPrecis
 
     // Drawing loop: Iterates over horizontal lines
     // As part of optimisation, this algorithm is moving between drawing boundaries,
-    // so drawing box has to be substracted from its clipping extremes
+    // so drawing box has to be subtracted from its clipping extremes
     const int16_t clip_min_y = ctx->draw_state.clip_box.origin.y
                                - ctx->draw_state.drawing_box.origin.y;
     const int16_t clip_max_y = clip_min_y + ctx->draw_state.clip_box.size.h;
@@ -475,7 +475,7 @@ void prv_draw_stroked_line_precise(GContext* ctx, GPointPrecise p0, GPointPrecis
       Fixed_S16_3 left_margin = {.raw_value = INT16_MAX};
       Fixed_S16_3 right_margin = {.raw_value = INT16_MIN};
 
-      // Find edges of the line's straigth part
+      // Find edges of the line's straight part
       if (y >= far_top.y.integer && y <= far_bottom.y.integer) {
         // TODO: possible performance optimization: PBL-14744
         // TODO: ^^ also possible avoid of following logic to avoid division by zero
@@ -543,7 +543,7 @@ void prv_draw_stroked_line_precise(GContext* ctx, GPointPrecise p0, GPointPrecis
 
     // Drawing loop: Iterates over vertical lines from left to right
     // As part of optimisation, this algorithm is moving between drawing boundaries,
-    // so drawing box has to be substracted from its clipping extremes
+    // so drawing box has to be subtracted from its clipping extremes
     const int16_t clip_min_x = ctx->draw_state.clip_box.origin.x
                                - ctx->draw_state.drawing_box.origin.x;
     const int16_t clip_max_x = clip_min_x + ctx->draw_state.clip_box.size.w;
@@ -603,7 +603,7 @@ void prv_draw_stroked_line_precise(GContext* ctx, GPointPrecise p0, GPointPrecis
       Fixed_S16_3 top_margin = {.raw_value = INT16_MAX};
       Fixed_S16_3 bottom_margin = {.raw_value = INT16_MIN};
 
-      // Find edges of the line's straigth part
+      // Find edges of the line's straight part
       if (x >= far_left.x.integer && x <= far_right.x.integer) {
         // Main part of the stroked line
         if (tm_p1.x.raw_value != tm_p0.x.raw_value) {
@@ -732,7 +732,7 @@ void graphics_draw_line(GContext* ctx, GPoint p0, GPoint p1) {
       graphics_line_draw_stroked_aa(ctx, p0, p1, ctx->draw_state.stroke_width);
       return;
     } else {
-      // Antialiased and Stroke Width == 1 (not suppported on 1-bit color)
+      // Antialiased and Stroke Width == 1 (not supported on 1-bit color)
       graphics_line_draw_1px_aa(ctx, p0, p1);
       return;
     }

--- a/src/fw/applib/graphics/graphics_private.c
+++ b/src/fw/applib/graphics/graphics_private.c
@@ -178,7 +178,7 @@ void graphics_private_draw_horizontal_line_prepared(GContext *ctx, GBitmap *fram
 
 void graphics_private_draw_horizontal_line_integral(GContext *ctx, GBitmap *framebuffer, int16_t y,
                                                     int16_t x1, int16_t x2, GColor color) {
-  // This is a wrapper for prv_draw_horizontal_line_raw for integral coordintaes
+  // This is a wrapper for prv_draw_horizontal_line_raw for integral coordinates
 
   // End of the line is inclusive so we subtract one
   x2--;

--- a/src/fw/applib/graphics/graphics_private_raw.c
+++ b/src/fw/applib/graphics/graphics_private_raw.c
@@ -163,7 +163,7 @@ T_STATIC void prv_assign_vertical_line_raw(GContext *ctx, int16_t x, Fixed_S16_3
 }
 
 // This function draws horizontal line with blending, given values have to be clipped and adjusted
-//   clip_box and draw_box respecively.
+//   clip_box and draw_box respectively.
 T_STATIC void prv_blend_horizontal_line_raw(GContext *ctx, int16_t y, int16_t x1, int16_t x2,
                                             GColor color) {
   PBL_ASSERTN(ctx);
@@ -187,7 +187,7 @@ T_STATIC void prv_blend_horizontal_line_raw(GContext *ctx, int16_t y, int16_t x1
 }
 
 // This function draws vertical line with blending, given values have to be clipped and adjusted
-//   clip_box and draw_box respecively.
+//   clip_box and draw_box respectively.
 T_STATIC void prv_blend_vertical_line_raw(GContext *ctx, int16_t x, int16_t y1, int16_t y2,
                                           GColor color) {
   PBL_ASSERTN(ctx);

--- a/src/fw/applib/graphics/gtransform.c
+++ b/src/fw/applib/graphics/gtransform.c
@@ -101,7 +101,7 @@ bool gtransform_is_equal(const GTransform * const t1, const GTransform * const t
 //////////////////////////////////////
 /// Modifying Transforms
 //////////////////////////////////////
-// Note that t_new can be set to either of t1 or t2 safely to do in place muliplication
+// Note that t_new can be set to either of t1 or t2 safely to do in place multiplication
 // Note this operation is not commutative. The operation is as follows t_new = t1 * t2
 void gtransform_concat(GTransform *t_new, const GTransform *t1, const GTransform * t2) {
   if ((!t_new) || (!t1) || (!t2)) {

--- a/src/fw/applib/graphics/gtransform.h
+++ b/src/fw/applib/graphics/gtransform.h
@@ -157,7 +157,7 @@ bool gtransform_is_equal(const GTransform * const t1, const GTransform * const t
 //////////////////////////////////////
 //! Concatenates two transformation matrices and returns the resulting matrix in t1
 //! The operation performed is t_new = t1*t2. This order is not commutative so be careful
-//! when contactenating the matrices.
+//! when concatenating the matrices.
 //! Note t_new can safely be be the same pointer as t1 or t2.
 //! @param t_new Pointer to destination transformation matrix
 //! @param t1 Pointer to transformation matrix to concatenate with t2 where t_new = t1*t2

--- a/src/fw/applib/graphics/gtypes.h
+++ b/src/fw/applib/graphics/gtypes.h
@@ -655,7 +655,7 @@ typedef struct {
 #define GEdgeInsets(...) \
   GEdgeInsetsN(__VA_ARGS__, GEdgeInsets4, GEdgeInsets3, GEdgeInsets2, GEdgeInsets1)(__VA_ARGS__)
 
-//! Returns a rectangle that is shrinked or expanded by the given edge insets.
+//! Returns a rectangle that is shrunk or expanded by the given edge insets.
 //! @note The rectangle is standardized and then the inset parameters are applied.
 //! If the resulting rectangle would have a negative height or width, a GRectZero is returned.
 //! @param rect The rectangle that will be inset
@@ -1047,7 +1047,7 @@ GBitmap *gbitmap_create_with_resource_system(ResAppNum app_num, uint32_t resourc
 //! @internal
 //! @see gbitmap_init_with_resource
 //! @param app_num The app's resource bank number
-//! @return true if we were sucessful, false otherwise
+//! @return true if we were successful, false otherwise
 bool gbitmap_init_with_resource_system(GBitmap* bitmap, ResAppNum app_num, uint32_t resource_id);
 
 //! @internal
@@ -1328,7 +1328,7 @@ typedef struct PACKED {
 typedef Fixed_S32_16 GTransformNumber;
 
 //! @internal
-//! Data structure that contains the internal representation of a 3x3 tranformation matrix
+//! Data structure that contains the internal representation of a 3x3 transformation matrix
 //! The transformation matrix will be expressed as follows:
 //! [ a  b  0 ]
 //! [ c  d  0 ]

--- a/src/fw/applib/graphics/text.h
+++ b/src/fw/applib/graphics/text.h
@@ -33,14 +33,14 @@ typedef enum {
   GTextOverflowModeWordWrap,
   //! On overflow, wrap words to a new line below the current one.
   //! Once vertical space is consumed, truncate as needed to fit a trailing ellipsis (...).
-  //! Clipping may occur if the vertical space cannot accomodate the first line of text.
+  //! Clipping may occur if the vertical space cannot accommodate the first line of text.
   GTextOverflowModeTrailingEllipsis,
   //! Acts like \ref GTextOverflowModeTrailingEllipsis, plus trims leading and trailing newlines,
   //! while treating all other newlines as spaces.
   GTextOverflowModeFill
 } GTextOverflowMode;
 
-//! Text aligment controls the way the text is aligned inside the box the text is drawn into.
+//! Text alignment controls the way the text is aligned inside the box the text is drawn into.
 //! @see graphics_draw_text
 //! @see text_layer_set_text_alignment
 typedef enum {
@@ -125,7 +125,7 @@ void graphics_text_init(void);
 
 //! Draw text into the current graphics context, using the context's current text color.
 //! The text will be drawn inside a box with the specified dimensions and
-//! configuration, with clipping occuring automatically.
+//! configuration, with clipping occurring automatically.
 //! @param ctx The destination graphics context in which to draw
 //! @param text The zero terminated UTF-8 string to draw
 //! @param font The font in which the text should be set

--- a/src/fw/applib/graphics/text_layout.c
+++ b/src/fw/applib/graphics/text_layout.c
@@ -401,13 +401,13 @@ static bool prv_line_iter_is_vertical_overflow(const LineIterState* const line_i
   // if we're not rendering the first line.
   //    - This, because the user does not expect to see more text drawn below, after the '...'.
   //    - The first-line exception means that text, and therefore the telltale
-  //      ellipsis, will always be visisble.
+  //      ellipsis, will always be visible.
   if ((text_box_params->overflow_mode == GTextOverflowModeTrailingEllipsis ||
        text_box_params->overflow_mode == GTextOverflowModeFill) &&
       line_iter_state->current->origin.y != text_box_params->box.origin.y) {
     // We're in a truncation mode AND not on the first line.
     // So, include the full height of the current line in next_line_y_extent, so text will stop
-    // being layed out immediately after it exceeds the height of the container.
+    // being laid out immediately after it exceeds the height of the container.
     next_line_y_extent = line_iter_state->current->origin.y + prv_get_line_height(text_box_params);
   } else {
     // We're either in a non-truncating mode, or on the first line of a truncating mode.
@@ -1312,11 +1312,11 @@ static inline void prv_walk_lines_down(Iterator* const line_iter, TextLayout* co
     const Word word_before_rendering = *current_word_ref;
     const OrphanLineState orphan_state = prv_capture_orphan_state(line);
 
-    // When repeating text to prevent orhpans we could run into the situation where repeating text
+    // When repeating text to prevent orphans we could run into the situation where repeating text
     // pushes down the remaining text far enough so it ends up on yet another page. This would
     // enter an infinite loop.
     // To avoid that, we only apply this strategy, when it's "safe" to do so (in theory, there's
-    // still the propability to run into this scenario if the perimeter isn't vertically symmetric).
+    // still the probability to run into this scenario if the perimeter isn't vertically symmetric).
     // The chosen number should be large enough for the previous line, the orphan line plus some
     // buffer.
     const int num_safe_lines = 3;
@@ -1344,7 +1344,7 @@ render_line: {} // this {} is just an empty statement that both C and our linter
         if (is_orphan) {
           *current_word_ref = prev_line_word;
           prv_apply_orphan_state(&orphan_state, line);
-          avoiding_orphans = false; // prevent infinte loops
+          avoiding_orphans = false; // prevent infinite loops
           goto render_line;
         }
       }

--- a/src/fw/applib/graphics/text_layout_private.h
+++ b/src/fw/applib/graphics/text_layout_private.h
@@ -45,7 +45,7 @@ typedef struct {
 //!   - Word end points to codepoint after the last printable codepoint in a word,
 //!     excluding whitespace (eg, end of word, exclusive); note this codepoint may
 //!     not be valid since it may be the end of the string
-//!   - The preceeding whitespace of a word is trimmed if the word wraps
+//!   - The preceding whitespace of a word is trimmed if the word wraps
 //!   - Reserved codepoints are skipped
 //!   - Newlines are treated as stand-alone words so as to not mess up the height
 //!     and width word metrics

--- a/src/fw/applib/graphics/text_render.c
+++ b/src/fw/applib/graphics/text_render.c
@@ -123,9 +123,9 @@ void render_glyph(GContext* const ctx, const uint32_t codepoint, FontInfo* const
 
   // The number of bits between the beginning of dest_block and glyph_block.
   // If x is negative we need to be fancy to get the rounded down remainder. This
-  // is the number of bits to the right of the next 32-bit boundry to the left.
+  // is the number of bits to the right of the next 32-bit boundary to the left.
   // For example, if x is -5 we want this shift to be 27, since -32 (the nearest
-  // boundry) + 27 = -5
+  // boundary) + 27 = -5
   const uint8_t dest_shift_at_line_begin = (x >= 0) ?
       x % 32 :
       (x - ((x / 32) * 32));

--- a/src/fw/applib/graphics/text_resources.c
+++ b/src/fw/applib/graphics/text_resources.c
@@ -212,7 +212,7 @@ static GlyphData *prv_decompress_glyph_data(GlyphData *g, uint8_t *src) {
   // *src is a pointer to the beginning of <encoded glyph>
   //
   // Once decompressed, Glyph Data will be formatted like this:
-  //  [ <header> | <decoded glyph> | <free space & remenants of encoded glyph data> ]
+  //  [ <header> | <decoded glyph> | <free space & remnants of encoded glyph data> ]
   //
   // The glyph is decoded in-place, so obviously, it's imperative that <decoded glyph> and
   // <encoded glyph> not overlap at any time. This is checked by fontgen.py and confirmed

--- a/src/fw/applib/graphics/text_resources.h
+++ b/src/fw/applib/graphics/text_resources.h
@@ -84,7 +84,7 @@ typedef struct FontCache {
   int offset_table_id;
   uint16_t offset_table_size;
   //! The currently loaded font's offset table.
-  //! @note this needs to be able to accomodate legacy fonts
+  //! @note this needs to be able to accommodate legacy fonts
   union {
     OffsetTableEntry_2_2 offsets_buffer_2_2[OFFSET_TABLE_MAX_SIZE / sizeof(OffsetTableEntry_2_2)];
     OffsetTableEntry_2_4 offsets_buffer_2_4[OFFSET_TABLE_MAX_SIZE / sizeof(OffsetTableEntry_2_4)];

--- a/src/fw/applib/health_service.c
+++ b/src/fw/applib/health_service.c
@@ -174,7 +174,7 @@ static bool prv_metric_aggregation_implemented(HealthMetric metric, time_t time_
             return true;
           }
         }
-        /* FALLTHRU */
+        /* FALLTHROUGH */
         case HealthAggregationMax:
         case HealthAggregationMin: {
           // Only supported using minute data (short time range, no scope) because

--- a/src/fw/applib/health_service.h
+++ b/src/fw/applib/health_service.h
@@ -315,7 +315,7 @@ HealthServiceAccessibilityMask health_service_metric_accessible(
 //! @param time_start Earliest UTC time you are interested in.
 //! @param time_end Latest UTC time you are interested in.
 //! @param scope \ref HealthServiceTimeScope value describing how the average should be computed.
-//! @return A \ref HealthServiceAccessibilityMask value decribing whether averaged data is available.
+//! @return A \ref HealthServiceAccessibilityMask value describing whether averaged data is available.
 HealthServiceAccessibilityMask health_service_metric_averaged_accessible(
     HealthMetric metric, time_t time_start, time_t time_end, HealthServiceTimeScope scope);
 
@@ -329,7 +329,7 @@ HealthServiceAccessibilityMask health_service_metric_averaged_accessible(
 //! @param time_end Latest UTC time you are interested in.
 //! @param aggregation The aggregation to perform
 //! @param scope \ref HealthServiceTimeScope value describing how the average should be computed.
-//! @return A \ref HealthServiceAccessibilityMask value decribing whether averaged data is available.
+//! @return A \ref HealthServiceAccessibilityMask value describing whether averaged data is available.
 HealthServiceAccessibilityMask health_service_metric_aggregate_averaged_accessible(
     HealthMetric metric, time_t time_start, time_t time_end, HealthAggregation aggregation,
     HealthServiceTimeScope scope);
@@ -368,7 +368,7 @@ typedef enum {
 
 //! Developer-supplied event handler, called when a health-related event occurs after subscribing
 //! via \ref health_service_events_subscribe();
-//! @param event The type of health-related event that occured.
+//! @param event The type of health-related event that occurred.
 //! @param context The developer-supplied context pointer.
 typedef void (*HealthEventHandler)(HealthEventType event, void *context);
 
@@ -448,7 +448,7 @@ uint16_t health_service_get_heart_rate_sample_period_expiration_sec(void);
 //! \endcode
 //!
 //! In the current implementation, only one alert per metric can be registered at a time. Future
-//! implementations may support two or more simulataneous alert registrations per metric. To change
+//! implementations may support two or more simultaneous alert registrations per metric. To change
 //! the alert threshold in the current implementation, cancel the original registration
 //! using `health_service_cancel_metric_alert` before registering the new threshold.
 //! @param metric Which \ref HealthMetric to query.

--- a/src/fw/applib/legacy2/ui/action_bar_layer_legacy2.h
+++ b/src/fw/applib/legacy2/ui/action_bar_layer_legacy2.h
@@ -123,7 +123,7 @@ typedef struct ActionBarLayerLegacy2 {
 //! @param action_bar The action bar to initialize
 void action_bar_layer_legacy2_init(ActionBarLayerLegacy2 *action_bar);
 
-//! Creates a new ActionBarLayerLegacy2 on the heap and initalizes it with the default values.
+//! Creates a new ActionBarLayerLegacy2 on the heap and initializes it with the default values.
 //! * Background color: \ref GColorBlack
 //! * No click configuration provider (`NULL`)
 //! * No icons
@@ -207,7 +207,7 @@ void action_bar_layer_legacy2_clear_icon(ActionBarLayerLegacy2 *action_bar, Butt
 //! @note It is advised to call this is in the window's `.load` or `.appear`
 //! handler. Make sure to call \ref action_bar_layer_legacy2_remove_from_window() in the
 //! window's `.unload` or `.disappear` handler.
-//! @note Adding additional layers to the window's root layer after this calll
+//! @note Adding additional layers to the window's root layer after this call
 //! can occlude the action bar.
 //! @param action_bar The action bar to associate with the window
 //! @param window The window with which the action bar is to be associated

--- a/src/fw/applib/legacy2/ui/animation_legacy2.h
+++ b/src/fw/applib/legacy2/ui/animation_legacy2.h
@@ -31,7 +31,7 @@ struct AnimationLegacy2Implementation;
 struct AnimationLegacy2Handlers;
 
 
-//! Creates a new AnimationLegacy2 on the heap and initalizes it with the default values.
+//! Creates a new AnimationLegacy2 on the heap and initializes it with the default values.
 //!
 //! * Duration: 250ms,
 //! * Curve: \ref AnimationCurveEaseInOut (ease-in-out),

--- a/src/fw/applib/legacy2/ui/property_animation_legacy2.h
+++ b/src/fw/applib/legacy2/ui/property_animation_legacy2.h
@@ -22,7 +22,7 @@
 //! Actually, property animations do more than just moving a Layer around over time.
 //! PropertyAnimationLegacy2 is a concrete class of animations and is built around the Animation
 //! subsystem, which covers anything timing related, but does not move anything around.
-//! A ProperyAnimation animates a "property" of a "subject".
+//! A PropertyAnimation animates a "property" of a "subject".
 //!
 //! <h3>Animating a Layer's frame property</h3>
 //! Currently there is only one specific type of property animation offered off-the-shelf, namely

--- a/src/fw/applib/legacy2/ui/text_layer_legacy2.h
+++ b/src/fw/applib/legacy2/ui/text_layer_legacy2.h
@@ -58,7 +58,7 @@ typedef struct TextLayerLegacy2 {
 //!
 //! The text layer is automatically marked dirty after this operation.
 //! @param text_layer The TextLayerLegacy2 to initialize
-//! @param frame The frame with which to initialze the TextLayerLegacy2
+//! @param frame The frame with which to initialize the TextLayerLegacy2
 void text_layer_legacy2_init(TextLayerLegacy2 *text_layer, const GRect *frame);
 
 //! Creates a new TextLayerLegacy2 on the heap and initializes it with the default values.
@@ -72,7 +72,7 @@ void text_layer_legacy2_init(TextLayerLegacy2 *text_layer, const GRect *frame);
 //! * Caching: `false`
 //!
 //! The text layer is automatically marked dirty after this operation.
-//! @param frame The frame with which to initialze the TextLayerLegacy2
+//! @param frame The frame with which to initialize the TextLayerLegacy2
 //! @return A pointer to the TextLayerLegacy2. `NULL` if the TextLayerLegacy2 could not
 //! be created
 TextLayerLegacy2* text_layer_legacy2_create(GRect frame);
@@ -148,7 +148,7 @@ void text_layer_legacy2_set_text_alignment(TextLayerLegacy2 *text_layer,
 //! By default, layout caching is off (false). Layout caches store the max used
 //! height and width of a text layer.
 //! NOTE: when using cached layouts, text_layer_legacy2_deinit() MUST be called at some
-//! point in time to prevent memory leaks from occuring.
+//! point in time to prevent memory leaks from occurring.
 void text_layer_legacy2_set_should_cache_layout(TextLayerLegacy2 *text_layer,
                                                 bool should_cache_layout);
 

--- a/src/fw/applib/plugin_service.c
+++ b/src/fw/applib/plugin_service.c
@@ -36,7 +36,7 @@ static uint16_t prv_get_service_index(Uuid *uuid) {
 
 
 // ---------------------------------------------------------------------------------------------------------------
-// Used by list_find to locate the handler for a specfic service index.
+// Used by list_find to locate the handler for a specific service index.
 static bool prv_service_filter(ListNode *node, void *tp) {
   PluginServiceEntry *info = (PluginServiceEntry *)node;
   uint16_t service_idx = (uint16_t)(uintptr_t)tp;

--- a/src/fw/applib/ui/action_bar_layer.h
+++ b/src/fw/applib/ui/action_bar_layer.h
@@ -145,7 +145,7 @@ typedef struct {
 //! @param action_bar The action bar to initialize
 void action_bar_layer_init(ActionBarLayer *action_bar);
 
-//! Creates a new ActionBarLayer on the heap and initalizes it with the default values.
+//! Creates a new ActionBarLayer on the heap and initializes it with the default values.
 //! * Background color: \ref GColorBlack
 //! * No click configuration provider (`NULL`)
 //! * No icons
@@ -255,7 +255,7 @@ void action_bar_layer_clear_icon(ActionBarLayer *action_bar, ButtonId button_id)
 //! @note It is advised to call this is in the window's `.load` or `.appear`
 //! handler. Make sure to call \ref action_bar_layer_remove_from_window() in the
 //! window's `.unload` or `.disappear` handler.
-//! @note Adding additional layers to the window's root layer after this calll
+//! @note Adding additional layers to the window's root layer after this call
 //! can occlude the action bar.
 //! @param action_bar The action bar to associate with the window
 //! @param window The window with which the action bar is to be associated

--- a/src/fw/applib/ui/action_menu_layer.c
+++ b/src/fw/applib/ui/action_menu_layer.c
@@ -602,7 +602,7 @@ static void prv_draw_separator_cb(GContext *ctx, const Layer *cell_layer,
         system_theme_get_default_content_size_for_runtime_platform();
     const ActionMenuSeparatorConfig *config = &s_separator_configs[runtime_platform_default_size];
 
-    // If this index is the seperator index, we want to draw the separator line
+    // If this index is the separator index, we want to draw the separator line
     // in the vertical center of the separator
     const int16_t nudge_down = PBL_IF_RECT_ELSE(3, 0);
 

--- a/src/fw/applib/ui/action_menu_window.h
+++ b/src/fw/applib/ui/action_menu_window.h
@@ -54,7 +54,7 @@ typedef void (*ActionMenuWillCloseCb)(ActionMenu *menu,
 //! Configuration struct for the ActionMenu
 typedef struct {
   const ActionMenuLevel *root_level; //!< the root level of the ActionMenu
-  void *context; //!< a context pointer which will be accessbile when actions are performed
+  void *context; //!< a context pointer which will be accessible when actions are performed
   struct {
     GColor background; //!< the color of the left column of the ActionMenu
     GColor foreground; //!< the color of the individual "crumbs" that indicate menu depth

--- a/src/fw/applib/ui/animation.h
+++ b/src/fw/applib/ui/animation.h
@@ -116,7 +116,7 @@ typedef enum {
 } AnimationCurve;
 
 
-//! Creates a new Animation on the heap and initalizes it with the default values.
+//! Creates a new Animation on the heap and initializes it with the default values.
 //!
 //! * Duration: 250ms,
 //! * Curve: \ref AnimationCurveEaseInOut (ease-in-out),

--- a/src/fw/applib/ui/animation_interpolate.h
+++ b/src/fw/applib/ui/animation_interpolate.h
@@ -35,7 +35,7 @@ int64_t interpolate_int64_linear(int32_t normalized, int64_t from, int64_t to);
 
 //! Interpolation between two int64_t.
 //! In most cases, this is a linear interpolation but the behavior can vary if this function
-//! is called from within an animation's update handdler that uses
+//! is called from within an animation's update handler that uses
 //! AnimationCurveCustomInterpolationFunction. This allows clients to transparently implement
 //! effects such as spatial easing. See \ref animation_set_custom_interpolation().
 int64_t interpolate_int64(int32_t normalized, int64_t from, int64_t to);
@@ -100,7 +100,7 @@ int64_t interpolate_moook_in_only(int32_t normalized, int64_t from, int64_t to);
 //! @param num_frames_from Number of frames in the animation that do not consist of the Moook
 //! ease out curve.
 //! @param bounce_back Whether to lead up to the end point from the opposite direction if we were
-//! to lead up from the start poing, which a normal Moook curve would do.
+//! to lead up from the start point, which a normal Moook curve would do.
 int64_t interpolate_moook_out(int32_t normalized, int64_t from, int64_t to,
                               int32_t num_frames_from, bool bounce_back);
 

--- a/src/fw/applib/ui/bitmap_layer.c
+++ b/src/fw/applib/ui/bitmap_layer.c
@@ -22,7 +22,7 @@ void bitmap_layer_update_proc(BitmapLayer *image, GContext* ctx) {
     if (!process_manager_compiled_with_legacy2_sdk()) {
       // Dirty workaround for calculation of offset in graphics_draw_bitmap_in_rect
       // and preserving state of bitmap alignment in bitmap_layer
-      // The previous behavior is relied on by some 2.x apps, and therefore we exlude
+      // The previous behavior is relied on by some 2.x apps, and therefore we exclude
       // the fix for apps compiled with older SDKs. See PBL-19136 for details.
       rect.origin.x -= image->layer.bounds.origin.x;
       rect.origin.y -= image->layer.bounds.origin.y;

--- a/src/fw/applib/ui/bitmap_layer.h
+++ b/src/fw/applib/ui/bitmap_layer.h
@@ -62,10 +62,10 @@ typedef struct BitmapLayer {
 //!
 //! The bitmap layer is automatically marked dirty after this operation.
 //! @param bitmap_layer The BitmapLayer to initialize
-//! @param frame The frame with which to initialze the BitmapLayer
+//! @param frame The frame with which to initialize the BitmapLayer
 void bitmap_layer_init(BitmapLayer *bitmap_layer, const GRect *frame);
 
-//! Creates a new bitmap layer on the heap and initalizes it the default values.
+//! Creates a new bitmap layer on the heap and initializes it the default values.
 //!
 //! * Bitmap: `NULL` (none)
 //! * Background color: \ref GColorClear
@@ -107,13 +107,13 @@ const GBitmap* bitmap_layer_get_bitmap(BitmapLayer *bitmap_layer);
 void bitmap_layer_set_bitmap(BitmapLayer *bitmap_layer, const GBitmap *bitmap);
 
 //! Sets the alignment of the image to draw with in frame of the BitmapLayer.
-//! The aligment parameter specifies which edges of the bitmap should overlap
+//! The alignment parameter specifies which edges of the bitmap should overlap
 //! with the frame of the BitmapLayer.
 //! If the bitmap is smaller than the frame of the BitmapLayer, the background
 //! is filled with the background color.
 //!
 //! The bitmap layer is automatically marked dirty after this operation.
-//! @param bitmap_layer The BitmapLayer for which to set the aligment
+//! @param bitmap_layer The BitmapLayer for which to set the alignment
 //! @param alignment The new alignment for the image inside the BitmapLayer
 void bitmap_layer_set_alignment(BitmapLayer *bitmap_layer, GAlign alignment);
 

--- a/src/fw/applib/ui/date_selection_window.h
+++ b/src/fw/applib/ui/date_selection_window.h
@@ -51,5 +51,5 @@ void date_selection_window_init(DateSelectionWindowData *window, const char *lab
                                 GColor color, DateSelectionCompleteCallback complete,
                                 void *context);
 
-//! Deinitialise the date selection window.
+//! Deinitialize the date selection window.
 void date_selection_window_deinit(DateSelectionWindowData *window);

--- a/src/fw/applib/ui/dialogs/expandable_dialog.h
+++ b/src/fw/applib/ui/dialogs/expandable_dialog.h
@@ -66,7 +66,7 @@ ExpandableDialog *expandable_dialog_create_with_params(const char *dialog_name, 
 //! Simple callback which closes the dialog when called
 void expandable_dialog_close_cb(ClickRecognizerRef recognizer, void *e_dialog);
 
-//! Intializes an ExpandableDialog
+//! Initializes an ExpandableDialog
 //! @param expandable_dialog Pointer to an \ref ExpandableDialog
 //! @param dialog_name The name to give the \ref ExpandableDialog
 void expandable_dialog_init(ExpandableDialog *expandable_dialog, const char *dialog_name);

--- a/src/fw/applib/ui/dialogs/simple_dialog.c
+++ b/src/fw/applib/ui/dialogs/simple_dialog.c
@@ -169,7 +169,7 @@ static void prv_click_handler(ClickRecognizerRef recognizer, void *context) {
 }
 
 static void prv_config_provider(void *context) {
-  // Simple dialogs are dimissed when any button is pushed.
+  // Simple dialogs are dismissed when any button is pushed.
   window_single_click_subscribe(BUTTON_ID_SELECT, prv_click_handler);
   window_single_click_subscribe(BUTTON_ID_UP, prv_click_handler);
   window_single_click_subscribe(BUTTON_ID_DOWN, prv_click_handler);

--- a/src/fw/applib/ui/menu_layer.c
+++ b/src/fw/applib/ui/menu_layer.c
@@ -712,7 +712,7 @@ static void prv_menu_layer_walk_downward_from_iterator(MenuIterator *it) {
       it->cursor.sep = prv_menu_layer_get_separator_height(it->menu_layer, &it->cursor.index);
       it->cursor.y = it->cell_bottom_y; // Bottom of previous cell is y of the next cell
 
-      // Don't leave space for the seperator for the (non-existent) row after the last row.
+      // Don't leave space for the separator for the (non-existent) row after the last row.
       // This doesn't impact cell drawing in this loop (this condition will only trip on the last run).
       // But, other parts of the system rely on the cursor being set properly at the end of this iteration.
       if (it->cursor.index.row < num_rows_in_section - 1 || it->cursor.index.section < num_sections - 1) {
@@ -790,7 +790,7 @@ static void prv_menu_layer_walk_upward_from_iterator(MenuIterator *it) {
         const int16_t total_height = it->cursor.h + it->cursor.sep;
         if (total_height > it->cursor.y) {
           // If the total height is greater than the cursor y, don't
-          // add in space to accodomate the separator as the downwards callback
+          // add in space to accommodate the separator as the downwards callback
           // will add it for us.
           it->cursor.y -= it->cursor.h;
         } else {
@@ -1401,7 +1401,7 @@ void prv_center_focus_animation_update_in_and_out(Animation *animation,
 
 void prv_center_focus_animation_update_out_only(Animation *animation,
                                                 const AnimationProgress progress) {
-  // anwalys only render the bounce back
+  // always only render the bounce back
   prv_center_focus_animation_update_impl(animation, true, progress);
 }
 
@@ -2015,7 +2015,7 @@ static void prv_menu_touch_settle_to_center(MenuLayer *menu_layer, bool animated
 
 //! While a touch gesture (pan, coast, or the settle that follows) drives a carousel, the
 //! selection highlight is pinned to the viewport centre: rows slide through the fixed box, the
-//! way button steps look, instead of the box travelling with the selected row and jumping at
+//! way button steps look, instead of the box traveling with the selected row and jumping at
 //! every crossing. The pin releases itself lazily: the moment the pinned frame coincides with
 //! the settled selection's own frame (the row reached the centre), the highlight is back in its
 //! normal selection-owned state.
@@ -2287,7 +2287,7 @@ void menu_layer_touch_handle_tap(MenuLayer *menu_layer, GPoint point_on_screen) 
 }
 
 // Emit BACK through the bridge ops, mirroring the Tier-2 bridge: pop the window when it has no back
-// handler, otherwise synthesise the button. Guarded against a mid-transition drop.
+// handler, otherwise synthesize the button. Guarded against a mid-transition drop.
 static void prv_menu_touch_emit_back(void) {
   const TouchNavState *state = prv_task_touch_nav_state();
   if (!state || !state->ops) {
@@ -2394,7 +2394,7 @@ static void prv_menu_touch_nav_register(MenuLayer *menu_layer) {
   }
 
   // Register the menu as a migrated Tier-1 widget: the unified widget set drives it through
-  // s_menu_touch_nav_ops. The registry add dedups by address and re-applies the ops/layer, so a
+  // s_menu_touch_nav_ops. The registry add dedupes by address and re-applies the ops/layer, so a
   // repeated init on the same menu (no intervening deinit) keeps routing to and driving it.
   Layer *layer = menu_layer_get_layer(menu_layer);
   touch_nav_registry_add(state, TouchNavWidgetType_Menu,

--- a/src/fw/applib/ui/menu_layer.h
+++ b/src/fw/applib/ui/menu_layer.h
@@ -200,7 +200,7 @@ typedef void (*MenuLayerDrawSeparatorCallback)(GContext* ctx,
 
 //! Function signature for the callback to handle the event that a user hits
 //! the SELECT button.
-//! @param menu_layer The \ref MenuLayer for which the selection event occured
+//! @param menu_layer The \ref MenuLayer for which the selection event occurred
 //! @param cell_index The MenuIndex of the cell that is selected
 //! @param callback_context The callback context
 //! @see \ref menu_layer_set_callbacks()
@@ -211,7 +211,7 @@ typedef void (*MenuLayerSelectCallback)(struct MenuLayer *menu_layer,
 
 //! Function signature for the callback to handle a change in the current
 //! selected item in the menu.
-//! @param menu_layer The \ref MenuLayer for which the selection event occured
+//! @param menu_layer The \ref MenuLayer for which the selection event occurred
 //! @param new_index The MenuIndex of the new item that is selected now
 //! @param old_index The MenuIndex of the old item that was selected before
 //! @param callback_context The callback context
@@ -225,7 +225,7 @@ typedef void (*MenuLayerSelectionChangedCallback)(struct MenuLayer *menu_layer,
 //! Function signature for the callback which allows or changes selection behavior of the menu.
 //! In order to change the cell that should be selected, modify the passed in new_index.
 //! Preventing the selection from changing, new_index can be assigned the value of old_index.
-//! @param menu_layer The \ref MenuLayer for which the selection event that occured
+//! @param menu_layer The \ref MenuLayer for which the selection event that occurred
 //! @param new_index Pointer to the index that the MenuLayer is going to change selection to.
 //! @param old_index The index that is being unselected.
 //! @param callback_context The callback context
@@ -368,13 +368,13 @@ typedef struct MenuLayer {
     uint8_t button_repeat_scrolling:2;
   } cache;
   //! @internal
-  //! Selected cell index + geometery cache of the selected cell
+  //! Selected cell index + geometry cache of the selected cell
   MenuCellSpan selection;
   MenuLayerCallbacks callbacks;
   void *callback_context;
 
   //! Default colors to be used for \ref MenuLayer.
-  //! Use MenuLayerColorNormal and MenuLayerColorHightlight for indexing.
+  //! Use MenuLayerColorNormal and MenuLayerColorHighlight for indexing.
   GColor normal_colors[MenuLayerColor_Count];
   GColor highlight_colors[MenuLayerColor_Count];
 
@@ -532,10 +532,10 @@ typedef struct MenuLayer {
 //!   will be selected initially.
 //! The layer is marked dirty automatically.
 //! @param menu_layer The \ref MenuLayer to initialize
-//! @param frame The frame with which to initialze the \ref MenuLayer
+//! @param frame The frame with which to initialize the \ref MenuLayer
 void menu_layer_init(MenuLayer *menu_layer, const GRect *frame);
 
-//! Creates a new \ref MenuLayer on the heap and initalizes it with the default values.
+//! Creates a new \ref MenuLayer on the heap and initializes it with the default values.
 //!
 //! * Clips: `true`
 //! * Hidden: `false`
@@ -657,7 +657,7 @@ void menu_layer_set_selected_next(MenuLayer *menu_layer,
 //! @param scroll_align The alignment of the new selection
 //! @param animated Supply `true` to animate changing the selection, or `false`
 //! to change the selection instantly.
-//! @note If the section and/or row index exceeds the avaible number of sections
+//! @note If the section and/or row index exceeds the available number of sections
 //! or resp. rows, the exceeding index/indices will be capped, effectively
 //! selecting the last section and/or row, resp.
 void menu_layer_set_selected_index(MenuLayer *menu_layer,

--- a/src/fw/applib/ui/number_window.c
+++ b/src/fw/applib/ui/number_window.c
@@ -88,7 +88,7 @@ void prv_update_proc(Layer *layer, GContext* ctx) {
   graphics_context_set_fill_color(ctx, GColorWhite);
   graphics_fill_rect(ctx, &layer->bounds);
 
-  // This is safe becase Layer is the first member in Window and Window is the first member in
+  // This is safe because Layer is the first member in Window and Window is the first member in
   // NumberWindow.
   _Static_assert(offsetof(Window, layer) == 0, "");
   _Static_assert(offsetof(NumberWindow, window) == 0, "");

--- a/src/fw/applib/ui/number_window.h
+++ b/src/fw/applib/ui/number_window.h
@@ -76,7 +76,7 @@ typedef struct NumberWindow {
 //! See code fragment here: NumberWindow
 void number_window_init(NumberWindow *numberwindow, const char *label, NumberWindowCallbacks callbacks, void *callback_context);
 
-//! Creates a new NumberWindow on the heap and initalizes it with the default values.
+//! Creates a new NumberWindow on the heap and initializes it with the default values.
 //!
 //! @param label The title or prompt to display in the NumberWindow. Must be long-lived and cannot be stack-allocated.
 //! @param callbacks The callbacks

--- a/src/fw/applib/ui/progress_window.h
+++ b/src/fw/applib/ui/progress_window.h
@@ -94,7 +94,7 @@ void progress_window_set_max_fake_progress(ProgressWindow *window,
 
 //! Update the progress to a given percentage. This will stop any further fake progress being shown
 //! the first time this is called. Note that setting progress to 100 is not the same as calling
-//! one of the progress_windw_set_result_* methods.
+//! one of the progress_window_set_result_* methods.
 void progress_window_set_progress(ProgressWindow *window, int16_t progress);
 
 //! Tell the ProgressWindow it should animate in a way to show success. When the animation is

--- a/src/fw/applib/ui/property_animation.h
+++ b/src/fw/applib/ui/property_animation.h
@@ -16,7 +16,7 @@
 //!   @addtogroup Animation
 //!   @{
 //!     @addtogroup PropertyAnimation
-//! \brief A ProperyAnimation animates the value of a "property" of a "subject" over time.
+//! \brief A PropertyAnimation animates the value of a "property" of a "subject" over time.
 //!
 //! <h3>Animating a Layer's frame property</h3>
 //! Currently there is only one specific type of property animation offered off-the-shelf, namely

--- a/src/fw/applib/ui/qr_code.h
+++ b/src/fw/applib/ui/qr_code.h
@@ -52,7 +52,7 @@ typedef struct QRCode {
 //!
 //! The QR code is automatically marked dirty after this operation.
 //! @param qr_code The QRCode to initialize
-//! @param frame The frame with which to initialze the QRCode
+//! @param frame The frame with which to initialize the QRCode
 void qr_code_init(QRCode *qr_code, const GRect *frame);
 
 //! Creates a new QRCode on the heap and initializes it with the default values.
@@ -62,7 +62,7 @@ void qr_code_init(QRCode *qr_code, const GRect *frame);
 //! * Foreground color: \ref GColorBlack
 //! * Background color: \ref GColorWhite
 //!
-//! @param frame The frame with which to initialze the QRCode
+//! @param frame The frame with which to initialize the QRCode
 //! @return A pointer to the QRCode. `NULL` if the QRCode could not be created
 QRCode* qr_code_create(GRect frame);
 

--- a/src/fw/applib/ui/recognizer/touch_nav.c
+++ b/src/fw/applib/ui/recognizer/touch_nav.c
@@ -65,7 +65,7 @@ void touch_nav_registry_add(TouchNavState *state, TouchNavWidgetType type, Touch
     return;
   }
   TouchNavWidgetNode **head = prv_registry_head(state, type);
-  // Dedup by address: a re-add is a WARN and a no-op. Walk with a predecessor so we never touch a
+  // Dedupe by address: a re-add is a WARN and a no-op. Walk with a predecessor so we never touch a
   // node that isn't already threaded onto this list (robust to *_init zeroing the node).
   for (TouchNavWidgetNode *cur = *head; cur; cur = cur->next) {
     if (cur == node) {

--- a/src/fw/applib/ui/recognizer/touch_nav.h
+++ b/src/fw/applib/ui/recognizer/touch_nav.h
@@ -231,7 +231,7 @@ void touch_nav_set_action_bar(TouchNavState *state, const GRect *frame, uint8_t 
 ButtonId touch_nav_action_bar_zone_button(const TouchNavActionBar *bar, GPoint point,
                                           bool require_icon_zone);
 
-//! Register a Tier-1 widget node under the given registry. Dedup-by-address (a re-add WARNs and is
+//! Register a Tier-1 widget node under the given registry. Dedupe-by-address (a re-add WARNs and is
 //! a no-op). Robust to a node zeroed by the widget's *_init. \a ops and \a widget are the migrated
 //! widget's apply-vtable and opaque self pointer (both NULL for an un-migrated widget still driven
 //! by its own recognizer set); they are re-applied on a re-add so an init-without-deinit keeps

--- a/src/fw/applib/ui/rotbmp_pair_layer.h
+++ b/src/fw/applib/ui/rotbmp_pair_layer.h
@@ -19,7 +19,7 @@ typedef struct {
 
 } RotBmpPairLayer;
 
-//! white and black *must* have the same dimensions, and *shouldn't* have any overlapp of eachother
+//! white and black *must* have the same dimensions, and *shouldn't* have any overlap of each other
 void rotbmp_pair_layer_init(RotBmpPairLayer *pair, GBitmap *white, GBitmap *black);
 
 void rotbmp_pair_layer_deinit(RotBmpPairLayer *pair);

--- a/src/fw/applib/ui/scroll_layer.c
+++ b/src/fw/applib/ui/scroll_layer.c
@@ -318,7 +318,7 @@ static void prv_scroll_touch_nav_register(ScrollLayer *scroll_layer) {
   }
 
   // Register the scroll layer as a migrated Tier-1 widget: the unified widget set drives it through
-  // s_scroll_touch_nav_ops. The registry add dedups by address and re-applies the ops/layer, so a
+  // s_scroll_touch_nav_ops. The registry add dedupes by address and re-applies the ops/layer, so a
   // repeated init on the same scroll layer (no intervening deinit) keeps routing to and driving it.
   touch_nav_registry_add(state, TouchNavWidgetType_Scroll,
                          (TouchNavWidgetNode *)&scroll_layer->touch_nav_node, &scroll_layer->layer,

--- a/src/fw/applib/ui/scroll_layer.h
+++ b/src/fw/applib/ui/scroll_layer.h
@@ -38,7 +38,7 @@
 //! UP and DOWN buttons with scrolling up and down.
 //! * The SELECT button can be configured by installing a click configuration
 //! provider using \ref scroll_layer_set_callbacks().
-//! * To scroll programatically to a certain offset, use
+//! * To scroll programmatically to a certain offset, use
 //! \ref scroll_layer_set_content_offset().
 //! * It is possible to get called back for each scrolling increment, by
 //! installing the `.content_offset_changed_handler` callback using
@@ -159,10 +159,10 @@ _Static_assert(offsetof(struct ScrollPaging, flags) == offsetof(Layer, flags),
 //! * Callback context: `NULL`
 //! The layer is marked dirty automatically.
 //! @param scroll_layer The ScrollLayer to initialize
-//! @param frame The frame with which to initialze the ScrollLayer
+//! @param frame The frame with which to initialize the ScrollLayer
 void scroll_layer_init(ScrollLayer *scroll_layer, const GRect *frame);
 
-//! Creates a new ScrollLayer on the heap and initalizes it with the default values:
+//! Creates a new ScrollLayer on the heap and initializes it with the default values:
 //! * Clips: `true`
 //! * Hidden: `false`
 //! * Content size: `frame.size`

--- a/src/fw/applib/ui/selection_layer.c
+++ b/src/fw/applib/ui/selection_layer.c
@@ -279,7 +279,7 @@ static void prv_draw_text(SelectionLayer *selection_layer, GContext *ctx) {
           height += prv_get_pixels_for_bump_settle(selection_layer->bump_settle_anim_progress);
         }
         // The text should be be vertically centered, unless we are performing an increment /
-        // decrment animation.
+        // decrement animation.
         int y_offset =
             prv_get_y_offset_which_vertically_centers_font(selection_layer->font, height);
 

--- a/src/fw/applib/ui/text_layer.h
+++ b/src/fw/applib/ui/text_layer.h
@@ -58,7 +58,7 @@ typedef struct TextLayer {
 //!
 //! The text layer is automatically marked dirty after this operation.
 //! @param text_layer The TextLayer to initialize
-//! @param frame The frame with which to initialze the TextLayer
+//! @param frame The frame with which to initialize the TextLayer
 void text_layer_init(TextLayer *text_layer, const GRect *frame);
 
 //! Creates a new TextLayer on the heap and initializes it with the default values.
@@ -72,7 +72,7 @@ void text_layer_init(TextLayer *text_layer, const GRect *frame);
 //! * Caching: `false`
 //!
 //! The text layer is automatically marked dirty after this operation.
-//! @param frame The frame with which to initialze the TextLayer
+//! @param frame The frame with which to initialize the TextLayer
 //! @return A pointer to the TextLayer. `NULL` if the TextLayer could not
 //! be created
 TextLayer* text_layer_create(GRect frame);
@@ -145,7 +145,7 @@ void text_layer_set_text_alignment(TextLayer *text_layer, GTextAlignment text_al
 //! By default, layout caching is off (false). Layout caches store the max used
 //! height and width of a text layer.
 //! NOTE: when using cached layouts, text_layer_deinit() MUST be called at some
-//! point in time to prevent memory leaks from occuring.
+//! point in time to prevent memory leaks from occurring.
 void text_layer_set_should_cache_layout(TextLayer *text_layer, bool should_cache_layout);
 
 //! @internal

--- a/src/fw/applib/ui/time_range_selection_window.c
+++ b/src/fw/applib/ui/time_range_selection_window.c
@@ -127,7 +127,7 @@ void time_range_selection_window_init(TimeRangeSelectionWindowData *time_range_s
   const int from_top_offset = config->top_origin + config->selection_y_offset;
   const int to_top_offset = from_top_offset + config->start_end_y_offset;
 
-  // FROM selection layer steup
+  // FROM selection layer setup
   SelectionLayer *from_selection_layer = &time_range_selection_window->from_selection_layer;
   GRect frame = GRect(left_offset, from_top_offset, width, selection_layer_default_cell_height());
   selection_layer_init(from_selection_layer, &frame, num_cells);
@@ -145,7 +145,7 @@ void time_range_selection_window_init(TimeRangeSelectionWindowData *time_range_s
     .decrement = prv_handle_from_dec,
   });
 
-  // TO selection layer steup
+  // TO selection layer setup
   SelectionLayer *to_selection_layer = &time_range_selection_window->to_selection_layer;
   frame.origin.y = to_top_offset;
   selection_layer_init(to_selection_layer, &frame, num_cells);

--- a/src/fw/applib/ui/window.h
+++ b/src/fw/applib/ui/window.h
@@ -176,7 +176,7 @@ typedef struct Window {
 //! @param debug_name The window's debug name
 void window_init(Window *window, const char* debug_name);
 
-//! Creates a new Window on the heap and initalizes it with the default values.
+//! Creates a new Window on the heap and initializes it with the default values.
 //!
 //! * Background color : `GColorWhite`
 //! * Root layer's `update_proc` : function that fills the window's background using `background_color`.
@@ -326,14 +326,14 @@ struct Layer* window_get_root_layer(const Window *window);
 void window_set_background_color(Window *window, GColor background_color);
 void window_set_background_color_2bit(Window *window, GColor2 background_color);
 
-//! Sets whether or not the window is fullscreen, consequently hiding the sytem status bar.
+//! Sets whether or not the window is fullscreen, consequently hiding the system status bar.
 //! @note This needs to be called before pushing a window to the window stack.
 //! @param window The window for which to set its full-screen property
 //! @param enabled True to make the window full-screen or false to leave space for the system status bar.
 //! @see \ref window_get_fullscreen()
 void window_set_fullscreen(Window *window, bool enabled);
 
-//! Gets whether the window is full-screen, consequently hiding the sytem status bar.
+//! Gets whether the window is full-screen, consequently hiding the system status bar.
 //! @param window The window for which to get its full-screen property
 //! @return True if the window is marked as fullscreen, false if it is not marked as fullscreen.
 bool window_get_fullscreen(const Window *window);

--- a/src/fw/applib/ui/window_stack_animation.h
+++ b/src/fw/applib/ui/window_stack_animation.h
@@ -23,7 +23,7 @@ typedef void (*WindowTransitionImplementationRenderFunc)(WindowTransitioningCont
 // needs to
 //   create an animation that drives the visible transition
 //   (e.g. by moving context.window_to.layer.frame)
-//   call context.window_from.handlers.disappear and context.window_to.handers.appear et al.
+//   call context.window_from.handlers.disappear and context.window_to.handlers.appear et al.
 // doesn't need to
 //   restore context.window_from.layer.frame (framework will do that)
 // if no animation is returned by .create_animation, the windows will be replaced immediately


### PR DESCRIPTION
Took a pass with cSpell, but sending them in a few batches instead of a big "treewide" one so it's still reviewable.