### PR TITLE
v4.9.142: bounded MFG discharge test with PASS/FAIL, CST816 reflash backport

### DIFF
--- a/src/fw/apps/prf/mfg_discharge.c
+++ b/src/fw/apps/prf/mfg_discharge.c
@@ -23,17 +23,26 @@
 
 #define CHARGE_TARGET_PERCENT 99
 #define DRAIN_TARGET_PERCENT 70
+#define SETTLE_DURATION_S (2 * SECONDS_PER_HOUR)
+#define MAX_DURATION_S (10 * SECONDS_PER_HOUR)
+#define MAX_PERCENT_DROP 3
 
 typedef enum {
   DischargeStateChargeTo100 = 0,
   DischargeStateDrainTo70,
+  DischargeStateSettling,
   DischargeStateDischarging,
+  DischargeStatePass,
+  DischargeStateFail,
 } DischargeTestState;
 
 static const char *status_text[] = {
     [DischargeStateChargeTo100] = "Charge to 100%",
     [DischargeStateDrainTo70] = "Drain to 70%",
+    [DischargeStateSettling] = "Settling",
     [DischargeStateDischarging] = "Discharging",
+    [DischargeStatePass] = "PASS",
+    [DischargeStateFail] = "FAIL",
 };
 
 typedef struct {
@@ -47,7 +56,7 @@ typedef struct {
 
   DischargeTestState test_state;
 
-  // Battery state at start of discharge phase
+  // Battery state at end of settling phase
   int32_t initial_voltage_mv;
   uint8_t initial_percent;
 
@@ -64,21 +73,57 @@ static void prv_handle_battery_state(BatteryChargeState charge) {
   prv_render(app_state_get_user_data());
 }
 
-static void prv_handle_tick(struct tm *tick_time, TimeUnits units_changed) {
-  if ((units_changed & MINUTE_UNIT) != 0) {
-    AppData *data = app_state_get_user_data();
-    data->elapsed_seconds += SECONDS_PER_MINUTE;
-    prv_render(data);
-  }
-}
-
-static void prv_start_discharge_phase(AppData *data) {
+static void prv_finish_test(AppData *data) {
   BatteryConstants battery_const;
   BatteryChargeState charge_state;
 
   battery_get_constants(&battery_const);
   charge_state = battery_get_charge_state();
 
+  tick_timer_service_unsubscribe();
+
+  int32_t voltage_drop = data->initial_voltage_mv - battery_const.v_mv;
+  int8_t percent_drop = (int8_t)data->initial_percent - (int8_t)charge_state.charge_percent;
+  bool passed = percent_drop <= MAX_PERCENT_DROP;
+
+  data->test_state = passed ? DischargeStatePass : DischargeStateFail;
+  PBL_LOG_INFO("Discharge test %s - V:%" PRId32 "mV pct:%" PRIu8 " dV:%" PRId32 "mV dpct:%" PRId8,
+               passed ? "PASS" : "FAIL", battery_const.v_mv, charge_state.charge_percent,
+               voltage_drop, percent_drop);
+  prv_render(data);
+}
+
+static void prv_handle_tick(struct tm *tick_time, TimeUnits units_changed) {
+  if ((units_changed & MINUTE_UNIT) == 0) {
+    return;
+  }
+
+  AppData *data = app_state_get_user_data();
+  data->elapsed_seconds += SECONDS_PER_MINUTE;
+
+  if (data->test_state == DischargeStateSettling &&
+      data->elapsed_seconds >= SETTLE_DURATION_S) {
+    // The fuel gauge keeps converging for a while after the high-current
+    // drain phase, so the baseline is only taken once that has settled
+    BatteryConstants battery_const;
+    BatteryChargeState charge_state;
+
+    battery_get_constants(&battery_const);
+    charge_state = battery_get_charge_state();
+
+    data->test_state = DischargeStateDischarging;
+    data->initial_voltage_mv = battery_const.v_mv;
+    data->initial_percent = charge_state.charge_percent;
+  } else if (data->test_state == DischargeStateDischarging &&
+             data->elapsed_seconds >= MAX_DURATION_S) {
+    prv_finish_test(data);
+    return;
+  }
+
+  prv_render(data);
+}
+
+static void prv_start_discharge_phase(AppData *data) {
   light_enable(false);
 
   // Discharge phase: drive updates from a once-a-minute tick rather than
@@ -86,10 +131,8 @@ static void prv_start_discharge_phase(AppData *data) {
   battery_state_service_unsubscribe();
   tick_timer_service_subscribe(MINUTE_UNIT, prv_handle_tick);
 
-  data->test_state = DischargeStateDischarging;
+  data->test_state = DischargeStateSettling;
   data->elapsed_seconds = 0;
-  data->initial_voltage_mv = battery_const.v_mv;
-  data->initial_percent = charge_state.charge_percent;
   prv_render(data);
 }
 
@@ -139,6 +182,17 @@ static void prv_render(AppData *data) {
       }
       break;
 
+    case DischargeStateSettling: {
+      int hours = data->elapsed_seconds / 3600;
+      int mins = (data->elapsed_seconds % 3600) / 60;
+
+      sniprintf(data->details_string, sizeof(data->details_string),
+                "Elapsed: %02d:%02d\n\n"
+                "Current:\n"
+                "%" PRId32 "mV %" PRIu8 "%%",
+                hours, mins, battery_const.v_mv, charge_state.charge_percent);
+    } break;
+
     case DischargeStateDischarging: {
       int hours = data->elapsed_seconds / 3600;
       int mins = (data->elapsed_seconds % 3600) / 60;
@@ -155,6 +209,20 @@ static void prv_render(AppData *data) {
                 hours, mins,
                 battery_const.v_mv, charge_state.charge_percent,
                 voltage_delta, percent_delta);
+    } break;
+
+    case DischargeStatePass:
+    case DischargeStateFail: {
+      int32_t voltage_drop = data->initial_voltage_mv - battery_const.v_mv;
+      int8_t percent_drop = (int8_t)data->initial_percent - (int8_t)charge_state.charge_percent;
+
+      sniprintf(data->details_string, sizeof(data->details_string),
+                "Final:\n"
+                "%" PRId32 "mV %" PRIu8 "%%\n"
+                "Drop:\n"
+                "%" PRId32 "mV  %" PRId8 "%%",
+                battery_const.v_mv, charge_state.charge_percent,
+                voltage_drop, percent_drop);
     } break;
   }
 

--- a/src/fw/apps/prf/mfg_discharge.c
+++ b/src/fw/apps/prf/mfg_discharge.c
@@ -13,6 +13,7 @@
 #include "applib/tick_timer_service.h"
 #include "console/console_internal.h"
 #include "drivers/battery.h"
+#include "drivers/touch/touch_sensor.h"
 #include "kernel/pbl_malloc.h"
 #include "process_state/app_state/app_state.h"
 #include "services/common/bluetooth/bluetooth_ctl.h"
@@ -236,6 +237,9 @@ static void prv_render(AppData *data) {
 static void prv_back_click_handler(ClickRecognizerRef recognizer, void *data) {
   serial_console_set_rx_enabled(true);
   bt_ctl_set_enabled(true);
+#if CAPABILITY_HAS_TOUCHSCREEN
+  touch_sensor_set_enabled(true);
+#endif
 
   app_window_stack_pop(true);
 }
@@ -275,6 +279,9 @@ static void app_init(void) {
   // Disable sources of power consumption to minimize impact on discharge test results
   serial_console_set_rx_enabled(false);
   bt_ctl_set_enabled(false);
+#if CAPABILITY_HAS_TOUCHSCREEN
+  touch_sensor_set_enabled(false);
+#endif
 
   *data = (AppData){
       .test_state = DischargeStateChargeTo100,

--- a/src/fw/drivers/touch/cst816/cst816.c
+++ b/src/fw/drivers/touch/cst816/cst816.c
@@ -216,30 +216,34 @@ void touch_sensor_init(void) {
   rv = prv_read_data(CST816_CHIP_ID_REG, &chip_id, 1, 1);
   if (!rv) {
     PBL_LOG_ERR("Could not read CST816 chip ID");
-    return;
+  } else {
+    rv = prv_read_data(CST816_FW_VERSION_REG, &fw_version, 1, 1);
+    if (!rv) {
+      PBL_LOG_ERR("Could not read CST816 firmware version");
+    } else {
+      PBL_LOG_DBG("CST816 firmware: 0x%02X", fw_version);
+    }
   }
-
-  rv = prv_read_data(CST816_FW_VERSION_REG, &fw_version, 1, 1);
-  if (!rv) {
-    PBL_LOG_ERR("Could not read CST816 firmware version");
-    return;
-  }
-
-  PBL_LOG_DBG("CST816 firmware: 0x%02X", fw_version);
 
 #if PLATFORM_OBELIX
   uint8_t target_ver = app_bin[sizeof(app_bin) + CST816_FW_VER_INFO_INDEX];
 
-  if (target_ver != fw_version) {
-    if (cst816_enter_bootmode()) {
-      rv = cst816_fw_update();
-      if (!rv) {
-        return;
-      }
-    } else {
+  // A chip stranded in boot mode by an interrupted update stops answering at
+  // the work-mode address; only a reflash brings it back, so attempt the
+  // update even when the probe above failed.
+  if (!rv || target_ver != fw_version) {
+    if (!cst816_enter_bootmode()) {
       PBL_LOG_ERR("Could not enter CST816 boot mode");
       return;
     }
+    rv = cst816_fw_update();
+    if (!rv) {
+      return;
+    }
+  }
+#else
+  if (!rv) {
+    return;
   }
 #endif
 

--- a/src/fw/drivers/touch/cst816/cst816.c
+++ b/src/fw/drivers/touch/cst816/cst816.c
@@ -291,8 +291,9 @@ static void prv_exti_cb(bool *should_context_switch) {
 }
 
 void touch_sensor_set_enabled(bool enabled) {
+  cst816_hw_reset();
+
   if (enabled) {
-    cst816_hw_reset();
     exti_enable(CST816->int_exti);
   } else {
     uint8_t data = CST816_POWER_MODE_SLEEP;


### PR DESCRIPTION
## Summary

- **MFG discharge test**: stop after 10 h and report PASS/FAIL with the final voltage, percentage and drops. The baseline is taken 2 h into the discharge phase because the fuel gauge keeps converging after the backlight drain (V32 field data shows 5–9 % apparent drop within the first 10 h on known-good units); the drop is judged over the remaining 8 h with a 3 % threshold.
- **MFG discharge test**: put the CST816 to sleep for the duration of the test alongside the serial console and BT, restored on exit.
- **CST816**: backport of #1ca6a287a (reflash when the boot probe fails) so a chip stranded in boot mode by an interrupted update recovers. The `PLATFORM_OBELIX` guard on this branch is kept; the non-obelix path retains the previous bail-out on probe failure.
- **CST816**: backport of #af8677375 (always hardware-reset on enable/disable) so the sleep write on disable succeeds even when the IC has auto-idled — required for the discharge test's disable to actually take effect.

## Test plan

- [x] `obelix_pvt` `--mfg` main firmware and PRF build clean
- [ ] Run the discharge test on an obelix PVT unit through a full cycle and confirm PASS with the final screen showing mV / % / drops
- [ ] Interrupt a CST816 update and confirm the driver reflashes on next boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
