### PR TITLE
tests: update the timezone region count for Pacific/Guam

### DIFF
--- a/tests/fw/services/test_timezone_database.c
+++ b/tests/fw/services/test_timezone_database.c
@@ -30,9 +30,8 @@ void test_timezone_database__get_region_count(void) {
   // Note this test will break every time we update the timezone database and that's ok. Just
   // make sure the new number is sane and update the expected number. The count is derived from
   // the number of Zone entries in resources/normal/base/tzdata/timezones_olson.txt after the
-  // generator's filtering (build_zoneinfo_list); it dropped to 308 as the bundled tzdata has been
-  // updated since the original 336.
-  cl_assert_equal_i(timezone_database_get_region_count(), 308);
+  // generator's filtering (build_zoneinfo_list).
+  cl_assert_equal_i(timezone_database_get_region_count(), 309);
 }
 
 void test_timezone_database__find_region_by_name_simple(void) {


### PR DESCRIPTION
The zone parser now accepts lowercase timezone abbreviations (c67218ae1), so Pacific/Guam (ChST) is included in the database and the region count went from 308 to 309. The test expectation was not updated, which broke the Test workflow on main (https://github.com/coredevices/PebbleOS/actions/runs/34130508257).

🤖 Generated with [Claude Code](https://claude.com/claude-code)