### PR TITLE
gitlint: allow underscore in commit title start

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -12,7 +12,7 @@ regex=(?i)dependabot
 ignore=all
 
 [title-match-regex]
-regex=^[a-z0-9/]+: .*
+regex=^[a-z0-9/_]+: .*
 
 [title-max-length]
 line-length=100


### PR DESCRIPTION
Notice that the underscore was being blocked in CI for a few titles that included things like `blob_db` or `process_management` before the colon.