### PR TITLE
nix: refresh dependencies on shell entry

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -139,13 +139,21 @@
               if [ ! -d "$VENV_DIR" ]; then
                 echo "Creating virtual environment..."
                 python -m venv "$VENV_DIR"
-                source "$VENV_DIR/bin/activate"
-                if [ -f "requirements.txt" ]; then
+              fi
+              source "$VENV_DIR/bin/activate"
+
+              # Refresh existing environments when project dependencies change.
+              if [ -f "requirements.txt" ]; then
+                requirements_hash=$(${pkgs.coreutils}/bin/sha256sum requirements.txt)
+                requirements_stamp="$VENV_DIR/.requirements.sha256"
+                if [ "$requirements_hash" != "$(cat "$requirements_stamp" 2>/dev/null)" ]; then
                   echo "Installing Python dependencies..."
-                  pip install -r requirements.txt
+                  if python -m pip install -r requirements.txt; then
+                    printf '%s\n' "$requirements_hash" > "$requirements_stamp"
+                  else
+                    return 1
+                  fi
                 fi
-              else
-                source "$VENV_DIR/bin/activate"
               fi
               
               echo "Python virtual environment activated."


### PR DESCRIPTION
I am not back until next week but I wanted to check out the new commits (cuz I was thinking WTF)

Install requirements.txt whenever the development shell starts so existing virtual environments pick up dependency changes. Use python -m pip to install through the active interpreter.