### PR TITLE
src/fw/kernel: fix PebbleAppCacheEventNum typo

### DIFF
--- a/src/fw/kernel/events.h
+++ b/src/fw/kernel/events.h
@@ -708,7 +708,7 @@ _Static_assert(sizeof(PebbleTimelinePeekEvent) == 8,
 typedef enum PebbleAppCacheEventType {
   PebbleAppCacheEvent_Removed,
 
-  PebbleAppCacehEventNum
+  PebbleAppCacheEventNum
 } PebbleAppCacheEventType;
 
 typedef struct PACKED PebbleAppCacheEvent {


### PR DESCRIPTION
Only the other enum value seems to be refrenced, but fixed this one anyway.