### PR TITLE
ci: run build and test workflows on release branch pull requests

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, '*-branch']
   workflow_call:
 
 jobs:

--- a/.github/workflows/build-prf.yml
+++ b/.github/workflows/build-prf.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, '*-branch']
   workflow_call:
 
 jobs:

--- a/.github/workflows/build-qemu-sdkshell.yml
+++ b/.github/workflows/build-qemu-sdkshell.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, '*-branch']
   workflow_call:
 
 jobs:

--- a/.github/workflows/build-qemu.yml
+++ b/.github/workflows/build-qemu.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, '*-branch']
   workflow_call:
 
 jobs:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, '*-branch']
 
 jobs:
   changes-nix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, '*-branch']
 
 jobs:
   changes-test:


### PR DESCRIPTION
Build and test workflows (`build-firmware`, `build-prf`, `build-qemu`, `build-qemu-sdkshell`, `nix`, `test`) only triggered on pull requests to `main`, so pull requests against release branches — e.g. the backport #2020 opened by #2019 — only got compliance checks. Extend the `pull_request` branch filters to `'*-branch'` so release branches get the same coverage. `push` triggers are left untouched: post-merge builds stay `main` only.

Note that `pull_request` runs use the workflow files from the base branch, so this needs to be backported to each release branch that should get CI (e.g. `v4.27-branch`, `4.36-branch`) — a good first use of the backport labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
