### PR TITLE
treewide: fix GattClientOp Response typo

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -79,15 +79,15 @@ typedef struct GattClientOpResponseHdr {
   void *context;
 } GattClientOpResponseHdr;
 
-typedef struct GattClientOpReadReponse {
+typedef struct GattClientOpReadResponse {
   GattClientOpResponseHdr hdr;
   uint16_t value_length;
   uint8_t *value;
-} GattClientOpReadReponse;
+} GattClientOpReadResponse;
 
-typedef struct GattClientOpWriteReponse {
+typedef struct GattClientOpWriteResponse {
   GattClientOpResponseHdr hdr;
-} GattClientOpWriteReponse;
+} GattClientOpWriteResponse;
 
 // -- Gatt Data Structures
 

--- a/src/bluetooth-fw/nimble/gatt_client_operations.c
+++ b/src/bluetooth-fw/nimble/gatt_client_operations.c
@@ -32,7 +32,7 @@ static int prv_gatt_write_event_cb(uint16_t conn_handle, const struct ble_gatt_e
               error->att_handle, error->status);
   }
 
-  GattClientOpWriteReponse resp = {
+  GattClientOpWriteResponse resp = {
       .hdr = {
           .type = GattClientOpResponseWrite,
           .error_code = prv_gatt_error_code(error->status),
@@ -49,7 +49,7 @@ static int prv_gatt_read_event_cb(uint16_t conn_handle, const struct ble_gatt_er
               error->att_handle, error->status);
   }
 
-  GattClientOpReadReponse resp = {
+  GattClientOpReadResponse resp = {
       .hdr =
           {
               .type = GattClientOpResponseRead,

--- a/src/fw/comm/ble/gatt_client_operations.c
+++ b/src/fw/comm/ble/gatt_client_operations.c
@@ -77,7 +77,7 @@ static void prv_internal_write_cccd_response_cb(GattClientOpResponseHdr *event) 
   gatt_client_subscriptions_handle_write_cccd_response(cccd, error);
 }
 
-static BLEGATTError prv_handle_response(const GattClientOpReadReponse *resp,
+static BLEGATTError prv_handle_response(const GattClientOpReadResponse *resp,
                                         const GattClientEventContext *data,
                                         uint16_t *gatt_value_length) {
   uint16_t val_len = resp->value_length;
@@ -140,7 +140,7 @@ void bt_driver_cb_gatt_client_operations_handle_response(GattClientOpResponseHdr
     } else {
       switch (event->type) {
         case GattClientOpResponseRead: {
-          const GattClientOpReadReponse *resp = (GattClientOpReadReponse *)event;
+          const GattClientOpReadResponse *resp = (GattClientOpReadResponse *)event;
           PBL_ASSERTN(data->subtype == PebbleBLEGATTClientEventTypeCharacteristicRead ||
                       data->subtype == PebbleBLEGATTClientEventTypeDescriptorRead);
             gatt_err_code = prv_handle_response(resp, data, &gatt_value_length);


### PR DESCRIPTION
Separated this out from the other typos, since this potentially is a breaking change. I used "treewide", but I guess this could be split into separate commits with different scopes if that's better