### PR TITLE
sdk: fix env var dependencies for resource ball and timeline resources

### DIFF
--- a/sdk/waftools/generate_resource_ball.py
+++ b/sdk/waftools/generate_resource_ball.py
@@ -90,12 +90,12 @@ def process_resource_ball(task_gen):
         prb_task = task_gen.create_task(
             "resource_ball", bundled_resos, task_gen.project_resource_ball
         )
-        prb_task.dep_node = getattr(task_gen, "resource_dependencies", [])
-        prb_task.dep_vars = getattr(task_gen, "vars", [])
+        prb_task.dep_nodes = getattr(task_gen, "resource_dependencies", [])
+        prb_task.vars = getattr(task_gen, "vars", [])
 
     task = task_gen.create_task(
         "resource_ball", resource_objects, task_gen.resource_ball
     )
     task.resource_declarations = getattr(task_gen, "resource_declarations", [])
     task.dep_nodes = getattr(task_gen, "resource_dependencies", [])
-    task.dep_vars = getattr(task_gen, "vars", [])
+    task.vars = getattr(task_gen, "vars", [])

--- a/sdk/waftools/process_timeline_resources.py
+++ b/sdk/waftools/process_timeline_resources.py
@@ -260,6 +260,8 @@ def process_timeline_resources(task_gen):
         "timeline_reso", src=None, tgt=timeline_resource_table
     )
     timeline_reso_task.published_media = published_media
+    timeline_reso_task.vars = getattr(task_gen, "vars", [])
 
     layouts_json_task = task_gen.create_task("layouts_json", src=None, tgt=layouts_json)
     layouts_json_task.published_media = published_media
+    layouts_json_task.vars = getattr(task_gen, "vars", [])


### PR DESCRIPTION
Follow-up to #2011: the same `dep_vars` mistake exists in two more places in the SDK waftools, so the env vars those task generators declare never reach the task signatures.

**`generate_resource_ball.py`** — `dep_vars` is not a waf attribute, so `RESOURCES_JSON`, `LIB_RESOURCES_JSON` and `RESOURCE_ID_MAPPING` were silently dropped. `resource_ball.run()` reads `env.RESOURCE_ID_MAPPING` at run time, so a `package.json` edit that changes the mapping without changing the set of `.reso` inputs leaves a resource ball with stale IDs, which propagates into `resource_ids.auto.h`/`.c`. Also fixes the neighbouring `dep_node` typo (waf expects `dep_nodes`), inert today only because nothing sets `resource_dependencies`.

**`process_timeline_resources.py`** — the tgen declares `vars=["RESOURCE_ID_MAPPING", "PUBLISHED_MEDIA_JSON"]` but never forwards them to the tasks, in any form. Both tasks are created with `src=None`, so they had no inputs *and* no vars: their signature was effectively constant. Editing `publishedMedia` and rebuilding incrementally left a stale `timeline_resource_table.reso` (TLUT) and `layouts.json`, recoverable only with a clean build.

Verified against the vendored waf (`sdk/waf`) that an instance-level `vars` is honoured — these are hand-written `run()` subclasses, so `Task.sig_vars()` (`sdk/waf/waflib/Task.py:789`) applies and hashes `self.vars`; a mapping change flips the signature with `vars` and does not with `dep_vars`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)