### PR TITLE
pbl: feed the emulator simulated phone data (weather, music)

### DIFF
--- a/.agents/skills/working-with-qemu/SKILL.md
+++ b/.agents/skills/working-with-qemu/SKILL.md
@@ -15,6 +15,8 @@ Agent notes:
 - Use `./pbl screenshot` to validate UI changes; read the resulting PNG.
 - Drive the UI over the socket monitor (`build/qemu-mon.sock`) with
   `sendkey` rather than the interactive QEMU window.
+- Phone-dependent features get their data from `./pbl feed <feed>` (e.g.
+  `./pbl feed weather`); feeds live in `tools/libs/pbl-cli/pbl/feeds/`.
 
 ## Touch
 

--- a/docs/development/pbl.md
+++ b/docs/development/pbl.md
@@ -102,8 +102,10 @@ top-level help the command is listed under.
 is a module in `pbl/feeds/` with a `Feed` subclass, discovered the same
 way commands are: it names its subcommand, adds its own options in
 `add_arguments()` and writes its data in `run()` through the `Watch` it is
-given, which wraps the blob DB client and turns into a printer under
-`--dry-run`.
+given, which wraps the blob DB client, sends and receives raw protocol
+packets, and turns into a printer under `--dry-run`. A feed that has to
+answer the watch registers handlers with `watch.on()` and keeps `run()`
+going until interrupted.
 
 ```python
 from pbl.feeds import BlobDb, Feed

--- a/docs/development/pbl.md
+++ b/docs/development/pbl.md
@@ -96,6 +96,31 @@ things from the workspace root and honor `--dry-run`; raising
 `CommandError` is how a command fails. `group` picks the section of the
 top-level help the command is listed under.
 
+### Feeds
+
+`pbl feed <feed>` writes simulated phone data into the emulator. Each feed
+is a module in `pbl/feeds/` with a `Feed` subclass, discovered the same
+way commands are: it names its subcommand, adds its own options in
+`add_arguments()` and writes its data in `run()` through the `Watch` it is
+given, which wraps the blob DB client and turns into a printer under
+`--dry-run`.
+
+```python
+from pbl.feeds import BlobDb, Feed
+
+
+class Steps(Feed):
+    name = "steps"
+    help = "A day of step counts"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--steps", type=int, default=8000)
+
+    def run(self, args, watch, inf):
+        watch.blobdb_insert(BlobDb.HEALTH, key, value)
+        inf(f"pushed {args.steps} steps")
+```
+
 ### Extension commands
 
 A command that should not live in the package is declared in `pbl.yml`

--- a/docs/development/qemu.md
+++ b/docs/development/qemu.md
@@ -107,9 +107,16 @@ Pebble protocol serial port. Each kind of data is a subcommand:
 pbl feed weather                        # a forecast for a few built-in cities
 pbl feed weather Tokyo Sydney --seed 3   # a subset; the first is the current location
 pbl feed weather --clear                 # remove every location
+pbl feed music                           # a player and playlist; keeps serving until Ctrl-C
+pbl feed music --title "Demo" --paused   # a single track of your own
 ```
 
 `pbl feed --help` lists the feeds and `pbl feed <feed> --help` their options.
+A feed that writes a database, like weather, exits once the data is stored.
+One that stands in for the phone, like music, keeps running: it acts on the
+watch's controls, advances playback and draws album art when asked (album
+art is off by default, under Settings > Music). The emulator's port serves
+one host client at a time, so run one such feed at once.
 The feeds live in `tools/libs/pbl-cli/pbl/feeds/`, one module per kind of
 data; see [the `pbl` CLI](pbl.md) for how to add one.
 

--- a/docs/development/qemu.md
+++ b/docs/development/qemu.md
@@ -97,6 +97,22 @@ injection. A tap is a finger down then up; a swipe streams intermediate moves
 so that drag gestures are seen as continuous. Injection uses the
 absolute-pointer input path; multi-touch is not wired up in the device.
 
+## Feeding phone data
+
+Features that depend on the phone app can be exercised without one:
+`pbl feed` writes into the running emulator what the phone would, over the
+Pebble protocol serial port. Each kind of data is a subcommand:
+
+```shell
+pbl feed weather                        # a forecast for a few built-in cities
+pbl feed weather Tokyo Sydney --seed 3   # a subset; the first is the current location
+pbl feed weather --clear                 # remove every location
+```
+
+`pbl feed --help` lists the feeds and `pbl feed <feed> --help` their options.
+The feeds live in `tools/libs/pbl-cli/pbl/feeds/`, one module per kind of
+data; see [the `pbl` CLI](pbl.md) for how to add one.
+
 ## Debug
 
 You can debug with GDB using:

