### PR TITLE
include/bluetooth: fix BLEGATTErrorInsufficientEncryptionKeySize name

### DIFF
--- a/include/bluetooth/bluetooth_types.h
+++ b/include/bluetooth/bluetooth_types.h
@@ -96,7 +96,7 @@ typedef enum {
   BLEGATTErrorPrepareQueueFull = 0x09,
   BLEGATTErrorAttributeNotFound = 0x0A,
   BLEGATTErrorAttributeNotLong = 0x0B,
-  BLEGATTErrorInsufficientEncrpytionKeySize = 0x0C,
+  BLEGATTErrorInsufficientEncryptionKeySize = 0x0C,
   BLEGATTErrorInvalidAttributeValueLength = 0x0D,
   BLEGATTErrorUnlikelyError = 0x0E,
   BLEGATTErrorInsufficientEncryption = 0x0F,


### PR DESCRIPTION
Separated this out from the other typos, since this potentially is a breaking change. I couldn't find anything directly referencing the value though.