### PR TITLE
src/fw: cleanup typos

### DIFF
--- a/src/fw/apps/demo/activity_test/activity_test.c
+++ b/src/fw/apps/demo/activity_test/activity_test.c
@@ -672,7 +672,7 @@ static void prv_test_steps(void *context) {
   // Reset all stored data
   activity_test_reset(true /*reset_settings*/, true /*tracking_on*/, NULL, NULL);
 
-  // Fill the steps pipleine then capture step count before
+  // Fill the steps pipeline then capture step count before
   activity_test_feed_samples(s_walk_30_steps, ARRAY_LENGTH(s_walk_30_steps));
   int32_t before;
   activity_get_metric(ActivityMetricStepCount, 1, &before);

--- a/src/fw/apps/demo/animated_demo/animated_demo.c
+++ b/src/fw/apps/demo/animated_demo/animated_demo.c
@@ -83,7 +83,7 @@ static void click_handler(ClickRecognizerRef recognizer, Window *window) {
   }
 
   /*
-  // Exmple animation parameters:
+  // Example animation parameters:
 
   // Duration defaults to 250 ms
   animation_set_duration(animation, 1000);

--- a/src/fw/apps/demo/fps_test.c
+++ b/src/fw/apps/demo/fps_test.c
@@ -170,7 +170,7 @@ static void prv_window_load(Window *window) {
   // one image at the top left .topleft_layer,
   // and two menu layers .action_list1 and .action_list2 that overlay each other
 
-  // some hackery with the two menu layers goes on to keep their scroll offest in sync
+  // some hackery with the two menu layers goes on to keep their scroll offset in sync
   // and to have the inverter layer rendered only once
 
   const int16_t navbar_width = s_fps_topleft_bitmap.bounds.size.w;

--- a/src/fw/apps/demo/menu_round/menu_round.c
+++ b/src/fw/apps/demo/menu_round/menu_round.c
@@ -44,7 +44,7 @@ static const MenuDetailRowData menu_detail_row_data_notifications[] = {
   {"Liron Damir", "Late again. Sorry, I'll be on time in the future.", NULL},
   {"Angela Tam", "Late again? Can you be on time for once?", NULL},
   {"Eric Migicovsky", "Friday meeting will be held in the big room.", NULL},
-  {"Intagram", "Keep scrolling down.", NULL},
+  {"Instagram", "Keep scrolling down.", NULL},
   {"Liron Levak", "That's not my name.", NULL},
   {"Kimberly North West Kardashian", "I broke the Internet again.", NULL},
   {"Henry Damir", "That's not my name.", NULL},

--- a/src/fw/apps/demo/mpu_test/test_mpu_cache.c
+++ b/src/fw/apps/demo/mpu_test/test_mpu_cache.c
@@ -44,7 +44,7 @@ static void prv_verify_modify_on_app_task(void *data) {
   if (app_data->test != 0x3C3C3C3C) {
     text_layer_set_text(&app_data->text, "FAILED");
   } else {
-    text_layer_set_text(&app_data->text, "PASSSED");
+    text_layer_set_text(&app_data->text, "PASSED");
   }
 }
 

--- a/src/fw/apps/demo/pebble_colors/pebble_colors.c
+++ b/src/fw/apps/demo/pebble_colors/pebble_colors.c
@@ -215,7 +215,7 @@ static void set_text_layers(AppData *data) {
   } else if (data->alpha == ALPHA_66) {
     alpha_percent = 50; // FIXME: Currently don't support 66
   } else if (data->alpha == ALPHA_33) {
-    alpha_percent = 25; // FIXME: Currenlty don't support 33
+    alpha_percent = 25; // FIXME: Currently don't support 33
   } else if (data->alpha == ALPHA_0) {
     alpha_percent = 0;
   }

--- a/src/fw/apps/demo/statusbar/statusbar_demo.c
+++ b/src/fw/apps/demo/statusbar/statusbar_demo.c
@@ -21,7 +21,7 @@ static void prv_handle_click(ClickRecognizerRef ref, void *context) {
   app_window_stack_push(window, true);
 }
 
-static void prv_click_config_proivider(void *context) {
+static void prv_click_config_provider(void *context) {
   window_single_click_subscribe(BUTTON_ID_SELECT, prv_handle_click);
 }
 
@@ -93,7 +93,7 @@ static Window *prv_window_create(void) {
     layer_add_child(&window->window.layer, &status_bar->layer);
   }
 
-  window_set_click_config_provider(result, prv_click_config_proivider);
+  window_set_click_config_provider(result, prv_click_config_provider);
 
   window_set_window_handlers(&window->window, &(WindowHandlers){
      .unload = prv_window_unload,

--- a/src/fw/apps/demo/test_sys_timer/test_sys_timer.c
+++ b/src/fw/apps/demo/test_sys_timer/test_sys_timer.c
@@ -302,7 +302,7 @@ void stuck_callback_menu_cb(int index, void *ctx) {
 }
 
 // =================================================================================
-void invaid_timer_id_menu_cb(int index, void *ctx) {
+void invalid_timer_id_menu_cb(int index, void *ctx) {
   void *cb_data = 0;
   uint32_t zero_flags = 0;
 
@@ -392,7 +392,7 @@ static void prv_window_load(Window *window) {
       .callback = stuck_callback_menu_cb
     }, {
       .title = "invalid timer ID",
-      .callback = invaid_timer_id_menu_cb
+      .callback = invalid_timer_id_menu_cb
     }, {
       .title = "RT: sch 1 sec from cb",
       .callback = reg_timer_schedule_1sec_from_cb_menu_cb

--- a/src/fw/apps/demo/timeline_pins/timeline_pins_demo.c
+++ b/src/fw/apps/demo/timeline_pins/timeline_pins_demo.c
@@ -58,7 +58,7 @@ static void prv_add_notification(int32_t delta_time_s) {
       "Angela Tam", "Liron Damir", "Heiko Behrens", "Kevin Conley", "Matt Hungerford",
   };
   char *bodies[] = {
-      "Late again? Can you be on time ever? Seriosly? Dude!!!",
+      "Late again? Can you be on time ever? Seriously? Dude!!!",
       "Late again. Sorry, I'll be there a few minutes. Meanwhile, I am just texting long messages.",
       "What's up for lunch?",
       "\xF0\x9F\x98\x83 \xF0\x9F\x92\xA9",

--- a/src/fw/apps/prf/mfg_mic_obelix.c
+++ b/src/fw/apps/prf/mfg_mic_obelix.c
@@ -130,7 +130,7 @@ static void prv_recording_start(void) {
 
   snprintf(app_data->status_text, PROCESS_STATUS_STR_LEN, "Pls Speak");
   mic_init(MIC);
-  //set to maximum make it's more audiable in testing
+  //set to maximum make it's more audible in testing
   mic_set_volume(MIC, 100);
   mic_start(MIC, prv_mic_data_handler, NULL, app_data->pcm, PCM_BUFFER_SIZE);
   app_data->mic_recording = true;

--- a/src/fw/apps/prf/recovery_first_use/getting_started_button_combo.h
+++ b/src/fw/apps/prf/recovery_first_use/getting_started_button_combo.h
@@ -19,8 +19,8 @@
 //! The reason it's not just a boring set of long click handlers is because we don't support
 //! registering a long click handler for a combination of buttons like up+down.
 //!
-//! I tried to split this out from a seperate file from the recovery_first_use.c file so I could
-//! test this behaviour in a unit test independant in the UI. I think it turned out /okay/. The
+//! I tried to split this out from a separate file from the recovery_first_use.c file so I could
+//! test this behaviour in a unit test independent in the UI. I think it turned out /okay/. The
 //! callback specification is a little odd (only for select but not for the other ones, should we
 //! be blowing memory on static behaviour like this?) but it was worth a shot.
 
@@ -33,7 +33,7 @@ typedef struct {
 
   //! Timer for how long the combination has been held for. We use new_timer instead of app_timer
   //! even though it's a little more dangerous (doesn't automatically get cleaned up by the app)
-  //! because the api is nicer for starting/stopping/resceduling the same timer over and over
+  //! because the api is nicer for starting/stopping/rescheduling the same timer over and over
   //! again with different callbacks.
   TimerID combo_timer;
 

--- a/src/fw/apps/system/app_fetch_ui.c
+++ b/src/fw/apps/system/app_fetch_ui.c
@@ -68,7 +68,7 @@ static void prv_app_fetch_launch_app(AppFetchUIData *data) {
     vibes_short_pulse();
   }
 
-  // Allocate and inialize the data that would have been sent to the app originally before the
+  // Allocate and initialize the data that would have been sent to the app originally before the
   // fetch request.
   PebbleLaunchAppEventExtended *ext = kernel_malloc_check(sizeof(PebbleLaunchAppEventExtended));
   *ext = (PebbleLaunchAppEventExtended) {

--- a/src/fw/apps/system/health/activity_summary_card_segments.h
+++ b/src/fw/apps/system/health/activity_summary_card_segments.h
@@ -7,7 +7,7 @@
 #include "board/display.h"
 
 //! 5 main segments + 2 real corners + 2 endcaps implemented as corners (for bw)
-//! Each of the 5 non-corener segments get 20% of the total
+//! Each of the 5 non-corner segments get 20% of the total
 #define AMOUNT_PER_SEGMENT (HEALTH_PROGRESS_BAR_MAX_VALUE * 20 / 100)
 
 // Found through trial and error

--- a/src/fw/apps/system/health/card_view.c
+++ b/src/fw/apps/system/health/card_view.c
@@ -91,7 +91,7 @@ static int prv_get_next_card_idx(Card current, bool up) {
   if (next == Card_HrSummary && !activity_is_hrm_present()) {
     next = next + direction;
   }
-  // if heart rate is diabled, change the order of cards to Activiy <-> Sleep <-> HR
+  // if heart rate is diabled, change the order of cards to Activity <-> Sleep <-> HR
   else if (activity_is_hrm_present() && !activity_prefs_heart_rate_is_enabled()) {
     if (current == Card_ActivitySummary) {
       next = up ? Card_SleepSummary : BACK_TO_WATCHFACE;

--- a/src/fw/apps/system/health/data.h
+++ b/src/fw/apps/system/health/data.h
@@ -47,7 +47,7 @@ void health_data_update_step_derived_metrics(HealthData *health_data);
 
 //! Update the number of steps the user has taken today
 //! @param health_data A pointer to the health data to use
-//! @param new_steps the new value of the steps for toaday
+//! @param new_steps the new value of the steps for today
 void health_data_update_steps(HealthData *health_data, uint32_t new_steps);
 
 //! Update the number of seconds the user has slept today
@@ -77,7 +77,7 @@ int32_t *health_data_steps_get(HealthData *health_data);
 
 //! Get the current distance traveled in meters
 //! @param health_data A pointer to the health data to use
-//! @return the current distance travelled in meters
+//! @return the current distance traveled in meters
 int32_t health_data_current_distance_meters_get(HealthData *health_data);
 
 //! Get the current calories

--- a/src/fw/apps/system/health/data_private.h
+++ b/src/fw/apps/system/health/data_private.h
@@ -7,7 +7,7 @@
 
 typedef struct HealthData {
   //!< Current step / activity info
-  int32_t step_data[DAYS_PER_WEEK]; //!< Step histroy for today and the previous 6 days
+  int32_t step_data[DAYS_PER_WEEK]; //!< Step history for today and the previous 6 days
   int32_t current_distance_meters;
   int32_t current_calories;
 

--- a/src/fw/apps/system/health/detail_card.c
+++ b/src/fw/apps/system/health/detail_card.c
@@ -174,7 +174,7 @@ static void prv_draw_progress_bar_in_zone(GContext *ctx, const GRect *zone_rect,
 
   HealthProgressSegment segments[] = {
     {
-      // Left side vertical line (needed for the draw outline function to draw the verticle lines)
+      // Left side vertical line (needed for the draw outline function to draw the vertical lines)
       .type = HealthProgressSegmentType_Corner,
       .points = {
         {progress_bar_x, progress_bar_y},
@@ -184,7 +184,7 @@ static void prv_draw_progress_bar_in_zone(GContext *ctx, const GRect *zone_rect,
       },
     },
     {
-      // Right side vertical line (needed for the draw outline function to draw the verticle lines)
+      // Right side vertical line (needed for the draw outline function to draw the vertical lines)
       .type = HealthProgressSegmentType_Corner,
       .points = {
         {progress_bar_x + progress_bar_width, progress_bar_y},

--- a/src/fw/apps/system/health/hr_summary_card_segments.h
+++ b/src/fw/apps/system/health/hr_summary_card_segments.h
@@ -7,7 +7,7 @@
 #include "progress.h"
 
 //! 4 main segments + 4 real corners
-//! Each of the 4 non-corener segments get 25% of the total
+//! Each of the 4 non-corner segments get 25% of the total
 #define AMOUNT_PER_SEGMENT (HEALTH_PROGRESS_BAR_MAX_VALUE * 25 / 100)
 
 // The shape is the same, but the offsets are different

--- a/src/fw/apps/system/health/sleep_summary_card_segments.h
+++ b/src/fw/apps/system/health/sleep_summary_card_segments.h
@@ -19,7 +19,7 @@
 #define X_SHIFT (((DISP_COLS - LEGACY_2X_DISP_COLS) / 2) + PBL_IF_ROUND_ELSE(23, PBL_IF_BW_ELSE(1, 0)))
 #define Y_SHIFT (((DISP_ROWS - LEGACY_2X_DISP_ROWS) / 2) + PBL_IF_ROUND_ELSE(8, PBL_IF_BW_ELSE(3, 0)))
 
-// Used to shrink the thinkness of the bars
+// Used to shrink the thickness of the bars
 #define X_SHRINK (PBL_IF_BW_ELSE(2, 0))
 
 // These are used to shrink the shape for round

--- a/src/fw/apps/system/settings/activity_tracker.c
+++ b/src/fw/apps/system/settings/activity_tracker.c
@@ -123,7 +123,7 @@ static void prv_draw_no_activities_cell_rect(GContext *ctx, const Layer *cell_la
   const GSize text_size = graphics_text_layout_get_max_used_size(ctx, no_activities_string, font,
                                                                  box, overflow, alignment, NULL);
 
-  // We want to position the text in the center of the cell veritically,
+  // We want to position the text in the center of the cell vertically,
   // we divide the height of the cell by two and subtract half of the text size.
   // However, that just puts the TOP of a line vertically aligned.
   // So we also have to subtract half of a single line's width.

--- a/src/fw/apps/system/settings/certifications.h
+++ b/src/fw/apps/system/settings/certifications.h
@@ -62,7 +62,7 @@ typedef struct CertificationIds {
 static const RegulatoryFlags s_regulatory_flags_fallback = {
 };
 
-// Certifiation ID strings used for bigboards and such.
+// Certification ID strings used for bigboards and such.
 static const CertificationIds s_certification_ids_fallback = {
   .company_name = "ACME Inc.",
   .product_type = "Product Type",

--- a/src/fw/apps/system/settings/quick_launch.c
+++ b/src/fw/apps/system/settings/quick_launch.c
@@ -4,7 +4,7 @@
 //! This file displays the main Quick Launch menu that is found in our settings menu
 //! It allows the feature to be enabled or for an app to be set
 //! The list of apps that the user can choose from is found in settings_quick_launch_app_menu.c
-//! This file is also responsible for saving / storing the uuid of each quichlaunch app as well as
+//! This file is also responsible for saving / storing the uuid of each quicklaunch app as well as
 //! whether or not the quicklaunch app is enabled.
 
 #include "menu.h"

--- a/src/fw/apps/system/weather/forecast_list.c
+++ b/src/fw/apps/system/weather/forecast_list.c
@@ -358,7 +358,7 @@ static void prv_scroll_to(int target) {
 
 // Shared animation boilerplate: create + duration + curve + impl + optional stopped
 // handler + schedule. Every moook here runs a manual curve in its update proc, so
-// the wrapper just parameterizes the pieces that differ. (Shared region: used by
+// the wrapper just parametrizes the pieces that differ. (Shared region: used by
 // both the rect-only squash block below and the round+rect transitions further down.)
 static Animation *prv_start_anim(uint32_t dur_ms, AnimationCurve curve,
                                  const AnimationImplementation *impl,

--- a/src/fw/apps/system/weather/weather_app_layout.c
+++ b/src/fw/apps/system/weather/weather_app_layout.c
@@ -1197,7 +1197,7 @@ static void prv_draw_bottom_half_text(const WeatherAppLayout *layout, GPoint *cu
 
 #if PBL_ROUND
 // Round's day-flip disc size for the SCALER layer. Gabbro now rests a 35px
-// circle in the footer slot, so the travelling disc must land on it: it lerps
+// circle in the footer slot, so the traveling disc must land on it: it lerps
 // between the footer disc and the today disc across the icon's own width range.
 // (Emery keeps collapsing to zero -- its footer bitmap is bare, so there is
 // nothing there for the disc to become.)

--- a/src/fw/apps/watch/kickstart/kickstart.c
+++ b/src/fw/apps/watch/kickstart/kickstart.c
@@ -262,7 +262,7 @@ static void prv_draw_steps_and_shoe(GContext *ctx, const char *steps_buffer, GFo
   icon_bounds.origin.x += 23; // icon left offset
   icon_bounds.origin.y += 9; // icon top offset
 #elif EMERY_SCREEN_RES
-  icon_bounds.origin.y += (46 - icon_bounds.size.h); // icon top offest
+  icon_bounds.origin.y += (46 - icon_bounds.size.h); // icon top offset
 #elif SNOWY_SCREEN_RES
   icon_bounds.origin.x = screen_is_obstructed ? bounds.origin.x // icon_left offset
                                               : (bounds.size.w / 2) - (icon_bounds.size.w / 2);
@@ -440,7 +440,7 @@ static void prv_base_layer_update_proc(Layer *layer, GContext *ctx) {
 #if EMERY_SCREEN_RES
   bounds = grect_inset(bounds, GEdgeInsets(0, 25));
 
-  // draw deperator
+  // draw separator
   if (!screen_is_obstructed) {
     prv_draw_seperator(ctx, bounds, GColorWhite);
   }
@@ -466,7 +466,7 @@ static void prv_update_steps_buffer(KickstartData *data) {
   const int thousands = data->current_steps / 1000;
   const int hundreds = data->current_steps % 1000;
   if (thousands) {
-    /// Step count greater than 1000 with a thousands seperator
+    /// Step count greater than 1000 with a thousands separator
     snprintf(data->steps_buffer, sizeof(data->steps_buffer), i18n_get("%d,%03d", data),
              thousands, hundreds);
   } else {

--- a/src/fw/board/board_nrf5.h
+++ b/src/fw/board/board_nrf5.h
@@ -26,7 +26,7 @@
 //! Guaranteed invalid IRQ priority
 #define IRQ_PRIORITY_INVALID (1 << __NVIC_PRIO_BITS)
 
-// This is generated in order to faciliate the check within the IRQ_MAP macro below
+// This is generated in order to facilitate the check within the IRQ_MAP macro below
 enum {
 #define IRQ_DEF(num, irq) IS_VALID_IRQ__##irq,
 #if defined(CONFIG_SOC_NRF52)

--- a/src/fw/comm/ble/gap_le_advert.c
+++ b/src/fw/comm/ble/gap_le_advert.c
@@ -46,7 +46,7 @@ PBL_LOG_MODULE_DECLARE(bt, CONFIG_BT_LOG_LEVEL);
 //! To-Do's:
 //! --------
 //! - ble_discoverability/pairability.c
-//! - Use private addresses for privacy / harder tracebility.
+//! - Use private addresses for privacy / harder traceability.
 
 // Advertising interval parameters in ms, indexed by GAPLEAdvertisingInterval.
 // Values comply with Apple Accessory Design Guidelines.

--- a/src/fw/comm/ble/gap_le_scan.h
+++ b/src/fw/comm/ble/gap_le_scan.h
@@ -9,7 +9,7 @@
 
 //! @internal
 //! The number of reports that the circular reports buffer can contain.
-//! Accomodate for 4 reports with advertisment and scan reponse data:
+//! Accommodate for 4 reports with advertisement and scan response data:
 #define GAP_LE_SCAN_REPORTS_BUFFER_SIZE (4 * (sizeof(GAPLERawAdReport) + \
 (2 * GAP_LE_AD_REPORT_DATA_MAX_LENGTH)))
 
@@ -39,12 +39,12 @@ typedef struct {
 //! reports and scan responses will be buffered. A PEBBLE_BLE_SCAN_EVENT will
 //! be generated when there is data to be collected.
 //! @see gap_le_consume_scan_results
-//! @return 0 if scanning started succesfully or an error code otherwise.
+//! @return 0 if scanning started successfully or an error code otherwise.
 bool gap_le_start_scan(void);
 
 //! @internal
 //! Stops scanning.
-//! @return 0 if scanning stopped succesfully or an error code otherwise.
+//! @return 0 if scanning stopped successfully or an error code otherwise.
 bool gap_le_stop_scan(void);
 
 //! @internal
@@ -66,6 +66,6 @@ bool gap_le_consume_scan_results(uint8_t *buffer, uint16_t *size_in_out);
 void gap_le_scan_init(void);
 
 //! @internal
-//! Stops any ongoing scanning and related activitie and cleans up anything that
+//! Stops any ongoing scanning and related activities and cleans up anything that
 //! had been created by gap_le_scan_init()
 void gap_le_scan_deinit(void);

--- a/src/fw/comm/ble/gap_le_slave_discovery.h
+++ b/src/fw/comm/ble/gap_le_slave_discovery.h
@@ -4,21 +4,21 @@
 #pragma once
 
 //! @file gap_le_slave_discovery.h
-//! This sub-module is responsible for advertising explicitely for device
+//! This sub-module is responsible for advertising explicitly for device
 //! discovery purposes. The advertisement will contain the device name,
 //! transmit power level (to be able to order devices by estimated proximity),
 //! Pebble Service UUID and discoverability flags.
-//! Advertising devices will implicitely become the slave when being connected
+//! Advertising devices will implicitly become the slave when being connected
 //! to, so the "slave" part in the file name is redundant, but kept for
 //! the sake of completeness.
 
 #include <stdbool.h>
 
-//! @return True is Pebble is currently explicitely discoverable as BLE slave
+//! @return True is Pebble is currently explicitly discoverable as BLE slave
 //! or false if not.
 bool gap_le_slave_is_discoverable(void);
 
-//! @param discoverable True to make Pebble currently explicitely discoverable
+//! @param discoverable True to make Pebble currently explicitly discoverable
 //! as BLE slave. Initially, Pebble will advertise at a relatively high rate for
 //! a few seconds. After this, the rate will drop to save battery life.
 void gap_le_slave_set_discoverable(bool discoverable);

--- a/src/fw/comm/ble/gatt_client_discovery.c
+++ b/src/fw/comm/ble/gatt_client_discovery.c
@@ -470,7 +470,7 @@ unlock:
   return ret_val;
 }
 
-//! extern for gap_le_connnection.c
+//! extern for gap_le_connection.c
 //! Cleans up any state and frees the associated memory of all the things this module might have
 //! created for a given connection.
 //! bt_lock() is assumed to be taken by the caller

--- a/src/fw/comm/ble/gatt_client_subscriptions.h
+++ b/src/fw/comm/ble/gatt_client_subscriptions.h
@@ -18,7 +18,7 @@ struct GAPLEConnection;
    CONFIG_BLE_GATT_SUBSCRIPTION_DEPTH)
 
 //! Data structure representing a subscription of a specific client for
-//! noticications or indications of a GATT characteristic for a specific
+//! notifications or indications of a GATT characteristic for a specific
 //! client (GAPLEClientApp or GAPLEClientKernel). The GAPLEConnection struct has
 //! the head for each BLE connection.
 typedef struct {
@@ -67,7 +67,7 @@ bool gatt_client_subscriptions_get_notification_header(GAPLEClient client,
 //! Out: the number of bytes copied into the value_out buffer.
 //! @param client The client for which to consume the next notification.
 //! @param[out] has_more_out Cannot be NULL. Will be set to true if there are more notifications
-//! in the buffer, or to false if there are no more notifiations in the buffer.
+//! in the buffer, or to false if there are no more notifications in the buffer.
 //! @return The length of the next notification's payload, if there is any (has_more_out is true),
 //! undefined otherwise.
 uint16_t gatt_client_subscriptions_consume_notification(BLECharacteristic *characteristic_ref_out,

--- a/src/fw/comm/ble/gatt_service_changed.h
+++ b/src/fw/comm/ble/gatt_service_changed.h
@@ -29,7 +29,7 @@
 struct GAPLEConnection;
 
 //! Optionally handles GATT Value Indications, in case the ATT handle matches the GATT Service
-//! Changed characteristic value for the connection. When it matches, it will autonomously iniate
+//! Changed characteristic value for the connection. When it matches, it will autonomously initiate
 //! GATT Service Discovery to refresh the local GATT cache.
 //! @note bt_lock is assumed to be taken by the caller
 bool gatt_service_changed_client_handle_indication(struct GAPLEConnection *connection,

--- a/src/fw/comm/ble/kernel_le_client/ams/ams_util.h
+++ b/src/fw/comm/ble/kernel_le_client/ams/ams_util.h
@@ -12,8 +12,8 @@
 //! The string does not have to be zero-terminated, since the length is passed as an argument.
 //! @param number_str_length The length of the number_str buffer.
 //! @param multiplier The factor by which to multiply the parsed number.
-//! @param[out] number_out If the parsing was succesfull, the result will be stored here.
-//! @return True if the string was parsed succesfully.
+//! @param[out] number_out If the parsing was successful, the result will be stored here.
+//! @return True if the string was parsed successfully.
 //! @note The first comma or period found is treated as decimal separator. Any subsequent comma or
 //! period that is found will cause parsing to be aborted and return false.
 //! @note An empty / zero-length string still will fail to parse and return false.

--- a/src/fw/comm/ble/kernel_le_client/ancs/ancs.c
+++ b/src/fw/comm/ble/kernel_le_client/ancs/ancs.c
@@ -1072,7 +1072,7 @@ static void prv_handle_ns_notification(uint32_t length, const uint8_t *notificat
     case EventIDNotificationAdded:
       // In iOS 8.2 several apps (especially mail.app) seem to be setting the pre-existing flag
       // when they shouldn't. This appeared to be fixed in iOS 9 beta 1.
-      // By skipping the pre-existing check we will re-recieve all the notifications
+      // By skipping the pre-existing check we will re-receive all the notifications
       // we got in the past 2 hours. To get past this ignore notifications for the first couple
       // seconds after connecting
       if (s_just_connected && (nsnotification->event_flags & EventFlagPreExisting)) {
@@ -1243,7 +1243,7 @@ void ancs_handle_ios9_or_newer_detected(void) {
 }
 
 // -------------------------------------------------------------------------------------------------
-// Lifecyle
+// Lifecycle
 
 void ancs_create(void) {
   PBL_ASSERTN(s_ancs_client == NULL);

--- a/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
+++ b/src/fw/comm/ble/kernel_le_client/ppogatt/ppogatt.c
@@ -638,7 +638,7 @@ static void prv_start_reset(PPoGATTClient *client) {
 
 static void prv_handle_reset_request(PPoGATTClient *client) {
   if (client->state == StateConnectedClosedAwaitingResetCompleteSelfInitiatedReset) {
-    // Already in self-initated reset procedure, client should ignore the request from the server.
+    // Already in self-initiated reset procedure, client should ignore the request from the server.
     PBL_LOG_INFO("Ignoring reset request because local client already requested.");
     return;
   }

--- a/src/fw/comm/bt_conn_mgr.h
+++ b/src/fw/comm/bt_conn_mgr.h
@@ -53,8 +53,8 @@ void conn_mgr_set_ble_conn_response_time(
 //! Informs the BT manager module that we want to run the provided classic
 //! connection at the requested rate.
 //!
-//! Note: This currently supports two modes. ResponseTimeMax maps to BT clasic sniff mode
-//!       and anything fatser maps to BT classic active mode
+//! Note: This currently supports two modes. ResponseTimeMax maps to BT classic sniff mode
+//!       and anything faster maps to BT classic active mode
 //!
 //! @param[in] remote          The BT Classic connection requesting the rate change
 //! @param[in] consumer        The consumer requesting the rate change

--- a/src/fw/comm/internals/bt_conn_mgr.c
+++ b/src/fw/comm/internals/bt_conn_mgr.c
@@ -275,7 +275,7 @@ void conn_mgr_set_ble_conn_response_time_ext(
     uint16_t max_period_secs, ResponsivenessGrantedHandler granted_handler) {
   ConnectionMgrInfo *conn_mgr_info;
   if (!hdl || !((conn_mgr_info = hdl->conn_mgr_info))) {
-    PBL_LOG_ERR("GAP Handle not properly intialized");
+    PBL_LOG_ERR("GAP Handle not properly initialized");
     return;
   }
 

--- a/src/fw/console/reliable_transport.c
+++ b/src/fw/console/reliable_transport.c
@@ -213,7 +213,7 @@ void pulse2_reliable_transport_on_command_packet(
         }
       } else {
         PBL_LOG_DBG("Received truncated or corrupt info packet "
-                "field (expeced %" PRIu16 ", got %" PRIu16 " data bytes). "
+                "field (expected %" PRIu16 ", got %" PRIu16 " data bytes). "
                 "Discarding.", ntoh16(packet->i.length), (uint16_t)length);
         return;
       }

--- a/src/fw/drivers/flash/flash_api.c
+++ b/src/fw/drivers/flash/flash_api.c
@@ -70,7 +70,7 @@ TimerID flash_api_get_erase_poll_timer_for_test(void) {
 //! Assumes that s_flash_lock is held.
 static void prv_erase_pause(void) {
   if (s_erase.in_progress && !s_erase.suspended) {
-    // If an erase is in progress, make sure it gets at least a mininum time slice to progress.
+    // If an erase is in progress, make sure it gets at least a minimum time slice to progress.
     // If not, the successive kicking of the suspend timer could starve it out completely
     psleep(100);
     task_watchdog_bit_set(s_erase.task);

--- a/src/fw/drivers/qemu/qemu_serial.c
+++ b/src/fw/drivers/qemu/qemu_serial.c
@@ -253,7 +253,7 @@ void qemu_serial_init(void) {
 
 
 // -----------------------------------------------------------------------------------------
-// KernelMain callback triggred by our ISR handler when we detect a high water mark on our
+// KernelMain callback triggered by our ISR handler when we detect a high water mark on our
 //  receive buffer or a footer signature
 static void prv_process_receive_buffer(void *context) {
   uint32_t msg_bytes;

--- a/src/fw/drivers/qemu/qemu_serial_util.c
+++ b/src/fw/drivers/qemu/qemu_serial_util.c
@@ -34,7 +34,7 @@ void qemu_serial_private_init_state(QemuSerialGlobals *state)
 
 
 // -----------------------------------------------------------------------------------------
-// Helper function triggred by our ISR handler when we detect a high water mark on our receive
+// Helper function triggered by our ISR handler when we detect a high water mark on our receive
 // buffer or a footer signature.
 //
 // Parses the ISR's circular buffer and collects assembled message into a message buffer. If

--- a/src/fw/drivers/rtc/nrf5.c
+++ b/src/fw/drivers/rtc/nrf5.c
@@ -236,7 +236,7 @@ const char *time_t_to_string(char *buffer, time_t t) {
 }
 
 //! We attempt to save registers by placing both the timezone abbreviation
-//! timezone index and the daylight_savingtime into the same register set
+//! timezone index and the daylight_savings_time into the same register set
 void rtc_set_timezone(TimezoneInfo *tzinfo) {
   uint32_t *raw = (uint32_t*)tzinfo;
   _Static_assert(sizeof(TimezoneInfo) <= 5 * sizeof(uint32_t),

--- a/src/fw/drivers/rtc/sf32lb.c
+++ b/src/fw/drivers/rtc/sf32lb.c
@@ -144,7 +144,7 @@ static void prv_rtc_cal_timer_cb(void* data) {
     delta = rtc_b - s_rtc_a;
     // Calculate accurate rtc_b
     rtc_cal = delta * ref_cycle / s_rtc_cycle_count_init + s_rtc_a;
-    // Detla time of accurrate rtc_b and current rtc_b
+    // Delta time of accurate rtc_b and current rtc_b
     delta = rtc_cal - rtc_b;
 
     // Accumulate error

--- a/src/fw/drivers/task_watchdog.c
+++ b/src/fw/drivers/task_watchdog.c
@@ -354,7 +354,7 @@ static void prv_task_watchdog_feed(void) {
     s_ticks_since_successful_feed = 0;
 
     if (s_last_warning_message_tick_time) {
-      // We logged a warning message, clear this state as we apparently recoved.
+      // We logged a warning message, clear this state as we apparently recovered.
 
       reboot_reason_clear();
       // Trigger our lower priority interrupt to fire. If it fires when reboot reason is not RebootReasonCode_Watchdog,

--- a/src/fw/kernel/core_dump_private.h
+++ b/src/fw/kernel/core_dump_private.h
@@ -72,7 +72,7 @@ typedef struct {
   uint32_t    unformatted;          // set of 1 bit flags, bit n set means region n is still unformatted
 } CoreDumpFlashHeader;
 
-// This comes first in the front of each possibe flash region. It is NOT returned as part of the core dump
+// This comes first in the front of each possible flash region. It is NOT returned as part of the core dump
 // image.
 typedef struct {
   uint32_t    magic;                // set to CORE_DUMP_FLASH_HDR_MAGIC

--- a/src/fw/kernel/events.c
+++ b/src/fw/kernel/events.c
@@ -93,7 +93,7 @@ static void prv_queue_dump(struct pbl_msgq *queue) {
 #endif
 
 void events_init(void) {
-  // This assert is to make sure we don't accidentally bloat our PebbleEvent unecessarily. If you hit this
+  // This assert is to make sure we don't accidentally bloat our PebbleEvent unnecessarily. If you hit this
   // assert and you have a good reason for making the event bigger, feel free to relax the restriction.
   //PBL_LOG_DBG("PebbleEvent size is %u", sizeof(PebbleEvent));
   // FIXME:

--- a/src/fw/kernel/memory_layout.c
+++ b/src/fw/kernel/memory_layout.c
@@ -209,7 +209,7 @@ void memory_layout_setup_mpu(void) {
 #endif
 
   // RAM parts
-  // The background memory map only allows privileged access. We need to add aditional regions to
+  // The background memory map only allows privileged access. We need to add additional regions to
   // enable access to unprivileged code.
 
   mpu_set_region(&s_readonly_bss_region);

--- a/src/fw/kernel/pebble_tasks.c
+++ b/src/fw/kernel/pebble_tasks.c
@@ -329,7 +329,7 @@ void pbl_thread_stack_overflow(struct pbl_thread *thread, const char *name) {
   PebbleTask task = pebble_task_get_task_for_thread(thread);
 
   // If the task is application or worker, ignore this hook. We have a memory protection region
-  // setup at the bottom of those stacks and the code that catches MPU violiations to that
+  // setup at the bottom of those stacks and the code that catches MPU violations to that
   // area in fault_handling.c has the logic to safely kill those user tasks without forcing
   // a reboot.
   if ((task != PebbleTask_App) && (task != PebbleTask_Worker)) {

--- a/src/fw/kernel/remote_input.c
+++ b/src/fw/kernel/remote_input.c
@@ -221,7 +221,7 @@ RemoteInputResult remote_input_button_set(uint8_t buttons) {
 // keeps the newest 3 samples for its velocity estimate, so a handful is plenty.
 #define REMOTE_INPUT_SWIPE_STEPS 5
 
-// Fraction of the travelled axis the finger covers, as numerator/denominator (60%). Must clear the
+// Fraction of the traveled axis the finger covers, as numerator/denominator (60%). Must clear the
 // recognizer's minimum length on every board.
 #define REMOTE_INPUT_SWIPE_TRAVEL_NUM 3
 #define REMOTE_INPUT_SWIPE_TRAVEL_DEN 5

--- a/src/fw/kernel/reset.c
+++ b/src/fw/kernel/reset.c
@@ -40,7 +40,7 @@ NORETURN system_reset(void) {
     reboot_reason_set_restarted_safely();
   }
 
-  // If a software failure occcured, do a core dump before resetting
+  // If a software failure occurred, do a core dump before resetting
   if (failure_occurred) {
     core_dump_reset(false /* don't force overwrite */);
   } else {

--- a/src/fw/kernel/system_message.h
+++ b/src/fw/kernel/system_message.h
@@ -13,7 +13,7 @@ typedef enum SystemMessageType {
   SysMsgFirmwareComplete = 0x02,
   SysMsgFirmwareFail = 0x03,
   SysMsgFirmwareUpToDate = 0x04,
-  // SysMsgFirmarewOutOfDate = 0x05, DEPRECATED
+  // SysMsgFirmWareOutOfDate = 0x05, DEPRECATED
   SysMsgReconnectRequestStop = 0x06,
   SysMsgReconnectRequestStart = 0x07,
   SysMsgMAPRetry = 0x08,  // MAP is no longer used

--- a/src/fw/kernel/task_timer.h
+++ b/src/fw/kernel/task_timer.h
@@ -49,7 +49,7 @@ TaskTimerID task_timer_create(TaskTimerManager *manager);
 //! @param[in] cb pointer to the user's callback procedure
 //! @param[in] cb_data reference data for the callback
 //! @param[in] flags one or more TIMER_START_FLAG_.* flags
-//! @return True if succesful, false if timer was not rescheduled. Note that it will never return
+//! @return True if successful, false if timer was not rescheduled. Note that it will never return
 //!     false if none of the FAIL_IF_* flags are set.
 bool task_timer_start(TaskTimerManager *manager, TaskTimerID timer, uint32_t timeout_ms,
                       TaskTimerCallback cb, void *cb_data, uint32_t flags);

--- a/src/fw/kernel/task_timer_manager.h
+++ b/src/fw/kernel/task_timer_manager.h
@@ -31,8 +31,8 @@ typedef struct TaskTimerManager {
 
 //! Initialize a passed in manager object.
 //! @param[in] manager The manager object to initialize
-//! @param[in] semaphore a sempahore the TaskTimerManager should give if the next expiring timer
-//!                      has changed. The task event loop should block on this same semphore to
+//! @param[in] semaphore a semaphore the TaskTimerManager should give if the next expiring timer
+//!                      has changed. The task event loop should block on this same semaphore to
 //!                      handle timer updates in a timely fashion.
 void task_timer_manager_init(TaskTimerManager *manager, struct pbl_sem *semaphore);
 
@@ -41,7 +41,7 @@ void task_timer_manager_init(TaskTimerManager *manager, struct pbl_sem *semaphor
 //!         returns PBL_TICK_FOREVER.
 pbl_tick_t task_timer_manager_execute_expired_timers(TaskTimerManager *manager);
 
-//! Debugging interface to help understand why the task_timer exuction is stuck and what
+//! Debugging interface to help understand why the task_timer execution is stuck and what
 //! its stuck on.
 //! @return A pointer to the current callback that's running, NULL if no callback
 //!         is currently running.

--- a/src/fw/kernel/util/factory_reset.c
+++ b/src/fw/kernel/util/factory_reset.c
@@ -119,7 +119,7 @@ void factory_reset_fast(void *unused) {
 }
 #endif // !defined(CONFIG_RECOVERY_FW)
 
-//! Used by the mfg flow to kick us out the MFG firmware and into the conumer PRF that's stored
+//! Used by the mfg flow to kick us out the MFG firmware and into the consumer PRF that's stored
 //! on the external flash.
 void command_enter_consumer_mode(void) {
   boot_bit_set(BOOT_BIT_FORCE_PRF);

--- a/src/fw/linker/sections/kernel-ram.ld
+++ b/src/fw/linker/sections/kernel-ram.ld
@@ -4,7 +4,7 @@
  */
 
     .kernel_data : ALIGN(32) {
-        __data_start = .; /* This is used by the startup in order to initialize the .data secion */
+        __data_start = .; /* This is used by the startup in order to initialize the .data section */
 
         *(.data)
         *(.data.*)
@@ -15,7 +15,7 @@
     __data_load_start = LOADADDR(.kernel_data);
 
     .kernel_ro_bss (NOLOAD) : {
-        __bss_start = .; /* This is used by the startup in order to initialize the .bss secion */
+        __bss_start = .; /* This is used by the startup in order to initialize the .bss section */
 
         . = ALIGN(__unpriv_ro_bss_size__);
         __unpriv_ro_bss_start__ = .;

--- a/src/fw/mfg/mfg_serials.h
+++ b/src/fw/mfg/mfg_serials.h
@@ -37,7 +37,7 @@ typedef enum MfgSerialsResult {
 //! zero. Must be 13.
 //! @param[out] out_index Will contain the OTP index that was used to write the
 //! serial number, if the return value was OtpWriteSuccess.
-//! @return OtpWriteSuccess if the write was successfull or
+//! @return OtpWriteSuccess if the write was successful or
 //! MfgSerialsResultFailNoMoreSpace if all 3 slots were taken already, or
 //! MfgSerialsResultFailIncorrectLength if the serial_size was not 13.
 MfgSerialsResult mfg_write_serial_number(const char* serial, size_t serial_size, uint8_t *out_index);

--- a/src/fw/popups/notifications/notification_window.c
+++ b/src/fw/popups/notifications/notification_window.c
@@ -684,7 +684,7 @@ static bool prv_should_show_action_in_action_menu(NotificationWindowData *data,
     } else {
       // If we are in the notifications app, only show non ANCS actions. Pre iOS9 we can't really
       // know if the notification is still in the notification center or not, so we play it safe
-      // and only show non ACNS actions. Once iOS9 is more widespread we can look at updating this
+      // and only show non ANCS actions. Once iOS9 is more widespread we can look at updating this
       return !timeline_item_action_is_ancs(action);
     }
   } else { // Android
@@ -1435,7 +1435,7 @@ void notification_window_add_notification_by_id(Uuid *id) {
   prv_notification_window_add_notification(id, NotificationMobile);
 }
 
-//! The animate mode slides the notificaiton in from the top as if it was a new notification.
+//! The animate mode slides the notification in from the top as if it was a new notification.
 void notification_window_focus_notification(Uuid *id, bool animated) {
   NotificationWindowData *data = &s_notification_window_data;
 
@@ -1480,7 +1480,7 @@ void notification_window_service_init(void) {
 
 
 //////////////////
-// Event Handers
+// Event Handlers
 //////////////////
 
 static void prv_handle_action_result(PebbleSysNotificationActionResult *action_result) {
@@ -1608,7 +1608,7 @@ static void prv_handle_notification_added_common(Uuid *id, NotificationType type
       const bool should_animate = !do_not_disturb_is_active();
       notification_window_focus_notification(id, should_animate);
     } else {
-      // If we are inserting into the middle of this list, just reaload the swap layer so the
+      // If we are inserting into the middle of this list, just reload the swap layer so the
       // number of notifications displayed is correct
       prv_reload_swap_layer(data);
     }

--- a/src/fw/popups/notifications/notifications_presented_list.h
+++ b/src/fw/popups/notifications/notifications_presented_list.h
@@ -59,7 +59,7 @@ void notifications_presented_list_init(void);
 
 typedef void (*NotificationListEachCallback)(Uuid *id, NotificationType type, void *cb_data);
 
-//! Executes the specified callback for each notificaiton in the presented list
+//! Executes the specified callback for each notification in the presented list
 //! @param callback If null this function is a no-op
 //! @param cb_data Context passed to the callback
 void notifications_presented_list_each(NotificationListEachCallback callback, void *cb_data);

--- a/src/fw/popups/phone_ui.c
+++ b/src/fw/popups/phone_ui.c
@@ -777,7 +777,7 @@ static const char *prv_get_app_id(const char *number, PhoneCallSource source) {
   return NULL;
 }
 
-// Checks for the existance of a call reply action in the notif pref db and loads it into
+// Checks for the existence of a call reply action in the notif pref db and loads it into
 // a timeline item
 static bool prv_load_sms_reply_action(const char *number, PhoneCallSource source) {
   const char *app_id = prv_get_app_id(number, source);
@@ -953,7 +953,7 @@ static void prv_window_pop(void) {
   // The window_stack_remove() call should run the unload handler (which deinits the ui),
   // but in the rare case that the window never loaded (i.e. a higher priority modal was up)
   // then we could leak the phone_ui data and assert on the next phone call.
-  // Deinit again to cover this case (will be a no-op) if the window was alredy deinited.
+  // Deinit again to cover this case (will be a no-op) if the window was already deinited.
   prv_phone_ui_deinit();
 }
 

--- a/src/fw/popups/wakeup_ui.h
+++ b/src/fw/popups/wakeup_ui.h
@@ -7,7 +7,7 @@
 
 #include "process_management/app_install_types.h"
 
-//! This function creates a popup window displaying a missed wakeup events notificatoin
+//! This function creates a popup window displaying a missed wakeup events notification
 //! along with the application names that were missed
 //! Note: missed_apps_ids is free'd by this function
 //! @param missed_apps_count number of app names to display

--- a/src/fw/process_management/app_manager.c
+++ b/src/fw/process_management/app_manager.c
@@ -514,7 +514,7 @@ static void prv_app_show_crash_ui(AppInstallId install_id) {
 //! Switch to the app stored in the s_next_app global. The gracefully flag tells us whether to attempt a graceful
 //! exit or not.
 //!
-//! For a graceful exit, if the app has not alreeady finished it's de-init, we post a de_init event to the app, set
+//! For a graceful exit, if the app has not already finished it's de-init, we post a de_init event to the app, set
 //! a 3 second timer, and return immediately to the caller. If/when the app finally finishes deinit, it will post a
 //! PEBBLE_PROCESS_KILL_EVENT (graceful=true), which results in this method being again with graceful=true. We will then
 //! see that the de_init already finished in that second invocation.

--- a/src/fw/process_management/app_menu_data_source.h
+++ b/src/fw/process_management/app_menu_data_source.h
@@ -79,12 +79,12 @@ typedef struct AppMenuDataSource {
   bool is_list_loaded;
 } AppMenuDataSource;
 
-//! Initalize the AppMenuDataSource
+//! Initialize the AppMenuDataSource
 void app_menu_data_source_init(AppMenuDataSource *source,
                                const AppMenuDataSourceCallbacks *handlers,
                                void *callback_context);
 
-//! Deinitalize the AppMenuDataSource
+//! Deinitialize the AppMenuDataSource
 void app_menu_data_source_deinit(AppMenuDataSource *source);
 
 //! Will load the icons for each `AppMenuNode`. Will automatically be unloaded when

--- a/src/fw/process_management/app_run_state.c
+++ b/src/fw/process_management/app_run_state.c
@@ -77,7 +77,7 @@ void app_run_state_command(CommSession *session, AppRunStateCommand cmd, const U
       // Determine the running application
       uuid = &app_manager_get_current_app_md()->uuid;
       if (session != NULL) {
-        // We check the session here as to be backwards compatibile with the 0x31 endpoint and
+        // We check the session here as to be backwards compatible with the 0x31 endpoint and
         // to avoid repeating code, the endpoint makes use of this function, but since it does
         // not have an active session (it's session is NULL), it will fall to the else case.
         AppRunState *app_run_state = kernel_malloc_check(sizeof(AppRunState));

--- a/src/fw/process_management/launcher_app_message.h
+++ b/src/fw/process_management/launcher_app_message.h
@@ -8,6 +8,6 @@
 //! Launcher App Message is deprecated and on Android >= 2.3 and other devices that pass the
 //! support flags for the AppRunState endpoint will use that endpoint (0x34) instead.  That
 //! endpoint should be used for sending messages on start/stop status of applications and
-//! sending/recieving application states.  The LauncherAppMessage endpoint is kept for
-//! backwards compability with older mobile applications.
+//! sending/receiving application states.  The LauncherAppMessage endpoint is kept for
+//! backwards compatibility with older mobile applications.
 void launcher_app_message_send_app_state_deprecated(const Uuid *uuid, bool running);

--- a/src/fw/process_management/pebble_process_md.h
+++ b/src/fw/process_management/pebble_process_md.h
@@ -51,7 +51,7 @@ typedef enum {
 //! This structure is used internally to describe the process. This struct here is actually a polymorphic base
 //! class, and can be casted to either \ref PebbleProcessMdSystem or \ref PebbleProcessMdFlash depending on the value
 //! of @c process_storage. Clients shouldn't do this casting themselves though, and instead should use the
-//! process_metadata_get_* functions to safely retreive values from this struct.
+//! process_metadata_get_* functions to safely retrieve values from this struct.
 typedef struct PebbleProcessMd {
   Uuid uuid;
 

--- a/src/fw/process_management/process_manager.c
+++ b/src/fw/process_management/process_manager.c
@@ -375,7 +375,7 @@ void process_manager_launch_process(const ProcessLaunchConfig *config) {
 //! this time it will see the safe to kill is set and return true
 //!
 //! If the task does not exit by itself before the timer expires, then the timer will post another KILL event
-//! with graceful set to false. This will result in this method being alled again with gracefully = false. When
+//! with graceful set to false. This will result in this method being called again with gracefully = false. When
 //! we see this, we just try and make sure the app is not stuck in privilege code. If it's not, we return true
 //! and allow the caller to kill the task.
 //!
@@ -525,7 +525,7 @@ void process_manager_process_setup(PebbleTask task) {
 }
 
 // ---------------------------------------------------------------------------------------------
-//! Kills the process, giving it no chance to clean things up or exit gracefully. The proces must already be in a
+//! Kills the process, giving it no chance to clean things up or exit gracefully. The process must already be in a
 //! state where it's safe to exit, so the caller must call process_manager_make_process_safe_to_kill() first and only
 //! call this method if process_manager_make_process_safe_to_kill() returns true;
 void process_manager_process_cleanup(PebbleTask task) {
@@ -536,7 +536,7 @@ void process_manager_process_cleanup(PebbleTask task) {
 
   PBL_LOG_DBG("%s is getting cleaned up", pebble_task_get_name(task));
 
-  // Shutdown services that may be running. Do this before we destory the task and clear the queue
+  // Shutdown services that may be running. Do this before we destroy the task and clear the queue
   // just in case other services are still in flight.
   accel_service_cleanup_task_session(task);
   animation_service_cleanup(task);

--- a/src/fw/process_management/process_manager.h
+++ b/src/fw/process_management/process_manager.h
@@ -98,7 +98,7 @@ void process_manager_init(void);
 void process_manager_init_context(ProcessContext* context,
                                   const PebbleProcessMd *app_md, const void *args);
 
-//! Checks if the app refered to by the given AppInstallId is SDK compatible
+//! Checks if the app referred to by the given AppInstallId is SDK compatible
 //! Returns true if it is compatible, false otherwise
 //! Shows an error dialog if it is not compatible
 bool process_manager_check_SDK_compatible(const AppInstallId id);

--- a/src/fw/process_management/sdk_version.h
+++ b/src/fw/process_management/sdk_version.h
@@ -5,7 +5,7 @@
 #include "pebble_process_info.h"
 #include <stdbool.h>
 
-//! Inspects the app metatdata whether the app supports app messaging.
+//! Inspects the app metadata whether the app supports app messaging.
 //! Only if this returns true, the .messaging_info field of PebbleAppHandlers can be used.
 //! @return true if the app is built with an SDK that supports app messaging or not
 bool sdk_version_is_app_messaging_supported(const Version * const sdk_version);

--- a/src/fw/resource/resource_storage_impl.h
+++ b/src/fw/resource/resource_storage_impl.h
@@ -10,7 +10,7 @@
 
 //! @file resource_storage_impl.h
 //!
-//! Shared functionality that all the different ResourceStoreImplemention's need.
+//! Shared functionality that all the different ResourceStoreImplementation's need.
 
 // TODO PBL-21382: Abstract these details out of the resource storage implementation.
 

--- a/src/fw/syscall/syscall.h
+++ b/src/fw/syscall/syscall.h
@@ -287,7 +287,7 @@ void sys_process_get_wakeup_info(WakeupInfo *info);
 const PebbleProcessMd* sys_process_manager_get_current_process_md(void);
 
 //! Copy UUID for the current process.
-//! @return True if the UUID was succesfully copied.
+//! @return True if the UUID was successfully copied.
 bool sys_process_manager_get_current_process_uuid(Uuid *uuid_out);
 
 //! Get the AppInstallId for the current process

--- a/src/fw/util/dict.h
+++ b/src/fw/util/dict.h
@@ -309,7 +309,7 @@ Tuple * dict_read_first(DictionaryIterator *iter);
 //! See also \ref Tuple, with is the header of a serialized key/value pair.
 typedef struct Tuplet {
   //! The type of the Tuplet. This determines which of the struct fields in the
-  //! anonymomous union are valid.
+  //! anonymous union are valid.
   TupleType type;
   //! The key.
   uint32_t key;
@@ -445,7 +445,7 @@ typedef void (*DictionaryKeyUpdatedCallback)(const uint32_t key, const Tuple *ne
 
 //! Merges entries from another "source" dictionary into a "destination" dictionary.
 //! All Tuples from the source are written into the destination dictionary, while
-//! updating the exsting Tuples with matching keys.
+//! updating the existing Tuples with matching keys.
 //! @param dest The destination dictionary to update
 //! @param [in,out] dest_max_size_in_out In: the maximum size of buffer backing `dest`. Out: the final size of the updated dictionary.
 //! @param source The source dictionary of which its Tuples will be used to update dest.

--- a/src/fw/util/pstring.h
+++ b/src/fw/util/pstring.h
@@ -43,7 +43,7 @@ void pstring_pstring16_to_string(const PascalString16 *pstring, char *string_out
 //!                    Must be at least size (string + 1).
 void pstring_string_to_pstring16(char string[], PascalString16 *pstring_out);
 
-//! Checks if 2 pstrings are euqual and returns true if so.
+//! Checks if 2 pstrings are equal and returns true if so.
 //! @note returns false if either / both pstrings are NULL
 bool pstring_equal(const PascalString16 *ps1, const PascalString16 *ps2);
 

--- a/src/fw/util/shared_circular_buffer.c
+++ b/src/fw/util/shared_circular_buffer.c
@@ -11,7 +11,7 @@
 
 
 // -------------------------------------------------------------------------------------------------
-// Returns the amount of data available for the given clien
+// Returns the amount of data available for the given client
 static uint32_t prv_get_data_length(const SharedCircularBuffer* buffer, SharedCircularBufferClient *client) {
 
   uint32_t  len;
@@ -249,7 +249,7 @@ void subsampled_shared_circular_buffer_client_set_ratio(
   PBL_ASSERTN(numerator > 0 && denominator >= numerator);
   if (client->numerator != numerator || client->denominator != denominator) {
     // The subsampling algorithm does not need the subsampling ratio to
-    // be normalied to reduced form.
+    // be normalized to reduced form.
     client->numerator = numerator;
     client->denominator = denominator;
     // Initialize the state so that the next item in the buffer is copied,

--- a/src/fw/util/shared_circular_buffer.h
+++ b/src/fw/util/shared_circular_buffer.h
@@ -78,10 +78,10 @@ void shared_circular_buffer_remove_client(SharedCircularBuffer* buffer, SharedCi
 //!
 //! If the circular buffer wraps in the middle of the requested data, this function call will return true but will
 //! provide fewer bytes that requested. When this happens, the length_out parameter will be set to a value smaller
-//! than length. A second read call can be made with the remaining smaller length to retreive the rest.
+//! than length. A second read call can be made with the remaining smaller length to retrieve the rest.
 //!
 //! The reason this read doesn't consume is to avoid having to copy out the data. The data_out pointer should be
-//! stable until you explicitely ask for it to be consumed with circular_buffer_consume.
+//! stable until you explicitly ask for it to be consumed with circular_buffer_consume.
 //!
 //! @param buffer The buffer to read from
 //! @param client pointer to the client struct originally passed to circular_buffer_add_client


### PR DESCRIPTION
Took a pass with cSpell, but sending them in a few batches instead of a big "treewide" one so it's still reviewable. I'll do a last treewide one next.