### PR TITLE
treewide: fix workout_active_create_triple_layout typo

### DIFF
--- a/src/fw/apps/system/workout/active.c
+++ b/src/fw/apps/system/workout/active.c
@@ -960,12 +960,12 @@ WorkoutActiveWindow *workout_active_create_double_layout(WorkoutMetricType top_m
   return active_window;
 }
 
-WorkoutActiveWindow *workout_active_create_tripple_layout(WorkoutMetricType top_metric,
-                                                          WorkoutMetricType middle_metric,
-                                                          int num_scrollable_metrics,
-                                                          WorkoutMetricType *scrollable_metrics,
-                                                          void *workout_data,
-                                                          WorkoutController *workout_controller) {
+WorkoutActiveWindow *workout_active_create_triple_layout(WorkoutMetricType top_metric,
+                                                         WorkoutMetricType middle_metric,
+                                                         int num_scrollable_metrics,
+                                                         WorkoutMetricType *scrollable_metrics,
+                                                         void *workout_data,
+                                                         WorkoutController *workout_controller) {
   if (top_metric == WorkoutMetricType_None || middle_metric == WorkoutMetricType_None ||
       (num_scrollable_metrics != 0 && !scrollable_metrics)) {
     PBL_LOG_ERR("Invalid argument(s)");

--- a/src/fw/apps/system/workout/active.h
+++ b/src/fw/apps/system/workout/active.h
@@ -21,12 +21,12 @@ WorkoutActiveWindow *workout_active_create_double_layout(WorkoutMetricType top_m
                                                          void *workout_data,
                                                          WorkoutController *workout_controller);
 
-WorkoutActiveWindow *workout_active_create_tripple_layout(WorkoutMetricType top_metric,
-                                                          WorkoutMetricType middle_metric,
-                                                          int num_scrollable_metrics,
-                                                          WorkoutMetricType *scrollable_metrics,
-                                                          void *workout_data,
-                                                          WorkoutController *workout_controller);
+WorkoutActiveWindow *workout_active_create_triple_layout(WorkoutMetricType top_metric,
+                                                         WorkoutMetricType middle_metric,
+                                                         int num_scrollable_metrics,
+                                                         WorkoutMetricType *scrollable_metrics,
+                                                         void *workout_data,
+                                                         WorkoutController *workout_controller);
 
 WorkoutActiveWindow *workout_active_create_for_activity_type(ActivitySessionType type,
                                                              void *workout_data,

--- a/src/fw/apps/system/workout/sports.c
+++ b/src/fw/apps/system/workout/sports.c
@@ -318,12 +318,12 @@ static void prv_init(void) {
     .get_custom_metric_label_string = prv_get_custom_metric_label_string,
   };
 
-  data->active_window = workout_active_create_tripple_layout(WorkoutMetricType_Duration,
-                                                             WorkoutMetricType_Distance,
-                                                             0,
-                                                             NULL,
-                                                             NULL,
-                                                             &data->workout_controller);
+  data->active_window = workout_active_create_triple_layout(WorkoutMetricType_Duration,
+                                                            WorkoutMetricType_Distance,
+                                                            0,
+                                                            NULL,
+                                                            NULL,
+                                                            &data->workout_controller);
   data->pace_speed_metric = DEFAULT_PACE_SPEED_METRIC;
   prv_update_scrollable_metrics(data);
   workout_active_window_push(data->active_window);

--- a/tests/fw/apps/system_apps/workout/test_workout_active.c
+++ b/tests/fw/apps/system_apps/workout/test_workout_active.c
@@ -367,7 +367,7 @@ void test_workout_active__sports_pace(void) {
   WorkoutMetricType scrollable_metrics[] = {WorkoutMetricType_Pace,
                                             WorkoutMetricType_Hr};
 
-  WorkoutActiveWindow *active_window = workout_active_create_tripple_layout(
+  WorkoutActiveWindow *active_window = workout_active_create_triple_layout(
       top_metric, middle_metric, ARRAY_LENGTH(scrollable_metrics), scrollable_metrics,
       &s_sports_data, &s_sports_controller);
   prv_create_window_and_render(active_window, 0);
@@ -387,7 +387,7 @@ void test_workout_active__sports_pace_long_values(void) {
   WorkoutMetricType scrollable_metrics[] = {WorkoutMetricType_Pace,
                                             WorkoutMetricType_Hr};
 
-  WorkoutActiveWindow *active_window = workout_active_create_tripple_layout(
+  WorkoutActiveWindow *active_window = workout_active_create_triple_layout(
       top_metric, middle_metric, ARRAY_LENGTH(scrollable_metrics), scrollable_metrics,
       &s_sports_data, &s_sports_controller);
   prv_create_window_and_render(active_window, 0);
@@ -407,7 +407,7 @@ void test_workout_active__sports_speed(void) {
   WorkoutMetricType scrollable_metrics[] = {WorkoutMetricType_Speed,
                                             WorkoutMetricType_Hr};
 
-  WorkoutActiveWindow *active_window = workout_active_create_tripple_layout(
+  WorkoutActiveWindow *active_window = workout_active_create_triple_layout(
       top_metric, middle_metric, ARRAY_LENGTH(scrollable_metrics), scrollable_metrics,
       &s_sports_data, &s_sports_controller);
   prv_create_window_and_render(active_window, 0);
@@ -428,7 +428,7 @@ void test_workout_active__sports_no_hrm(void) {
   WorkoutMetricType middle_metric = WorkoutMetricType_Distance;
   WorkoutMetricType scrollable_metrics[] = {WorkoutMetricType_Pace};
 
-  WorkoutActiveWindow *active_window = workout_active_create_tripple_layout(
+  WorkoutActiveWindow *active_window = workout_active_create_triple_layout(
       top_metric, middle_metric, ARRAY_LENGTH(scrollable_metrics), scrollable_metrics,
       &s_sports_data, &s_sports_controller);
   prv_create_window_and_render(active_window, 0);
@@ -448,7 +448,7 @@ void test_workout_active__sports_hr_z0(void) {
   WorkoutMetricType scrollable_metrics[] = {WorkoutMetricType_Pace,
                                             WorkoutMetricType_Hr};
 
-  WorkoutActiveWindow *active_window = workout_active_create_tripple_layout(
+  WorkoutActiveWindow *active_window = workout_active_create_triple_layout(
       top_metric, middle_metric, ARRAY_LENGTH(scrollable_metrics), scrollable_metrics,
       &s_sports_data, &s_sports_controller);
   prv_create_window_and_render(active_window, 1);
@@ -468,7 +468,7 @@ void test_workout_active__sports_hr_z1(void) {
   WorkoutMetricType scrollable_metrics[] = {WorkoutMetricType_Pace,
                                             WorkoutMetricType_Hr};
 
-  WorkoutActiveWindow *active_window = workout_active_create_tripple_layout(
+  WorkoutActiveWindow *active_window = workout_active_create_triple_layout(
       top_metric, middle_metric, ARRAY_LENGTH(scrollable_metrics), scrollable_metrics,
       &s_sports_data, &s_sports_controller);
   prv_create_window_and_render(active_window, 1);
@@ -488,7 +488,7 @@ void test_workout_active__sports_hr_z2(void) {
   WorkoutMetricType scrollable_metrics[] = {WorkoutMetricType_Pace,
                                             WorkoutMetricType_Hr};
 
-  WorkoutActiveWindow *active_window = workout_active_create_tripple_layout(
+  WorkoutActiveWindow *active_window = workout_active_create_triple_layout(
       top_metric, middle_metric, ARRAY_LENGTH(scrollable_metrics), scrollable_metrics,
       &s_sports_data, &s_sports_controller);
   prv_create_window_and_render(active_window, 1);
@@ -508,7 +508,7 @@ void test_workout_active__sports_hr_z3(void) {
   WorkoutMetricType scrollable_metrics[] = {WorkoutMetricType_Pace,
                                             WorkoutMetricType_Hr};
 
-  WorkoutActiveWindow *active_window = workout_active_create_tripple_layout(
+  WorkoutActiveWindow *active_window = workout_active_create_triple_layout(
       top_metric, middle_metric, ARRAY_LENGTH(scrollable_metrics), scrollable_metrics,
       &s_sports_data, &s_sports_controller);
   prv_create_window_and_render(active_window, 1);
@@ -530,7 +530,7 @@ void test_workout_active__sports_custom_field(void) {
   WorkoutMetricType scrollable_metrics[] = {WorkoutMetricType_Pace,
                                             WorkoutMetricType_Custom};
 
-  WorkoutActiveWindow *active_window = workout_active_create_tripple_layout(
+  WorkoutActiveWindow *active_window = workout_active_create_triple_layout(
       top_metric, middle_metric, ARRAY_LENGTH(scrollable_metrics), scrollable_metrics,
       &s_sports_data, &s_sports_controller);
   prv_create_window_and_render(active_window, 1);
@@ -552,7 +552,7 @@ void test_workout_active__sports_custom_long_values(void) {
   WorkoutMetricType scrollable_metrics[] = {WorkoutMetricType_Pace,
                                             WorkoutMetricType_Custom};
 
-  WorkoutActiveWindow *active_window = workout_active_create_tripple_layout(
+  WorkoutActiveWindow *active_window = workout_active_create_triple_layout(
       top_metric, middle_metric, ARRAY_LENGTH(scrollable_metrics), scrollable_metrics,
       &s_sports_data, &s_sports_controller);
   prv_create_window_and_render(active_window, 1);
@@ -574,7 +574,7 @@ void test_workout_active__sports_custom_hanging_label(void) {
   WorkoutMetricType scrollable_metrics[] = {WorkoutMetricType_Pace,
                                             WorkoutMetricType_Custom};
 
-  WorkoutActiveWindow *active_window = workout_active_create_tripple_layout(
+  WorkoutActiveWindow *active_window = workout_active_create_triple_layout(
       top_metric, middle_metric, ARRAY_LENGTH(scrollable_metrics), scrollable_metrics,
       &s_sports_data, &s_sports_controller);
   prv_create_window_and_render(active_window, 1);


### PR DESCRIPTION
I believe "triple" was misspelled. I realigned the parameters after the rename to stay aligned