### PR TITLE
Fix app crash on the native kernel and pulse console/dehasher bugs

### DIFF
--- a/docs/architecture/kernel_internals.md
+++ b/docs/architecture/kernel_internals.md
@@ -85,6 +85,10 @@ copies the exception frame onto the thread's dedicated syscall stack when
 pointer and stacked return slot to `pbl_kernel_syscall_entered()`, which is
 what the firmware's syscall island expects.
 
+The port defines `pbl_cur` in `.kernel_unpriv_ro_bss`, the firmware's
+unprivileged-readable kernel data, because `pbl_thread_current()` and
+`pebble_task_get_current()` run unprivileged inside apps.
+
 ## POSIX arch and tests
 
 Each kernel thread is a pthread; exactly one runs at a time, and control

--- a/kernel/arch/arch.h
+++ b/kernel/arch/arch.h
@@ -11,6 +11,10 @@
 
 //! What the portable kernel needs from an architecture.
 
+//! The running thread. The arch defines it so it can live where unprivileged
+//! threads may read it: pbl_thread_current() runs without privilege.
+extern struct pbl_thread *pbl_cur;
+
 void arch_init(void);
 
 //! Builds the initial context so that the first switch to @p t runs

--- a/kernel/arch/arm/arch.c
+++ b/kernel/arch/arm/arch.c
@@ -51,6 +51,8 @@
 #define SHPR_PENDSV 10
 #define SHPR_SYSTICK 11
 
