### PR TITLE
ci: add backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,36 @@
+name: Backport
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    if: >
+      github.event.pull_request.merged &&
+      contains(toJSON(github.event.pull_request.labels.*.name), '"backport-')
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Create app token
+        id: app-token
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          app-id: ${{ secrets.BACKPORT_APP_ID }}
+          private-key: ${{ secrets.BACKPORT_APP_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Create backport pull requests
+        uses: korthout/backport-action@v4.6.0
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          label_pattern: ^backport-(.+)$
+          pull_title: '[Backport ${target_branch}] ${pull_title}'
+          pull_description: 'Backport of #${pull_number} to `${target_branch}`.'

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -8,3 +8,11 @@
 - Keep code comments short and concise; extended rationale belongs in the Git
   commit message. Do not reference issue numbers in code, only in commit
   messages.
+- To backport a merged pull request to a release branch, add a
+  `backport-<branch>` label (e.g. `backport-4.36-branch`) to it, either
+  before or after merging. A workflow cherry-picks the pull request's commits
+  onto `<branch>` and opens a new pull request against it; on conflicts it
+  comments on the original pull request instead. The workflow authenticates
+  as a GitHub App (`BACKPORT_APP_ID` / `BACKPORT_APP_KEY` repository secrets)
+  so that backport pull requests trigger CI, which the default
+  `GITHUB_TOKEN` cannot do.


### PR DESCRIPTION
Add a label-driven backport workflow based on [korthout/backport-action](https://github.com/korthout/backport-action).

Adding a `backport-<branch>` label (e.g. `backport-4.36-branch`) to a pull request, before or after merging, cherry-picks its commits onto that branch and opens a new pull request against it. On conflicts the action comments on the original pull request with manual steps.

Pull requests opened with the default `GITHUB_TOKEN` do not trigger other workflows, so the workflow authenticates as a GitHub App via `actions/create-github-app-token`. Before merging, the app needs to be created and installed:

1. Org settings → Developer settings → GitHub Apps → New GitHub App. Repository permissions: Contents (read/write), Pull requests (read/write), Workflows (read/write). No webhook.
2. Install the app on `coredevices/PebbleOS` only.
3. Generate a private key for the app and set the repository secrets `BACKPORT_APP_ID` and `BACKPORT_APP_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