--- a/src/fw/services/weather/weather_service.c
+++ b/src/fw/services/weather/weather_service.c
@@ -298,6 +298,9 @@ void weather_service_locations_list_destroy(WeatherDataListNode *head) {
 }
 
 bool weather_service_supported_by_phone(void) {
+#ifdef CONFIG_QEMU
+  return true;
+#endif
   PebbleProtocolCapabilities capabilities;
   bt_persistent_storage_get_cached_system_capabilities(&capabilities);
   if (!capabilities.weather_app_support) {

--- a/tools/libs/pbl-cli/pbl/commands/feed.py
+++ b/tools/libs/pbl-cli/pbl/commands/feed.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from pbl import emulator
+from pbl.command import global_options
+from pbl.commands.qemu import _QemuCommand
+from pbl.feeds import Watch, builtin_feeds
+
+
+class Feed(_QemuCommand):
+    def __init__(self):
+        super().__init__(
+            "feed",
+            "Feed the emulator simulated phone data",
+            "Write into the running emulator what the phone app would, so "
+            "features that depend on the phone can be exercised without one.",
+        )
+        self.feeds = builtin_feeds()
+
+    def do_add_parser(self, parser_adder):
+        parser = self.add_subparser(parser_adder)
+        parser.add_argument(
+            "--host",
+            default=f"127.0.0.1:{emulator.PEBBLE_TOOL_PORT}",
+            help="host:port of the emulator's Pebble protocol serial port "
+            "(default: %(default)s)",
+        )
+        subparsers = parser.add_subparsers(dest="feed", metavar="FEED", required=True)
+        for feed in self.feeds.values():
+            subparser = subparsers.add_parser(
+                feed.name,
+                help=feed.help,
+                description=feed.description or feed.help,
+                parents=[global_options()],
+            )
+            feed.add_arguments(subparser)
+        return parser
+
+    def do_run(self, args, unknown):
+        self.emulated_build()
+        feed = self.feeds[args.feed]
+
+        if self.dry_run:
+            watch = Watch()
+        else:
+            host, _, port = args.host.rpartition(":")
+            watch = Watch(emulator.connect_watch(host or "127.0.0.1", int(port)))
+
+        try:
+            feed.run(args, watch, self.inf)
+        except ValueError as e:
+            self.parser.error(str(e))

--- a/tools/libs/pbl-cli/pbl/emulator.py
+++ b/tools/libs/pbl-cli/pbl/emulator.py
@@ -134,6 +134,7 @@ def connect_watch(host="127.0.0.1", port=PEBBLE_TOOL_PORT):
         from libpebble2.communication import PebbleConnection
         from libpebble2.communication.transports.qemu import QemuTransport
         from libpebble2.exceptions import ConnectionError as PebbleConnectionError
+        from libpebble2.exceptions import TimeoutError as PebbleTimeoutError
     except ImportError as e:
         raise CommandContextError(f"libpebble2 is not installed ({e})") from e
 
@@ -145,5 +146,44 @@ def connect_watch(host="127.0.0.1", port=PEBBLE_TOOL_PORT):
             f"cannot reach the emulator's Pebble protocol port at {host}:{port} "
             f"-- is 'pbl qemu' running? ({e})"
         ) from e
-    pebble.run_async()
+    try:
+        pebble.run_async()
+    except PebbleTimeoutError:
+        raise CommandContextError(
+            f"the firmware is not answering on {host}:{port} -- the port serves "
+            "one client at a time; is another feed or pebble tool connected?"
+        ) from None
+    identify_as_phone(pebble)
     return pebble
+
+
+# What the version response tells the firmware: an Android phone app, with
+# every protocol capability. The OS is in the low three bits.
+PHONE_OS_ANDROID = 2
+PHONE_CAPABILITIES = 0xFFFFFFFFFFFFFFFF
+
+
+def identify_as_phone(pebble):
+    """Answer the firmware's version request without waiting for one.
+
+    The firmware only asks once, when the emulated session first opens, and
+    the session outlives host connections; what depends on the answer (the
+    phone's OS gates the music endpoint, for one) would otherwise never be
+    re-established after the first connection goes away.
+    """
+    from libpebble2.protocol.system import AppVersionResponse, PhoneAppVersion
+
+    pebble.send_packet(
+        PhoneAppVersion(
+            message=AppVersionResponse(
+                protocol_version=0xFFFFFFFF,
+                session_caps=0x80000000,
+                platform_flags=PHONE_OS_ANDROID,
+                response_version=2,
+                major_version=3,
+                minor_version=0,
+                bugfix_version=0,
+                protocol_caps=PHONE_CAPABILITIES,
+            )
+        )
+    )

--- a/tools/libs/pbl-cli/pbl/emulator.py
+++ b/tools/libs/pbl-cli/pbl/emulator.py
@@ -4,7 +4,9 @@
 """Talking to a running QEMU.
 
 ``pbl qemu`` exposes two unix sockets in the build directory: the human
-monitor, used for screendumps, and QMP, used to inject input events.
+monitor, used for screendumps, and QMP, used to inject input events. The
+firmware's Pebble protocol is served over a TCP serial port, reached with
+:func:`connect_watch`.
 """
 
 import json
@@ -124,3 +126,24 @@ class Qmp:
     @staticmethod
     def button(down):
         return [{"type": "btn", "data": {"button": "left", "down": down}}]
+
+
+def connect_watch(host="127.0.0.1", port=PEBBLE_TOOL_PORT):
+    """A libpebble2 connection to the firmware, as the phone app would have."""
+    try:
+        from libpebble2.communication import PebbleConnection
+        from libpebble2.communication.transports.qemu import QemuTransport
+        from libpebble2.exceptions import ConnectionError as PebbleConnectionError
+    except ImportError as e:
+        raise CommandContextError(f"libpebble2 is not installed ({e})") from e
+
+    pebble = PebbleConnection(QemuTransport(host, port))
+    try:
+        pebble.connect()
+    except PebbleConnectionError as e:
+        raise CommandContextError(
+            f"cannot reach the emulator's Pebble protocol port at {host}:{port} "
+            f"-- is 'pbl qemu' running? ({e})"
+        ) from e
+    pebble.run_async()
+    return pebble

--- a/tools/libs/pbl-cli/pbl/feeds/__init__.py
+++ b/tools/libs/pbl-cli/pbl/feeds/__init__.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Simulated phone data for the firmware.
+
+A feed writes what the phone app would into the running emulator, so a
+feature that depends on the phone can be exercised without one. Every
+module in this package that defines :class:`Feed` subclasses contributes a
+``pbl feed <name>`` subcommand; adding a feed is adding a file here.
+"""
+
+import importlib
+import inspect
+import pkgutil
+from abc import ABC, abstractmethod
+from enum import IntEnum
+
+from pbl import util
+from pbl.errors import CommandError
+
+
+class BlobDb(IntEnum):
+    """The firmware's blob DB ids (see pbl/services/blob_db/api.h)."""
+
+    TEST = 0x00
+    PINS = 0x01
+    APPS = 0x02
+    REMINDERS = 0x03
+    NOTIFS = 0x04
+    WEATHER = 0x05
+    IOS_NOTIF_PREF = 0x06
+    PREFS = 0x07
+    CONTACTS = 0x08
+    WATCH_APP_PREFS = 0x09
+    HEALTH = 0x0A
+    APP_GLANCE = 0x0B
+    SETTINGS = 0x0C
+
+
+class _RawKey:
+    """A blob DB key that is not a UUID; the client only wants its bytes."""
+
+    def __init__(self, raw):
+        self.bytes = raw
+
+
+class Watch:
+    """What a feed writes through: the firmware over a libpebble2 connection,
+    or nothing but a log line in a dry run."""
+
+    def __init__(self, pebble=None):
+        self._pebble = pebble
+        self._blobdb = None
+
+    @property
+    def dry_run(self):
+        return self._pebble is None
+
+    def _client(self):
+        if self._blobdb is None:
+            from libpebble2.services.blobdb import BlobDBClient
+
+            self._blobdb = BlobDBClient(self._pebble)
+        return self._blobdb
+
+    def _blobdb_call(self, what, method, *args):
+        if self.dry_run:
+            util.inf("[dry-run]", what, color="yellow")
+            return
+        from libpebble2.protocol.blobdb import BlobStatus
+        from libpebble2.services.blobdb import SyncWrapper
+
+        status = SyncWrapper(getattr(self._client(), method), *args).wait()
+        if status is None:
+            raise CommandError(f"{what}: no response from the firmware")
+        if status != BlobStatus.Success:
+            raise CommandError(f"{what}: firmware answered {BlobStatus(status).name}")
+
+    def blobdb_insert(self, database, key, value):
+        """Insert ``value`` under ``key`` (a UUID, or raw bytes) in ``database``."""
+        if isinstance(key, (bytes, bytearray)):
+            key = _RawKey(bytes(key))
+        self._blobdb_call(
+            f"{database.name}: insert {len(value)} bytes",
+            "insert",
+            database,
+            key,
+            value,
+        )
+
+    def blobdb_clear(self, database):
+        self._blobdb_call(f"{database.name}: clear", "clear", database)
+
+
+class Feed(ABC):
+    #: The ``pbl feed <name>`` subcommand.
+    name = None
+    help = None
+    description = None
+
+    def add_arguments(self, parser):
+        """Add the feed's own options to its subparser."""
+
+    @abstractmethod
+    def run(self, args, watch, inf):
+        """Write the feed's data through ``watch``; ``inf`` prints a line."""
+
+
+def builtin_feeds():
+    """Discover and instantiate every feed in this package, by name."""
+    feeds = {}
+    for info in pkgutil.iter_modules(__path__, __name__ + "."):
+        module = importlib.import_module(info.name)
+        for obj in vars(module).values():
+            if (
+                inspect.isclass(obj)
+                and issubclass(obj, Feed)
+                and obj.__module__ == module.__name__
+                and not inspect.isabstract(obj)
+            ):
+                feed = obj()
+                feeds[feed.name] = feed
+    return dict(sorted(feeds.items()))

--- a/tools/libs/pbl-cli/pbl/feeds/__init__.py
+++ b/tools/libs/pbl-cli/pbl/feeds/__init__.py
@@ -91,6 +91,18 @@ class Watch:
     def blobdb_clear(self, database):
         self._blobdb_call(f"{database.name}: clear", "clear", database)
 
+    def send(self, packet, what=None):
+        """Send one Pebble protocol packet."""
+        if self.dry_run:
+            util.inf("[dry-run]", what or type(packet).__name__, color="yellow")
+            return
+        self._pebble.send_packet(packet)
+
+    def on(self, packet_class, handler):
+        """Call ``handler(packet)`` for every ``packet_class`` the firmware sends."""
+        if not self.dry_run:
+            self._pebble.register_endpoint(packet_class, handler)
+
 
 class Feed(ABC):
     #: The ``pbl feed <name>`` subcommand.

--- a/tools/libs/pbl-cli/pbl/feeds/music.py
+++ b/tools/libs/pbl-cli/pbl/feeds/music.py
@@ -1,0 +1,363 @@
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Music, as the phone app reports it: the player, the track and its playback
+state over the music control endpoint, and album art when the watch asks.
+The feed keeps serving until interrupted, acting on the watch's controls."""
+
+import hashlib
+import struct
+import threading
+import time
+
+from pbl.feeds import Feed
+
+# MusicEndpointCmdID
+(
+    TOGGLE_PLAY_PAUSE,
+    PAUSE,
+    PLAY,
+    NEXT_TRACK,
+    PREVIOUS_TRACK,
+    VOLUME_UP,
+    VOLUME_DOWN,
+    GET_ALL_INFO,
+) = range(1, 9)
+NOW_PLAYING, PLAY_STATE, VOLUME, PLAYER = 0x10, 0x11, 0x12, 0x13
+COMMAND_NAMES = {
+    TOGGLE_PLAY_PAUSE: "toggle play/pause",
+    PAUSE: "pause",
+    PLAY: "play",
+    NEXT_TRACK: "next track",
+    PREVIOUS_TRACK: "previous track",
+    VOLUME_UP: "volume up",
+    VOLUME_DOWN: "volume down",
+    GET_ALL_INFO: "get all info",
+}
+
+STATE_PAUSED, STATE_PLAYING = 0, 1
+SHUFFLE_OFF, REPEAT_OFF = 1, 1
+
+# Imaging endpoint (pbl/services/imaging_endpoint_types.h).
+IMAGING_ENDPOINT = 0x35
+IMAGING_REQUEST, IMAGING_RESPONSE = 0x01, 0x02
+IMAGE_TYPE_ALBUM_ART = 0
+FORMAT_1BIT, FORMAT_8BIT, FORMAT_4BIT_PALETTE = 0, 1, 2
+FLAG_FIRST, FLAG_LAST, FLAG_NO_IMAGE, FLAG_UNSUPPORTED = 1, 2, 4, 8
+ART_CHUNK = 512
+
+PLAYLIST = [
+    ("Northern Lights", "The Fjords", "Midnight Sun", 214),
+    ("Paper Planes", "Cala Sol", "Mediterranean", 187),
+    ("Static Bloom", "Ada Vector", "Signal / Noise", 251),
+    ("Slow Orbit", "Kessler & Lo", "Apogee", 322),
+]
+
+
+def _gcolor8(r, g, b):
+    """GColor8: two bits per channel, opaque."""
+    return 0xC0 | (r << 4) | (g << 2) | b
+
+
+def album_art(title, width, height, fmt):
+    """A cover for the track: concentric rings between two hues picked from
+    its title. Returns (palette, pixel rows) in the requested format."""
+    digest = hashlib.sha1(title.encode()).digest()
+    start = [digest[0] & 3, digest[1] & 3, digest[2] & 3]
+    end = [3 - start[0], (digest[3] & 3), 3 - start[2]]
+    palette = [
+        _gcolor8(*(round(s + (e - s) * i / 15) for s, e in zip(start, end)))
+        for i in range(16)
+    ]
+    cx, cy = width / 2, height / 2
+    radius = max(cx, cy)
+    rows = []
+    for y in range(height):
+        indices = []
+        for x in range(width):
+            distance = ((x - cx) ** 2 + (y - cy) ** 2) ** 0.5
+            indices.append(int(distance / radius * 15 * 1.5) % 16)
+        if fmt == FORMAT_4BIT_PALETTE:
+            if len(indices) % 2:
+                indices.append(0)
+            row = bytes((a << 4) | b for a, b in zip(indices[::2], indices[1::2]))
+        elif fmt == FORMAT_8BIT:
+            row = bytes(palette[i] for i in indices)
+        else:
+            stride = ((width + 31) // 32) * 4
+            row = bytearray(stride)
+            for x, i in enumerate(indices):
+                if i >= 8:
+                    row[x // 8] |= 1 << (x % 8)
+            row = bytes(row)
+        rows.append(row)
+    return (palette if fmt == FORMAT_4BIT_PALETTE else []), b"".join(rows)
+
+
+_imaging = None
+
+
+def _imaging_packet():
+    """The imaging endpoint, which libpebble2 does not know."""
+    global _imaging
+    if _imaging is None:
+        from libpebble2.protocol.base import PebblePacket
+        from libpebble2.protocol.base.types import BinaryArray, Uint8
+
+        class Imaging(PebblePacket):
+            class Meta:
+                endpoint = IMAGING_ENDPOINT
+                endianness = "<"
+
+            cmd = Uint8()
+            token = Uint8()
+            payload = BinaryArray()
+
+        _imaging = Imaging
+    return _imaging
+
+
+class Player:
+    """The simulated player's state, and the packets that report it."""
+
+    def __init__(self, playlist, name, volume, playing, position_ms):
+        self.playlist = playlist
+        self.index = 0
+        self.name = name
+        self.volume = volume
+        self.playing = playing
+        self.position_ms = position_ms
+        self.lock = threading.Lock()
+
+    @property
+    def track(self):
+        return self.playlist[self.index]
+
+    def describe(self):
+        title, artist, _, length = self.track
+        state = "playing" if self.playing else "paused"
+        return (
+            f"{title} - {artist} [{self.position_ms // 1000}s/{length}s], "
+            f"{state}, volume {self.volume}%"
+        )
+
+    def now_playing_packet(self):
+        from libpebble2.protocol.music import (
+            MusicControl,
+            MusicControlUpdateCurrentTrack,
+        )
+
+        title, artist, album, length = self.track
+        return MusicControl(
+            command=NOW_PLAYING,
+            data=MusicControlUpdateCurrentTrack(
+                artist=artist,
+                album=album,
+                title=title,
+                track_length=length * 1000,
+                track_count=len(self.playlist),
+                current_track=self.index,
+            ),
+        )
+
+    def play_state_packet(self):
+        from libpebble2.protocol.music import (
+            MusicControl,
+            MusicControlUpdatePlayStateInfo,
+        )
+
+        return MusicControl(
+            command=PLAY_STATE,
+            data=MusicControlUpdatePlayStateInfo(
+                state=STATE_PLAYING if self.playing else STATE_PAUSED,
+                track_position=self.position_ms,
+                play_rate=100 if self.playing else 0,
+                shuffle=SHUFFLE_OFF,
+                repeat=REPEAT_OFF,
+            ),
+        )
+
+    def volume_packet(self):
+        from libpebble2.protocol.music import MusicControl, MusicControlUpdateVolumeInfo
+
+        return MusicControl(
+            command=VOLUME,
+            data=MusicControlUpdateVolumeInfo(volume_percent=self.volume),
+        )
+
+    def player_packet(self):
+        from libpebble2.protocol.music import MusicControl, MusicControlUpdatePlayerInfo
+
+        return MusicControl(
+            command=PLAYER,
+            data=MusicControlUpdatePlayerInfo(
+                package="com.pebble.feed", name=self.name
+            ),
+        )
+
+    def all_packets(self):
+        return [
+            self.player_packet(),
+            self.now_playing_packet(),
+            self.play_state_packet(),
+            self.volume_packet(),
+        ]
+
+    def skip(self, step):
+        self.index = (self.index + step) % len(self.playlist)
+        self.position_ms = 0
+
+    def command(self, command):
+        """Apply one of the watch's commands; return the packets to answer with."""
+        if command == GET_ALL_INFO:
+            return self.all_packets()
+        if command == TOGGLE_PLAY_PAUSE:
+            self.playing = not self.playing
+        elif command == PLAY:
+            self.playing = True
+        elif command == PAUSE:
+            self.playing = False
+        elif command in (NEXT_TRACK, PREVIOUS_TRACK):
+            self.skip(1 if command == NEXT_TRACK else -1)
+            return [self.now_playing_packet(), self.play_state_packet()]
+        elif command in (VOLUME_UP, VOLUME_DOWN):
+            self.volume = min(
+                100, max(0, self.volume + (10 if command == VOLUME_UP else -10))
+            )
+            return [self.volume_packet()]
+        else:
+            return []
+        return [self.play_state_packet()]
+
+    def tick(self, seconds):
+        """Advance playback; return the packets to send, if anything changed."""
+        if not self.playing:
+            return []
+        self.position_ms += seconds * 1000
+        if self.position_ms >= self.track[3] * 1000:
+            self.skip(1)
+            return [self.now_playing_packet(), self.play_state_packet()]
+        return []
+
+
+class Music(Feed):
+    name = "music"
+    help = "A music player and its playlist"
+    description = (
+        "Report a player and a playing track, then keep serving: the watch's "
+        "controls act on the playlist, playback advances, and album art is "
+        "drawn on request. Stop with Ctrl-C."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--title", help="Play a single track with this title instead"
+        )
+        parser.add_argument("--artist", default="Unknown Artist")
+        parser.add_argument("--album", default="Unknown Album")
+        parser.add_argument(
+            "--length", type=int, default=240, help="Its length in seconds"
+        )
+        parser.add_argument(
+            "--player", default="Simulated Player", help="The player's name"
+        )
+        parser.add_argument("--paused", action="store_true", help="Start paused")
+        parser.add_argument(
+            "--position",
+            type=int,
+            default=42,
+            help="Seconds into the track (default: 42)",
+        )
+        parser.add_argument(
+            "--volume", type=int, default=60, help="Percent (default: 60)"
+        )
+        parser.add_argument(
+            "--no-art", action="store_true", help="Tell the watch there is no album art"
+        )
+        parser.add_argument(
+            "--once", action="store_true", help="Report the state once and exit"
+        )
+
+    def run(self, args, watch, inf):
+        playlist = PLAYLIST
+        if args.title:
+            playlist = [(args.title, args.artist, args.album, args.length)]
+        player = Player(
+            playlist, args.player, args.volume, not args.paused, args.position * 1000
+        )
+
+        def send_all(packets):
+            for packet in packets:
+                watch.send(packet, f"{type(packet.data).__name__}")
+
+        def on_music(packet):
+            if packet.command not in COMMAND_NAMES:
+                return
+            with player.lock:
+                inf(f"watch: {COMMAND_NAMES[packet.command]}")
+                send_all(player.command(packet.command))
+                inf(player.describe())
+
+        def on_imaging(packet):
+            if packet.cmd != IMAGING_REQUEST or len(packet.payload) < 6:
+                return
+            image_type, fmt, width, height = struct.unpack_from("<BBHH", packet.payload)
+            flags = image_type << 4
+            if image_type != IMAGE_TYPE_ALBUM_ART:
+                self._art_reply(watch, packet.token, flags | FLAG_UNSUPPORTED)
+                return
+            if args.no_art:
+                self._art_reply(watch, packet.token, flags | FLAG_NO_IMAGE)
+                return
+            with player.lock:
+                title = player.track[0]
+            inf(f"watch: album art for {title!r}, {width}x{height} format {fmt}")
+            palette, pixels = album_art(title, width, height, fmt)
+            header = struct.pack("<HHBB", width, height, fmt, len(palette)) + bytes(
+                palette
+            )
+            for offset in range(0, len(pixels), ART_CHUNK):
+                chunk = pixels[offset : offset + ART_CHUNK]
+                chunk_flags = flags
+                if offset == 0:
+                    chunk_flags |= FLAG_FIRST
+                if offset + len(chunk) >= len(pixels):
+                    chunk_flags |= FLAG_LAST
+                self._art_reply(
+                    watch,
+                    packet.token,
+                    chunk_flags,
+                    offset,
+                    chunk,
+                    header if offset == 0 else b"",
+                )
+
+        send_all(player.all_packets())
+        inf(player.describe())
+        if args.once or watch.dry_run:
+            return
+
+        from libpebble2.protocol.music import MusicControl
+
+        watch.on(MusicControl, on_music)
+        watch.on(_imaging_packet(), on_imaging)
+        inf("serving; Ctrl-C to stop")
+        try:
+            while True:
+                time.sleep(1)
+                with player.lock:
+                    changed = player.tick(1)
+                    send_all(changed)
+                    if changed:
+                        inf(player.describe())
+        except KeyboardInterrupt:
+            inf("stopped")
+
+    @staticmethod
+    def _art_reply(watch, token, flags, offset=0, chunk=b"", header=b""):
+        packet = _imaging_packet()(
+            cmd=IMAGING_RESPONSE,
+            token=token,
+            payload=struct.pack("<BIH", flags, offset, len(chunk)) + header + chunk,
+        )
+        watch.send(packet, "Imaging response")

--- a/tools/libs/pbl-cli/pbl/feeds/weather.py
+++ b/tools/libs/pbl-cli/pbl/feeds/weather.py
@@ -1,0 +1,301 @@
+# SPDX-FileCopyrightText: 2026 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Weather, as the phone app syncs it: one v4 record per location in the
+weather blob DB and the ordered location list in the watch app prefs."""
+
+import math
+import random
+import struct
+import time
+import uuid
+
+from pbl.feeds import BlobDb, Feed
+
+PREFS_KEY = b"weatherApp"
+
+DB_VERSION = 4
+DB_MINOR_VERSION = 5
+DAYS = 7
+HOURS = 24
+
+LOCATION_NAMESPACE = uuid.UUID("3c2f5c1e-6b7a-4d0e-9a7e-1b2c3d4e5f60")
+
+# WeatherType, as the firmware numbers it.
+(
+    PARTLY_CLOUDY,
+    CLOUDY,
+    LIGHT_SNOW,
+    LIGHT_RAIN,
+    HEAVY_RAIN,
+    HEAVY_SNOW,
+    GENERIC,
+    SUN,
+    SLEET,
+) = range(9)
+
+PHRASES = {
+    PARTLY_CLOUDY: "Partly Cloudy",
+    CLOUDY: "Cloudy",
+    LIGHT_SNOW: "Light Snow",
+    LIGHT_RAIN: "Light Rain",
+    HEAVY_RAIN: "Heavy Rain",
+    HEAVY_SNOW: "Heavy Snow",
+    GENERIC: "Mixed",
+    SUN: "Sunny",
+    SLEET: "Sleet",
+}
+
+WMO_CODES = {
+    PARTLY_CLOUDY: 2,
+    CLOUDY: 3,
+    LIGHT_SNOW: 71,
+    LIGHT_RAIN: 61,
+    HEAVY_RAIN: 65,
+    HEAVY_SNOW: 75,
+    GENERIC: 45,
+    SUN: 0,
+    SLEET: 68,
+}
+
+# How much of the clear-sky UV gets through each kind of sky.
+SKY_UV = {SUN: 1.0, PARTLY_CLOUDY: 0.7, CLOUDY: 0.4, GENERIC: 0.3}
+
+# Each city is a weather regime: metric temperatures and wind, the sky types
+# it cycles through, and how wet, windy and hazy it tends to be.
+CITIES = {
+    "Barcelona": {
+        "lat": 41.39,
+        "lon": 2.17,
+        "utc": 120,
+        "temp": 26,
+        "swing": 8,
+        "types": [SUN, SUN, PARTLY_CLOUDY],
+        "precip": 5,
+        "wind": 12,
+        "humidity": 55,
+        "uv": 8,
+    },
+    "New York": {
+        "lat": 40.71,
+        "lon": -74.01,
+        "utc": -240,
+        "temp": 18,
+        "swing": 7,
+        "types": [LIGHT_RAIN, HEAVY_RAIN, CLOUDY],
+        "precip": 80,
+        "wind": 28,
+        "humidity": 90,
+        "uv": 2,
+    },
+    "Tokyo": {
+        "lat": 35.68,
+        "lon": 139.69,
+        "utc": 540,
+        "temp": 22,
+        "swing": 6,
+        "types": [CLOUDY, PARTLY_CLOUDY, LIGHT_RAIN],
+        "precip": 40,
+        "wind": 18,
+        "humidity": 75,
+        "uv": 4,
+    },
+    "Reykjavik": {
+        "lat": 64.15,
+        "lon": -21.94,
+        "utc": 0,
+        "temp": -3,
+        "swing": 4,
+        "types": [HEAVY_SNOW, LIGHT_SNOW, CLOUDY],
+        "precip": 70,
+        "wind": 45,
+        "humidity": 85,
+        "uv": 1,
+    },
+    "Sydney": {
+        "lat": -33.87,
+        "lon": 151.21,
+        "utc": 600,
+        "temp": 15,
+        "swing": 6,
+        "types": [PARTLY_CLOUDY, SUN, LIGHT_RAIN],
+        "precip": 25,
+        "wind": 22,
+        "humidity": 60,
+        "uv": 5,
+    },
+}
+
+# WeatherDBEntry up to (excluding) the trailing strings, little-endian, packed.
+FIXED = struct.Struct(
+    "<BhBhhBhhIBBhhhHHhhB"  # v3 prefix + v4.0 scalars
+    + "hhB" * DAYS  # daily[]
+    + "B"
+    + "B" * HOURS
+    + "b" * HOURS  # today's hourly series
+    + "h"
+    + "BBB" * DAYS  # v4.1: utc offset, daily_metrics[]
+    + "BBHH"
+    + "h" * DAYS  # v4.2: warning readings, daily_feels_like[]
+    + "h"
+    + "h" * DAYS  # v4.3: wind direction
+    + "B" * HOURS  # v4.4: hourly UV
+    + "B"
+    + "B" * HOURS
+    + "b" * HOURS  # v4.5: tomorrow's hourly series
+)
+assert FIXED.size == 250
+
+
+def _day(rng, city, offset):
+    """One day's forecast: dominant sky, hourly sky and temperature, UV."""
+    dominant = rng.choice(city["types"])
+    base = city["temp"] + rng.uniform(-3, 3) + offset * rng.uniform(-1, 1)
+    types, temps, uvs = [], [], []
+    sky = dominant
+    for hour in range(HOURS):
+        if rng.random() < 0.15:
+            sky = rng.choice(city["types"])
+        types.append(sky)
+        temps.append(
+            round(
+                base - city["swing"] / 2 * math.cos(2 * math.pi * (hour - 16) / HOURS)
+            )
+        )
+        clear_sky = max(0.0, math.sin(math.pi * (hour - 6) / 12))
+        uvs.append(city["uv"] * clear_sky * SKY_UV.get(sky, 0.2))
+    return {
+        "type": dominant,
+        "types": types,
+        "temps": temps,
+        "uvs": uvs,
+        "precip": min(100, max(0, city["precip"] + rng.randint(-20, 20))),
+        "wind": max(0, city["wind"] + rng.randint(-8, 8)),
+        "wind_dir": rng.randint(0, 359),
+    }
+
+
+def _to_f(celsius):
+    return round(celsius * 9 / 5 + 32)
+
+
+def _to_mph(kmh):
+    return round(kmh / 1.609)
+
+
+def simulate(name, rng, now, current, fahrenheit):
+    """The blob DB value for one city as the phone would build it now."""
+    city = CITIES[name]
+    days = [_day(rng, city, offset) for offset in range(DAYS)]
+    today, tomorrow = days[0], days[1]
+    local_hour = int(((now + city["utc"] * 60) % 86400) // 3600)
+
+    temp = _to_f if fahrenheit else (lambda c: c)
+    wind = _to_mph if fahrenheit else (lambda k: k)
+
+    sky = today["types"][local_hour]
+    wet = sky in (LIGHT_RAIN, HEAVY_RAIN, LIGHT_SNOW, HEAVY_SNOW, SLEET)
+    heavy = sky in (HEAVY_RAIN, HEAVY_SNOW)
+    current_temp = today["temps"][local_hour]
+    feels = current_temp - (today["wind"] // 10 if current_temp < 10 else 0)
+
+    fields = [
+        DB_VERSION,
+        temp(current_temp),
+        sky,
+        temp(max(today["temps"])),
+        temp(min(today["temps"])),
+        tomorrow["type"],
+        temp(max(tomorrow["temps"])),
+        temp(min(tomorrow["temps"])),
+        int(now),
+        current,
+        DB_MINOR_VERSION,
+        temp(feels),
+        round(max(today["uvs"]) * 10),
+        today["precip"],
+        wind(today["wind"]),
+        today["wind_dir"],
+        round(city["lat"] * 100),
+        round(city["lon"] * 100),
+        DAYS,
+    ]
+    for day in days:
+        fields += [temp(max(day["temps"])), temp(min(day["temps"])), day["type"]]
+    fields += [HOURS, *today["types"], *(temp(t) for t in today["temps"])]
+    fields.append(city["utc"])
+    for day in days:
+        fields += [day["precip"], wind(day["wind"]), round(max(day["uvs"]) * 10)]
+    fields += [
+        WMO_CODES[sky],
+        min(100, city["humidity"] + (10 if wet else 0)),
+        2000 if heavy else 8000 if wet else 20000,
+        (12 if heavy else 3) if wet else 0,
+    ]
+    fields += [temp(max(day["temps"]) - 1) for day in days]
+    fields.append(today["wind_dir"])
+    fields += [day["wind_dir"] for day in days]
+    fields += [round(uv * 10) for uv in today["uvs"]]
+    fields += [HOURS, *tomorrow["types"], *(temp(t) for t in tomorrow["temps"])]
+
+    strings = b"".join(
+        struct.pack("<H", len(s)) + s for s in (name.encode(), PHRASES[sky].encode())
+    )
+    return FIXED.pack(*fields) + struct.pack("<H", len(strings)) + strings
+
+
+def location_key(name):
+    return uuid.uuid5(LOCATION_NAMESPACE, name)
+
+
+class Weather(Feed):
+    name = "weather"
+    help = "A forecast for a few cities"
+    description = (
+        "Write a forecast for each CITY, the first one being the current "
+        "location. Cities: " + ", ".join(CITIES) + "."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "cities",
+            metavar="CITY",
+            nargs="*",
+            help="Cities to push, in order (default: all of them)",
+        )
+        parser.add_argument(
+            "--fahrenheit",
+            action="store_true",
+            help="Send temperatures in Fahrenheit and wind in mph",
+        )
+        parser.add_argument(
+            "--seed", type=int, help="Seed for the forecast generator (default: random)"
+        )
+        parser.add_argument(
+            "--clear", action="store_true", help="Remove every location instead"
+        )
+
+    def run(self, args, watch, inf):
+        for name in args.cities:
+            if name not in CITIES:
+                raise ValueError(
+                    f"unknown city {name!r}; pick from {', '.join(CITIES)}"
+                )
+        cities = [] if args.clear else (args.cities or list(CITIES))
+        seed = args.seed if args.seed is not None else random.randrange(1 << 32)
+        now = time.time()
+
+        if args.clear:
+            watch.blobdb_clear(BlobDb.WEATHER)
+        for index, name in enumerate(cities):
+            record = simulate(
+                name, random.Random(f"{seed}:{name}"), now, index == 0, args.fahrenheit
+            )
+            watch.blobdb_insert(BlobDb.WEATHER, location_key(name), record)
+        prefs = bytes([len(cities)]) + b"".join(location_key(n).bytes for n in cities)
+        watch.blobdb_insert(BlobDb.WATCH_APP_PREFS, PREFS_KEY, prefs)
+
+        if cities:
+            inf(f"pushed {', '.join(cities)} (seed {seed})")
+        else:
+            inf("cleared every weather location")

--- a/tools/libs/pbl-cli/pbl/util.py
+++ b/tools/libs/pbl-cli/pbl/util.py
@@ -26,7 +26,7 @@ def _emit(stream, color, args):
     msg = " ".join(str(a) for a in args)
     if color and _use_color(stream):
         msg = _colorize(color, msg)
-    print(msg, file=stream)
+    print(msg, file=stream, flush=True)
 
 
 def inf(*args, color="cyan"):


### PR DESCRIPTION
## Summary

Features that depend on the phone app could not be exercised on QEMU: nothing ever wrote what the phone keeps in sync, and the Weather app was not even listed because the phone capability bit gating it is never set there.

This adds `pbl feed <feed>`, which connects to the emulator's Pebble protocol serial port with libpebble2 and writes what the phone would. Feeds are modules in `tools/libs/pbl-cli/pbl/feeds/`, discovered like commands, so more can be added as sibling files.

- **weather**: a v4.5 record per city into the weather DB plus the ordered location list into the watch app prefs, from a few built-in regimes with a seedable forecast. Exits once stored.
- **music**: stands in for the phone's player. Reports player, track and playback state, then keeps serving: the watch's controls act on a small playlist, playback advances and rolls over, and album art is drawn on request over the imaging endpoint in the format the watch asks for.

```shell
pbl feed weather                        # all built-in cities, first is the current location
pbl feed weather Tokyo Sydney --seed 3
pbl feed music                          # keeps serving until Ctrl-C
pbl feed music --title "Demo" --paused
```

Two things found along the way, fixed in their own commits:

- The firmware asks for the phone's version only when the emulated session first opens, and that session outlives host connections. The music endpoint gates on the answer, so nothing after the first host connection would work. The connection helper now sends the version response unsolicited on every connect.
- The emulator's port serves one host client at a time; a second connection now fails with a clear message instead of a libpebble2 timeout.

Docs: `docs/development/qemu.md` (usage) and `docs/development/pbl.md` (adding a feed).

## Test plan

Verified on `qemu_emery`:

- [x] Weather appears in the launcher without a phone; glance shows the pushed current location.
- [x] Weather app renders forecast strip, precipitation, hourly dial, day pages and warnings from pushed records; refreshes live on a new push.
- [x] Music app shows track, artist, progress; launcher glance updates.
- [x] Play/pause, next/previous, volume up/down round-trip to the feed and update the watch; track rolls over at its end.
- [x] Album art (166x166, 4-bit palette) renders once enabled under Settings > Music.
- [x] `--dry-run` for both feeds; unknown city and busy-port errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