+struct pbl_thread *pbl_cur __attribute__((section(".kernel_unpriv_ro_bss")));
+
 //! Saved context, lowest address first. Matches the layout core dump tooling
 //! learned from the FreeRTOS port so the canonical register walk is unchanged.
 struct saved_context {

--- a/kernel/arch/posix/arch.c
+++ b/kernel/arch/posix/arch.c
@@ -16,6 +16,8 @@
 // kernel considers running. Switches hand s_cpu over explicitly, so the
 // scheduling is as deterministic as on the target.
 
+struct pbl_thread *pbl_cur;
+
 static pthread_mutex_t s_cpu = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t s_stop_cond = PTHREAD_COND_INITIALIZER;
 static bool s_switch_pending;

--- a/kernel/kernel.h
+++ b/kernel/kernel.h
@@ -16,8 +16,6 @@
 //! Internal interface between the objects, the scheduler and the arch code.
 //! Everything here is called with interrupts locked unless noted.
 
-extern struct pbl_thread *pbl_cur;
-
 #define KERNEL_ASSERT(x) OS_ASSERT(x)
 
 //! Woken by resume after being suspended while blocked.

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -10,7 +10,6 @@
 #define NUM_PRIO CONFIG_KERNEL_NUM_PRIORITIES
 _Static_assert(NUM_PRIO <= 32, "the ready bitmap is 32 bits wide");
 
-struct pbl_thread *pbl_cur;
 struct pbl_thread *pbl_all_threads;
 
 static struct pbl_thread *s_ready_head[NUM_PRIO];

--- a/src/fw/console/dbgserial_input.c
+++ b/src/fw/console/dbgserial_input.c
@@ -11,8 +11,8 @@
 static DbgSerialCharacterCallback s_character_callback;
 
 //! We DMA into this buffer as a circular buffer
-#define DMA_BUFFER_LENGTH (200)
-static uint8_t s_dma_buffer[DMA_BUFFER_LENGTH] __attribute__((aligned(4)));
+#define DMA_BUFFER_LENGTH (256)
+static uint8_t s_dma_buffer[DMA_BUFFER_LENGTH] __attribute__((aligned(32)));
 static bool s_dma_enabled = false;
 
 static bool prv_uart_irq_handler(UARTDevice *dev, uint8_t data, const UARTRXErrorFlags *err_flags) {

--- a/src/fw/drivers/uart/sf32lb.c
+++ b/src/fw/drivers/uart/sf32lb.c
@@ -4,6 +4,7 @@
 #include <pbl/drivers/uart/sf32lb.h>
 
 #include <pbl/drivers/uart.h>
+#include "pbl/mcu/cache.h"
 #include "pbl/soc/sf32lb/sleep.h"
 #include "system/passert.h"
 
@@ -174,6 +175,7 @@ void uart_irq_handler(UARTDevice *dev) {
         (__HAL_UART_GET_IT_SOURCE(&dev->state->huart, UART_IT_IDLE) != RESET)) {
       // process bytes from the DMA buffer
       const uint32_t dma_length = dev->state->rx_dma_length;
+      dcache_invalidate(dev->state->rx_dma_buffer, dma_length);
       const uint32_t recv_total_index = dma_length - __HAL_DMA_GET_COUNTER(&dev->state->hdma);
       int32_t recv_len = recv_total_index - dev->state->rx_dma_index;
       if (recv_len < 0) {
@@ -234,6 +236,7 @@ void HAL_UART_RxHalfCpltCallback(UART_HandleTypeDef *huart) {
   UARTDeviceState *state = container_of(huart, UARTDeviceState, huart);
   UARTDevice *dev = (UARTDevice *)state->dev;
 
+  dcache_invalidate(state->rx_dma_buffer, state->rx_dma_length);
   recv_total_index = state->rx_dma_length - __HAL_DMA_GET_COUNTER(&state->hdma);
   if (recv_total_index < state->rx_dma_index)
     recv_len = state->rx_dma_length + recv_total_index - state->rx_dma_index;
@@ -266,13 +269,12 @@ void uart_dma_irq_handler(UARTDevice *dev) {
   HAL_DMA_IRQHandler(&dev->state->hdma);
 }
 
-// FIXME(SF32LB52): the IRQ paths above read `rx_dma_buffer[idx]` straight
-// without invalidating D-cache, so the CPU could pick up stale pre-DMA bytes.
-// There is no active SF32LB52 caller today (dbgserial_set_rx_dma_enabled is a
-// no-op for CONFIG_SOC_SF32LB52), so this hasn't been wired up. Before
-// enabling, the buffer needs to be cache-line aligned/sized and the callbacks
-// must dcache_invalidate the freshly-DMA'd range.
 void uart_start_rx_dma(UARTDevice *dev, void *buffer, uint32_t length) {
+  // The DMA buffer is invalidated whole from the IRQ paths, so it must not
+  // share cache lines with anything else.
+  const uintptr_t line_mask = dcache_line_size() - 1;
+  PBL_ASSERTN(((uintptr_t)buffer & line_mask) == 0 && (length & line_mask) == 0);
+  dcache_flush_invalidate(buffer, length);
   dev->state->rx_dma_buffer = buffer;
   dev->state->rx_dma_length = length;
   dev->state->rx_dma_index = 0;

--- a/tools/activity/parse_activity_data_logging_records.py
+++ b/tools/activity/parse_activity_data_logging_records.py
@@ -346,7 +346,7 @@ class ParseAccelSamplesFile:
             logger.debug(f"Got encoded sample {i:d}: 0x{encoded:x}")
 
             if (self.session_num_samples % 25) == 0 and self.format == "c":
-                print(f"    // {self.session_num_samples / 25:d} seconds")
+                print(f"    // {self.session_num_samples // 25:d} seconds")
 
             # Decode it
             if version == self.ACTIVITY_RAW_SAMPLES_VERSION_1:
@@ -386,7 +386,7 @@ class ParseAccelSamplesFile:
                     and (self.session_num_samples % samples_per_minute) == 0
                 ):
                     print(
-                        f"    // elapsed: {self.session_num_samples / samples_per_minute:d} minutes"
+                        f"    // elapsed: {self.session_num_samples // samples_per_minute:d} minutes"
                     )
                 self._output_sample(x, y, z)
                 num_samples_decoded += 1

--- a/tools/libs/pebble-commander/pebble/commander/__init__.py
+++ b/tools/libs/pebble-commander/pebble/commander/__init__.py
@@ -1,8 +1,10 @@
 # SPDX-FileCopyrightText: 2024 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-from . import _commands
+# isort: off
 from .commander import PebbleCommander
+from . import _commands
+# isort: on
 
 __all__ = [
     "PebbleCommander",

--- a/tools/libs/pebble-loghash/pebble/loghashing/constants.py
+++ b/tools/libs/pebble-loghash/pebble/loghashing/constants.py
@@ -34,6 +34,9 @@ NEWLOG_HASHED_INFO_REGEX = (
 )
 POINTER_FORMAT_TAG_REGEX = r"(?P<format>%-?[0-9]*)p"
 HEX_FORMAT_SPECIFIER_REGEX = r"%[- +#0]*\d*(\.\d+)?(hh|h|l|ll|j|z|t|L)?(x|X)"
+LENGTH_MODIFIER_REGEX = (
+    r"(?P<format>%[- +#0]*\d*(?:\.\d+)?)(?:hh|h|ll|l|j|z|t|L)(?=[diouxXc])"
+)
 
 # re patterns
 STR_LITERAL_PATTERN = re.compile(STR_LITERAL_REGEX)
@@ -50,6 +53,7 @@ NEWLOG_LINE_SUPPORT_PATTERN = re.compile(NEWLOG_LINE_SUPPORT_REGEX)
 NEWLOG_HASHED_INFO_PATTERN = re.compile(NEWLOG_HASHED_INFO_REGEX)
 POINTER_FORMAT_TAG_PATTERN = re.compile(POINTER_FORMAT_TAG_REGEX)
 HEX_FORMAT_SPECIFIER_PATTERN = re.compile(HEX_FORMAT_SPECIFIER_REGEX)
+LENGTH_MODIFIER_PATTERN = re.compile(LENGTH_MODIFIER_REGEX)
 
 # Output file lines
 FORMAT_IDENTIFIER_STRING_FMT = 'char *format_string_{} = "{}";\n'

--- a/tools/libs/pebble-loghash/pebble/loghashing/newlogging.py
+++ b/tools/libs/pebble-loghash/pebble/loghashing/newlogging.py
@@ -211,11 +211,15 @@ def parse_message(msg, log_dict):
         if index == -1:
             # This is going to cause an error below...
             arg_list.append(arg)
-        elif HEX_FORMAT_SPECIFIER_PATTERN.match(safe_output_msg, index):
+            continue
+        if isinstance(arg, int) and HEX_FORMAT_SPECIFIER_PATTERN.match(
+            safe_output_msg, index
+        ):
             # We found a %<format>X
             arg_list.append(arg & 0xFFFFFFFF)
         else:
             arg_list.append(arg)
+        index += 1
 
     # Use "printf" to generate the reconstructed string. Make sure the arguments are correct
     try:

--- a/tools/libs/pebble-loghash/pebble/loghashing/newlogging.py
+++ b/tools/libs/pebble-loghash/pebble/loghashing/newlogging.py
@@ -13,6 +13,7 @@ import struct
 
 from pebble.loghashing.constants import (
     HEX_FORMAT_SPECIFIER_PATTERN,
+    LENGTH_MODIFIER_PATTERN,
     NEWLOG_HASHED_INFO_PATTERN,
     NEWLOG_LINE_CONSOLE_PATTERN,
     NEWLOG_LINE_SUPPORT_PATTERN,
@@ -200,6 +201,10 @@ def parse_message(msg, log_dict):
 
     # Python's 'printf' doesn't support %p. Sigh. Convert to %x and hope for the best
     safe_output_msg = POINTER_FORMAT_TAG_PATTERN.sub(r"\g<format>x", output_dict["msg"])
+
+    # Python's 'printf' rejects hh/ll/j/z/t length modifiers. Every argument is already a
+    # 32-bit integer, so drop them.
+    safe_output_msg = LENGTH_MODIFIER_PATTERN.sub(r"\g<format>", safe_output_msg)
 
     # Python's 'printf' doesn't handle (negative) 32-bit hex values correct. Build a new
     # arg list from the parsed arg list by searching for %<format>X conversions and masking

--- a/tools/libs/pebble-loghash/test_newlogging.py
+++ b/tools/libs/pebble-loghash/test_newlogging.py
@@ -70,6 +70,13 @@ test_log_dict = {
         "line": "69",
         "msg": "Init BLE SPI Protocol",
     },
+    "40807": {
+        "color": "GREEN",
+        "file": "battery_state.c",
+        "level": "100",
+        "line": "415",
+        "msg": "Percent: %hhu, V: %ld mV, I: %ld uA, size: %zu, big: 0x%08llx, neg: %hhd",
+    },
     "new_logging_version": "NL0102",
 }
 
@@ -251,6 +258,20 @@ def test_unformatted():
     assert os.path.basename(line_dict["file"]) == "ispp.c"
     assert line_dict["line"] == "1872"
     assert line_dict["formatted_msg"] == "Start Authentication Process 10 (a) Success"
+
+
+def test_length_modifiers():
+    """
+    Test that C length modifiers Python's printf rejects are stripped
+    """
+
+    line = f"? A 21:35:14.375 :0> NL:{40807:x} 1c ed0 fffea7cb 10 fffffffe fffffffb"
+    line_dict = dehash_line_unformatted(line, test_log_dict)
+
+    assert (
+        line_dict["formatted_msg"]
+        == "Percent: 28, V: 3792 mV, I: -88117 uA, size: 16, big: 0xfffffffe, neg: -5"
+    )
 
 
 def test_core_number():

--- a/tools/log_hashing/logdehash.py
+++ b/tools/log_hashing/logdehash.py
@@ -178,7 +178,7 @@ class LogDehash:
             # Use the current time if one isn't provided by the system
             now = datetime.now().astimezone()
             output.append(
-                f"[{now.hour:02d}:{now.minute:02d}:{now.second:02d}.{now.microsecond / 1000:03d}]"
+                f"[{now.hour:02d}:{now.minute:02d}:{now.second:02d}.{now.microsecond // 1000:03d}]"
             )
 
         if "support" not in line_dict and line_dict.get("re_level"):

--- a/tools/pulse_console.py
+++ b/tools/pulse_console.py
@@ -29,6 +29,8 @@ def handle_prompt_command(interface, session):
             print(line)
     except commander.exceptions.CommandTimedOut:
         print(f"Command '{cmd}' timed out")
+    except pulse2.exceptions.SocketClosed:
+        print(f"Connection lost while running '{cmd}'")
     finally:
         prompt.close()
 


### PR DESCRIPTION
Seven fixes found while bringing up the native kernel on obelix.

**Every third-party app crashes since the FreeRTOS drop**

```
[Memory Management Failure!]
MMFARVALID = yes 0x2002817c   DACCVIOL = yes
Task: App  PC: 0x1211cece (pbl_thread_current)  LR: 0x1214aa3b (pebble_task_get_current)
```

`pebble_task_get_current()` runs unprivileged inside apps and reads `pbl_cur` through `pbl_thread_current()`, but the native scheduler kept that pointer in plain kernel `.bss`, which the app MPU regions do not grant. The FreeRTOS port placed `pxCurrentTCB` in `.kernel_unpriv_ro_bss` for the same reason. The definition of `pbl_cur` moves into the arch ports: the Cortex-M port puts it in `.kernel_unpriv_ro_bss`, the POSIX port used by the host tests keeps it in ordinary data. Verified on obelix: `pbl_cur` now lands inside the UNPRIV_RO_BSS MPU region, and `test_kernel` passes on the host.

**SF32LB52 debug UART RX DMA reads stale cache lines**

Since the D-cache was enabled, the IRQ paths read `rx_dma_buffer[]` through stale lines, so the watch answered pulse frames only on cache misses and replayed old frames on hits. Any multi-packet pulse exchange dropped the link. The buffer is now invalidated before every read and flush-invalidated before DMA starts, with an alignment/size assert so the invalidate cannot clobber neighbours.

**pbl console / pulse tooling**

- `pbl console` failed with an ImportError: a Ruff import sort put `_commands` ahead of `PebbleCommander`, which `_commands` needs bound first.
- The printf-to-f-string lint conversion kept `/` for `:d` fields, crashing the log thread on the first line without a device timestamp. Use floor division.
- The dehasher only masked the first `%x` conversion per message, so later ones printed negative values as `-0x...`.
- The dehasher rejected `hh`, `ll`, `j`, `z`, `t` and `L` length modifiers (`PRIu8`, `%zu`, ...). Every hashed argument is 32-bit, so strip them.
- The pulse console crashed with a `SocketClosed` traceback when the reliable transport restarted mid-command. Print a message and return to the prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)