### PR TITLE
drivers/touch/cst816: take the i2c lock around the hardware reset

### DIFF
--- a/src/fw/drivers/touch/cst816/cst816.c
+++ b/src/fw/drivers/touch/cst816/cst816.c
@@ -222,6 +222,7 @@ static bool cst816_fw_update(void) {
 }
 
 static void cst816_hw_reset(void) {
+  pbl_mutex_lock(&s_i2c_lock, PBL_FOREVER);
 #ifdef RESET_PIN_CTRLBY_NPM1300
   NPM1300_OPS.gpio_set(Npm1300_Gpio2, 0);
   psleep(CST816_RESET_CYCLE_TIME);
@@ -233,6 +234,7 @@ static void cst816_hw_reset(void) {
   gpio_output_set(&CST816->reset, false);
   psleep(CST816_POR_DELAY_TIME);
 #endif
+  pbl_mutex_unlock(&s_i2c_lock);
 }
 
 void touch_sensor_init(void) {


### PR DESCRIPTION
Supersedes #1896 (originally by @Mearman) with review feedback applied: the verbose inline comment explaining the race is dropped, since the same rationale is already in the commit message.

cst816_hw_reset toggles the chip's reset pin with no synchronisation against the bus: touch_sensor_set_enabled is reached synchronously from arbitrary tasks (subscribe/unsubscribe callbacks, the backlight and system-hold toggles) and calls the reset as its first statement, while the system task may be mid-transfer inside prv_read_data clocking the same chip. A chip hit by reset mid-byte stops ACKing and corrupts the in-flight transfer.

This takes s_i2c_lock inside cst816_hw_reset, the same per-transfer lock the read/write paths use. No caller holds it already, so the acquisition cannot self-deadlock, and the bootmode/fw-update sequences keep their existing per-operation interleaving.

No unit test: the driver has no test target (it sits on real I2C, GPIO and EXTI) and the race is a cross-task timing window against hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)