### PR TITLE
src/fw/services: cleanup typos

### DIFF
--- a/src/fw/services/accel_manager/service.c
+++ b/src/fw/services/accel_manager/service.c
@@ -162,7 +162,7 @@ static void prv_double_tap_remove_subscriber_cb(PebbleTask task) {
 //! 200ms, and subscriber B at 250ms, new samples will become available every
 //! 200ms, so subscriber B's data buffer would not fill until 400ms, resulting
 //! in a 150ms latency. This is how the legacy implementation worked as well
-//! but is potentionally something we could improve in the future if it becomes
+//! but is potentially something we could improve in the future if it becomes
 //! a problem.
 static uint32_t prv_get_sample_interval_info(uint32_t *lowest_interval_us,
                                              uint32_t *max_n_samples) {

--- a/src/fw/services/activity/activity.c
+++ b/src/fw/services/activity/activity.c
@@ -375,7 +375,7 @@ static SettingsFile *prv_settings_migrate(SettingsFile *file, uint16_t *written_
     return file;
   }
 
-  PBL_LOG_INFO("Performing settings file migration from verison %"PRIu16"", version);
+  PBL_LOG_INFO("Performing settings file migration from version %"PRIu16"", version);
 
   // Perform migration
   if ((version == 1) || (version == 2)) {
@@ -387,7 +387,7 @@ static SettingsFile *prv_settings_migrate(SettingsFile *file, uint16_t *written_
     }
   } else {
     // If the version is totally unexpected, remove the file and create a new one
-    PBL_LOG_ERR("Unknown settings file verison %"PRIu16"", version);
+    PBL_LOG_ERR("Unknown settings file version %"PRIu16"", version);
   }
 
   if (result != S_SUCCESS) {
@@ -416,7 +416,7 @@ static void NOINLINE prv_update_storage(time_t utc_sec) {
     SettingsFile *file = activity_private_settings_open();
 
     if (file && (s_activity_state.update_settings_counter <= 0)) {
-      // Peridocically save current stats into settings, so that if watch resets or crashes we
+      // Periodically save current stats into settings, so that if watch resets or crashes we
       // don't lose too much info
       ACTIVITY_LOG_DEBUG("updating current stats in settings");
 

--- a/src/fw/services/activity/activity_sessions.c
+++ b/src/fw/services/activity/activity_sessions.c
@@ -284,7 +284,7 @@ void activity_sessions_prv_send_activity_session_to_data_logging(ActivitySession
 }
 
 
-// This structre holds stats we collected from going through a list of sleep sessions. It is
+// This structure holds stats we collected from going through a list of sleep sessions. It is
 // filled in by prv_compute_sleep_stats
 typedef struct {
   ActivityScalarStore total_minutes;
@@ -547,7 +547,7 @@ static void prv_log_activities(time_t now_utc) {
     }
     PBL_ASSERTN(params);
 
-    // If this is an event we already logged, or it's still onging, don't log it
+    // If this is an event we already logged, or it's still ongoing, don't log it
     if (session->ongoing || (session_exit_utc <= *params->exit_utc)) {
       continue;
     }
@@ -628,7 +628,7 @@ void activity_sessions_prv_init(SettingsFile *file, time_t utc_now) {
       // flash got corrupted, as in PBL-37848
       PBL_HEXDUMP(LOG_LEVEL_INFO, (void *)state->activity_sessions,
                   sizeof(state->activity_sessions));
-      PBL_LOG_ERR("Invalid activity session detected - could be flash corrruption");
+      PBL_LOG_ERR("Invalid activity session detected - could be flash corruption");
 
       // Zero out flash so that we don't get into a reboot loop
       memset(state->activity_sessions, 0, sizeof(state->activity_sessions));
@@ -672,7 +672,7 @@ void NOINLINE activity_sessions_prv_minute_handler(time_t utc_sec) {
   prv_update_sleep_metrics(utc_sec, last_sleep_utc_of_day,
                                              last_sleep_processed_utc);
 
-  // Log any new activites we detected to the phone
+  // Log any new activities we detected to the phone
   prv_log_activities(utc_sec);
 }
 

--- a/src/fw/services/activity/kraepelin/activity_algorithm_kraepelin.c
+++ b/src/fw/services/activity/kraepelin/activity_algorithm_kraepelin.c
@@ -573,7 +573,7 @@ static bool NOINLINE prv_prepare_minute_data(uint16_t uncertain_m, time_t sleep_
 
     // See if we need to zero out steps in this record. We check that the start of the minute
     // is within the sleep bounds. The WITHIN macro returns true if the test value is
-    // <= end_value, so we need to subract one minute from the end to see if the start of this
+    // <= end_value, so we need to subtract one minute from the end to see if the start of this
     // test minute is entirely within the sleep range.
     bool was_sleeping =  WITHIN(cbuf_record->utc_sec, sleep_start_utc,
                                 sleep_end_utc - SECONDS_PER_MINUTE);
@@ -736,7 +736,7 @@ void activity_algorithm_post_process_sleep_sessions(uint16_t num_input_sessions,
     const time_t end_utc = session->start_utc + (session->length_min * SECONDS_PER_MINUTE);
     const unsigned end_minute = time_util_get_minute_of_day(end_utc);
 
-    ACTIVITY_LOG_DEBUG("procesing activity %d, start_min: %u, len: %"PRIu16"",
+    ACTIVITY_LOG_DEBUG("processing activity %d, start_min: %u, len: %"PRIu16"",
                        (int)session->type, start_minute, session->length_min);
 
     // Skip if not a sleep session
@@ -1352,7 +1352,7 @@ bool activity_algorithm_test_fill_minute_file(void) {
   AlgMinuteFileRecord record = { };
   prv_init_minute_record(&record.hdr, utc_sec, true /*for_file*/);
 
-  // Delete old file so this doesn't take forver, in case it's already got a lot of data in it
+  // Delete old file so this doesn't take forever, in case it's already got a lot of data in it
   pfs_remove(ALG_MINUTE_DATA_FILE_NAME);
   s_alg_state->num_minute_records = 0;
 

--- a/src/fw/services/activity/kraepelin/kraepelin_algorithm.c
+++ b/src/fw/services/activity/kraepelin/kraepelin_algorithm.c
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 This license is taken to apply to any other files in the Project Kraepelin
-Pebble App roject.
+Pebble App project.
 */
 #include <stdbool.h>
 #include <stdint.h>
@@ -171,7 +171,7 @@ typedef struct {
   uint16_t max_wake_minutes_early;        // early in the session
   uint16_t max_wake_minutes_late;         // later in the session
 
-  // Minimum sleep cyle length
+  // Minimum sleep cycle length
   uint16_t min_sleep_cycle_len_minutes;
 
   // If we see a scores less than this value, we consider it a "zero" (no movement)
@@ -470,7 +470,7 @@ static int32_t prv_integral_abs(int16_t *d, int16_t start, int16_t end) {
 // -----------------------------------------------------------------------------------------
 // Return the sum(abs(x-mean)) for each x in the array
 static uint32_t prv_pim_filter(KAlgState *state, int16_t *d, int16_t dlen, int16_t axis) {
-  // We use a butterworth second order digital fitler with a bandpass
+  // We use a butterworth second order digital filter with a bandpass
   // design of 0.25 to 1.75 hz
   static const Fixed_S64_32 cb[KALG_BUTTERWORTH_NUM_COEFICIENTS] = {
       {0x000000000721d150LL},   //  0.027859766117136
@@ -538,7 +538,7 @@ static uint32_t prv_real_counts_from_raw(uint32_t raw) {
   // 125 = 1G. We have empirically determined that scaling the VMC by
   // KALG_x100_RAW_1G_PIM_CPM_TO_REAL_CPM / 100 produces values equivalent to the Actigraph values.
   // So, to convert from raw VMC to real VMC, we need
-  // to multiply by KALG_x100_RAW_1G_PIM_CPM_TO_REAL_CPM/100 and divide by 125 and we acccomplish
+  // to multiply by KALG_x100_RAW_1G_PIM_CPM_TO_REAL_CPM/100 and divide by 125 and we accomplish
   // this in integer arithmetic by multiplying by KALG_x100_RAW_1G_PIM_CPM_TO_REAL_CPM and
   // dividing by 12500.
   uint32_t real_counts = raw * KALG_x100_RAW_1G_PIM_CPM_TO_REAL_CPM / 12500;
@@ -550,13 +550,13 @@ static uint32_t prv_real_counts_from_raw(uint32_t raw) {
 // Real-valued, in-place, 2-radix Fourier transform
 //
 //   This implementation of the fourier transform is taken directly from
-//   Henrik V. Sorensen's 1987 paper "Real-valued Fast Fourier Tranform
+//   Henrik V. Sorensen's 1987 paper "Real-valued Fast Fourier Transform
 //   Algorithms" with slight modifications to allow use of Pebble's cos and
 //   sin lookup functions with input range of 0 to 2*pi angle scaled to
 //   0 to 65536 and output range of -1 to 1 scaled to -65535 to 65536. This
-//   descretization introduces some discrepancies between the results of this
+//   discretization introduces some discrepancies between the results of this
 //   function and the floating point equivalents that are not important for its
-//   use here, but nonetheless documented in the accompaning Julia test code.
+//   use here, but nonetheless documented in the accompanying Julia test code.
 //
 //   INPUT
 //     d = input signal array pointer
@@ -564,7 +564,7 @@ static uint32_t prv_real_counts_from_raw(uint32_t raw) {
 //     width_log_2 the log base 2 of width: 2^width_log_2 = width
 //
 //   OUTPUT
-//     d = fourier tranformed array pointer, with array of real coefficents of form
+//     d = fourier transformed array pointer, with array of real coefficients of form
 //       [Re(0), Re(1),..., Re(N/2-1), Re(N/2), Im(N/2-1),..., Im(1)]
 //
 static void prv_fft_2radix_real(int16_t *d, int16_t width, int16_t width_log_2) {
@@ -634,10 +634,10 @@ static void prv_fft_2radix_real(int16_t *d, int16_t width, int16_t width_log_2) 
 
 
 // -----------------------------------------------------------------------------------------
-// Evaluate the magnitude of the FFT coefficents and write back to the first width/2 elements
+// Evaluate the magnitude of the FFT coefficients and write back to the first width/2 elements
 // NOTE! this function modifies the input array in place
 static void prv_fft_mag(int16_t *d, int16_t width) {
-  // evaluate the fourier coefficent magnitude
+  // evaluate the fourier coefficient magnitude
   // NOTE: coeff @ index 0 and width/2 only have real components
   //    so their magnitude is exactly that
   for (int16_t i = 1; i < (width / 2); i++) {
@@ -728,7 +728,7 @@ static void prv_get_fftmag_0pad_mean0(int16_t *d, int16_t num_samples, int16_t f
   // Compute the FFT coefficients
   prv_fft_2radix_real(d, fft_width, fft_width_log_2);
 
-  // Evaluate the magnitude of the coefficents and write back to the first fft_width/2
+  // Evaluate the magnitude of the coefficients and write back to the first fft_width/2
   // elements
   prv_fft_mag(d, fft_width);
 }
@@ -830,9 +830,9 @@ static uint32_t prv_calc_raw_vmc(uint32_t *pims) {
 // the energy of the walking frequency, the arm frequency, and each of their harmonics.
 // @param[in] d pointer to array of magnitudes
 // @param[in] d_len length of d array
-// @param[in] walk_hz which walking frequency to evalute
+// @param[in] walk_hz which walking frequency to evaluate
 // @param[in] log log debugging information for this specific walking frequency
-// @return the sum of the magntudes of the signal frequencies
+// @return the sum of the magnitudes of the signal frequencies
 static uint32_t prv_compute_signal_energy(int16_t *d, int16_t d_len, uint16_t walk_hz, bool log) {
   static const int k_min_arm_freq = 5;
 
@@ -1040,7 +1040,7 @@ static bool prv_is_stepping(KAlgState *state, uint16_t max_mag_hz, uint16_t scor
   const uint16_t k_partial_min_vmc = 120;
 
   // If the frequency is high (close to running speed), insure that the VMC is also high.
-  // This can filter out some false steps if we get a high freqency and low VMC.
+  // This can filter out some false steps if we get a high frequency and low VMC.
   static const uint32_t k_high_step_freq_threshold = 12;
   static const uint32_t k_high_step_freq_vmc = 1000;
 
@@ -1106,7 +1106,7 @@ static uint16_t prv_calc_steps_in_epoch(KAlgState *state, int16_t num_samples, i
   // 125 = 1G. We have empirically determined that scaling the VMC by
   // KALG_x100_RAW_1G_PIM_CPM_TO_REAL_CPM / 100 produces values equivalent to the Actigraph values.
   // So, to convert from raw VMC to real VMC, we need
-  // to multiply by KALG_x100_RAW_1G_PIM_CPM_TO_REAL_CPM/100 and divide by 125 and we acccomplish
+  // to multiply by KALG_x100_RAW_1G_PIM_CPM_TO_REAL_CPM/100 and divide by 125 and we accomplish
   // this in integer arithmetic by multiplying by KALG_x100_RAW_1G_PIM_CPM_TO_REAL_CPM and
   // dividing by 12500.
   uint32_t real_vmc_5s = prv_real_counts_from_raw(prv_calc_raw_vmc(pim_epoch));
@@ -1142,7 +1142,7 @@ static uint16_t prv_calc_steps_in_epoch(KAlgState *state, int16_t num_samples, i
   const char *type_str = stepping ? "STEP" : (partial_steps ? "HALF" : "----");
   KALG_LOG_DEBUG("%s steps: %2"PRIu16", freq: %2"PRIu16", vmc: %4"PRIu32", score0: %"PRIu16", ",
                  type_str, return_steps, max_mag_hz, real_vmc_5s, score_0);
-  KALG_LOG_DEBUG("score_hf: %"PRIi16", score_lf: %"PRIi16", total_energry: %"PRIi32" ",
+  KALG_LOG_DEBUG("score_hf: %"PRIi16", score_lf: %"PRIi16", total_energy: %"PRIi32" ",
                  score_hf, score_lf, total_energy);
   prv_log_overall_magnitudes("freq", state->work, 0, (fft_width / 2) - 1 /*index of last element*/);
 
@@ -1234,7 +1234,7 @@ static uint32_t prv_analyze_epoch(KAlgState *state) {
     prv_log_axis_magnitudes("accel-before", &state->accel_samples[axis][0], 0,
                             state->num_samples - 1 /*index of last element*/);
 
-    // Apply a cosine filter to the data before we FFT to reduce the chance of introduing
+    // Apply a cosine filter to the data before we FFT to reduce the chance of introducing
     // false high frequency components. See the function comment for prv_filt_cosine_win_mean0()
     // for more info.
     prv_filt_cosine_win_mean0(&state->accel_samples[axis][0], state->num_samples, 1);
@@ -1522,7 +1522,7 @@ static bool prv_not_worn_during_session(KAlgState *alg_state, time_t session_sta
 
 
 // ------------------------------------------------------------------------------------------
-// Register the deep sleep sesions we've found
+// Register the deep sleep sessions we've found
 static void prv_deep_sleep_register_sessions(KAlgState *alg_state, time_t sample_time,
                                              bool abort, bool ongoing,
                                              KAlgActivitySessionCallback sessions_cb,
@@ -1534,7 +1534,7 @@ static void prv_deep_sleep_register_sessions(KAlgState *alg_state, time_t sample
                  ongoing ? "register" : (abort ? "abort" : "end"));
   PBL_ASSERT(state->sleep_start_time != KALG_START_TIME_NONE, "Unexpected call");
 
-  // Register/delete prevous sessions we captured
+  // Register/delete previous sessions we captured
   for (uint8_t i = 0; i < state->num_sessions; i++) {
     time_t start_utc = state->sleep_start_time + state->start_delta_sec[i];
     sessions_cb(context, KAlgActivityType_RestfulSleep, start_utc,
@@ -1565,7 +1565,7 @@ static void prv_deep_sleep_register_sessions(KAlgState *alg_state, time_t sample
 // @param[in] action which action to take:
 //    KAlgDeepSleepAction_Start:    start of a new sleep session, start capturing
 //    KAlgDeepSleepAction_Continue: Another sample for the current sleep session
-//    KAlgDeepSleepAction_End:      current sleep sesion has ended
+//    KAlgDeepSleepAction_End:      current sleep session has ended
 //    KAlgDeepSleepAction_Abort:    Abort the current sleep session
 // @param[in] ok_to_register if true, it is OK to register this as a deep sleep session. We don't
 //    allow registration until we're sure the container sleep session it is in is valid.
@@ -1729,7 +1729,7 @@ static bool prv_sleep_activity_update_stats(KAlgState *alg_state, time_t utc_now
     state->current_stats.consecutive_awake_minutes++;
   }
   if (score > params->min_valid_vmc) {
-    // If there is any movememnt at all, increment the "non-zero" minutes count.
+    // If there is any movement at all, increment the "non-zero" minutes count.
     state->current_stats.num_non_zero_minutes++;
   }
   if (state->current_stats.start_time != KALG_START_TIME_NONE) {
@@ -1925,7 +1925,7 @@ static void prv_sleep_activity_update(KAlgState *alg_state, time_t utc_now, uint
 
       sessions_cb(context, KAlgActivityType_Sleep, state->current_stats.start_time,
                   session_len_m * SECONDS_PER_MINUTE, false /*ongoing*/, false /*delete*/,
-                  0 /*steps*/, 0 /*resting_calories*/, 0 /*active_calories*/, 0 /*distane_mm*/);
+                  0 /*steps*/, 0 /*resting_calories*/, 0 /*active_calories*/, 0 /*distance_mm*/);
 
       // Inform the deep sleep detection logic that the sleep session just ended
       prv_deep_sleep_update(alg_state, sample_utc, score, KAlgDeepSleepAction_End,
@@ -1942,7 +1942,7 @@ static void prv_sleep_activity_update(KAlgState *alg_state, time_t utc_now, uint
       // Delete the previously registered ongoing session
       sessions_cb(context, KAlgActivityType_Sleep, state->current_stats.start_time,
                   session_len_m * SECONDS_PER_MINUTE, true /*ongoing*/, true /*delete*/,
-                  0 /*steps*/, 0 /*resting_calories*/, 0 /*active_calories*/, 0 /*distane_mm*/);
+                  0 /*steps*/, 0 /*resting_calories*/, 0 /*active_calories*/, 0 /*distance_mm*/);
 
       // Inform the deep sleep detection logic that this sleep session was aborted
       prv_deep_sleep_update(alg_state, sample_utc, score, KAlgDeepSleepAction_Abort,
@@ -1964,7 +1964,7 @@ static void prv_sleep_activity_update(KAlgState *alg_state, time_t utc_now, uint
         sessions_cb(context, KAlgActivityType_Sleep, state->current_stats.start_time,
                     minutes_since_sleep_started * SECONDS_PER_MINUTE, true /*ongoing*/,
                     false /*delete*/, 0 /*steps*/, 0 /*resting_calories*/, 0 /*active_calories*/,
-                    0 /*distane_mm*/);
+                    0 /*distance_mm*/);
 
         // Update summary stats
         state->summary_stats.sleep_start_utc = state->current_stats.start_time;
@@ -1989,7 +1989,7 @@ static const KAlgActivityAttributes *prv_get_step_activity_attributes(KAlgActivi
   static const KAlgActivityAttributes k_attributes[KAlgActivityTypeCount] = {
     // min_steps_per_min, max_steps_per_min
     {0, 0},            // KAlgActivityType_Sleep
-    {0, 0},            // KAlgActivityType_ResetfulSleep
+    {0, 0},            // KAlgActivityType_RestfulSleep
     {40,  130},        // KAlgActivityType_Walk
     {130, 255},        // KAlgActivityType_Run
   };

--- a/src/fw/services/alarms/alarm.c
+++ b/src/fw/services/alarms/alarm.c
@@ -614,10 +614,10 @@ static int prv_get_day_for_just_once_alarm(int hour, int minute) {
   localtime_r(&current_time, &local_time);
 
   if (hour < local_time.tm_hour || (hour == local_time.tm_hour && minute <= local_time.tm_min)) {
-    // The time is before or equal to the current time. Sechedule the alarm for tomorrow
+    // The time is before or equal to the current time. Schedule the alarm for tomorrow
     return (local_time.tm_wday + 1) % DAYS_PER_WEEK;
   } else {
-    // The time hasn't happend yet today. Schedule it for today
+    // The time hasn't happened yet today. Schedule it for today
     return local_time.tm_wday;
   }
 }

--- a/src/fw/services/app_fetch_endpoint/service.c
+++ b/src/fw/services/app_fetch_endpoint/service.c
@@ -147,7 +147,7 @@ static void prv_cleanup(AppFetchResult result) {
 }
 
 //! System task callback triggered by app_fetch_put_bytes_event_handler() when we are receiving
-//! put_bytes messages in reponse to a fetch request to the phone.
+//! put_bytes messages in response to a fetch request to the phone.
 void prv_put_bytes_event_system_task_cb(void *data) {
   PebblePutBytesEvent *pb_event = (PebblePutBytesEvent *)data;
 

--- a/src/fw/services/app_inbox_service/service.c
+++ b/src/fw/services/app_inbox_service/service.c
@@ -133,7 +133,7 @@ DEFINE_SYSCALL(bool, sys_app_inbox_service_register, uint8_t *storage, size_t st
 }
 
 DEFINE_SYSCALL(uint32_t, sys_app_inbox_service_unregister, uint8_t *storage) {
-  // No check is needed on the value of `storage `, we're not going to derefence it.
+  // No check is needed on the value of `storage `, we're not going to dereference it.
   return app_inbox_service_unregister_by_storage(storage);
 }
 

--- a/src/fw/services/app_message/app_message_receiver.c
+++ b/src/fw/services/app_message/app_message_receiver.c
@@ -90,7 +90,7 @@ static Receiver *prv_app_message_receiver_prepare(CommSession *session,
   rcv->header_bytes_remaining = header_bytes_remaining;
 
   // Always forward the header to default system receiver as well, we'll cancel it later on if the
-  // message was written succesfully to the app inbox.
+  // message was written successfully to the app inbox.
   if (!prv_fwd_prepare(rcv, session, header_bytes_remaining)) {
     kernel_free(rcv);
     return NULL;

--- a/src/fw/services/battery/voltage/battery_state.c
+++ b/src/fw/services/battery/voltage/battery_state.c
@@ -115,7 +115,7 @@ static void battery_state_put_change_event(PreciseBatteryChargeState state) {
 
 void battery_state_reset_filter(void) {
   s_last_battery_state.voltage = battery_get_millivolts();
-  // Reset the stablization timer in case we encountered a current spike during the reset
+  // Reset the stabilization timer in case we encountered a current spike during the reset
   s_last_battery_state.init_time = rtc_get_ticks();
 }
 
@@ -188,7 +188,7 @@ static void prv_update_state(void *force_update) {
   // - We are charging
   // - We are discharging and:
   //    - The readings have stabilized and the battery percent did not go up
-  //    - The readings have not yet stablized
+  //    - The readings have not yet stabilized
   // TL;DR: Allow updates unless we're stable and discharging but the % went up.
   if (!charging && likely_stable &&
       new_charge_percent > s_last_battery_state.percent) {

--- a/src/fw/services/bluetooth/bluetooth_persistent_storage_normal.c
+++ b/src/fw/services/bluetooth/bluetooth_persistent_storage_normal.c
@@ -84,7 +84,7 @@ typedef struct PACKED {
 #define BT_PERSISTENT_STORAGE_FILE_SIZE (4096)
 
 //! All of the actual pairings use a BTBondingID as a key. This is because with BLE pairings an
-//! address is not alwaywas available, and it made it easier to have BT Classic and BLE pairings
+//! address is not alway available, and it made it easier to have BT Classic and BLE pairings
 //! use the same type of key. When adding pairings there is no BTBondingID so a free key has to
 //! be found by iterating over all possible keys.
 
@@ -798,7 +798,7 @@ bool bt_persistent_storage_update_ble_device_name(BTBondingID bonding, const cha
   GapBondingFileSetStatus status;
   status = prv_file_set(&bonding, sizeof(bonding), &data, sizeof(data));
 
-  // If this is the gateway, update SPRF so our pairing info betwen PRF and normal
+  // If this is the gateway, update SPRF so our pairing info between PRF and normal
   // FW is in sync
   if (data.ble_data.is_gateway && (status == GapBondingFileSetUpdated)) {
     prv_update_bondings(bonding, BtPersistBondingTypeBLE);

--- a/src/fw/services/comm_session/session_send_queue.c
+++ b/src/fw/services/comm_session/session_send_queue.c
@@ -94,7 +94,7 @@ size_t comm_session_send_queue_get_read_pointer(const CommSession *session,
 }
 
 void comm_session_send_queue_consume(CommSession *session, size_t remaining_length) {
-  // The data has sucessfully been sent out at this point
+  // The data has successfully been sent out at this point
   PBL_ASSERTN(session->send_queue_head);
   SessionSendQueueJob *job = session->send_queue_head;
   while (job && remaining_length) {

--- a/src/fw/services/data_logging/dls_endpoint.c
+++ b/src/fw/services/data_logging/dls_endpoint.c
@@ -439,7 +439,7 @@ static void prv_reopen_next_session_system_task_cb(void* data) {
   }
 }
 
-//! For use with dls_list_for_each_session. Appends this session to our list of sesions we need to open.
+//! For use with dls_list_for_each_session. Appends this session to our list of sessions we need to open.
 //! On entry, 'data' points to the variable holding the head of the list.
 static bool dls_endpoint_add_reopen_sessions_cb(DataLoggingSession *session, void *data) {
   DataLoggingReopenEntry **head_ptr = (DataLoggingReopenEntry **)data;

--- a/src/fw/services/data_logging/dls_list.c
+++ b/src/fw/services/data_logging/dls_list.c
@@ -35,7 +35,7 @@ void dls_assert_own_list_mutex(void) {
 //   * session->data->open_count can only be read/modified while holding the list mutex
 //     and is only available if session->status == DataLoggingStatusActive
 //   * In order to avoid deadlocks,
-//      - s_list_mutex MUST be released befored trying to grab session->data->mutex.
+//      - s_list_mutex MUST be released before trying to grab session->data->mutex.
 //      - session->data->open_count must incremented to be > 0 under s_list_mutex before you can
 //        grab session->data-mutex
 //      - if you already own session->data-mutex, it is OK to grab s_list_mutex

--- a/src/fw/services/data_logging/dls_main.c
+++ b/src/fw/services/data_logging/dls_main.c
@@ -151,7 +151,7 @@ static void prv_send_all_sessions_system_task_cb(void *empty_all_data) {
 static void prv_check_all_sessions_timer_cb(void *data) {
   // If sends are not enabled, do nothing
   if (!prv_sends_enabled()) {
-    PBL_LOG_INFO("Not sending sessions beause sending is disabled");
+    PBL_LOG_INFO("Not sending sessions because sending is disabled");
     return;
   }
 
@@ -202,7 +202,7 @@ bool dls_private_send_session(DataLoggingSession *logging_session, bool empty) {
 
   // If sends are not enabled, ignore
   if (!prv_sends_enabled()) {
-    PBL_LOG_INFO("Not sending session beause sending is disabled");
+    PBL_LOG_INFO("Not sending session because sending is disabled");
     return true;
   }
 
@@ -363,7 +363,7 @@ static bool prv_inactivate_sessions_each_cb(DataLoggingSession *session, void *d
 void dls_send_all_sessions(void) {
   // If sends are not enabled, do nothing
   if (!prv_sends_enabled()) {
-    PBL_LOG_INFO("Not sending sessions beause sending is disabled");
+    PBL_LOG_INFO("Not sending sessions because sending is disabled");
     return;
   }
   system_task_add_callback(prv_send_all_sessions_system_task_cb, (void*) true);

--- a/src/fw/services/data_logging/dls_storage.c
+++ b/src/fw/services/data_logging/dls_storage.c
@@ -335,7 +335,7 @@ static bool prv_get_session_file(DataLoggingSession *session, uint32_t space_nee
   }
 
   // Add a minium buffer to needed. This gives us a little insurance and also allows for the
-  // extra space needed for the chunk header byte that occurs at least once evvery
+  // extra space needed for the chunk header byte that occurs at least once every
   // DLS_MAX_CHUNK_SIZE_BYTES bytes.
   space_needed += DLS_MIN_FREE_BYTES;
   uint32_t space_avail = file_size - session->storage.write_offset;

--- a/src/fw/services/ecompass/service.c
+++ b/src/fw/services/ecompass/service.c
@@ -109,7 +109,7 @@ static int32_t prv_correct_for_roll_and_pitch(AccelRawData *accel_data,
 
   int32_t mx_rot, my_rot;
 
-  // per freescale AN4249, roll is unstable close to verticle but pitch is ok
+  // per freescale AN4249, roll is unstable close to vertical but pitch is ok
   int32_t corr = 0;
   if (TRIGANGLE_TO_DEG(pitch) > 82) {
     pitch = TRIG_MAX_ANGLE / 4;

--- a/src/fw/services/filesystem/pfs.c
+++ b/src/fw/services/filesystem/pfs.c
@@ -717,7 +717,7 @@ static status_t find_free_page(uint16_t *free_page, bool use_gc_allocator,
   // we should now be processing on a sector aligned boundary
   PBL_ASSERTN((start_pg % PFS_PAGES_PER_ERASE_SECTOR) == 0);
 
-  // if we could not find a free page in the sector we were previosuly using
+  // if we could not find a free page in the sector we were previously using
   // we need to scan through the erase regions and either perform some garbage
   // collection or find an erased page in another erase region
   if (next_page == INVALID_PAGE) {
@@ -759,7 +759,7 @@ static status_t find_free_page(uint16_t *free_page, bool use_gc_allocator,
 
 //! Note: expects that the caller does _not_ hold the pfs mutex
 //! Note: If pages are already pre-erased on the FS, this routine will return
-//!  very quickly. If we need to do erases, it will take longer becauses this
+//!  very quickly. If we need to do erases, it will take longer because this
 //!  operation can take seconds to complete on certain flash parts
 //!
 //! @param file_size - The amount of file space to erase
@@ -901,7 +901,7 @@ static status_t create_flash_file(File *f) {
     }
   }
 
-  // we have succesfully allocated space for the file, so add file specific info
+  // we have successfully allocated space for the file, so add file specific info
   f->start_page = f->curr_page = start_page;
 
   FileHeader file_hdr;

--- a/src/fw/services/get_bytes/get_bytes.c
+++ b/src/fw/services/get_bytes/get_bytes.c
@@ -203,7 +203,7 @@ bool prv_setup_state_for_command(GetBytesCmd cmd, GetBytesState *state,
   switch (cmd) {
     case GET_BYTES_CMD_GET_NEW_COREDUMP:
       info.only_get_new_coredump = true;
-      /* FALLTHRU */
+      /* FALLTHROUGH */
     case GET_BYTES_CMD_GET_COREDUMP:
       state->object_type = GetBytesObjectCoredump;
       return gb_storage_setup(&state->storage, state->object_type, &info);

--- a/src/fw/services/notifications/ancs/ancs_item.c
+++ b/src/fw/services/notifications/ancs/ancs_item.c
@@ -440,7 +440,7 @@ TimelineItem *ancs_item_create_and_populate(ANCSAttribute *notif_attributes[],
   int num_native_actions = (positive_action ? 1 : 0) + (negative_action ? 1 : 0);
   int num_actions = num_native_actions + num_pebble_actions;
 
-  const int max_num_actions = 8; // Arbitratily chosen
+  const int max_num_actions = 8; // Arbitrarily chosen
   uint8_t attributes_per_action[max_num_actions];
   int action_idx = 0;
 

--- a/src/fw/services/notifications/notification_storage.c
+++ b/src/fw/services/notifications/notification_storage.c
@@ -683,7 +683,7 @@ void notification_storage_rewrite(void (*iter_callback)(TimelineItem *notificati
   // Close the old file
   prv_file_close(fd);
 
-  // We have to close and reopend the new file pointed to by the file descriptor, so
+  // We have to close and reopened the new file pointed to by the file descriptor, so
   // that it's temp flag is cleared.
   pfs_close(new_fd);
   new_fd = prv_file_open(OP_FLAG_READ | OP_FLAG_WRITE);

--- a/src/fw/services/phone_call/service.c
+++ b/src/fw/services/phone_call/service.c
@@ -22,7 +22,7 @@ PBL_LOG_MODULE_DEFINE(service_phone_call, CONFIG_SERVICE_PHONE_CALL_LOG_LEVEL);
 //! - The watch gets PP messages (parsed in phone_pp.c), which come in as events happen.
 //! - The watch can decline / hangup the call by sending PP messages to the phone.
 //! On iOS:
-//! - The watch gets incomming calls from ANCS (parsed in ancs_notifications.c).
+//! - The watch gets incoming calls from ANCS (parsed in ancs_notifications.c).
 //! - After that the watch must poll the phone for its status if not iOS 9+ (using PP messages).
 //! - On iOS 9, ANCS tells us when the phone stops ringing
 //! - The watch can pickup / decline a call using ANCS actions
@@ -64,7 +64,7 @@ static void prv_timer_callback(void *context) {
 }
 
 static void prv_schedule_call_watchdog(int poll_interval_ms) {
-  // The Android app currently crashes if it recieves the get_state event. It currently doesn't
+  // The Android app currently crashes if it receives the get_state event. It currently doesn't
   // respond either so don't bother sending messages we don't need to. We also don't need to poll
   // iOS 9 since we can rely on ANCS to tell us when the phone stops ringing
   if (s_call_source == PhoneCallSource_ANCS_Legacy) {
@@ -93,7 +93,7 @@ static bool prv_should_show_ongoing_call_ui(void) {
   return (s_call_source == PhoneCallSource_PP);
 }
 
-// hangup != decline. Decline == reject incomming call, Hangup == stop in progress call
+// hangup != decline. Decline == reject incoming call, Hangup == stop in progress call
 static bool prv_can_hangup(void) {
   // We can't hangup with iOS
   return !prv_call_is_ancs();

--- a/src/fw/services/put_bytes/put_bytes.c
+++ b/src/fw/services/put_bytes/put_bytes.c
@@ -666,7 +666,7 @@ static bool prv_setup_storage_for_init_request(const InitRequest *request, uint3
     case ObjectSysResources:
       // Clear out, in case a prior, non-installed FW or sys resources transfer was still dangling:
       s_ready_to_install[request->type - 1].type = 0;
-      /* FALLTHRU */
+      /* FALLTHROUGH */
     default: {
       storage_info = kernel_malloc_check(sizeof(PutBytesStorageInfo));
       storage_info->index = request->index;

--- a/src/fw/services/regular_timer/service.c
+++ b/src/fw/services/regular_timer/service.c
@@ -108,7 +108,7 @@ static void timer_callback(void* data) {
 //! Used only once when we first start up. This should be really close to the 0ms point.
 static void timer_callback_initializing(void* data) {
   // FIXME: FreeRTOS timers are subject to skew if something else is running on the millisecond.
-  // We'll need to continously adjust our timer period in really annoying ways.
+  // We'll need to continuously adjust our timer period in really annoying ways.
   new_timer_start(s_timer_id, 1000, timer_callback, NULL, TIMER_START_FLAG_REPEATING);
 
   timer_callback(data);

--- a/src/fw/services/settings/settings_file.c
+++ b/src/fw/services/settings/settings_file.c
@@ -36,7 +36,7 @@ static status_t prv_open(SettingsFile *file, const char *name, uint8_t flags,
   // max_space_total == alloc_used_space, then if the file is full, changing a
   // single value would force the whole file to be rewritten- every single
   // time! It's probably worth it to "waste" a bit of flash space to avoid
-  // this pathalogical case.
+  // this pathological case.
   int max_space_total = pfs_sector_optimal_size(alloc_used_space * 12 / 10, strlen(name));
 
   int fd = pfs_open(name, flags, FILE_TYPE_STATIC, max_space_total);
@@ -170,10 +170,10 @@ static bool flag_is_set(SettingsRecordHeader *hdr, uint8_t flags) {
 //     the entire record has not been completely written yet. Records in this
 //     state are removed on bootup, since they are in an indeterminate state.
 // - written: The typical state for a record. == !partially_written
-// - partially_overwritten: This record has been superceeded by another, which
+// - partially_overwritten: This record has been superseded by another, which
 //     we are currently in the process of writing out to flash. Records in
 //     this state are restored on bootup.
-// - overwritten: This record has been superceeded by another, which has been
+// - overwritten: This record has been superseded by another, which has been
 //     completely written out to flash. We skip over and ignore overwritten
 //     records.
 static bool partially_written(SettingsRecordHeader *hdr) {
@@ -288,7 +288,7 @@ status_t settings_file_rewrite_filtered(
   settings_file_close(file);
   // We have to close and reopen the new_file so that it's temp flag is cleared.
   // Before the close succeeds, if we reboot, we will just end up reading the
-  // old file. After the close suceeds, we will end up reading the new
+  // old file. After the close succeeds, we will end up reading the new
   // (compacted) file.
   int alloc_used_space = new_file.alloc_used_space;
   int min_alloc_used_space = new_file.min_alloc_used_space;
@@ -717,7 +717,7 @@ status_t settings_file_rewrite(SettingsFile *file,
   settings_file_close(file);
   // We have to close and reopen the new_file so that it's temp flag is cleared.
   // Before the close succeeds, if we reboot, we will just end up reading the
-  // old file. After the close suceeds, we will end up reading the new
+  // old file. After the close succeeds, we will end up reading the new
   // (compacted) file.
   int alloc_used_space = new_file.alloc_used_space;
   int min_alloc_used_space = new_file.min_alloc_used_space;

--- a/src/fw/services/stationary/service.c
+++ b/src/fw/services/stationary/service.c
@@ -137,7 +137,7 @@ static void prv_stationary_check_launcher_task_cb(void *unused_data) {
   }
 }
 
-//! Called every minute to determine whether any motion has occured since the last time
+//! Called every minute to determine whether any motion has occurred since the last time
 //! the call was made. The current position is updated at this time
 static void prv_stationary_check_timer_cb(void *unused_data) {
   //! All stationary events need to be handled by kernel main

--- a/src/fw/services/system_task/service.c
+++ b/src/fw/services/system_task/service.c
@@ -63,7 +63,7 @@ static void system_task_main(void* paramater) {
     // Get event from the activated queue
     bool result = (pbl_msgq_get(activated_queue, &event, PBL_NO_WAIT) == 0);
 
-    // I believe its possible that we just reset the queue and accidently
+    // I believe its possible that we just reset the queue and accidentally
     // pended an extra event to the queue set so handle that case gracefully
     if (result) {
       s_system_task_idle = false;

--- a/src/fw/services/timeline/swap_layer.c
+++ b/src/fw/services/timeline/swap_layer.c
@@ -1066,7 +1066,7 @@ void swap_layer_touch_register(SwapLayer *swap_layer) {
   }
 
   // Register the swap layer as a migrated Tier-1 widget: the unified widget set drives it through
-  // s_swap_touch_nav_ops. The registry add dedups by address and re-applies the ops/layer, so a
+  // s_swap_touch_nav_ops. The registry add dedupes by address and re-applies the ops/layer, so a
   // repeated init/re-show on the same swap layer (no intervening deinit) keeps routing to and
   // driving it.
   touch_nav_registry_add(state, TouchNavWidgetType_Swap,

--- a/src/fw/services/timeline/timeline_actions.c
+++ b/src/fw/services/timeline/timeline_actions.c
@@ -537,7 +537,7 @@ static ActionResultData *prv_invoke_remote_action(ActionMenu *action_menu,
       // To give the iOS app some context (let it do lookups), give it all the
       // info about the notification
 
-      // Copy every attribtue from the notification and add:
+      // Copy every attribute from the notification and add:
       // - Timestamp attribute
       const int num_extra_attributes = 1;
       const int num_attributes = pin->attr_list.num_attributes + num_extra_attributes;

--- a/src/fw/services/vibe_pattern/service.c
+++ b/src/fw/services/vibe_pattern/service.c
@@ -183,7 +183,7 @@ static int32_t s_vibe_strength = VIBE_STRENGTH_OFF;
 // Tick at which the motor was last active (turned on or last transitioned off).
 // Used to suppress vibration-induced false shake/tap detections. 0 = never.
 static RtcTicks s_last_vibe_active_tick = 0;
-// s_vibe_strength_default is the vibrations trength of the motor used when one is not specified
+// s_vibe_strength_default is the vibrations strength of the motor used when one is not specified
 // explicitly, and can be changed in the notification vibration strength setting.
 static int32_t s_vibe_strength_default = VIBE_STRENGTH_MAX;
 

--- a/src/fw/services/wakeup/service.c
+++ b/src/fw/services/wakeup/service.c
@@ -62,7 +62,7 @@ struct prv_missed_events_s {
 };
 
 struct prv_check_app_and_wakeup_event_s {
-  time_t wakeup_timestamp; //!< Timestamp of the WakupEntry
+  time_t wakeup_timestamp; //!< Timestamp of the WakeupEntry
   int wakeup_count; //!< wakeup event count for app, negative for error (StatusCode)
 };
 
@@ -290,7 +290,7 @@ static void prv_update_events_callback(SettingsFile *old_file, SettingsFile *new
   } else {
     if (entry.notify_if_missed) {
       if (missed_events->missed_app_ids == NULL) {
-        // This is allocated here, but free'd in the wakup_ui.h module
+        // This is allocated here, but free'd in the wakeup_ui.h module
         missed_events->missed_app_ids =
             kernel_malloc(NUM_APPS_ALERT_ON_BOOT * sizeof(AppInstallId));
       }


### PR DESCRIPTION
Took a pass with cSpell, but sending them in a few batches instead of a big "treewide" one so it's still reviewable.